### PR TITLE
Complete remediation authoring and operator UI (MoonLadderStudios/MoonMind#3623)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -105,7 +105,7 @@ from moonmind.schemas.manifest_ingest_models import (
     ManifestStatusSnapshotModel,
 )
 from moonmind.schemas.temporal_artifact_models import ArtifactRefModel
-from moonmind.utils.logging import redact_sensitive_text
+from moonmind.utils.logging import redact_sensitive_payload, redact_sensitive_text
 from moonmind.schemas.temporal_models import (
     CancelExecutionRequest,
     ConfigureIntegrationMonitoringRequest,
@@ -616,6 +616,67 @@ class RemediationCheckpointBranchLinkModel(BaseModel):
     workflowId: str
     branchId: str
     branchTurnId: str | None = None
+    logicalStepId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    branchState: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    workspacePolicy: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    runtimeContextPolicy: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    gitBaseBranch: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    gitWorkBranch: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    currentHeadCommit: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    pullRequestUrl: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    publishStatus: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    promotionEvidence: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    archiveReason: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    promotedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    archivedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    turnState: str | None = Field(default=None, exclude_if=lambda value: value is None)
+    runtimeAgentRunId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    providerSessionId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    instructionRef: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    turnStartedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    turnCompletedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    outputArtifacts: dict[str, str] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    comparisonArtifacts: dict[str, str] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
     operation: str | None = None
     idempotencyKey: str | None = None
     checkpointRef: str | None = None
@@ -680,6 +741,26 @@ class RemediationActionCapabilityModel(BaseModel):
     blockedReasons: list[str]
 
 
+class RemediationOperatorControlsModel(BaseModel):
+    canCancel: bool = False
+    canTakeOver: bool = False
+    canResume: bool = False
+    paused: bool = False
+    disabledReasons: dict[str, str] = Field(default_factory=dict)
+
+
+class RemediationLifecycleArtifactModel(BaseModel):
+    artifactRef: str
+    artifactType: str
+    status: str
+    label: str | None = None
+    createdAt: datetime | str | None = None
+    expiresAt: datetime | str | None = None
+    freshness: str
+    bounded: bool = True
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 class RemediationLinkSummaryModel(BaseModel):
     remediationWorkflowId: str
     remediationRunId: str
@@ -695,6 +776,7 @@ class RemediationLinkSummaryModel(BaseModel):
     # ``resolution`` is the terminal remediation lifecycle resolution. They are
     # distinct projections (issue #3622) and must never share a column.
     deliveryStatus: str | None = None
+    verificationOutcome: str | None = None
     resolution: str | None = None
     contextArtifactRef: str | None = None
     selectedSteps: list[str] | None = None
@@ -710,6 +792,39 @@ class RemediationLinkSummaryModel(BaseModel):
     approvalState: RemediationApprovalStateModel | None = None
     checkpointBranches: list[RemediationCheckpointBranchLinkModel] = Field(
         default_factory=list
+    )
+    authoredContract: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    selectedStepEvidence: list[dict[str, Any]] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    contextGeneratedAt: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    contextEvidenceAvailability: list[dict[str, Any]] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    contextBoundedness: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    diagnosisHints: list[str] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    lifecycleArtifacts: list[RemediationLifecycleArtifactModel] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    latestActionRequest: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    latestActionResult: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    lifecycleSummary: dict[str, Any] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    operatorControls: RemediationOperatorControlsModel | None = Field(
+        default=None, exclude_if=lambda value: value is None
     )
     createdAt: datetime
     updatedAt: datetime
@@ -8961,6 +9076,49 @@ def _validate_pr_base_branch_submission(
             )
 
 
+def _validate_remediation_branch_submission(
+    *, task_payload: Mapping[str, Any], git_payload: Mapping[str, Any]
+) -> None:
+    remediation = task_payload.get("remediation")
+    if not isinstance(remediation, Mapping):
+        return
+    for field_name, value in (
+        ("payload.workflow.git.branch", git_payload.get("branch")),
+        (
+            "payload.workflow.git.startingBranch",
+            git_payload.get("startingBranch"),
+        ),
+        ("payload.workflow.branch", task_payload.get("branch")),
+        ("payload.workflow.startingBranch", task_payload.get("startingBranch")),
+    ):
+        branch = str(value or "")
+        if not branch:
+            continue
+        try:
+            TemporalExecutionService._validate_remediation_git_branch(
+                branch, path=field_name, allow_protected=True
+            )
+        except TemporalExecutionValidationError as exc:
+            raise _invalid_workflow_request(str(exc)) from exc
+
+    checkpoint_policy = remediation.get("checkpointBranchPolicy")
+    if not isinstance(checkpoint_policy, Mapping):
+        return
+    work_branch = str(checkpoint_policy.get("gitWorkBranch") or "")
+    if not work_branch:
+        return
+    try:
+        TemporalExecutionService._validate_remediation_git_branch(
+            work_branch,
+            path=(
+                "payload.workflow.remediation.checkpointBranchPolicy.gitWorkBranch"
+            ),
+            allow_protected=False,
+        )
+    except TemporalExecutionValidationError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
+
+
 def _normalize_merge_automation_payload(raw_merge_automation: Any) -> dict[str, Any]:
     return _coerce_mapping(raw_merge_automation)
 
@@ -10636,6 +10794,10 @@ async def _create_execution_from_workflow_request(
         task_payload=task_payload,
         git_payload=git_payload,
     )
+    _validate_remediation_branch_submission(
+        task_payload=task_payload,
+        git_payload=git_payload,
+    )
     if git_payload:
         normalized_git_payload: dict[str, str] = {}
         for git_key in ("startingBranch", "branch"):
@@ -11748,8 +11910,25 @@ def _remediation_approval_state_from_link(
     raw_state = getattr(link, "approval_state", None)
     if isinstance(raw_state, dict):
         projected = dict(raw_state)
-        projected.setdefault("decision", projected.get("status", "pending"))
-        projected.setdefault("canDecide", projected.get("status") == "pending")
+        approval_status = str(projected.get("status") or "pending")
+        expires_at = projected.get("expiresAt")
+        if approval_status == "pending" and expires_at:
+            try:
+                parsed_expiration = datetime.fromisoformat(str(expires_at))
+                if parsed_expiration.tzinfo is None:
+                    parsed_expiration = parsed_expiration.replace(tzinfo=UTC)
+                if parsed_expiration <= datetime.now(UTC):
+                    approval_status = "expired"
+                    projected["status"] = "expired"
+            except ValueError:
+                approval_status = "stale"
+                projected["status"] = "stale"
+        projected.setdefault("decision", approval_status)
+        if projected.get("decision") == "pending" and approval_status != "pending":
+            projected["decision"] = approval_status
+        projected["canDecide"] = (
+            bool(projected.get("canDecide", True)) and approval_status == "pending"
+        )
         return RemediationApprovalStateModel.model_validate(projected)
 
     approval_pending = status_value in _PENDING_REMEDIATION_APPROVAL_STATUSES
@@ -11824,6 +12003,7 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         activeLockHolder=getattr(link, "active_lock_holder", None),
         latestActionSummary=getattr(link, "latest_action_summary", None),
         deliveryStatus=getattr(link, "outcome", None),
+        verificationOutcome=getattr(link, "verification_outcome", None),
         resolution=getattr(link, "resolution", None),
         contextArtifactRef=getattr(link, "context_artifact_ref", None),
         selectedSteps=_bounded_string_list(getattr(link, "selected_steps", None)),
@@ -11846,13 +12026,277 @@ def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryMode
         checkpointBranches=_bounded_checkpoint_branch_links(
             getattr(link, "checkpoint_branch_links", None)
         ),
+        authoredContract=getattr(link, "authored_contract", None),
+        selectedStepEvidence=getattr(link, "selected_step_evidence", None),
+        contextGeneratedAt=getattr(link, "context_generated_at", None),
+        contextEvidenceAvailability=getattr(
+            link, "context_evidence_availability", None
+        ),
+        contextBoundedness=getattr(link, "context_boundedness", None),
+        diagnosisHints=_bounded_string_list(getattr(link, "diagnosis_hints", None)),
+        lifecycleArtifacts=getattr(link, "lifecycle_artifacts", None),
+        latestActionRequest=getattr(link, "latest_action_request", None),
+        latestActionResult=getattr(link, "latest_action_result", None),
+        lifecycleSummary=getattr(link, "lifecycle_summary", None),
+        operatorControls=getattr(link, "operator_controls", None),
         createdAt=getattr(link, "created_at", None),
         updatedAt=getattr(link, "updated_at", None),
     )
 
 
+_REMEDIATION_LIFECYCLE_ARTIFACT_TYPES = frozenset(
+    {
+        "remediation.context",
+        "remediation.plan",
+        "remediation.attempt",
+        "remediation.approval_request",
+        "remediation.approval_decision",
+        "remediation.action_request",
+        "remediation.action_result",
+        "remediation.verification",
+        "remediation.audit_event",
+        "remediation.target_annotation",
+        "remediation.decision_log",
+        "remediation.summary",
+    }
+)
+_REMEDIATION_ARTIFACT_METADATA_KEYS = frozenset(
+    {
+        "artifact_type",
+        "schemaVersion",
+        "name",
+        "targetWorkflowId",
+        "targetRunId",
+        "remediationWorkflowId",
+        "remediationRunId",
+        "actionId",
+        "actionKind",
+        "status",
+        "outcome",
+        "resolution",
+        "verificationOutcome",
+        "phase",
+        "riskTier",
+        "bounded",
+    }
+)
+
+
+def _bounded_remediation_projection(
+    value: Any, *, depth: int = 0, max_string_length: int = 8_000
+) -> Any:
+    """Return a redacted, compact browser projection of canonical JSON evidence."""
+
+    if depth > 6:
+        return "[bounded]"
+    redacted = redact_sensitive_payload(value)
+    if isinstance(redacted, Mapping):
+        return {
+            str(key)[:128]: _bounded_remediation_projection(
+                item, depth=depth + 1, max_string_length=max_string_length
+            )
+            for key, item in list(redacted.items())[:50]
+        }
+    if isinstance(redacted, list | tuple):
+        return [
+            _bounded_remediation_projection(
+                item, depth=depth + 1, max_string_length=max_string_length
+            )
+            for item in redacted[:50]
+        ]
+    if isinstance(redacted, str):
+        if len(redacted) <= max_string_length:
+            return redacted
+        return f"{redacted[:max_string_length]}… [bounded]"
+    if redacted is None or isinstance(redacted, bool | int | float):
+        return redacted
+    return str(redacted)[:max_string_length]
+
+
+def _authored_remediation_contract(
+    parameters: Mapping[str, Any], workflow: Mapping[str, Any]
+) -> dict[str, Any]:
+    remediation = workflow.get("remediation")
+    remediation = remediation if isinstance(remediation, Mapping) else {}
+    profile_snapshot = parameters.get("agentProfileSnapshot")
+    profile_snapshot = (
+        profile_snapshot if isinstance(profile_snapshot, Mapping) else {}
+    )
+    profile_fields = {
+        key: profile_snapshot[key]
+        for key in (
+            "profileId",
+            "version",
+            "digest",
+            "providerProfileRef",
+            "executionTargetRef",
+            "launchPolicyRef",
+            "model",
+            "effort",
+        )
+        if key in profile_snapshot
+    }
+    contract = {
+        "instructions": workflow.get("instructions"),
+        "repository": parameters.get("repository"),
+        "startingBranch": (
+            (workflow.get("git") or {}).get("startingBranch")
+            if isinstance(workflow.get("git"), Mapping)
+            else workflow.get("startingBranch") or workflow.get("branch")
+        ),
+        "runtime": workflow.get("runtime"),
+        "targetRuntime": parameters.get("targetRuntime"),
+        "agentProfileSnapshot": profile_fields or None,
+        "omnigent": parameters.get("omnigent"),
+        "retrieval": {
+            "rag": parameters.get("rag"),
+            "followUpRetrieval": parameters.get("followUpRetrieval"),
+        },
+        "publish": workflow.get("publish") or parameters.get("publish"),
+        "remediation": remediation,
+    }
+    return _bounded_remediation_projection(
+        {key: value for key, value in contract.items() if value is not None}
+    )
+
+
+def _selected_step_labels(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    labels: list[str] = []
+    for item in value[:25]:
+        if not isinstance(item, Mapping):
+            continue
+        label = str(
+            item.get("logicalStepId")
+            or item.get("checkpointRef")
+            or item.get("agentRunId")
+            or ""
+        ).strip()
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def _context_evidence_availability_projection(
+    value: Any, *, generated_at: str | None
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    projection: list[dict[str, Any]] = []
+    for entry in value[:50]:
+        if not isinstance(entry, Mapping):
+            continue
+        projected_entry = dict(entry)
+        projected_entry.setdefault("bounded", True)
+        projected_entry.setdefault(
+            "freshness", "source_reported" if generated_at else "unknown"
+        )
+        if generated_at:
+            projected_entry.setdefault("observedAt", generated_at)
+        entry_status = str(projected_entry.get("status") or "unknown")
+        if entry_status not in {"available", "active"}:
+            projected_entry.setdefault(
+                "degradedReason",
+                projected_entry.get("reason")
+                or projected_entry.get("fallback")
+                or f"evidence status is {entry_status}",
+            )
+        projection.append(projected_entry)
+    return projection
+
+
+async def _attach_remediation_artifact_projection(
+    link: Any, *, session: AsyncSession, principal: str
+) -> None:
+    result = await session.execute(
+        select(db_models.TemporalArtifactLink, db_models.TemporalArtifact)
+        .join(
+            db_models.TemporalArtifact,
+            db_models.TemporalArtifact.artifact_id
+            == db_models.TemporalArtifactLink.artifact_id,
+        )
+        .where(
+            db_models.TemporalArtifactLink.workflow_id
+            == str(getattr(link, "remediation_workflow_id", "")),
+            db_models.TemporalArtifactLink.run_id
+            == str(getattr(link, "remediation_run_id", "")),
+            db_models.TemporalArtifactLink.link_type.in_(
+                _REMEDIATION_LIFECYCLE_ARTIFACT_TYPES
+            ),
+        )
+        .order_by(db_models.TemporalArtifactLink.created_at.desc())
+        .limit(50)
+    )
+    rows = list(result.all())
+    now = datetime.now(UTC)
+    lifecycle_artifacts: list[dict[str, Any]] = []
+    latest_by_type: dict[str, Any] = {}
+    for artifact_link, artifact in rows:
+        artifact_type = str(artifact_link.link_type or "").strip()
+        latest_by_type.setdefault(artifact_type, artifact)
+        metadata = (
+            artifact.metadata_json
+            if isinstance(artifact.metadata_json, Mapping)
+            else {}
+        )
+        expires_at = getattr(artifact, "expires_at", None)
+        if expires_at is None:
+            freshness = "durable"
+        else:
+            comparable_expiration = expires_at
+            if comparable_expiration.tzinfo is None:
+                comparable_expiration = comparable_expiration.replace(tzinfo=UTC)
+            freshness = "expired" if comparable_expiration <= now else "current"
+        lifecycle_artifacts.append(
+            {
+                "artifactRef": artifact.artifact_id,
+                "artifactType": artifact_type,
+                "status": _enum_value(getattr(artifact, "status", None)),
+                "label": artifact_link.label,
+                "createdAt": artifact_link.created_at,
+                "expiresAt": expires_at,
+                "freshness": freshness,
+                "bounded": True,
+                "metadata": _bounded_remediation_projection(
+                    {
+                        key: metadata[key]
+                        for key in _REMEDIATION_ARTIFACT_METADATA_KEYS
+                        if key in metadata
+                    }
+                ),
+            }
+        )
+    link.lifecycle_artifacts = lifecycle_artifacts or None
+
+    artifact_service = get_temporal_artifact_service(session)
+    for artifact_type, attribute in (
+        ("remediation.action_request", "latest_action_request"),
+        ("remediation.action_result", "latest_action_result"),
+        ("remediation.summary", "lifecycle_summary"),
+    ):
+        artifact = latest_by_type.get(artifact_type)
+        if artifact is None:
+            continue
+        try:
+            _, body = await artifact_service.read(
+                artifact_id=artifact.artifact_id,
+                principal=principal,
+            )
+            decoded = json.loads((body or b"").decode("utf-8"))
+        except (
+            TemporalArtifactAuthorizationError,
+            TemporalArtifactNotFoundError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+        ):
+            continue
+        if isinstance(decoded, Mapping):
+            setattr(link, attribute, _bounded_remediation_projection(decoded))
+
+
 async def _attach_remediation_capability_projection(
-    link: Any, *, session: AsyncSession
+    link: Any, *, session: AsyncSession, principal: str
 ) -> None:
     """Resolve exact-target inputs that are intentionally absent from the link row."""
 
@@ -11897,6 +12341,9 @@ async def _attach_remediation_capability_projection(
     remediation_workflow = (
         remediation_workflow if isinstance(remediation_workflow, Mapping) else {}
     )
+    link.authored_contract = _authored_remediation_contract(
+        remediation_parameters, remediation_workflow
+    )
     policy = remediation_workflow.get("remediation")
     policy = policy if isinstance(policy, Mapping) else {}
     link.allowed_actions = (
@@ -11926,6 +12373,115 @@ async def _attach_remediation_capability_projection(
     link.host_mode = str(launch.get("hostMode") or "").strip() or None
     link.evidence_degraded = False
     link.unavailable_evidence_classes = ()
+    actions = _build_action_capabilities(remediation)
+    link.operator_controls = {
+        "canCancel": bool(actions.can_cancel),
+        # Takeover is intentionally the durable workflow Pause signal. It does
+        # not transfer host credentials or grant a raw runtime/session handle.
+        "canTakeOver": bool(actions.can_pause),
+        "canResume": bool(actions.can_resume),
+        "paused": bool(getattr(remediation, "paused", False)),
+        "disabledReasons": dict(actions.disabled_reasons or {}),
+    }
+    lock_state = getattr(link, "mutation_guard_lock_state", None)
+    if isinstance(lock_state, Mapping):
+        link.lock_outcome = {
+            "state": lock_state.get("state") or lock_state.get("status"),
+            "holder": lock_state.get("holder") or link.active_lock_holder,
+            "releasedAt": lock_state.get("releasedAt"),
+        }
+
+    target_policy = policy.get("target")
+    target_policy = target_policy if isinstance(target_policy, Mapping) else {}
+    authored_selectors = target_policy.get("stepSelectors")
+    if isinstance(authored_selectors, list):
+        link.selected_step_evidence = _bounded_remediation_projection(
+            authored_selectors[:25]
+        )
+        link.selected_steps = _selected_step_labels(authored_selectors)
+
+    if link.context_artifact_ref:
+        try:
+            context = await _read_remediation_context_payload(
+                session=session,
+                context_artifact_ref=link.context_artifact_ref,
+                target_workflow_id=link.target_workflow_id,
+                target_run_id=link.target_run_id,
+                principal=principal,
+            )
+        except (
+            HTTPException,
+            TemporalArtifactAuthorizationError,
+            TemporalArtifactNotFoundError,
+        ):
+            link.evidence_degraded = True
+            link.unavailable_evidence_classes = ("remediation_context",)
+        else:
+            selected_steps = context.get("selectedSteps")
+            if isinstance(selected_steps, list):
+                link.selected_step_evidence = _bounded_remediation_projection(
+                    selected_steps[:25]
+                )
+                link.selected_steps = _selected_step_labels(selected_steps)
+            evidence = context.get("evidence")
+            evidence = evidence if isinstance(evidence, Mapping) else {}
+            availability = evidence.get("availability")
+            omnigent_index = evidence.get("omnigentIndex")
+            raw_availability = [
+                *(
+                    availability
+                    if isinstance(availability, list)
+                    else []
+                ),
+                *(
+                    omnigent_index
+                    if isinstance(omnigent_index, list)
+                    else []
+                ),
+            ]
+            link.context_generated_at = str(context.get("generatedAt") or "") or None
+            combined_availability = _context_evidence_availability_projection(
+                raw_availability,
+                generated_at=link.context_generated_at,
+            )
+            link.context_evidence_availability = _bounded_remediation_projection(
+                combined_availability
+            )
+            boundedness = context.get("boundedness")
+            if isinstance(boundedness, Mapping):
+                link.context_boundedness = _bounded_remediation_projection(
+                    boundedness
+                )
+            link.diagnosis_hints = _bounded_string_list(
+                evidence.get("diagnosisHints")
+            )
+            link.evidence_degraded = bool(evidence.get("evidenceDegraded"))
+            link.unavailable_evidence_classes = tuple(
+                _bounded_string_list(
+                    evidence.get("unavailableEvidenceClasses")
+                )
+                or ()
+            )
+            live_follow = context.get("liveFollow")
+            if isinstance(live_follow, Mapping):
+                resume_cursor = live_follow.get("resumeCursor")
+                link.live_observation = {
+                    "status": live_follow.get("status"),
+                    "label": live_follow.get("mode"),
+                    "sequenceCursor": (
+                        json.dumps(resume_cursor, sort_keys=True)
+                        if isinstance(resume_cursor, Mapping)
+                        else None
+                    ),
+                    "reconnectState": (
+                        "available" if live_follow.get("supported") else "unavailable"
+                    ),
+                    "fallbackReason": live_follow.get("reason"),
+                }
+
+    await _attach_remediation_artifact_projection(
+        link, session=session, principal=principal
+    )
 
 
 def _remediation_approval_request_id(remediation_workflow_id: str) -> str:
@@ -12110,7 +12666,11 @@ async def list_execution_remediations(
 
     await asyncio.gather(
         *(
-            _attach_remediation_capability_projection(link, session=session)
+            _attach_remediation_capability_projection(
+                link,
+                session=session,
+                principal=_owner_id(user) or "system",
+            )
             for link in links
         )
     )

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -612,6 +612,46 @@ class RemediationNextActionBaselineModel(BaseModel):
     workspaceDigest: str
     headVersion: int
 
+
+class RemediationCheckpointBranchTurnLinkModel(BaseModel):
+    branchTurnId: str
+    parentTurnId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    status: str
+    createdStepExecutionId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    runtimeAgentRunId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    providerSessionId: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    instructionRef: str
+    instructionDigest: str
+    sourceCheckpointRef: str
+    contextBundleRef: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    stepExecutionManifestRef: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    gitWorkBranch: str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    startedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    completedAt: datetime | str | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    createdAt: datetime | str
+    updatedAt: datetime | str
+    outputArtifacts: dict[str, str] = Field(default_factory=dict)
+    comparisonArtifacts: dict[str, str] = Field(default_factory=dict)
+
+
 class RemediationCheckpointBranchLinkModel(BaseModel):
     workflowId: str
     branchId: str
@@ -676,6 +716,9 @@ class RemediationCheckpointBranchLinkModel(BaseModel):
     )
     comparisonArtifacts: dict[str, str] | None = Field(
         default=None, exclude_if=lambda value: value is None
+    )
+    turns: list[RemediationCheckpointBranchTurnLinkModel] = Field(
+        default_factory=list
     )
     operation: str | None = None
     idempotencyKey: str | None = None
@@ -11065,6 +11108,22 @@ async def _create_execution_from_workflow_request(
             consumer_id=reserved_workflow_id,
             user=user,
         )
+        authored_execution_target_ref = (
+            str(authored_omnigent.get("executionTargetRef") or "").strip()
+            if isinstance(authored_omnigent, Mapping)
+            else ""
+        )
+        resolved_execution_target_ref = str(
+            profile_snapshot.get("executionProfileRef") or ""
+        ).strip()
+        if (
+            authored_execution_target_ref
+            and authored_execution_target_ref != resolved_execution_target_ref
+        ):
+            raise _invalid_workflow_request(
+                "omnigent.executionTargetRef must match the selected "
+                "Agent Profile executionProfileRef."
+            )
         initial_parameters = compile_agent_profile_snapshot_parameters(
             initial_parameters,
             snapshot=profile_snapshot,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -193,6 +193,7 @@ from moonmind.workflows.temporal.title_search import tokenize_title
 from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactAuthorizationError,
     TemporalArtifactNotFoundError,
+    TemporalArtifactStateError,
     build_artifact_ref,
 )
 from moonmind.workflows.temporal.report_artifacts import build_report_projection_summary
@@ -11965,6 +11966,8 @@ def _remediation_approval_state_from_link(
     *,
     authority_mode: str,
     status_value: str,
+    actor: str | None = None,
+    actor_can_approve_high_risk: bool = False,
 ) -> RemediationApprovalStateModel | None:
     raw_state = getattr(link, "approval_state", None)
     if isinstance(raw_state, dict):
@@ -11985,8 +11988,17 @@ def _remediation_approval_state_from_link(
         projected.setdefault("decision", approval_status)
         if projected.get("decision") == "pending" and approval_status != "pending":
             projected["decision"] = approval_status
-        projected["canDecide"] = (
-            bool(projected.get("canDecide", True)) and approval_status == "pending"
+        reviewer_eligible = not (
+            projected.get("reviewerRule") == "high_risk_reviewer"
+            and not actor_can_approve_high_risk
+        )
+        requesting_actor = str(projected.get("requestingActor") or "").strip()
+        if actor and requesting_actor and actor == requesting_actor:
+            reviewer_eligible = False
+        projected["canDecide"] = bool(
+            projected.get("canDecide", True)
+            and approval_status == "pending"
+            and reviewer_eligible
         )
         return RemediationApprovalStateModel.model_validate(projected)
 
@@ -12005,13 +12017,20 @@ def _remediation_approval_state_from_link(
         canDecide=approval_pending,
     )
 
-def _serialize_remediation_link_summary(link: Any) -> RemediationLinkSummaryModel:
+def _serialize_remediation_link_summary(
+    link: Any,
+    *,
+    actor: str | None = None,
+    actor_can_approve_high_risk: bool = False,
+) -> RemediationLinkSummaryModel:
     authority_mode = str(getattr(link, "authority_mode", "") or "")
     status_value = str(getattr(link, "status", "") or "")
     approval_state = _remediation_approval_state_from_link(
         link,
         authority_mode=authority_mode,
         status_value=status_value,
+        actor=actor,
+        actor_can_approve_high_risk=actor_can_approve_high_risk,
     )
 
     policy_actions = _bounded_string_list(getattr(link, "allowed_actions", None))
@@ -12346,6 +12365,7 @@ async def _attach_remediation_artifact_projection(
         except (
             TemporalArtifactAuthorizationError,
             TemporalArtifactNotFoundError,
+            TemporalArtifactStateError,
             UnicodeDecodeError,
             json.JSONDecodeError,
         ):
@@ -12735,7 +12755,16 @@ async def list_execution_remediations(
     )
     return RemediationLinksResponseModel(
         direction=direction,
-        items=[_serialize_remediation_link_summary(link) for link in links],
+        items=[
+            _serialize_remediation_link_summary(
+                link,
+                actor=str(getattr(user, "email", "") or "").strip() or None,
+                actor_can_approve_high_risk=bool(
+                    getattr(user, "is_superuser", False)
+                ),
+            )
+            for link in links
+        ],
     )
 
 @router.post(

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -54,6 +54,24 @@ This document does **not** define:
 - `/api/executions` is the **execution-oriented** surface for Temporal-managed work.
 - Callers should treat `workflowId` as the canonical execution handle for this API.
 - This contract should remain stable even if backing reads move closer to Temporal Visibility.
+- Remediation authoring uses the same `POST /api/executions` endpoint and
+  persists canonical `task.remediation`; there is no privileged one-click UI
+  submission path.
+- `GET /api/executions/{workflowId}/remediations?direction=inbound|outbound`
+  returns bidirectional link identity plus bounded canonical projections of the
+  authored contract, selected evidence, context availability/boundedness,
+  approval/lock/operator controls, action request/result, target-level repair
+  verification, lifecycle artifacts/summary, and Checkpoint Branch state.
+- Approval decisions use
+  `POST /api/executions/{remediationWorkflowId}/remediation/approvals/{requestId}`
+  with `decision` and optional rationale `comment`. Takeover/pause, resume, and
+  cancellation remain ordinary Workflow signal/cancel operations.
+
+Create admission independently revalidates target visibility and exact run,
+selected Step Executions/checkpoints/Agent Runs, Agent and Provider Profile
+snapshots, launch-policy identity, remediation mode/authority/action policy,
+repository and work-branch syntax, and publish mode. Posted UI state never
+confers target or runtime authority.
 
 ### 2.4 Current implementation note
 

--- a/docs/Artifacts/ArtifactPresentationContract.md
+++ b/docs/Artifacts/ArtifactPresentationContract.md
@@ -1309,3 +1309,17 @@ The artifact system is still execution-linked and Temporal-compatible, but the p
 - future UI convenience surfaces
 
 This document should therefore move to `docs/Artifacts/ArtifactPresentationContract.md` and remain the generic presentation layer that more specific documents, especially `docs/Artifacts/ReportArtifacts.md`, build on.
+
+## 21. Remediation evidence presentation
+
+`remediation.context`, approval request/decision, action request/result,
+verification, audit, target annotation, decision log, and lifecycle summary
+artifacts retain durable links and remain the deep evidence authority. Workflow
+Detail may project only bounded, redacted JSON and metadata: artifact class,
+status, freshness/expiry, boundedness, and safe lifecycle fields. Per-class
+availability and degradation come from the canonical context artifact.
+
+Action delivery, repair verification, and prevention verification remain
+separate. The UI must never reconstruct them from rendered logs, chat text, or
+assistant prose. When a compact projection is unavailable, the durable artifact
+link remains visible and the UI reports degradation rather than inventing state.

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -383,6 +383,38 @@ Branch behavior:
 - Allow manual branch entry as an advanced fallback.
 - Show generated publish branch names before submission when relevant.
 
+## Remediation Prefill
+
+When Workflow Detail opens `/workflows/new?intent=remediate&draftId=…`, the
+normal Create page imports a tab-scoped remediation draft. This remains ordinary,
+editable authoring: Create never submits a remediation implicitly.
+
+The visible **Remediation Draft** section separates:
+
+- **Pinned target identity (immutable):** target Workflow, exact run, original
+  outcome, and selected failed Step Execution/checkpoint evidence.
+- **Editable repair intent:** instructions, repository, starting and isolated
+  work branches, publish mode, Codex via Omnigent runtime, Agent Profile,
+  Provider Profile, execution target and launch policy, model, effort, retrieval
+  controls, remediation mode/authority, and the action, evidence, approval,
+  lock, verification, and Checkpoint Branch policies.
+
+The draft body stays in `sessionStorage`; a non-sensitive presence marker may be
+used only to explain that a copied URL belongs to another tab. Drafts carry
+schema version `1`, a `createdAt` timestamp, and a two-hour TTL. Import is
+single-use: storage is cleared after the complete draft has been validated and
+successfully copied into visible form state, or after explicit discard. Missing,
+malformed, expired, and cross-tab drafts produce distinct actionable errors and
+never partially prefill the form. Discard removes the storage marker and the
+`intent`/`draftId` query parameters.
+
+Submission uses ordinary `POST /api/executions` and persists canonical
+`task.remediation`. The server independently resolves target visibility and the
+exact current/pinned run, validates selected steps/checkpoints and Agent Runs,
+re-resolves profile and policy selections, validates branch/publish/authority
+values, and creates the durable bidirectional link. A target-run freshness
+warning directs the operator to open **Remediate** again when the pin changed.
+
 ## Jira Integration on Create
 
 Jira can appear in multiple places on the Create page:

--- a/docs/UI/WorkflowDetailsPage.md
+++ b/docs/UI/WorkflowDetailsPage.md
@@ -587,6 +587,42 @@ Panel button destination:
 
 The remediation panel never replaces the header action buttons.
 
+### Authoritative remediation relationships
+
+The Artifacts view renders a distinct **Remediation** region from canonical
+remediation links, immutable Workflow inputs, context artifacts, lifecycle
+artifacts, approval state, and Checkpoint Branch records. It never parses logs,
+chat text, or model prose as authority.
+
+The target-side **Remediation Workflows** list preserves the target's original
+outcome separately and shows each remediation Workflow/run link, pinned target
+run and selected step/checkpoint, current target state, phase/mode/authority,
+profile and policy identity, mutation lock and release, diagnosis, latest action
+delivery, approval, explicit repair verification, resolution, prevention,
+created branch/run/PR, and cleanup evidence.
+
+The remediation-side **Remediation Target** list additionally shows the complete
+authored remediation contract; per-class context availability, freshness,
+boundedness, and degradation; live-follow cursor/status; the bounded action
+request and result authority chain; cumulative candidate attempt/head state;
+Checkpoint Branch source, isolated work branch, publication/promotion/archive;
+and the final repair, prevention, cleanup, lease-release, and unresolved-operator
+work summary. Durable artifact refs remain available for the full evidence.
+
+Action delivery and repair verification are separate. Branch creation, branch
+execution, action delivery, and verification each have their own state. Actions
+are offered only when the capability matrix says the execution, approval, and
+verification backends are ready; disabled actions show bounded reasons.
+
+Pending approval UI shows action, risk, expected state, policy, expiration,
+blast radius, and artifact evidence. Authorized operators can approve or deny
+with a rationale, which is sent as the durable decision `comment`. Expired or
+stale decisions explain why a new request is required. Operator **Take over and
+pause**, **Resume remediation**, and **Cancel remediation** use ordinary durable
+Workflow signal/cancel endpoints; takeover never exposes credentials or raw
+runtime/session authority. All controls retain labels, keyboard access,
+loading/error states, and responsive layout.
+
 ## Outputs section
 
 The outputs section is present when outputs exist.

--- a/docs/Workflows/CheckpointBranchSystem.md
+++ b/docs/Workflows/CheckpointBranchSystem.md
@@ -100,6 +100,14 @@ Creating, continuing, or publishing a branch does not automatically make it the 
 
 Promotion is a workflow-owned decision. It must be gated by structured evidence, side-effect classification, workspace validation, and approval policy where applicable.
 
+For remediation, branch creation, branch execution, action delivery, and repair
+verification are separate lifecycle states. A created branch does not prove a
+turn ran, an action reached the target, or verification passed. Workflow Detail
+projects the source step/checkpoint, workspace and runtime-context policies,
+isolated work branch, cumulative attempt/version and workspace head, output
+commit/PR, verification and remaining-work refs, publication, promotion, and
+archive/cleanup state from canonical Checkpoint Branch records.
+
 ### 2.5 Provider sessions are runtime bindings, not branch authority
 
 External provider sessions, including Omnigent sessions, may be associated with a branch or branch turn. They do not become the branch source of truth.

--- a/docs/Workflows/WorkflowRemediation.md
+++ b/docs/Workflows/WorkflowRemediation.md
@@ -371,17 +371,30 @@ The important rule is that **automatic remediation is policy-driven and bounded*
 
 ### 7.7 Create-page first remediation flow
 
-The dashboard `Remediate` action should open `/workflows/new` with an editable remediation draft instead of immediately submitting a hidden remediation run. The Create page should prefill:
+The dashboard `Remediate` action opens `/workflows/new?intent=remediate&draftId=…` with an editable remediation draft instead of immediately submitting a hidden remediation run. The Create page prefills:
 
 - target `workflowId` and pinned `runId`;
 - selected step or checkpoint refs when available;
 - repository `MoonLadderStudios/MoonMind` for MoonMind platform or prevention work;
+- starting and isolated Checkpoint work branches;
+- Codex via Omnigent runtime, Provider Profile, Agent Profile, execution target,
+  launch policy, model, effort, and retrieval controls from the target run;
 - default mode `snapshot_then_follow`;
 - default authority `approval_gated`;
 - default action policy `admin_healer_default`;
+- evidence, approval, mutation-lock, verification, and Checkpoint Branch policy;
 - branch and publish controls through the normal Create page fields.
 
-The operator can then edit instructions, runtime, model, branch, and publish mode before submitting through the normal `POST /api/executions` path with `task.remediation`.
+The UI separates immutable pinned target/run/failed-evidence identity from the
+editable repair intent. The operator edits instructions, repository, runtime,
+profiles, policy, branches, retrieval, and publish choices before ordinary
+`POST /api/executions` submission with `task.remediation`.
+
+The tab-scoped draft is schema-versioned, timestamped, and expires after two
+hours. It is removed after a complete successful import into visible form state
+or explicit discard. Missing, malformed, expired, and cross-tab drafts surface
+distinct safe errors and never partially import. A local presence marker contains
+no target or repair content and exists only to explain cross-tab URLs.
 
 ---
 
@@ -451,6 +464,32 @@ GET /api/executions/{workflowId}/remediations?direction=outbound
 Where:
 - `inbound` means remediation Workflow Executions targeting this execution,
 - `outbound` means executions that this Workflow Execution is remediating.
+
+The link response also projects the immutable authored contract, detailed
+selected-step evidence, context generation/boundedness and per-class
+availability, diagnosis hints, lifecycle artifact index, latest bounded action
+request/result, final lifecycle summary, target-level verification outcome,
+Checkpoint Branch publication/promotion/archive state, and durable Workflow
+operator controls. These values come from canonical rows and artifacts, not
+rendered logs or chat.
+
+### 8.6 Approval and Workflow operator APIs
+
+Authorized approval decisions use:
+
+```http
+POST /api/executions/{remediationWorkflowId}/remediation/approvals/{requestId}
+```
+
+The body is `{ "decision": "approved" | "rejected", "comment"?: "…" }`.
+The optional comment is the bounded decision rationale persisted by the durable
+approval owner. Expired, stale, terminal, mismatched, or self-approved requests
+fail closed.
+
+Operator takeover never grants raw Omnigent/runtime authority. It pauses the
+remediation Workflow through `POST /api/executions/{workflowId}/signal` with
+`Pause`; resume uses `Resume`, and cancellation uses the ordinary durable
+`POST /api/executions/{workflowId}/cancel` endpoint.
 
 ---
 
@@ -1380,12 +1419,14 @@ The create UI should let the operator:
 ### 15.2 Target Workflow detail
 
 The target Workflow should show a **Remediation Workflows** panel with:
-- remediation Workflow links,
-- status,
-- authority mode,
-- last action,
-- resolution,
-- active lock badge.
+- remediation Workflow/run links and lifecycle phase/status,
+- pinned target run and selected Step Execution/checkpoint,
+- authority plus authored profile/policy identity,
+- active mutation lock and release state,
+- diagnosis, action delivery, approval, explicit repair verification,
+  resolution, prevention, resulting run/branch/PR, and cleanup evidence.
+
+This is an annotation region. It never overwrites the original target outcome.
 
 ### 15.3 Remediation Workflow detail
 
@@ -1395,7 +1436,16 @@ The remediation Workflow detail should show a **Remediation Target** panel with:
 - selected steps,
 - current target state,
 - evidence bundle link,
-- allowed actions,
+- immutable authored instructions/runtime/profile/policy/branch/retrieval/publish contract,
+- per-class evidence availability, freshness, boundedness, and degradation,
+- live-follow state and cursor,
+- action request/result authority chain, risk, expected state, policy decision,
+  idempotency, actor, approval, before/after refs, and delivery,
+- cumulative attempts and workspace head,
+- Checkpoint Branch source, isolated work branch, output, publication,
+  promotion, and archive state,
+- repair, prevention, cleanup, lease release, and unresolved operator work,
+- allowed actions with bounded disabled reasons,
 - approval state,
 - lock state.
 
@@ -1450,7 +1500,9 @@ request, and the `high_risk_reviewer` rule requires a privileged reviewer.
 - show the proposed action,
 - show preconditions,
 - show expected blast radius,
-- allow approve/reject,
+- allow authorized approve/deny with a recorded rationale,
+- show expired and stale decisions and why a new request is required,
+- expose durable Workflow cancellation/takeover without raw runtime authority,
 - keep the decision in the audit trail.
 
 ---

--- a/frontend/src/browser/remediationJourney.browser.test.tsx
+++ b/frontend/src/browser/remediationJourney.browser.test.tsx
@@ -1,0 +1,504 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { DashboardApp } from '../entrypoints/dashboard-app';
+import { renderWithClient, screen, waitFor, within } from '../utils/test-utils';
+import '../styles/dashboard.css';
+
+// Controlling real-browser journey for MoonLadderStudios/MoonMind#3623. This
+// mounts the production dashboard router and entrypoints, then follows the
+// same source Detail -> normal Create -> remediation Detail route transitions
+// that an operator uses. API reads are bounded canonical projections; the
+// ordinary POST /api/executions request is captured as the authority handoff.
+
+const DESKTOP = { width: 1280, height: 900 } as const;
+const MOBILE = { width: 390, height: 844 } as const;
+
+const sourceExecution = {
+  taskId: 'source-workflow',
+  workflowId: 'source-workflow',
+  namespace: 'default',
+  temporalRunId: 'source-run',
+  runId: 'source-run',
+  source: 'temporal',
+  workflowType: 'MoonMind.UserWorkflow',
+  entry: 'user_workflow',
+  title: 'Failed source workflow',
+  summary: 'The test step failed and needs bounded repair.',
+  taskInstructions: 'Implement and verify the source change.',
+  status: 'failed',
+  state: 'failed',
+  rawState: 'failed',
+  temporalStatus: 'failed',
+  attentionRequired: true,
+  repository: 'MoonLadderStudios/MoonMind',
+  targetRuntime: 'omnigent',
+  model: 'gpt-5.6-codex',
+  effort: 'high',
+  profileId: 'oauth-1',
+  publishMode: 'pr',
+  startingBranch: 'main',
+  createdAt: '2026-08-12T00:00:00Z',
+  updatedAt: '2026-08-12T00:05:00Z',
+  actions: { canSetTitle: true },
+  agentProfile: {
+    profileId: 'team-codex',
+    version: 1,
+    providerProfileRef: 'oauth-1',
+  },
+  inputParameters: {
+    omnigent: {
+      executionTargetRef: 'omnigent-codex-default',
+      launchPolicyRef: 'on-demand-v1',
+    },
+    agentProfile: { profileId: 'team-codex', version: 1 },
+    agentProfileSnapshot: {
+      profileId: 'team-codex',
+      version: 1,
+      providerProfileRef: 'oauth-1',
+      executionProfileRef: 'omnigent-codex-default',
+      launchPolicyRef: 'on-demand-v1',
+    },
+    workflow: {
+      git: { startingBranch: 'main', branch: 'main' },
+    },
+  },
+  checkpoints: [
+    {
+      logicalStepId: 'run-tests',
+      checkpointRef: 'artifact://checkpoint/run-tests',
+      checkpointDigest: 'sha256:run-tests',
+      attempt: 2,
+    },
+  ],
+};
+
+const createdExecution = {
+  taskId: 'mm:remediation-created',
+  workflowId: 'mm:remediation-created',
+  namespace: 'default',
+  temporalRunId: 'remediation-run',
+  runId: 'remediation-run',
+  source: 'temporal',
+  workflowType: 'MoonMind.UserWorkflow',
+  entry: 'user_workflow',
+  title: 'Created remediation workflow',
+  summary: 'Repair is running against the pinned source run.',
+  status: 'running',
+  state: 'executing',
+  rawState: 'executing',
+  temporalStatus: 'running',
+  repository: 'MoonLadderStudios/MoonMind',
+  targetRuntime: 'omnigent',
+  model: 'gpt-5.6-codex',
+  effort: 'high',
+  profileId: 'oauth-1',
+  createdAt: '2026-08-12T00:06:00Z',
+  updatedAt: '2026-08-12T00:07:00Z',
+  actions: { canSetTitle: true },
+};
+
+const createdRelationship = {
+  remediationWorkflowId: 'mm:remediation-created',
+  remediationRunId: 'remediation-run',
+  targetWorkflowId: 'source-workflow',
+  targetRunId: 'source-run',
+  mode: 'snapshot_then_follow',
+  authorityMode: 'approval_gated',
+  status: 'executing',
+  deliveryStatus: 'pending',
+  verificationOutcome: null,
+  contextArtifactRef: 'art_remediation_context',
+  selectedSteps: ['run-tests'],
+  currentTargetState: 'failed',
+  authoredContract: {
+    instructions: 'Repair the routed browser failure with bounded evidence.',
+    runtime: { mode: 'omnigent' },
+    remediation: { authorityMode: 'approval_gated' },
+  },
+  selectedStepEvidence: [
+    {
+      logicalStepId: 'run-tests',
+      checkpointRef: 'artifact://checkpoint/run-tests',
+    },
+  ],
+  contextEvidenceAvailability: [
+    { class: 'step_ledger', status: 'available', bounded: true },
+  ],
+  contextBoundedness: { rawLogBodiesIncluded: false, maxTailLines: 2000 },
+  lifecycleSummary: {
+    repair: { repairOutcome: 'running' },
+    prevention: { status: 'pending' },
+    cleanup: 'pending',
+  },
+  checkpointBranches: [
+    {
+      workflowId: 'source-workflow',
+      branchId: 'cbr-routed-remediation',
+      branchTurnId: 'turn-routed-1',
+      branchState: 'active',
+      gitBaseBranch: 'main',
+      gitWorkBranch: 'remediation/routed-browser-edited',
+      checkpointRef: 'artifact://checkpoint/run-tests',
+      turns: [
+        {
+          branchTurnId: 'turn-routed-1',
+          status: 'running',
+          createdStepExecutionId: 'repair:execution:1',
+          runtimeAgentRunId: 'agent-run-routed-1',
+          providerSessionId: 'provider-session-routed-1',
+          instructionRef: 'artifact://instructions/routed-1',
+          instructionDigest: 'sha256:instructions-routed-1',
+          sourceCheckpointRef: 'artifact://checkpoint/run-tests',
+          startedAt: '2026-08-12T00:06:30Z',
+          createdAt: '2026-08-12T00:06:20Z',
+          updatedAt: '2026-08-12T00:06:30Z',
+          outputArtifacts: { result: 'art_routed_turn_output' },
+          comparisonArtifacts: {},
+        },
+      ],
+    },
+  ],
+  approvalState: {
+    requestId: 'approval-routed-1',
+    actionKind: 'checkpoint_branch.create',
+    riskTier: 'medium',
+    decision: 'pending',
+    canDecide: false,
+  },
+  createdAt: '2026-08-12T00:06:00Z',
+  updatedAt: '2026-08-12T00:07:00Z',
+};
+
+const readyOmnigentCatalog = {
+  schemaVersion: 'moonmind.omnigent-codex-readiness.v2',
+  runtimeId: 'omnigent',
+  displayName: 'Codex via Omnigent',
+  available: true,
+  defaultExecutionProfileRef: 'omnigent-codex-default',
+  executionProfiles: [
+    {
+      ref: 'omnigent-codex-default',
+      displayName: 'Codex default',
+      available: true,
+      providerRuntime: 'codex_cli',
+      launchPolicies: [
+        {
+          ref: 'on-demand-v1',
+          displayName: 'On-demand Docker',
+          hostMode: 'on_demand_docker',
+          isDefault: true,
+        },
+      ],
+      gateReasons: [],
+    },
+  ],
+  eligibleProviderProfiles: [
+    {
+      profileId: 'oauth-1',
+      label: 'Codex OAuth',
+      providerId: 'openai',
+      runtimeId: 'codex_cli',
+      busy: false,
+      queueWhenBusy: true,
+    },
+  ],
+  ineligibleProviderProfiles: [],
+  hostModes: ['on_demand_docker'],
+  gateReasons: [],
+};
+
+const uiInfo = {
+  app: 'moonmind',
+  buildId: 'remediation-browser-test',
+  apiBase: '/api',
+  features: {
+    workflowList: true,
+    workflowActions: true,
+    workflowLiveUpdates: false,
+    artifacts: true,
+    schedules: true,
+    skills: true,
+    settings: true,
+    manifests: true,
+    remediationCollection: true,
+    omnigentAgents: true,
+    omnigentPolicies: true,
+  },
+  limits: {},
+  endpoints: {},
+  dashboardConfig: {
+    pollIntervalsMs: { list: 60_000, detail: 60_000, events: 60_000 },
+    sources: {
+      temporal: { create: '/api/executions', artifactCreate: '/api/artifacts' },
+      github: { branches: '/api/github/branches?repository={repository}' },
+    },
+    system: {
+      defaultRepository: 'MoonLadderStudios/MoonMind',
+      defaultAgentRuntime: 'codex_cli',
+      defaultTaskModel: 'gpt-5.6-codex',
+      defaultTaskEffort: 'high',
+      defaultPublishMode: 'pr',
+      supportedAgentRuntimes: ['omnigent', 'codex_cli', 'claude_code'],
+      providerProfiles: { list: '/api/v1/provider-profiles' },
+      presetCatalog: { enabled: true, list: '/api/presets' },
+      omnigentExecutionCatalog: {
+        profiles: [
+          {
+            ref: 'omnigent-codex-default',
+            displayName: 'Codex default',
+            defaultPolicyRef: 'on-demand-v1',
+            providerRuntime: 'codex_cli',
+          },
+        ],
+        policies: [
+          {
+            ref: 'on-demand-v1',
+            displayName: 'On-demand Docker',
+            hostMode: 'on_demand_docker',
+          },
+        ],
+      },
+    },
+    features: {
+      temporalDashboard: {
+        actionsEnabled: true,
+        listEnabled: false,
+        workspaceShellEnabled: false,
+      },
+    },
+  },
+  settingsPermissions: [],
+};
+
+const payload: BootPayload = { page: 'dashboard', apiBase: '/api' };
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+let fetchSpy: MockInstance;
+let cleanupRender: (() => void) | null = null;
+let createRequests: Array<Record<string, unknown>>;
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+  window.history.replaceState({}, '', '/workflows/source-workflow/evidence?source=temporal');
+  createRequests = [];
+  fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/ui/info') return jsonResponse(uiInfo);
+      if (url === '/api/executions' && init?.method === 'POST') {
+        createRequests.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+        return jsonResponse({
+          workflowId: 'mm:remediation-created',
+          runId: 'remediation-run',
+          redirectPath: '/workflows/mm%3Aremediation-created/evidence?source=temporal',
+        }, 201);
+      }
+      if (url.includes('mm%3Aremediation-created/remediations?direction=outbound')) {
+        return jsonResponse({ direction: 'outbound', items: [createdRelationship] });
+      }
+      if (url.includes('mm%3Aremediation-created/remediations?direction=inbound')) {
+        return jsonResponse({ direction: 'inbound', items: [] });
+      }
+      if (url.includes('/executions/source-workflow/remediations?')) {
+        const direction = url.includes('direction=outbound') ? 'outbound' : 'inbound';
+        return jsonResponse({ direction, items: [] });
+      }
+      if (url.includes('/executions/mm%3Aremediation-created')) {
+        if (url.includes('/checkpoint-branches')) return jsonResponse({ items: [] });
+        if (url.includes('/artifacts')) return jsonResponse({ artifacts: [] });
+        return jsonResponse(createdExecution);
+      }
+      if (url.includes('/executions/source-workflow')) {
+        if (url.includes('/checkpoint-branches')) return jsonResponse({ items: [] });
+        if (url.includes('/artifacts')) return jsonResponse({ artifacts: [] });
+        return jsonResponse(sourceExecution);
+      }
+      if (url.startsWith('/api/omnigent/codex-catalog-readiness')) {
+        return jsonResponse(readyOmnigentCatalog);
+      }
+      if (url === '/api/omnigent/agent-profiles') {
+        return jsonResponse([
+          {
+            profileId: 'team-codex',
+            displayName: 'Team Codex',
+            state: 'active',
+            activeVersion: 1,
+            defaultForRuntime: true,
+            versions: [
+              {
+                version: 1,
+                digest: `sha256:${'a'.repeat(64)}`,
+                document: {
+                  execution: {
+                    defaultExecutionProfileRef: 'omnigent-codex-default',
+                    allowedLaunchPolicyRefs: ['on-demand-v1'],
+                  },
+                  policyRef: 'on-demand-v1',
+                },
+                validationResult: { ready: true },
+              },
+            ],
+          },
+        ]);
+      }
+      if (url.startsWith('/api/v1/provider-profiles')) {
+        return jsonResponse([
+          {
+            profile_id: 'oauth-1',
+            account_label: 'Codex OAuth',
+            provider_id: 'openai',
+            default_model: 'gpt-5.6-codex',
+            default_effort: 'high',
+            enabled: true,
+            launch_ready: true,
+          },
+        ]);
+      }
+      if (url.startsWith('/api/github/branches')) {
+        return jsonResponse({
+          items: [{ value: 'main', label: 'main', source: 'github' }],
+          defaultBranch: 'main',
+          error: null,
+        });
+      }
+      if (url.startsWith('/api/workflows/skills')) return jsonResponse({ items: {} });
+      if (url.startsWith('/api/presets')) return jsonResponse({ items: [] });
+      if (url.startsWith('/api/artifacts')) return jsonResponse({ artifacts: [] });
+      if (url.startsWith('/api/executions')) return jsonResponse({ items: [] });
+      return jsonResponse({});
+    },
+  );
+});
+
+afterEach(async () => {
+  cleanupRender?.();
+  cleanupRender = null;
+  fetchSpy.mockRestore();
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+  window.history.replaceState({}, '', '/');
+  await page.viewport(DESKTOP.width, DESKTOP.height);
+});
+
+describe('routed remediation operator journey', () => {
+  for (const viewport of [DESKTOP, MOBILE]) {
+    it(`authors through normal Create and inspects the created lifecycle at ${viewport.width}px`, async () => {
+      await page.viewport(viewport.width, viewport.height);
+      const { unmount } = renderWithClient(<DashboardApp payload={payload} />);
+      cleanupRender = unmount;
+
+      expect(await screen.findByText('Failed source workflow', {}, { timeout: 10_000 })).toBeTruthy();
+      const actionTrigger = screen.getByRole('button', { name: 'Workflow actions' });
+      expect(actionTrigger.getAttribute('aria-haspopup')).toBe('menu');
+      actionTrigger.focus();
+      expect(document.activeElement).toBe(actionTrigger);
+      await userEvent.keyboard('{Enter}');
+      const actionMenu = screen.getByRole('menu', { name: 'Workflow actions' });
+      const remediate = await within(actionMenu).findByRole('menuitem', { name: 'Remediate' });
+      remediate.focus();
+      await userEvent.keyboard('{Enter}');
+
+      await waitFor(() => expect(window.location.pathname).toBe('/workflows/new'));
+      expect(await screen.findByText('Remediation Draft', {}, { timeout: 10_000 })).toBeTruthy();
+      const pinned = screen.getByLabelText('Pinned target identity');
+      const editable = screen.getByLabelText('Editable repair intent');
+      expect(pinned).toBeTruthy();
+      expect(editable).toBeTruthy();
+      expect((screen.getByLabelText('Target workflow') as HTMLInputElement).value).toBe('source-workflow');
+      expect((screen.getByLabelText('Target workflow') as HTMLInputElement).readOnly).toBe(true);
+      expect((screen.getByLabelText('Pinned run') as HTMLInputElement).value).toBe('source-run');
+      expect((screen.getByLabelText('Pinned run') as HTMLInputElement).readOnly).toBe(true);
+      expect((screen.getByLabelText('Selected evidence') as HTMLInputElement).value).toContain('run-tests');
+
+      const startingBranch = screen.getByLabelText('Starting branch') as HTMLInputElement;
+      const workBranch = screen.getByLabelText('Checkpoint work branch') as HTMLInputElement;
+      startingBranch.focus();
+      await userEvent.tab();
+      expect(document.activeElement).toBe(workBranch);
+      await userEvent.fill(workBranch, 'remediation/routed-browser-edited');
+      await userEvent.fill(
+        screen.getByLabelText('Instructions'),
+        'Repair the routed browser failure with bounded evidence.',
+      );
+      await userEvent.fill(screen.getByLabelText('Action policy'), 'operator_review_only');
+      await userEvent.selectOptions(screen.getByLabelText('Publish Mode'), 'branch');
+
+      const createButton = screen.getByRole('button', { name: 'Start Workflow' });
+      await waitFor(() => expect((createButton as HTMLButtonElement).disabled).toBe(false), {
+        timeout: 10_000,
+      });
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+      await userEvent.click(createButton);
+
+      await waitFor(
+        () => expect(window.location.pathname).toBe('/workflows/mm%3Aremediation-created/evidence'),
+        { timeout: 10_000 },
+      );
+      expect(createRequests).toHaveLength(1);
+      expect(createRequests[0]).toMatchObject({
+        payload: {
+          targetRuntime: 'omnigent',
+          publishMode: 'branch',
+          task: {
+            instructions: 'Repair the routed browser failure with bounded evidence.',
+            remediation: {
+              target: {
+                workflowId: 'source-workflow',
+                runId: 'source-run',
+              },
+              authorityMode: 'approval_gated',
+              actionPolicyRef: 'operator_review_only',
+              checkpointBranchPolicy: {
+                gitWorkBranch: 'remediation/routed-browser-edited',
+              },
+            },
+          },
+        },
+      });
+
+      expect(await screen.findByText('Created remediation workflow', {}, { timeout: 10_000 })).toBeTruthy();
+      expect(await screen.findByRole('heading', { name: 'Remediation Target' })).toBeTruthy();
+      expect(screen.getAllByText('source-workflow').length).toBeGreaterThan(0);
+      expect(screen.getByText('Authored remediation contract')).toBeTruthy();
+      const turnList = screen.getByRole('list', {
+        name: 'Checkpoint Branch turns for cbr-routed-remediation',
+      });
+      expect(within(turnList).getByText('turn-routed-1')).toBeTruthy();
+      expect(within(turnList).getByText('agent-run-routed-1')).toBeTruthy();
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+    }, 30_000);
+  }
+
+  it('shows and safely discards a copied cross-tab draft URL', async () => {
+    await page.viewport(MOBILE.width, MOBILE.height);
+    window.localStorage.setItem(
+      'moonmind.remediation-create-draft-presence.copied-tab',
+      JSON.stringify({ createdAt: new Date().toISOString() }),
+    );
+    window.history.replaceState(
+      {},
+      '',
+      '/workflows/new?intent=remediate&draftId=copied-tab',
+    );
+    const { unmount } = renderWithClient(<DashboardApp payload={payload} />);
+    cleanupRender = unmount;
+
+    expect((await screen.findAllByText(/belongs to another browser tab/i)).length).toBeGreaterThan(0);
+    expect(screen.queryByText('Remediation Draft')).toBeNull();
+    const discard = screen.getByRole('button', { name: 'Discard draft reference' });
+    discard.focus();
+    expect(document.activeElement).toBe(discard);
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(window.location.search).toBe(''));
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  }, 20_000);
+});

--- a/frontend/src/browser/remediationJourney.browser.test.tsx
+++ b/frontend/src/browser/remediationJourney.browser.test.tsx
@@ -429,7 +429,8 @@ describe('routed remediation operator journey', () => {
         screen.getByLabelText('Instructions'),
         'Repair the routed browser failure with bounded evidence.',
       );
-      await userEvent.fill(screen.getByLabelText('Action policy'), 'operator_review_only');
+      expect((screen.getByLabelText('Action policy') as HTMLSelectElement).value)
+        .toBe('admin_healer_default');
       await userEvent.selectOptions(screen.getByLabelText('Publish Mode'), 'branch');
 
       const createButton = screen.getByRole('button', { name: 'Start Workflow' });
@@ -456,7 +457,7 @@ describe('routed remediation operator journey', () => {
                 runId: 'source-run',
               },
               authorityMode: 'approval_gated',
-              actionPolicyRef: 'operator_review_only',
+              actionPolicyRef: 'admin_healer_default',
               checkpointBranchPolicy: {
                 gitWorkBranch: 'remediation/routed-browser-edited',
               },

--- a/frontend/src/browser/remediationJourney.browser.test.tsx
+++ b/frontend/src/browser/remediationJourney.browser.test.tsx
@@ -325,6 +325,11 @@ beforeEach(() => {
       if (url.startsWith('/api/omnigent/codex-catalog-readiness')) {
         return jsonResponse(readyOmnigentCatalog);
       }
+      if (url === '/api/v1/secrets') {
+        return jsonResponse({
+          items: [{ slug: 'GITHUB_TOKEN', status: 'active' }],
+        });
+      }
       if (url === '/api/omnigent/agent-profiles') {
         return jsonResponse([
           {

--- a/frontend/src/browser/remediationResponsive.browser.test.ts
+++ b/frontend/src/browser/remediationResponsive.browser.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+
+import '../styles/dashboard.css';
+
+// Real-browser guardrail for MoonLadderStudios/MoonMind#3623. Route-level
+// tests own the source Workflow Detail -> Create draft -> remediation Detail
+// behavior; this harness exercises the production markup and stylesheet at
+// the supported desktop/mobile boundaries that jsdom cannot lay out.
+
+const DESKTOP = { width: 1280, height: 800 } as const;
+const MOBILE = { width: 375, height: 812 } as const;
+
+let host: HTMLElement;
+
+beforeEach(() => {
+  host = document.createElement('main');
+  host.innerHTML = `
+    <form class="queue-submit-form">
+      <section class="card queue-remediation-draft-summary stack" aria-label="Remediation draft">
+        <div class="queue-section-heading">
+          <h2>Remediation Draft</h2>
+          <button type="button" class="secondary" aria-label="Discard remediation draft">Discard draft</button>
+        </div>
+        <fieldset class="queue-remediation-pinned-target stack" aria-label="Pinned target identity">
+          <legend>Pinned target identity (immutable)</legend>
+          <div class="grid-2">
+            <label>Target workflow<input value="mm:target-with-a-very-long-identity-that-must-not-overflow" readonly /></label>
+            <label>Pinned run<input value="run:pinned" readonly /></label>
+          </div>
+        </fieldset>
+        <fieldset class="queue-remediation-repair-intent stack" aria-label="Editable repair intent">
+          <legend>Editable repair intent</legend>
+          <div class="grid-2">
+            <label>Starting branch<input value="main" /></label>
+            <label>Checkpoint work branch<input value="remediation/mm-3623-browser-coverage" /></label>
+          </div>
+        </fieldset>
+      </section>
+    </form>
+    <section class="stack td-remediation-region td-evidence-region" aria-label="Authoritative remediation lifecycle">
+      <ul class="td-remediation-list">
+        <li class="card">
+          <code>artifact-with-a-very-long-unbroken-identity-that-must-wrap-inside-the-remediation-card-on-mobile</code>
+          <div class="stack td-remediation-lifecycle">
+            <details class="td-remediation-canonical">
+              <summary>Authored remediation contract</summary>
+              <pre>{"authorityMode":"approval_gated","bounded":true}</pre>
+            </details>
+          </div>
+          <div class="stack td-remediation-approval-controls">
+            <label>Decision rationale<textarea rows="2"></textarea></label>
+            <button type="button" class="secondary">Approve remediation action</button>
+          </div>
+        </li>
+      </ul>
+    </section>
+  `;
+  document.body.appendChild(host);
+});
+
+afterEach(async () => {
+  host.remove();
+  await page.viewport(DESKTOP.width, DESKTOP.height);
+});
+
+describe('remediation authoring and lifecycle responsive layout', () => {
+  it('keeps immutable/editable semantics keyboard-visible without horizontal overflow', async () => {
+    for (const viewport of [DESKTOP, MOBILE]) {
+      await page.viewport(viewport.width, viewport.height);
+
+      const pinned = host.querySelector<HTMLFieldSetElement>('.queue-remediation-pinned-target')!;
+      const editable = host.querySelector<HTMLFieldSetElement>('.queue-remediation-repair-intent')!;
+      const target = pinned.querySelector<HTMLInputElement>('input')!;
+      const startingBranch = editable.querySelector<HTMLInputElement>('input')!;
+      const approval = host.querySelector<HTMLButtonElement>('.td-remediation-approval-controls button')!;
+
+      expect(pinned.getAttribute('aria-label')).toBe('Pinned target identity');
+      expect(editable.getAttribute('aria-label')).toBe('Editable repair intent');
+      expect(target.readOnly).toBe(true);
+      expect(startingBranch.readOnly).toBe(false);
+
+      approval.focus();
+      expect(document.activeElement).toBe(approval);
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+      expect(host.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+    }
+  });
+});

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6516,8 +6516,61 @@ describe('Workflow Detail Entrypoint', () => {
                 activeLockScope: 'target_execution',
                 activeLockHolder: 'mm:remediation-1',
                 latestActionSummary: 'Proposed session interrupt',
+                deliveryStatus: 'applied',
+                verificationOutcome: 'verified_resolved',
                 resolution: null,
                 contextArtifactRef: 'art_context',
+                selectedSteps: ['run-tests'],
+                currentTargetState: 'awaiting_external',
+                authoredContract: {
+                  instructions: 'Repair the selected failed test step.',
+                  runtime: { mode: 'omnigent' },
+                  remediation: { authorityMode: 'approval_gated' },
+                },
+                selectedStepEvidence: [
+                  { logicalStepId: 'run-tests', checkpointRef: 'artifact://checkpoints/inbound' },
+                ],
+                contextGeneratedAt: '2026-04-22T00:00:02Z',
+                contextEvidenceAvailability: [
+                  { class: 'step_ledger', status: 'available', bounded: true, freshness: 'source_reported' },
+                ],
+                contextBoundedness: { rawLogBodiesIncluded: false, maxTailLines: 2000 },
+                diagnosisHints: ['Test runner state diverged after restart.'],
+                latestActionRequest: {
+                  actionKind: 'session.interrupt',
+                  riskTier: 'high',
+                  idempotencyKey: 'action-3623',
+                  expectedTargetState: 'awaiting_external',
+                },
+                latestActionResult: {
+                  actionKind: 'session.interrupt',
+                  status: 'applied',
+                  beforeStateRef: 'artifact://before',
+                  afterStateRef: 'artifact://after',
+                },
+                lifecycleSummary: {
+                  repair: { repairOutcome: 'repaired' },
+                  prevention: { status: 'reviewable_change_created', pullRequestUrl: 'https://github.com/example/pull/1' },
+                  lockRelease: 'released',
+                  unresolvedOperatorWork: 'Review prevention PR.',
+                },
+                lifecycleArtifacts: [
+                  {
+                    artifactRef: 'art_summary',
+                    artifactType: 'remediation.summary',
+                    status: 'complete',
+                    freshness: 'durable',
+                    bounded: true,
+                    metadata: {},
+                  },
+                ],
+                operatorControls: {
+                  canCancel: true,
+                  canTakeOver: true,
+                  canResume: false,
+                  paused: false,
+                  disabledReasons: {},
+                },
                 checkpointBranches: [
                   {
                     workflowId: 'test-123',
@@ -6532,6 +6585,16 @@ describe('Workflow Detail Entrypoint', () => {
                     headAttemptOrdinal: 2,
                     headVersion: 3,
                     headStatus: 'verified_incomplete',
+                    branchState: 'running',
+                    logicalStepId: 'run-tests',
+                    gitBaseBranch: 'main',
+                    gitWorkBranch: 'remediation/test-123',
+                    currentHeadCommit: 'abc123',
+                    pullRequestUrl: 'https://github.com/example/pull/1',
+                    publishStatus: 'published',
+                    instructionRef: 'art_branch_instructions',
+                    outputArtifacts: { result: 'art_branch_output' },
+                    comparisonArtifacts: { comparison: 'art_branch_comparison' },
                     latestVerificationVerdict: 'ADDITIONAL_WORK_NEEDED',
                     remainingWorkRef: 'artifact://verification/V2#remainingWork',
                     nextActionBaseline: {
@@ -6543,12 +6606,17 @@ describe('Workflow Detail Entrypoint', () => {
                 ],
                 approvalState: {
                   requestId: 'approval-1',
+                  actionKind: 'session.interrupt',
+                  riskTier: 'high',
+                  preconditions: 'Pinned target is current.',
+                  blastRadius: 'One managed session.',
                   decision: 'pending',
                   canDecide: true,
                   requestingActor: 'operator:requester-3620',
                   expectedTargetState: 'awaiting external session',
                   checkpointRef: 'artifact://checkpoint/approval-3620',
                   policyRef: 'omnigent-policy-3620@7',
+                  expiresAt: '2099-04-22T01:00:00Z',
                 },
                 createdAt: '2026-04-22T00:00:02Z',
                 updatedAt: '2026-04-22T00:00:03Z',
@@ -6623,6 +6691,9 @@ describe('Workflow Detail Entrypoint', () => {
           }),
         } as Response);
       }
+      if (url.includes('/executions/mm%3Aremediation-1/signal') && init?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: async () => ({ accepted: true }) } as Response);
+      }
       return Promise.resolve({
         ok: true,
         json: async () => mockExecution,
@@ -6648,12 +6719,27 @@ describe('Workflow Detail Entrypoint', () => {
     expect(screen.getByText('awaiting external session')).toBeTruthy();
     expect(screen.getByText('artifact://checkpoint/approval-3620')).toBeTruthy();
     expect(screen.getByText('omnigent-policy-3620@7')).toBeTruthy();
+    expect(screen.getByText('Authored remediation contract')).toBeTruthy();
+    expect(screen.getByText('Latest action request and authority decision')).toBeTruthy();
+    expect(screen.getByText('Repair, prevention, cleanup, and unresolved work')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'art_summary' }).getAttribute('href')).toBe(
+      '/api/artifacts/art_summary/download',
+    );
+    expect(screen.getByText('Test runner state diverged after restart.')).toBeTruthy();
+    expect(screen.getByText('remediation/test-123')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'art_branch_output' }).getAttribute('href')).toBe(
+      '/api/artifacts/art_branch_output/download',
+    );
+    expect(screen.getByRole('button', { name: 'Take over and pause' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Remediation Evidence' })).toBeTruthy();
     expect(screen.getByText('Context')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Open Evidence' }).getAttribute('href')).toBe(
       '/api/artifacts/art_context/download',
     );
 
+    fireEvent.change(screen.getByLabelText(/Decision rationale/), {
+      target: { value: 'Pinned evidence reviewed.' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Approve remediation action' }));
 
     await waitFor(() => {
@@ -6665,6 +6751,21 @@ describe('Workflow Detail Entrypoint', () => {
       expect(approvalCall).toBeTruthy();
       expect(JSON.parse(String(approvalCall?.[1]?.body))).toEqual({
         decision: 'approved',
+        comment: 'Pinned evidence reviewed.',
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Take over and pause' }));
+    await waitFor(() => {
+      const takeoverCall = fetchSpy.mock.calls.find(
+        ([url, init]) =>
+          String(url) === '/api/executions/mm%3Aremediation-1/signal' &&
+          init?.method === 'POST',
+      );
+      expect(takeoverCall).toBeTruthy();
+      expect(JSON.parse(String(takeoverCall?.[1]?.body))).toMatchObject({
+        signalName: 'Pause',
+        payload: { reason: 'operator_takeover' },
       });
     });
 

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6595,6 +6595,42 @@ describe('Workflow Detail Entrypoint', () => {
                     instructionRef: 'art_branch_instructions',
                     outputArtifacts: { result: 'art_branch_output' },
                     comparisonArtifacts: { comparison: 'art_branch_comparison' },
+                    turns: [
+                      {
+                        branchTurnId: 'cbt-remediation-inbound-1',
+                        status: 'completed',
+                        createdStepExecutionId: 'repair:execution:1',
+                        runtimeAgentRunId: 'agent-run-inbound-1',
+                        providerSessionId: 'provider-session-inbound-1',
+                        instructionRef: 'artifact://instructions/inbound-1',
+                        instructionDigest: 'sha256:instructions-inbound-1',
+                        sourceCheckpointRef: 'artifact://workspace/C0',
+                        contextBundleRef: 'artifact://context/inbound-1',
+                        stepExecutionManifestRef: 'artifact://manifest/inbound-1',
+                        startedAt: '2026-04-22T00:00:02Z',
+                        completedAt: '2026-04-22T00:00:03Z',
+                        createdAt: '2026-04-22T00:00:01Z',
+                        updatedAt: '2026-04-22T00:00:03Z',
+                        outputArtifacts: { result: 'art_turn_inbound_1_output' },
+                        comparisonArtifacts: {},
+                      },
+                      {
+                        branchTurnId: 'cbt-remediation-inbound-2',
+                        parentTurnId: 'cbt-remediation-inbound-1',
+                        status: 'running',
+                        createdStepExecutionId: 'repair:execution:2',
+                        runtimeAgentRunId: 'agent-run-inbound-2',
+                        providerSessionId: 'provider-session-inbound-2',
+                        instructionRef: 'artifact://instructions/inbound-2',
+                        instructionDigest: 'sha256:instructions-inbound-2',
+                        sourceCheckpointRef: 'artifact://workspace/C1',
+                        startedAt: '2026-04-22T00:00:04Z',
+                        createdAt: '2026-04-22T00:00:04Z',
+                        updatedAt: '2026-04-22T00:00:04Z',
+                        outputArtifacts: {},
+                        comparisonArtifacts: { comparison: 'art_turn_inbound_2_comparison' },
+                      },
+                    ],
                     latestVerificationVerdict: 'ADDITIONAL_WORK_NEEDED',
                     remainingWorkRef: 'artifact://verification/V2#remainingWork',
                     nextActionBaseline: {
@@ -6646,6 +6682,19 @@ describe('Workflow Detail Entrypoint', () => {
                     branchId: 'cbr-remediation-outbound',
                     branchTurnId: 'cbt-remediation-outbound',
                     checkpointRef: 'artifact://checkpoints/outbound',
+                    turns: [
+                      {
+                        branchTurnId: 'cbt-remediation-outbound-1',
+                        status: 'created',
+                        instructionRef: 'artifact://instructions/outbound-1',
+                        instructionDigest: 'sha256:instructions-outbound-1',
+                        sourceCheckpointRef: 'artifact://checkpoints/outbound',
+                        createdAt: '2026-04-22T00:00:05Z',
+                        updatedAt: '2026-04-22T00:00:05Z',
+                        outputArtifacts: { result: 'art_turn_outbound_1_output' },
+                        comparisonArtifacts: {},
+                      },
+                    ],
                   },
                 ],
                 approvalState: null,
@@ -6726,7 +6775,23 @@ describe('Workflow Detail Entrypoint', () => {
       '/api/artifacts/art_summary/download',
     );
     expect(screen.getByText('Test runner state diverged after restart.')).toBeTruthy();
-    expect(screen.getByText('remediation/test-123')).toBeTruthy();
+    expect(screen.getAllByText('remediation/test-123').length).toBeGreaterThan(0);
+    const inboundTurns = screen.getByRole('list', {
+      name: 'Checkpoint Branch turns for cbr-remediation-inbound',
+    });
+    expect(within(inboundTurns).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(inboundTurns).getAllByText('cbt-remediation-inbound-1').length).toBeGreaterThan(0);
+    expect(within(inboundTurns).getByText('cbt-remediation-inbound-2')).toBeTruthy();
+    expect(screen.getByText('agent-run-inbound-2')).toBeTruthy();
+    expect(screen.getByText('provider-session-inbound-2')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'art_turn_inbound_2_comparison' }).getAttribute('href')).toBe(
+      '/api/artifacts/art_turn_inbound_2_comparison/download',
+    );
+    const outboundTurns = screen.getByRole('list', {
+      name: 'Checkpoint Branch turns for cbr-remediation-outbound',
+    });
+    expect(within(outboundTurns).getAllByRole('listitem')).toHaveLength(1);
+    expect(within(outboundTurns).getByText('cbt-remediation-outbound-1')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'art_branch_output' }).getAttribute('href')).toBe(
       '/api/artifacts/art_branch_output/download',
     );

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1037,11 +1037,24 @@ const RemediationApprovalStateSchema = z
     requestingActor: z.string().nullable().optional(),
     requestedAt: z.string().nullable().optional(),
     expiresAt: z.string().nullable().optional(),
+    rationale: z.string().nullable().optional(),
+    status: z.string().nullable().optional(),
     decidedAt: z.string().nullable().optional(),
     consumedAt: z.string().nullable().optional(),
+    consumedByActionId: z.string().nullable().optional(),
     expectedTargetState: z.string().nullable().optional(),
     checkpointRef: z.string().nullable().optional(),
+    stepExecutionId: z.string().nullable().optional(),
+    bridgeSessionId: z.string().nullable().optional(),
+    omnigentSessionId: z.string().nullable().optional(),
+    hostRef: z.string().nullable().optional(),
+    hostLeaseRef: z.string().nullable().optional(),
+    providerProfileLeaseRef: z.string().nullable().optional(),
+    credentialGeneration: z.number().int().nullable().optional(),
     policyRef: z.string().nullable().optional(),
+    policyDigest: z.string().nullable().optional(),
+    policySnapshotRef: z.string().nullable().optional(),
+    securityProfileRef: z.string().nullable().optional(),
     artifactRefs: z.record(z.string(), z.string()).nullable().optional(),
   })
   .passthrough();
@@ -1080,6 +1093,30 @@ const RemediationActionCapabilitySchema = z
   })
   .passthrough();
 
+const RemediationLifecycleArtifactSchema = z
+  .object({
+    artifactRef: z.string(),
+    artifactType: z.string(),
+    status: z.string(),
+    label: z.string().nullable().optional(),
+    createdAt: z.string().nullable().optional(),
+    expiresAt: z.string().nullable().optional(),
+    freshness: z.string(),
+    bounded: z.boolean().default(true),
+    metadata: z.record(z.string(), z.unknown()).default({}),
+  })
+  .passthrough();
+
+const RemediationOperatorControlsSchema = z
+  .object({
+    canCancel: z.boolean().default(false),
+    canTakeOver: z.boolean().default(false),
+    canResume: z.boolean().default(false),
+    paused: z.boolean().default(false),
+    disabledReasons: z.record(z.string(), z.string()).default({}),
+  })
+  .passthrough();
+
 const RemediationLinkSchema = z
   .object({
     remediationWorkflowId: z.string(),
@@ -1093,6 +1130,7 @@ const RemediationLinkSchema = z
     activeLockHolder: z.string().nullable().optional(),
     latestActionSummary: z.string().nullable().optional(),
     deliveryStatus: z.string().nullable().optional(),
+    verificationOutcome: z.string().nullable().optional(),
     resolution: z.string().nullable().optional(),
     contextArtifactRef: z.string().nullable().optional(),
     selectedSteps: z.array(z.string()).nullable().optional(),
@@ -1111,6 +1149,27 @@ const RemediationLinkSchema = z
             workflowId: z.string(),
             branchId: z.string(),
             branchTurnId: z.string().nullable().optional(),
+            logicalStepId: z.string().nullable().optional(),
+            branchState: z.string().nullable().optional(),
+            workspacePolicy: z.string().nullable().optional(),
+            runtimeContextPolicy: z.string().nullable().optional(),
+            gitBaseBranch: z.string().nullable().optional(),
+            gitWorkBranch: z.string().nullable().optional(),
+            currentHeadCommit: z.string().nullable().optional(),
+            pullRequestUrl: z.string().nullable().optional(),
+            publishStatus: z.string().nullable().optional(),
+            promotionEvidence: z.record(z.string(), z.unknown()).nullable().optional(),
+            archiveReason: z.string().nullable().optional(),
+            promotedAt: z.string().nullable().optional(),
+            archivedAt: z.string().nullable().optional(),
+            turnState: z.string().nullable().optional(),
+            runtimeAgentRunId: z.string().nullable().optional(),
+            providerSessionId: z.string().nullable().optional(),
+            instructionRef: z.string().nullable().optional(),
+            turnStartedAt: z.string().nullable().optional(),
+            turnCompletedAt: z.string().nullable().optional(),
+            outputArtifacts: z.record(z.string(), z.string()).nullable().optional(),
+            comparisonArtifacts: z.record(z.string(), z.string()).nullable().optional(),
             checkpointRef: z.string().nullable().optional(),
             contextArtifactRef: z.string().nullable().optional(),
             loopId: z.string().nullable().optional(),
@@ -1137,6 +1196,17 @@ const RemediationLinkSchema = z
           .passthrough(),
       )
       .default([]),
+    authoredContract: z.record(z.string(), z.unknown()).nullable().optional(),
+    selectedStepEvidence: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    contextGeneratedAt: z.string().nullable().optional(),
+    contextEvidenceAvailability: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    contextBoundedness: z.record(z.string(), z.unknown()).nullable().optional(),
+    diagnosisHints: z.array(z.string()).nullable().optional(),
+    lifecycleArtifacts: z.array(RemediationLifecycleArtifactSchema).nullable().optional(),
+    latestActionRequest: z.record(z.string(), z.unknown()).nullable().optional(),
+    latestActionResult: z.record(z.string(), z.unknown()).nullable().optional(),
+    lifecycleSummary: z.record(z.string(), z.unknown()).nullable().optional(),
+    operatorControls: RemediationOperatorControlsSchema.nullable().optional(),
     createdAt: z.string().nullable().optional(),
     updatedAt: z.string().nullable().optional(),
   })
@@ -7622,10 +7692,37 @@ function remediationVerificationSummary(
   };
 }
 
+function RemediationArtifactRefs({
+  apiBase,
+  refs,
+}: {
+  apiBase: string;
+  refs: Record<string, string> | null | undefined;
+}) {
+  const entries = Object.entries(refs || {}).filter(([, ref]) => Boolean(ref));
+  if (entries.length === 0) return <>—</>;
+  return (
+    <span className="live-logs-artifact-links">
+      {entries.map(([kind, ref]) => {
+        const href = artifactRefHref(apiBase, ref);
+        return href ? (
+          <a key={`${kind}:${ref}`} href={href} target="_blank" rel="noreferrer">
+            <code className="text-xs break-all">{ref}</code>
+          </a>
+        ) : (
+          <code key={`${kind}:${ref}`} className="text-xs break-all">{ref}</code>
+        );
+      })}
+    </span>
+  );
+}
+
 function RemediationCheckpointBranches({
   branches,
+  apiBase,
 }: {
   branches: z.infer<typeof RemediationLinkSchema>['checkpointBranches'];
+  apiBase: string;
 }) {
   if (!branches || branches.length === 0) return null;
   return (
@@ -7640,20 +7737,172 @@ function RemediationCheckpointBranches({
             <div className="grid-2">
               <Card label="Target Workflow"><code className="text-xs break-all">{branch.workflowId}</code></Card>
               <Card label="Turn">{branch.branchTurnId || '—'}</Card>
-              <Card label="Checkpoint">{branch.checkpointRef || '—'}</Card>
-              <Card label="Context">{branch.contextArtifactRef || '—'}</Card>
+              <Card label="Checkpoint"><RemediationArtifactRefs apiBase={apiBase} refs={branch.checkpointRef ? { checkpoint: branch.checkpointRef } : null} /></Card>
+              <Card label="Context"><RemediationArtifactRefs apiBase={apiBase} refs={branch.contextArtifactRef ? { context: branch.contextArtifactRef } : null} /></Card>
               <Card label="Head status">{branch.headStatus ? formatStatusLabel(branch.headStatus) : '—'}</Card>
               <Card label="Attempt / version">{branch.headAttemptOrdinal != null && branch.headVersion != null ? `${branch.headAttemptOrdinal} / ${branch.headVersion}` : '—'}</Card>
+              <Card label="Branch lifecycle">{branch.branchState ? formatStatusLabel(branch.branchState) : '—'}</Card>
+              <Card label="Selected step">{branch.logicalStepId || '—'}</Card>
+              <Card label="Workspace policy">{branch.workspacePolicy || '—'}</Card>
+              <Card label="Runtime context">{branch.runtimeContextPolicy || '—'}</Card>
+              <Card label="Base branch"><code className="text-xs break-all">{branch.gitBaseBranch || '—'}</code></Card>
+              <Card label="Isolated work branch"><code className="text-xs break-all">{branch.gitWorkBranch || '—'}</code></Card>
+              <Card label="Workspace head"><code className="text-xs break-all">{branch.currentHeadCommit || branch.headWorkspaceDigest || '—'}</code></Card>
+              <Card label="Publication">{branch.publishStatus || 'not published'}</Card>
+              <Card label="Resulting PR">{branch.pullRequestUrl ? <a href={branch.pullRequestUrl}>Open pull request</a> : '—'}</Card>
+              <Card label="Promotion">{branch.promotedAt ? `promoted ${formatWhen(branch.promotedAt)}` : 'not promoted'}</Card>
+              <Card label="Archive / cleanup">{branch.archivedAt ? `archived ${formatWhen(branch.archivedAt)}` : branch.archiveReason || 'active'}</Card>
+              <Card label="Turn execution">{branch.turnState ? formatStatusLabel(branch.turnState) : 'not started'}</Card>
+              <Card label="Resulting Agent Run"><code className="text-xs break-all">{branch.runtimeAgentRunId || '—'}</code></Card>
+              <Card label="Provider session"><code className="text-xs break-all">{branch.providerSessionId || '—'}</code></Card>
+              <Card label="Turn instructions"><RemediationArtifactRefs apiBase={apiBase} refs={branch.instructionRef ? { instructions: branch.instructionRef } : null} /></Card>
+              <Card label="Turn timing">{branch.turnStartedAt ? `${formatWhen(branch.turnStartedAt)}${branch.turnCompletedAt ? ` → ${formatWhen(branch.turnCompletedAt)}` : ' → running'}` : 'pending'}</Card>
+              <Card label="Output artifacts"><RemediationArtifactRefs apiBase={apiBase} refs={branch.outputArtifacts} /></Card>
+              <Card label="Comparison artifacts"><RemediationArtifactRefs apiBase={apiBase} refs={branch.comparisonArtifacts} /></Card>
               <Card label="Root candidate"><code className="text-xs break-all">{branch.rootCheckpointRef || '—'}</code></Card>
               <Card label="Current candidate"><code className="text-xs break-all">{branch.headCheckpointRef || '—'}</code></Card>
               <Card label="Candidate digest"><code className="text-xs break-all">{branch.headWorkspaceDigest || '—'}</code></Card>
-              <Card label="Latest verification">{branch.latestVerificationVerdict || '—'}</Card>
+              <Card label="Latest verification">
+                {branch.latestVerificationVerdict || '—'}{' '}
+                <RemediationArtifactRefs apiBase={apiBase} refs={branch.latestVerificationRef ? { verification: branch.latestVerificationRef } : null} />
+              </Card>
               <Card label="Next attempt baseline"><code className="text-xs break-all">{branch.nextActionBaseline ? `${branch.nextActionBaseline.checkpointRef} @ v${branch.nextActionBaseline.headVersion}` : '—'}</code></Card>
-              <Card label="Remaining work"><code className="text-xs break-all">{branch.remainingWorkRef || '—'}</code></Card>
+              <Card label="Remaining work"><RemediationArtifactRefs apiBase={apiBase} refs={branch.remainingWorkRef ? { remainingWork: branch.remainingWorkRef } : null} /></Card>
             </div>
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function branchVerificationPhase(
+  branch: z.infer<typeof RemediationLinkSchema>['checkpointBranches'][number],
+): { phase: 'pending' | 'running' | 'terminal'; label: string } {
+  const verdict = String(branch.latestVerificationVerdict || '').trim();
+  if (verdict) return { phase: 'terminal', label: verdict };
+  if (branch.latestVerificationRef) {
+    return { phase: 'running', label: 'Verification running' };
+  }
+  return { phase: 'pending', label: 'Verification pending' };
+}
+
+function RemediationVerificationSummary({
+  branches,
+  outcome,
+}: {
+  branches: z.infer<typeof RemediationLinkSchema>['checkpointBranches'];
+  outcome?: string | null | undefined;
+}) {
+  if ((!branches || branches.length === 0) && !outcome) return null;
+  return (
+    <div className="td-remediation-live" aria-label="Repair verification">
+      <strong>Repair verification</strong>
+      {outcome ? <p className="small">Target-level outcome: {outcome}</p> : null}
+      <ul className="td-remediation-list">
+        {branches.map((branch) => {
+          const { phase, label } = branchVerificationPhase(branch);
+          return (
+            <li key={`verify:${branch.workflowId}:${branch.branchId}`} className="card">
+              <div className="grid-2">
+                <Card label="Branch"><code className="text-xs break-all">{`Verification for ${branch.branchId}`}</code></Card>
+                <Card label="Verification state">{formatStatusLabel(phase)}</Card>
+                <Card label="Verdict">{label}</Card>
+                <Card label="Evidence"><code className="text-xs break-all">{branch.latestVerificationRef || '—'}</code></Card>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function RemediationCanonicalProjection({
+  title,
+  value,
+}: {
+  title: string;
+  value: Record<string, unknown> | null | undefined;
+}) {
+  if (!value || Object.keys(value).length === 0) return null;
+  return (
+    <details className="td-remediation-canonical">
+      <summary>{title}</summary>
+      <pre className="text-xs break-all">{JSON.stringify(value, null, 2)}</pre>
+    </details>
+  );
+}
+
+function RemediationLifecycleProjection({
+  item,
+  apiBase,
+}: {
+  item: z.infer<typeof RemediationLinkSchema>;
+  apiBase: string;
+}) {
+  const availability = item.contextEvidenceAvailability || [];
+  const artifacts = item.lifecycleArtifacts || [];
+  return (
+    <div className="stack td-remediation-lifecycle" aria-label="Authoritative remediation lifecycle">
+      <RemediationCanonicalProjection title="Authored remediation contract" value={item.authoredContract} />
+      {item.selectedStepEvidence?.length ? (
+        <RemediationCanonicalProjection
+          title="Pinned step and checkpoint evidence"
+          value={{ selectedSteps: item.selectedStepEvidence }}
+        />
+      ) : null}
+      {item.diagnosisHints?.length ? (
+        <p className="small"><strong>Latest diagnosis:</strong> {item.diagnosisHints.join('; ')}</p>
+      ) : null}
+      {item.contextGeneratedAt ? (
+        <p className="small"><strong>Context snapshot:</strong> {formatWhen(item.contextGeneratedAt)}</p>
+      ) : null}
+      {availability.length > 0 ? (
+        <div>
+          <strong>Context evidence availability</strong>
+          <div className="grid-2">
+            {availability.map((entry, index) => (
+              <Card key={`${String(entry.class || 'evidence')}:${index}`} label={String(entry.class || 'evidence')}>
+                {String(entry.status || 'unknown')}
+                {entry.freshness ? ` · ${String(entry.freshness)}` : ''}
+                {entry.bounded === true ? ' · bounded' : entry.bounded === false ? ' · unbounded' : ''}
+                {entry.degradedReason ? ` · ${String(entry.degradedReason)}` : ''}
+              </Card>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {item.contextBoundedness ? (
+        <RemediationCanonicalProjection title="Context boundedness" value={item.contextBoundedness} />
+      ) : null}
+      <RemediationCanonicalProjection title="Latest action request and authority decision" value={item.latestActionRequest} />
+      <RemediationCanonicalProjection title="Latest action delivery result" value={item.latestActionResult} />
+      <RemediationCanonicalProjection title="Repair, prevention, cleanup, and unresolved work" value={item.lifecycleSummary} />
+      {artifacts.length > 0 ? (
+        <details>
+          <summary>Durable lifecycle artifacts ({artifacts.length})</summary>
+          <ul className="td-remediation-list">
+            {artifacts.map((artifact) => (
+              <li key={`${artifact.artifactType}:${artifact.artifactRef}`}>
+                <code>{artifact.artifactType}</code>{' '}
+                {artifactRefHref(apiBase, artifact.artifactRef) ? (
+                  <a
+                    href={artifactRefHref(apiBase, artifact.artifactRef) || undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <code className="text-xs break-all">{artifact.artifactRef}</code>
+                  </a>
+                ) : (
+                  <code className="text-xs break-all">{artifact.artifactRef}</code>
+                )}{' '}
+                — {artifact.status}, {artifact.freshness}, {artifact.bounded ? 'bounded' : 'unbounded'}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
     </div>
   );
 }
@@ -7674,6 +7923,14 @@ function RemediationApprovalSummary({
   );
 
   if (!hasDetails) return null;
+  const expired = approval.status === 'expired' || approval.decision === 'expired' || (
+    approval.expiresAt ? Date.parse(approval.expiresAt) <= Date.now() : false
+  );
+  const decisionRecorded =
+    approval.decision === 'approved' || approval.decision === 'rejected' || approval.decision === 'denied';
+  const staleDecision = approval.status === 'stale' || approval.decision === 'stale' || Boolean(
+    decisionRecorded && approval.canDecide && approval.requestId,
+  );
 
   return (
     <div className="td-remediation-approval">
@@ -7688,34 +7945,162 @@ function RemediationApprovalSummary({
         <Card label="Expected target state">{approval.expectedTargetState || '—'}</Card>
         <Card label="Checkpoint"><code className="text-xs break-all">{approval.checkpointRef || '—'}</code></Card>
         <Card label="Policy"><code className="text-xs break-all">{approval.policyRef || '—'}</code></Card>
+        <Card label="Policy digest"><code className="text-xs break-all">{approval.policyDigest || '—'}</code></Card>
+        <Card label="Policy snapshot"><code className="text-xs break-all">{approval.policySnapshotRef || '—'}</code></Card>
+        <Card label="Security profile"><code className="text-xs break-all">{approval.securityProfileRef || '—'}</code></Card>
         <Card label="Preconditions">{approval.preconditions || '—'}</Card>
         <Card label="Blast Radius">{approval.blastRadius || '—'}</Card>
+        <Card label="Decision rationale">{approval.rationale || '—'}</Card>
+        <Card label="Decision status">{approval.status || approval.decision || '—'}</Card>
+        <Card label="Decided by">{approval.decisionActor || '—'}</Card>
+        <Card label="Decided at">{approval.decidedAt || approval.decisionAt ? formatWhen(approval.decidedAt || approval.decisionAt) : '—'}</Card>
+        <Card label="Consumed by action">{approval.consumedByActionId || '—'}</Card>
       </div>
       {approval.artifactRefs ? (
         <div className="small">Evidence: {Object.entries(approval.artifactRefs).map(([kind, ref]) => `${kind}: ${ref}`).join(', ')}</div>
       ) : null}
-      {approval.requestId && !approval.canDecide && approval.decision === 'pending' ? (
+      {expired ? (
+        <p className="notice warning" role="status">
+          This approval request expired. Refresh the target state and create a new request before acting.
+        </p>
+      ) : staleDecision ? (
+        <p className="notice warning" role="status">
+          This decision is stale because the action or pinned target evidence changed. A new approval request is required.
+        </p>
+      ) : approval.requestId && !approval.canDecide && approval.decision === 'pending' ? (
         <p className="notice subtle">Approval is read-only for this operator.</p>
       ) : null}
     </div>
   );
 }
 
+function RemediationApprovalControls({
+  remediationWorkflowId,
+  requestId,
+  busy,
+  onApprovalDecision,
+}: {
+  remediationWorkflowId: string;
+  requestId: string;
+  busy: boolean;
+  onApprovalDecision: (
+    workflowId: string,
+    requestId: string,
+    decision: 'approved' | 'rejected',
+    comment?: string,
+  ) => void;
+}) {
+  const [rationale, setRationale] = useState('');
+  return (
+    <div className="stack td-remediation-approval-controls">
+      <label>
+        Decision rationale (recorded in the approval audit trail)
+        <textarea
+          value={rationale}
+          onChange={(event) => setRationale(event.target.value)}
+          rows={2}
+          placeholder="Explain the bounded operator decision"
+        />
+      </label>
+      <div className="actions">
+        <button
+          type="button"
+          className="secondary"
+          disabled={busy}
+          onClick={() => onApprovalDecision(remediationWorkflowId, requestId, 'approved', rationale)}
+        >
+          Approve remediation action
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          disabled={busy}
+          onClick={() => onApprovalDecision(remediationWorkflowId, requestId, 'rejected', rationale)}
+        >
+          Deny remediation action
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RemediationOperatorControls({
+  item,
+  busy,
+  onOperatorControl,
+}: {
+  item: z.infer<typeof RemediationLinkSchema>;
+  busy: boolean;
+  onOperatorControl: (
+    workflowId: string,
+    action: 'cancel' | 'takeover' | 'resume',
+  ) => void;
+}) {
+  const controls = item.operatorControls;
+  if (!controls) return null;
+  const hasControl = controls.canCancel || controls.canTakeOver || controls.canResume;
+  return (
+    <div className="stack td-remediation-operator-controls">
+      <strong>Operator controls</strong>
+      <p className="small">
+        Takeover pauses autonomous remediation through the durable Workflow signal; it does not expose runtime credentials or raw session authority.
+      </p>
+      {hasControl ? (
+        <div className="actions" role="group" aria-label="Remediation operator controls">
+          {controls.canTakeOver ? (
+            <button type="button" className="secondary" disabled={busy} onClick={() => onOperatorControl(item.remediationWorkflowId, 'takeover')}>
+              Take over and pause
+            </button>
+          ) : null}
+          {controls.canResume ? (
+            <button type="button" className="secondary" disabled={busy} onClick={() => onOperatorControl(item.remediationWorkflowId, 'resume')}>
+              Resume remediation
+            </button>
+          ) : null}
+          {controls.canCancel ? (
+            <button type="button" className="queue-action-danger" disabled={busy} onClick={() => onOperatorControl(item.remediationWorkflowId, 'cancel')}>
+              Cancel remediation
+            </button>
+          ) : null}
+        </div>
+      ) : (
+        <p className="notice subtle">
+          Operator controls are unavailable: {Object.values(controls.disabledReasons).join(', ') || 'workflow state is terminal'}.
+        </p>
+      )}
+    </div>
+  );
+}
+
 function RemediationRelationshipsPanel({
+  apiBase,
   inbound,
   outbound,
   inboundError,
   outboundError,
   onApprovalDecision,
   approvalBusy,
+  onOperatorControl,
+  operatorBusy,
   showEmpty,
 }: {
+  apiBase: string;
   inbound: z.infer<typeof RemediationLinksSchema> | undefined;
   outbound: z.infer<typeof RemediationLinksSchema> | undefined;
   inboundError: Error | null;
   outboundError: Error | null;
-  onApprovalDecision: (workflowId: string, requestId: string, decision: 'approved' | 'rejected') => void;
+  onApprovalDecision: (
+    workflowId: string,
+    requestId: string,
+    decision: 'approved' | 'rejected',
+    comment?: string,
+  ) => void;
   approvalBusy: boolean;
+  onOperatorControl: (
+    workflowId: string,
+    action: 'cancel' | 'takeover' | 'resume',
+  ) => void;
+  operatorBusy: boolean;
   showEmpty: boolean;
 }) {
   const inboundItems = inbound?.items ?? [];
@@ -7728,7 +8113,9 @@ function RemediationRelationshipsPanel({
     <section className="stack td-remediation-region td-evidence-region">
       <div>
         <h3>Remediation</h3>
-        <p className="small">Target and remediator relationships are shown from bounded remediation link metadata.</p>
+        <p className="small">
+          Target and remediator relationships are shown from canonical links and bounded artifacts. The original target outcome shown above is unchanged; later repair, verification, and prevention records are annotations in this separate lifecycle.
+        </p>
       </div>
       {inboundError || outboundError ? (
         <div className="notice error">
@@ -7745,39 +8132,39 @@ function RemediationRelationshipsPanel({
                   <code className="text-xs break-all">{item.remediationWorkflowId}</code>
                 </a>
                 <div className="grid-2">
+                  <Card label="Remediation Run"><code className="text-xs break-all">{item.remediationRunId || '—'}</code></Card>
+                  <Card label="Pinned Target Run"><code className="text-xs break-all">{item.targetRunId || '—'}</code></Card>
                   <Card label="Status">{formatStatusLabel(item.status)}</Card>
+                  <Card label="Mode">{item.mode || '—'}</Card>
                   <Card label="Authority">{item.authorityMode || '—'}</Card>
+                  <Card label="Selected Steps">{remediationListValue(item.selectedSteps)}</Card>
+                  <Card label="Current Target">{item.currentTargetState || '—'}</Card>
                   <Card label="Latest Action">{item.latestActionSummary || '—'}</Card>
                   <Card label="Delivery">{item.deliveryStatus || '—'}</Card>
+                  <Card label="Repair verification">{item.verificationOutcome || 'pending'}</Card>
                   <Card label="Resolution">{item.resolution || '—'}</Card>
                   <Card label="Lock">{item.activeLockScope || 'None'}</Card>
                   {item.activeLockHolder && item.activeLockHolder !== item.remediationWorkflowId ? (
                     <Card label="Lock Holder">{item.activeLockHolder}</Card>
                   ) : null}
+                  {item.lockOutcome?.releasedAt ? (
+                    <Card label="Lock Released">{formatWhen(item.lockOutcome.releasedAt)}</Card>
+                  ) : null}
                   <Card label="Updated">{formatWhen(item.updatedAt)}</Card>
                 </div>
-                <RemediationCheckpointBranches branches={item.checkpointBranches} />
+                <RemediationLifecycleProjection item={item} apiBase={apiBase} />
+                <RemediationVerificationSummary branches={item.checkpointBranches} outcome={item.verificationOutcome} />
+                <RemediationCheckpointBranches branches={item.checkpointBranches} apiBase={apiBase} />
                 {item.approvalState ? <RemediationApprovalSummary approval={item.approvalState} /> : null}
                 {item.approvalState?.canDecide && item.approvalState.requestId ? (
-                  <div className="actions">
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={approvalBusy}
-                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'approved')}
-                    >
-                      Approve remediation action
-                    </button>
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={approvalBusy}
-                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'rejected')}
-                    >
-                      Reject remediation action
-                    </button>
-                  </div>
+                  <RemediationApprovalControls
+                    remediationWorkflowId={item.remediationWorkflowId}
+                    requestId={item.approvalState.requestId}
+                    busy={approvalBusy}
+                    onApprovalDecision={onApprovalDecision}
+                  />
                 ) : null}
+                <RemediationOperatorControls item={item} busy={operatorBusy} onOperatorControl={onOperatorControl} />
               </li>
             ))}
           </ul>
@@ -7799,7 +8186,19 @@ function RemediationRelationshipsPanel({
                   <Card label="Mode">{item.mode || '—'}</Card>
                   <Card label="Authority">{item.authorityMode || '—'}</Card>
                   <Card label="Status">{formatStatusLabel(item.status)}</Card>
-                  <Card label="Evidence Bundle">{item.contextArtifactRef || 'Missing'}</Card>
+                  <Card label="Action delivery">{item.deliveryStatus || '—'}</Card>
+                  <Card label="Repair verification">{item.verificationOutcome || 'pending'}</Card>
+                  <Card label="Evidence Bundle">
+                    {item.contextArtifactRef && artifactRefHref(apiBase, item.contextArtifactRef) ? (
+                      <a
+                        href={artifactRefHref(apiBase, item.contextArtifactRef) || undefined}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <code className="text-xs break-all">{item.contextArtifactRef}</code>
+                      </a>
+                    ) : item.contextArtifactRef || 'Missing'}
+                  </Card>
                   <Card label="Approval">{item.approvalState?.decision || 'not_required'}</Card>
                   <Card label="Selected Steps">{remediationListValue(item.selectedSteps)}</Card>
                   <Card label="Current Target">{item.currentTargetState || '—'}</Card>
@@ -7807,7 +8206,17 @@ function RemediationRelationshipsPanel({
                   <Card label="Lock">{item.activeLockScope || 'None'}</Card>
                   <Card label="Lock Holder">{item.activeLockHolder || item.lockOutcome?.holder || '—'}</Card>
                   <Card label="Lock Outcome">{item.lockOutcome?.state || '—'}</Card>
+                  {item.lockOutcome?.releasedAt ? (
+                    <Card label="Lock Released">{formatWhen(item.lockOutcome.releasedAt)}</Card>
+                  ) : null}
                 </div>
+                {(!item.allowedActions || item.allowedActions.length === 0) ? (
+                  <p className="notice subtle">
+                    {item.authorityMode === 'observe_only'
+                      ? 'Observe-only authority: no mutating actions are offered for this target.'
+                      : 'No actions are currently offered; policy or backend readiness has bounded the action surface.'}
+                  </p>
+                ) : null}
                 <RemediationCapabilityMatrix rows={item.actionCapabilities} />
                 {item.evidenceDegraded ? (
                   <p className="notice subtle">
@@ -7831,7 +8240,9 @@ function RemediationRelationshipsPanel({
                 {!item.contextArtifactRef ? (
                   <p className="notice subtle">Evidence bundle is missing.</p>
                 ) : null}
-                <RemediationCheckpointBranches branches={item.checkpointBranches} />
+                <RemediationLifecycleProjection item={item} apiBase={apiBase} />
+                <RemediationVerificationSummary branches={item.checkpointBranches} outcome={item.verificationOutcome} />
+                <RemediationCheckpointBranches branches={item.checkpointBranches} apiBase={apiBase} />
                 {item.mode?.includes('follow') && !item.contextArtifactRef ? (
                   <p className="notice subtle">
                     Live follow is unavailable; durable remediation artifacts remain authoritative.
@@ -7839,25 +8250,14 @@ function RemediationRelationshipsPanel({
                 ) : null}
                 {item.approvalState ? <RemediationApprovalSummary approval={item.approvalState} /> : null}
                 {item.approvalState?.canDecide && item.approvalState.requestId ? (
-                  <div className="actions">
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={approvalBusy}
-                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'approved')}
-                    >
-                      Approve remediation action
-                    </button>
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={approvalBusy}
-                      onClick={() => onApprovalDecision(item.remediationWorkflowId, item.approvalState!.requestId!, 'rejected')}
-                    >
-                      Reject remediation action
-                    </button>
-                  </div>
+                  <RemediationApprovalControls
+                    remediationWorkflowId={item.remediationWorkflowId}
+                    requestId={item.approvalState.requestId}
+                    busy={approvalBusy}
+                    onApprovalDecision={onApprovalDecision}
+                  />
                 ) : null}
+                <RemediationOperatorControls item={item} busy={operatorBusy} onOperatorControl={onOperatorControl} />
               </li>
             ))}
           </ul>
@@ -9124,17 +9524,20 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
       remediationWorkflowId,
       requestId,
       decision,
+      comment,
     }: {
       remediationWorkflowId: string;
       requestId: string;
       decision: 'approved' | 'rejected';
+      comment?: string;
     }) => {
+      const trimmedComment = (comment || '').trim();
       const response = await fetch(
         `${payload.apiBase}/executions/${encodeURIComponent(remediationWorkflowId)}/remediation/approvals/${encodeURIComponent(requestId)}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify({ decision }),
+          body: JSON.stringify(trimmedComment ? { decision, comment: trimmedComment } : { decision }),
         },
       );
       if (!response.ok) {
@@ -9145,6 +9548,54 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
     },
     onSuccess: () => {
       setActionNotice('Remediation approval decision recorded.');
+      invalidate();
+    },
+    onError: (error: Error) => setActionError(error.message),
+  });
+
+  const remediationOperatorMutation = useMutation({
+    mutationFn: async ({
+      remediationWorkflowId,
+      action,
+    }: {
+      remediationWorkflowId: string;
+      action: 'cancel' | 'takeover' | 'resume';
+    }) => {
+      const encodedWorkflowId = encodeURIComponent(remediationWorkflowId);
+      const isCancel = action === 'cancel';
+      const response = await fetch(
+        `${payload.apiBase}/executions/${encodedWorkflowId}/${isCancel ? 'cancel' : 'signal'}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify(
+            isCancel
+              ? { action: 'cancel', graceful: true, reason: 'operator_remediation_control' }
+              : {
+                  signalName: action === 'takeover' ? 'Pause' : 'Resume',
+                  payload: {
+                    reason: action === 'takeover'
+                      ? 'operator_takeover'
+                      : 'operator_resume_after_takeover',
+                  },
+                },
+          ),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || response.statusText);
+      }
+      return { action, body: await response.json() };
+    },
+    onSuccess: ({ action }) => {
+      setActionNotice(
+        action === 'cancel'
+          ? 'Remediation cancellation requested.'
+          : action === 'takeover'
+            ? 'Operator takeover requested; autonomous remediation is pausing.'
+            : 'Remediation resume requested.',
+      );
       invalidate();
     },
     onError: (error: Error) => setActionError(error.message),
@@ -10489,15 +10940,26 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
 
           {artifactsTabActive ? (
             <RemediationRelationshipsPanel
+              apiBase={payload.apiBase}
               inbound={inboundRemediationsQuery.data}
               outbound={outboundRemediationsQuery.data}
               inboundError={inboundRemediationsQuery.isError ? (inboundRemediationsQuery.error as Error) : null}
               outboundError={outboundRemediationsQuery.isError ? (outboundRemediationsQuery.error as Error) : null}
               approvalBusy={remediationApprovalMutation.isPending}
+              operatorBusy={remediationOperatorMutation.isPending}
               showEmpty={shouldFetchRemediationLinks && (inboundRemediationsQuery.isSuccess || outboundRemediationsQuery.isSuccess)}
-              onApprovalDecision={(remediationWorkflowId, requestId, decision) => {
+              onApprovalDecision={(remediationWorkflowId, requestId, decision, comment) => {
                 setActionError(null);
-                remediationApprovalMutation.mutate({ remediationWorkflowId, requestId, decision });
+                remediationApprovalMutation.mutate({
+                  remediationWorkflowId,
+                  requestId,
+                  decision,
+                  ...(comment ? { comment } : {}),
+                });
+              }}
+              onOperatorControl={(remediationWorkflowId, action) => {
+                setActionError(null);
+                remediationOperatorMutation.mutate({ remediationWorkflowId, action });
               }}
             />
           ) : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -1170,6 +1170,26 @@ const RemediationLinkSchema = z
             turnCompletedAt: z.string().nullable().optional(),
             outputArtifacts: z.record(z.string(), z.string()).nullable().optional(),
             comparisonArtifacts: z.record(z.string(), z.string()).nullable().optional(),
+            turns: z.array(z.object({
+              branchTurnId: z.string(),
+              parentTurnId: z.string().nullable().optional(),
+              status: z.string(),
+              createdStepExecutionId: z.string().nullable().optional(),
+              runtimeAgentRunId: z.string().nullable().optional(),
+              providerSessionId: z.string().nullable().optional(),
+              instructionRef: z.string(),
+              instructionDigest: z.string(),
+              sourceCheckpointRef: z.string(),
+              contextBundleRef: z.string().nullable().optional(),
+              stepExecutionManifestRef: z.string().nullable().optional(),
+              gitWorkBranch: z.string().nullable().optional(),
+              startedAt: z.string().nullable().optional(),
+              completedAt: z.string().nullable().optional(),
+              createdAt: z.string(),
+              updatedAt: z.string(),
+              outputArtifacts: z.record(z.string(), z.string()).default({}),
+              comparisonArtifacts: z.record(z.string(), z.string()).default({}),
+            }).passthrough()).default([]),
             checkpointRef: z.string().nullable().optional(),
             contextArtifactRef: z.string().nullable().optional(),
             loopId: z.string().nullable().optional(),
@@ -7769,6 +7789,40 @@ function RemediationCheckpointBranches({
               <Card label="Next attempt baseline"><code className="text-xs break-all">{branch.nextActionBaseline ? `${branch.nextActionBaseline.checkpointRef} @ v${branch.nextActionBaseline.headVersion}` : '—'}</code></Card>
               <Card label="Remaining work"><RemediationArtifactRefs apiBase={apiBase} refs={branch.remainingWorkRef ? { remainingWork: branch.remainingWorkRef } : null} /></Card>
             </div>
+            {branch.turns.length > 0 ? (
+              <div className="td-remediation-live">
+                <strong>{`Checkpoint Branch turns (${branch.turns.length})`}</strong>
+                <ol
+                  className="td-remediation-list"
+                  aria-label={`Checkpoint Branch turns for ${branch.branchId}`}
+                >
+                  {branch.turns.map((turn) => (
+                    <li key={turn.branchTurnId} className="card">
+                      <div className="grid-2">
+                        <Card label="Turn ID"><code className="text-xs break-all">{turn.branchTurnId}</code></Card>
+                        <Card label="Parent turn"><code className="text-xs break-all">{turn.parentTurnId || 'root'}</code></Card>
+                        <Card label="Turn state">{formatStatusLabel(turn.status)}</Card>
+                        <Card label="Step Execution"><code className="text-xs break-all">{turn.createdStepExecutionId || '—'}</code></Card>
+                        <Card label="Agent Run"><code className="text-xs break-all">{turn.runtimeAgentRunId || '—'}</code></Card>
+                        <Card label="Provider session"><code className="text-xs break-all">{turn.providerSessionId || '—'}</code></Card>
+                        <Card label="Instructions"><RemediationArtifactRefs apiBase={apiBase} refs={{ instructions: turn.instructionRef }} /></Card>
+                        <Card label="Source checkpoint"><RemediationArtifactRefs apiBase={apiBase} refs={{ checkpoint: turn.sourceCheckpointRef }} /></Card>
+                        <Card label="Context bundle"><RemediationArtifactRefs apiBase={apiBase} refs={turn.contextBundleRef ? { context: turn.contextBundleRef } : null} /></Card>
+                        <Card label="Step manifest"><RemediationArtifactRefs apiBase={apiBase} refs={turn.stepExecutionManifestRef ? { manifest: turn.stepExecutionManifestRef } : null} /></Card>
+                        <Card label="Work branch"><code className="text-xs break-all">{turn.gitWorkBranch || branch.gitWorkBranch || '—'}</code></Card>
+                        <Card label="Timing">
+                          {turn.startedAt
+                            ? `${formatWhen(turn.startedAt)}${turn.completedAt ? ` → ${formatWhen(turn.completedAt)}` : ' → running'}`
+                            : `created ${formatWhen(turn.createdAt)}`}
+                        </Card>
+                        <Card label="Output"><RemediationArtifactRefs apiBase={apiBase} refs={turn.outputArtifacts} /></Card>
+                        <Card label="Comparison"><RemediationArtifactRefs apiBase={apiBase} refs={turn.comparisonArtifacts} /></Card>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ) : null}
           </li>
         ))}
       </ul>

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -798,6 +798,154 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
   });
 
+  it("submits an imported remediation draft through the ordinary create boundary", async () => {
+    const draft = {
+      source: "remediation",
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+      target: {
+        workflowId: "mm:target-3623",
+        runId: "run-target-3623",
+        state: "failed",
+        stepSelectors: [{
+          logicalStepId: "run-tests",
+          checkpointRef: "artifact://checkpoint/run-tests",
+        }],
+      },
+      repository: "MoonLadderStudios/MoonMind",
+      branch: "main",
+      startingBranch: "main",
+      workBranch: "remediation/mm-3623",
+      publishMode: "pr",
+      executionProfileRef: "omnigent-codex-default",
+      launchPolicyRef: "on-demand-v1",
+      contextRetrieval: {
+        initial: { collections: ["docs"], allowStale: false, required: true },
+        followUp: {
+          enabled: true,
+          required: false,
+          collections: ["docs"],
+          budgetPreset: "balanced",
+          topK: 8,
+          maxContextTokens: 8192,
+          maxQueries: 12,
+          latencyMs: 5000,
+          maxLifetimeSeconds: 900,
+          overlayPolicy: "include",
+          staleOverlayAllowed: false,
+          fallbackAllowed: false,
+        },
+      },
+      runtime: { mode: "omnigent" },
+      agentProfile: {
+        profileId: "team-codex",
+        version: 1,
+        providerProfileRef: "oauth-1",
+      },
+      instructions: "Repair the pinned test failure.",
+      remediation: {
+        target: {
+          workflowId: "mm:target-3623",
+          runId: "run-target-3623",
+          stepSelectors: [{
+            logicalStepId: "run-tests",
+            checkpointRef: "artifact://checkpoint/run-tests",
+          }],
+        },
+        mode: "snapshot_then_follow",
+        authorityMode: "approval_gated",
+        actionPolicyRef: "admin_healer_default",
+        evidencePolicy: { includeStepLedger: true },
+        approvalPolicy: { requiredForHighRisk: true },
+        lockPolicy: { targetMutationLock: true },
+        verificationPolicy: { verifyAppliedActions: true },
+        checkpointBranchPolicy: {
+          actionKind: "checkpoint_branch.create_from_remediation_context",
+          runtimeContextPolicy: "fresh_agent_run",
+          workspacePolicy: "apply_previous_execution_diff_to_clean_baseline",
+          gitWorkBranch: "remediation/mm-3623",
+        },
+        trigger: { type: "manual" },
+      },
+    };
+    window.sessionStorage.setItem(
+      "moonmind.remediation-create-draft.issue-3623",
+      JSON.stringify(draft),
+    );
+    window.history.replaceState(
+      {},
+      "Create remediation",
+      "/workflows/new?intent=remediate&draftId=issue-3623",
+    );
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => readyOmnigentCatalog } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
+      }
+      if (url === "/api/executions/mm%3Atarget-3623?source=temporal") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ workflowId: "mm:target-3623", runId: "run-target-3623" }),
+        } as Response);
+      }
+      if (url === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: "mm:remediation-3623" }) } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+
+    expect(await screen.findByText("Remediation Draft")).toBeTruthy();
+    const start = screen.getByRole("button", { name: "Start Workflow" });
+    await waitFor(() => expect((start as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.click(start);
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith(
+      "/workflows/mm%3Aremediation-3623?source=temporal",
+    ));
+    const createCall = fetchSpy.mock.calls.find(([url, options]) =>
+      String(url) === "/api/executions" &&
+      (options as RequestInit | undefined)?.method === "POST"
+    );
+    const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
+    expect(request).toMatchObject({
+      type: "task",
+      payload: {
+        targetRuntime: "omnigent",
+        repository: {
+          repository: { name: "MoonLadderStudios/MoonMind" },
+          branch: { name: "main" },
+        },
+        publishMode: "pr",
+        omnigent: {
+          executionTargetRef: "omnigent-codex-default",
+          launchPolicyRef: "on-demand-v1",
+        },
+        agentProfile: {
+          profileId: "team-codex",
+          version: 1,
+          providerProfileRef: "oauth-1",
+          launchPolicyRef: "on-demand-v1",
+        },
+        rag: { collections: ["docs"], required: true },
+        followUpRetrieval: { enabled: true, collections: ["docs"] },
+        task: {
+          remediation: draft.remediation,
+        },
+      },
+    });
+  });
+
   it("adopts the active default policy version without requiring a host-policy choice", async () => {
     const activePolicyCatalog = {
       ...readyOmnigentCatalog,
@@ -19423,7 +19571,8 @@ describe("Task Create runtime command previews", () => {
   it("warns when a remediation draft target run changed before submit", async () => {
     const draft = {
       source: "remediation",
-      createdAt: "2026-07-07T00:00:00.000Z",
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
       target: {
         workflowId: "mm:remediation-target",
         runId: "run-original",
@@ -19453,6 +19602,7 @@ describe("Task Create runtime command previews", () => {
           actionKind: "checkpoint_branch.create_from_remediation_context",
           runtimeContextPolicy: "fresh_agent_run",
         },
+        trigger: { type: "manual" },
       },
     };
     window.sessionStorage.setItem(
@@ -19520,6 +19670,121 @@ describe("Task Create runtime command previews", () => {
         "Target workflow changed after this remediation draft was created. Open Remediate again before submitting.",
       ),
     ).toBeTruthy();
+  });
+
+  it("imports the complete remediation draft once and keeps pinned identity separate from editable intent", async () => {
+    const draft = {
+      source: "remediation",
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+      target: {
+        workflowId: "mm:remediation-target",
+        runId: "run-original",
+        title: "Failed workflow",
+        state: "failed",
+        stepSelectors: [
+          {
+            logicalStepId: "test",
+            checkpointRef: "artifact://checkpoint/test",
+          },
+        ],
+      },
+      repository: "MoonLadderStudios/MoonMind",
+      branch: "main",
+      startingBranch: "main",
+      workBranch: "repair/mm-3623",
+      publishMode: "pr",
+      executionProfileRef: "execution-profile:codex",
+      launchPolicyRef: "launch-policy:remediation",
+      contextRetrieval: {
+        initial: { collections: ["docs"], allowStale: false, required: true },
+        followUp: {
+          enabled: false,
+          required: false,
+          collections: [],
+          budgetPreset: "balanced",
+          topK: 8,
+          maxContextTokens: 8192,
+          maxQueries: 12,
+          latencyMs: 5000,
+          maxLifetimeSeconds: 900,
+          overlayPolicy: "include",
+          staleOverlayAllowed: false,
+          fallbackAllowed: false,
+        },
+      },
+      instructions: "Repair the failed workflow.",
+      runtime: { mode: "omnigent" },
+      remediation: {
+        target: {
+          workflowId: "mm:remediation-target",
+          runId: "run-original",
+          stepSelectors: [
+            {
+              logicalStepId: "test",
+              checkpointRef: "artifact://checkpoint/test",
+            },
+          ],
+        },
+        mode: "snapshot_then_follow",
+        authorityMode: "approval_gated",
+        actionPolicyRef: "admin_healer_default",
+        checkpointBranchPolicy: {
+          actionKind: "checkpoint_branch.create_from_remediation_context",
+          runtimeContextPolicy: "fresh_agent_run",
+          gitWorkBranch: "repair/mm-3623",
+        },
+        trigger: { type: "manual" },
+      },
+    };
+    window.sessionStorage.setItem(
+      "moonmind.remediation-create-draft.complete",
+      JSON.stringify(draft),
+    );
+    window.history.pushState(
+      {},
+      "Task Create",
+      "/workflows/new?intent=remediate&draftId=complete",
+    );
+
+    renderWithClient(<WorkflowStartPage payload={withRuntimeCommandPreview()} />);
+
+    expect(await screen.findByText("Remediation Draft")).toBeTruthy();
+    expect(screen.getByLabelText("Pinned target identity")).toBeTruthy();
+    expect(screen.getByLabelText("Editable repair intent")).toBeTruthy();
+    expect((screen.getByLabelText("Target workflow") as HTMLInputElement).readOnly).toBe(true);
+    expect((screen.getByLabelText("Pinned run") as HTMLInputElement).readOnly).toBe(true);
+    expect((screen.getByLabelText("Starting branch") as HTMLInputElement).value).toBe("main");
+    expect((screen.getByLabelText("Checkpoint work branch") as HTMLInputElement).value).toBe("repair/mm-3623");
+    expect((screen.getByLabelText("Publish Mode") as HTMLSelectElement).value).toBe("pr");
+    expect(
+      window.sessionStorage.getItem(
+        "moonmind.remediation-create-draft.complete",
+      ),
+    ).toBeNull();
+  });
+
+  it("reports a copied cross-tab remediation URL without importing content", async () => {
+    window.localStorage.setItem(
+      "moonmind.remediation-create-draft-presence.other-tab",
+      JSON.stringify({ createdAt: new Date().toISOString() }),
+    );
+    window.history.pushState(
+      {},
+      "Task Create",
+      "/workflows/new?intent=remediate&draftId=other-tab",
+    );
+
+    renderWithClient(<WorkflowStartPage payload={withRuntimeCommandPreview()} />);
+
+    expect(
+      (await screen.findAllByText(/belongs to another browser tab/i)).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Remediation Draft")).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard draft reference" }),
+    );
+    expect(window.location.search).toBe("");
   });
 
   it("previews unknown valid slash commands as opaque pass-through", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -652,7 +652,16 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     state: "active",
     activeVersion: 1,
     defaultForRuntime: true,
-    versions: [{ version: 1, digest: `sha256:${"a".repeat(64)}`, validationResult: { ready: true } }],
+    versions: [{
+      version: 1,
+      digest: `sha256:${"a".repeat(64)}`,
+      document: {
+        execution: {
+          defaultExecutionProfileRef: "omnigent-codex-default",
+        },
+      },
+      validationResult: { ready: true },
+    }],
   }];
 
   it("keeps an unready runtime selectable and explicitly revalidates stale readiness", async () => {
@@ -796,6 +805,115 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       },
     });
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
+  });
+
+  it("synchronizes the execution target when the Agent Profile changes", async () => {
+    const payload = omnigentPayload();
+    const initialData = payload.initialData as {
+      dashboardConfig: { system: Record<string, unknown> };
+    };
+    initialData.dashboardConfig.system.omnigentExecutionCatalog = {
+      profiles: [
+        {
+          ref: "omnigent-codex-default",
+          displayName: "Codex default",
+          defaultPolicyRef: "on-demand-v1",
+          providerRuntime: "codex_cli",
+        },
+        {
+          ref: "omnigent-claude-default",
+          displayName: "Claude default",
+          defaultPolicyRef: "claude-on-demand-v1",
+          providerRuntime: "claude_code",
+        },
+      ],
+      policies: [
+        {
+          ref: "on-demand-v1",
+          displayName: "Codex on-demand",
+          hostMode: "on_demand_docker",
+        },
+        {
+          ref: "claude-on-demand-v1",
+          displayName: "Claude on-demand",
+          hostMode: "on_demand_docker",
+        },
+      ],
+    };
+    const catalog = {
+      ...readyOmnigentCatalog,
+      executionProfiles: [
+        ...readyOmnigentCatalog.executionProfiles,
+        {
+          ref: "omnigent-claude-default",
+          displayName: "Claude default",
+          available: true,
+          launchPolicies: [{
+            ref: "claude-on-demand-v1",
+            displayName: "Claude on-demand",
+            hostMode: "on_demand_docker",
+            isDefault: true,
+          }],
+          gateReasons: [],
+        },
+      ],
+    };
+    const profiles = [
+      readyAgentProfiles[0],
+      {
+        profileId: "team-claude",
+        displayName: "Team Claude",
+        state: "active",
+        activeVersion: 1,
+        defaultForRuntime: false,
+        versions: [{
+          version: 1,
+          digest: `sha256:${"b".repeat(64)}`,
+          document: {
+            execution: {
+              defaultExecutionProfileRef: "omnigent-claude-default",
+            },
+          },
+          validationResult: { ready: true },
+        }],
+      },
+    ];
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => catalog } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => profiles } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(payload);
+    fireEvent.change(await screen.findByLabelText("Runtime"), {
+      target: { value: "omnigent" },
+    });
+    await waitFor(() => {
+      expect((screen.getByLabelText("Agent profile") as HTMLSelectElement).value)
+        .toBe("team-codex");
+      expect((screen.getByLabelText("Execution target") as HTMLSelectElement).value)
+        .toBe("omnigent-codex-default");
+    });
+
+    fireEvent.change(screen.getByLabelText("Agent profile"), {
+      target: { value: "team-claude" },
+    });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Execution target") as HTMLSelectElement).value)
+        .toBe("omnigent-claude-default");
+    });
   });
 
   it("submits an imported remediation draft through the ordinary create boundary", async () => {
@@ -19658,12 +19776,14 @@ describe("Task Create runtime command previews", () => {
     const actionPolicy = screen.getByLabelText("Action policy");
     fireEvent.change(remediationMode, { target: { value: "live_follow" } });
     fireEvent.change(remediationAuthority, { target: { value: "observe_only" } });
-    fireEvent.change(actionPolicy, { target: { value: "operator_review_only" } });
     fireEvent.click(screen.getByLabelText("Diagnostics"));
 
     expect((remediationMode as HTMLSelectElement).value).toBe("live_follow");
     expect((remediationAuthority as HTMLSelectElement).value).toBe("observe_only");
-    expect((actionPolicy as HTMLInputElement).value).toBe("operator_review_only");
+    expect((actionPolicy as HTMLSelectElement).value).toBe("admin_healer_default");
+    expect(within(actionPolicy).queryByRole("option", {
+      name: "operator_review_only",
+    })).toBeNull();
     expect((screen.getByLabelText("Diagnostics") as HTMLInputElement).checked).toBe(false);
     expect(
       await screen.findByText(

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -31,8 +31,9 @@ import { WorkflowWorkspaceSidebarPanel } from "../components/workflows/WorkflowW
 import { WORKFLOW_START_ROUTE_CHANGE_REQUEST_EVENT } from "../lib/workflowStartRouteGuard";
 import {
   clearRemediationCreateDraft,
-  readRemediationCreateDraft,
+  inspectRemediationCreateDraft,
   type RemediationCreateDraft,
+  type RemediationCreateDraftReadResult,
 } from "../lib/remediationCreateDraft";
 import { ContextRetrievalControls } from "../components/ContextRetrievalControls";
 import {
@@ -59,6 +60,19 @@ function readWorkflowStartDashboardConfig(payload: BootPayload): WorkflowStartDa
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
+const REMEDIATION_DRAFT_LOAD_MESSAGES: Record<
+  Exclude<RemediationCreateDraftReadResult["status"], "valid">,
+  string
+> = {
+  missing:
+    "This remediation draft is missing or was already imported. Return to the target workflow and choose Remediate again.",
+  cross_tab:
+    "This remediation draft belongs to another browser tab. Return to the target workflow in this tab and choose Remediate again; draft contents are intentionally tab-scoped.",
+  malformed:
+    "This remediation draft is malformed or was altered, so it was not imported. Discard the draft URL or return to the target workflow and choose Remediate again.",
+  expired:
+    "This remediation draft expired before import. Return to the target workflow and choose Remediate again to pin current target evidence.",
+};
 export const ARTIFACT_COMPLETE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 2000];
 const ARTIFACT_COMPLETE_RETRY_MESSAGE = "artifact upload is not complete";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
@@ -5784,6 +5798,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [selectedDependencyWorkflowId, setSelectedDependencyWorkflowId] = useState("");
   const [selectedDependencies, setSelectedDependencies] = useState<string[]>([]);
   const [remediationDraft, setRemediationDraft] = useState<RemediationCreateDraft | null>(null);
+  const [remediationDraftFailure, setRemediationDraftFailure] = useState<{
+    draftId: string;
+    status: Exclude<RemediationCreateDraftReadResult["status"], "valid">;
+  } | null>(null);
   const remediationDraftIdRef = useRef<string | null>(null);
   const [contextRetrieval, setContextRetrieval] =
     useState<ContextRetrievalAuthoring>(defaultContextRetrievalAuthoring);
@@ -6464,25 +6482,30 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     const params = new URLSearchParams(window.location.search);
     if (params.get("intent") !== "remediate") {
       setRemediationDraft(null);
+      setRemediationDraftFailure(null);
       remediationDraftAppliedRef.current = null;
       remediationDraftIdRef.current = null;
       return;
     }
     const draftId = String(params.get("draftId") || "").trim();
-    if (!draftId || remediationDraftAppliedRef.current === draftId) {
+    const draftLoadKey = draftId || "__missing__";
+    if (remediationDraftAppliedRef.current === draftLoadKey) {
       return;
     }
-    const draft = readRemediationCreateDraft(draftId);
-    if (!draft) {
+    const draftResult = inspectRemediationCreateDraft(draftId);
+    if (draftResult.status !== "valid") {
       setRemediationDraft(null);
-      remediationDraftAppliedRef.current = null;
+      remediationDraftAppliedRef.current = draftLoadKey;
       remediationDraftIdRef.current = null;
-      setSubmitMessage("The remediation draft is no longer available. Open Remediate from the target workflow again.");
+      setRemediationDraftFailure({ draftId, status: draftResult.status });
+      setSubmitMessage(REMEDIATION_DRAFT_LOAD_MESSAGES[draftResult.status]);
       return;
     }
+    const draft = draftResult.draft;
 
-    remediationDraftAppliedRef.current = draftId;
+    remediationDraftAppliedRef.current = draftLoadKey;
     remediationDraftIdRef.current = draftId;
+    setRemediationDraftFailure(null);
     setRemediationDraft(draft);
     setRepository(draft.repository || "MoonLadderStudios/MoonMind");
     setRepositoryTouched(true);
@@ -6492,6 +6515,16 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (draft.publishMode) {
       setPublishMode(normalizePublishModeForSubmit(draft.publishMode));
+    }
+    if (draft.executionProfileRef) {
+      setOmnigentExecutionTargetRef(draft.executionProfileRef);
+    }
+    if (draft.launchPolicyRef) {
+      setOmnigentLaunchPolicyRef(draft.launchPolicyRef);
+      setOmnigentLaunchPolicyAuthored(true);
+    }
+    if (draft.contextRetrieval) {
+      setContextRetrieval(draft.contextRetrieval);
     }
     if (draft.runtime?.mode) {
       prevRuntimeRef.current = draft.runtime.mode;
@@ -6504,6 +6537,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (draft.agentProfile?.profileId) {
       setAgentProfile(draft.agentProfile.profileId);
+      prevProviderProfileRef.current = draft.agentProfile.providerProfileRef;
+      setProviderProfile(draft.agentProfile.providerProfileRef);
     }
     if (draft.runtime?.model) {
       setModel(draft.runtime.model);
@@ -6528,6 +6563,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       ]);
       setNextStepNumber(2);
     }
+    // The draft has now crossed its single-hop authority boundary into React
+    // state. Remove both storage markers so it cannot be imported again from a
+    // copied URL; the visible form remains editable until ordinary submission.
+    clearRemediationCreateDraft(draftId);
+    remediationDraftIdRef.current = null;
   }, [pageMode.mode, setSubmitMessage]);
 
   const remediationTargetFreshnessQuery = useQuery({
@@ -11520,11 +11560,47 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           disabled={isTemporalFormBlocked}
           aria-busy={isTemporalFormBlocked}
         >
+        {remediationDraftFailure ? (
+          <section
+            className="card queue-remediation-draft-summary stack"
+            aria-label="Remediation draft import error"
+          >
+            <h2>Remediation draft was not imported</h2>
+            <p className="notice error" role="alert">
+              {REMEDIATION_DRAFT_LOAD_MESSAGES[remediationDraftFailure.status]}
+            </p>
+            <div className="actions">
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  clearRemediationCreateDraft(remediationDraftFailure.draftId);
+                  setRemediationDraftFailure(null);
+                  remediationDraftAppliedRef.current = null;
+                  const url = new URL(window.location.href);
+                  url.searchParams.delete("intent");
+                  url.searchParams.delete("draftId");
+                  window.history.replaceState(
+                    {},
+                    "",
+                    `${url.pathname}${url.search}${url.hash}`,
+                  );
+                  setSubmitMessage(
+                    "Remediation draft reference discarded. Create remains open as an ordinary workflow.",
+                  );
+                }}
+              >
+                Discard draft reference
+              </button>
+            </div>
+          </section>
+        ) : null}
         {remediationDraft ? (
           <section
             className="card queue-remediation-draft-summary stack"
             aria-label="Remediation draft"
             data-jira-issue="MM-1119"
+            data-github-issue="MoonLadderStudios/MoonMind#3623"
           >
             <div className="queue-section-heading">
               <div>
@@ -11533,8 +11609,41 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   Target {remediationDraft.target.title || remediationDraft.target.workflowId}
                 </p>
               </div>
+              <button
+                type="button"
+                className="secondary"
+                aria-label="Discard remediation draft"
+                onClick={() => {
+                  clearRemediationCreateDraft(remediationDraftIdRef.current);
+                  remediationDraftAppliedRef.current = null;
+                  remediationDraftIdRef.current = null;
+                  setRemediationDraft(null);
+                  const url = new URL(window.location.href);
+                  url.searchParams.delete("intent");
+                  url.searchParams.delete("draftId");
+                  window.history.replaceState(
+                    {},
+                    "",
+                    `${url.pathname}${url.search}${url.hash}`,
+                  );
+                  setSubmitMessage(
+                    "Remediation draft discarded. Create remains open as an ordinary workflow.",
+                  );
+                }}
+              >
+                Discard draft
+              </button>
             </div>
-            <div className="grid-2">
+            <fieldset
+              className="queue-remediation-pinned-target stack"
+              aria-label="Pinned target identity"
+            >
+              <legend>Pinned target identity (immutable)</legend>
+              <p className="small">
+                These values identify the original outcome and exact run. Editing
+                the repair intent below never changes this pinned identity.
+              </p>
+              <div className="grid-2">
               <label>
                 Target workflow
                 <input value={remediationDraft.target.workflowId} readOnly />
@@ -11542,6 +11651,86 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               <label>
                 Pinned run
                 <input value={remediationDraft.target.runId} readOnly />
+              </label>
+              {remediationDraft.target.state ? (
+                <label>
+                  Original target outcome
+                  <input value={remediationDraft.target.state} readOnly />
+                </label>
+              ) : null}
+              <label>
+                Selected evidence
+                <input
+                  value={
+                    remediationDraft.remediation.target.stepSelectors
+                      ?.map((selector) =>
+                        String(
+                          selector.logicalStepId ||
+                            selector.checkpointRef ||
+                            selector.source ||
+                            "",
+                        ),
+                      )
+                      .filter(Boolean)
+                      .join(", ") || "No step/checkpoint selected"
+                  }
+                  readOnly
+                />
+              </label>
+              </div>
+            </fieldset>
+            <fieldset
+              className="queue-remediation-repair-intent stack"
+              aria-label="Editable repair intent"
+            >
+              <legend>Editable repair intent</legend>
+              <p className="small">
+                Instructions, runtime/profile selections, policies, branches,
+                retrieval, and publication controls remain editable until submit.
+              </p>
+            <div className="grid-2">
+              <label>
+                Starting branch
+                <input
+                  value={branch}
+                  onChange={(event) => {
+                    setBranchTouched(true);
+                    setBranch(event.target.value);
+                    setRemediationDraft((current) => current ? {
+                      ...current,
+                      branch: event.target.value,
+                      startingBranch: event.target.value,
+                    } : current);
+                  }}
+                />
+              </label>
+              <label>
+                Checkpoint work branch
+                <input
+                  value={remediationDraft.workBranch || ""}
+                  placeholder="Generated when left blank"
+                  onChange={(event) => {
+                    const workBranch = event.target.value;
+                    setRemediationDraft((current) => {
+                      if (!current) return current;
+                      const {
+                        gitWorkBranch: _previousWorkBranch,
+                        ...checkpointBranchPolicy
+                      } = current.remediation.checkpointBranchPolicy || {};
+                      return {
+                        ...current,
+                        workBranch,
+                        remediation: {
+                          ...current.remediation,
+                          checkpointBranchPolicy: {
+                            ...checkpointBranchPolicy,
+                            ...(workBranch ? { gitWorkBranch: workBranch } : {}),
+                          },
+                        },
+                      };
+                    });
+                  }}
+                />
               </label>
               <label>
                 Remediation mode
@@ -11733,6 +11922,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 Create branch for corrected inputs
               </label>
             </div>
+            </fieldset>
             {remediationTargetFreshnessWarning ? (
               <p className="notice small" role="alert">
                 {remediationTargetFreshnessWarning}

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -35,6 +35,7 @@ import {
   type RemediationCreateDraft,
   type RemediationCreateDraftReadResult,
 } from "../lib/remediationCreateDraft";
+import { DEFAULT_REMEDIATION_ACTION_POLICY } from "../lib/workflowActions";
 import { ContextRetrievalControls } from "../components/ContextRetrievalControls";
 import {
   type ContextRetrievalAuthoring,
@@ -6188,6 +6189,23 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           selectedOmnigentAgentProfile.activeVersion),
     );
   useEffect(() => {
+    if (runtime !== "omnigent") return;
+    const profileExecutionTargetRef = String(
+      selectedOmnigentAgentProfileVersion?.document?.execution
+        ?.defaultExecutionProfileRef || "",
+    ).trim();
+    if (
+      profileExecutionTargetRef &&
+      profileExecutionTargetRef !== omnigentExecutionTargetRef
+    ) {
+      setOmnigentExecutionTargetRef(profileExecutionTargetRef);
+    }
+  }, [
+    omnigentExecutionTargetRef,
+    runtime,
+    selectedOmnigentAgentProfileVersion,
+  ]);
+  useEffect(() => {
     if (runtime !== "omnigent" || agentProfile) return;
     const preferred = readyAgentProfiles.find((profile) => profile.defaultForRuntime) || readyAgentProfiles[0];
     if (preferred) setAgentProfile(preferred.profileId);
@@ -11768,7 +11786,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               </label>
               <label>
                 Action policy
-                <input
+                <select
                   value={remediationDraft.remediation.actionPolicyRef || ""}
                   onChange={(event) => {
                     const actionPolicyRef = event.target.value;
@@ -11777,7 +11795,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                       remediation: { ...current.remediation, actionPolicyRef },
                     } : current);
                   }}
-                />
+                >
+                  <option value={DEFAULT_REMEDIATION_ACTION_POLICY}>
+                    Administrator healer default
+                  </option>
+                </select>
               </label>
               <label>
                 Checkpoint

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11748,6 +11748,8 @@ export interface components {
             comparisonArtifacts?: {
                 [key: string]: string;
             } | null;
+            /** Turns */
+            turns?: components["schemas"]["RemediationCheckpointBranchTurnLinkModel"][];
             /** Operation */
             operation?: string | null;
             /** Idempotencykey */
@@ -11817,6 +11819,49 @@ export interface components {
             agentProfile?: {
                 [key: string]: unknown;
             } | null;
+        };
+        /** RemediationCheckpointBranchTurnLinkModel */
+        RemediationCheckpointBranchTurnLinkModel: {
+            /** Branchturnid */
+            branchTurnId: string;
+            /** Parentturnid */
+            parentTurnId?: string | null;
+            /** Status */
+            status: string;
+            /** Createdstepexecutionid */
+            createdStepExecutionId?: string | null;
+            /** Runtimeagentrunid */
+            runtimeAgentRunId?: string | null;
+            /** Providersessionid */
+            providerSessionId?: string | null;
+            /** Instructionref */
+            instructionRef: string;
+            /** Instructiondigest */
+            instructionDigest: string;
+            /** Sourcecheckpointref */
+            sourceCheckpointRef: string;
+            /** Contextbundleref */
+            contextBundleRef?: string | null;
+            /** Stepexecutionmanifestref */
+            stepExecutionManifestRef?: string | null;
+            /** Gitworkbranch */
+            gitWorkBranch?: string | null;
+            /** Startedat */
+            startedAt?: string | null;
+            /** Completedat */
+            completedAt?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+            /** Outputartifacts */
+            outputArtifacts?: {
+                [key: string]: string;
+            };
+            /** Comparisonartifacts */
+            comparisonArtifacts?: {
+                [key: string]: string;
+            };
         };
         /** RemediationCollectionItemModel */
         RemediationCollectionItemModel: {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11700,6 +11700,54 @@ export interface components {
             branchId: string;
             /** Branchturnid */
             branchTurnId?: string | null;
+            /** Logicalstepid */
+            logicalStepId?: string | null;
+            /** Branchstate */
+            branchState?: string | null;
+            /** Workspacepolicy */
+            workspacePolicy?: string | null;
+            /** Runtimecontextpolicy */
+            runtimeContextPolicy?: string | null;
+            /** Gitbasebranch */
+            gitBaseBranch?: string | null;
+            /** Gitworkbranch */
+            gitWorkBranch?: string | null;
+            /** Currentheadcommit */
+            currentHeadCommit?: string | null;
+            /** Pullrequesturl */
+            pullRequestUrl?: string | null;
+            /** Publishstatus */
+            publishStatus?: string | null;
+            /** Promotionevidence */
+            promotionEvidence?: {
+                [key: string]: unknown;
+            } | null;
+            /** Archivereason */
+            archiveReason?: string | null;
+            /** Promotedat */
+            promotedAt?: string | null;
+            /** Archivedat */
+            archivedAt?: string | null;
+            /** Turnstate */
+            turnState?: string | null;
+            /** Runtimeagentrunid */
+            runtimeAgentRunId?: string | null;
+            /** Providersessionid */
+            providerSessionId?: string | null;
+            /** Instructionref */
+            instructionRef?: string | null;
+            /** Turnstartedat */
+            turnStartedAt?: string | null;
+            /** Turncompletedat */
+            turnCompletedAt?: string | null;
+            /** Outputartifacts */
+            outputArtifacts?: {
+                [key: string]: string;
+            } | null;
+            /** Comparisonartifacts */
+            comparisonArtifacts?: {
+                [key: string]: string;
+            } | null;
             /** Operation */
             operation?: string | null;
             /** Idempotencykey */
@@ -11813,6 +11861,32 @@ export interface components {
             /** Items */
             items: components["schemas"]["RemediationCollectionItemModel"][];
         };
+        /** RemediationLifecycleArtifactModel */
+        RemediationLifecycleArtifactModel: {
+            /** Artifactref */
+            artifactRef: string;
+            /** Artifacttype */
+            artifactType: string;
+            /** Status */
+            status: string;
+            /** Label */
+            label?: string | null;
+            /** Createdat */
+            createdAt?: string | null;
+            /** Expiresat */
+            expiresAt?: string | null;
+            /** Freshness */
+            freshness: string;
+            /**
+             * Bounded
+             * @default true
+             */
+            bounded: boolean;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
         /** RemediationLinkSummaryModel */
         RemediationLinkSummaryModel: {
             /** Remediationworkflowid */
@@ -11837,6 +11911,8 @@ export interface components {
             latestActionSummary?: string | null;
             /** Deliverystatus */
             deliveryStatus?: string | null;
+            /** Verificationoutcome */
+            verificationOutcome?: string | null;
             /** Resolution */
             resolution?: string | null;
             /** Contextartifactref */
@@ -11858,6 +11934,41 @@ export interface components {
             approvalState?: components["schemas"]["RemediationApprovalStateModel"] | null;
             /** Checkpointbranches */
             checkpointBranches?: components["schemas"]["RemediationCheckpointBranchLinkModel"][];
+            /** Authoredcontract */
+            authoredContract?: {
+                [key: string]: unknown;
+            } | null;
+            /** Selectedstepevidence */
+            selectedStepEvidence?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Contextgeneratedat */
+            contextGeneratedAt?: string | null;
+            /** Contextevidenceavailability */
+            contextEvidenceAvailability?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Contextboundedness */
+            contextBoundedness?: {
+                [key: string]: unknown;
+            } | null;
+            /** Diagnosishints */
+            diagnosisHints?: string[] | null;
+            /** Lifecycleartifacts */
+            lifecycleArtifacts?: components["schemas"]["RemediationLifecycleArtifactModel"][] | null;
+            /** Latestactionrequest */
+            latestActionRequest?: {
+                [key: string]: unknown;
+            } | null;
+            /** Latestactionresult */
+            latestActionResult?: {
+                [key: string]: unknown;
+            } | null;
+            /** Lifecyclesummary */
+            lifecycleSummary?: {
+                [key: string]: unknown;
+            } | null;
+            operatorControls?: components["schemas"]["RemediationOperatorControlsModel"] | null;
             /**
              * Createdat
              * Format: date-time
@@ -11908,6 +12019,33 @@ export interface components {
             workspaceDigest: string;
             /** Headversion */
             headVersion: number;
+        };
+        /** RemediationOperatorControlsModel */
+        RemediationOperatorControlsModel: {
+            /**
+             * Cancancel
+             * @default false
+             */
+            canCancel: boolean;
+            /**
+             * Cantakeover
+             * @default false
+             */
+            canTakeOver: boolean;
+            /**
+             * Canresume
+             * @default false
+             */
+            canResume: boolean;
+            /**
+             * Paused
+             * @default false
+             */
+            paused: boolean;
+            /** Disabledreasons */
+            disabledReasons?: {
+                [key: string]: string;
+            };
         };
         /** RemediationPolicy */
         RemediationPolicy: {

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -109,6 +109,27 @@ describe('remediationCreateDraft', () => {
     });
   });
 
+  it('bounds generated checkpoint selectors to the create contract limit', () => {
+    const draft = buildRemediationCreateDraft({
+      workflowId: 'mm:target',
+      runId: 'run-target',
+      checkpoints: Array.from({ length: 30 }, (_, index) => ({
+        logicalStepId: `step-${index + 1}`,
+        checkpointRef: `artifact://checkpoint/${index + 1}`,
+      })),
+    });
+
+    expect(draft.target.stepSelectors).toHaveLength(25);
+    expect(draft.remediation.target.stepSelectors).toHaveLength(25);
+    expect(draft.target.stepSelectors?.[24]).toMatchObject({
+      logicalStepId: 'step-25',
+      checkpointRef: 'artifact://checkpoint/25',
+    });
+
+    const draftId = storeRemediationCreateDraft(draft);
+    expect(inspectRemediationCreateDraft(draftId).status).toBe('valid');
+  });
+
   it('prepopulates source/work branches, Omnigent launch identity, and retrieval controls', () => {
     const draft = buildRemediationCreateDraft({
       workflowId: 'mm:target',
@@ -179,6 +200,19 @@ describe('remediationCreateDraft', () => {
     );
     expect(
       inspectRemediationCreateDraft('malformed-selectors').status,
+    ).toBe('malformed');
+    window.sessionStorage.setItem(
+      'moonmind.remediation-create-draft.unsupported-action-policy',
+      JSON.stringify({
+        ...draft,
+        remediation: {
+          ...draft.remediation,
+          actionPolicyRef: 'operator_review_only',
+        },
+      }),
+    );
+    expect(
+      inspectRemediationCreateDraft('unsupported-action-policy').status,
     ).toBe('malformed');
     window.sessionStorage.setItem(
       'moonmind.remediation-create-draft.expired',

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   buildRemediationCreateDraft,
   clearRemediationCreateDraft,
+  inspectRemediationCreateDraft,
+  REMEDIATION_CREATE_DRAFT_TTL_MS,
   remediationCreateDraftHref,
   readRemediationCreateDraft,
   storeRemediationCreateDraft,
@@ -11,6 +13,7 @@ import {
 describe('remediationCreateDraft', () => {
   beforeEach(() => {
     window.sessionStorage.clear();
+    window.localStorage.clear();
     window.history.pushState({}, '', '/workflows');
   });
 
@@ -30,6 +33,7 @@ describe('remediationCreateDraft', () => {
 
     expect(draft).toMatchObject({
       source: 'remediation',
+      schemaVersion: 1,
       repository: 'MoonLadderStudios/MoonMind',
       target: {
         workflowId: 'mm:target',
@@ -70,6 +74,7 @@ describe('remediationCreateDraft', () => {
     expect(draft.target.stepSelectors?.[0]).toMatchObject({
       checkpointRef: 'artifact://checkpoint/failed-step',
     });
+    expect(Date.parse(draft.createdAt)).not.toBeNaN();
   });
 
   it('stores, reads, builds a href, and clears a short-lived draft', () => {
@@ -102,6 +107,100 @@ describe('remediationCreateDraft', () => {
       version: 2,
       providerProfileRef: 'oauth-team',
     });
+  });
+
+  it('prepopulates source/work branches, Omnigent launch identity, and retrieval controls', () => {
+    const draft = buildRemediationCreateDraft({
+      workflowId: 'mm:target',
+      runId: 'run-target',
+      targetRuntime: 'omnigent',
+      inputParameters: {
+        repository: {
+          provider: 'git',
+          repository: { name: 'MoonLadderStudios/MoonMind' },
+          branch: { name: 'main' },
+        },
+        omnigent: {
+          executionTargetRef: 'execution-profile:codex-default',
+          launchPolicyRef: 'launch-policy:remediation-v3',
+        },
+        rag: { collections: ['docs'], required: true },
+        workflow: {
+          remediation: {
+            checkpointBranchPolicy: {
+              gitWorkBranch: 'repair/mm-3623',
+            },
+          },
+        },
+      },
+    });
+
+    expect(draft.branch).toBe('main');
+    expect(draft.startingBranch).toBe('main');
+    expect(draft.workBranch).toBe('repair/mm-3623');
+    expect(draft.executionProfileRef).toBe('execution-profile:codex-default');
+    expect(draft.launchPolicyRef).toBe('launch-policy:remediation-v3');
+    expect(draft.contextRetrieval).toMatchObject({
+      initial: { collections: ['docs'], required: true },
+    });
+    expect(draft.remediation.checkpointBranchPolicy).toMatchObject({
+      gitWorkBranch: 'repair/mm-3623',
+    });
+  });
+
+  it('distinguishes missing, malformed, expired, and cross-tab draft failures', () => {
+    expect(inspectRemediationCreateDraft('missing')).toEqual({
+      status: 'missing',
+      draft: null,
+    });
+
+    window.sessionStorage.setItem(
+      'moonmind.remediation-create-draft.malformed',
+      JSON.stringify({ source: 'remediation', schemaVersion: 1 }),
+    );
+    expect(inspectRemediationCreateDraft('malformed').status).toBe('malformed');
+
+    const draft = buildRemediationCreateDraft({
+      workflowId: 'mm:target',
+      runId: 'run-target',
+    });
+    window.sessionStorage.setItem(
+      'moonmind.remediation-create-draft.malformed-selectors',
+      JSON.stringify({
+        ...draft,
+        remediation: {
+          ...draft.remediation,
+          target: {
+            ...draft.remediation.target,
+            stepSelectors: 'tampered',
+          },
+        },
+      }),
+    );
+    expect(
+      inspectRemediationCreateDraft('malformed-selectors').status,
+    ).toBe('malformed');
+    window.sessionStorage.setItem(
+      'moonmind.remediation-create-draft.expired',
+      JSON.stringify({
+        ...draft,
+        createdAt: new Date(
+          Date.now() - REMEDIATION_CREATE_DRAFT_TTL_MS - 1,
+        ).toISOString(),
+      }),
+    );
+    expect(inspectRemediationCreateDraft('expired').status).toBe('expired');
+    expect(
+      window.sessionStorage.getItem('moonmind.remediation-create-draft.expired'),
+    ).toBeNull();
+
+    const draftId = storeRemediationCreateDraft(draft);
+    window.sessionStorage.removeItem(
+      `moonmind.remediation-create-draft.${draftId}`,
+    );
+    expect(inspectRemediationCreateDraft(draftId).status).toBe('cross_tab');
+    clearRemediationCreateDraft(draftId);
+    expect(inspectRemediationCreateDraft(draftId).status).toBe('missing');
   });
 
   it('recovers the immutable selection from execution input parameters', () => {

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -1,4 +1,8 @@
 import {
+  type ContextRetrievalAuthoring,
+  parseContextRetrievalParameters,
+} from './contextRetrievalAuthoring';
+import {
   buildRemediationRuntimeRequestFields,
   DEFAULT_REMEDIATION_ACTION_POLICY,
   DEFAULT_REMEDIATION_AUTHORITY,
@@ -6,10 +10,21 @@ import {
 } from './workflowActions';
 
 const DRAFT_STORAGE_PREFIX = 'moonmind.remediation-create-draft.';
+const DRAFT_PRESENCE_PREFIX = 'moonmind.remediation-create-draft-presence.';
 const DEFAULT_REMEDIATION_REPOSITORY = 'MoonLadderStudios/MoonMind';
+export const REMEDIATION_CREATE_DRAFT_TTL_MS = 2 * 60 * 60 * 1000;
+
+export type RemediationCreateDraftReadResult =
+  | { status: 'valid'; draft: RemediationCreateDraft }
+  | {
+      status: 'missing' | 'cross_tab' | 'malformed' | 'expired';
+      draft: null;
+    };
 
 export type RemediationCreateDraft = {
   source: 'remediation';
+  schemaVersion: 1;
+  createdAt: string;
   target: {
     workflowId: string;
     runId: string;
@@ -19,8 +34,16 @@ export type RemediationCreateDraft = {
     agentRunIds?: string[];
   };
   repository: string;
+  /** Source branch used to create the remediation workflow workspace. */
   branch?: string;
+  /** Explicit alias shown in the remediation authoring summary. */
+  startingBranch?: string;
+  /** Isolated Checkpoint Branch work branch, distinct from the source branch. */
+  workBranch?: string;
   publishMode?: string;
+  executionProfileRef?: string;
+  launchPolicyRef?: string;
+  contextRetrieval?: ContextRetrievalAuthoring;
   runtime?: {
     mode?: string;
     model?: string;
@@ -90,6 +113,12 @@ function cleanText(value: unknown): string {
   return String(value ?? '').trim();
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
 function remediationMode(value: unknown): RemediationCreateDraft['remediation']['mode'] {
   const normalized = cleanText(value);
   if (
@@ -118,6 +147,10 @@ function remediationAuthorityMode(
 
 function storageKey(draftId: string): string {
   return `${DRAFT_STORAGE_PREFIX}${draftId}`;
+}
+
+function presenceKey(draftId: string): string {
+  return `${DRAFT_PRESENCE_PREFIX}${draftId}`;
 }
 
 function randomDraftId(): string {
@@ -224,8 +257,43 @@ export function buildRemediationCreateDraft(
   const selectedAgentProfileVersion = Number(
     execution.agentProfile?.version || storedAgentProfile.version || storedSnapshot.version || 0,
   );
+  const inputParameters = asRecord(execution.inputParameters);
+  const workflowParameters = asRecord(
+    inputParameters.workflow || inputParameters.task,
+  );
+  const repositoryParameters = asRecord(inputParameters.repository);
+  const repositoryBranch = asRecord(repositoryParameters.branch);
+  const gitParameters = asRecord(workflowParameters.git || inputParameters.git);
+  const omnigentParameters = asRecord(inputParameters.omnigent);
+  const remediationParameters = asRecord(workflowParameters.remediation);
+  const checkpointBranchPolicy = asRecord(
+    remediationParameters.checkpointBranchPolicy,
+  );
+  const startingBranch = cleanText(
+    gitParameters.startingBranch ||
+      workflowParameters.startingBranch ||
+      repositoryBranch.name ||
+      inputParameters.startingBranch ||
+      gitParameters.branch ||
+      workflowParameters.branch ||
+      inputParameters.branch,
+  );
+  const workBranch = cleanText(
+    checkpointBranchPolicy.gitWorkBranch ||
+      gitParameters.workBranch ||
+      inputParameters.gitWorkBranch,
+  );
+  const executionProfileRef = cleanText(
+    omnigentParameters.executionTargetRef || runtime.executionProfileRef,
+  );
+  const launchPolicyRef = cleanText(
+    omnigentParameters.launchPolicyRef || storedSnapshot.launchPolicyRef,
+  );
+  const contextRetrieval = parseContextRetrievalParameters(inputParameters);
   return {
     source: 'remediation',
+    schemaVersion: 1,
+    createdAt: new Date().toISOString(),
     target: {
       workflowId,
       runId,
@@ -234,7 +302,12 @@ export function buildRemediationCreateDraft(
       ...(stepSelectors.length > 0 ? { stepSelectors } : {}),
     },
     repository: cleanText(execution.repository) || DEFAULT_REMEDIATION_REPOSITORY,
+    ...(startingBranch ? { branch: startingBranch, startingBranch } : {}),
+    ...(workBranch ? { workBranch } : {}),
     publishMode: 'pr',
+    ...(executionProfileRef ? { executionProfileRef } : {}),
+    ...(launchPolicyRef ? { launchPolicyRef } : {}),
+    ...(contextRetrieval ? { contextRetrieval } : {}),
     runtime: {
       ...(cleanText(runtime.mode) ? { mode: cleanText(runtime.mode) } : {}),
       ...(cleanText(runtime.model) ? { model: cleanText(runtime.model) } : {}),
@@ -282,6 +355,7 @@ export function buildRemediationCreateDraft(
         actionKind: 'checkpoint_branch.create_from_remediation_context',
         runtimeContextPolicy: 'fresh_agent_run',
         workspacePolicy: 'apply_previous_execution_diff_to_clean_baseline',
+        ...(workBranch ? { gitWorkBranch: workBranch } : {}),
       },
       trigger: { type: 'manual' },
     },
@@ -290,27 +364,180 @@ export function buildRemediationCreateDraft(
 
 export function storeRemediationCreateDraft(draft: RemediationCreateDraft): string {
   const draftId = randomDraftId();
-  window.sessionStorage.setItem(storageKey(draftId), JSON.stringify(draft));
+  const storedDraft = {
+    ...draft,
+    schemaVersion: 1 as const,
+    createdAt: draft.createdAt || new Date().toISOString(),
+  };
+  window.sessionStorage.setItem(storageKey(draftId), JSON.stringify(storedDraft));
+  // Session storage intentionally keeps the draft body tab-scoped. This
+  // non-sensitive local marker lets a copied URL report the cross-tab failure
+  // precisely without exposing target identity or authored repair content.
+  window.localStorage.setItem(
+    presenceKey(draftId),
+    JSON.stringify({ createdAt: storedDraft.createdAt }),
+  );
   return draftId;
 }
 
-export function readRemediationCreateDraft(draftId: string | null | undefined): RemediationCreateDraft | null {
-  const normalized = cleanText(draftId);
-  if (!normalized) return null;
-  const raw = window.sessionStorage.getItem(storageKey(normalized));
-  if (!raw) return null;
+function isNonEmptyText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function optionalRecordIsValid(value: unknown): boolean {
+  return value === undefined || isRecordValue(value);
+}
+
+function optionalTextIsValid(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function stepSelectorsAreValid(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value) || value.length > 25) return false;
+  return value.every((item) => {
+    if (!isRecordValue(item)) return false;
+    const logicalStepId = cleanText(item.logicalStepId || item.stepId);
+    const checkpointRef = cleanText(item.checkpointRef || item.checkpoint_ref);
+    const agentRunId = cleanText(item.agentRunId || item.agent_run_id);
+    return Boolean(logicalStepId || checkpointRef || agentRunId || cleanText(item.source));
+  });
+}
+
+function agentRunIdsAreValid(value: unknown): boolean {
+  return value === undefined || (
+    Array.isArray(value) &&
+    value.length <= 25 &&
+    value.every(isNonEmptyText)
+  );
+}
+
+function createdAtMillis(value: unknown): number | null {
+  if (!isNonEmptyText(value)) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function draftIsStructurallyValid(value: unknown): value is RemediationCreateDraft {
+  const draft = asRecord(value);
+  const target = asRecord(draft.target);
+  const remediation = asRecord(draft.remediation);
+  const remediationTarget = asRecord(remediation.target);
+  const trigger = asRecord(remediation.trigger);
+  const agentProfile = asRecord(draft.agentProfile);
+  return (
+    draft.source === 'remediation' &&
+    draft.schemaVersion === 1 &&
+    createdAtMillis(draft.createdAt) !== null &&
+    isNonEmptyText(target.workflowId) &&
+    isNonEmptyText(target.runId) &&
+    isNonEmptyText(draft.repository) &&
+    remediationTarget.workflowId === target.workflowId &&
+    remediationTarget.runId === target.runId &&
+    stepSelectorsAreValid(target.stepSelectors) &&
+    stepSelectorsAreValid(remediationTarget.stepSelectors) &&
+    agentRunIdsAreValid(target.agentRunIds) &&
+    agentRunIdsAreValid(remediationTarget.agentRunIds) &&
+    optionalTextIsValid(draft.branch) &&
+    optionalTextIsValid(draft.startingBranch) &&
+    optionalTextIsValid(draft.workBranch) &&
+    optionalTextIsValid(draft.publishMode) &&
+    optionalTextIsValid(draft.executionProfileRef) &&
+    optionalTextIsValid(draft.launchPolicyRef) &&
+    optionalRecordIsValid(draft.runtime) &&
+    optionalRecordIsValid(draft.agentProfile) &&
+    (
+      draft.agentProfile === undefined ||
+      (isNonEmptyText(agentProfile.profileId) &&
+        isNonEmptyText(agentProfile.providerProfileRef))
+    ) &&
+    optionalRecordIsValid(draft.contextRetrieval) &&
+    optionalRecordIsValid(remediation.evidencePolicy) &&
+    optionalRecordIsValid(remediation.approvalPolicy) &&
+    optionalRecordIsValid(remediation.lockPolicy) &&
+    optionalRecordIsValid(remediation.verificationPolicy) &&
+    optionalRecordIsValid(remediation.checkpointBranchPolicy) &&
+    ['snapshot', 'live_follow', 'snapshot_then_follow'].includes(
+      cleanText(remediation.mode),
+    ) &&
+    ['observe_only', 'approval_gated', 'admin_auto'].includes(
+      cleanText(remediation.authorityMode),
+    ) &&
+    trigger.type === 'manual'
+  );
+}
+
+function inspectPresenceMarker(
+  draftId: string,
+  now: number,
+): 'cross_tab' | 'expired' | 'missing' {
+  const raw = window.localStorage.getItem(presenceKey(draftId));
+  if (!raw) return 'missing';
   try {
-    const parsed = JSON.parse(raw) as RemediationCreateDraft;
-    return parsed?.source === 'remediation' ? parsed : null;
+    const createdAt = createdAtMillis(asRecord(JSON.parse(raw)).createdAt);
+    if (createdAt === null) {
+      window.localStorage.removeItem(presenceKey(draftId));
+      return 'missing';
+    }
+    if (now - createdAt > REMEDIATION_CREATE_DRAFT_TTL_MS) {
+      window.localStorage.removeItem(presenceKey(draftId));
+      return 'expired';
+    }
+    return 'cross_tab';
   } catch {
-    return null;
+    window.localStorage.removeItem(presenceKey(draftId));
+    return 'missing';
   }
+}
+
+export function inspectRemediationCreateDraft(
+  draftId: string | null | undefined,
+  now = Date.now(),
+): RemediationCreateDraftReadResult {
+  const normalized = cleanText(draftId);
+  if (!normalized) return { status: 'missing', draft: null };
+  const raw = window.sessionStorage.getItem(storageKey(normalized));
+  if (!raw) {
+    return { status: inspectPresenceMarker(normalized, now), draft: null };
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!draftIsStructurallyValid(parsed)) {
+      return { status: 'malformed', draft: null };
+    }
+    const createdAt = createdAtMillis(parsed.createdAt);
+    if (
+      createdAt === null ||
+      createdAt > now + 5 * 60 * 1000
+    ) {
+      return { status: 'malformed', draft: null };
+    }
+    if (now - createdAt > REMEDIATION_CREATE_DRAFT_TTL_MS) {
+      clearRemediationCreateDraft(normalized);
+      return { status: 'expired', draft: null };
+    }
+    return { status: 'valid', draft: parsed };
+  } catch {
+    return { status: 'malformed', draft: null };
+  }
+}
+
+export function readRemediationCreateDraft(
+  draftId: string | null | undefined,
+): RemediationCreateDraft | null {
+  const result = inspectRemediationCreateDraft(draftId);
+  return result.status === 'valid' ? result.draft : null;
 }
 
 export function clearRemediationCreateDraft(draftId: string | null | undefined): void {
   const normalized = cleanText(draftId);
   if (normalized) {
     window.sessionStorage.removeItem(storageKey(normalized));
+    window.localStorage.removeItem(presenceKey(normalized));
   }
 }
 

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -12,6 +12,7 @@ import {
 const DRAFT_STORAGE_PREFIX = 'moonmind.remediation-create-draft.';
 const DRAFT_PRESENCE_PREFIX = 'moonmind.remediation-create-draft-presence.';
 const DEFAULT_REMEDIATION_REPOSITORY = 'MoonLadderStudios/MoonMind';
+const MAX_REMEDIATION_STEP_SELECTORS = 25;
 export const REMEDIATION_CREATE_DRAFT_TTL_MS = 2 * 60 * 60 * 1000;
 
 export type RemediationCreateDraftReadResult =
@@ -195,12 +196,14 @@ function checkpointSelectors(execution: RemediationDraftExecution): Array<Record
   if (directCheckpoint) selectors.push({ source: 'execution', checkpointRef: directCheckpoint });
 
   const seen = new Set<string>();
-  return selectors.filter((selector) => {
-    const key = cleanText(selector.checkpointRef);
-    if (!key || seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  return selectors
+    .filter((selector) => {
+      const key = cleanText(selector.checkpointRef);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, MAX_REMEDIATION_STEP_SELECTORS);
 }
 
 export function buildRemediationCreateDraft(
@@ -398,7 +401,7 @@ function optionalTextIsValid(value: unknown): boolean {
 
 function stepSelectorsAreValid(value: unknown): boolean {
   if (value === undefined) return true;
-  if (!Array.isArray(value) || value.length > 25) return false;
+  if (!Array.isArray(value) || value.length > MAX_REMEDIATION_STEP_SELECTORS) return false;
   return value.every((item) => {
     if (!isRecordValue(item)) return false;
     const logicalStepId = cleanText(item.logicalStepId || item.stepId);
@@ -448,6 +451,10 @@ function draftIsStructurallyValid(value: unknown): value is RemediationCreateDra
     optionalTextIsValid(draft.publishMode) &&
     optionalTextIsValid(draft.executionProfileRef) &&
     optionalTextIsValid(draft.launchPolicyRef) &&
+    (
+      remediation.actionPolicyRef === undefined ||
+      remediation.actionPolicyRef === DEFAULT_REMEDIATION_ACTION_POLICY
+    ) &&
     optionalRecordIsValid(draft.runtime) &&
     optionalRecordIsValid(draft.agentProfile) &&
     (

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -4323,6 +4323,21 @@ form {
   border: 0;
 }
 
+.queue-remediation-pinned-target,
+.queue-remediation-repair-intent {
+  min-inline-size: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.queue-remediation-pinned-target > legend,
+.queue-remediation-repair-intent > legend {
+  padding: 0;
+  font-weight: 700;
+  color: rgb(var(--mm-ink));
+}
+
 label {
   font-weight: 600;
   font-size: 0.9rem;
@@ -8816,6 +8831,32 @@ button.workflow-workspace-sidebar-row:active {
   display: grid;
   gap: 0.6rem;
   margin-top: 0.65rem;
+}
+
+.td-remediation-approval-controls,
+.td-remediation-operator-controls,
+.td-remediation-lifecycle {
+  margin-top: 0.65rem;
+  padding: 0.7rem;
+  border: 1px solid rgb(var(--mm-border) / 0.68);
+  border-radius: 0.7rem;
+  background: rgb(var(--mm-panel) / 0.38);
+}
+
+.td-remediation-approval-controls textarea {
+  width: 100%;
+  min-width: 0;
+}
+
+.td-remediation-canonical pre {
+  max-height: 24rem;
+  margin: 0.55rem 0 0;
+  padding: 0.65rem;
+  overflow: auto;
+  border-radius: 0.55rem;
+  background: rgb(var(--mm-panel) / 0.86);
+  color: rgb(var(--mm-ink));
+  white-space: pre-wrap;
 }
 
 .td-remediation-create-preview {

--- a/moonmind/workflows/temporal/remediation_actions.py
+++ b/moonmind/workflows/temporal/remediation_actions.py
@@ -1049,6 +1049,15 @@ class RemediationActionAuthorityService:
         parameter_digest = remediation_parameter_digest(
             safe_parameters if isinstance(safe_parameters, Mapping) else {}
         )
+        action_contract = _ACTION_CATALOG.get(result.action_kind, {})
+        action_preconditions = action_contract.get("preconditions")
+        preconditions = (
+            ", ".join(str(item) for item in action_preconditions)
+            if isinstance(action_preconditions, Sequence)
+            and not isinstance(action_preconditions, str | bytes)
+            else None
+        )
+        target_type = str(action_contract.get("target_type") or "resource")
         approval_state = (
             dict(existing)
             if existing is not None
@@ -1065,6 +1074,11 @@ class RemediationActionAuthorityService:
                 "riskTier": result.risk,
                 "redactedParameters": safe_parameters,
                 "expectedTargetState": target_state,
+                "preconditions": preconditions,
+                "blastRadius": (
+                    f"One {target_type} bound to pinned target run "
+                    f"{link.target_run_id}."
+                ),
                 "checkpointRef": _authority_parameter(parameters, "checkpointRef"),
                 "stepExecutionId": (
                     getattr(bridge, "step_execution_id", None)

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -18,7 +18,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import ValidationError
-from sqlalchemy import Select, case, func, select
+from sqlalchemy import Select, case, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -259,6 +259,9 @@ ALLOWED_REMEDIATION_MODES = frozenset(
     {"snapshot", "live_follow", "snapshot_then_follow"}
 )
 MAX_REMEDIATION_STEP_SELECTORS = 25
+MAX_REMEDIATION_CHECKPOINT_BRANCH_LINKS = 10
+MAX_REMEDIATION_CHECKPOINT_BRANCH_TURNS = 25
+MAX_REMEDIATION_CHECKPOINT_BRANCH_ARTIFACTS = 500
 
 
 def _first_nonempty_text(*values: Any) -> str | None:
@@ -908,6 +911,28 @@ class TemporalExecutionService:
                     raise TemporalExecutionValidationError(
                         "workflow.remediation.target.stepSelectors checkpointDigest must match the target checkpoint."
                     )
+                supplied_identity = {
+                    key: value
+                    for key, value in {
+                        "logical_step_id": logical_step_id,
+                        "step_execution_id": step_execution_id,
+                        "checkpoint_ref": checkpoint_ref,
+                        "checkpoint_digest": checkpoint_digest,
+                        "agent_run_id": agent_run_id,
+                        "attempt": attempt,
+                    }.items()
+                    if value not in {None, ""}
+                }
+                if not any(
+                    all(
+                        candidate.get(key) == value
+                        for key, value in supplied_identity.items()
+                    )
+                    for candidate in selector_identity["canonical_tuples"]
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors fields must identify one target Step Execution/checkpoint."
+                    )
 
         evidence_policy = remediation.get("evidencePolicy")
         self._validate_remediation_evidence_policy(evidence_policy)
@@ -1055,6 +1080,7 @@ class TemporalExecutionService:
             "checkpoint_refs": set(),
             "checkpoint_digests": {},
             "agent_run_ids": set(),
+            "canonical_tuples": [],
         }
         for payload in (
             getattr(record, "parameters", None),
@@ -1074,9 +1100,13 @@ class TemporalExecutionService:
 
     @classmethod
     def _collect_target_step_selector_identity(
-        cls, value: Any, output: dict[str, Any]
+        cls,
+        value: Any,
+        output: dict[str, Any],
+        inherited: Mapping[str, Any] | None = None,
     ) -> None:
         if isinstance(value, Mapping):
+            canonical = dict(inherited or {})
             logical_step_id = str(
                 value.get("logicalStepId")
                 or value.get("logical_step_id")
@@ -1086,6 +1116,7 @@ class TemporalExecutionService:
             ).strip()
             if logical_step_id:
                 output["logical_step_ids"].add(logical_step_id)
+                canonical["logical_step_id"] = logical_step_id
 
             step_execution_id = str(
                 value.get("stepExecutionId")
@@ -1094,6 +1125,7 @@ class TemporalExecutionService:
             ).strip()
             if step_execution_id:
                 output["step_execution_ids"].add(step_execution_id)
+                canonical["step_execution_id"] = step_execution_id
 
             attempt = value.get("attempt")
             if (
@@ -1105,12 +1137,14 @@ class TemporalExecutionService:
                 output["attempts_by_logical_step"].setdefault(
                     logical_step_id, set()
                 ).add(attempt)
+                canonical["attempt"] = attempt
 
             checkpoint_digest = str(
                 value.get("checkpointDigest")
                 or value.get("checkpoint_digest")
                 or ""
             ).strip()
+            checkpoint_refs: list[str] = []
             for key in (
                 "checkpointRef",
                 "checkpoint_ref",
@@ -1123,6 +1157,7 @@ class TemporalExecutionService:
                 if not checkpoint_ref:
                     continue
                 output["checkpoint_refs"].add(checkpoint_ref)
+                checkpoint_refs.append(checkpoint_ref)
                 if checkpoint_digest:
                     output["checkpoint_digests"].setdefault(
                         checkpoint_ref, set()
@@ -1133,18 +1168,36 @@ class TemporalExecutionService:
                     checkpoint_ref = str(item or "").strip()
                     if checkpoint_ref:
                         output["checkpoint_refs"].add(checkpoint_ref)
+                        checkpoint_refs.append(checkpoint_ref)
 
             agent_run_id = str(
                 value.get("agentRunId") or value.get("agent_run_id") or ""
             ).strip()
             if agent_run_id:
                 output["agent_run_ids"].add(agent_run_id)
+                canonical["agent_run_id"] = agent_run_id
+            if checkpoint_digest:
+                canonical["checkpoint_digest"] = checkpoint_digest
+            for checkpoint_ref in dict.fromkeys(checkpoint_refs):
+                output["canonical_tuples"].append(
+                    {**canonical, "checkpoint_ref": checkpoint_ref}
+                )
+            if canonical and not checkpoint_refs:
+                output["canonical_tuples"].append(dict(canonical))
+
+            child_identity = {
+                key: item
+                for key, item in canonical.items()
+                if key != "checkpoint_digest"
+            }
             for item in value.values():
-                cls._collect_target_step_selector_identity(item, output)
+                cls._collect_target_step_selector_identity(
+                    item, output, child_identity
+                )
             return
         if isinstance(value, list | tuple):
             for item in value:
-                cls._collect_target_step_selector_identity(item, output)
+                cls._collect_target_step_selector_identity(item, output, inherited)
 
     @classmethod
     def _collect_agent_run_ids(cls, value: Any, output: set[str]) -> None:
@@ -1198,9 +1251,7 @@ class TemporalExecutionService:
             TemporalExecutionRemediationLink.updated_at.desc(),
             TemporalExecutionRemediationLink.remediation_workflow_id.asc(),
         )
-        links = await self._scalars_all(stmt)
-        await self._attach_remediation_checkpoint_branch_links(links)
-        return links
+        return await self._scalars_all(stmt)
 
     async def list_remediations_for_target(
         self, target_workflow_id: str
@@ -1236,66 +1287,104 @@ class TemporalExecutionService:
         }
         if not remediation_ids or not target_ids:
             return
-        result = await self._session.execute(
-            select(WorkflowCheckpointBranchOperation).where(
+        operation_result = await self._session.execute(
+            select(WorkflowCheckpointBranchOperation)
+            .where(
                 WorkflowCheckpointBranchOperation.workflow_id.in_(target_ids),
                 WorkflowCheckpointBranchOperation.operation == "checkpoint_branch.create",
+                or_(
+                    WorkflowCheckpointBranchOperation.response_payload[
+                        "remediation"
+                    ]["workflowId"].as_string().in_(remediation_ids),
+                    WorkflowCheckpointBranchOperation.response_payload[
+                        "remediation"
+                    ]["remediationWorkflowId"].as_string().in_(remediation_ids),
+                ),
             )
+            .order_by(WorkflowCheckpointBranchOperation.created_at.desc())
+            .limit(MAX_REMEDIATION_CHECKPOINT_BRANCH_LINKS)
         )
+        operations = list(operation_result.scalars())
+        branch_ids = {
+            str(operation.branch_id)
+            for operation in operations
+            if operation.branch_id
+        }
+        if not branch_ids:
+            return
         branch_result = await self._session.execute(
             select(WorkflowCheckpointBranch).where(
-                WorkflowCheckpointBranch.workflow_id.in_(target_ids)
+                WorkflowCheckpointBranch.branch_id.in_(branch_ids)
             )
         )
         branches_by_id = {
             branch.branch_id: branch for branch in branch_result.scalars()
         }
-        branch_ids = set(branches_by_id)
         turns_by_id: dict[str, WorkflowCheckpointBranchTurn] = {}
         turns_by_branch: dict[str, list[WorkflowCheckpointBranchTurn]] = {}
         artifacts_by_branch: dict[str, dict[str, dict[str, str]]] = {}
         artifacts_by_turn: dict[str, dict[str, dict[str, str]]] = {}
         if branch_ids:
-            turn_result = await self._session.execute(
-                select(WorkflowCheckpointBranchTurn)
-                .where(WorkflowCheckpointBranchTurn.branch_id.in_(branch_ids))
-                .order_by(
-                    WorkflowCheckpointBranchTurn.created_at.asc(),
-                    WorkflowCheckpointBranchTurn.branch_turn_id.asc(),
+            for branch_id in sorted(branch_ids):
+                turn_result = await self._session.execute(
+                    select(WorkflowCheckpointBranchTurn)
+                    .where(WorkflowCheckpointBranchTurn.branch_id == branch_id)
+                    .order_by(
+                        WorkflowCheckpointBranchTurn.created_at.desc(),
+                        WorkflowCheckpointBranchTurn.branch_turn_id.desc(),
+                    )
+                    .limit(MAX_REMEDIATION_CHECKPOINT_BRANCH_TURNS)
                 )
-            )
-            for turn in turn_result.scalars():
-                turns_by_id[turn.branch_turn_id] = turn
-                turns_by_branch.setdefault(turn.branch_id, []).append(turn)
+                branch_turns = list(turn_result.scalars())
+                branch_turns.reverse()
+                for turn in branch_turns:
+                    turns_by_id[turn.branch_turn_id] = turn
+                    turns_by_branch.setdefault(turn.branch_id, []).append(turn)
+            selected_turn_ids = set(turns_by_id)
             artifact_result = await self._session.execute(
                 select(WorkflowCheckpointBranchArtifact)
-                .where(WorkflowCheckpointBranchArtifact.branch_id.in_(branch_ids))
-                .order_by(
-                    WorkflowCheckpointBranchArtifact.created_at.asc(),
-                    WorkflowCheckpointBranchArtifact.artifact_kind.asc(),
+                .where(
+                    WorkflowCheckpointBranchArtifact.branch_id.in_(branch_ids),
+                    or_(
+                        WorkflowCheckpointBranchArtifact.branch_turn_id.is_(None),
+                        WorkflowCheckpointBranchArtifact.branch_turn_id.in_(
+                            selected_turn_ids
+                        ),
+                    ),
                 )
+                .order_by(
+                    WorkflowCheckpointBranchArtifact.created_at.desc(),
+                    WorkflowCheckpointBranchArtifact.artifact_kind.desc(),
+                )
+                .limit(MAX_REMEDIATION_CHECKPOINT_BRANCH_ARTIFACTS)
             )
-            for artifact in artifact_result.scalars():
+            artifacts = list(artifact_result.scalars())
+            artifacts.reverse()
+            for artifact in artifacts:
                 artifact_kind = str(artifact.artifact_kind or "").strip()
                 artifact_ref = str(artifact.artifact_ref or "").strip()
                 if not artifact_kind or not artifact_ref:
                     continue
-                category = (
-                    "comparisonArtifacts"
-                    if "comparison" in artifact_kind
-                    else "outputArtifacts"
-                )
-                artifacts_by_branch.setdefault(artifact.branch_id, {}).setdefault(
-                    category, {}
-                )[artifact_kind] = artifact_ref
+                if artifact_kind.startswith(
+                    ("comparison.", "output.branch_comparison.")
+                ):
+                    category = "comparisonArtifacts"
+                elif artifact_kind.startswith("output."):
+                    category = "outputArtifacts"
+                else:
+                    continue
                 if artifact.branch_turn_id:
                     artifacts_by_turn.setdefault(
                         artifact.branch_turn_id, {}
                     ).setdefault(category, {})[artifact_kind] = artifact_ref
+                else:
+                    artifacts_by_branch.setdefault(
+                        artifact.branch_id, {}
+                    ).setdefault(category, {})[artifact_kind] = artifact_ref
         branch_links_by_remediation: dict[str, list[dict[str, Any]]] = {
             remediation_id: [] for remediation_id in remediation_ids
         }
-        for operation in result.scalars():
+        for operation in reversed(operations):
             payload = operation.response_payload
             if not isinstance(payload, Mapping):
                 continue

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1252,21 +1252,28 @@ class TemporalExecutionService:
         }
         branch_ids = set(branches_by_id)
         turns_by_id: dict[str, WorkflowCheckpointBranchTurn] = {}
+        turns_by_branch: dict[str, list[WorkflowCheckpointBranchTurn]] = {}
         artifacts_by_branch: dict[str, dict[str, dict[str, str]]] = {}
+        artifacts_by_turn: dict[str, dict[str, dict[str, str]]] = {}
         if branch_ids:
             turn_result = await self._session.execute(
-                select(WorkflowCheckpointBranchTurn).where(
-                    WorkflowCheckpointBranchTurn.branch_id.in_(branch_ids)
+                select(WorkflowCheckpointBranchTurn)
+                .where(WorkflowCheckpointBranchTurn.branch_id.in_(branch_ids))
+                .order_by(
+                    WorkflowCheckpointBranchTurn.created_at.asc(),
+                    WorkflowCheckpointBranchTurn.branch_turn_id.asc(),
                 )
             )
-            turns_by_id = {
-                turn.branch_turn_id: turn for turn in turn_result.scalars()
-            }
+            for turn in turn_result.scalars():
+                turns_by_id[turn.branch_turn_id] = turn
+                turns_by_branch.setdefault(turn.branch_id, []).append(turn)
             artifact_result = await self._session.execute(
                 select(WorkflowCheckpointBranchArtifact)
                 .where(WorkflowCheckpointBranchArtifact.branch_id.in_(branch_ids))
-                .order_by(WorkflowCheckpointBranchArtifact.created_at.desc())
-                .limit(250)
+                .order_by(
+                    WorkflowCheckpointBranchArtifact.created_at.asc(),
+                    WorkflowCheckpointBranchArtifact.artifact_kind.asc(),
+                )
             )
             for artifact in artifact_result.scalars():
                 artifact_kind = str(artifact.artifact_kind or "").strip()
@@ -1281,6 +1288,10 @@ class TemporalExecutionService:
                 artifacts_by_branch.setdefault(artifact.branch_id, {}).setdefault(
                     category, {}
                 )[artifact_kind] = artifact_ref
+                if artifact.branch_turn_id:
+                    artifacts_by_turn.setdefault(
+                        artifact.branch_turn_id, {}
+                    ).setdefault(category, {})[artifact_kind] = artifact_ref
         branch_links_by_remediation: dict[str, list[dict[str, Any]]] = {
             remediation_id: [] for remediation_id in remediation_ids
         }
@@ -1338,6 +1349,38 @@ class TemporalExecutionService:
                     }
                 )
                 branch_link.update(artifacts_by_branch.get(branch.branch_id, {}))
+                branch_link["turns"] = [
+                    {
+                        "branchTurnId": branch_turn.branch_turn_id,
+                        "parentTurnId": branch_turn.parent_turn_id,
+                        "status": branch_turn.status,
+                        "createdStepExecutionId": branch_turn.created_step_execution_id,
+                        "runtimeAgentRunId": branch_turn.runtime_agent_run_id,
+                        "providerSessionId": branch_turn.provider_session_id,
+                        "instructionRef": branch_turn.instruction_ref,
+                        "instructionDigest": branch_turn.instruction_digest,
+                        "sourceCheckpointRef": branch_turn.source_checkpoint_ref,
+                        "contextBundleRef": branch_turn.context_bundle_ref,
+                        "stepExecutionManifestRef": (
+                            branch_turn.step_execution_manifest_ref
+                        ),
+                        "gitWorkBranch": branch_turn.git_work_branch,
+                        "startedAt": (
+                            branch_turn.started_at.isoformat()
+                            if branch_turn.started_at
+                            else None
+                        ),
+                        "completedAt": (
+                            branch_turn.completed_at.isoformat()
+                            if branch_turn.completed_at
+                            else None
+                        ),
+                        "createdAt": branch_turn.created_at.isoformat(),
+                        "updatedAt": branch_turn.updated_at.isoformat(),
+                        **artifacts_by_turn.get(branch_turn.branch_turn_id, {}),
+                    }
+                    for branch_turn in turns_by_branch.get(branch.branch_id, [])
+                ]
             if turn is not None:
                 branch_link.update(
                     {

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -39,7 +39,9 @@ from api_service.db.models import (
     TemporalIntegrationCorrelationRecord,
     TemporalWorkflowType,
     WorkflowCheckpointBranch,
+    WorkflowCheckpointBranchArtifact,
     WorkflowCheckpointBranchOperation,
+    WorkflowCheckpointBranchTurn,
 )
 from moonmind.config.settings import settings
 from moonmind.security import scan_outbound_text
@@ -83,6 +85,7 @@ from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
 )
 from moonmind.workflows.executions.repository_contract import (
+    repository_branch_from_value,
     repository_name_from_value,
 )
 from moonmind.workflows.temporal.hard_switch_cutover import (
@@ -252,6 +255,10 @@ def _workflow_start_task_queue(parameters: Mapping[str, Any]) -> str | None:
 ALLOWED_REMEDIATION_AUTHORITY_MODES = frozenset(
     {"observe_only", "approval_gated", "admin_auto"}
 )
+ALLOWED_REMEDIATION_MODES = frozenset(
+    {"snapshot", "live_follow", "snapshot_then_follow"}
+)
+MAX_REMEDIATION_STEP_SELECTORS = 25
 
 
 def _first_nonempty_text(*values: Any) -> str | None:
@@ -651,6 +658,7 @@ class TemporalExecutionService:
         new_run_id: str,
         owner_id: str | None,
         owner_type: TemporalExecutionOwnerType,
+        submission_parameters: Mapping[str, Any],
     ) -> TemporalExecutionRemediationLink:
         target = remediation.get("target")
         if not isinstance(target, Mapping):
@@ -688,6 +696,40 @@ class TemporalExecutionService:
             raise TemporalExecutionValidationError(
                 "Unsupported workflow.remediation.authorityMode "
                 f"'{authority_mode}'. Supported values: {supported}."
+            )
+
+        remediation_mode = str(
+            remediation.get("mode") or "snapshot_then_follow"
+        ).strip() or "snapshot_then_follow"
+        if remediation_mode not in ALLOWED_REMEDIATION_MODES:
+            supported = ", ".join(sorted(ALLOWED_REMEDIATION_MODES))
+            raise TemporalExecutionValidationError(
+                "Unsupported workflow.remediation.mode "
+                f"'{remediation_mode}'. Supported values: {supported}."
+            )
+
+        authored_branch = repository_branch_from_value(
+            submission_parameters.get("repository")
+        )
+        if authored_branch:
+            self._validate_remediation_git_branch(
+                authored_branch,
+                path="repository.branch.name",
+                allow_protected=True,
+            )
+        task_payload = _workflow_payload(submission_parameters)
+        publish_payload = task_payload.get("publish")
+        publish_payload = (
+            publish_payload if isinstance(publish_payload, Mapping) else {}
+        )
+        publish_mode = str(
+            publish_payload.get("mode")
+            or submission_parameters.get("publishMode")
+            or ""
+        ).strip()
+        if publish_mode and publish_mode not in {"auto", "none", "branch", "pr"}:
+            raise TemporalExecutionValidationError(
+                "workflow.publish.mode is unsupported for remediation."
             )
 
         target_record = await self._session.get(
@@ -747,13 +789,17 @@ class TemporalExecutionService:
                 raise TemporalExecutionValidationError(
                     "workflow.remediation.target.agentRunIds must be a list of strings."
                 )
+            if len(agent_run_ids) > MAX_REMEDIATION_STEP_SELECTORS:
+                raise TemporalExecutionValidationError(
+                    "workflow.remediation.target.agentRunIds must contain at most "
+                    f"{MAX_REMEDIATION_STEP_SELECTORS} items."
+                )
             allowed_agent_run_ids = self._target_agent_run_ids(target_record)
-            if allowed_agent_run_ids:
-                requested_agent_run_ids = {str(item).strip() for item in agent_run_ids}
-                if not requested_agent_run_ids.issubset(allowed_agent_run_ids):
-                    raise TemporalExecutionValidationError(
-                        "workflow.remediation.target.agentRunIds must belong to the target execution."
-                    )
+            requested_agent_run_ids = {str(item).strip() for item in agent_run_ids}
+            if not requested_agent_run_ids.issubset(allowed_agent_run_ids):
+                raise TemporalExecutionValidationError(
+                    "workflow.remediation.target.agentRunIds must belong to the target execution."
+                )
         step_selectors = (
             target.get("stepSelectors")
             if "stepSelectors" in target
@@ -766,13 +812,101 @@ class TemporalExecutionService:
                 raise TemporalExecutionValidationError(
                     "workflow.remediation.target.stepSelectors must be a list of objects."
                 )
+            if len(step_selectors) > MAX_REMEDIATION_STEP_SELECTORS:
+                raise TemporalExecutionValidationError(
+                    "workflow.remediation.target.stepSelectors must contain at most "
+                    f"{MAX_REMEDIATION_STEP_SELECTORS} items."
+                )
+            selector_identity = self._target_step_selector_identity(target_record)
             for item in step_selectors:
+                logical_step_id = str(
+                    item.get("logicalStepId")
+                    or item.get("logical_step_id")
+                    or item.get("stepId")
+                    or item.get("step_id")
+                    or ""
+                ).strip()
                 checkpoint_ref = str(
                     item.get("checkpointRef") or item.get("checkpoint_ref") or ""
                 ).strip()
+                agent_run_id = str(
+                    item.get("agentRunId") or item.get("agent_run_id") or ""
+                ).strip()
+                step_execution_id = str(
+                    item.get("stepExecutionId")
+                    or item.get("step_execution_id")
+                    or ""
+                ).strip()
+                if (
+                    not logical_step_id
+                    and not checkpoint_ref
+                    and not agent_run_id
+                    and not step_execution_id
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors entries must identify a step, Step Execution, checkpoint, or Agent Run."
+                    )
                 if checkpoint_ref and not checkpoint_ref.startswith("artifact://"):
                     raise TemporalExecutionValidationError(
                         "workflow.remediation.target.stepSelectors checkpointRef must be an artifact ref."
+                    )
+                if (
+                    logical_step_id
+                    and logical_step_id not in selector_identity["logical_step_ids"]
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors logicalStepId must belong to the target execution."
+                    )
+                if (
+                    checkpoint_ref
+                    and checkpoint_ref not in selector_identity["checkpoint_refs"]
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors checkpointRef must belong to the target execution."
+                    )
+                if (
+                    agent_run_id
+                    and agent_run_id not in selector_identity["agent_run_ids"]
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors agentRunId must belong to the target execution."
+                    )
+                if (
+                    step_execution_id
+                    and step_execution_id
+                    not in selector_identity["step_execution_ids"]
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors stepExecutionId must belong to the target execution."
+                    )
+                attempt = item.get("attempt")
+                if attempt is not None and (
+                    isinstance(attempt, bool)
+                    or not isinstance(attempt, int)
+                    or attempt < 1
+                ):
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors attempt must be a positive integer."
+                    )
+                if attempt is not None:
+                    known_attempts = selector_identity[
+                        "attempts_by_logical_step"
+                    ].get(logical_step_id, set())
+                    if not logical_step_id or attempt not in known_attempts:
+                        raise TemporalExecutionValidationError(
+                            "workflow.remediation.target.stepSelectors attempt must match the target Step Execution."
+                        )
+                checkpoint_digest = str(
+                    item.get("checkpointDigest")
+                    or item.get("checkpoint_digest")
+                    or ""
+                ).strip()
+                known_digests = selector_identity["checkpoint_digests"].get(
+                    checkpoint_ref, set()
+                )
+                if checkpoint_digest and checkpoint_digest not in known_digests:
+                    raise TemporalExecutionValidationError(
+                        "workflow.remediation.target.stepSelectors checkpointDigest must match the target checkpoint."
                     )
 
         evidence_policy = remediation.get("evidencePolicy")
@@ -814,11 +948,37 @@ class TemporalExecutionService:
                 raise TemporalExecutionValidationError(
                     "workflow.remediation.checkpointBranchPolicy.runtimeContextPolicy must be fresh_agent_run."
                 )
+            workspace_policy = str(
+                checkpoint_branch_policy.get("workspacePolicy") or ""
+            ).strip()
+            if workspace_policy and workspace_policy not in {
+                "continue_from_previous_execution",
+                "restore_pre_execution",
+                "apply_previous_execution_diff_to_clean_baseline",
+                "start_from_last_passed_commit",
+                "fresh_branch_from_source",
+            }:
+                raise TemporalExecutionValidationError(
+                    "workflow.remediation.checkpointBranchPolicy.workspacePolicy is unsupported."
+                )
+            work_branch = str(
+                checkpoint_branch_policy.get("gitWorkBranch") or ""
+            ).strip()
+            if work_branch:
+                self._validate_remediation_git_branch(
+                    work_branch,
+                    path="workflow.remediation.checkpointBranchPolicy.gitWorkBranch",
+                    allow_protected=False,
+                )
 
         trigger = remediation.get("trigger")
         trigger_type = None
         if isinstance(trigger, Mapping):
             trigger_type = str(trigger.get("type") or "").strip() or None
+        elif trigger is not None:
+            raise TemporalExecutionValidationError(
+                "workflow.remediation.trigger must be an object."
+            )
         action_policy_ref = str(remediation.get("actionPolicyRef") or "").strip()
         if (
             action_policy_ref
@@ -835,8 +995,7 @@ class TemporalExecutionService:
             remediation_run_id=new_run_id,
             target_workflow_id=target_record.workflow_id,
             target_run_id=target_record.run_id,
-            mode=str(remediation.get("mode") or "snapshot_then_follow").strip()
-            or "snapshot_then_follow",
+            mode=remediation_mode,
             authority_mode=authority_mode,
             status="created",
             trigger_type=trigger_type,
@@ -854,6 +1013,138 @@ class TemporalExecutionService:
         ):
             cls._collect_agent_run_ids(payload, output)
         return output
+
+    @staticmethod
+    def _validate_remediation_git_branch(
+        value: str, *, path: str, allow_protected: bool
+    ) -> None:
+        parts = value.split("/")
+        invalid = (
+            len(value) > 255
+            or value != value.strip()
+            or value.startswith(("/", "-", "refs/"))
+            or value.endswith(("/", ".", ".lock"))
+            or "//" in value
+            or ".." in value
+            or "@{" in value
+            or any(character in value for character in " ~^:?*[\\")
+            or any(ord(character) < 32 or ord(character) == 127 for character in value)
+            or any(part.startswith(".") or part.endswith(".lock") for part in parts)
+        )
+        protected = value.lower() in {"main", "master", "head"}
+        if invalid or (protected and not allow_protected):
+            raise TemporalExecutionValidationError(
+                f"{path} is not an allowed git branch."
+            )
+
+    @classmethod
+    def _target_step_selector_identity(
+        cls, record: TemporalExecutionCanonicalRecord
+    ) -> dict[str, Any]:
+        """Collect target-owned selector identity from canonical persisted state.
+
+        Remediation authoring may copy selectors from several bounded target
+        projections, but create admission must never trust those posted values.
+        The canonical record remains the source of truth for exact membership.
+        """
+
+        output: dict[str, Any] = {
+            "logical_step_ids": set(),
+            "step_execution_ids": set(),
+            "attempts_by_logical_step": {},
+            "checkpoint_refs": set(),
+            "checkpoint_digests": {},
+            "agent_run_ids": set(),
+        }
+        for payload in (
+            getattr(record, "parameters", None),
+            getattr(record, "memo", None),
+            getattr(record, "search_attributes", None),
+            getattr(record, "finish_summary_json", None),
+            getattr(record, "integration_state", None),
+        ):
+            cls._collect_target_step_selector_identity(payload, output)
+        cls._collect_agent_run_ids(
+            {
+                "artifactRefs": getattr(record, "artifact_refs", None),
+            },
+            output["agent_run_ids"],
+        )
+        return output
+
+    @classmethod
+    def _collect_target_step_selector_identity(
+        cls, value: Any, output: dict[str, Any]
+    ) -> None:
+        if isinstance(value, Mapping):
+            logical_step_id = str(
+                value.get("logicalStepId")
+                or value.get("logical_step_id")
+                or value.get("stepId")
+                or value.get("step_id")
+                or ""
+            ).strip()
+            if logical_step_id:
+                output["logical_step_ids"].add(logical_step_id)
+
+            step_execution_id = str(
+                value.get("stepExecutionId")
+                or value.get("step_execution_id")
+                or ""
+            ).strip()
+            if step_execution_id:
+                output["step_execution_ids"].add(step_execution_id)
+
+            attempt = value.get("attempt")
+            if (
+                logical_step_id
+                and isinstance(attempt, int)
+                and not isinstance(attempt, bool)
+                and attempt > 0
+            ):
+                output["attempts_by_logical_step"].setdefault(
+                    logical_step_id, set()
+                ).add(attempt)
+
+            checkpoint_digest = str(
+                value.get("checkpointDigest")
+                or value.get("checkpoint_digest")
+                or ""
+            ).strip()
+            for key in (
+                "checkpointRef",
+                "checkpoint_ref",
+                "stateCheckpointRef",
+                "stepCheckpointRef",
+                "checkpointBeforeRef",
+                "checkpointAfterRef",
+            ):
+                checkpoint_ref = str(value.get(key) or "").strip()
+                if not checkpoint_ref:
+                    continue
+                output["checkpoint_refs"].add(checkpoint_ref)
+                if checkpoint_digest:
+                    output["checkpoint_digests"].setdefault(
+                        checkpoint_ref, set()
+                    ).add(checkpoint_digest)
+            refs_by_boundary = value.get("checkpointRefsByBoundary")
+            if isinstance(refs_by_boundary, Mapping):
+                for item in refs_by_boundary.values():
+                    checkpoint_ref = str(item or "").strip()
+                    if checkpoint_ref:
+                        output["checkpoint_refs"].add(checkpoint_ref)
+
+            agent_run_id = str(
+                value.get("agentRunId") or value.get("agent_run_id") or ""
+            ).strip()
+            if agent_run_id:
+                output["agent_run_ids"].add(agent_run_id)
+            for item in value.values():
+                cls._collect_target_step_selector_identity(item, output)
+            return
+        if isinstance(value, list | tuple):
+            for item in value:
+                cls._collect_target_step_selector_identity(item, output)
 
     @classmethod
     def _collect_agent_run_ids(cls, value: Any, output: set[str]) -> None:
@@ -959,6 +1250,37 @@ class TemporalExecutionService:
         branches_by_id = {
             branch.branch_id: branch for branch in branch_result.scalars()
         }
+        branch_ids = set(branches_by_id)
+        turns_by_id: dict[str, WorkflowCheckpointBranchTurn] = {}
+        artifacts_by_branch: dict[str, dict[str, dict[str, str]]] = {}
+        if branch_ids:
+            turn_result = await self._session.execute(
+                select(WorkflowCheckpointBranchTurn).where(
+                    WorkflowCheckpointBranchTurn.branch_id.in_(branch_ids)
+                )
+            )
+            turns_by_id = {
+                turn.branch_turn_id: turn for turn in turn_result.scalars()
+            }
+            artifact_result = await self._session.execute(
+                select(WorkflowCheckpointBranchArtifact)
+                .where(WorkflowCheckpointBranchArtifact.branch_id.in_(branch_ids))
+                .order_by(WorkflowCheckpointBranchArtifact.created_at.desc())
+                .limit(250)
+            )
+            for artifact in artifact_result.scalars():
+                artifact_kind = str(artifact.artifact_kind or "").strip()
+                artifact_ref = str(artifact.artifact_ref or "").strip()
+                if not artifact_kind or not artifact_ref:
+                    continue
+                category = (
+                    "comparisonArtifacts"
+                    if "comparison" in artifact_kind
+                    else "outputArtifacts"
+                )
+                artifacts_by_branch.setdefault(artifact.branch_id, {}).setdefault(
+                    category, {}
+                )[artifact_kind] = artifact_ref
         branch_links_by_remediation: dict[str, list[dict[str, Any]]] = {
             remediation_id: [] for remediation_id in remediation_ids
         }
@@ -988,6 +1310,51 @@ class TemporalExecutionService:
                 "contextArtifactRef": remediation.get("contextArtifactRef"),
             }
             branch = branches_by_id.get(operation.branch_id)
+            turn = turns_by_id.get(str(operation.branch_turn_id or ""))
+            if branch is not None:
+                branch_link.update(
+                    {
+                        "logicalStepId": branch.logical_step_id,
+                        "branchState": branch.state,
+                        "workspacePolicy": branch.workspace_policy,
+                        "runtimeContextPolicy": branch.runtime_context_policy,
+                        "gitBaseBranch": branch.git_base_branch,
+                        "gitWorkBranch": branch.git_work_branch,
+                        "currentHeadCommit": branch.current_head_commit,
+                        "pullRequestUrl": branch.pull_request_url,
+                        "publishStatus": branch.publish_status,
+                        "promotionEvidence": branch.promotion_evidence,
+                        "archiveReason": branch.archive_reason,
+                        "promotedAt": (
+                            branch.promoted_at.isoformat()
+                            if branch.promoted_at
+                            else None
+                        ),
+                        "archivedAt": (
+                            branch.archived_at.isoformat()
+                            if branch.archived_at
+                            else None
+                        ),
+                    }
+                )
+                branch_link.update(artifacts_by_branch.get(branch.branch_id, {}))
+            if turn is not None:
+                branch_link.update(
+                    {
+                        "turnState": turn.status,
+                        "runtimeAgentRunId": turn.runtime_agent_run_id,
+                        "providerSessionId": turn.provider_session_id,
+                        "instructionRef": turn.instruction_ref,
+                        "turnStartedAt": (
+                            turn.started_at.isoformat() if turn.started_at else None
+                        ),
+                        "turnCompletedAt": (
+                            turn.completed_at.isoformat()
+                            if turn.completed_at
+                            else None
+                        ),
+                    }
+                )
             if branch is not None and branch.remediation_loop_id:
                 remaining_work_ref = (branch.artifact_refs or {}).get(
                     "remediationRemainingWork"
@@ -1438,6 +1805,7 @@ class TemporalExecutionService:
                     new_run_id=run_id,
                     owner_id=owner,
                     owner_type=owner_type_enum,
+                    submission_parameters=initial_parameters or {},
                 )
 
         if (

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4614,6 +4614,62 @@ def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
     assert "agent" not in initial_parameters["omnigent"]
 
 
+def test_create_execution_rejects_agent_profile_execution_target_mismatch(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "omnigent-bootstrap-default",
+        "version": 1,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "codex-openai-oauth",
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "upstream-codex-agent",
+        "document": {
+            "model": {"settings": {}},
+            "rag": {},
+            "capture": {"stream": True},
+            "workspace": {"mutation": "allowed"},
+        },
+    }
+
+    with patch(
+        "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+        new=AsyncMock(return_value=snapshot),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "omnigent",
+                    "agentProfile": {
+                        "profileId": "omnigent-bootstrap-default",
+                        "providerProfileRef": "codex-openai-oauth",
+                    },
+                    "omnigent": {
+                        "executionTargetRef": "tampered-execution-profile",
+                        "launchPolicyRef": "codex-on-demand@1",
+                    },
+                    "workflow": {
+                        "instructions": "Run the selected agent profile.",
+                        "runtime": {"mode": "omnigent"},
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["message"] == (
+        "omnigent.executionTargetRef must match the selected Agent Profile "
+        "executionProfileRef."
+    )
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_rejects_unsupported_step_runtime(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
@@ -5841,6 +5897,26 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
                         "workspaceDigest": "sha256:head",
                         "headVersion": 3,
                     },
+                    "turns": [
+                        {
+                            "branchTurnId": "cbt-rich",
+                            "status": "running",
+                            "runtimeAgentRunId": "agent-run-rich",
+                            "providerSessionId": "provider-session-rich",
+                            "instructionRef": "artifact://instructions/rich",
+                            "instructionDigest": "sha256:instructions-rich",
+                            "sourceCheckpointRef": "artifact://workspace/C0",
+                            "startedAt": "2026-08-12T00:00:01Z",
+                            "createdAt": "2026-08-12T00:00:00Z",
+                            "updatedAt": "2026-08-12T00:00:01Z",
+                            "outputArtifacts": {
+                                "output.branch_turn.result.json": "artifact://output/rich"
+                            },
+                            "comparisonArtifacts": {
+                                "comparison.branch_turn.diff.json": "artifact://comparison/rich"
+                            },
+                        }
+                    ],
                 }
             ],
             authored_contract={
@@ -5966,6 +6042,26 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
                 "workspaceDigest": "sha256:head",
                 "headVersion": 3,
             },
+            "turns": [
+                {
+                    "branchTurnId": "cbt-rich",
+                    "status": "running",
+                    "runtimeAgentRunId": "agent-run-rich",
+                    "providerSessionId": "provider-session-rich",
+                    "instructionRef": "artifact://instructions/rich",
+                    "instructionDigest": "sha256:instructions-rich",
+                    "sourceCheckpointRef": "artifact://workspace/C0",
+                    "startedAt": "2026-08-12T00:00:01Z",
+                    "createdAt": "2026-08-12T00:00:00Z",
+                    "updatedAt": "2026-08-12T00:00:01Z",
+                    "outputArtifacts": {
+                        "output.branch_turn.result.json": "artifact://output/rich"
+                    },
+                    "comparisonArtifacts": {
+                        "comparison.branch_turn.diff.json": "artifact://comparison/rich"
+                    },
+                }
+            ],
             "createdAt": None,
         }
     ]

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -91,7 +91,10 @@ from moonmind.workflows.temporal import (
     TemporalExecutionNotFoundError,
     TemporalExecutionValidationError,
 )
-from moonmind.workflows.temporal.artifacts import TemporalArtifactAuthorizationError
+from moonmind.workflows.temporal.artifacts import (
+    TemporalArtifactAuthorizationError,
+    TemporalArtifactStateError,
+)
 from moonmind.schemas.temporal_models import (
     ExecutionMergeAutomationResolverChildModel,
     ExecutionProgressModel,
@@ -185,6 +188,46 @@ def test_remediation_approval_projection_disables_expired_request() -> None:
     assert projection.status == "expired"
     assert projection.decision == "expired"
     assert projection.canDecide is False
+
+
+def test_remediation_approval_projection_enforces_reviewer_eligibility() -> None:
+    link = SimpleNamespace(
+        approval_state={
+            "requestId": "approval-high-risk",
+            "status": "pending",
+            "reviewerRule": "high_risk_reviewer",
+            "requestingActor": "requester@example.com",
+        }
+    )
+
+    ordinary_projection = executions_module._remediation_approval_state_from_link(
+        link,
+        authority_mode="approval_gated",
+        status_value="awaiting_approval",
+        actor="owner@example.com",
+        actor_can_approve_high_risk=False,
+    )
+    privileged_projection = executions_module._remediation_approval_state_from_link(
+        link,
+        authority_mode="approval_gated",
+        status_value="awaiting_approval",
+        actor="reviewer@example.com",
+        actor_can_approve_high_risk=True,
+    )
+    requester_projection = executions_module._remediation_approval_state_from_link(
+        link,
+        authority_mode="approval_gated",
+        status_value="awaiting_approval",
+        actor="requester@example.com",
+        actor_can_approve_high_risk=True,
+    )
+
+    assert ordinary_projection is not None
+    assert ordinary_projection.canDecide is False
+    assert privileged_projection is not None
+    assert privileged_projection.canDecide is True
+    assert requester_projection is not None
+    assert requester_projection.canDecide is False
 
 
 def test_authored_remediation_contract_preserves_follow_up_retrieval() -> None:
@@ -315,6 +358,59 @@ async def test_remediation_artifact_projection_is_bounded_redacted_and_linkable(
         artifact_id="art_action_request",
         principal="operator-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_remediation_artifact_projection_keeps_metadata_when_body_is_unreadable() -> None:
+    created_at = datetime.now(UTC)
+    artifact_link = SimpleNamespace(
+        link_type="remediation.summary",
+        label="lifecycle summary",
+        created_at=created_at,
+    )
+    artifact = SimpleNamespace(
+        artifact_id="art_pending_summary",
+        status=TemporalArtifactStatus.PENDING_UPLOAD,
+        metadata_json={"phase": "verification"},
+        expires_at=None,
+    )
+    session = AsyncMock()
+    session.execute.return_value = SimpleNamespace(
+        all=lambda: [(artifact_link, artifact)]
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(side_effect=TemporalArtifactStateError("artifact is not readable"))
+    )
+    link = SimpleNamespace(
+        remediation_workflow_id="mm:remediation-artifact",
+        remediation_run_id="run-remediation-artifact",
+    )
+
+    with patch.object(
+        executions_module,
+        "get_temporal_artifact_service",
+        return_value=artifact_service,
+    ):
+        await executions_module._attach_remediation_artifact_projection(
+            link,
+            session=session,
+            principal="operator-1",
+        )
+
+    assert link.lifecycle_artifacts == [
+        {
+            "artifactRef": "art_pending_summary",
+            "artifactType": "remediation.summary",
+            "status": "pending_upload",
+            "label": "lifecycle summary",
+            "createdAt": created_at,
+            "expiresAt": None,
+            "freshness": "durable",
+            "bounded": True,
+            "metadata": {"phase": "verification"},
+        }
+    ]
+    assert not hasattr(link, "lifecycle_summary")
 
 
 def _phase_11_manifest(**overrides: Any) -> StepExecutionManifestModel:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -133,6 +133,190 @@ class _ExecuteResult:
         return self._rows[0] if self._rows else None
 
 
+def test_remediation_submission_branch_validation_rejects_tampered_refs() -> None:
+    with pytest.raises(HTTPException, match="not an allowed git branch"):
+        executions_module._validate_remediation_branch_submission(
+            task_payload={
+                "remediation": {"target": {"workflowId": "mm:target"}}
+            },
+            git_payload={"startingBranch": "main..tampered"},
+        )
+
+    with pytest.raises(HTTPException, match="not an allowed git branch"):
+        executions_module._validate_remediation_branch_submission(
+            task_payload={
+                "remediation": {
+                    "target": {"workflowId": "mm:target"},
+                    "checkpointBranchPolicy": {"gitWorkBranch": "main"},
+                }
+            },
+            git_payload={"startingBranch": "main"},
+        )
+
+
+def test_remediation_submission_branch_validation_accepts_editable_safe_refs() -> None:
+    executions_module._validate_remediation_branch_submission(
+        task_payload={
+            "remediation": {
+                "target": {"workflowId": "mm:target"},
+                "checkpointBranchPolicy": {
+                    "gitWorkBranch": "remediation/mm-3623-fix"
+                },
+            }
+        },
+        git_payload={"startingBranch": "release/2026-Q3"},
+    )
+
+
+def test_remediation_approval_projection_disables_expired_request() -> None:
+    projection = executions_module._remediation_approval_state_from_link(
+        SimpleNamespace(
+            approval_state={
+                "requestId": "approval-expired",
+                "status": "pending",
+                "expiresAt": "2020-01-01T00:00:00+00:00",
+            }
+        ),
+        authority_mode="approval_gated",
+        status_value="awaiting_approval",
+    )
+
+    assert projection is not None
+    assert projection.status == "expired"
+    assert projection.decision == "expired"
+    assert projection.canDecide is False
+
+
+def test_authored_remediation_contract_preserves_follow_up_retrieval() -> None:
+    contract = executions_module._authored_remediation_contract(
+        {
+            "followUpRetrieval": {
+                "enabled": True,
+                "budgetPreset": "balanced",
+            }
+        },
+        {"remediation": {"authorityMode": "approval_gated"}},
+    )
+
+    assert contract["retrieval"] == {
+        "rag": None,
+        "followUpRetrieval": {
+            "enabled": True,
+            "budgetPreset": "balanced",
+        },
+    }
+
+
+def test_context_evidence_projection_adds_per_class_freshness_and_degradation() -> None:
+    projection = executions_module._context_evidence_availability_projection(
+        [
+            {"class": "stdout", "status": "available"},
+            {
+                "class": "diagnostics",
+                "status": "missing",
+                "fallback": "merged_logs",
+            },
+            {
+                "class": "omnigent_capture",
+                "status": "available",
+                "bounded": False,
+                "freshness": "provider_reported",
+            },
+        ],
+        generated_at="2026-08-12T10:00:00Z",
+    )
+
+    assert projection[0] == {
+        "class": "stdout",
+        "status": "available",
+        "bounded": True,
+        "freshness": "source_reported",
+        "observedAt": "2026-08-12T10:00:00Z",
+    }
+    assert projection[1]["degradedReason"] == "merged_logs"
+    assert projection[2]["bounded"] is False
+    assert projection[2]["freshness"] == "provider_reported"
+
+
+@pytest.mark.asyncio
+async def test_remediation_artifact_projection_is_bounded_redacted_and_linkable() -> None:
+    created_at = datetime.now(UTC)
+    artifact_link = SimpleNamespace(
+        link_type="remediation.action_request",
+        label="latest action request",
+        created_at=created_at,
+    )
+    artifact = SimpleNamespace(
+        artifact_id="art_action_request",
+        status=TemporalArtifactStatus.COMPLETE,
+        metadata_json={
+            "actionKind": "execution.pause",
+            "riskTier": "medium",
+            "untrustedExtra": "excluded",
+        },
+        # SQLite commonly returns a naive timestamp. Projection comparison must
+        # remain safe while the API emits the original persisted value.
+        expires_at=(created_at + timedelta(hours=1)).replace(tzinfo=None),
+    )
+    session = AsyncMock()
+    session.execute.return_value = SimpleNamespace(
+        all=lambda: [(artifact_link, artifact)]
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(
+                artifact,
+                json.dumps(
+                    {
+                        "actionKind": "execution.pause",
+                        "password": "must-not-reach-the-browser",
+                        "expectedState": "paused",
+                    }
+                ).encode("utf-8"),
+            )
+        )
+    )
+    link = SimpleNamespace(
+        remediation_workflow_id="mm:remediation-artifact",
+        remediation_run_id="run-remediation-artifact",
+    )
+
+    with patch.object(
+        executions_module,
+        "get_temporal_artifact_service",
+        return_value=artifact_service,
+    ):
+        await executions_module._attach_remediation_artifact_projection(
+            link,
+            session=session,
+            principal="operator-1",
+        )
+
+    assert link.lifecycle_artifacts == [
+        {
+            "artifactRef": "art_action_request",
+            "artifactType": "remediation.action_request",
+            "status": "complete",
+            "label": "latest action request",
+            "createdAt": created_at,
+            "expiresAt": artifact.expires_at,
+            "freshness": "current",
+            "bounded": True,
+            "metadata": {
+                "actionKind": "execution.pause",
+                "riskTier": "medium",
+            },
+        }
+    ]
+    assert link.latest_action_request["actionKind"] == "execution.pause"
+    assert link.latest_action_request["expectedState"] == "paused"
+    assert "must-not-reach-the-browser" not in json.dumps(link.latest_action_request)
+    artifact_service.read.assert_awaited_once_with(
+        artifact_id="art_action_request",
+        principal="operator-1",
+    )
+
+
 def _phase_11_manifest(**overrides: Any) -> StepExecutionManifestModel:
     now = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
     payload: dict[str, Any] = {
@@ -5430,6 +5614,7 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
             active_lock_holder="mm:remediation-1",
             latest_action_summary="Proposed session interrupt",
             outcome=None,
+            verification_outcome=None,
             context_artifact_ref="art_context",
             created_at=now,
             updated_at=now,
@@ -5469,6 +5654,7 @@ def test_list_remediations_for_target_returns_compact_inbound_links(
                 "activeLockHolder": "mm:remediation-1",
                 "latestActionSummary": "Proposed session interrupt",
                 "deliveryStatus": None,
+                "verificationOutcome": None,
                 "resolution": None,
                 "contextArtifactRef": "art_context",
                 "selectedSteps": None,
@@ -5521,6 +5707,7 @@ def test_list_remediations_for_remediation_returns_compact_outbound_links(
             active_lock_holder=None,
             latest_action_summary=None,
             outcome="applied",
+            verification_outcome="verified_resolved",
             resolution="resolved",
             context_artifact_ref=None,
             created_at=now,
@@ -5559,6 +5746,7 @@ def test_list_remediations_for_remediation_returns_compact_outbound_links(
         "activeLockHolder": None,
         "latestActionSummary": None,
         "deliveryStatus": "applied",
+        "verificationOutcome": "verified_resolved",
         "resolution": "resolved",
         "contextArtifactRef": None,
         "selectedSteps": None,
@@ -5598,6 +5786,7 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
             active_lock_holder="mm:remediation-rich",
             latest_action_summary="Proposed session interrupt",
             outcome="precondition_failed",
+            verification_outcome="still_failed",
             context_artifact_ref="art_context_rich",
             selected_steps=["collect-context", "repair-runtime"],
             current_target_state="awaiting_external",
@@ -5654,6 +5843,34 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
                     },
                 }
             ],
+            authored_contract={
+                "instructions": "Repair the pinned target.",
+                "runtime": {"mode": "omnigent"},
+            },
+            selected_step_evidence=[{"logicalStepId": "collect-context"}],
+            context_generated_at="2026-08-12T00:00:00Z",
+            context_evidence_availability=[
+                {"class": "step_ledger", "status": "available", "bounded": True}
+            ],
+            context_boundedness={"rawLogBodiesIncluded": False},
+            diagnosis_hints=["Target session stopped responding."],
+            lifecycle_artifacts=[
+                {
+                    "artifactRef": "art_summary",
+                    "artifactType": "remediation.summary",
+                    "status": "complete",
+                    "freshness": "durable",
+                }
+            ],
+            latest_action_request={"actionKind": "session.interrupt"},
+            latest_action_result={"status": "precondition_failed"},
+            lifecycle_summary={"resolution": "operator_required"},
+            operator_controls={
+                "canCancel": True,
+                "canTakeOver": True,
+                "canResume": False,
+                "paused": False,
+            },
             created_at=now,
             updated_at=now,
         )
@@ -5679,6 +5896,16 @@ def test_list_remediations_for_remediation_returns_rich_operator_metadata(
     assert response.status_code == 200
     item = response.json()["items"][0]
     assert item["selectedSteps"] == ["collect-context", "repair-runtime"]
+    assert item["verificationOutcome"] == "still_failed"
+    assert item["authoredContract"]["runtime"] == {"mode": "omnigent"}
+    assert item["selectedStepEvidence"] == [{"logicalStepId": "collect-context"}]
+    assert item["contextEvidenceAvailability"][0]["bounded"] is True
+    assert item["diagnosisHints"] == ["Target session stopped responding."]
+    assert item["lifecycleArtifacts"][0]["artifactType"] == "remediation.summary"
+    assert item["latestActionRequest"] == {"actionKind": "session.interrupt"}
+    assert item["latestActionResult"] == {"status": "precondition_failed"}
+    assert item["lifecycleSummary"] == {"resolution": "operator_required"}
+    assert item["operatorControls"]["canTakeOver"] is True
     assert item["currentTargetState"] == "awaiting_external"
     assert item["allowedActions"] == []
     assert item["actionCapabilities"] == []

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -428,7 +428,23 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters=_valid_user_workflow_parameters(),
+            initial_parameters={
+                **_valid_user_workflow_parameters(),
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "run-tests",
+                            "attempt": 1,
+                            "agentRunId": "tr_selected",
+                            "checkpointRef": "artifact://checkpoints/run-tests",
+                            "checkpointDigest": "sha256:runtests",
+                        }
+                    ]
+                },
+                "agentRuns": [
+                    {"agentRunId": f"tr_{index:02d}"} for index in range(25)
+                ],
+            },
             idempotency_key=None,
             summary="Target summary",
         )
@@ -462,7 +478,7 @@ async def test_remediation_context_builder_creates_bounded_linked_artifact(
                             "stepSelectors": [
                                 {
                                     "logicalStepId": "run-tests",
-                                    "attempt": "1",
+                                    "attempt": 1,
                                     "agentRunId": "tr_selected",
                                     "checkpointRef": "artifact://checkpoints/run-tests",
                                     "checkpointDigest": "sha256:runtests",
@@ -694,7 +710,7 @@ async def test_remediation_context_builder_enriches_agent_run_evidence_and_live_
                             "stepSelectors": [
                                 {
                                     "logicalStepId": "run-tests",
-                                    "attempt": "2",
+                                    "attempt": 2,
                                     "agentRunId": "tr_live",
                                 }
                             ],
@@ -1983,7 +1999,10 @@ async def test_remediation_evidence_tools_read_only_context_declared_evidence(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters=_valid_user_workflow_parameters(),
+            initial_parameters={
+                **_valid_user_workflow_parameters(),
+                "agentRuns": [{"agentRunId": "tr_allowed"}],
+            },
             idempotency_key=None,
         )
         target_artifact, _upload = await artifact_service.create(
@@ -2120,7 +2139,10 @@ async def test_remediation_evidence_tools_gate_live_follow_by_context_policy(
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters=_valid_user_workflow_parameters(),
+            initial_parameters={
+                **_valid_user_workflow_parameters(),
+                "agentRuns": [{"agentRunId": "tr_live"}],
+            },
             idempotency_key=None,
         )
         remediation = await execution_service.create_execution(
@@ -2243,7 +2265,10 @@ async def test_remediation_evidence_tools_prepare_action_request_rereads_target_
             plan_artifact_ref=None,
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters=_valid_user_workflow_parameters(),
+            initial_parameters={
+                **_valid_user_workflow_parameters(),
+                "agentRuns": [{"agentRunId": "tr_action"}],
+            },
             idempotency_key=None,
             summary="Initial target summary",
         )

--- a/tests/unit/workflows/temporal/test_remediation_issue_3511.py
+++ b/tests/unit/workflows/temporal/test_remediation_issue_3511.py
@@ -127,6 +127,12 @@ async def test_issue_3620_authority_persists_and_resolves_exact_expiring_approva
     assert link.approval_state["requestDigest"]
     assert link.approval_state["expectedTargetState"] == "failed"
     assert link.approval_state["parameterDigest"]
+    assert link.approval_state["preconditions"] == (
+        "target_visible, force_termination_approved"
+    )
+    assert link.approval_state["blastRadius"] == (
+        "One execution bound to pinned target run target-run-1."
+    )
     assert link.approval_state["artifactRefs"] == {
         "approvalRequest": "artifact-approval-request"
     }

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1814,7 +1814,10 @@ async def test_create_execution_rejects_remediation_same_session_branch_policy(
                         "remediation": {
                             "target": {"workflowId": target.workflow_id},
                             "checkpointBranchPolicy": {
-                                "actionKind": "checkpoint_branch.create_from_remediation_context",
+                                "actionKind": (
+                                    "checkpoint_branch."
+                                    "create_from_remediation_context"
+                                ),
                                 "runtimeContextPolicy": "external_provider_continuation",
                             },
                         },
@@ -2314,6 +2317,239 @@ async def test_create_execution_accepts_owned_remediation_agent_run_ids(
         )
         assert link is not None
         assert link.target_workflow_id == target.workflow_id
+
+
+@pytest.mark.asyncio
+async def test_create_execution_accepts_target_owned_remediation_step_selector(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {"instructions": "Fail at the test step."},
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "run-tests",
+                            "stepExecutionId": "run-tests:execution:2",
+                            "attempt": 2,
+                            "checkpointRef": "artifact://checkpoint/run-tests",
+                            "checkpointDigest": "sha256:target-checkpoint",
+                            "agentRunId": "target-agent-run",
+                        }
+                    ]
+                },
+            },
+            idempotency_key=None,
+        )
+
+        remediation = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {
+                    "instructions": "Repair the selected failed step.",
+                    "remediation": {
+                        "target": {
+                            "workflowId": target.workflow_id,
+                            "runId": target.run_id,
+                            "stepSelectors": [
+                                {
+                                    "logicalStepId": "run-tests",
+                                    "stepExecutionId": "run-tests:execution:2",
+                                    "attempt": 2,
+                                    "checkpointRef": "artifact://checkpoint/run-tests",
+                                    "checkpointDigest": "sha256:target-checkpoint",
+                                    "agentRunId": "target-agent-run",
+                                }
+                            ],
+                        }
+                    },
+                }
+            },
+            idempotency_key=None,
+        )
+
+        link = await session.get(
+            TemporalExecutionRemediationLink, remediation.workflow_id
+        )
+        assert link is not None
+        assert link.target_run_id == target.run_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("selector", "error"),
+    [
+        (
+            {"logicalStepId": "tampered-step"},
+            "logicalStepId must belong to the target execution",
+        ),
+        (
+            {"checkpointRef": "artifact://checkpoint/tampered"},
+            "checkpointRef must belong to the target execution",
+        ),
+        (
+            {
+                "checkpointRef": "artifact://checkpoint/run-tests",
+                "checkpointDigest": "sha256:tampered",
+            },
+            "checkpointDigest must match the target checkpoint",
+        ),
+        (
+            {"logicalStepId": "run-tests", "attempt": 0},
+            "attempt must be a positive integer",
+        ),
+        (
+            {"logicalStepId": "run-tests", "attempt": 999},
+            "attempt must match the target Step Execution",
+        ),
+        (
+            {
+                "logicalStepId": "run-tests",
+                "stepExecutionId": "tampered-step-execution",
+            },
+            "stepExecutionId must belong to the target execution",
+        ),
+    ],
+)
+async def test_create_execution_rejects_tampered_remediation_step_selector(
+    tmp_path, mock_client_adapter, selector, error
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {"instructions": "Fail at the test step."},
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "run-tests",
+                            "stepExecutionId": "run-tests:execution:2",
+                            "attempt": 2,
+                            "checkpointRef": "artifact://checkpoint/run-tests",
+                            "checkpointDigest": "sha256:target-checkpoint",
+                        }
+                    ]
+                },
+            },
+            idempotency_key=None,
+        )
+
+        with pytest.raises(TemporalExecutionValidationError, match=error):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Tampered remediation",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {
+                                "workflowId": target.workflow_id,
+                                "runId": target.run_id,
+                                "stepSelectors": [selector],
+                            }
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_tampered_remediation_mode_and_work_branch(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="Unsupported workflow.remediation.mode",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Tampered remediation mode",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "mode": "unbounded_follow",
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="gitWorkBranch is not an allowed git branch",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Tampered remediation branch",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "checkpointBranchPolicy": {
+                                "actionKind": "checkpoint_branch.create_from_remediation_context",
+                                "runtimeContextPolicy": "fresh_agent_run",
+                                "gitWorkBranch": "main",
+                            },
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
 
 @pytest.mark.asyncio
 async def test_create_execution_normalizes_depends_on_before_limit_and_persistence(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -37,6 +37,11 @@ from api_service.db.models import (
     TemporalExecutionRecord,
     TemporalExecutionRemediationLink,
     TemporalWorkflowType,
+    WorkflowCheckpointBranchOperation,
+)
+from api_service.services.checkpoint_branch_service import (
+    CheckpointBranchService,
+    build_branch_turn_launch_idempotency_key,
 )
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.service import (
@@ -1241,6 +1246,183 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
 
         prerequisites = await service.list_prerequisites(remediation.workflow_id)
         assert prerequisites == []
+
+
+@pytest.mark.asyncio
+async def test_remediation_relationship_projects_every_checkpoint_branch_turn(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    monkeypatch.setattr(settings.workflow, "temporal_artifact_backend", "local_fs")
+    monkeypatch.setattr(
+        settings.workflow,
+        "temporal_artifact_root",
+        str(tmp_path / "artifacts"),
+    )
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        mock_client_adapter.start_workflow.side_effect = [
+            SimpleNamespace(run_id="target-temporal-run"),
+            SimpleNamespace(run_id="remediation-temporal-run"),
+        ]
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        remediation = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Remediate target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {
+                    "instructions": "Repair the target cumulatively.",
+                    "remediation": {
+                        "target": {"workflowId": target.workflow_id},
+                        "mode": "snapshot",
+                        "authorityMode": "approval_gated",
+                    },
+                }
+            },
+            idempotency_key=None,
+        )
+
+        branch_id = f"cbr-{uuid4().hex[:12]}"
+        first_turn_id = f"{branch_id}-turn-1"
+        branch_service = CheckpointBranchService(session)
+        await branch_service.create_branch_graph(
+            {
+                "branchId": branch_id,
+                "branchTurnId": first_turn_id,
+                "source": {
+                    "workflowId": target.workflow_id,
+                    "runId": target.run_id,
+                    "logicalStepId": "repair",
+                    "sourceExecutionOrdinal": 1,
+                    "checkpointBoundary": "after_execution",
+                    "checkpointRef": "artifact://checkpoint/target-root",
+                    "checkpointDigest": "sha256:target-root",
+                },
+                "label": "Cumulative remediation",
+                "workspacePolicy": "apply_previous_execution_diff_to_clean_baseline",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "gitRepository": "repo://moonmind",
+                "gitBaseBranch": "main",
+                "gitWorkBranch": f"remediation/{branch_id}",
+                "createdBy": remediation.workflow_id,
+                "instructionRef": "artifact://instructions/turn-1",
+                "instructionDigest": "sha256:instructions-1",
+                "idempotencyKey": f"{branch_id}:create",
+            }
+        )
+        await branch_service.launch_turn(
+            workflow_id=target.workflow_id,
+            branch_id=branch_id,
+            branch_turn_id=first_turn_id,
+            context_bundle_ref="artifact://context/turn-1",
+            step_execution_manifest_ref="artifact://manifest/turn-1",
+            checkpoint_ref="artifact://checkpoint/turn-1",
+            diagnostics_ref="artifact://diagnostics/turn-1",
+            created_step_execution_id="repair:execution:1",
+            runtime_agent_run_id="agent-run-1",
+            provider_session_id="provider-session-1",
+            agent_result_ref="artifact://result/turn-1",
+            idempotency_key=build_branch_turn_launch_idempotency_key(
+                workflow_id=target.workflow_id,
+                branch_id=branch_id,
+                branch_turn_id=first_turn_id,
+            ),
+        )
+        second_turn_id = f"{branch_id}-turn-2"
+        second_turn = await branch_service.continue_branch(
+            workflow_id=target.workflow_id,
+            branch_id=branch_id,
+            payload={
+                "branchTurnId": second_turn_id,
+                "instructionRef": "artifact://instructions/turn-2",
+                "instructionDigest": "sha256:instructions-2",
+                "idempotencyKey": f"{branch_id}:continue:2",
+            },
+        )
+        assert second_turn.parent_turn_id == first_turn_id
+        await branch_service.launch_turn(
+            workflow_id=target.workflow_id,
+            branch_id=branch_id,
+            branch_turn_id=second_turn_id,
+            context_bundle_ref="artifact://context/turn-2",
+            step_execution_manifest_ref="artifact://manifest/turn-2",
+            checkpoint_ref="artifact://checkpoint/turn-2",
+            diagnostics_ref="artifact://diagnostics/turn-2",
+            created_step_execution_id="repair:execution:2",
+            runtime_agent_run_id="agent-run-2",
+            provider_session_id="provider-session-2",
+            agent_result_ref="artifact://result/turn-2",
+            idempotency_key=build_branch_turn_launch_idempotency_key(
+                workflow_id=target.workflow_id,
+                branch_id=branch_id,
+                branch_turn_id=second_turn_id,
+            ),
+        )
+        await branch_service.record_artifact(
+            branch_id=branch_id,
+            branch_turn_id=second_turn_id,
+            artifact_kind="comparison.branch_turn.diff.json",
+            artifact_ref="artifact://comparison/turn-2",
+        )
+        session.add(
+            WorkflowCheckpointBranchOperation(
+                workflow_id=target.workflow_id,
+                branch_id=branch_id,
+                branch_turn_id=first_turn_id,
+                operation="checkpoint_branch.create",
+                idempotency_key=f"{branch_id}:remediation:create",
+                request_digest="sha256:" + "1" * 64,
+                response_payload={
+                    "branchId": branch_id,
+                    "branchTurnId": first_turn_id,
+                    "checkpointRef": "artifact://checkpoint/target-root",
+                    "remediation": {
+                        "workflowId": remediation.workflow_id,
+                        "runId": remediation.run_id,
+                        "checkpointRef": "artifact://checkpoint/target-root",
+                    },
+                },
+            )
+        )
+        await session.commit()
+
+        outbound = await service.list_remediation_targets(remediation.workflow_id)
+        projected_branch = outbound[0].checkpoint_branch_links[0]
+        assert [turn["branchTurnId"] for turn in projected_branch["turns"]] == [
+            first_turn_id,
+            second_turn_id,
+        ]
+        assert projected_branch["turns"][0]["status"] == "running"
+        assert projected_branch["turns"][0]["runtimeAgentRunId"] == "agent-run-1"
+        assert projected_branch["turns"][0]["providerSessionId"] == (
+            "provider-session-1"
+        )
+        assert projected_branch["turns"][0]["startedAt"]
+        assert projected_branch["turns"][1]["parentTurnId"] == first_turn_id
+        assert projected_branch["turns"][1]["instructionRef"] == (
+            "artifact://instructions/turn-2"
+        )
+        assert projected_branch["turns"][1]["outputArtifacts"][
+            "runtime.branch_turn.agent_result.json"
+        ] == "artifact://result/turn-2"
+        assert projected_branch["turns"][1]["comparisonArtifacts"] == {
+            "comparison.branch_turn.diff.json": "artifact://comparison/turn-2"
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1244,6 +1244,17 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
             remediation.workflow_id
         ]
 
+        with patch.object(
+            service,
+            "_attach_remediation_checkpoint_branch_links",
+            new=AsyncMock(),
+        ) as attach_branch_links:
+            inventory = await service.list_remediation_links()
+        assert [item.remediation_workflow_id for item in inventory] == [
+            remediation.workflow_id
+        ]
+        attach_branch_links.assert_not_awaited()
+
         prerequisites = await service.list_prerequisites(remediation.workflow_id)
         assert prerequisites == []
 
@@ -1417,9 +1428,19 @@ async def test_remediation_relationship_projects_every_checkpoint_branch_turn(
         assert projected_branch["turns"][1]["instructionRef"] == (
             "artifact://instructions/turn-2"
         )
-        assert projected_branch["turns"][1]["outputArtifacts"][
-            "runtime.branch_turn.agent_result.json"
-        ] == "artifact://result/turn-2"
+        assert projected_branch["turns"][1]["outputArtifacts"] == {
+            "output.branch_turn.step_execution_manifest.json": (
+                "artifact://manifest/turn-2"
+            ),
+            "output.branch_turn.checkpoint.json": "artifact://checkpoint/turn-2",
+            "output.branch_turn.diagnostics.json": "artifact://diagnostics/turn-2",
+        }
+        assert "input.branch_turn.instructions.md" not in projected_branch[
+            "turns"
+        ][1]["outputArtifacts"]
+        assert "runtime.branch_turn.agent_result.json" not in projected_branch[
+            "turns"
+        ][1]["outputArtifacts"]
         assert projected_branch["turns"][1]["comparisonArtifacts"] == {
             "comparison.branch_turn.diff.json": "artifact://comparison/turn-2"
         }
@@ -2571,6 +2592,78 @@ async def test_create_execution_accepts_target_owned_remediation_step_selector(
         )
         assert link is not None
         assert link.target_run_id == target.run_id
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_mixed_target_step_selector_tuple(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "workflow": {"instructions": "Fail two independent steps."},
+                "stepLedger": {
+                    "steps": [
+                        {
+                            "logicalStepId": "step-a",
+                            "stepExecutionId": "step-a:execution:1",
+                            "attempt": 1,
+                            "checkpointRef": "artifact://checkpoint/step-a",
+                            "agentRunId": "agent-run-a",
+                        },
+                        {
+                            "logicalStepId": "step-b",
+                            "stepExecutionId": "step-b:execution:1",
+                            "attempt": 1,
+                            "checkpointRef": "artifact://checkpoint/step-b",
+                            "agentRunId": "agent-run-b",
+                        },
+                    ]
+                },
+            },
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="fields must identify one target Step Execution/checkpoint",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=owner_id,
+                title="Mixed selector remediation",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "workflow": {
+                        "remediation": {
+                            "target": {
+                                "workflowId": target.workflow_id,
+                                "stepSelectors": [
+                                    {
+                                        "logicalStepId": "step-a",
+                                        "stepExecutionId": "step-a:execution:1",
+                                        "checkpointRef": "artifact://checkpoint/step-b",
+                                        "agentRunId": "agent-run-b",
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Issue

MoonLadderStudios/MoonMind#3623

Closes MoonLadderStudios/MoonMind#3623

## Summary

- Import bounded remediation drafts into the ordinary editable Create workflow, with pinned target identity, safe discard and expiry handling, and authored runtime, profile, retrieval, branch, publication, and policy controls.
- Revalidate remediation target, run, profile, execution target, authority, policies, and related selections at the server create boundary while preserving the canonical immutable task.remediation snapshot and bidirectional relationship.
- Project and render complete target-side and remediation-side lifecycle evidence, approvals, operator controls, capability readiness, checkpoint branch turns, artifacts, verification, prevention, cleanup, and publication state.
- Align canonical workflow, API, artifact, Create, Workflow Detail, checkpoint-branch, and approval documentation and add focused accessibility and responsive coverage.

## Tests run

- Managed Python API and Temporal service boundary: 3 passed.
- Focused frontend unit tests: 334 passed, 238 intentionally skipped.
- Frontend TypeScript compilation: passed.
- Dashboard brand and style contract: 9 passed.
- Diff hygiene: passed.
- Routed Playwright remediation journey: attempted, but Chromium could not launch because this managed host lacks the required native NSS, NSPR, ATK, DBus, and X11 libraries; no browser test body ran.

## Remaining risks

- The routed browser journey is compiled and committed but was not executed in this host because the Playwright native runtime dependencies are unavailable. The focused Python, frontend, TypeScript, and style suites passed.