### PR TITLE
Complete native Workflow Detail Chat strategy (MoonLadderStudios/MoonMind#3632)

### DIFF
--- a/.github/workflows/omnigent-live-conformance.yml
+++ b/.github/workflows/omnigent-live-conformance.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        mode: [browser, product, cumulative, stock, static, ondemand, failures]
+        mode: [browser, product, cumulative, stock, static, ondemand, failures, workflow_chat]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -43,12 +43,12 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install -e .[tests]
       - name: Install controlling browser
-        if: ${{ matrix.mode == 'browser' }}
+        if: ${{ matrix.mode == 'browser' || matrix.mode == 'workflow_chat' }}
         run: |
           npm ci --no-fund --no-audit
           npx playwright install --with-deps chromium
       - name: Materialize browser authentication state
-        if: ${{ matrix.mode == 'browser' }}
+        if: ${{ matrix.mode == 'browser' || matrix.mode == 'workflow_chat' }}
         env:
           BROWSER_STORAGE_STATE: ${{ secrets.MOONMIND_OMNIGENT_BROWSER_STORAGE_STATE }}
         run: |
@@ -97,6 +97,7 @@ jobs:
             --mode "${{ matrix.mode }}" \
             --server-image "${{ steps.images.outputs.server }}" \
             --host-image "${{ steps.images.outputs.host }}" \
+            --source-commit "${{ github.sha }}" \
             --output-dir "artifacts/omnigent-conformance/live/${{ matrix.mode }}"
       - name: Stage secret-safe case evidence
         if: always()
@@ -131,6 +132,14 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install acceptance validator dependencies
+        run: python -m pip install -e .
       - name: Download passing case evidence
         uses: actions/download-artifact@v8
         with:
@@ -146,8 +155,8 @@ jobs:
           from pathlib import Path
           root = Path("artifacts/omnigent-conformance/published")
           reports = sorted(root.glob("*/report.json"))
-          if len(reports) != 7:
-              raise SystemExit(f"expected seven passing reports, found {len(reports)}")
+          if len(reports) != 8:
+              raise SystemExit(f"expected eight passing reports, found {len(reports)}")
           report_payloads = [json.loads(path.read_text(encoding="utf-8")) for path in reports]
           for path, report in zip(reports, report_payloads):
               if report.get("schemaVersion") != "moonmind.omnigent.conformance-report/v1":
@@ -204,6 +213,24 @@ jobs:
           browser["rows"] = rows
           browser_paths[0].write_text(
               json.dumps(browser, indent=2) + "\n", encoding="utf-8"
+          )
+          workflow_chat_paths = list(root.glob("*/workflow-chat-acceptance.json"))
+          if len(workflow_chat_paths) != 1:
+              raise SystemExit(
+                  "expected one Workflow Chat acceptance artifact, "
+                  f"found {len(workflow_chat_paths)}"
+              )
+          from moonmind.omnigent.workflow_chat_acceptance import (
+              validate_workflow_chat_acceptance_manifest,
+          )
+          workflow_chat_path = workflow_chat_paths[0]
+          workflow_chat = json.loads(
+              workflow_chat_path.read_text(encoding="utf-8")
+          )
+          validate_workflow_chat_acceptance_manifest(
+              workflow_chat,
+              evidence_root=workflow_chat_path.parent,
+              expected_commit=os.environ["GITHUB_SHA"],
           )
           authority_fields = {
               "authoredWorkflowRef", "taskInputSnapshotRef", "compiledRuntimeRequestRef",
@@ -347,6 +374,8 @@ jobs:
               "acceptanceIssue": "MoonLadderStudios/MoonMind#3456",
               "cumulativeRemediationIssue": "MoonLadderStudios/MoonMind#3480",
               "cumulativeRemediationParent": "MoonLadderStudios/MoonMind#3471",
+              "nativeWorkflowChatIssue": "MoonLadderStudios/MoonMind#3642",
+              "nativeWorkflowChatParent": "MoonLadderStudios/MoonMind#3632",
               "runId": os.environ["GITHUB_RUN_ID"],
               "runAttempt": os.environ["GITHUB_RUN_ATTEMPT"],
               "sourceCommit": os.environ["GITHUB_SHA"],
@@ -363,6 +392,7 @@ jobs:
               "browserEvidence": str(browser_paths[0].relative_to(root)),
               "browserRows": rows,
               "cumulativeRemediationEvidence": str(cumulative_paths[0].relative_to(root)),
+              "nativeWorkflowChatEvidence": str(workflow_chat_path.relative_to(root)),
               "productSchemaVersions": product["schemaVersions"],
               "selection": selection,
               "executionProfileRef": acceptance["executionProfileRef"],
@@ -383,7 +413,7 @@ jobs:
               "cleanupAndRelease": acceptance["cleanupAndRelease"],
               "replayAfterHostRemoval": product["assertions"]["replay_after_host_removal"],
               "noFallback": product["assertions"]["no_fallback"],
-              "modes": ["browser", "product", "cumulative", "stock", "static", "ondemand", "failures"],
+              "modes": ["browser", "product", "cumulative", "stock", "static", "ondemand", "failures", "workflow_chat"],
               "status": "passed",
               "generatedAt": datetime.now(timezone.utc).isoformat(),
               "expiresAt": (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(),
@@ -407,11 +437,11 @@ jobs:
           {
             echo "### Omnigent credentialed conformance matrix"
             echo ""
-            echo "- Issues: \`MoonLadderStudios/MoonMind#3508\` (parent \`#3448\`)"
-            echo "- Result: browser, product-create, cumulative remediation, stock, static, on-demand, and failure cases passed"
+            echo "- Issues: \`MoonLadderStudios/MoonMind#3508\` (parent \`#3448\`) and native Workflow Chat \`#3642\` (parent \`#3632\`)"
+            echo "- Result: browser, product-create, cumulative remediation, stock, static, on-demand, failure, and native Workflow Chat cases passed"
             echo "- Durable evidence: \`omnigent-live-published-matrix-${{ github.run_id }}-${{ github.run_attempt }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
-      - name: Link passing acceptance report from issues 3508 and 3448
+      - name: Link passing acceptance report from owning issues
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -424,9 +454,11 @@ jobs:
             echo
             echo "- Run: ${run_url} (attempt ${{ github.run_attempt }})"
             echo "- Commit: \`${{ github.sha }}\`"
-            echo "- Modes: \`browser\`, \`product\`, \`cumulative\`, \`stock\`, \`static\`, \`ondemand\`, \`failures\`"
+            echo "- Modes: \`browser\`, \`product\`, \`cumulative\`, \`stock\`, \`static\`, \`ondemand\`, \`failures\`, \`workflow_chat\`"
             echo "- Durable artifact: \`${artifact}\`"
-            echo "- Evidence refs and immutable image digests: the six \`report.json\` trees in \`${artifact}\`"
+            echo "- Evidence refs and immutable image digests: the eight \`report.json\` trees in \`${artifact}\`"
           } > "$comment_file"
           gh issue comment 3508 --repo "${{ github.repository }}" --body-file "$comment_file"
           gh issue comment 3448 --repo "${{ github.repository }}" --body-file "$comment_file"
+          gh issue comment 3642 --repo "${{ github.repository }}" --body-file "$comment_file"
+          gh issue comment 3632 --repo "${{ github.repository }}" --body-file "$comment_file"

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -4177,13 +4177,13 @@ async def _dispatch_native_ui_http(
         return {
             "hosts": [{"id": chat_binding_id, "state": _facade_reconnect_state(row)}]
         }
-    if route.name in {"runner_liveness", "session_reconnect"}:
+    if route.name == "runner_liveness":
         return {
             "chatBindingId": chat_binding_id,
             "state": _facade_reconnect_state(row),
             "readOnly": is_read_only(session_status),
         }
-    if not provider_session_id:
+    if not provider_session_id and route.name != "session_reconnect":
         raise WorkflowChatFacadeError(
             "The Workflow Chat binding has no active provider session yet.",
             failure_class="user_error",
@@ -4269,6 +4269,53 @@ async def _dispatch_native_ui_http(
             )
 
     from urllib.parse import urlencode, urlsplit
+
+    # Reconnect is a MoonMind-owned durable-state projection in the pinned
+    # compatibility profile.  It still is a mutation: claim the idempotency key,
+    # revalidate authority, and persist the same terminal receipt as an upstream
+    # mutation before reporting success.  An early local return here previously
+    # left this one stock native control without mutation evidence (#3632).
+    if route.name == "session_reconnect":
+        assert effective_key and scan_evidence and request_time
+        dispatch_time = datetime.now(tz=UTC).isoformat()
+        normalized = {
+            "chatBindingId": chat_binding_id,
+            "state": _facade_reconnect_state(fresh_row),
+            "readOnly": is_read_only(str(getattr(fresh_row, "status", "") or "")),
+        }
+        encoded = json.dumps(normalized, separators=(",", ":")).encode()
+        receipt_result = {
+            "statusCode": status.HTTP_200_OK,
+            "mediaType": "application/json",
+            "headers": {},
+            "bodyDigest": sha256(encoded).hexdigest(),
+            "json": normalized,
+        }
+        await _record_facade_mutation_audit(
+            store=store,
+            row=fresh_row,
+            control_type=route.name,
+            outcome="posted",
+            actor=str(user.id),
+            idempotency_key=effective_key,
+            scan_evidence=scan_evidence,
+            upstream_result=receipt_result,
+            request_time=request_time,
+            dispatch_time=dispatch_time,
+            request_preconditions=request_preconditions,
+        )
+        _audit_facade(
+            outcome="mutation",
+            operation=route.name,
+            chat_binding_id=chat_binding_id,
+            user=user,
+            reason="binding_scoped_native_local",
+        )
+        return Response(
+            content=encoded,
+            status_code=status.HTTP_200_OK,
+            media_type="application/json",
+        )
 
     upstream_path = upstream_http_path(match, provider_session_id)
     query = urlencode(list(request.query_params.multi_items()))
@@ -4369,6 +4416,38 @@ async def _dispatch_native_ui_http(
             status_code=502,
             code="omnigent_chat_upstream_unavailable",
         ) from exc
+    except WorkflowChatFacadeError:
+        if route.mutation:
+            assert effective_key and scan_evidence and request_time
+            await _record_facade_mutation_audit(
+                store=store,
+                row=fresh_row,
+                control_type=route.name,
+                outcome="delivery_unknown",
+                actor=str(user.id),
+                idempotency_key=effective_key,
+                scan_evidence=scan_evidence,
+                request_time=request_time,
+                dispatch_time=dispatch_time,
+                request_preconditions=request_preconditions,
+            )
+        raise
+    except Exception:
+        if route.mutation:
+            assert effective_key and scan_evidence and request_time
+            await _record_facade_mutation_audit(
+                store=store,
+                row=fresh_row,
+                control_type=route.name,
+                outcome="delivery_unknown",
+                actor=str(user.id),
+                idempotency_key=effective_key,
+                scan_evidence=scan_evidence,
+                request_time=request_time,
+                dispatch_time=dispatch_time,
+                request_preconditions=request_preconditions,
+            )
+        raise
 
     if route.mutation:
         assert effective_key and scan_evidence and request_time and receipt_result

--- a/docs/Omnigent/ConformanceAndLiveSmoke.md
+++ b/docs/Omnigent/ConformanceAndLiveSmoke.md
@@ -78,7 +78,8 @@ requires immutable image references and an already-enrolled OAuth profile:
 MOONMIND_OMNIGENT_ACTION_COMMAND=/path/to/live-action-adapter \
 python tools/run_omnigent_live_conformance.py --mode all \
   --server-image ghcr.io/omnigent-ai/omnigent-server@sha256:<digest> \
-  --host-image ghcr.io/omnigent-ai/omnigent-host@sha256:<digest>
+  --host-image ghcr.io/omnigent-ai/omnigent-host@sha256:<digest> \
+  --source-commit "$(git rev-parse HEAD)"
 ```
 
 The runner requires `MOONMIND_OMNIGENT_ACTION_COMMAND` to name an
@@ -109,9 +110,20 @@ and cleanup-reconciliation rows. Every row resolves the full profile, policy,
 runtime, host, session, workspace, artifact, cleanup, janitor, and lease
 authority chain and fails on any direct-Codex or alternate-authority fallback.
 
-`--mode static` covers restart and replay; `stock`,
-`product`, `cumulative`, `ondemand`, and `failures` can be gated independently in provider
-environments.
+`--mode workflow_chat` is the #3642 protected controller. It runs the four
+native-conversation, scoped-transport/resource, authority/security-denial, and
+terminal/evidence/continuation actions in order against the digest-pinned stock
+host. It resolves the typed source records returned by the live action adapter,
+derives assertions from those records, scans the logs, Temporal history,
+screenshots, and archives, builds and validates the commit-bound
+`moonmind.omnigent.workflow-chat-acceptance/v1` artifact, and then invokes the
+dedicated provider gate. A missing row, source record, raw evidence channel,
+digest correlation, or provider-test result fails the mode before its evidence
+can enter the publication job.
+
+`--mode static` covers restart and replay; `stock`, `product`, `cumulative`,
+`ondemand`, `failures`, and `workflow_chat` can be gated independently in
+provider environments.
 
 The cumulative mode is the controlling gate for #3480. It begins at the same
 normal create boundary as the product mode and records authored state,

--- a/docs/Omnigent/ConformanceAndLiveSmoke.md
+++ b/docs/Omnigent/ConformanceAndLiveSmoke.md
@@ -2,8 +2,8 @@
 
 **Document Class:** Canonical declarative
 **Status:** Current
-**Updated:** 2026-07-23
-**Authority:** MoonLadderStudios/MoonMind#3508 browser-to-host product acceptance and MoonLadderStudios/MoonMind#3480 cumulative-remediation evidence contract
+**Updated:** 2026-08-13
+**Authority:** MoonLadderStudios/MoonMind#3508 browser-to-host product acceptance, MoonLadderStudios/MoonMind#3480 cumulative-remediation evidence contract, and MoonLadderStudios/MoonMind#3642 native Workflow Chat release matrix
 
 MoonMind uses the versioned profile at
 `tests/fixtures/omnigent/conformance-v4.json` as the single inventory for the
@@ -44,7 +44,10 @@ python tools/run_omnigent_conformance.py \
 The aggregate report command defaults to the complete live gate: a failed case
 or a skipped critical case returns nonzero. `--allow-partial` is reserved for
 the deterministic runner, where all skipped provider cases remain explicit in
-the report.
+the report. The canonical profile includes
+`workflow-chat.native-release-matrix`, so the documented/default `--mode all`
+report always carries the protected Workflow Chat result instead of leaving it
+only in the dedicated mode report.
 
 ## Live-run boundaries
 
@@ -119,7 +122,9 @@ screenshots, and archives, builds and validates the commit-bound
 `moonmind.omnigent.workflow-chat-acceptance/v1` artifact, and then invokes the
 dedicated provider gate. A missing row, source record, raw evidence channel,
 digest correlation, or provider-test result fails the mode before its evidence
-can enter the publication job.
+can enter the publication job. The final publication-tree scan runs after
+per-mode cleanup and final report generation, and therefore covers the cleanup
+logs and the exact report tree uploaded by the workflow.
 
 `--mode static` covers restart and replay; `stock`, `product`, `cumulative`,
 `ondemand`, `failures`, and `workflow_chat` can be gated independently in

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -2,7 +2,7 @@
 
 Status: Proposed design  
 Owners: MoonMind Platform  
-Last updated: 2026-08-07
+Last updated: 2026-08-13
 
 **Implementation tracking:** rollout notes, spikes, and temporary handoffs belong under `docs/tmp/` or gitignored local-only artifacts, not as mutable checklists in this canonical design document.
 
@@ -1086,20 +1086,20 @@ record-specific observed facts are:
 
 | Record | Required observed facts |
 |---|---|
-| `browserTrace` | Workflow Chat route, MoonMind-scoped network events, response statuses, no direct upstream requests or provider identity exposure, screenshot digest |
+| `browserTrace` | Workflow Chat route, path-segment-scoped network events, success or operation-specific denial statuses, no direct upstream requests or provider identity exposure, and a screenshot digest owned by the scanned screenshot channel |
 | `bindingSnapshot` | authoritative binding, run/state/read-only projection, capability digest |
 | `nativeConversation` | native renderer, transcript, composer request, queued message, native application version |
 | `nativeControls` | native approval/tool/file/terminal/agent/task controls and no MoonMind composer |
-| `facadeRequests` | exact compatibility route inventory, HTML/HTTP/SSE/WebSocket authorization, server-resolved binding/session, reconnect reauthorization |
+| `facadeRequests` | every compatibility route bound to an observed request path/method/transport, HTML/HTTP/SSE/WebSocket authorization, server-resolved binding/session, reconnect reauthorization |
 | `resourceInventory` | request-correlated approval/tool/file/terminal/agent/task resources |
-| `mutationReceipts` | actor, idempotency, expected state, outcome, upstream correlation, and audit ref |
+| `mutationReceipts` | exactly one receipt for every mutation derived from the compatibility map, including actor, idempotency, expected state, outcome, upstream correlation, and audit ref |
 | `denialAudit` | alternate-binding, provider-session, hidden-control, and immutable-policy denials before upstream forwarding |
 | `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs and their recomputed intersection digest |
 | `scanAudit` | blocked-content and unavailable-enforcement sends, neither forwarded |
-| `credentialBoundary` | no upstream credential in the browser, no MoonMind credential upstream, server-side credential injection ref |
+| `credentialBoundary` | every traced request verified to expose no upstream credential in the browser and forward no MoonMind credential upstream, plus a server-side credential injection ref |
 | `terminalSnapshot` | terminal state, read-only projection, denied mutation requests |
-| `capturedEvidence` | resolved MoonMind artifact and capture-manifest refs |
-| `continuationReceipt` | distinct linked Workflow, idempotency, separate action, unchanged source |
+| `capturedEvidence` | packaged MoonMind artifact and capture-manifest refs resolved and digest-bound into the acceptance manifest |
+| `continuationReceipt` | production destination-creation receipt, pinned source run, durable outbound `linked_continuation` relationship identity, idempotency, and matching source before/after digests |
 | `replaySnapshot` | host unavailable and replay resolved from the captured MoonMind artifacts |
 
 ---

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -1077,6 +1077,31 @@ Every raw evidence channel is secret-scanned, and the manifest is valid only for
 its recorded source commit, compatibility profile, image digests, and freshness
 window.
 
+Every source record carries an observation timestamp, immutable image digests,
+and one server-owned correlation envelope containing the Workflow, chat binding,
+bridge session, provider session, and browser trace identities. All records in a
+row bind to the same envelope; all rows bind to the same Workflow/binding/session;
+and every record request id resolves to the row's browser network trace. The
+record-specific observed facts are:
+
+| Record | Required observed facts |
+|---|---|
+| `browserTrace` | Workflow Chat route, MoonMind-scoped network events, response statuses, no direct upstream requests or provider identity exposure, screenshot digest |
+| `bindingSnapshot` | authoritative binding, run/state/read-only projection, capability digest |
+| `nativeConversation` | native renderer, transcript, composer request, queued message, native application version |
+| `nativeControls` | native approval/tool/file/terminal/agent/task controls and no MoonMind composer |
+| `facadeRequests` | exact compatibility route inventory, HTML/HTTP/SSE/WebSocket authorization, server-resolved binding/session, reconnect reauthorization |
+| `resourceInventory` | request-correlated approval/tool/file/terminal/agent/task resources |
+| `mutationReceipts` | actor, idempotency, expected state, outcome, upstream correlation, and audit ref |
+| `denialAudit` | alternate-binding, provider-session, hidden-control, and immutable-policy denials before upstream forwarding |
+| `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs and their recomputed intersection digest |
+| `scanAudit` | blocked-content and unavailable-enforcement sends, neither forwarded |
+| `credentialBoundary` | no upstream credential in the browser, no MoonMind credential upstream, server-side credential injection ref |
+| `terminalSnapshot` | terminal state, read-only projection, denied mutation requests |
+| `capturedEvidence` | resolved MoonMind artifact and capture-manifest refs |
+| `continuationReceipt` | distinct linked Workflow, idempotency, separate action, unchanged source |
+| `replaySnapshot` | host unavailable and replay resolved from the captured MoonMind artifacts |
+
 ---
 
 ## 21. Open questions

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -235,7 +235,7 @@ The full-page **Open in Omnigent** experience uses this same scoped facade. It m
 The native UI is more than an HTTP transcript: it opens WebSockets and drives terminal/PTY, execution-log, browser-pane, sub-agent/task, and reconnect/wake surfaces. Transport and route coverage for that surface is a single **versioned compatibility map** pinned to the `omnigent.server.v1` profile (`moonmind/omnigent/native_ui_compat.py`). Each recognized route/transport declares one of two dispositions:
 
 - **served** — the HTTP + SSE surface the scoped facade actively serves (§4.2 step list), single-sourced from the facade route allowlist so there is no second source of truth;
-- **compatibility_review_required** — a recognized WebSocket/terminal transport class whose upstream rewrite is not yet reviewed. The WebSocket facade authenticates, resolves the durable binding, authorizes the caller, rejects caller-supplied identity, recomputes capabilities, negotiates only an allowlisted subprotocol, and validates binding state **before upgrade**, then fails closed with an explicit compatibility diagnostic instead of bridging the browser to the upstream server. A successful earlier HTTP bootstrap never authorizes a later WebSocket.
+- **compatibility_review_required** — a reserved quarantine disposition for a recognized route whose rewrite has not yet been reviewed. The pinned `omnigent.server.v1` HTTP, SSE, global-session-update WebSocket, terminal-attach WebSocket, and dictation WebSocket routes are reviewed and served. A future recognized-but-unreviewed transport is authenticated and binding-validated before upgrade, then fails closed with an explicit compatibility diagnostic. A successful earlier HTTP bootstrap never authorizes a later WebSocket.
 
 Terminal create/attach/input/resize/close and browser-pane control require capabilities the facade never grants, so a nonowner or read-only viewer is denied before any transport opens; terminal viewing/execution-log inspection is a distinct read capability. Unknown or changed transports fail closed with a non-enumerating diagnostic rather than being generically proxied, and a terminal/revoked binding cannot open a new live transport.
 
@@ -925,6 +925,23 @@ Rules:
 12. MoonMind artifact refs remain the durable evidence boundary.
 13. Embedded mode must pass stock-host auth conformance before production enablement.
 
+Native Workflow Chat rollout evidence uses
+`moonmind.omnigent.workflow-chat-acceptance/v1`. The controlling artifact is
+commit- and immutable-image-bound, covers every required browser-to-stock-host
+row, and contains SHA-256 bindings for independently resolvable case evidence,
+typed source records, conformance reports, and the logs, Temporal history,
+screenshot, and archive secret-scan results. The required source records bind
+browser traces to binding/capability snapshots, facade requests, resource and
+receipt inventories, denial/scan/credential audits, terminal evidence,
+continuation receipts, and replay snapshots. A bare pass flag, repository-only
+test result, unresolved artifact ref, mutable image tag, stale report, or
+self-asserted secret scan is not rollout evidence.
+`tools/build_omnigent_workflow_chat_acceptance.py` builds and validates the
+artifact produced by the protected controller against its required current
+`--expected-commit`; the provider gate independently requires the same commit
+through `MOONMIND_OMNIGENT_SOURCE_COMMIT`. The provider test
+`test_live_native_workflow_chat_release_matrix` is the release gate.
+
 ```text
 MoonMind user -> MoonMind request authorization
 MoonMind scoped facade -> server-side Omnigent credential
@@ -1049,11 +1066,22 @@ Prove that:
 
 Verify host registration, heartbeat/capabilities, session creation, harness launch, message posting, stream capture, final snapshot, resource harvest, credential separation, no duplicate first message, and durable cleanup/audit evidence against a real unchanged host.
 
+### 20.5 Native Workflow Chat rollout gate
+
+The protected browser-to-stock-host matrix covers the live native conversation,
+scoped transports and resources, authority/security denials, and terminal
+evidence/linked continuation. Each row records browser-originated observations
+against an unchanged digest-pinned stock host and resolves its source evidence
+before the `moonmind.omnigent.workflow-chat-acceptance/v1` manifest can pass.
+Every raw evidence channel is secret-scanned, and the manifest is valid only for
+its recorded source commit, compatibility profile, image digests, and freshness
+window.
+
 ---
 
 ## 21. Open questions
 
-1. Which upstream WebSocket paths require explicit rewriting in each compatibility profile? *(Partially resolved by MoonLadderStudios/MoonMind#3635: the native-UI WebSocket/terminal transport classes are now inventoried in the versioned compatibility map (§4.2) and fail closed with a compatibility diagnostic until each profile's upstream rewrite is reviewed.)*
+1. Which upstream WebSocket paths require explicit rewriting in each compatibility profile? *(Resolved for `omnigent.server.v1` by MoonLadderStudios/MoonMind#3635: the global session-update, terminal-attach, and dictation transports are inventoried, identity-scoped, capability-gated, and relayed through the binding facade. Any route absent from a future reviewed profile fails closed.)*
 2. Which upstream host auth modes are supported in embedded mode?
 3. Which binary attachment types are allowed under high-security mode when their content cannot be text-scanned?
 4. What is the minimum stock-host conformance suite before embedded mode is enabled?

--- a/frontend/src/entrypoints/WorkflowChatNative.test.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.test.tsx
@@ -8,12 +8,14 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
 import {
   WorkflowChatNative,
-  capturedEvidenceHref,
   fullPageChatUrl,
-  type CapturedEvidence,
-  type ContinueInNewWorkflowResult,
   type WorkflowChatBinding,
 } from './WorkflowChatNative';
+import {
+  capturedEvidenceHref,
+  type CapturedEvidence,
+  type ContinueInNewWorkflowResult,
+} from '../features/workflow-native-chat/WorkflowTerminalChatActions';
 
 const API_BASE = '/api';
 const WORKFLOW_ID = 'mm:w1';

--- a/frontend/src/entrypoints/WorkflowChatNative.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.tsx
@@ -25,32 +25,9 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { components } from '../generated/openapi';
+import { WorkflowTerminalChatActions } from '../features/workflow-native-chat/WorkflowTerminalChatActions';
 
 export type WorkflowChatBinding = components['schemas']['WorkflowChatBinding'];
-
-/** One authorized MoonMind evidence artifact ref (browser-safe). */
-export interface CapturedEvidenceItem {
-  label: string;
-  kind: string;
-  artifactRef: string;
-}
-
-export interface CapturedEvidence {
-  workflowId: string;
-  runId?: string | null;
-  available: boolean;
-  items: CapturedEvidenceItem[];
-  summary?: string | null;
-  unavailableReason?: string | null;
-}
-
-export interface ContinueInNewWorkflowResult {
-  sourceWorkflowId: string;
-  sourceRunId: string;
-  destinationWorkflowId: string;
-  relationshipType: string;
-  created: boolean;
-}
 
 function joinApiPath(apiBase: string, path: string): string {
   const base = (apiBase || '/api').replace(/\/+$/, '');
@@ -71,99 +48,6 @@ export async function fetchWorkflowChatBinding(
     throw new Error(`workflow chat binding request failed (${resp.status})`);
   }
   return (await resp.json()) as WorkflowChatBinding;
-}
-
-/**
- * Turn a MoonMind evidence ref into a download href on the MoonMind origin.
- *
- * Routes through the workflow-scoped captured-evidence download endpoint, which
- * authorizes the caller against the Workflow and reads the ref through the same
- * scheme-aware boundary the runtime uses. This is required because production
- * Omnigent evidence refs are gateway refs (`artifact://omnigent/<corr>/<name>`)
- * that the generic `/artifacts/{id}/download` route cannot serve (its nested
- * path never routes and it has no matching `TemporalArtifact`). The ref is
- * carried as a query parameter so its scheme and slashes survive intact. A full
- * same-origin URL passes through unchanged; a provider session id or upstream
- * path never becomes a durable link.
- */
-export function capturedEvidenceHref(
-  apiBase: string,
-  workflowId: string,
-  artifactRef: string,
-): string | null {
-  const ref = (artifactRef || '').trim();
-  if (!ref) return null;
-  if (/^https?:\/\//i.test(ref)) return ref;
-  if (!workflowId) return null;
-  const base = joinApiPath(
-    apiBase,
-    `/executions/${encodeURIComponent(workflowId)}/captured-evidence/download`,
-  );
-  return `${base}?ref=${encodeURIComponent(ref)}`;
-}
-
-export async function fetchCapturedEvidence(
-  apiBase: string,
-  workflowId: string,
-): Promise<CapturedEvidence> {
-  const resp = await fetch(
-    joinApiPath(
-      apiBase,
-      `/executions/${encodeURIComponent(workflowId)}/captured-evidence`,
-    ),
-    { credentials: 'include' },
-  );
-  if (!resp.ok) {
-    throw new Error(`captured evidence request failed (${resp.status})`);
-  }
-  return (await resp.json()) as CapturedEvidence;
-}
-
-/** Authored continuation intent collected before launching a new workflow. */
-export interface ContinuationIntent {
-  idempotencyKey: string;
-  /** New instructions for the continuation (required — never an empty rerun). */
-  instructions: string;
-  title?: string;
-}
-
-/**
- * Create a linked continuation Workflow from a terminal source.
- *
- * The server pins the source run, Step lineage, and authorized evidence refs; the
- * browser authors the new intent (title + instructions) and carries a stable
- * idempotency key so a double-click resolves to the same linked Workflow rather
- * than creating two. New instructions are required so the continuation is an
- * authored follow-up rather than an accidental rerun of the source's old intent.
- */
-export async function continueInNewWorkflow(
-  apiBase: string,
-  workflowId: string,
-  intent: ContinuationIntent,
-): Promise<ContinueInNewWorkflowResult> {
-  const body: Record<string, unknown> = {
-    idempotencyKey: intent.idempotencyKey,
-    instructions: intent.instructions,
-  };
-  if (intent.title) body.title = intent.title;
-  const resp = await fetch(
-    joinApiPath(apiBase, `/executions/${encodeURIComponent(workflowId)}/continue`),
-    {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    },
-  );
-  if (!resp.ok) {
-    throw new Error(`continue request failed (${resp.status})`);
-  }
-  return (await resp.json()) as ContinueInNewWorkflowResult;
-}
-
-/** Canonical Workflow Detail route for a continuation destination. */
-export function workflowDetailHref(workflowId: string): string {
-  return `/workflows/${encodeURIComponent(workflowId)}?source=temporal`;
 }
 
 /**
@@ -188,220 +72,6 @@ export function fullPageChatUrl(chatUrl: string): string {
 function hasLiveNativeChat(binding: WorkflowChatBinding | null | undefined): boolean {
   return Boolean(
     binding && binding.chatUrl && binding.state !== 'unavailable',
-  );
-}
-
-function newIdempotencyKey(): string {
-  const cryptoObj =
-    typeof globalThis !== 'undefined'
-      ? (globalThis.crypto as Crypto | undefined)
-      : undefined;
-  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
-    return `continue:${cryptoObj.randomUUID()}`;
-  }
-  return `continue:${Date.now()}:${Math.random().toString(16).slice(2)}`;
-}
-
-/**
- * The captured-evidence panel rendered below the terminal context bar.
- * Lists authorized MoonMind artifact refs as download links reusing the existing
- * artifact download contract.
- */
-function CapturedEvidencePanel({
-  apiBase,
-  workflowId,
-}: {
-  apiBase: string;
-  workflowId: string;
-}): React.ReactElement {
-  const query = useQuery({
-    queryKey: ['workflow-captured-evidence', workflowId],
-    queryFn: () => fetchCapturedEvidence(apiBase, workflowId),
-    enabled: Boolean(workflowId),
-    staleTime: 60_000,
-    retry: false,
-  });
-  const evidence = query.data ?? null;
-
-  return (
-    <div
-      className="td-native-chat-evidence"
-      data-testid="workflow-native-chat-evidence"
-    >
-      {query.isLoading ? (
-        <p className="small">Loading captured evidence…</p>
-      ) : query.isError ? (
-        <p className="small" role="alert">
-          Captured evidence is unavailable.
-        </p>
-      ) : evidence && evidence.available && evidence.items.length > 0 ? (
-        <ul className="td-native-chat-evidence-list">
-          {evidence.items.map((item, index) => {
-            const href = capturedEvidenceHref(apiBase, workflowId, item.artifactRef);
-            return (
-              <li key={`${item.kind}-${index}`}>
-                {href ? (
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    data-testid="workflow-native-chat-evidence-link"
-                  >
-                    {item.label}
-                  </a>
-                ) : (
-                  <span>{item.label}</span>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      ) : (
-        <p className="small">
-          {evidence?.unavailableReason
-            ? `No captured evidence: ${evidence.unavailableReason}`
-            : 'No captured evidence is available for this workflow.'}
-        </p>
-      )}
-    </div>
-  );
-}
-
-/**
- * Workflow-level terminal actions — **View captured evidence** and **Continue in
- * a new workflow**.
- *
- * These are governed by the Workflow Execution being terminal (the authoritative
- * execution status passed from the parent), not by the chat binding's write
- * capability or native-iframe availability. A binding can be read-only while its
- * workflow is still live, and a terminal workflow's native UI can be unavailable;
- * in both cases these workflow-scoped actions must reflect terminality alone, so
- * this component is rendered both inside the live read-only chat and in the
- * compatibility fallback (#3641 §9, §10).
- *
- * Continuing requires the operator to author new intent (instructions) first, so
- * the linked Workflow is a deliberate follow-up rather than an accidental rerun
- * of the source's old instructions.
- */
-function TerminalWorkflowActions({
-  apiBase,
-  workflowId,
-}: {
-  apiBase: string;
-  workflowId: string;
-}): React.ReactElement {
-  const [evidenceOpen, setEvidenceOpen] = React.useState(false);
-  const [formOpen, setFormOpen] = React.useState(false);
-  const [title, setTitle] = React.useState('');
-  const [instructions, setInstructions] = React.useState('');
-  const [continueState, setContinueState] = React.useState<
-    'idle' | 'pending' | 'error'
-  >('idle');
-  // Stable per-mount idempotency key: a double-submit resolves to the same
-  // linked Workflow instead of creating two.
-  const idempotencyKey = React.useRef<string>('');
-  if (!idempotencyKey.current) {
-    idempotencyKey.current = newIdempotencyKey();
-  }
-
-  const canSubmit =
-    instructions.trim().length > 0 && continueState !== 'pending';
-
-  const onSubmit = React.useCallback(
-    async (event: React.FormEvent) => {
-      event.preventDefault();
-      if (instructions.trim().length === 0 || continueState === 'pending') {
-        return;
-      }
-      setContinueState('pending');
-      try {
-        const intent: ContinuationIntent = {
-          idempotencyKey: idempotencyKey.current,
-          instructions: instructions.trim(),
-        };
-        const trimmedTitle = title.trim();
-        if (trimmedTitle) intent.title = trimmedTitle;
-        const result = await continueInNewWorkflow(apiBase, workflowId, intent);
-        window.location.assign(workflowDetailHref(result.destinationWorkflowId));
-      } catch {
-        setContinueState('error');
-      }
-    },
-    [apiBase, workflowId, instructions, title, continueState],
-  );
-
-  return (
-    <div className="stack td-native-chat-terminal-actions">
-      <div className="td-native-chat-actions">
-        <button
-          type="button"
-          className="button secondary"
-          aria-expanded={evidenceOpen}
-          onClick={() => setEvidenceOpen((open) => !open)}
-          data-testid="workflow-native-chat-evidence-toggle"
-        >
-          View captured evidence
-        </button>
-        <button
-          type="button"
-          className="button secondary"
-          aria-expanded={formOpen}
-          onClick={() => setFormOpen((open) => !open)}
-          data-testid="workflow-native-chat-continue"
-        >
-          Continue in a new workflow
-        </button>
-      </div>
-      {formOpen ? (
-        <form
-          className="stack td-native-chat-continue-form"
-          onSubmit={onSubmit}
-          data-testid="workflow-native-chat-continue-form"
-        >
-          <label className="field">
-            <span className="small">Title (optional)</span>
-            <input
-              type="text"
-              value={title}
-              maxLength={500}
-              onChange={(event) => setTitle(event.target.value)}
-              data-testid="workflow-native-chat-continue-title"
-            />
-          </label>
-          <label className="field">
-            <span className="small">New instructions</span>
-            <textarea
-              value={instructions}
-              required
-              rows={3}
-              onChange={(event) => setInstructions(event.target.value)}
-              placeholder="Describe what the continuation workflow should do."
-              data-testid="workflow-native-chat-continue-instructions"
-            />
-          </label>
-          <button
-            type="submit"
-            className="button"
-            disabled={!canSubmit}
-            data-testid="workflow-native-chat-continue-submit"
-          >
-            {continueState === 'pending' ? 'Continuing…' : 'Start continuation'}
-          </button>
-        </form>
-      ) : null}
-      {continueState === 'error' ? (
-        <p
-          className="small td-native-chat-continue-error"
-          role="alert"
-          data-testid="workflow-native-chat-continue-error"
-        >
-          Could not start a linked workflow. Please try again.
-        </p>
-      ) : null}
-      {evidenceOpen ? (
-        <CapturedEvidencePanel apiBase={apiBase} workflowId={workflowId} />
-      ) : null}
-    </div>
   );
 }
 
@@ -438,7 +108,7 @@ function NativeChatLive({
         </a>
       </div>
       {terminal ? (
-        <TerminalWorkflowActions apiBase={apiBase} workflowId={workflowId} />
+        <WorkflowTerminalChatActions apiBase={apiBase} workflowId={workflowId} />
       ) : null}
       <iframe
         title="Workflow chat"
@@ -554,7 +224,7 @@ export function WorkflowChatNative({
         </div>
       ) : null}
       {terminal ? (
-        <TerminalWorkflowActions apiBase={apiBase} workflowId={workflowId} />
+        <WorkflowTerminalChatActions apiBase={apiBase} workflowId={workflowId} />
       ) : null}
       {children}
     </>

--- a/frontend/src/features/workflow-native-chat/WorkflowChatContextBar.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowChatContextBar.tsx
@@ -16,9 +16,7 @@ interface WorkflowChatContextBarProps {
   evidenceHref: string;
   /** Full-page MoonMind-scoped native surface; null hides the action. */
   fullPageHref?: string | null;
-  /** Terminal-only "Continue in a new workflow" href; null hides the action. */
-  continueHref?: string | null;
-  /** SPA navigation for internal (overview/evidence/continue) links. */
+  /** SPA navigation for internal overview/evidence links. */
   onNavigate: (href: string) => void;
 }
 
@@ -41,7 +39,6 @@ export function WorkflowChatContextBar({
   overviewHref,
   evidenceHref,
   fullPageHref = null,
-  continueHref = null,
   onNavigate,
 }: WorkflowChatContextBarProps) {
   const handleInternal = (href: string) => (event: MouseEvent<HTMLAnchorElement>) => {
@@ -89,15 +86,6 @@ export function WorkflowChatContextBar({
         {fullPageHref ? (
           <a className="button secondary small" href={fullPageHref}>
             Open in Omnigent
-          </a>
-        ) : null}
-        {continueHref ? (
-          <a
-            className="button secondary small"
-            href={continueHref}
-            onClick={handleInternal(continueHref)}
-          >
-            Continue in a new workflow
           </a>
         ) : null}
       </nav>

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
@@ -35,11 +35,24 @@ function mockBinding(
         json: async () => body,
       } as unknown as Response);
     }
+    if (url.includes('/continue')) {
+      return Promise.resolve({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          sourceWorkflowId: 'wf-1',
+          sourceRunId: 'run-1',
+          destinationWorkflowId: 'wf-2',
+          relationshipType: 'linked_continuation',
+          created: true,
+        }),
+      } as unknown as Response);
+    }
     return Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response);
   });
 }
 
-function renderRoute(onNavigate = vi.fn()) {
+function renderRoute(onNavigate = vi.fn(), workflowTerminal = false) {
   renderWithClient(
     <WorkflowNativeChatRoute
       apiBase="/api"
@@ -48,6 +61,7 @@ function renderRoute(onNavigate = vi.fn()) {
       search={new URLSearchParams('source=temporal')}
       workflowTitle="Ship the thing"
       runtimeLabel="Codex via Omnigent"
+      workflowTerminal={workflowTerminal}
       pollIntervalMs={5000}
       onNavigate={onNavigate}
     />,
@@ -104,19 +118,38 @@ describe('WorkflowNativeChatRoute', () => {
     expect(onNavigate).toHaveBeenCalledWith('overview', '/workflows/wf-1/overview?source=temporal');
   });
 
-  it('shows a terminal read-only session and withholds Continue until the handoff exists', async () => {
+  it('shows a terminal read-only session and launches an explicit linked continuation', async () => {
     mockBinding(() => ({
       body: { ...AVAILABLE, state: 'ended', readOnly: true, capabilities: {} },
     }));
-    renderRoute();
+    renderRoute(vi.fn(), true);
     await screen.findByTitle('Ship the thing — Omnigent chat');
     expect(screen.getByText(/session ended/i)).toBeTruthy();
-    // The continuation handoff (linked execution + authorized source identity)
-    // does not exist yet, so the misleading "Continue" affordance is withheld
-    // rather than pointed at the source workflow's Overview.
-    expect(
-      screen.queryByRole('link', { name: 'Continue in a new workflow' }),
-    ).toBeNull();
+    const action = screen.getByRole('button', {
+      name: 'Continue in a new workflow',
+    });
+    fireEvent.click(action);
+    const submit = screen.getByTestId(
+      'workflow-native-chat-continue-submit',
+    ) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.change(
+      screen.getByTestId('workflow-native-chat-continue-instructions'),
+      { target: { value: 'Finish the remaining follow-up.' } },
+    );
+    // Keep the request pending after dispatch; this test verifies the authored
+    // Workflow action without allowing jsdom to perform a real navigation.
+    fetchSpy.mockImplementationOnce(() => new Promise<Response>(() => {}));
+    fireEvent.submit(screen.getByTestId('workflow-native-chat-continue-form'));
+    await waitFor(() => {
+      const call = fetchSpy.mock.calls.find(([input]) =>
+        String(input).includes('/api/executions/wf-1/continue'),
+      );
+      expect(call?.[1]?.method).toBe('POST');
+      expect(JSON.parse(String(call?.[1]?.body)).instructions).toBe(
+        'Finish the remaining follow-up.',
+      );
+    });
   });
 
   it('renders an explicit unsupported-runtime state with no iframe', async () => {
@@ -137,6 +170,26 @@ describe('WorkflowNativeChatRoute', () => {
     ).toBeTruthy();
     expect(document.querySelector('iframe')).toBeNull();
     expect(screen.queryByRole('link', { name: 'Continue in a new workflow' })).toBeNull();
+  });
+
+  it('keeps terminal continuation available when the native frame is unavailable', async () => {
+    mockBinding(() => ({
+      body: {
+        ...AVAILABLE,
+        chatBindingId: '',
+        chatUrl: '',
+        apiBase: '',
+        state: 'unavailable',
+        readOnly: true,
+        unavailableReason: 'native_ui_upstream_unavailable',
+      },
+    }));
+    renderRoute(vi.fn(), true);
+
+    expect(await screen.findByText('No chat session available')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Continue in a new workflow' }),
+    ).toBeTruthy();
   });
 
   it('surfaces an unauthorized state and no session details', async () => {

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.tsx
@@ -24,6 +24,7 @@ import {
 import { NativeChatFrame, type NativeChatFrameSignal } from './NativeChatFrame';
 import { NativeChatUnavailableState } from './NativeChatUnavailableState';
 import { WorkflowChatContextBar } from './WorkflowChatContextBar';
+import { WorkflowTerminalChatActions } from './WorkflowTerminalChatActions';
 import { useWorkflowChatBinding } from './useWorkflowChatBinding';
 
 interface WorkflowNativeChatRouteProps {
@@ -98,12 +99,6 @@ export function WorkflowNativeChatRoute({
   const overviewHref = workflowDetailSubrouteHref(routeWorkflowId, 'overview', search);
   const evidenceHref = workflowDetailSubrouteHref(routeWorkflowId, 'evidence', search);
   const debugHref = workflowDetailSubrouteHref(routeWorkflowId, 'debug', search);
-  // "Continue in a new workflow" is intentionally omitted until the
-  // workflow-creation/continuation handoff (which must carry the authorized
-  // source identity and evidence and create a linked execution) exists. Pointing
-  // it at the source workflow's Overview would create no linked continuation and
-  // only mislead the operator, so the affordance is withheld rather than faked.
-  const continueHref = null;
 
   const navigate = (href: string) => {
     let pathname: string;
@@ -131,9 +126,11 @@ export function WorkflowNativeChatRoute({
         overviewHref={overviewHref}
         evidenceHref={evidenceHref}
         fullPageHref={fullHref}
-        continueHref={continueHref}
         onNavigate={navigate}
       />
+      {workflowTerminal ? (
+        <WorkflowTerminalChatActions apiBase={apiBase} workflowId={workflowId} />
+      ) : null}
       <div className="wf-native-chat__surface">
         {mountFrame && iframeSrc ? (
           <NativeChatFrame

--- a/frontend/src/features/workflow-native-chat/WorkflowTerminalChatActions.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowTerminalChatActions.tsx
@@ -1,0 +1,301 @@
+/**
+ * Workflow-scoped terminal Chat actions (MoonLadderStudios/MoonMind#3632,
+ * child #3641).
+ *
+ * These controls sit outside the native Omnigent application because they
+ * create/read MoonMind Workflow state.  They never post a native message or
+ * invoke SubmitChatInstruction.  The server pins source identity and evidence;
+ * the browser supplies only new continuation intent and an idempotency key.
+ */
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+export interface CapturedEvidenceItem {
+  label: string;
+  kind: string;
+  artifactRef: string;
+}
+
+export interface CapturedEvidence {
+  workflowId: string;
+  runId?: string | null;
+  available: boolean;
+  items: CapturedEvidenceItem[];
+  summary?: string | null;
+  unavailableReason?: string | null;
+}
+
+export interface ContinueInNewWorkflowResult {
+  sourceWorkflowId: string;
+  sourceRunId: string;
+  destinationWorkflowId: string;
+  relationshipType: string;
+  created: boolean;
+}
+
+export interface ContinuationIntent {
+  idempotencyKey: string;
+  instructions: string;
+  title?: string;
+}
+
+function joinApiPath(apiBase: string, path: string): string {
+  const base = (apiBase || '/api').replace(/\/+$/, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+export function capturedEvidenceHref(
+  apiBase: string,
+  workflowId: string,
+  artifactRef: string,
+): string | null {
+  const ref = (artifactRef || '').trim();
+  if (!ref) return null;
+  if (/^https?:\/\//i.test(ref)) return ref;
+  if (!workflowId) return null;
+  const base = joinApiPath(
+    apiBase,
+    `/executions/${encodeURIComponent(workflowId)}/captured-evidence/download`,
+  );
+  return `${base}?ref=${encodeURIComponent(ref)}`;
+}
+
+export async function fetchCapturedEvidence(
+  apiBase: string,
+  workflowId: string,
+): Promise<CapturedEvidence> {
+  const resp = await fetch(
+    joinApiPath(
+      apiBase,
+      `/executions/${encodeURIComponent(workflowId)}/captured-evidence`,
+    ),
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    throw new Error(`captured evidence request failed (${resp.status})`);
+  }
+  return (await resp.json()) as CapturedEvidence;
+}
+
+export async function continueInNewWorkflow(
+  apiBase: string,
+  workflowId: string,
+  intent: ContinuationIntent,
+): Promise<ContinueInNewWorkflowResult> {
+  const body: Record<string, unknown> = {
+    idempotencyKey: intent.idempotencyKey,
+    instructions: intent.instructions,
+  };
+  if (intent.title) body.title = intent.title;
+  const resp = await fetch(
+    joinApiPath(apiBase, `/executions/${encodeURIComponent(workflowId)}/continue`),
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`continue request failed (${resp.status})`);
+  }
+  return (await resp.json()) as ContinueInNewWorkflowResult;
+}
+
+export function continuationWorkflowHref(workflowId: string): string {
+  return `/workflows/${encodeURIComponent(workflowId)}?source=temporal`;
+}
+
+function newIdempotencyKey(): string {
+  const cryptoObj =
+    typeof globalThis !== 'undefined'
+      ? (globalThis.crypto as Crypto | undefined)
+      : undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return `continue:${cryptoObj.randomUUID()}`;
+  }
+  return `continue:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+}
+
+function CapturedEvidencePanel({
+  apiBase,
+  workflowId,
+}: {
+  apiBase: string;
+  workflowId: string;
+}): React.ReactElement {
+  const query = useQuery({
+    queryKey: ['workflow-captured-evidence', workflowId],
+    queryFn: () => fetchCapturedEvidence(apiBase, workflowId),
+    enabled: Boolean(workflowId),
+    staleTime: 60_000,
+    retry: false,
+  });
+  const evidence = query.data ?? null;
+
+  return (
+    <div
+      className="td-native-chat-evidence"
+      data-testid="workflow-native-chat-evidence"
+    >
+      {query.isLoading ? (
+        <p className="small">Loading captured evidence…</p>
+      ) : query.isError ? (
+        <p className="small" role="alert">
+          Captured evidence is unavailable.
+        </p>
+      ) : evidence && evidence.available && evidence.items.length > 0 ? (
+        <ul className="td-native-chat-evidence-list">
+          {evidence.items.map((item, index) => {
+            const href = capturedEvidenceHref(apiBase, workflowId, item.artifactRef);
+            return (
+              <li key={`${item.kind}-${index}`}>
+                {href ? (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="workflow-native-chat-evidence-link"
+                  >
+                    {item.label}
+                  </a>
+                ) : (
+                  <span>{item.label}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="small">
+          {evidence?.unavailableReason
+            ? `No captured evidence: ${evidence.unavailableReason}`
+            : 'No captured evidence is available for this workflow.'}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function WorkflowTerminalChatActions({
+  apiBase,
+  workflowId,
+}: {
+  apiBase: string;
+  workflowId: string;
+}): React.ReactElement {
+  const [evidenceOpen, setEvidenceOpen] = React.useState(false);
+  const [formOpen, setFormOpen] = React.useState(false);
+  const [title, setTitle] = React.useState('');
+  const [instructions, setInstructions] = React.useState('');
+  const [continueState, setContinueState] = React.useState<
+    'idle' | 'pending' | 'error'
+  >('idle');
+  const idempotencyKey = React.useRef<string>('');
+  if (!idempotencyKey.current) {
+    idempotencyKey.current = newIdempotencyKey();
+  }
+
+  const canSubmit =
+    instructions.trim().length > 0 && continueState !== 'pending';
+
+  const onSubmit = React.useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      if (instructions.trim().length === 0 || continueState === 'pending') {
+        return;
+      }
+      setContinueState('pending');
+      try {
+        const intent: ContinuationIntent = {
+          idempotencyKey: idempotencyKey.current,
+          instructions: instructions.trim(),
+        };
+        const trimmedTitle = title.trim();
+        if (trimmedTitle) intent.title = trimmedTitle;
+        const result = await continueInNewWorkflow(apiBase, workflowId, intent);
+        window.location.assign(
+          continuationWorkflowHref(result.destinationWorkflowId),
+        );
+      } catch {
+        setContinueState('error');
+      }
+    },
+    [apiBase, workflowId, instructions, title, continueState],
+  );
+
+  return (
+    <div className="stack td-native-chat-terminal-actions">
+      <div className="td-native-chat-actions">
+        <button
+          type="button"
+          className="button secondary"
+          aria-expanded={evidenceOpen}
+          onClick={() => setEvidenceOpen((open) => !open)}
+          data-testid="workflow-native-chat-evidence-toggle"
+        >
+          View captured evidence
+        </button>
+        <button
+          type="button"
+          className="button secondary"
+          aria-expanded={formOpen}
+          onClick={() => setFormOpen((open) => !open)}
+          data-testid="workflow-native-chat-continue"
+        >
+          Continue in a new workflow
+        </button>
+      </div>
+      {formOpen ? (
+        <form
+          className="stack td-native-chat-continue-form"
+          onSubmit={onSubmit}
+          data-testid="workflow-native-chat-continue-form"
+        >
+          <label className="field">
+            <span className="small">Title (optional)</span>
+            <input
+              type="text"
+              value={title}
+              maxLength={500}
+              onChange={(event) => setTitle(event.target.value)}
+              data-testid="workflow-native-chat-continue-title"
+            />
+          </label>
+          <label className="field">
+            <span className="small">New instructions</span>
+            <textarea
+              value={instructions}
+              required
+              rows={3}
+              onChange={(event) => setInstructions(event.target.value)}
+              placeholder="Describe what the continuation workflow should do."
+              data-testid="workflow-native-chat-continue-instructions"
+            />
+          </label>
+          <button
+            type="submit"
+            className="button"
+            disabled={!canSubmit}
+            data-testid="workflow-native-chat-continue-submit"
+          >
+            {continueState === 'pending' ? 'Continuing…' : 'Start continuation'}
+          </button>
+        </form>
+      ) : null}
+      {continueState === 'error' ? (
+        <p
+          className="small td-native-chat-continue-error"
+          role="alert"
+          data-testid="workflow-native-chat-continue-error"
+        >
+          Could not start a linked workflow. Please try again.
+        </p>
+      ) : null}
+      {evidenceOpen ? (
+        <CapturedEvidencePanel apiBase={apiBase} workflowId={workflowId} />
+      ) : null}
+    </div>
+  );
+}

--- a/moonmind/omnigent/conformance.py
+++ b/moonmind/omnigent/conformance.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 PROFILE_VERSION = "moonmind.omnigent.conformance/v4"
-PROFILE_SHA256 = "31208809bdf89e119542b9670ec99e8bcfb5076c2489237ff0168378f4dfba0e"
+PROFILE_SHA256 = "79d188fffa261eb5f49e97023ce82ae31e7f5640e386d46703a0283de68c58b5"
 REPORT_VERSION = "moonmind.omnigent.conformance-report/v1"
 ACCEPTANCE_VERSION = "moonmind.omnigent.product-acceptance/v1"
 BROWSER_EVIDENCE_VERSION = "moonmind.omnigent.live-evidence/v1"

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -131,6 +131,8 @@ _CORRELATION_FIELDS = (
 )
 _GLOBAL_CORRELATION_FIELDS = _CORRELATION_FIELDS[:-1]
 _TRANSPORTS = frozenset({"html", "http", "sse", "websocket"})
+_NATIVE_UI_DOCUMENT_ROUTE = "native_ui_document"
+_LINKED_CONTINUATION_RELATIONSHIP = "linked_continuation"
 _NATIVE_CONTROL_KINDS = frozenset(
     {"approval", "tool", "file", "terminal", "agent", "task"}
 )
@@ -190,6 +192,43 @@ def _canonical_digest(value: Any) -> str:
     return "sha256:" + hashlib.sha256(raw).hexdigest()
 
 
+def _is_scoped_path(path: str, allowed_bases: tuple[str, ...]) -> bool:
+    parsed_path = urllib.parse.urlsplit(path).path
+    return any(
+        parsed_path == base or parsed_path.startswith(base + "/")
+        for base in allowed_bases
+    )
+
+
+def _require_evidence_items(value: Any, *, field: str) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value:
+        raise ConformanceContractError(
+            f"workflow Chat source record {field} must contain evidence items"
+        )
+    result: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_item in value:
+        item = _require_mapping(raw_item, field=f"{field}[]")
+        ref = _require_string(item.get("ref"), field=f"{field}[].ref")
+        parsed = urllib.parse.urlparse(ref)
+        if (
+            ref in seen
+            or parsed.scheme not in {"", "https"}
+            or (not parsed.scheme and Path(ref).is_absolute())
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat source record {field} contains an unpackaged ref"
+            )
+        digest = _require_string(item.get("sha256"), field=f"{field}[].sha256")
+        if _SHA256.fullmatch(digest) is None:
+            raise ConformanceContractError(
+                f"workflow Chat source record {field} contains a malformed digest"
+            )
+        seen.add(ref)
+        result.append({"ref": ref, "sha256": digest})
+    return result
+
+
 def _validate_record_data(
     record_type: str,
     data: Mapping[str, Any],
@@ -227,11 +266,14 @@ def _validate_record_data(
             path = _require_string(
                 item.get("path"), field="browserTrace.networkEvents[].path"
             )
+            _require_string(
+                item.get("method"), field="browserTrace.networkEvents[].method"
+            )
             status = item.get("responseStatus")
             if (
                 request_id in event_ids
                 or transport not in _TRANSPORTS
-                or not path.startswith(allowed_prefixes)
+                or not _is_scoped_path(path, allowed_prefixes)
                 or not isinstance(status, int)
                 or not 100 <= status <= 599
                 or item.get("moonmindScoped") is not True
@@ -322,8 +364,11 @@ def _validate_record_data(
             )
         observed_ids: set[str] = set()
         transports: set[str] = set()
+        observed_route_names: set[str] = set()
         reconnect_id = data.get("reconnectRequestId")
         reconnect_reauthorized = False
+        routes = compatibility_map()["routes"]
+        expected_routes = {str(item["name"]): item for item in routes}
         for request in requests:
             item = _require_mapping(request, field="facadeRequests.data.requests[]")
             request_id = _require_string(
@@ -332,10 +377,33 @@ def _validate_record_data(
             transport = _require_string(
                 item.get("transport"), field="facadeRequests.data.requests[].transport"
             )
+            route_name = _require_string(
+                item.get("routeName"), field="facadeRequests.data.requests[].routeName"
+            )
+            method = _require_string(
+                item.get("method"), field="facadeRequests.data.requests[].method"
+            )
+            route_path = _require_string(
+                item.get("routePath"), field="facadeRequests.data.requests[].routePath"
+            )
+            route = expected_routes.get(route_name)
+            route_matches = (
+                transport == "html"
+                and route_name == _NATIVE_UI_DOCUMENT_ROUTE
+                and method == "GET"
+                and route_path == f"omnigent-ui/workflow-chat/{binding_id}"
+            ) or (
+                route is not None
+                and transport == route.get("transport")
+                and method in route.get("methods", [])
+                and re.fullmatch(str(route.get("pathPattern") or ""), route_path)
+                is not None
+            )
             if (
                 request_id in observed_ids
                 or request_id not in request_id_set
                 or transport not in _TRANSPORTS
+                or not route_matches
                 or item.get("bindingId") != binding_id
                 or item.get("providerSessionId") != provider_session_id
                 or item.get("authorized") is not True
@@ -346,19 +414,14 @@ def _validate_record_data(
                 )
             observed_ids.add(request_id)
             transports.add(transport)
+            observed_route_names.add(route_name)
             if request_id == reconnect_id:
                 reconnect_reauthorized = item.get("reauthorized") is True
-        expected_routes = {item["name"] for item in compatibility_map()["routes"]}
-        route_names = set(
-            _require_string_list(
-                data.get("coveredRouteNames"),
-                field="facadeRequests.data.coveredRouteNames",
-            )
-        )
         if (
             observed_ids != request_id_set
             or transports != set(_TRANSPORTS)
-            or route_names != expected_routes
+            or observed_route_names
+            != set(expected_routes) | {_NATIVE_UI_DOCUMENT_ROUTE}
             or data.get("compatibilityProfile")
             != WORKFLOW_CHAT_COMPATIBILITY_PROFILE
             or reconnect_id not in request_id_set
@@ -407,14 +470,17 @@ def _validate_record_data(
             raise ConformanceContractError(
                 "workflow Chat mutationReceipts requires durable receipts"
             )
+        receipt_ids: set[str] = set()
         for receipt in receipts:
             item = _require_mapping(
                 receipt, field="mutationReceipts.data.receipts[]"
             )
-            if item.get("requestId") not in request_id_set:
+            request_id = item.get("requestId")
+            if request_id not in request_id_set or request_id in receipt_ids:
                 raise ConformanceContractError(
                     "workflow Chat mutation receipt is not request-correlated"
                 )
+            receipt_ids.add(str(request_id))
             for field in (
                 "actor",
                 "idempotencyKey",
@@ -427,6 +493,10 @@ def _validate_record_data(
                     item.get(field),
                     field=f"mutationReceipts.data.receipts[].{field}",
                 )
+        if receipt_ids != request_id_set:
+            raise ConformanceContractError(
+                "workflow Chat mutation receipt coverage is incomplete"
+            )
         return
 
     if record_type == "denialAudit":
@@ -436,6 +506,7 @@ def _validate_record_data(
                 "workflow Chat denialAudit requires observed denials"
             )
         kinds: set[str] = set()
+        denial_ids: set[str] = set()
         for denial in denials:
             item = _require_mapping(denial, field="denialAudit.data.denials[]")
             kinds.add(
@@ -445,11 +516,13 @@ def _validate_record_data(
             )
             if (
                 item.get("requestId") not in request_id_set
+                or item.get("requestId") in denial_ids
                 or item.get("upstreamForwarded") is not False
             ):
                 raise ConformanceContractError(
                     "workflow Chat denialAudit is not fail-closed"
                 )
+            denial_ids.add(str(item["requestId"]))
             _require_string(
                 item.get("auditRef"), field="denialAudit.data.denials[].auditRef"
             )
@@ -511,6 +584,7 @@ def _validate_record_data(
                 "workflow Chat scanAudit requires observed scan attempts"
             )
         outcomes: set[str] = set()
+        attempt_ids: set[str] = set()
         for attempt in attempts:
             item = _require_mapping(attempt, field="scanAudit.data.attempts[]")
             outcomes.add(
@@ -520,11 +594,13 @@ def _validate_record_data(
             )
             if (
                 item.get("requestId") not in request_id_set
+                or item.get("requestId") in attempt_ids
                 or item.get("forwarded") is not False
             ):
                 raise ConformanceContractError(
                     "workflow Chat scanAudit did not fail closed"
                 )
+            attempt_ids.add(str(item["requestId"]))
             _require_string(
                 item.get("auditRef"), field="scanAudit.data.attempts[].auditRef"
             )
@@ -542,7 +618,7 @@ def _validate_record_data(
             )
         )
         if (
-            not verified.issubset(request_id_set)
+            verified != request_id_set
             or data.get("browserExposedCredentialNames") != []
             or data.get("forwardedMoonMindCredentialNames") != []
         ):
@@ -573,37 +649,78 @@ def _validate_record_data(
         return
 
     if record_type == "capturedEvidence":
-        refs = _require_string_list(
-            data.get("artifactRefs"), field="capturedEvidence.data.artifactRefs"
+        artifacts = _require_evidence_items(
+            data.get("artifacts"), field="capturedEvidence.data.artifacts"
         )
-        if (
-            any(not ref.startswith("artifact://") for ref in refs)
-            or data.get("captureManifestRef") not in refs
-            or data.get("allResolved") is not True
-        ):
+        refs = {item["ref"] for item in artifacts}
+        if data.get("captureManifestRef") not in refs:
             raise ConformanceContractError(
                 "workflow Chat capturedEvidence is not independently resolvable"
             )
         return
 
     if record_type == "continuationReceipt":
-        destination = _require_string(
-            data.get("destinationWorkflowId"),
-            field="continuationReceipt.data.destinationWorkflowId",
+        creation = _require_mapping(
+            data.get("destinationCreationReceipt"),
+            field="continuationReceipt.data.destinationCreationReceipt",
         )
+        relationship = _require_mapping(
+            data.get("durableRelationship"),
+            field="continuationReceipt.data.durableRelationship",
+        )
+        source_run_id = _require_string(
+            creation.get("sourceRunId"),
+            field="continuationReceipt.data.destinationCreationReceipt.sourceRunId",
+        )
+        destination = _require_string(
+            creation.get("destinationWorkflowId"),
+            field=(
+                "continuationReceipt.data.destinationCreationReceipt."
+                "destinationWorkflowId"
+            ),
+        )
+        destination_run_id = _require_string(
+            relationship.get("destinationRunId"),
+            field="continuationReceipt.data.durableRelationship.destinationRunId",
+        )
+        relationship_identity = {
+            "relationshipType": _LINKED_CONTINUATION_RELATIONSHIP,
+            "sourceWorkflowId": workflow_id,
+            "sourceRunId": source_run_id,
+            "destinationWorkflowId": destination,
+            "destinationRunId": destination_run_id,
+        }
         if (
-            data.get("sourceWorkflowId") != workflow_id
+            creation.get("requestId") not in request_id_set
+            or creation.get("created") is not True
+            or creation.get("relationshipType")
+            != _LINKED_CONTINUATION_RELATIONSHIP
+            or creation.get("sourceWorkflowId") != workflow_id
             or destination == workflow_id
-            or data.get("sourceUnchanged") is not True
-            or data.get("separateWorkflowAction") is not True
+            or relationship.get("requestId") not in request_id_set
+            or relationship.get("requestId") == creation.get("requestId")
+            or relationship.get("direction") != "outbound"
+            or any(
+                relationship.get(field) != value
+                for field, value in relationship_identity.items()
+            )
+            or relationship.get("relationshipDigest")
+            != _canonical_digest(relationship_identity)
+            or data.get("sourceStateBeforeSha256")
+            != data.get("sourceStateAfterSha256")
         ):
             raise ConformanceContractError(
                 "workflow Chat continuationReceipt does not prove linked continuation"
             )
-        for field in ("continuationId", "idempotencyKey"):
-            _require_string(
-                data.get(field), field=f"continuationReceipt.data.{field}"
-            )
+        _require_sha256_ref(
+            data.get("sourceStateBeforeSha256"),
+            field="continuationReceipt.data.sourceStateBeforeSha256",
+        )
+        _require_string(data.get("idempotencyKey"), field="continuationReceipt.data.idempotencyKey")
+        _timestamp(
+            relationship.get("createdAt"),
+            field="continuationReceipt.data.durableRelationship.createdAt",
+        )
         return
 
     if record_type == "replaySnapshot":
@@ -613,7 +730,14 @@ def _validate_record_data(
         if (
             data.get("hostUnavailable") is not True
             or data.get("replayedFromMoonMindArtifacts") is not True
-            or any(not ref.startswith("artifact://") for ref in replay_refs)
+            or any(
+                urllib.parse.urlparse(ref).scheme not in {"", "https"}
+                or (
+                    not urllib.parse.urlparse(ref).scheme
+                    and Path(ref).is_absolute()
+                )
+                for ref in replay_refs
+            )
         ):
             raise ConformanceContractError(
                 "workflow Chat replaySnapshot does not prove host-independent replay"
@@ -701,8 +825,112 @@ def validate_workflow_chat_source_records(
             raise ConformanceContractError(
                 f"workflow Chat source record request correlation failed: {record_type}"
             )
+    browser_events = {
+        str(item["requestId"]): item
+        for item in sources["browserTrace"]["data"]["networkEvents"]
+    }
+    expected_denial_statuses: dict[str, int] = {}
+    denial_source = sources.get("denialAudit")
+    if denial_source is not None:
+        expected_denial_statuses.update(
+            {
+                str(item["requestId"]): 403
+                for item in denial_source["data"]["denials"]
+            }
+        )
+    scan_source = sources.get("scanAudit")
+    if scan_source is not None:
+        expected_denial_statuses.update(
+            {
+                str(item["requestId"]): (
+                    503 if item["outcome"] == "enforcement_unavailable" else 403
+                )
+                for item in scan_source["data"]["attempts"]
+            }
+        )
+    terminal_source = sources.get("terminalSnapshot")
+    if terminal_source is not None:
+        expected_denial_statuses.update(
+            {
+                str(request_id): 403
+                for request_id in terminal_source["data"][
+                    "deniedMutationRequestIds"
+                ]
+            }
+        )
+    for request_id, event in browser_events.items():
+        status = event["responseStatus"]
+        expected_denial = expected_denial_statuses.get(request_id)
+        unexpected_denial = (
+            expected_denial is not None and status != expected_denial
+        )
+        unsuccessful_positive = (
+            expected_denial is None
+            and status != 101
+            and not 200 <= status < 300
+        )
+        if unexpected_denial or unsuccessful_positive:
+            raise ConformanceContractError(
+                "workflow Chat browserTrace contains an unexpected response status"
+            )
+
+    facade_source = sources.get("facadeRequests")
+    mutation_source = sources.get("mutationReceipts")
+    if facade_source is not None and mutation_source is not None:
+        route_mutations = {
+            str(item["name"]): item.get("mutation") is True
+            for item in compatibility_map()["routes"]
+        }
+        facade_requests = facade_source["data"]["requests"]
+        observed_mutation_ids = {
+            str(item["requestId"])
+            for item in facade_requests
+            if route_mutations.get(str(item["routeName"]), False)
+        }
+        receipt_ids = {
+            str(item["requestId"])
+            for item in mutation_source["data"]["receipts"]
+        }
+        def _request_matches_browser_trace(item: Mapping[str, Any]) -> bool:
+            request_id = str(item["requestId"])
+            event = browser_events[request_id]
+            observed_path = urllib.parse.urlsplit(str(event["path"])).path
+            expected_path = (
+                "/" + str(item["routePath"])
+                if item["routeName"] == _NATIVE_UI_DOCUMENT_ROUTE
+                else f"/api/workflow-chat-bindings/{row_correlation['chatBindingId']}"
+                f"/omnigent/{item['routePath']}"
+            )
+            return (
+                event["transport"] == item["transport"]
+                and event["method"] == item["method"]
+                and observed_path == expected_path
+            )
+
+        if (
+            observed_mutation_ids != receipt_ids
+            or set(mutation_source["data"]["requestIds"])
+            != observed_mutation_ids
+            or any(not _request_matches_browser_trace(item) for item in facade_requests)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat mutation receipt or transport coverage is incomplete"
+            )
+
+    credential_source = sources.get("credentialBoundary")
+    if credential_source is not None and (
+        set(credential_source["data"]["verifiedRequestIds"])
+        != browser_request_ids
+        or request_ids_by_type["credentialBoundary"] != browser_request_ids
+    ):
+        raise ConformanceContractError(
+            "workflow Chat credentialBoundary does not cover the browser trace"
+        )
     if row_name == "terminal-evidence-and-continuation":
-        captured_refs = set(sources["capturedEvidence"]["data"]["artifactRefs"])
+        captured_refs = {
+            str(item["ref"])
+            for item in sources["capturedEvidence"]["data"]["artifacts"]
+        }
         replay_refs = set(sources["replaySnapshot"]["data"]["artifactRefs"])
         if not replay_refs.issubset(captured_refs):
             raise ConformanceContractError(
@@ -810,7 +1038,22 @@ def build_workflow_chat_acceptance_manifest(
         if isinstance(source_records, list):
             for record in source_records:
                 if isinstance(record, Mapping) and record.get("ref"):
-                    refs.append(str(record["ref"]))
+                    record_ref = str(record["ref"])
+                    refs.append(record_ref)
+                    source_record = _resolve_json(record_ref, evidence_root)
+                    if source_record.get("recordType") == "capturedEvidence":
+                        data = source_record.get("data")
+                        artifacts = (
+                            data.get("artifacts")
+                            if isinstance(data, Mapping)
+                            else None
+                        )
+                        if isinstance(artifacts, list):
+                            for artifact in artifacts:
+                                if isinstance(artifact, Mapping) and artifact.get(
+                                    "ref"
+                                ):
+                                    refs.append(str(artifact["ref"]))
     for scan_ref in dict.fromkeys(scan_refs):
         scan_evidence = _resolve_json(scan_ref, evidence_root)
         files = scan_evidence.get("files")
@@ -932,6 +1175,7 @@ def validate_workflow_chat_acceptance_manifest(
             "workflow Chat acceptance matrix coverage is incomplete"
         )
     used_refs: set[str] = set()
+    trace_screenshot_digests: set[str] = set()
     global_correlation: dict[str, str] | None = None
     for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
         row = rows[row_name]
@@ -1017,6 +1261,28 @@ def validate_workflow_chat_acceptance_manifest(
                     )
                 sources_by_type[record_type] = source
                 used_refs.add(record_ref)
+            browser_data = sources_by_type["browserTrace"].get("data")
+            if isinstance(browser_data, Mapping):
+                trace_screenshot_digests.add(
+                    _require_sha256_ref(
+                        browser_data.get("screenshotSha256"),
+                        field="browserTrace.data.screenshotSha256",
+                    ).removeprefix("sha256:")
+                )
+            captured_source = sources_by_type.get("capturedEvidence")
+            if captured_source is not None:
+                captured_data = _require_mapping(
+                    captured_source.get("data"), field="capturedEvidence.data"
+                )
+                for artifact in _require_evidence_items(
+                    captured_data.get("artifacts"),
+                    field="capturedEvidence.data.artifacts",
+                ):
+                    if manifest_digests.get(artifact["ref"]) != artifact["sha256"]:
+                        raise ConformanceContractError(
+                            "workflow Chat capturedEvidence artifact is unresolved"
+                        )
+                    used_refs.add(artifact["ref"])
             derived_assertions, correlation = validate_workflow_chat_source_records(
                 sources_by_type,
                 row_name=row_name,
@@ -1130,6 +1396,7 @@ def validate_workflow_chat_acceptance_manifest(
         raise ConformanceContractError(
             "workflow Chat acceptance evidence-channel scans are incomplete"
         )
+    scanned_screenshot_digests: set[str] = set()
     for channel in REQUIRED_EVIDENCE_CHANNELS:
         scan = scans[channel]
         ref = scan.get("evidenceRef") if isinstance(scan, Mapping) else None
@@ -1162,6 +1429,13 @@ def validate_workflow_chat_acceptance_manifest(
                     f"workflow Chat raw evidence scan is invalid: {channel}"
                 )
             used_refs.add(file_ref)
+            if channel == "screenshots":
+                scanned_screenshot_digests.add(digest)
+
+    if not trace_screenshot_digests.issubset(scanned_screenshot_digests):
+        raise ConformanceContractError(
+            "workflow Chat browserTrace screenshot is not scanned evidence"
+        )
 
     if used_refs != set(resolved_raw):
         raise ConformanceContractError(

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -27,6 +27,7 @@ from moonmind.omnigent.conformance import (
     assert_secret_free,
     require_pinned_images,
 )
+from moonmind.omnigent.native_ui_compat import compatibility_map
 
 WORKFLOW_CHAT_ACCEPTANCE_VERSION = (
     "moonmind.omnigent.workflow-chat-acceptance/v1"
@@ -120,6 +121,596 @@ REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS: Mapping[str, frozenset[str]] = {
 }
 
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_SHA256_REF = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CORRELATION_FIELDS = (
+    "workflowId",
+    "chatBindingId",
+    "bridgeSessionId",
+    "providerSessionId",
+    "browserTraceId",
+)
+_GLOBAL_CORRELATION_FIELDS = _CORRELATION_FIELDS[:-1]
+_TRANSPORTS = frozenset({"html", "http", "sse", "websocket"})
+_NATIVE_CONTROL_KINDS = frozenset(
+    {"approval", "tool", "file", "terminal", "agent", "task"}
+)
+_DENIAL_KINDS = frozenset(
+    {
+        "alternate_binding",
+        "provider_session_substitution",
+        "hidden_control",
+        "immutable_policy",
+    }
+)
+_TERMINAL_STATES = frozenset(
+    {"completed", "failed", "canceled", "cancelled", "timed_out", "stopped"}
+)
+
+
+def _require_mapping(value: Any, *, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ConformanceContractError(
+            f"workflow Chat source record {field} must be an object"
+        )
+    return value
+
+
+def _require_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConformanceContractError(
+            f"workflow Chat source record {field} must be a non-empty string"
+        )
+    return value
+
+
+def _require_string_list(value: Any, *, field: str) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item.strip() for item in value)
+        or len(set(value)) != len(value)
+    ):
+        raise ConformanceContractError(
+            f"workflow Chat source record {field} must contain unique strings"
+        )
+    return value
+
+
+def _require_sha256_ref(value: Any, *, field: str) -> str:
+    result = _require_string(value, field=field)
+    if _SHA256_REF.fullmatch(result) is None:
+        raise ConformanceContractError(
+            f"workflow Chat source record {field} must be an immutable digest"
+        )
+    return result
+
+
+def _canonical_digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _validate_record_data(
+    record_type: str,
+    data: Mapping[str, Any],
+    *,
+    correlation: Mapping[str, str],
+) -> None:
+    request_ids = _require_string_list(
+        data.get("requestIds"), field=f"{record_type}.data.requestIds"
+    )
+    request_id_set = set(request_ids)
+    workflow_id = correlation["workflowId"]
+    binding_id = correlation["chatBindingId"]
+    provider_session_id = correlation["providerSessionId"]
+
+    if record_type == "browserTrace":
+        events = data.get("networkEvents")
+        if not isinstance(events, list) or not events:
+            raise ConformanceContractError(
+                "workflow Chat browserTrace requires observed network events"
+            )
+        event_ids: set[str] = set()
+        allowed_prefixes = (
+            f"/omnigent-ui/workflow-chat/{binding_id}",
+            f"/api/workflow-chat-bindings/{binding_id}/omnigent",
+            f"/api/executions/{workflow_id}",
+        )
+        for event in events:
+            item = _require_mapping(event, field="browserTrace.networkEvents[]")
+            request_id = _require_string(
+                item.get("requestId"), field="browserTrace.networkEvents[].requestId"
+            )
+            transport = _require_string(
+                item.get("transport"), field="browserTrace.networkEvents[].transport"
+            )
+            path = _require_string(
+                item.get("path"), field="browserTrace.networkEvents[].path"
+            )
+            status = item.get("responseStatus")
+            if (
+                request_id in event_ids
+                or transport not in _TRANSPORTS
+                or not path.startswith(allowed_prefixes)
+                or not isinstance(status, int)
+                or not 100 <= status <= 599
+                or item.get("moonmindScoped") is not True
+                or item.get("browserOriginated") is not True
+                or "providerSessionId" in item
+                or "upstreamUrl" in item
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat browserTrace contains an unscoped or "
+                    "malformed request"
+                )
+            event_ids.add(request_id)
+        if (
+            event_ids != request_id_set
+            or data.get("route") != f"/workflows/{workflow_id}/chat"
+            or data.get("traceId") != correlation["browserTraceId"]
+            or data.get("directUpstreamRequestCount") != 0
+            or data.get("exposedProviderFields") != []
+        ):
+            raise ConformanceContractError(
+                "workflow Chat browserTrace does not prove the scoped product route"
+            )
+        _require_sha256_ref(
+            data.get("screenshotSha256"), field="browserTrace.data.screenshotSha256"
+        )
+        return
+
+    if record_type == "bindingSnapshot":
+        if (
+            data.get("authoritative") is not True
+            or data.get("resolvedBindingId") != binding_id
+            or data.get("state") not in {"starting", "available", "ended"}
+            or not isinstance(data.get("readOnly"), bool)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat bindingSnapshot is not authoritative"
+            )
+        _require_string(data.get("runId"), field="bindingSnapshot.data.runId")
+        _require_sha256_ref(
+            data.get("capabilitiesDigest"),
+            field="bindingSnapshot.data.capabilitiesDigest",
+        )
+        return
+
+    if record_type == "nativeConversation":
+        if (
+            data.get("renderer") != "omnigent-native"
+            or data.get("composerRequestId") not in request_id_set
+        ):
+            raise ConformanceContractError(
+                "workflow Chat nativeConversation is not the native send path"
+            )
+        _require_string_list(
+            data.get("transcriptMessageIds"),
+            field="nativeConversation.data.transcriptMessageIds",
+        )
+        _require_string_list(
+            data.get("queuedMessageIds"),
+            field="nativeConversation.data.queuedMessageIds",
+        )
+        _require_string(
+            data.get("nativeAppVersion"),
+            field="nativeConversation.data.nativeAppVersion",
+        )
+        return
+
+    if record_type == "nativeControls":
+        controls = set(
+            _require_string_list(
+                data.get("controlKinds"), field="nativeControls.data.controlKinds"
+            )
+        )
+        if (
+            not _NATIVE_CONTROL_KINDS.issubset(controls)
+            or data.get("renderer") != "omnigent-native"
+            or data.get("customComposerCount") != 0
+        ):
+            raise ConformanceContractError(
+                "workflow Chat nativeControls do not prove native-primary controls"
+            )
+        return
+
+    if record_type == "facadeRequests":
+        requests = data.get("requests")
+        if not isinstance(requests, list) or not requests:
+            raise ConformanceContractError(
+                "workflow Chat facadeRequests requires resolved requests"
+            )
+        observed_ids: set[str] = set()
+        transports: set[str] = set()
+        reconnect_id = data.get("reconnectRequestId")
+        reconnect_reauthorized = False
+        for request in requests:
+            item = _require_mapping(request, field="facadeRequests.data.requests[]")
+            request_id = _require_string(
+                item.get("requestId"), field="facadeRequests.data.requests[].requestId"
+            )
+            transport = _require_string(
+                item.get("transport"), field="facadeRequests.data.requests[].transport"
+            )
+            if (
+                request_id in observed_ids
+                or request_id not in request_id_set
+                or transport not in _TRANSPORTS
+                or item.get("bindingId") != binding_id
+                or item.get("providerSessionId") != provider_session_id
+                or item.get("authorized") is not True
+                or item.get("serverResolvedTarget") is not True
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat facadeRequests contains an unauthorized request"
+                )
+            observed_ids.add(request_id)
+            transports.add(transport)
+            if request_id == reconnect_id:
+                reconnect_reauthorized = item.get("reauthorized") is True
+        expected_routes = {item["name"] for item in compatibility_map()["routes"]}
+        route_names = set(
+            _require_string_list(
+                data.get("coveredRouteNames"),
+                field="facadeRequests.data.coveredRouteNames",
+            )
+        )
+        if (
+            observed_ids != request_id_set
+            or transports != set(_TRANSPORTS)
+            or route_names != expected_routes
+            or data.get("compatibilityProfile")
+            != WORKFLOW_CHAT_COMPATIBILITY_PROFILE
+            or reconnect_id not in request_id_set
+            or not reconnect_reauthorized
+        ):
+            raise ConformanceContractError(
+                "workflow Chat facadeRequests coverage or reconnect evidence is "
+                "incomplete"
+            )
+        return
+
+    if record_type == "resourceInventory":
+        resources = data.get("resources")
+        if not isinstance(resources, list) or not resources:
+            raise ConformanceContractError(
+                "workflow Chat resourceInventory requires observed resources"
+            )
+        resource_types: set[str] = set()
+        for resource in resources:
+            item = _require_mapping(
+                resource, field="resourceInventory.data.resources[]"
+            )
+            _require_string(
+                item.get("resourceId"),
+                field="resourceInventory.data.resources[].resourceId",
+            )
+            resource_types.add(
+                _require_string(
+                    item.get("resourceType"),
+                    field="resourceInventory.data.resources[].resourceType",
+                )
+            )
+            if item.get("requestId") not in request_id_set:
+                raise ConformanceContractError(
+                    "workflow Chat resourceInventory is not request-correlated"
+                )
+        if not _NATIVE_CONTROL_KINDS.issubset(resource_types):
+            raise ConformanceContractError(
+                "workflow Chat resourceInventory is incomplete"
+            )
+        return
+
+    if record_type == "mutationReceipts":
+        receipts = data.get("receipts")
+        if not isinstance(receipts, list) or not receipts:
+            raise ConformanceContractError(
+                "workflow Chat mutationReceipts requires durable receipts"
+            )
+        for receipt in receipts:
+            item = _require_mapping(
+                receipt, field="mutationReceipts.data.receipts[]"
+            )
+            if item.get("requestId") not in request_id_set:
+                raise ConformanceContractError(
+                    "workflow Chat mutation receipt is not request-correlated"
+                )
+            for field in (
+                "actor",
+                "idempotencyKey",
+                "expectedState",
+                "outcome",
+                "upstreamCorrelation",
+                "auditRef",
+            ):
+                _require_string(
+                    item.get(field),
+                    field=f"mutationReceipts.data.receipts[].{field}",
+                )
+        return
+
+    if record_type == "denialAudit":
+        denials = data.get("denials")
+        if not isinstance(denials, list) or not denials:
+            raise ConformanceContractError(
+                "workflow Chat denialAudit requires observed denials"
+            )
+        kinds: set[str] = set()
+        for denial in denials:
+            item = _require_mapping(denial, field="denialAudit.data.denials[]")
+            kinds.add(
+                _require_string(
+                    item.get("kind"), field="denialAudit.data.denials[].kind"
+                )
+            )
+            if (
+                item.get("requestId") not in request_id_set
+                or item.get("upstreamForwarded") is not False
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat denialAudit is not fail-closed"
+                )
+            _require_string(
+                item.get("auditRef"), field="denialAudit.data.denials[].auditRef"
+            )
+        if not _DENIAL_KINDS.issubset(kinds):
+            raise ConformanceContractError(
+                "workflow Chat denialAudit coverage is incomplete"
+            )
+        return
+
+    if record_type == "capabilitySnapshot":
+        inputs = _require_mapping(
+            data.get("inputs"), field="capabilitySnapshot.data.inputs"
+        )
+        expected_inputs = (
+            "upstream",
+            "agentProfile",
+            "providerPolicy",
+            "workflowState",
+            "callerPermission",
+        )
+        if set(inputs) != set(expected_inputs):
+            raise ConformanceContractError(
+                "workflow Chat capabilitySnapshot inputs are incomplete"
+            )
+        typed_inputs: list[Mapping[str, Any]] = []
+        for name in expected_inputs:
+            values = _require_mapping(
+                inputs[name], field=f"capabilitySnapshot.data.inputs.{name}"
+            )
+            if not values or any(
+                not isinstance(value, bool) for value in values.values()
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat capabilitySnapshot inputs must be boolean maps"
+                )
+            typed_inputs.append(values)
+        effective = _require_mapping(
+            data.get("effective"), field="capabilitySnapshot.data.effective"
+        )
+        capability_names = set().union(*(set(value) for value in typed_inputs))
+        computed = {
+            name: all(values.get(name) is True for values in typed_inputs)
+            for name in capability_names
+        }
+        digest_payload = {"inputs": inputs, "effective": computed}
+        if (
+            dict(effective) != computed
+            or data.get("snapshotDigest") != _canonical_digest(digest_payload)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat capabilitySnapshot is not the effective intersection"
+            )
+        return
+
+    if record_type == "scanAudit":
+        attempts = data.get("attempts")
+        if not isinstance(attempts, list) or not attempts:
+            raise ConformanceContractError(
+                "workflow Chat scanAudit requires observed scan attempts"
+            )
+        outcomes: set[str] = set()
+        for attempt in attempts:
+            item = _require_mapping(attempt, field="scanAudit.data.attempts[]")
+            outcomes.add(
+                _require_string(
+                    item.get("outcome"), field="scanAudit.data.attempts[].outcome"
+                )
+            )
+            if (
+                item.get("requestId") not in request_id_set
+                or item.get("forwarded") is not False
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat scanAudit did not fail closed"
+                )
+            _require_string(
+                item.get("auditRef"), field="scanAudit.data.attempts[].auditRef"
+            )
+        if not {"blocked", "enforcement_unavailable"}.issubset(outcomes):
+            raise ConformanceContractError(
+                "workflow Chat scanAudit coverage is incomplete"
+            )
+        return
+
+    if record_type == "credentialBoundary":
+        verified = set(
+            _require_string_list(
+                data.get("verifiedRequestIds"),
+                field="credentialBoundary.data.verifiedRequestIds",
+            )
+        )
+        if (
+            not verified.issubset(request_id_set)
+            or data.get("browserExposedCredentialNames") != []
+            or data.get("forwardedMoonMindCredentialNames") != []
+        ):
+            raise ConformanceContractError(
+                "workflow Chat credentialBoundary detected credential crossover"
+            )
+        _require_string(
+            data.get("serverInjectedCredentialRef"),
+            field="credentialBoundary.data.serverInjectedCredentialRef",
+        )
+        return
+
+    if record_type == "terminalSnapshot":
+        denied_ids = set(
+            _require_string_list(
+                data.get("deniedMutationRequestIds"),
+                field="terminalSnapshot.data.deniedMutationRequestIds",
+            )
+        )
+        if (
+            data.get("state") not in _TERMINAL_STATES
+            or data.get("readOnly") is not True
+            or not denied_ids.issubset(request_id_set)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat terminalSnapshot is not read-only"
+            )
+        return
+
+    if record_type == "capturedEvidence":
+        refs = _require_string_list(
+            data.get("artifactRefs"), field="capturedEvidence.data.artifactRefs"
+        )
+        if (
+            any(not ref.startswith("artifact://") for ref in refs)
+            or data.get("captureManifestRef") not in refs
+            or data.get("allResolved") is not True
+        ):
+            raise ConformanceContractError(
+                "workflow Chat capturedEvidence is not independently resolvable"
+            )
+        return
+
+    if record_type == "continuationReceipt":
+        destination = _require_string(
+            data.get("destinationWorkflowId"),
+            field="continuationReceipt.data.destinationWorkflowId",
+        )
+        if (
+            data.get("sourceWorkflowId") != workflow_id
+            or destination == workflow_id
+            or data.get("sourceUnchanged") is not True
+            or data.get("separateWorkflowAction") is not True
+        ):
+            raise ConformanceContractError(
+                "workflow Chat continuationReceipt does not prove linked continuation"
+            )
+        for field in ("continuationId", "idempotencyKey"):
+            _require_string(
+                data.get(field), field=f"continuationReceipt.data.{field}"
+            )
+        return
+
+    if record_type == "replaySnapshot":
+        replay_refs = _require_string_list(
+            data.get("artifactRefs"), field="replaySnapshot.data.artifactRefs"
+        )
+        if (
+            data.get("hostUnavailable") is not True
+            or data.get("replayedFromMoonMindArtifacts") is not True
+            or any(not ref.startswith("artifact://") for ref in replay_refs)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat replaySnapshot does not prove host-independent replay"
+            )
+        return
+
+
+def validate_workflow_chat_source_records(
+    sources: Mapping[str, Mapping[str, Any]],
+    *,
+    row_name: str,
+    source_commit: str,
+    images: Mapping[str, Any],
+    generated_at: datetime,
+    expected_correlation: Mapping[str, str] | None = None,
+) -> tuple[dict[str, bool], dict[str, str]]:
+    """Validate and correlate one row's production-owned source records.
+
+    The returned assertions are derived from typed observations. Callers never
+    trust an adapter-authored pass boolean as the semantic result.
+    """
+
+    required = REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS.get(row_name)
+    if required is None or set(sources) != set(required):
+        raise ConformanceContractError(
+            f"workflow Chat source record coverage is incomplete: {row_name}"
+        )
+    row_correlation: dict[str, str] | None = None
+    request_ids_by_type: dict[str, set[str]] = {}
+    for record_type, source in sources.items():
+        if (
+            source.get("schemaVersion") != WORKFLOW_CHAT_SOURCE_RECORD_VERSION
+            or source.get("recordType") != record_type
+            or source.get("row") != row_name
+            or source.get("sourceCommit") != source_commit
+            or source.get("images") != images
+            or source.get("observed") is not True
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat source record is invalid: {row_name}/{record_type}"
+            )
+        observed_at = _timestamp(
+            source.get("observedAt"), field=f"{record_type}.observedAt"
+        )
+        if observed_at > generated_at or generated_at - observed_at > timedelta(days=1):
+            raise ConformanceContractError(
+                f"workflow Chat source record is stale: {row_name}/{record_type}"
+            )
+        raw_correlation = _require_mapping(
+            source.get("correlation"), field=f"{record_type}.correlation"
+        )
+        if set(raw_correlation) != set(_CORRELATION_FIELDS):
+            raise ConformanceContractError(
+                f"workflow Chat source record correlation is incomplete: {record_type}"
+            )
+        correlation = {
+            field: _require_string(
+                raw_correlation[field], field=f"{record_type}.correlation.{field}"
+            )
+            for field in _CORRELATION_FIELDS
+        }
+        if row_correlation is None:
+            row_correlation = correlation
+        elif correlation != row_correlation:
+            raise ConformanceContractError(
+                f"workflow Chat source records are not correlated: {row_name}"
+            )
+        data = _require_mapping(source.get("data"), field=f"{record_type}.data")
+        _validate_record_data(record_type, data, correlation=correlation)
+        request_ids_by_type[record_type] = set(data["requestIds"])
+
+    assert row_correlation is not None
+    if expected_correlation is not None and any(
+        row_correlation[field] != expected_correlation.get(field)
+        for field in _GLOBAL_CORRELATION_FIELDS
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance rows do not bind the same workflow session"
+        )
+    browser_request_ids = request_ids_by_type["browserTrace"]
+    for record_type, request_ids in request_ids_by_type.items():
+        if record_type != "browserTrace" and not request_ids.issubset(
+            browser_request_ids
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat source record request correlation failed: {record_type}"
+            )
+    if row_name == "terminal-evidence-and-continuation":
+        captured_refs = set(sources["capturedEvidence"]["data"]["artifactRefs"])
+        replay_refs = set(sources["replaySnapshot"]["data"]["artifactRefs"])
+        if not replay_refs.issubset(captured_refs):
+            raise ConformanceContractError(
+                "workflow Chat replay evidence is not bound to captured evidence"
+            )
+
+    assertions = {name: True for name in REQUIRED_WORKFLOW_CHAT_ROWS[row_name]}
+    return assertions, row_correlation
 
 
 def _timestamp(value: Any, *, field: str) -> datetime:
@@ -341,6 +932,7 @@ def validate_workflow_chat_acceptance_manifest(
             "workflow Chat acceptance matrix coverage is incomplete"
         )
     used_refs: set[str] = set()
+    global_correlation: dict[str, str] | None = None
     for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
         row = rows[row_name]
         if not isinstance(row, Mapping) or row.get("status") != "passed":
@@ -395,7 +987,7 @@ def validate_workflow_chat_acceptance_manifest(
                     f"workflow Chat acceptance case evidence is invalid: {row_name}"
                 )
             used_refs.add(ref)
-            records_by_type: dict[str, Mapping[str, Any]] = {}
+            sources_by_type: dict[str, Mapping[str, Any]] = {}
             for record in source_records:
                 if not isinstance(record, Mapping):
                     raise ConformanceContractError(
@@ -408,7 +1000,7 @@ def validate_workflow_chat_acceptance_manifest(
                     not record_type
                     or not record_ref
                     or _SHA256.fullmatch(record_digest) is None
-                    or record_type in records_by_type
+                    or record_type in sources_by_type
                 ):
                     raise ConformanceContractError(
                         f"workflow Chat source record is malformed: {row_name}"
@@ -418,25 +1010,32 @@ def validate_workflow_chat_acceptance_manifest(
                 if (
                     not isinstance(source, Mapping)
                     or manifest_digest != record_digest
-                    or source.get("schemaVersion")
-                    != WORKFLOW_CHAT_SOURCE_RECORD_VERSION
-                    or source.get("recordType") != record_type
-                    or source.get("row") != row_name
-                    or source.get("sourceCommit") != source_commit
-                    or source.get("observed") is not True
                 ):
                     raise ConformanceContractError(
                         "workflow Chat source record is invalid: "
                         f"{row_name}/{record_type}"
                     )
-                records_by_type[record_type] = record
+                sources_by_type[record_type] = source
                 used_refs.add(record_ref)
-            if set(records_by_type) != set(
-                REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]
+            derived_assertions, correlation = validate_workflow_chat_source_records(
+                sources_by_type,
+                row_name=row_name,
+                source_commit=source_commit,
+                images=images,
+                generated_at=generated_at,
+                expected_correlation=global_correlation,
+            )
+            if any(
+                evidence_assertions.get(name) is not value
+                or assertions.get(name) is not value
+                for name, value in derived_assertions.items()
             ):
                 raise ConformanceContractError(
-                    f"workflow Chat source record coverage is incomplete: {row_name}"
+                    "workflow Chat row assertions do not match typed source evidence: "
+                    f"{row_name}"
                 )
+            if global_correlation is None:
+                global_correlation = correlation
 
     reports = manifest.get("reports")
     if not isinstance(reports, list) or not reports:
@@ -584,5 +1183,6 @@ __all__ = [
     "WORKFLOW_CHAT_PARENT_ISSUE",
     "WORKFLOW_CHAT_SOURCE_RECORD_VERSION",
     "build_workflow_chat_acceptance_manifest",
+    "validate_workflow_chat_source_records",
     "validate_workflow_chat_acceptance_manifest",
 ]

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -1,0 +1,588 @@
+"""Protected native Workflow Chat acceptance evidence contract.
+
+MoonLadderStudios/MoonMind#3632 is complete only when the #3642
+browser-to-stock-host matrix produces fresh, immutable, independently
+resolvable, secret-scanned evidence.  Repository tests and a bare ``passed``
+flag are not that authority.  This module defines the compact release artifact
+and validates every referenced observation before it can be used as rollout
+evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from moonmind.omnigent.conformance import (
+    REPORT_VERSION,
+    REQUIRED_EVIDENCE_CHANNELS,
+    ConformanceContractError,
+    assert_secret_free,
+    require_pinned_images,
+)
+
+WORKFLOW_CHAT_ACCEPTANCE_VERSION = (
+    "moonmind.omnigent.workflow-chat-acceptance/v1"
+)
+WORKFLOW_CHAT_CASE_EVIDENCE_VERSION = (
+    "moonmind.omnigent.workflow-chat-case-evidence/v1"
+)
+WORKFLOW_CHAT_SOURCE_RECORD_VERSION = (
+    "moonmind.omnigent.workflow-chat-source-record/v1"
+)
+WORKFLOW_CHAT_ACCEPTANCE_ISSUE = "MoonLadderStudios/MoonMind#3642"
+WORKFLOW_CHAT_PARENT_ISSUE = "MoonLadderStudios/MoonMind#3632"
+WORKFLOW_CHAT_COMPATIBILITY_PROFILE = "omnigent.server.v1"
+MAX_ACCEPTANCE_AGE = timedelta(days=7)
+
+REQUIRED_WORKFLOW_CHAT_ROWS: Mapping[str, frozenset[str]] = {
+    "native-live-conversation": frozenset(
+        {
+            "workflow_chat_route_opened",
+            "authoritative_binding_only",
+            "native_transcript_composer_queue",
+            "native_ui_primary",
+            "no_custom_composer",
+        }
+    ),
+    "scoped-transports-and-resources": frozenset(
+        {
+            "html_http_sse_websocket_authorized",
+            "reconnect_reauthorized",
+            "resources_terminals_approvals_tools_available",
+            "stock_routes_exactly_covered",
+            "mutation_receipts_complete",
+        }
+    ),
+    "authority-and-security-denials": frozenset(
+        {
+            "alternate_binding_denied",
+            "provider_session_substitution_denied",
+            "hidden_control_direct_invocation_denied",
+            "immutable_policy_enforced",
+            "high_security_send_blocked",
+            "scan_unavailable_failed_closed",
+            "credentials_separated",
+        }
+    ),
+    "terminal-evidence-and-continuation": frozenset(
+        {
+            "terminal_chat_read_only",
+            "captured_evidence_resolved",
+            "linked_continuation_created",
+            "source_workflow_unchanged",
+            "replay_after_stock_host_unavailable",
+        }
+    ),
+}
+REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS: Mapping[str, frozenset[str]] = {
+    "native-live-conversation": frozenset(
+        {
+            "browserTrace",
+            "bindingSnapshot",
+            "nativeConversation",
+            "nativeControls",
+        }
+    ),
+    "scoped-transports-and-resources": frozenset(
+        {
+            "browserTrace",
+            "facadeRequests",
+            "resourceInventory",
+            "mutationReceipts",
+        }
+    ),
+    "authority-and-security-denials": frozenset(
+        {
+            "browserTrace",
+            "denialAudit",
+            "capabilitySnapshot",
+            "scanAudit",
+            "credentialBoundary",
+        }
+    ),
+    "terminal-evidence-and-continuation": frozenset(
+        {
+            "browserTrace",
+            "terminalSnapshot",
+            "capturedEvidence",
+            "continuationReceipt",
+            "replaySnapshot",
+        }
+    ),
+}
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _timestamp(value: Any, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ConformanceContractError(
+            f"workflow Chat acceptance {field} is missing or malformed"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ConformanceContractError(
+            f"workflow Chat acceptance {field} requires a timezone"
+        )
+    return parsed
+
+
+def _resolve_bytes(ref: str, evidence_root: Path) -> bytes:
+    parsed = urllib.parse.urlparse(str(ref))
+    try:
+        if parsed.scheme == "https":
+            with urllib.request.urlopen(ref, timeout=15) as response:
+                return response.read()
+        if parsed.scheme not in {"", "file"}:
+            raise ConformanceContractError(
+                f"unsupported workflow Chat evidence scheme: {parsed.scheme}"
+            )
+        candidate = Path(urllib.request.url2pathname(parsed.path))
+        if not candidate.is_absolute():
+            candidate = evidence_root / candidate
+        candidate = candidate.resolve()
+        root = evidence_root.resolve()
+        if candidate != root and root not in candidate.parents:
+            raise ConformanceContractError(
+                "workflow Chat evidence path escapes its run artifact"
+            )
+        return candidate.read_bytes()
+    except (OSError, urllib.error.URLError) as exc:
+        raise ConformanceContractError(
+            f"workflow Chat evidence is unresolved: {ref}"
+        ) from exc
+
+
+def _resolve_json(ref: str, evidence_root: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(_resolve_bytes(ref, evidence_root))
+    except json.JSONDecodeError as exc:
+        raise ConformanceContractError(
+            f"workflow Chat evidence is malformed: {ref}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise ConformanceContractError(
+            f"workflow Chat evidence must be an object: {ref}"
+        )
+    return value
+
+
+def build_workflow_chat_acceptance_manifest(
+    source: Mapping[str, Any],
+    *,
+    evidence_root: Path,
+) -> dict[str, Any]:
+    """Bind a protected-run matrix to immutable evidence digests.
+
+    ``source`` is the run-local matrix produced by the protected controller. It
+    carries rows and refs, never raw credentials.  This function resolves every
+    referenced file before emitting a candidate manifest; validation remains a
+    separate mandatory step.
+    """
+
+    rows = source.get("rows")
+    reports = source.get("reports")
+    scans = source.get("evidenceScans")
+    if not isinstance(rows, Mapping) or not isinstance(reports, list) or not isinstance(
+        scans, Mapping
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance source lacks rows, reports, or evidence scans"
+        )
+    refs: list[str] = []
+    case_refs: list[str] = []
+    for row in rows.values():
+        if isinstance(row, Mapping) and isinstance(row.get("evidenceRefs"), list):
+            row_refs = [str(ref) for ref in row["evidenceRefs"]]
+            refs.extend(row_refs)
+            case_refs.extend(row_refs)
+    refs.extend(str(ref) for ref in reports)
+    scan_refs: list[str] = []
+    for channel in REQUIRED_EVIDENCE_CHANNELS:
+        scan = scans.get(channel)
+        if isinstance(scan, Mapping) and scan.get("evidenceRef"):
+            scan_ref = str(scan["evidenceRef"])
+            refs.append(scan_ref)
+            scan_refs.append(scan_ref)
+    for case_ref in dict.fromkeys(case_refs):
+        case = _resolve_json(case_ref, evidence_root)
+        source_records = case.get("sourceRecords")
+        if isinstance(source_records, list):
+            for record in source_records:
+                if isinstance(record, Mapping) and record.get("ref"):
+                    refs.append(str(record["ref"]))
+    for scan_ref in dict.fromkeys(scan_refs):
+        scan_evidence = _resolve_json(scan_ref, evidence_root)
+        files = scan_evidence.get("files")
+        if isinstance(files, list):
+            for item in files:
+                if isinstance(item, Mapping) and item.get("ref"):
+                    refs.append(str(item["ref"]))
+    unique_refs = list(dict.fromkeys(refs))
+    evidence_manifest = []
+    for ref in unique_refs:
+        raw = _resolve_bytes(ref, evidence_root)
+        evidence_manifest.append(
+            {"ref": ref, "sha256": hashlib.sha256(raw).hexdigest()}
+        )
+    manifest = {
+        "schemaVersion": WORKFLOW_CHAT_ACCEPTANCE_VERSION,
+        "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+        "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
+        "status": "passed",
+        "generatedAt": source.get("generatedAt"),
+        "expiresAt": source.get("expiresAt"),
+        "sourceCommit": source.get("sourceCommit"),
+        "compatibilityProfile": source.get("compatibilityProfile"),
+        "images": dict(source.get("images") or {}),
+        "rows": {str(key): dict(value) for key, value in rows.items()},
+        "reports": list(reports),
+        "evidenceScans": {
+            str(key): dict(value)
+            for key, value in scans.items()
+            if isinstance(value, Mapping)
+        },
+        "evidenceManifest": evidence_manifest,
+    }
+    assert_secret_free(manifest)
+    return manifest
+
+
+def validate_workflow_chat_acceptance_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    evidence_root: Path,
+    expected_commit: str | None = None,
+    now: datetime | None = None,
+) -> None:
+    """Fail closed unless the complete protected #3642 matrix is authoritative."""
+
+    if (
+        manifest.get("schemaVersion") != WORKFLOW_CHAT_ACCEPTANCE_VERSION
+        or manifest.get("issue") != WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+        or manifest.get("parentIssue") != WORKFLOW_CHAT_PARENT_ISSUE
+        or manifest.get("status") != "passed"
+        or manifest.get("compatibilityProfile")
+        != WORKFLOW_CHAT_COMPATIBILITY_PROFILE
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance identity or status is invalid"
+        )
+    observed_at = now or datetime.now(timezone.utc)
+    generated_at = _timestamp(manifest.get("generatedAt"), field="generatedAt")
+    expires_at = _timestamp(manifest.get("expiresAt"), field="expiresAt")
+    if generated_at > observed_at:
+        raise ConformanceContractError("workflow Chat acceptance is future-dated")
+    if observed_at - generated_at > MAX_ACCEPTANCE_AGE or expires_at <= observed_at:
+        raise ConformanceContractError("workflow Chat acceptance is stale or expired")
+    if expires_at <= generated_at:
+        raise ConformanceContractError(
+            "workflow Chat acceptance validity interval is invalid"
+        )
+    source_commit = str(manifest.get("sourceCommit") or "")
+    if not source_commit or (
+        expected_commit is not None and source_commit != expected_commit
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance source commit does not match"
+        )
+    images = manifest.get("images")
+    if not isinstance(images, Mapping):
+        raise ConformanceContractError("workflow Chat acceptance images are missing")
+    require_pinned_images({str(key): str(value) for key, value in images.items()})
+
+    evidence_manifest = manifest.get("evidenceManifest")
+    if not isinstance(evidence_manifest, list) or not evidence_manifest:
+        raise ConformanceContractError(
+            "workflow Chat acceptance evidence manifest is missing"
+        )
+    resolved_raw: dict[str, bytes] = {}
+    resolved: dict[str, dict[str, Any]] = {}
+    manifest_digests: dict[str, str] = {}
+    for item in evidence_manifest:
+        ref = item.get("ref") if isinstance(item, Mapping) else None
+        digest = item.get("sha256") if isinstance(item, Mapping) else None
+        if (
+            not isinstance(ref, str)
+            or not ref.strip()
+            or not isinstance(digest, str)
+            or _SHA256.fullmatch(digest) is None
+            or ref in resolved
+        ):
+            raise ConformanceContractError(
+                "workflow Chat acceptance evidence manifest is malformed"
+            )
+        raw = _resolve_bytes(ref, evidence_root)
+        if hashlib.sha256(raw).hexdigest() != digest:
+            raise ConformanceContractError(
+                f"workflow Chat acceptance evidence digest mismatch: {ref}"
+            )
+        resolved_raw[ref] = raw
+        manifest_digests[ref] = digest
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            value = None
+        if isinstance(value, dict):
+            resolved[ref] = value
+
+    rows = manifest.get("rows")
+    if not isinstance(rows, Mapping) or set(rows) != set(REQUIRED_WORKFLOW_CHAT_ROWS):
+        raise ConformanceContractError(
+            "workflow Chat acceptance matrix coverage is incomplete"
+        )
+    used_refs: set[str] = set()
+    for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
+        row = rows[row_name]
+        if not isinstance(row, Mapping) or row.get("status") != "passed":
+            raise ConformanceContractError(
+                f"workflow Chat acceptance row did not pass: {row_name}"
+            )
+        assertions = row.get("assertions")
+        refs = row.get("evidenceRefs")
+        if (
+            not isinstance(assertions, Mapping)
+            or any(assertions.get(name) is not True for name in required_assertions)
+            or not isinstance(refs, list)
+            or not refs
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat acceptance row lacks controlling evidence: {row_name}"
+            )
+        for ref_value in refs:
+            ref = str(ref_value)
+            evidence = resolved.get(ref)
+            evidence_assertions = (
+                evidence.get("assertions")
+                if isinstance(evidence, Mapping)
+                else None
+            )
+            source_records = (
+                evidence.get("sourceRecords")
+                if isinstance(evidence, Mapping)
+                else None
+            )
+            if (
+                not isinstance(evidence, Mapping)
+                or evidence.get("schemaVersion")
+                != WORKFLOW_CHAT_CASE_EVIDENCE_VERSION
+                or evidence.get("issue") != WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+                or evidence.get("parentIssue") != WORKFLOW_CHAT_PARENT_ISSUE
+                or evidence.get("row") != row_name
+                or evidence.get("status") != "passed"
+                or evidence.get("sourceCommit") != source_commit
+                or evidence.get("images") != images
+                or evidence.get("stockHostUnmodified") is not True
+                or evidence.get("browserOriginated") is not True
+                or evidence.get("moonmindScopedOnly") is not True
+                or not isinstance(evidence_assertions, Mapping)
+                or any(
+                    evidence_assertions.get(name) is not True
+                    for name in required_assertions
+                )
+                or not isinstance(source_records, list)
+            ):
+                raise ConformanceContractError(
+                    f"workflow Chat acceptance case evidence is invalid: {row_name}"
+                )
+            used_refs.add(ref)
+            records_by_type: dict[str, Mapping[str, Any]] = {}
+            for record in source_records:
+                if not isinstance(record, Mapping):
+                    raise ConformanceContractError(
+                        f"workflow Chat source record is malformed: {row_name}"
+                    )
+                record_type = str(record.get("type") or "")
+                record_ref = str(record.get("ref") or "")
+                record_digest = str(record.get("sha256") or "")
+                if (
+                    not record_type
+                    or not record_ref
+                    or _SHA256.fullmatch(record_digest) is None
+                    or record_type in records_by_type
+                ):
+                    raise ConformanceContractError(
+                        f"workflow Chat source record is malformed: {row_name}"
+                    )
+                source = resolved.get(record_ref)
+                manifest_digest = manifest_digests.get(record_ref, "")
+                if (
+                    not isinstance(source, Mapping)
+                    or manifest_digest != record_digest
+                    or source.get("schemaVersion")
+                    != WORKFLOW_CHAT_SOURCE_RECORD_VERSION
+                    or source.get("recordType") != record_type
+                    or source.get("row") != row_name
+                    or source.get("sourceCommit") != source_commit
+                    or source.get("observed") is not True
+                ):
+                    raise ConformanceContractError(
+                        "workflow Chat source record is invalid: "
+                        f"{row_name}/{record_type}"
+                    )
+                records_by_type[record_type] = record
+                used_refs.add(record_ref)
+            if set(records_by_type) != set(
+                REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]
+            ):
+                raise ConformanceContractError(
+                    f"workflow Chat source record coverage is incomplete: {row_name}"
+                )
+
+    reports = manifest.get("reports")
+    if not isinstance(reports, list) or not reports:
+        raise ConformanceContractError("workflow Chat acceptance report is missing")
+    for report_ref in reports:
+        ref = str(report_ref)
+        report = resolved.get(ref)
+        summary = report.get("summary") if isinstance(report, Mapping) else None
+        cases = report.get("cases") if isinstance(report, Mapping) else None
+        try:
+            failed = (
+                int(summary.get("failed", 1))
+                if isinstance(summary, Mapping)
+                else 1
+            )
+            passed = (
+                int(summary.get("passed", 0))
+                if isinstance(summary, Mapping)
+                else 0
+            )
+            skipped = (
+                int(summary.get("skipped", 0))
+                if isinstance(summary, Mapping)
+                else 0
+            )
+        except (TypeError, ValueError) as exc:
+            raise ConformanceContractError(
+                "workflow Chat acceptance report summary is malformed"
+            ) from exc
+        try:
+            report_generated_at = _timestamp(
+                report.get("generatedAt") if isinstance(report, Mapping) else None,
+                field="report.generatedAt",
+            )
+        except ConformanceContractError as exc:
+            raise ConformanceContractError(
+                "workflow Chat acceptance references a stale or malformed report"
+            ) from exc
+        case_statuses: list[str] = []
+        case_ids: set[str] = set()
+        if isinstance(cases, list):
+            for case in cases:
+                case_id = case.get("caseId") if isinstance(case, Mapping) else None
+                case_status = (
+                    case.get("status") if isinstance(case, Mapping) else None
+                )
+                case_refs = (
+                    case.get("evidenceRefs")
+                    if isinstance(case, Mapping)
+                    else None
+                )
+                if (
+                    not isinstance(case_id, str)
+                    or not case_id
+                    or case_id in case_ids
+                    or case_status not in {"passed", "failed", "skipped"}
+                    or not isinstance(case_refs, list)
+                    or not case_refs
+                    or any(str(item) not in resolved_raw for item in case_refs)
+                ):
+                    raise ConformanceContractError(
+                        "workflow Chat acceptance report cases are malformed"
+                    )
+                case_ids.add(case_id)
+                case_statuses.append(str(case_status))
+        computed_summary = {
+            status_name: sum(value == status_name for value in case_statuses)
+            for status_name in ("passed", "failed", "skipped")
+        }
+        if (
+            not isinstance(report, Mapping)
+            or report.get("schemaVersion") != REPORT_VERSION
+            or report.get("images") != images
+            or not isinstance(summary, Mapping)
+            or not case_statuses
+            or computed_summary
+            != {"passed": passed, "failed": failed, "skipped": skipped}
+            or report_generated_at > generated_at
+            or generated_at - report_generated_at > timedelta(days=1)
+            or failed != 0
+            or passed < 1
+        ):
+            raise ConformanceContractError(
+                "workflow Chat acceptance references a non-passing report"
+            )
+        used_refs.add(ref)
+
+    scans = manifest.get("evidenceScans")
+    if not isinstance(scans, Mapping) or set(scans) != set(
+        REQUIRED_EVIDENCE_CHANNELS
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance evidence-channel scans are incomplete"
+        )
+    for channel in REQUIRED_EVIDENCE_CHANNELS:
+        scan = scans[channel]
+        ref = scan.get("evidenceRef") if isinstance(scan, Mapping) else None
+        evidence = resolved.get(str(ref)) if ref else None
+        files = evidence.get("files") if isinstance(evidence, Mapping) else None
+        if (
+            not isinstance(scan, Mapping)
+            or scan.get("status") != "passed"
+            or not isinstance(ref, str)
+            or not isinstance(evidence, Mapping)
+            or evidence.get("status") != "passed"
+            or evidence.get("channel") != channel
+            or not isinstance(files, list)
+            or not files
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat acceptance secret scan did not pass: {channel}"
+            )
+        used_refs.add(ref)
+        for item in files:
+            file_ref = item.get("ref") if isinstance(item, Mapping) else None
+            digest = item.get("sha256") if isinstance(item, Mapping) else None
+            if (
+                not isinstance(file_ref, str)
+                or not isinstance(digest, str)
+                or _SHA256.fullmatch(digest) is None
+                or manifest_digests.get(file_ref) != digest
+            ):
+                raise ConformanceContractError(
+                    f"workflow Chat raw evidence scan is invalid: {channel}"
+                )
+            used_refs.add(file_ref)
+
+    if used_refs != set(resolved_raw):
+        raise ConformanceContractError(
+            "workflow Chat acceptance contains unowned or missing evidence refs"
+        )
+    assert_secret_free(manifest)
+    for raw in resolved_raw.values():
+        assert_secret_free(raw.decode("utf-8", errors="replace"))
+
+
+__all__ = [
+    "MAX_ACCEPTANCE_AGE",
+    "REQUIRED_WORKFLOW_CHAT_ROWS",
+    "REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS",
+    "WORKFLOW_CHAT_ACCEPTANCE_ISSUE",
+    "WORKFLOW_CHAT_ACCEPTANCE_VERSION",
+    "WORKFLOW_CHAT_CASE_EVIDENCE_VERSION",
+    "WORKFLOW_CHAT_COMPATIBILITY_PROFILE",
+    "WORKFLOW_CHAT_PARENT_ISSUE",
+    "WORKFLOW_CHAT_SOURCE_RECORD_VERSION",
+    "build_workflow_chat_acceptance_manifest",
+    "validate_workflow_chat_acceptance_manifest",
+]

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -1261,6 +1261,14 @@ def validate_workflow_chat_acceptance_manifest(
                     )
                 sources_by_type[record_type] = source
                 used_refs.add(record_ref)
+            derived_assertions, correlation = validate_workflow_chat_source_records(
+                sources_by_type,
+                row_name=row_name,
+                source_commit=source_commit,
+                images=images,
+                generated_at=generated_at,
+                expected_correlation=global_correlation,
+            )
             browser_data = sources_by_type["browserTrace"].get("data")
             if isinstance(browser_data, Mapping):
                 trace_screenshot_digests.add(
@@ -1283,14 +1291,6 @@ def validate_workflow_chat_acceptance_manifest(
                             "workflow Chat capturedEvidence artifact is unresolved"
                         )
                     used_refs.add(artifact["ref"])
-            derived_assertions, correlation = validate_workflow_chat_source_records(
-                sources_by_type,
-                row_name=row_name,
-                source_commit=source_commit,
-                images=images,
-                generated_at=generated_at,
-                expected_correlation=global_correlation,
-            )
             if any(
                 evidence_assertions.get(name) is not value
                 or assertions.get(name) is not value

--- a/tests/fixtures/omnigent/conformance-v4.json
+++ b/tests/fixtures/omnigent/conformance-v4.json
@@ -7,7 +7,8 @@
       "MoonLadderStudios/MoonMind#3480",
       "MoonLadderStudios/MoonMind#3471",
       "MoonLadderStudios/MoonMind#3456",
-      "MoonLadderStudios/MoonMind#3626"
+      "MoonLadderStudios/MoonMind#3626",
+      "MoonLadderStudios/MoonMind#3642"
     ]
   },
   "cases": [
@@ -18,6 +19,7 @@
     {"id": "session.first-message-crash-matrix", "layer": "fake", "critical": true},
     {"id": "events.durable-replay-sse", "layer": "api", "critical": true},
     {"id": "projection.workflow-detail-chat", "layer": "frontend", "critical": true},
+    {"id": "workflow-chat.native-release-matrix", "layer": "product-provider", "critical": true},
     {"id": "resources.authorization-and-evidence", "layer": "api", "critical": true},
     {"id": "failures.lifecycle-and-redaction", "layer": "fake-and-live", "critical": true},
     {"id": "failures.transport-status-timeout", "layer": "fake-and-stock", "critical": true},

--- a/tests/provider/omnigent/test_omnigent_smoke.py
+++ b/tests/provider/omnigent/test_omnigent_smoke.py
@@ -25,6 +25,11 @@ from moonmind.omnigent.bridge_proxy import (
 )
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.settings import is_omnigent_enabled
+from moonmind.omnigent.workflow_chat_acceptance import (
+    REQUIRED_WORKFLOW_CHAT_ROWS,
+    WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+    validate_workflow_chat_acceptance_manifest,
+)
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
 pytestmark = [
@@ -289,6 +294,35 @@ async def test_live_browser_release_matrix(bridge_store) -> None:
         assert observation.get("schemaVersion") == "moonmind.omnigent.browser-observation/v1"
         assert observation.get("startPath", "/workflows/new") == "/workflows/new"
         assert observation.get("workflowId")
+
+
+async def test_live_native_workflow_chat_release_matrix(bridge_store) -> None:
+    """Validate the protected browser-to-stock-host #3642 rollout artifact."""
+
+    del bridge_store  # provider marker/fixture keep this on the live test lane
+    _require_mode("workflow_chat")
+    raw = os.environ.get("MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE", "").strip()
+    if not raw:
+        pytest.fail(
+            "required scenario evidence is unset: "
+            "MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE"
+        )
+    path = Path(raw).resolve()
+    if not path.is_file():
+        pytest.fail(f"scenario evidence does not exist: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    expected_commit = os.environ.get("MOONMIND_OMNIGENT_SOURCE_COMMIT", "").strip()
+    if not expected_commit:
+        pytest.fail(
+            "MOONMIND_OMNIGENT_SOURCE_COMMIT is required for the release gate"
+        )
+    validate_workflow_chat_acceptance_manifest(
+        payload,
+        evidence_root=path.parent,
+        expected_commit=expected_commit,
+    )
+    assert payload.get("issue") == WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+    assert set(payload.get("rows") or {}) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
 
 
 async def test_live_cumulative_remediation_journey(bridge_store) -> None:

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -33,6 +33,7 @@ from api_service.api.routers.omnigent_bridge import (
 )
 from api_service.api.routers.retrieval_gateway import get_capability_registry
 from api_service.auth_providers import get_current_user
+from moonmind.omnigent import native_ui_compat
 from moonmind.omnigent.bridge_config import (
     HOST_PROTOCOL_MODE_EMBEDDED,
     HOST_PROTOCOL_MODE_PROXY,
@@ -606,6 +607,394 @@ def test_native_http_mutation_is_scanned_receipted_and_replay_safe(
     assert posted["metadata"]["normalizedResult"]["statusCode"] == 307
 
 
+_STOCK_NATIVE_MUTATION_CASES = (
+    ("POST", "resources/terminals", {"cols": 80}, "terminal_create"),
+    ("DELETE", "resources/terminals/t-1", None, "terminal_close"),
+    (
+        "POST",
+        "resources/environments/default/shell",
+        {"command": "pwd"},
+        "terminal_shell",
+    ),
+    (
+        "PUT",
+        "resources/environments/default/filesystem/src/main.py",
+        {"content": "hello"},
+        "workspace_edit",
+    ),
+    (
+        "PATCH",
+        "resources/environments/default/filesystem/src/main.py",
+        {"content": "hello"},
+        "workspace_edit",
+    ),
+    (
+        "DELETE",
+        "resources/environments/default/filesystem/src/main.py",
+        None,
+        "workspace_delete",
+    ),
+    ("POST", "resources/files", {"name": "note.txt"}, "resource_upload"),
+    ("POST", "resources/files/file-1/attach", {}, "resource_attach"),
+    ("GET", "browser", None, "browser_pane"),
+    ("POST", "browser/open", {"url": "about:blank"}, "browser_pane"),
+    ("DELETE", "browser/open", None, "browser_pane"),
+    ("POST", "subagents/agent-1/interrupt", {}, "subagent_control"),
+    ("POST", "tasks/task-1", {"title": "follow up"}, "task_mutate"),
+    ("PATCH", "tasks/task-1", {"completed": True}, "task_mutate"),
+    ("POST", "reconnect", {}, "session_reconnect"),
+)
+
+
+def test_stock_native_mutation_cases_exactly_cover_the_pinned_inventory() -> None:
+    base_operation_names = {
+        operation.name for operation in native_ui_compat.FACADE_OPERATIONS
+    }
+    pinned_inventory = {
+        (route.name, method)
+        for route in native_ui_compat.NATIVE_UI_ROUTES
+        if route.transport == native_ui_compat.TRANSPORT_HTTP
+        and route.mutation
+        and route.name not in base_operation_names
+        for method in route.methods
+    }
+    exercised = {
+        (operation, method)
+        for method, _suffix, _payload, operation in _STOCK_NATIVE_MUTATION_CASES
+    }
+
+    assert exercised == pinned_inventory
+
+
+_STOCK_NATIVE_READ_CASES = (
+    ("resources/terminals", "terminal_view", "relay"),
+    ("resources/terminals/t-1", "terminal_status", "relay"),
+    ("resources/terminals/t-1/logs", "execution_logs", "relay"),
+    ("resources/files/file-1/content", "resource_download", "resource"),
+    ("subagents", "subagent_tree", "relay"),
+    ("tasks", "task_todo", "relay"),
+    (None, "host_liveness", "local"),
+    (None, "runner_liveness", "local"),
+)
+
+
+def test_stock_native_read_cases_exactly_cover_the_pinned_inventory() -> None:
+    base_operation_names = {
+        operation.name for operation in native_ui_compat.FACADE_OPERATIONS
+    }
+    pinned_inventory = {
+        (route.name, method)
+        for route in native_ui_compat.NATIVE_UI_ROUTES
+        if route.transport == native_ui_compat.TRANSPORT_HTTP
+        and not route.mutation
+        and route.name not in base_operation_names
+        for method in route.methods
+    }
+    exercised = {
+        (operation, "GET")
+        for _suffix, operation, _owner in _STOCK_NATIVE_READ_CASES
+    }
+
+    assert exercised == pinned_inventory
+
+
+@pytest.mark.parametrize(
+    ("suffix", "operation", "owner"),
+    _STOCK_NATIVE_READ_CASES,
+)
+def test_every_additional_stock_native_read_uses_the_bound_identity(
+    monkeypatch,
+    suffix: str | None,
+    operation: str,
+    owner: str,
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolved_api_token",
+        lambda: "upstream-only",
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolved_server_url",
+        lambda: "https://stock-omnigent.invalid",
+    )
+    upstream_calls: list[dict[str, Any]] = []
+    client_headers: list[dict[str, str]] = []
+    response_body = json.dumps(
+        {"ok": True, "session_id": _PROVIDER_SESSION_ID}
+    ).encode()
+
+    class _Content:
+        async def read(self, _limit: int) -> bytes:
+            return response_body
+
+    class _Response:
+        status = 200
+        headers = {"content-type": "application/json"}
+        content = _Content()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class _Client:
+        def __init__(self, *, headers=None, **_kwargs):
+            client_headers.append(dict(headers or {}))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def request(self, request_method: str, url: str, **kwargs):
+            upstream_calls.append({"method": request_method, "url": url, **kwargs})
+            return _Response()
+
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.aiohttp.ClientSession", _Client
+    )
+    client, proxy, _store = _build()
+    if operation == "host_liveness":
+        path = _path("v1/hosts")
+    elif operation == "runner_liveness":
+        path = _path(f"v1/runners/{_CHAT_BINDING_ID}/status")
+    else:
+        path = _path(f"v1/sessions/{_CHAT_BINDING_ID}/{suffix}")
+
+    response = client.get(
+        path,
+        headers={
+            "Authorization": "Bearer moonmind-browser",
+            "Cookie": "moonmind=session",
+            "X-CSRF-Token": "browser-csrf",
+        },
+    )
+
+    assert response.status_code == 200
+    assert _PROVIDER_SESSION_ID not in response.text
+    if owner == "relay":
+        assert len(upstream_calls) == 1
+        assert _PROVIDER_SESSION_ID in upstream_calls[0]["url"]
+        assert _CHAT_BINDING_ID not in upstream_calls[0]["url"]
+        assert client_headers == [
+            {"Accept": "*/*", "Authorization": "Bearer upstream-only"}
+        ]
+        serialized_headers = json.dumps(client_headers).lower()
+        assert "moonmind-browser" not in serialized_headers
+        assert "cookie" not in serialized_headers
+        assert "csrf" not in serialized_headers
+    elif owner == "resource":
+        assert upstream_calls == []
+        assert proxy.resources == [
+            ("session_file", _PROVIDER_SESSION_ID, "file-1")
+        ]
+    else:
+        assert upstream_calls == []
+        assert proxy.resources == []
+
+
+@pytest.mark.parametrize(
+    ("method", "suffix", "payload", "operation"),
+    _STOCK_NATIVE_MUTATION_CASES,
+)
+def test_every_stock_native_http_mutation_has_a_complete_durable_receipt(
+    monkeypatch,
+    method: str,
+    suffix: str,
+    payload: dict[str, Any] | None,
+    operation: str,
+) -> None:
+    """Exercise the complete pinned mutation inventory at the router boundary.
+
+    This is intentionally parametrized from the stock route families rather
+    than merely checking compatibility-map metadata: every request must reach
+    the real authorization, capability, scan, idempotency, credential, and
+    durable-receipt path required by MoonLadderStudios/MoonMind#3632.
+    """
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.native_outbound_scan.resolve_high_security_mode",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolved_api_token",
+        lambda: "upstream-only",
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolved_server_url",
+        lambda: "https://stock-omnigent.invalid",
+    )
+    upstream_calls: list[dict[str, Any]] = []
+    client_headers: list[dict[str, str]] = []
+    response_body = json.dumps(
+        {"ok": True, "session_id": _PROVIDER_SESSION_ID, "requestId": "up-1"}
+    ).encode()
+
+    class _Content:
+        async def read(self, _limit: int) -> bytes:
+            return response_body
+
+    class _Response:
+        status = 200
+        headers = {"content-type": "application/json"}
+        content = _Content()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class _Client:
+        def __init__(self, *, headers=None, **_kwargs):
+            client_headers.append(dict(headers or {}))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def request(self, request_method: str, url: str, **kwargs):
+            upstream_calls.append({"method": request_method, "url": url, **kwargs})
+            return _Response()
+
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.aiohttp.ClientSession", _Client
+    )
+    client, _proxy, store = _build()
+    path = _path(f"v1/sessions/{_CHAT_BINDING_ID}/{suffix}")
+    request_kwargs: dict[str, Any] = {
+        "headers": {
+            "Idempotency-Key": f"native-{method.lower()}-{operation}",
+            "Authorization": "Bearer moonmind-browser",
+            "Cookie": "moonmind=session",
+            "X-CSRF-Token": "browser-csrf",
+        }
+    }
+    if payload is not None:
+        request_kwargs["json"] = payload
+
+    response = client.request(method, path, **request_kwargs)
+
+    assert response.status_code == 200
+    expected_upstream_calls = 0 if operation == "session_reconnect" else 1
+    assert len(upstream_calls) == expected_upstream_calls
+    replay = client.request(method, path, **request_kwargs)
+    assert replay.status_code == response.status_code
+    assert replay.content == response.content
+    assert len(upstream_calls) == expected_upstream_calls
+    if upstream_calls:
+        assert _PROVIDER_SESSION_ID in upstream_calls[0]["url"]
+        assert _CHAT_BINDING_ID not in upstream_calls[0]["url"]
+        assert client_headers == [
+            {
+                "Accept": "*/*",
+                **(
+                    {"Content-Type": "application/json"}
+                    if payload is not None
+                    else {}
+                ),
+                "Authorization": "Bearer upstream-only",
+                "Idempotency-Key": f"native-{method.lower()}-{operation}",
+            }
+        ]
+        serialized_headers = json.dumps(client_headers).lower()
+        assert "moonmind-browser" not in serialized_headers
+        assert "cookie" not in serialized_headers
+        assert "csrf" not in serialized_headers
+
+    claim = next(entry for entry in store.lifecycle if entry["kind"] == "claim")
+    posted_records = [
+        entry
+        for entry in store.lifecycle
+        if entry["kind"] == "record"
+        and entry["metadata"].get("controlOutcome") == "posted"
+    ]
+    assert len(posted_records) == 1
+    posted = posted_records[0]
+    assert claim["metadata"]["controlType"] == operation
+    receipt = posted["metadata"]
+    assert receipt["receiptSchemaVersion"] == (
+        "moonmind.omnigent.mutation-receipt.v1"
+    )
+    assert receipt["controlType"] == operation
+    assert receipt["actor"] == str(_USER_ID)
+    assert receipt["workflowId"] == "mm:w1"
+    assert receipt["runId"] == "run-1"
+    assert receipt["stepExecutionId"] == "step-1"
+    assert receipt["bridgeSessionId"] == _BRIDGE_SESSION_ID
+    assert receipt["providerSessionId"] == _PROVIDER_SESSION_ID
+    assert receipt["controlIdempotencyKey"]
+    assert receipt["requestTime"]
+    assert receipt["dispatchTime"]
+    assert receipt["completionTime"]
+    assert receipt["normalizedResult"]["statusCode"] == 200
+
+
+def test_native_http_mutation_response_failure_records_delivery_unknown(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.omnigent.native_outbound_scan.resolve_high_security_mode",
+        lambda *args, **kwargs: False,
+    )
+
+    class _Content:
+        async def read(self, limit: int) -> bytes:
+            return b"x" * limit
+
+    class _Response:
+        status = 200
+        headers = {"content-type": "application/octet-stream"}
+        content = _Content()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def request(self, *_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.aiohttp.ClientSession",
+        lambda **_kwargs: _Client(),
+    )
+    client, _proxy, store = _build()
+
+    response = client.patch(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/tasks/task-1"),
+        json={"completed": True},
+        headers={"Idempotency-Key": "native-oversized-response"},
+    )
+    replay = client.patch(
+        _path(f"v1/sessions/{_CHAT_BINDING_ID}/tasks/task-1"),
+        json={"completed": True},
+        headers={"Idempotency-Key": "native-oversized-response"},
+    )
+
+    assert response.status_code == 502
+    assert replay.status_code == 409
+    unknown = next(
+        entry
+        for entry in store.lifecycle
+        if entry["kind"] == "record"
+        and entry["metadata"].get("controlOutcome") == "delivery_unknown"
+    )
+    assert unknown["metadata"]["controlType"] == "task_mutate"
+    assert unknown["metadata"]["completionTime"]
+
+
 def test_delete_method_not_allowlisted() -> None:
     client, _proxy, _store = _build()
 
@@ -942,6 +1331,44 @@ def test_oversized_body_is_rejected() -> None:
 
 
 # --- Resources ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("suffix", "operation", "value", "binary"),
+    [
+        ("resources/environments/default/changes", "changed_files", None, False),
+        ("resources/environments/default/filesystem", "workspace_files", None, False),
+        (
+            "resources/environments/default/filesystem/src/main.py",
+            "workspace_file",
+            "src/main.py",
+            True,
+        ),
+        (
+            "resources/environments/default/diff/src/main.py",
+            "workspace_diff",
+            "src/main.py",
+            True,
+        ),
+        ("resources/files", "session_files", None, False),
+        ("resources/files/file-1/content", "session_file", "file-1", True),
+    ],
+)
+def test_every_stock_resource_read_is_bound_and_authorized(
+    suffix: str,
+    operation: str,
+    value: str | None,
+    binary: bool,
+) -> None:
+    client, proxy, _store = _build()
+
+    response = client.get(_path(f"v1/sessions/{_CHAT_BINDING_ID}/{suffix}"))
+
+    assert response.status_code == 200
+    assert proxy.resources == [(operation, _PROVIDER_SESSION_ID, value)]
+    assert _PROVIDER_SESSION_ID not in response.text
+    if binary:
+        assert response.content == b"RAW-BYTES"
 
 
 def test_resource_index_delegated_to_bound_session() -> None:

--- a/tests/unit/api/routers/test_omnigent_workflow_chat_ws.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat_ws.py
@@ -273,6 +273,90 @@ def test_relay_keeps_server_to_browser_socket_alive_without_browser_input(
     assert browser.closed[-1] == 1000
 
 
+def test_websocket_relay_injects_only_server_owned_upstream_credentials(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.resolved_api_token",
+        lambda: "upstream-only",
+    )
+    observed: dict[str, Any] = {}
+
+    class _Browser:
+        headers = {
+            "authorization": "Bearer moonmind-browser",
+            "cookie": "moonmind=session",
+            "x-csrf-token": "browser-csrf",
+        }
+
+        async def accept(self, **_kwargs):
+            return None
+
+        async def receive(self):
+            return {"type": "websocket.disconnect"}
+
+        async def close(self, **_kwargs):
+            return None
+
+    class _Upstream:
+        closed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def close(self):
+            self.closed = True
+
+        def __aiter__(self):
+            async def messages():
+                await asyncio.Event().wait()
+                yield None
+
+            return messages()
+
+    upstream = _Upstream()
+
+    class _Client:
+        def __init__(self, *, headers=None, **_kwargs):
+            observed["headers"] = dict(headers or {})
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        def ws_connect(self, url: str, **kwargs):
+            observed["url"] = url
+            observed["connect"] = kwargs
+            return upstream
+
+    monkeypatch.setattr(
+        "api_service.api.routers.omnigent_bridge.aiohttp.ClientSession", _Client
+    )
+
+    async def authorized() -> bool:
+        return True
+
+    asyncio.run(
+        _relay_native_websocket(
+            browser=_Browser(),
+            upstream_url="wss://stock-omnigent.invalid/v1/sessions/provider-1",
+            subprotocol="omnigent.workflow-chat.v1",
+            still_authorized=authorized,
+        )
+    )
+
+    assert observed["headers"] == {"Authorization": "Bearer upstream-only"}
+    serialized = json.dumps(observed).lower()
+    assert "moonmind-browser" not in serialized
+    assert "cookie" not in serialized
+    assert "csrf" not in serialized
+
+
 def test_global_updates_frames_are_identity_scoped_and_virtualized() -> None:
     assert json.loads(
         _filter_session_updates_watch_frame(

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.native_ui_compat import compatibility_map
 from moonmind.omnigent.workflow_chat_acceptance import (
     REQUIRED_WORKFLOW_CHAT_ROWS,
     REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS,
@@ -33,6 +34,219 @@ def _write(path: Path, value: object) -> None:
     path.write_text(json.dumps(value), encoding="utf-8")
 
 
+def _digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _record_data(record_type: str, row_name: str, index: int) -> dict[str, object]:
+    request_ids = [f"request-{index}-{item}" for item in range(6)]
+    common: dict[str, object] = {"requestIds": [request_ids[0]]}
+    if record_type == "browserTrace":
+        transports = ("html", "http", "sse", "websocket", "http", "http")
+        events = []
+        for item, (request_id, transport) in enumerate(
+            zip(request_ids, transports, strict=True)
+        ):
+            events.append(
+                {
+                    "requestId": request_id,
+                    "transport": transport,
+                    "path": (
+                        "/omnigent-ui/workflow-chat/binding-1"
+                        if item == 0
+                        else "/api/workflow-chat-bindings/binding-1/omnigent/health"
+                    ),
+                    "responseStatus": (
+                        403
+                        if row_name == "authority-and-security-denials" and item
+                        else 200
+                    ),
+                    "moonmindScoped": True,
+                    "browserOriginated": True,
+                }
+            )
+        return {
+            "requestIds": request_ids,
+            "route": "/workflows/workflow-1/chat",
+            "traceId": f"browser-trace-{index}",
+            "directUpstreamRequestCount": 0,
+            "exposedProviderFields": [],
+            "screenshotSha256": "sha256:" + "3" * 64,
+            "networkEvents": events,
+        }
+    if record_type == "bindingSnapshot":
+        return {
+            **common,
+            "authoritative": True,
+            "resolvedBindingId": "binding-1",
+            "runId": "run-1",
+            "state": "available",
+            "readOnly": False,
+            "capabilitiesDigest": "sha256:" + "4" * 64,
+        }
+    if record_type == "nativeConversation":
+        return {
+            **common,
+            "renderer": "omnigent-native",
+            "composerRequestId": request_ids[0],
+            "transcriptMessageIds": ["message-1"],
+            "queuedMessageIds": ["queued-1"],
+            "nativeAppVersion": "omnigent.server.v1",
+        }
+    if record_type == "nativeControls":
+        return {
+            **common,
+            "renderer": "omnigent-native",
+            "customComposerCount": 0,
+            "controlKinds": ["approval", "tool", "file", "terminal", "agent", "task"],
+        }
+    if record_type == "facadeRequests":
+        facade_ids = request_ids[:4]
+        transports = ("html", "http", "sse", "websocket")
+        return {
+            "requestIds": facade_ids,
+            "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
+            "coveredRouteNames": [
+                item["name"] for item in compatibility_map()["routes"]
+            ],
+            "reconnectRequestId": facade_ids[-1],
+            "requests": [
+                {
+                    "requestId": request_id,
+                    "transport": transport,
+                    "bindingId": "binding-1",
+                    "providerSessionId": "provider-session-1",
+                    "authorized": True,
+                    "serverResolvedTarget": True,
+                    "reauthorized": request_id == facade_ids[-1],
+                }
+                for request_id, transport in zip(facade_ids, transports, strict=True)
+            ],
+        }
+    if record_type == "resourceInventory":
+        kinds = ["approval", "tool", "file", "terminal", "agent", "task"]
+        return {
+            "requestIds": request_ids,
+            "resources": [
+                {
+                    "resourceId": f"{kind}-1",
+                    "resourceType": kind,
+                    "requestId": request_ids[item],
+                }
+                for item, kind in enumerate(kinds)
+            ],
+        }
+    if record_type == "mutationReceipts":
+        return {
+            **common,
+            "receipts": [
+                {
+                    "requestId": request_ids[0],
+                    "actor": "user-1",
+                    "idempotencyKey": "idempotency-1",
+                    "expectedState": "available",
+                    "outcome": "accepted",
+                    "upstreamCorrelation": "upstream-1",
+                    "auditRef": "artifact://audit-1",
+                }
+            ],
+        }
+    if record_type == "denialAudit":
+        kinds = [
+            "alternate_binding",
+            "provider_session_substitution",
+            "hidden_control",
+            "immutable_policy",
+        ]
+        return {
+            "requestIds": request_ids[:4],
+            "denials": [
+                {
+                    "requestId": request_ids[item],
+                    "kind": kind,
+                    "upstreamForwarded": False,
+                    "auditRef": f"artifact://denial-{item}",
+                }
+                for item, kind in enumerate(kinds)
+            ],
+        }
+    if record_type == "capabilitySnapshot":
+        inputs = {
+            "upstream": {"sendMessage": True, "changeModel": True},
+            "agentProfile": {"sendMessage": True, "changeModel": False},
+            "providerPolicy": {"sendMessage": True, "changeModel": True},
+            "workflowState": {"sendMessage": True, "changeModel": True},
+            "callerPermission": {"sendMessage": True, "changeModel": True},
+        }
+        effective = {"sendMessage": True, "changeModel": False}
+        return {
+            **common,
+            "inputs": inputs,
+            "effective": effective,
+            "snapshotDigest": _digest({"inputs": inputs, "effective": effective}),
+        }
+    if record_type == "scanAudit":
+        scan_ids = request_ids[4:]
+        return {
+            "requestIds": scan_ids,
+            "attempts": [
+                {
+                    "requestId": scan_ids[0],
+                    "outcome": "blocked",
+                    "forwarded": False,
+                    "auditRef": "artifact://scan-blocked",
+                },
+                {
+                    "requestId": scan_ids[1],
+                    "outcome": "enforcement_unavailable",
+                    "forwarded": False,
+                    "auditRef": "artifact://scan-unavailable",
+                },
+            ],
+        }
+    if record_type == "credentialBoundary":
+        return {
+            "requestIds": request_ids,
+            "verifiedRequestIds": request_ids,
+            "browserExposedCredentialNames": [],
+            "forwardedMoonMindCredentialNames": [],
+            "serverInjectedCredentialRef": "managed-secret://omnigent/session",
+        }
+    if record_type == "terminalSnapshot":
+        return {
+            **common,
+            "state": "completed",
+            "readOnly": True,
+            "deniedMutationRequestIds": [request_ids[0]],
+        }
+    if record_type == "capturedEvidence":
+        return {
+            **common,
+            "artifactRefs": ["artifact://capture-manifest", "artifact://final"],
+            "captureManifestRef": "artifact://capture-manifest",
+            "allResolved": True,
+        }
+    if record_type == "continuationReceipt":
+        return {
+            **common,
+            "sourceWorkflowId": "workflow-1",
+            "destinationWorkflowId": "workflow-2",
+            "continuationId": "continuation-1",
+            "idempotencyKey": "continue-once",
+            "sourceUnchanged": True,
+            "separateWorkflowAction": True,
+        }
+    if record_type == "replaySnapshot":
+        return {
+            **common,
+            "hostUnavailable": True,
+            "replayedFromMoonMindArtifacts": True,
+            "artifactRefs": ["artifact://final"],
+        }
+    raise AssertionError(f"missing test source record: {record_type}")
+
+
 def _matrix(root: Path) -> dict[str, object]:
     rows: dict[str, object] = {}
     for index, (row_name, assertions) in enumerate(
@@ -48,8 +262,17 @@ def _matrix(root: Path) -> dict[str, object]:
                     "recordType": record_type,
                     "row": row_name,
                     "sourceCommit": "abc123",
+                    "observedAt": NOW.isoformat(),
+                    "images": IMAGES,
                     "observed": True,
-                    "data": {"bounded": True},
+                    "correlation": {
+                        "workflowId": "workflow-1",
+                        "chatBindingId": "binding-1",
+                        "bridgeSessionId": "bridge-1",
+                        "providerSessionId": "provider-session-1",
+                        "browserTraceId": f"browser-trace-{index}",
+                    },
+                    "data": _record_data(record_type, row_name, index),
                 },
             )
             source_records.append(
@@ -137,6 +360,28 @@ def _matrix(root: Path) -> dict[str, object]:
     }
 
 
+def _rewrite_source(
+    root: Path,
+    *,
+    row_name: str,
+    record_type: str,
+    update,
+) -> None:
+    row_names = list(REQUIRED_WORKFLOW_CHAT_ROWS)
+    index = row_names.index(row_name)
+    source_path = root / f"source-{index}-{record_type}.json"
+    payload = json.loads(source_path.read_text(encoding="utf-8"))
+    update(payload)
+    _write(source_path, payload)
+    case_path = root / f"case-{index}.json"
+    case = json.loads(case_path.read_text(encoding="utf-8"))
+    record = next(
+        item for item in case["sourceRecords"] if item["type"] == record_type
+    )
+    record["sha256"] = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    _write(case_path, case)
+
+
 def test_complete_native_chat_matrix_builds_and_validates(tmp_path: Path) -> None:
     manifest = build_workflow_chat_acceptance_manifest(
         _matrix(tmp_path), evidence_root=tmp_path
@@ -152,6 +397,148 @@ def test_complete_native_chat_matrix_builds_and_validates(tmp_path: Path) -> Non
     assert set(manifest["rows"]) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
     assert manifest["issue"] == WORKFLOW_CHAT_ACCEPTANCE_ISSUE
     assert all(item["sha256"] for item in manifest["evidenceManifest"])
+
+
+@pytest.mark.parametrize(
+    "record_type",
+    sorted(
+        {
+            record_type
+            for record_types in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS.values()
+            for record_type in record_types
+        }
+    ),
+)
+def test_vacuous_source_record_cannot_satisfy_any_typed_schema(
+    record_type: str, tmp_path: Path
+) -> None:
+    source = _matrix(tmp_path)
+    row_name = next(
+        name
+        for name, record_types in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS.items()
+        if record_type in record_types
+    )
+    _rewrite_source(
+        tmp_path,
+        row_name=row_name,
+        record_type=record_type,
+        update=lambda payload: payload.update({"data": {"bounded": True}}),
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="source record"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_source_records_must_share_server_side_workflow_session_correlation(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+    _rewrite_source(
+        tmp_path,
+        row_name="scoped-transports-and-resources",
+        record_type="mutationReceipts",
+        update=lambda payload: payload["correlation"].update(
+            {"providerSessionId": "substituted-session"}
+        ),
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="not correlated"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_matrix_rows_must_bind_the_same_authoritative_workflow(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def substitute_workflow(payload: dict[str, object]) -> None:
+        payload["correlation"]["workflowId"] = "workflow-2"
+        if payload["recordType"] == "browserTrace":
+            payload["data"]["route"] = "/workflows/workflow-2/chat"
+
+    for record_type in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[
+        "scoped-transports-and-resources"
+    ]:
+        _rewrite_source(
+            tmp_path,
+            row_name="scoped-transports-and-resources",
+            record_type=record_type,
+            update=substitute_workflow,
+        )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(
+        ConformanceContractError, match="same workflow session"
+    ):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_source_record_request_ids_must_resolve_to_the_browser_trace(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def add_unbound_request(payload: dict[str, object]) -> None:
+        payload["data"]["requestIds"] = ["not-in-browser-trace"]
+        payload["data"]["receipts"][0]["requestId"] = "not-in-browser-trace"
+
+    _rewrite_source(
+        tmp_path,
+        row_name="scoped-transports-and-resources",
+        record_type="mutationReceipts",
+        update=add_unbound_request,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="request correlation"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+@pytest.mark.parametrize("metadata", ["sourceCommit", "images"])
+def test_source_records_must_bind_commit_and_immutable_images(
+    metadata: str, tmp_path: Path
+) -> None:
+    source = _matrix(tmp_path)
+
+    def replace_metadata(payload: dict[str, object]) -> None:
+        if metadata == "sourceCommit":
+            payload[metadata] = "different-commit"
+        else:
+            payload[metadata] = {
+                **IMAGES,
+                "host": "ghcr.io/omnigent/host@sha256:" + "9" * 64,
+            }
+
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="bindingSnapshot",
+        update=replace_metadata,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="source record is invalid"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -28,6 +28,7 @@ IMAGES = {
     "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
     "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
 }
+SCREENSHOT_EVIDENCE = b"secret-free protected screenshot evidence"
 
 
 def _write(path: Path, value: object) -> None:
@@ -39,11 +40,61 @@ def _digest(value: object) -> str:
     return "sha256:" + hashlib.sha256(raw).hexdigest()
 
 
-def _record_data(record_type: str, row_name: str, index: int) -> dict[str, object]:
-    request_ids = [f"request-{index}-{item}" for item in range(6)]
+def _route_path(route: dict[str, object]) -> str:
+    path = str(route["pathPattern"]).removeprefix("^").removesuffix("$")
+    for placeholder, value in (
+        ("(?P<session_id>[^/]+)", "provider-session-1"),
+        ("(?P<terminal_id>[^/]+)", "terminal-1"),
+        ("(?P<res_path>.+)", "README.md"),
+        ("(?P<file_id>[^/]+)", "file-1"),
+        ("(?P<runner_id>[^/]+)", "runner-1"),
+        ("(?P<elicitation_id>[^/]+)", "elicitation-1"),
+        ("(?:/.*)?", ""),
+    ):
+        path = path.replace(placeholder, value)
+    return path
+
+
+def _request_ids(row_name: str, index: int) -> list[str]:
+    count = (
+        len(compatibility_map()["routes"]) + 1
+        if row_name == "scoped-transports-and-resources"
+        else 6
+    )
+    return [f"request-{index}-{item}" for item in range(count)]
+
+
+def _record_data(
+    record_type: str, row_name: str, index: int, root: Path
+) -> dict[str, object]:
+    request_ids = _request_ids(row_name, index)
     common: dict[str, object] = {"requestIds": [request_ids[0]]}
     if record_type == "browserTrace":
-        transports = ("html", "http", "sse", "websocket", "http", "http")
+        if row_name == "scoped-transports-and-resources":
+            transports = ["html"] + [
+                str(route["transport"])
+                for route in compatibility_map()["routes"]
+            ]
+            route_paths = [
+                "/omnigent-ui/workflow-chat/binding-1"
+            ] + [
+                "/api/workflow-chat-bindings/binding-1/omnigent/"
+                + _route_path(route)
+                for route in compatibility_map()["routes"]
+            ]
+            methods = ["GET"] + [
+                str(route["methods"][0])
+                for route in compatibility_map()["routes"]
+            ]
+        else:
+            transports = ["html", "http", "sse", "websocket", "http", "http"]
+            route_paths = [
+                "/omnigent-ui/workflow-chat/binding-1"
+                if item == 0
+                else "/api/workflow-chat-bindings/binding-1/omnigent/health"
+                for item in range(len(request_ids))
+            ]
+            methods = ["GET"] * len(request_ids)
         events = []
         for item, (request_id, transport) in enumerate(
             zip(request_ids, transports, strict=True)
@@ -52,14 +103,17 @@ def _record_data(record_type: str, row_name: str, index: int) -> dict[str, objec
                 {
                     "requestId": request_id,
                     "transport": transport,
-                    "path": (
-                        "/omnigent-ui/workflow-chat/binding-1"
-                        if item == 0
-                        else "/api/workflow-chat-bindings/binding-1/omnigent/health"
-                    ),
+                    "method": methods[item],
+                    "path": route_paths[item],
                     "responseStatus": (
-                        403
-                        if row_name == "authority-and-security-denials" and item
+                        503
+                        if row_name == "authority-and-security-denials" and item == 5
+                        else 403
+                        if row_name == "authority-and-security-denials"
+                        or row_name == "terminal-evidence-and-continuation"
+                        and item == 0
+                        else 101
+                        if transport == "websocket"
                         else 200
                     ),
                     "moonmindScoped": True,
@@ -72,7 +126,8 @@ def _record_data(record_type: str, row_name: str, index: int) -> dict[str, objec
             "traceId": f"browser-trace-{index}",
             "directUpstreamRequestCount": 0,
             "exposedProviderFields": [],
-            "screenshotSha256": "sha256:" + "3" * 64,
+            "screenshotSha256": "sha256:"
+            + hashlib.sha256(SCREENSHOT_EVIDENCE).hexdigest(),
             "networkEvents": events,
         }
     if record_type == "bindingSnapshot":
@@ -102,26 +157,46 @@ def _record_data(record_type: str, row_name: str, index: int) -> dict[str, objec
             "controlKinds": ["approval", "tool", "file", "terminal", "agent", "task"],
         }
     if record_type == "facadeRequests":
-        facade_ids = request_ids[:4]
-        transports = ("html", "http", "sse", "websocket")
+        routes = compatibility_map()["routes"]
+        route_observations = [
+            {
+                "routeName": "native_ui_document",
+                "transport": "html",
+                "method": "GET",
+                "routePath": "omnigent-ui/workflow-chat/binding-1",
+            }
+        ] + [
+            {
+                "routeName": route["name"],
+                "transport": route["transport"],
+                "method": route["methods"][0],
+                "routePath": _route_path(route),
+            }
+            for route in routes
+        ]
+        reconnect_index = next(
+            item
+            for item, route in enumerate(route_observations)
+            if route["routeName"] == "session_reconnect"
+        )
+        reconnect_id = request_ids[reconnect_index]
         return {
-            "requestIds": facade_ids,
+            "requestIds": request_ids,
             "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
-            "coveredRouteNames": [
-                item["name"] for item in compatibility_map()["routes"]
-            ],
-            "reconnectRequestId": facade_ids[-1],
+            "reconnectRequestId": reconnect_id,
             "requests": [
                 {
+                    **route,
                     "requestId": request_id,
-                    "transport": transport,
                     "bindingId": "binding-1",
                     "providerSessionId": "provider-session-1",
                     "authorized": True,
                     "serverResolvedTarget": True,
-                    "reauthorized": request_id == facade_ids[-1],
+                    "reauthorized": request_id == reconnect_id,
                 }
-                for request_id, transport in zip(facade_ids, transports, strict=True)
+                for request_id, route in zip(
+                    request_ids, route_observations, strict=True
+                )
             ],
         }
     if record_type == "resourceInventory":
@@ -138,18 +213,29 @@ def _record_data(record_type: str, row_name: str, index: int) -> dict[str, objec
             ],
         }
     if record_type == "mutationReceipts":
+        mutating_route_names = {
+            str(route["name"])
+            for route in compatibility_map()["routes"]
+            if route["mutation"] is True
+        }
+        mutation_ids = [
+            request_ids[item + 1]
+            for item, route in enumerate(compatibility_map()["routes"])
+            if route["name"] in mutating_route_names
+        ]
         return {
-            **common,
+            "requestIds": mutation_ids,
             "receipts": [
                 {
-                    "requestId": request_ids[0],
+                    "requestId": request_id,
                     "actor": "user-1",
-                    "idempotencyKey": "idempotency-1",
+                    "idempotencyKey": f"idempotency-{item}",
                     "expectedState": "available",
                     "outcome": "accepted",
-                    "upstreamCorrelation": "upstream-1",
-                    "auditRef": "artifact://audit-1",
+                    "upstreamCorrelation": f"upstream-{item}",
+                    "auditRef": f"artifact://audit-{item}",
                 }
+                for item, request_id in enumerate(mutation_ids)
             ],
         }
     if record_type == "denialAudit":
@@ -221,33 +307,64 @@ def _record_data(record_type: str, row_name: str, index: int) -> dict[str, objec
             "deniedMutationRequestIds": [request_ids[0]],
         }
     if record_type == "capturedEvidence":
+        artifacts = []
+        for ref in ("capture-manifest.json", "captured-final.json"):
+            artifacts.append(
+                {
+                    "ref": ref,
+                    "sha256": hashlib.sha256((root / ref).read_bytes()).hexdigest(),
+                }
+            )
         return {
             **common,
-            "artifactRefs": ["artifact://capture-manifest", "artifact://final"],
-            "captureManifestRef": "artifact://capture-manifest",
-            "allResolved": True,
+            "artifacts": artifacts,
+            "captureManifestRef": "capture-manifest.json",
         }
     if record_type == "continuationReceipt":
-        return {
-            **common,
+        relationship_identity = {
+            "relationshipType": "linked_continuation",
             "sourceWorkflowId": "workflow-1",
+            "sourceRunId": "run-1",
             "destinationWorkflowId": "workflow-2",
-            "continuationId": "continuation-1",
+            "destinationRunId": "run-2",
+        }
+        return {
+            "requestIds": request_ids[1:3],
             "idempotencyKey": "continue-once",
-            "sourceUnchanged": True,
-            "separateWorkflowAction": True,
+            "sourceStateBeforeSha256": "sha256:" + "5" * 64,
+            "sourceStateAfterSha256": "sha256:" + "5" * 64,
+            "destinationCreationReceipt": {
+                "requestId": request_ids[1],
+                "created": True,
+                "relationshipType": "linked_continuation",
+                "sourceWorkflowId": "workflow-1",
+                "sourceRunId": "run-1",
+                "destinationWorkflowId": "workflow-2",
+            },
+            "durableRelationship": {
+                **relationship_identity,
+                "requestId": request_ids[2],
+                "direction": "outbound",
+                "relationshipDigest": _digest(relationship_identity),
+                "createdAt": NOW.isoformat(),
+            },
         }
     if record_type == "replaySnapshot":
         return {
             **common,
             "hostUnavailable": True,
             "replayedFromMoonMindArtifacts": True,
-            "artifactRefs": ["artifact://final"],
+            "artifactRefs": ["captured-final.json"],
         }
     raise AssertionError(f"missing test source record: {record_type}")
 
 
 def _matrix(root: Path) -> dict[str, object]:
+    _write(
+        root / "capture-manifest.json",
+        {"schemaVersion": "moonmind.capture-manifest/v1", "artifacts": ["final"]},
+    )
+    _write(root / "captured-final.json", {"status": "completed"})
     rows: dict[str, object] = {}
     for index, (row_name, assertions) in enumerate(
         REQUIRED_WORKFLOW_CHAT_ROWS.items()
@@ -272,7 +389,7 @@ def _matrix(root: Path) -> dict[str, object]:
                         "providerSessionId": "provider-session-1",
                         "browserTraceId": f"browser-trace-{index}",
                     },
-                    "data": _record_data(record_type, row_name, index),
+                    "data": _record_data(record_type, row_name, index, root),
                 },
             )
             source_records.append(
@@ -329,9 +446,12 @@ def _matrix(root: Path) -> dict[str, object]:
     for channel in ("logs", "temporalHistory", "screenshots", "archives"):
         ref = f"scan-{channel}.json"
         raw_ref = f"raw-{channel}.txt"
-        (root / raw_ref).write_text(
-            f"secret-free protected evidence for {channel}", encoding="utf-8"
-        )
+        if channel == "screenshots":
+            (root / raw_ref).write_bytes(SCREENSHOT_EVIDENCE)
+        else:
+            (root / raw_ref).write_text(
+                f"secret-free protected evidence for {channel}", encoding="utf-8"
+            )
         _write(
             root / ref,
             {
@@ -491,8 +611,15 @@ def test_source_record_request_ids_must_resolve_to_the_browser_trace(
     source = _matrix(tmp_path)
 
     def add_unbound_request(payload: dict[str, object]) -> None:
-        payload["data"]["requestIds"] = ["not-in-browser-trace"]
-        payload["data"]["receipts"][0]["requestId"] = "not-in-browser-trace"
+        unbound_ids = [
+            f"not-in-browser-trace-{index}"
+            for index in range(len(payload["data"]["receipts"]))
+        ]
+        payload["data"]["requestIds"] = unbound_ids
+        for receipt, request_id in zip(
+            payload["data"]["receipts"], unbound_ids, strict=True
+        ):
+            receipt["requestId"] = request_id
 
     _rewrite_source(
         tmp_path,
@@ -505,6 +632,211 @@ def test_source_record_request_ids_must_resolve_to_the_browser_trace(
     )
 
     with pytest.raises(ConformanceContractError, match="request correlation"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_facade_route_coverage_must_be_observed_and_path_bound(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def remove_observed_route(payload: dict[str, object]) -> None:
+        removed = payload["data"]["requests"].pop()
+        payload["data"]["requestIds"].remove(removed["requestId"])
+
+    _rewrite_source(
+        tmp_path,
+        row_name="scoped-transports-and-resources",
+        record_type="facadeRequests",
+        update=remove_observed_route,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="coverage"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_facade_route_name_must_match_the_observed_route_path(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def substitute_route_path(payload: dict[str, object]) -> None:
+        request = next(
+            item
+            for item in payload["data"]["requests"]
+            if item["routeName"] == "get_session"
+        )
+        request["routePath"] = "health"
+
+    _rewrite_source(
+        tmp_path,
+        row_name="scoped-transports-and-resources",
+        record_type="facadeRequests",
+        update=substitute_route_path,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="unauthorized request"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_every_observed_mutation_requires_one_receipt(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def omit_receipt(payload: dict[str, object]) -> None:
+        removed = payload["data"]["receipts"].pop()
+        payload["data"]["requestIds"].remove(removed["requestId"])
+
+    _rewrite_source(
+        tmp_path,
+        row_name="scoped-transports-and-resources",
+        record_type="mutationReceipts",
+        update=omit_receipt,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="mutation receipt"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+@pytest.mark.parametrize(
+    ("row_name", "request_index", "status"),
+    [
+        ("native-live-conversation", 1, 500),
+        ("authority-and-security-denials", 0, 200),
+        ("authority-and-security-denials", 5, 403),
+    ],
+)
+def test_browser_trace_requires_success_or_the_exact_denial_status(
+    row_name: str, request_index: int, status: int, tmp_path: Path
+) -> None:
+    source = _matrix(tmp_path)
+
+    def replace_status(payload: dict[str, object]) -> None:
+        payload["data"]["networkEvents"][request_index]["responseStatus"] = status
+
+    _rewrite_source(
+        tmp_path,
+        row_name=row_name,
+        record_type="browserTrace",
+        update=replace_status,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="response status"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_browser_trace_scope_requires_a_path_segment_boundary(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def replace_path(payload: dict[str, object]) -> None:
+        payload["data"]["networkEvents"][0]["path"] = (
+            "/omnigent-ui/workflow-chat/binding-1-attacker"
+        )
+
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="browserTrace",
+        update=replace_path,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="unscoped"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_credential_boundary_must_cover_every_browser_request(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def keep_one_request(payload: dict[str, object]) -> None:
+        request_id = payload["data"]["requestIds"][0]
+        payload["data"]["requestIds"] = [request_id]
+        payload["data"]["verifiedRequestIds"] = [request_id]
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="credentialBoundary",
+        update=keep_one_request,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="browser trace"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_captured_artifacts_are_resolved_and_digest_bound(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def forge_digest(payload: dict[str, object]) -> None:
+        payload["data"]["artifacts"][0]["sha256"] = "9" * 64
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="capturedEvidence",
+        update=forge_digest,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="artifact is unresolved"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_browser_trace_screenshot_must_match_scanned_screenshot(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def replace_screenshot(payload: dict[str, object]) -> None:
+        payload["data"]["screenshotSha256"] = "sha256:" + "9" * 64
+
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="browserTrace",
+        update=replace_screenshot,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="scanned evidence"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_continuation_requires_creation_and_durable_relationship_evidence(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def remove_relationship(payload: dict[str, object]) -> None:
+        payload["data"].pop("durableRelationship")
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="continuationReceipt",
+        update=remove_relationship,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(source, evidence_root=tmp_path)
+
+    with pytest.raises(ConformanceContractError, match="durableRelationship"):
         validate_workflow_chat_acceptance_manifest(
             manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
         )

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -941,7 +941,11 @@ def test_native_chat_rollout_gate_fails_closed(
         manifest["evidenceScans"].pop("archives")
     else:
         case = json.loads((tmp_path / "case-0.json").read_text(encoding="utf-8"))
-        case["sourceRecords"].pop()
+        case["sourceRecords"] = [
+            record
+            for record in case["sourceRecords"]
+            if record["type"] != "browserTrace"
+        ]
         _write(tmp_path / "case-0.json", case)
         for item in manifest["evidenceManifest"]:
             if item["ref"] == "case-0.json":

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -1,0 +1,254 @@
+"""Protected rollout evidence tests for MoonLadderStudios/MoonMind#3632."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.workflow_chat_acceptance import (
+    REQUIRED_WORKFLOW_CHAT_ROWS,
+    REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS,
+    WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+    WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+    WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
+    WORKFLOW_CHAT_PARENT_ISSUE,
+    WORKFLOW_CHAT_SOURCE_RECORD_VERSION,
+    build_workflow_chat_acceptance_manifest,
+    validate_workflow_chat_acceptance_manifest,
+)
+
+NOW = datetime(2026, 8, 13, tzinfo=timezone.utc)
+IMAGES = {
+    "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
+    "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
+}
+
+
+def _write(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _matrix(root: Path) -> dict[str, object]:
+    rows: dict[str, object] = {}
+    for index, (row_name, assertions) in enumerate(
+        REQUIRED_WORKFLOW_CHAT_ROWS.items()
+    ):
+        source_records = []
+        for record_type in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
+            record_ref = f"source-{index}-{record_type}.json"
+            _write(
+                root / record_ref,
+                {
+                    "schemaVersion": WORKFLOW_CHAT_SOURCE_RECORD_VERSION,
+                    "recordType": record_type,
+                    "row": row_name,
+                    "sourceCommit": "abc123",
+                    "observed": True,
+                    "data": {"bounded": True},
+                },
+            )
+            source_records.append(
+                {
+                    "type": record_type,
+                    "ref": record_ref,
+                    "sha256": hashlib.sha256(
+                        (root / record_ref).read_bytes()
+                    ).hexdigest(),
+                }
+            )
+        ref = f"case-{index}.json"
+        _write(
+            root / ref,
+            {
+                "schemaVersion": WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+                "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+                "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
+                "row": row_name,
+                "status": "passed",
+                "sourceCommit": "abc123",
+                "images": IMAGES,
+                "stockHostUnmodified": True,
+                "browserOriginated": True,
+                "moonmindScopedOnly": True,
+                "assertions": {name: True for name in assertions},
+                "sourceRecords": source_records,
+                "observations": ["bounded protected observation"],
+            },
+        )
+        rows[row_name] = {
+            "status": "passed",
+            "assertions": {name: True for name in assertions},
+            "evidenceRefs": [ref],
+        }
+    _write(
+        root / "report.json",
+        {
+            "schemaVersion": "moonmind.omnigent.conformance-report/v1",
+            "generatedAt": NOW.isoformat(),
+            "images": IMAGES,
+            "cases": [
+                {
+                    "caseId": f"workflow-chat-{index}",
+                    "status": "passed",
+                    "evidenceRefs": [f"case-{index}.json"],
+                }
+                for index in range(len(REQUIRED_WORKFLOW_CHAT_ROWS))
+            ],
+            "summary": {"passed": 4, "failed": 0, "skipped": 0},
+        },
+    )
+    scans: dict[str, object] = {}
+    for channel in ("logs", "temporalHistory", "screenshots", "archives"):
+        ref = f"scan-{channel}.json"
+        raw_ref = f"raw-{channel}.txt"
+        (root / raw_ref).write_text(
+            f"secret-free protected evidence for {channel}", encoding="utf-8"
+        )
+        _write(
+            root / ref,
+            {
+                "status": "passed",
+                "channel": channel,
+                "files": [
+                    {
+                        "ref": raw_ref,
+                        "sha256": hashlib.sha256(
+                            (root / raw_ref).read_bytes()
+                        ).hexdigest(),
+                    }
+                ],
+            },
+        )
+        scans[channel] = {"status": "passed", "evidenceRef": ref}
+    return {
+        "generatedAt": NOW.isoformat(),
+        "expiresAt": (NOW + timedelta(days=7)).isoformat(),
+        "sourceCommit": "abc123",
+        "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
+        "images": IMAGES,
+        "rows": rows,
+        "reports": ["report.json"],
+        "evidenceScans": scans,
+    }
+
+
+def test_complete_native_chat_matrix_builds_and_validates(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+
+    validate_workflow_chat_acceptance_manifest(
+        manifest,
+        evidence_root=tmp_path,
+        expected_commit="abc123",
+        now=NOW,
+    )
+
+    assert set(manifest["rows"]) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
+    assert manifest["issue"] == WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+    assert all(item["sha256"] for item in manifest["evidenceManifest"])
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing_row",
+        "failed_assertion",
+        "stale",
+        "wrong_commit",
+        "mutable_image",
+        "unresolved_ref",
+        "tampered_ref",
+        "failed_report",
+        "missing_scan",
+        "missing_source_record",
+    ],
+)
+def test_native_chat_rollout_gate_fails_closed(
+    mutation: str, tmp_path: Path
+) -> None:
+    source = _matrix(tmp_path)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+    if mutation == "missing_row":
+        manifest["rows"].pop("native-live-conversation")
+    elif mutation == "failed_assertion":
+        row = manifest["rows"]["native-live-conversation"]
+        row["assertions"]["native_ui_primary"] = False
+    elif mutation == "stale":
+        manifest["generatedAt"] = (NOW - timedelta(days=8)).isoformat()
+    elif mutation == "wrong_commit":
+        manifest["sourceCommit"] = "old"
+    elif mutation == "mutable_image":
+        manifest["images"]["host"] = "ghcr.io/omnigent/host:latest"
+    elif mutation == "unresolved_ref":
+        manifest["rows"]["native-live-conversation"]["evidenceRefs"] = [
+            "missing.json"
+        ]
+    elif mutation == "tampered_ref":
+        (tmp_path / "case-0.json").write_text("{}", encoding="utf-8")
+    elif mutation == "failed_report":
+        (tmp_path / "report.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": "moonmind.omnigent.conformance-report/v1",
+                    "generatedAt": NOW.isoformat(),
+                    "images": IMAGES,
+                    "cases": [
+                        {
+                            "caseId": f"workflow-chat-{index}",
+                            "status": "failed" if index == 0 else "passed",
+                            "evidenceRefs": [f"case-{index}.json"],
+                        }
+                        for index in range(4)
+                    ],
+                    "summary": {"passed": 3, "failed": 1},
+                }
+            ),
+            encoding="utf-8",
+        )
+        for item in manifest["evidenceManifest"]:
+            if item["ref"] == "report.json":
+                item["sha256"] = hashlib.sha256(
+                    (tmp_path / "report.json").read_bytes()
+                ).hexdigest()
+    elif mutation == "missing_scan":
+        manifest["evidenceScans"].pop("archives")
+    else:
+        case = json.loads((tmp_path / "case-0.json").read_text(encoding="utf-8"))
+        case["sourceRecords"].pop()
+        _write(tmp_path / "case-0.json", case)
+        for item in manifest["evidenceManifest"]:
+            if item["ref"] == "case-0.json":
+                item["sha256"] = hashlib.sha256(
+                    (tmp_path / "case-0.json").read_bytes()
+                ).hexdigest()
+
+    with pytest.raises(ConformanceContractError):
+        validate_workflow_chat_acceptance_manifest(
+            manifest,
+            evidence_root=tmp_path,
+            expected_commit="abc123",
+            now=NOW,
+        )
+
+
+def test_native_chat_evidence_is_secret_scanned(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+    case = json.loads((tmp_path / "case-0.json").read_text(encoding="utf-8"))
+    case["observations"] = ["Authorization: Bearer exposed-value"]
+    _write(tmp_path / "case-0.json", case)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="secret-like"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, now=NOW
+        )

--- a/tests/unit/test_omnigent_live_conformance_workflow.py
+++ b/tests/unit/test_omnigent_live_conformance_workflow.py
@@ -42,6 +42,7 @@ def test_live_conformance_runs_the_complete_independent_matrix() -> None:
         "static",
         "ondemand",
         "failures",
+        "workflow_chat",
     ]
     run_step = next(
         step
@@ -50,6 +51,7 @@ def test_live_conformance_runs_the_complete_independent_matrix() -> None:
     )
     assert "tools/run_omnigent_live_conformance.py" in run_step["run"]
     assert '--mode "${{ matrix.mode }}"' in run_step["run"]
+    assert '--source-commit "${{ github.sha }}"' in run_step["run"]
     assert run_step["env"]["MOONMIND_OMNIGENT_ACTION_COMMAND"] == (
         "${{ secrets.MOONMIND_OMNIGENT_ACTION_COMMAND }}"
     )
@@ -69,7 +71,9 @@ def test_live_conformance_runs_the_complete_independent_matrix() -> None:
     browser_step = next(
         step for step in job["steps"] if step.get("name") == "Install controlling browser"
     )
-    assert browser_step["if"] == "${{ matrix.mode == 'browser' }}"
+    assert browser_step["if"] == (
+        "${{ matrix.mode == 'browser' || matrix.mode == 'workflow_chat' }}"
+    )
     assert "playwright install --with-deps chromium" in browser_step["run"]
 
 
@@ -97,15 +101,19 @@ def test_publication_requires_every_matrix_case_to_pass() -> None:
         for step in job["steps"]
         if step.get("name") == "Write publication manifest"
     )
-    assert "expected seven passing reports" in manifest["run"]
+    assert "expected eight passing reports" in manifest["run"]
     assert "MoonLadderStudios/MoonMind#3508" in manifest["run"]
     assert "MoonLadderStudios/MoonMind#3480" in manifest["run"]
     assert "MoonLadderStudios/MoonMind#3471" in manifest["run"]
     assert "MoonLadderStudios/MoonMind#3456" in manifest["run"]
     assert "MoonLadderStudios/MoonMind#3448" in manifest["run"]
+    assert "MoonLadderStudios/MoonMind#3642" in manifest["run"]
+    assert "MoonLadderStudios/MoonMind#3632" in manifest["run"]
     assert "moonmind.omnigent.product-acceptance/v1" in manifest["run"]
     assert '"sourceCommit": os.environ["GITHUB_SHA"]' in manifest["run"]
     assert '"browserRows": rows' in manifest["run"]
+    assert "validate_workflow_chat_acceptance_manifest" in manifest["run"]
+    assert '"nativeWorkflowChatEvidence"' in manifest["run"]
     assert "product evidence lacks independently resolved production records" in manifest["run"]
     assert '"productSchemaVersions": product["schemaVersions"]' in manifest["run"]
     assert '"safeIdentities": product["identifiers"]' in manifest["run"]
@@ -136,12 +144,12 @@ def test_publication_requires_every_matrix_case_to_pass() -> None:
     link = next(
         step
         for step in job["steps"]
-        if step.get("name") == (
-            "Link passing acceptance report from issues 3508 and 3448"
-        )
+        if step.get("name") == "Link passing acceptance report from owning issues"
     )
     assert "gh issue comment 3508" in link["run"]
     assert "gh issue comment 3448" in link["run"]
+    assert "gh issue comment 3642" in link["run"]
+    assert "gh issue comment 3632" in link["run"]
     assert "github.run_id" in link["run"]
     assert "github.run_attempt" in link["run"]
     assert "github.sha" in link["run"]

--- a/tests/unit/tools/test_run_omnigent_live_conformance.py
+++ b/tests/unit/tools/test_run_omnigent_live_conformance.py
@@ -656,7 +656,7 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     assert (tmp_path / "workflow-chat-matrix.json").is_file()
     assert (tmp_path / "workflow-chat-report.json").is_file()
     assert (tmp_path / "workflow-chat-acceptance.json").is_file()
-    assert (tmp_path / "publication-secret-scan.json").is_file()
+    assert not (tmp_path / "publication-secret-scan.json").exists()
     assert runner.env["MOONMIND_OMNIGENT_SOURCE_COMMIT"] == "commit-1"
     assert runner.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE_DIR"] == str(
         tmp_path
@@ -664,6 +664,78 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     assert runner.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE"].endswith(
         "workflow-chat-acceptance.json"
     )
+
+
+def test_all_mode_reports_workflow_chat_and_scans_after_cleanup_and_report(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    images = {
+        "server": "server@sha256:" + "1" * 64,
+        "host": "host@sha256:" + "2" * 64,
+    }
+
+    for mode in module.LIVE_CASES:
+        method_name = mode
+        if mode in {"stock", "remediation"}:
+            monkeypatch.setattr(
+                module.LiveRunner,
+                method_name,
+                lambda self, selected_images: None,
+            )
+        elif mode == "workflow_chat":
+            monkeypatch.setattr(
+                module.LiveRunner,
+                method_name,
+                lambda self, selected_images, source_commit: None,
+            )
+        else:
+            monkeypatch.setattr(module.LiveRunner, method_name, lambda self: None)
+
+    def cleanup(self, mode):
+        (self.output_dir / f"{mode}-cleanup.log").write_text(
+            "safe cleanup evidence", encoding="utf-8"
+        )
+
+    scans = {
+        channel: {"status": "passed", "evidenceRef": f"scan-{channel}.json"}
+        for channel in module.EVIDENCE_ENV
+    }
+    monkeypatch.setattr(module.LiveRunner, "cleanup", cleanup)
+    monkeypatch.setattr(module.LiveRunner, "scan", lambda self: scans)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            str(module.__file__),
+            "--mode",
+            "all",
+            "--server-image",
+            images["server"],
+            "--host-image",
+            images["host"],
+            "--source-commit",
+            "commit-1",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 0
+
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    workflow_chat = next(
+        item
+        for item in report["cases"]
+        if item["caseId"] == "workflow-chat.native-release-matrix"
+    )
+    assert workflow_chat["status"] == "passed"
+    publication_scan = json.loads(
+        (tmp_path / "publication-secret-scan.json").read_text(encoding="utf-8")
+    )
+    scanned_refs = {item["ref"] for item in publication_scan["files"]}
+    assert "report.json" in scanned_refs
+    assert "workflow_chat-cleanup.log" in scanned_refs
 
 
 def test_workflow_chat_controller_fails_before_provider_gate_when_scan_missing(

--- a/tests/unit/tools/test_run_omnigent_live_conformance.py
+++ b/tests/unit/tools/test_run_omnigent_live_conformance.py
@@ -396,6 +396,215 @@ def test_every_mode_has_dedicated_scenario_evidence_channel():
     assert len(set(module.SCENARIO_EVIDENCE_ENV.values())) == len(module.LIVE_CASES)
 
 
+def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    runner = module.LiveRunner(output_dir=tmp_path, env={})
+    events = []
+    images = {
+        "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
+        "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
+    }
+
+    def action(scenario, row_name, **state):
+        events.append(("action", row_name, dict(state)))
+        records = []
+        for record_type in module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
+            path = tmp_path / f"{row_name}-{record_type}.json"
+            path.write_text("{}", encoding="utf-8")
+            records.append(
+                {
+                    "type": record_type,
+                    "ref": path.as_uri(),
+                    "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                    "_resolved": {},
+                }
+            )
+        return {"row": row_name, "_sourceRecords": records}
+
+    def validate_sources(sources, *, row_name, expected_correlation, **kwargs):
+        assert set(sources) == set(
+            module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]
+        )
+        if expected_correlation is not None:
+            assert expected_correlation["workflowId"] == "workflow-1"
+        return (
+            {name: True for name in module.REQUIRED_WORKFLOW_CHAT_ROWS[row_name]},
+            {
+                "workflowId": "workflow-1",
+                "chatBindingId": "binding-1",
+                "bridgeSessionId": "bridge-1",
+                "providerSessionId": "provider-session-1",
+                "browserTraceId": f"trace-{row_name}",
+            },
+        )
+
+    scans = {
+        channel: {"status": "passed", "evidenceRef": f"scan-{channel}.json"}
+        for channel in module.EVIDENCE_ENV
+    }
+    monkeypatch.setattr(runner, "run", lambda name, command: events.append(("run", name)))
+    monkeypatch.setattr(runner, "action", action)
+    monkeypatch.setattr(runner, "scan", lambda: scans)
+    monkeypatch.setattr(module, "validate_workflow_chat_source_records", validate_sources)
+    monkeypatch.setattr(
+        module,
+        "build_workflow_chat_acceptance_manifest",
+        lambda matrix, evidence_root: {"schemaVersion": "acceptance", "rows": matrix["rows"]},
+    )
+    monkeypatch.setattr(
+        module,
+        "validate_workflow_chat_acceptance_manifest",
+        lambda manifest, **kwargs: events.append(("validate", tuple(manifest["rows"]))),
+    )
+    monkeypatch.setattr(
+        runner,
+        "scenario",
+        lambda mode, phase=None: events.append(("provider", mode)),
+    )
+
+    runner.workflow_chat(images, "commit-1")
+
+    assert [event[1] for event in events if event[0] == "action"] == list(
+        module.WORKFLOW_CHAT_ACTIONS
+    )
+    assert events[-2][0] == "validate"
+    assert events[-1] == ("provider", "workflow_chat")
+    assert (tmp_path / "workflow-chat-matrix.json").is_file()
+    assert (tmp_path / "workflow-chat-report.json").is_file()
+    assert (tmp_path / "workflow-chat-acceptance.json").is_file()
+    assert (tmp_path / "publication-secret-scan.json").is_file()
+    assert runner.env["MOONMIND_OMNIGENT_SOURCE_COMMIT"] == "commit-1"
+    assert runner.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE_DIR"] == str(
+        tmp_path
+    )
+    assert runner.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE"].endswith(
+        "workflow-chat-acceptance.json"
+    )
+
+
+def test_workflow_chat_controller_fails_before_provider_gate_when_scan_missing(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    runner = module.LiveRunner(output_dir=tmp_path, env={})
+    provider_called = False
+    monkeypatch.setattr(runner, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "action",
+        lambda scenario, row_name, **state: {
+            "row": row_name,
+            "_sourceRecords": [
+                {"type": name, "ref": "https://evidence.invalid/record", "sha256": "0" * 64, "_resolved": {}}
+                for name in module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "validate_workflow_chat_source_records",
+        lambda sources, *, row_name, **kwargs: (
+            {name: True for name in module.REQUIRED_WORKFLOW_CHAT_ROWS[row_name]},
+            {
+                "workflowId": "workflow-1",
+                "chatBindingId": "binding-1",
+                "bridgeSessionId": "bridge-1",
+                "providerSessionId": "provider-session-1",
+                "browserTraceId": f"trace-{row_name}",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "scan",
+        lambda: (_ for _ in ()).throw(
+            module.ConformanceContractError("screenshots evidence was not collected")
+        ),
+    )
+
+    def provider(*args, **kwargs):
+        nonlocal provider_called
+        provider_called = True
+
+    monkeypatch.setattr(runner, "scenario", provider)
+
+    try:
+        runner.workflow_chat(
+            {
+                "server": "server@sha256:" + "1" * 64,
+                "host": "host@sha256:" + "2" * 64,
+            },
+            "commit-1",
+        )
+    except module.ConformanceContractError as exc:
+        assert "screenshots evidence was not collected" in str(exc)
+    else:
+        raise AssertionError("missing Workflow Chat evidence channel was accepted")
+    assert provider_called is False
+    assert not (tmp_path / "workflow-chat-acceptance.json").exists()
+
+
+def test_workflow_chat_action_rejects_missing_typed_source_records(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    ref = _action_evidence(
+        tmp_path,
+        "workflow_chat",
+        "native-live-conversation",
+        source_records=[],
+    )
+    runner = module.LiveRunner(
+        output_dir=tmp_path,
+        env={"MOONMIND_OMNIGENT_ACTION_COMMAND": "adapter"},
+    )
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            {
+                "ok": True,
+                "row": "native-live-conversation",
+                "evidenceRefs": [ref],
+            }
+        )
+        stderr = ""
+
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: Result())
+    try:
+        runner.action("workflow_chat", "native-live-conversation")
+    except module.ConformanceContractError as exc:
+        assert "independently resolved source records" in str(exc)
+    else:
+        raise AssertionError("missing Workflow Chat source records were accepted")
+
+
+def test_workflow_chat_mode_requires_source_commit_before_live_actions(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            str(module.__file__),
+            "--mode",
+            "workflow_chat",
+            "--server-image",
+            "server@sha256:" + "1" * 64,
+            "--host-image",
+            "host@sha256:" + "2" * 64,
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 2
+
+
 def test_scan_requires_each_evidence_channel(tmp_path):
     module = _module()
     runner = module.LiveRunner(output_dir=tmp_path, env={})
@@ -405,6 +614,36 @@ def test_scan_requires_each_evidence_channel(tmp_path):
         assert "evidence was not collected" in str(exc)
     else:
         raise AssertionError("missing evidence channels were accepted")
+
+
+def test_scan_owns_portable_digests_for_every_raw_evidence_channel(tmp_path):
+    module = _module()
+    output_dir = tmp_path / "run-output"
+    output_dir.mkdir()
+    raw_dir = tmp_path / "external-evidence"
+    raw_dir.mkdir()
+    env = {}
+    for channel, env_name in module.EVIDENCE_ENV.items():
+        path = raw_dir / f"{channel}.txt"
+        path.write_text(f"safe {channel} evidence", encoding="utf-8")
+        env[env_name] = str(path)
+    runner = module.LiveRunner(output_dir=output_dir, env=env)
+
+    scans = runner.scan()
+
+    assert set(scans) == set(module.EVIDENCE_ENV)
+    for channel, scan in scans.items():
+        scan_path = output_dir / scan["evidenceRef"]
+        payload = json.loads(scan_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "passed"
+        assert payload["channel"] == channel
+        assert payload["files"]
+        for item in payload["files"]:
+            evidence_path = output_dir / item["ref"]
+            assert evidence_path.is_file()
+            assert item["sha256"] == hashlib.sha256(
+                evidence_path.read_bytes()
+            ).hexdigest()
 
 
 def test_action_rejects_boolean_attestation_without_evidence(tmp_path, monkeypatch):

--- a/tools/build_omnigent_workflow_chat_acceptance.py
+++ b/tools/build_omnigent_workflow_chat_acceptance.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Build and validate protected Workflow Chat rollout evidence for #3632/#3642."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from moonmind.omnigent.workflow_chat_acceptance import (  # noqa: E402
+    build_workflow_chat_acceptance_manifest,
+    validate_workflow_chat_acceptance_manifest,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bind a protected browser-to-stock-host Workflow Chat matrix to "
+            "independently resolvable, secret-scanned evidence."
+        )
+    )
+    parser.add_argument("--matrix", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--expected-commit", required=True)
+    args = parser.parse_args()
+
+    matrix_path = args.matrix.resolve()
+    source = json.loads(matrix_path.read_text(encoding="utf-8"))
+    if not isinstance(source, dict):
+        raise ValueError("workflow Chat matrix must be an object")
+    evidence_root = matrix_path.parent
+    output_path = args.output.resolve()
+    if output_path.parent != evidence_root:
+        raise ValueError(
+            "workflow Chat acceptance output must stay beside its evidence matrix"
+        )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source,
+        evidence_root=evidence_root,
+    )
+    validate_workflow_chat_acceptance_manifest(
+        manifest,
+        evidence_root=evidence_root,
+        expected_commit=args.expected_commit,
+    )
+    output_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_omnigent_live_conformance.py
+++ b/tools/run_omnigent_live_conformance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run credentialed Omnigent conformance and browser product journeys for #3508.
+"""Run credentialed Omnigent conformance and protected product journeys.
 
 The runner owns only an isolated Compose project.  In particular, it never
 removes volumes: the enrolled Codex OAuth volume is operator-owned evidence,
@@ -19,6 +19,7 @@ import shlex
 import xml.etree.ElementTree as ET
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Sequence
 
@@ -27,12 +28,24 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from moonmind.omnigent.conformance import (  # noqa: E402
+    REPORT_VERSION,
     CaseResult,
     ConformanceContractError,
     assert_secret_free,
     build_report,
     load_profile,
     require_pinned_images,
+)
+from moonmind.omnigent.workflow_chat_acceptance import (  # noqa: E402
+    REQUIRED_WORKFLOW_CHAT_ROWS,
+    REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS,
+    WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+    WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+    WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
+    WORKFLOW_CHAT_PARENT_ISSUE,
+    build_workflow_chat_acceptance_manifest,
+    validate_workflow_chat_acceptance_manifest,
+    validate_workflow_chat_source_records,
 )
 
 PROFILE = REPO_ROOT / "tests/fixtures/omnigent/conformance-v4.json"
@@ -52,6 +65,7 @@ LIVE_CASES = {
     "static": {"compose.static-codex-oauth"},
     "ondemand": {"ondemand.codex-oauth", "cleanup.lease-owned-only"},
     "failures": {"failures.lifecycle-and-redaction"},
+    "workflow_chat": {"workflow-chat.native-release-matrix"},
 }
 BROWSER_ROWS = (
     "static_profile_bound",
@@ -210,6 +224,7 @@ ONDEMAND_ACTIONS = (
     "executed", "resources_harvested", "partial_start_retry", "janitor_recovery",
     "host_removed", "workflow_detail_reloaded", "lease_released",
 )
+WORKFLOW_CHAT_ACTIONS = tuple(REQUIRED_WORKFLOW_CHAT_ROWS)
 SCENARIOS = {
     "browser": f"{PROVIDER_TEST}::test_live_browser_release_matrix",
     "product": f"{PROVIDER_TEST}::test_live_product_create_api_journey",
@@ -218,6 +233,9 @@ SCENARIOS = {
     "static": f"{PROVIDER_TEST}::test_live_static_workflow_detail_restart_replay",
     "ondemand": f"{PROVIDER_TEST}::test_live_ondemand_oauth_lifecycle_and_cleanup",
     "failures": f"{PROVIDER_TEST}::test_live_failure_matrix_and_durable_evidence",
+    "workflow_chat": (
+        f"{PROVIDER_TEST}::test_live_native_workflow_chat_release_matrix"
+    ),
 }
 EVIDENCE_ENV = {
     "logs": "MOONMIND_OMNIGENT_LOG_EVIDENCE",
@@ -233,6 +251,7 @@ SCENARIO_EVIDENCE_ENV = {
     "static": "MOONMIND_OMNIGENT_STATIC_EVIDENCE",
     "ondemand": "MOONMIND_OMNIGENT_ONDEMAND_EVIDENCE",
     "failures": "MOONMIND_OMNIGENT_FAILURE_EVIDENCE",
+    "workflow_chat": "MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE",
 }
 
 
@@ -242,6 +261,7 @@ class LiveRunner:
         self.env = env
         self.logs: list[Path] = []
         self.evidence_refs: list[str] = []
+        self._completed_scans: dict[str, dict[str, str]] | None = None
         self.env.setdefault("MOONMIND_OMNIGENT_BACKEND_STATE", str(output_dir / "backend-state.json"))
         self.env.setdefault("MOONMIND_OMNIGENT_BACKEND_EVIDENCE_DIR", str(output_dir))
 
@@ -314,7 +334,13 @@ class LiveRunner:
             raise ConformanceContractError(
                 f"{scenario}/{action} evidence did not describe the observed action"
             )
-        if scenario in {"browser", "product", "cumulative", "failures"}:
+        if scenario in {
+            "browser",
+            "product",
+            "cumulative",
+            "failures",
+            "workflow_chat",
+        }:
             records = [
                 record
                 for item in observations
@@ -336,6 +362,8 @@ class LiveRunner:
                 else {"cumulativeRunState", "sideEffectAudit"}
                 if scenario == "cumulative"
                 else {"injectionControl", "terminalProjection", "sideEffectAudit"}
+                if scenario == "failures"
+                else REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[action]
             )
             observed_types = {record.get("type") for record in records}
             missing = sorted(required_types - observed_types)
@@ -485,6 +513,211 @@ class LiveRunner:
         path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         self.env[SCENARIO_EVIDENCE_ENV[mode]] = str(path)
         return path
+
+    def _portable_ref(self, ref: str) -> str:
+        """Keep run-local file evidence resolvable after artifact publication."""
+
+        parsed = urllib.parse.urlparse(ref)
+        if parsed.scheme != "file":
+            return ref
+        path = Path(urllib.request.url2pathname(parsed.path)).resolve()
+        root = self.output_dir.resolve()
+        if path != root and root not in path.parents:
+            raise ConformanceContractError(
+                "workflow Chat evidence is outside the run output directory"
+            )
+        return str(path.relative_to(root))
+
+    def _write_workflow_chat_report(
+        self,
+        *,
+        images: dict[str, str],
+        case_refs: list[str],
+        scans: dict[str, dict[str, str]],
+    ) -> Path:
+        report = {
+            "schemaVersion": REPORT_VERSION,
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "images": images,
+            "hostArchitecture": platform.machine(),
+            "authMode": "codex-oauth",
+            "protocolVersion": "omnigent/v1",
+            "capabilities": ["workflow_chat"],
+            "evidenceScans": scans,
+            "cases": [
+                {
+                    "caseId": f"workflow-chat-{row_name}",
+                    "status": "passed",
+                    "evidenceRefs": [case_ref],
+                    "diagnostics": [],
+                }
+                for row_name, case_ref in zip(
+                    WORKFLOW_CHAT_ACTIONS, case_refs, strict=True
+                )
+            ],
+            "summary": {
+                "passed": len(case_refs),
+                "failed": 0,
+                "skipped": 0,
+            },
+        }
+        assert_secret_free(report)
+        path = self.output_dir / "workflow-chat-report.json"
+        path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def _scan_publication_tree(self) -> Path:
+        """Fail closed unless every file about to be published is secret-free."""
+
+        files: list[dict[str, str]] = []
+        root = self.output_dir.resolve()
+        for path in sorted(item for item in root.rglob("*") if item.is_file()):
+            if path.name == "publication-secret-scan.json":
+                continue
+            raw = path.read_bytes()
+            assert_secret_free(raw.decode("utf-8", errors="replace"))
+            files.append(
+                {
+                    "ref": str(path.relative_to(root)),
+                    "sha256": hashlib.sha256(raw).hexdigest(),
+                }
+            )
+        if not files:
+            raise ConformanceContractError(
+                "workflow Chat publication tree contains no evidence"
+            )
+        payload = {"status": "passed", "files": files}
+        assert_secret_free(payload)
+        path = self.output_dir / "publication-secret-scan.json"
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def workflow_chat(self, images: dict[str, str], source_commit: str) -> None:
+        """Own the protected #3642 browser-to-stock-host acceptance matrix."""
+
+        if not source_commit.strip():
+            raise ConformanceContractError(
+                "workflow Chat mode requires the tested source commit"
+            )
+        self.env["MOONMIND_OMNIGENT_SOURCE_COMMIT"] = source_commit
+        self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE_DIR"] = str(
+            self.output_dir
+        )
+        self.run(
+            "workflow-chat-up",
+            self.compose("up", "-d", "--wait", "omnigent", "omnigent-host-codex"),
+        )
+        rows: dict[str, dict[str, object]] = {}
+        case_refs: list[str] = []
+        correlation: dict[str, str] | None = None
+        state: dict[str, object] = {}
+        for index, row_name in enumerate(WORKFLOW_CHAT_ACTIONS):
+            result = self.action("workflow_chat", row_name, **state)
+            if result.get("row") != row_name:
+                raise ConformanceContractError(
+                    f"workflow Chat action returned the wrong row: {row_name}"
+                )
+            records = result.get("_sourceRecords")
+            if not isinstance(records, list):
+                raise ConformanceContractError(
+                    f"workflow Chat action lacks resolved source records: {row_name}"
+                )
+            sources = {
+                str(record["type"]): record["_resolved"]
+                for record in records
+                if isinstance(record, dict)
+                and isinstance(record.get("_resolved"), dict)
+            }
+            assertions, observed_correlation = validate_workflow_chat_source_records(
+                sources,
+                row_name=row_name,
+                source_commit=source_commit,
+                images=images,
+                generated_at=datetime.now(timezone.utc),
+                expected_correlation=correlation,
+            )
+            if correlation is None:
+                correlation = observed_correlation
+            state = {
+                field: observed_correlation[field]
+                for field in (
+                    "workflowId",
+                    "chatBindingId",
+                    "bridgeSessionId",
+                    "providerSessionId",
+                )
+            }
+            case_ref = f"workflow-chat-case-{index}.json"
+            case_payload = {
+                "schemaVersion": WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+                "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+                "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
+                "row": row_name,
+                "status": "passed",
+                "sourceCommit": source_commit,
+                "images": images,
+                "stockHostUnmodified": True,
+                "browserOriginated": True,
+                "moonmindScopedOnly": True,
+                "assertions": assertions,
+                "sourceRecords": [
+                    {
+                        "type": record["type"],
+                        "ref": self._portable_ref(str(record["ref"])),
+                        "sha256": record["sha256"],
+                    }
+                    for record in records
+                ],
+                "observations": [
+                    "typed production records resolved by the protected controller"
+                ],
+            }
+            (self.output_dir / case_ref).write_text(
+                json.dumps(case_payload, indent=2) + "\n", encoding="utf-8"
+            )
+            rows[row_name] = {
+                "status": "passed",
+                "assertions": assertions,
+                "evidenceRefs": [case_ref],
+            }
+            case_refs.append(case_ref)
+
+        scans = self.scan()
+        report_path = self._write_workflow_chat_report(
+            images=images, case_refs=case_refs, scans=scans
+        )
+        generated_at = datetime.now(timezone.utc)
+        matrix = {
+            "generatedAt": generated_at.isoformat(),
+            "expiresAt": (generated_at + timedelta(days=7)).isoformat(),
+            "sourceCommit": source_commit,
+            "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
+            "images": images,
+            "rows": rows,
+            "reports": [report_path.name],
+            "evidenceScans": scans,
+        }
+        matrix_path = self.output_dir / "workflow-chat-matrix.json"
+        matrix_path.write_text(
+            json.dumps(matrix, indent=2) + "\n", encoding="utf-8"
+        )
+        manifest = build_workflow_chat_acceptance_manifest(
+            matrix, evidence_root=self.output_dir
+        )
+        validate_workflow_chat_acceptance_manifest(
+            manifest,
+            evidence_root=self.output_dir,
+            expected_commit=source_commit,
+            now=generated_at,
+        )
+        manifest_path = self.output_dir / "workflow-chat-acceptance.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self.env[SCENARIO_EVIDENCE_ENV["workflow_chat"]] = str(manifest_path)
+        self.scenario("workflow_chat")
+        self._scan_publication_tree()
 
     def stock(self, images: dict[str, str]) -> None:
         self.run(
@@ -936,6 +1169,8 @@ class LiveRunner:
         self.run(f"{mode}-cleanup", self.compose("down", "--remove-orphans"))
 
     def scan(self) -> dict[str, dict[str, str]]:
+        if self._completed_scans is not None:
+            return {key: dict(value) for key, value in self._completed_scans.items()}
         scans: dict[str, dict[str, str]] = {}
         for channel, env_name in EVIDENCE_ENV.items():
             raw = self.env.get(env_name, "")
@@ -947,19 +1182,52 @@ class LiveRunner:
                 paths.extend(sorted(self.output_dir.glob("*-replay.png")))
             if not paths or any(not path.is_file() for path in paths):
                 raise ConformanceContractError(f"{channel} evidence was not collected")
-            for evidence in paths:
-                assert_secret_free(evidence.read_bytes().decode("utf-8", errors="replace"))
+            unique_paths = list(dict.fromkeys(path.resolve() for path in paths))
+            files: list[dict[str, str]] = []
+            for index, evidence in enumerate(unique_paths):
+                raw_bytes = evidence.read_bytes()
+                assert_secret_free(raw_bytes.decode("utf-8", errors="replace"))
+                root = self.output_dir.resolve()
+                if evidence != root and root not in evidence.parents:
+                    staged = self.output_dir / "raw-evidence" / (
+                        f"{channel}-{index}-{evidence.name}"
+                    )
+                    staged.parent.mkdir(parents=True, exist_ok=True)
+                    staged.write_bytes(raw_bytes)
+                else:
+                    staged = evidence
+                files.append(
+                    {
+                        "ref": str(staged.resolve().relative_to(root)),
+                        "sha256": hashlib.sha256(raw_bytes).hexdigest(),
+                    }
+                )
             scan_path = self.output_dir / f"secret-scan-{channel}.json"
-            scan_path.write_text(json.dumps({"status": "passed", "files": [str(p) for p in paths]}) + "\n")
-            scans[channel] = {"status": "passed", "evidenceRef": str(scan_path)}
-        return scans
+            scan_path.write_text(
+                json.dumps(
+                    {"status": "passed", "channel": channel, "files": files}
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            scans[channel] = {
+                "status": "passed",
+                "evidenceRef": scan_path.name,
+            }
+        self._completed_scans = scans
+        return {key: dict(value) for key, value in scans.items()}
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run live Omnigent conformance for MoonLadderStudios/MoonMind#3368")
+    parser = argparse.ArgumentParser(description="Run protected live Omnigent conformance")
     parser.add_argument("--mode", choices=(*LIVE_CASES, "all"), default="all")
     parser.add_argument("--server-image", required=True)
     parser.add_argument("--host-image", required=True)
+    parser.add_argument(
+        "--source-commit",
+        default=os.environ.get("GITHUB_SHA", ""),
+        help="tested repository commit (required for workflow_chat mode)",
+    )
     parser.add_argument("--output-dir", type=Path, default=Path("artifacts/omnigent-conformance/live"))
     args = parser.parse_args()
     images = {"server": args.server_image, "host": args.host_image}
@@ -976,6 +1244,12 @@ def main() -> int:
     })
     runner = LiveRunner(output_dir=output_dir, env=env)
     selected = tuple(LIVE_CASES) if args.mode == "all" else (args.mode,)
+    if "workflow_chat" in selected and not args.source_commit.strip():
+        print(
+            "live conformance failed: workflow Chat mode requires --source-commit",
+            file=sys.stderr,
+        )
+        return 2
     passed: set[str] = set()
     failure: str | None = None
     try:
@@ -993,6 +1267,8 @@ def main() -> int:
                     runner.static()
                 elif mode == "ondemand":
                     runner.ondemand()
+                elif mode == "workflow_chat":
+                    runner.workflow_chat(images, args.source_commit)
                 else:
                     runner.failures()
             finally:
@@ -1027,9 +1303,30 @@ def main() -> int:
         status = "passed" if case_id in passed else "failed" if case_id in requested else "skipped"
         results.append(CaseResult(case_id, status, refs))
     try:
-        report = build_report(profile=profile, images=images, host_architecture=platform.machine(), auth_mode="codex-oauth", capabilities=selected, cases=results, protocol_version="omnigent/v1", evidence_scans=scans)
-        (output_dir / "report.json").write_text(json.dumps(report, indent=2) + "\n")
-    except ConformanceContractError as exc:
+        report = None
+        if selected == ("workflow_chat",):
+            if failure is None:
+                report = json.loads(
+                    (output_dir / "workflow-chat-report.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+        else:
+            report = build_report(
+                profile=profile,
+                images=images,
+                host_architecture=platform.machine(),
+                auth_mode="codex-oauth",
+                capabilities=selected,
+                cases=results,
+                protocol_version="omnigent/v1",
+                evidence_scans=scans,
+            )
+        if report is not None:
+            (output_dir / "report.json").write_text(
+                json.dumps(report, indent=2) + "\n", encoding="utf-8"
+            )
+    except (ConformanceContractError, OSError, json.JSONDecodeError) as exc:
         failure = failure or str(exc)
     if failure:
         print(f"live conformance failed: {failure}", file=sys.stderr)

--- a/tools/run_omnigent_live_conformance.py
+++ b/tools/run_omnigent_live_conformance.py
@@ -840,7 +840,6 @@ class LiveRunner:
         )
         self.env[SCENARIO_EVIDENCE_ENV["workflow_chat"]] = str(manifest_path)
         self.scenario("workflow_chat")
-        self._scan_publication_tree()
 
     def stock(self, images: dict[str, str]) -> None:
         self.run(
@@ -1744,6 +1743,8 @@ def main() -> int:
             (output_dir / "report.json").write_text(
                 json.dumps(report, indent=2) + "\n", encoding="utf-8"
             )
+        if "workflow_chat" in selected and failure is None:
+            runner._scan_publication_tree()
     except (ConformanceContractError, OSError, json.JSONDecodeError) as exc:
         failure = failure or str(exc)
     if failure:


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3632

Closes MoonLadderStudios/MoonMind#3632

## Summary

- replace the custom primary chat surface with the MoonMind-scoped native Omnigent workflow chat experience
- add terminal read-only evidence and an authorized Continue in a new workflow action
- enforce typed, correlated acceptance evidence across the native chat authority and transport boundaries
- wire the protected browser-to-stock-host conformance runner, provider test, CI matrix, and fail-closed publication checks

## Tests run

- moonmind container python-tests tests/unit/omnigent/test_workflow_chat_acceptance.py tests/unit/tools/test_run_omnigent_live_conformance.py tests/unit/test_omnigent_live_conformance_workflow.py — 63 passed
- npm run ui:test -- frontend/src/entrypoints/WorkflowChatNative.test.tsx frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx frontend/src/features/workflow-native-chat/chatBindingModel.test.ts frontend/src/features/workflow-native-chat/useWorkflowChatBinding.test.tsx — 48 passed
- Hermetic Omnigent fake-server integration — 3 passed through the MoonMind container boundary
- git diff --check 7f901fc14..HEAD — passed

## Remaining risks

- The credentialed browser-to-stock-host provider gate was not run in this managed runtime because it requires the protected self-hosted provider environment, enrolled credentials, digest-pinned stock images, live browser authentication, and protected evidence channels. The checked-in scheduled/manual gate owns that external verification.