### PR TITLE
Reconcile Omnigent image authority

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -264,17 +264,27 @@ async def _sync_omnigent_bootstrap_agent_profile() -> bool:
         return False
 
 
-async def _sync_omnigent_bootstrap_policies() -> bool:
+async def _sync_omnigent_bootstrap_policies(
+    *,
+    refresh_images: bool,
+) -> bool:
     """Acquire immutable stock images and reconcile the built-in policies."""
 
     try:
         from api_service.services.omnigent_policies import (
             bootstrap_policies_ready,
+            resolve_local_bootstrap_image_ref,
             seed_bootstrap_policies,
         )
 
         async with get_async_session_context() as session:
-            await seed_bootstrap_policies(session)
+            if refresh_images:
+                await seed_bootstrap_policies(session)
+            else:
+                await seed_bootstrap_policies(
+                    session,
+                    image_resolver=resolve_local_bootstrap_image_ref,
+                )
             return await bootstrap_policies_ready(session)
     except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
         logger.warning("Omnigent policy bootstrap deferred: %s", exc)
@@ -284,8 +294,13 @@ async def _sync_omnigent_bootstrap_policies() -> bool:
         return False
 
 
-async def _reconcile_omnigent_bootstrap_once() -> bool:
-    policies_ready = await _sync_omnigent_bootstrap_policies()
+async def _reconcile_omnigent_bootstrap_once(
+    *,
+    refresh_images: bool,
+) -> bool:
+    policies_ready = await _sync_omnigent_bootstrap_policies(
+        refresh_images=refresh_images
+    )
     agent_ready = await _sync_omnigent_bootstrap_agent_profile()
     return policies_ready and agent_ready
 
@@ -297,12 +312,13 @@ async def _maintain_omnigent_bootstrap_reconciliation(
 
     ready = initial_ready
     retry_delay_seconds = 5
+    refresh_images = True
     while True:
         await asyncio.sleep(120 if ready else retry_delay_seconds)
-        if ready:
-            ready = await _sync_omnigent_bootstrap_agent_profile()
-        else:
-            ready = await _reconcile_omnigent_bootstrap_once()
+        ready = await _reconcile_omnigent_bootstrap_once(
+            refresh_images=refresh_images or not ready
+        )
+        refresh_images = False
         if ready:
             retry_delay_seconds = 5
         else:
@@ -1637,7 +1653,11 @@ async def startup_event():
             exc,
         )
     await _sync_preset_seed_catalog()
-    omnigent_bootstrap_ready = await _reconcile_omnigent_bootstrap_once()
+    # Readiness uses only bounded local image inspection. Registry refresh runs
+    # in the lifespan-owned reconciler after the API can serve health checks.
+    omnigent_bootstrap_ready = await _reconcile_omnigent_bootstrap_once(
+        refresh_images=False
+    )
     app.state.omnigent_bootstrap_initial_ready = omnigent_bootstrap_ready
     await _sync_env_managed_secrets()
     # Embedded mode is an authority-sensitive enablement boundary. Evidence

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -800,13 +800,174 @@ def _canonical_bootstrap_agent_identity(row: OmnigentPolicyVersion) -> bool:
     )
 
 
+async def _cutover_inactive_bootstrap_bindings(
+    session: AsyncSession,
+    *,
+    previous_ref: str,
+    policy_ref: str,
+) -> tuple[int, int]:
+    """Move idle bindings while preserving authority for active host leases."""
+
+    bindings = list(
+        (
+            await session.execute(
+                select(OmnigentOAuthHostBindingRecord).where(
+                    OmnigentOAuthHostBindingRecord.launch_policy_ref
+                    == previous_ref
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    active_binding_refs: set[str] = set()
+    if bindings:
+        active_binding_refs = set(
+            (
+                await session.execute(
+                    select(OmnigentOAuthHostLeaseRecord.binding_ref).where(
+                        OmnigentOAuthHostLeaseRecord.binding_ref.in_(
+                            [binding.binding_ref for binding in bindings]
+                        ),
+                        OmnigentOAuthHostLeaseRecord.status.in_(
+                            ACTIVE_HOST_STATES
+                        ),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    cutover_bindings = [
+        binding
+        for binding in bindings
+        if binding.binding_ref not in active_binding_refs
+    ]
+    for binding in cutover_bindings:
+        binding.launch_policy_ref = policy_ref
+        binding.effective_launch_snapshot_json = None
+    return len(cutover_bindings), len(active_binding_refs)
+
+
+async def _reconcile_bootstrap_image_authority(
+    session: AsyncSession,
+    *,
+    service: OmnigentPolicyService,
+    server_image: str | None,
+    host_image: str | None,
+) -> list[str]:
+    """Advance bootstrap-owned defaults when their resolved images change."""
+
+    if not (
+        _DIGEST_IMAGE.fullmatch(server_image or "")
+        and _DIGEST_IMAGE.fullmatch(host_image or "")
+    ):
+        return []
+
+    reconciled: list[str] = []
+    for policy_id, *_ in _BOOTSTRAP_POLICY_DEFINITIONS:
+        policy = await session.get(OmnigentPolicy, policy_id)
+        if policy is None or policy.default_version is None:
+            continue
+        current = await service.get_version(policy_id, policy.default_version)
+        if (
+            current.created_by != "bootstrap"
+            or current.state != PolicyState.ACTIVE.value
+            or not current.validation_json.get("valid")
+        ):
+            continue
+        current_host = current.document_json.get("host")
+        if not isinstance(current_host, Mapping):
+            continue
+        if (
+            current_host.get("serverImageRef") == server_image
+            and current_host.get("hostImageRef") == host_image
+        ):
+            continue
+
+        current_ref = f"{policy_id}@{current.version}"
+        desired_payload = copy.deepcopy(current.document_json)
+        desired_payload["host"]["serverImageRef"] = server_image
+        desired_payload["host"]["hostImageRef"] = host_image
+        desired_document = PolicyDocument.model_validate(desired_payload)
+        desired_digest = document_digest(normalize_document(desired_document))
+        latest = (await service.versions(policy_id))[0]
+        if latest.version == current.version:
+            candidate = await service.new_version(
+                policy_id=policy_id,
+                document=desired_document,
+                actor="bootstrap",
+                expected_parent_ref=current_ref,
+            )
+        elif (
+            latest.created_by == "bootstrap"
+            and latest.parent_ref == current_ref
+            and latest.digest == desired_digest
+        ):
+            # Resume a startup interrupted between immutable version creation
+            # and activation instead of creating parallel policy authority.
+            candidate = latest
+        else:
+            logger.warning(
+                "Omnigent bootstrap image refresh for %s deferred because a "
+                "later policy version owns evolution",
+                policy_id,
+            )
+            continue
+        if (
+            candidate.state not in {
+                PolicyState.DRAFT.value,
+                PolicyState.ACTIVE.value,
+            }
+            or not candidate.validation_json.get("valid")
+        ):
+            continue
+        if not (
+            candidate.state == PolicyState.ACTIVE.value
+            and policy.default_version == candidate.version
+        ):
+            candidate = await service.transition(
+                policy_id=policy_id,
+                version=candidate.version,
+                state=PolicyState.ACTIVE,
+                actor="bootstrap",
+                make_default=True,
+            )
+
+        candidate_ref = f"{policy_id}@{candidate.version}"
+        updated_binding_count, deferred_binding_count = (
+            await _cutover_inactive_bootstrap_bindings(
+                session,
+                previous_ref=current_ref,
+                policy_ref=candidate_ref,
+            )
+        )
+        service._event(
+            policy_id,
+            candidate.version,
+            "bootstrap_image_authority_cutover",
+            "bootstrap",
+            {
+                "previousRef": current_ref,
+                "policyRef": candidate_ref,
+                "serverImageRef": server_image,
+                "hostImageRef": host_image,
+                "updatedBindingCount": updated_binding_count,
+                "deferredBindingCount": deferred_binding_count,
+            },
+        )
+        await session.commit()
+        reconciled.append(policy_id)
+    return reconciled
+
+
 async def seed_bootstrap_policies(
     session: AsyncSession,
     *,
     env: Mapping[str, str] | None = None,
     image_resolver: ImageResolver = resolve_bootstrap_image_ref,
 ) -> list[str]:
-    """Idempotently persist the three pre-existing built-in authorities."""
+    """Idempotently persist and refresh the built-in image authorities."""
 
     service = OmnigentPolicyService(session)
     reconciliation_required = False
@@ -860,13 +1021,17 @@ async def seed_bootstrap_policies(
         ):
             reconciliation_required = True
             break
-    if not reconciliation_required:
-        return []
-
     seeded: list[str] = []
     server_image, host_image = await resolve_bootstrap_image_refs(
         env=env, image_resolver=image_resolver
     )
+    if not reconciliation_required:
+        return await _reconcile_bootstrap_image_authority(
+            session,
+            service=service,
+            server_image=server_image,
+            host_image=host_image,
+        )
     for policy_id, name, host_mode, profile_ref in _BOOTSTRAP_POLICY_DEFINITIONS:
         document = bootstrap_document(
             host_mode=host_mode,
@@ -1011,6 +1176,13 @@ async def seed_bootstrap_policies(
                 make_default=True,
             )
         seeded.append(policy_id)
+    image_reconciled = await _reconcile_bootstrap_image_authority(
+        session,
+        service=service,
+        server_image=server_image,
+        host_image=host_image,
+    )
+    seeded.extend(item for item in image_reconciled if item not in seeded)
     return seeded
 
 

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import logging
 import os
@@ -51,6 +52,7 @@ _SERVER_IMAGE_REPOSITORY = "ghcr.io/omnigent-ai/omnigent-server"
 _HOST_IMAGE_REPOSITORY = "ghcr.io/omnigent-ai/omnigent-host"
 _IMAGE_INSPECT_FORMAT = '{{.Id}}\t{{join .RepoDigests ","}}'
 ImageResolver = Callable[[str], Awaitable[str | None]]
+LiveServerImageResolver = Callable[[str], Awaitable[str | None]]
 _BOOTSTRAP_POLICY_DEFINITIONS = (
     (
         "omnigent-codex",
@@ -621,20 +623,11 @@ async def resolve_bootstrap_image_ref(image_ref: str) -> str | None:
     if _DIGEST_IMAGE.fullmatch(image_ref):
         return image_ref
 
-    docker_binary = os.getenv("MOONMIND_DOCKER_BINARY", "docker").strip() or "docker"
-
-    async def inspect() -> str | None:
-        code, stdout, _ = await run_runtime_command(
-            (docker_binary, "image", "inspect", "--format", _IMAGE_INSPECT_FORMAT, image_ref),
-            timeout_seconds=30,
-            output_limit_bytes=64_000,
-        )
-        return None if code else _repository_digest(image_ref, stdout)
-
     try:
-        local_digest = await inspect()
+        local_digest = await _inspect_repository_digest(image_ref)
     except OSError:
         local_digest = None
+    docker_binary = os.getenv("MOONMIND_DOCKER_BINARY", "docker").strip() or "docker"
     try:
         code, _, stderr = await run_runtime_command(
             (docker_binary, "pull", image_ref),
@@ -659,9 +652,95 @@ async def resolve_bootstrap_image_ref(image_ref: str) -> str | None:
         )
         return None
     try:
-        return await inspect() or local_digest
+        return await _inspect_repository_digest(image_ref) or local_digest
     except OSError:
         return local_digest
+
+
+async def _inspect_repository_digest(
+    image_ref: str,
+    *,
+    inspect_ref: str | None = None,
+    timeout_seconds: int = 5,
+) -> str | None:
+    docker_binary = os.getenv("MOONMIND_DOCKER_BINARY", "docker").strip() or "docker"
+    code, stdout, _ = await run_runtime_command(
+        (
+            docker_binary,
+            "image",
+            "inspect",
+            "--format",
+            _IMAGE_INSPECT_FORMAT,
+            inspect_ref or image_ref,
+        ),
+        timeout_seconds=timeout_seconds,
+        output_limit_bytes=64_000,
+    )
+    return None if code else _repository_digest(image_ref, stdout)
+
+
+async def resolve_local_bootstrap_image_ref(image_ref: str) -> str | None:
+    """Resolve only already-acquired image evidence without registry access."""
+
+    image_ref = image_ref.strip()
+    if _DIGEST_IMAGE.fullmatch(image_ref):
+        return image_ref
+    try:
+        return await _inspect_repository_digest(image_ref)
+    except OSError:
+        return None
+
+
+async def resolve_live_server_image_ref(image_ref: str) -> str | None:
+    """Return the immutable image digest of the running Compose server."""
+
+    docker_binary = os.getenv("MOONMIND_DOCKER_BINARY", "docker").strip() or "docker"
+    project_name = (
+        os.getenv("MOONMIND_DEPLOYMENT_PROJECT_NAME", "moonmind").strip()
+        or "moonmind"
+    )
+    try:
+        code, stdout, _ = await run_runtime_command(
+            (
+                docker_binary,
+                "ps",
+                "--filter",
+                f"label=com.docker.compose.project={project_name}",
+                "--filter",
+                "label=com.docker.compose.service=omnigent",
+                "--format",
+                "{{.ID}}",
+            ),
+            timeout_seconds=5,
+            output_limit_bytes=64_000,
+        )
+        container_ids = [
+            item.strip()
+            for item in stdout.decode("utf-8", errors="replace").splitlines()
+            if item.strip()
+        ]
+        if code or len(container_ids) != 1:
+            return None
+        code, stdout, _ = await run_runtime_command(
+            (
+                docker_binary,
+                "inspect",
+                "--format",
+                "{{.Image}}",
+                container_ids[0],
+            ),
+            timeout_seconds=5,
+            output_limit_bytes=64_000,
+        )
+        image_id = stdout.decode("utf-8", errors="replace").strip()
+        if code or not re.fullmatch(r"sha256:[0-9a-f]{64}", image_id):
+            return None
+        return await _inspect_repository_digest(
+            image_ref,
+            inspect_ref=image_id,
+        )
+    except OSError:
+        return None
 
 
 async def resolve_bootstrap_image_refs(
@@ -670,8 +749,10 @@ async def resolve_bootstrap_image_refs(
     image_resolver: ImageResolver = resolve_bootstrap_image_ref,
 ) -> tuple[str | None, str | None]:
     server_input, host_input = configured_bootstrap_image_refs(env)
-    server_image = await image_resolver(server_input)
-    host_image = await image_resolver(host_input)
+    server_image, host_image = await asyncio.gather(
+        image_resolver(server_input),
+        image_resolver(host_input),
+    )
     return server_image, host_image
 
 
@@ -803,18 +884,23 @@ def _canonical_bootstrap_agent_identity(row: OmnigentPolicyVersion) -> bool:
 async def _cutover_inactive_bootstrap_bindings(
     session: AsyncSession,
     *,
-    previous_ref: str,
+    previous_refs: tuple[str, ...],
     policy_ref: str,
 ) -> tuple[int, int]:
     """Move idle bindings while preserving authority for active host leases."""
 
+    if not previous_refs:
+        return 0, 0
     bindings = list(
         (
             await session.execute(
-                select(OmnigentOAuthHostBindingRecord).where(
-                    OmnigentOAuthHostBindingRecord.launch_policy_ref
-                    == previous_ref
+                select(OmnigentOAuthHostBindingRecord)
+                .where(
+                    OmnigentOAuthHostBindingRecord.launch_policy_ref.in_(
+                        previous_refs
+                    )
                 )
+                .with_for_update()
             )
         )
         .scalars()
@@ -855,16 +941,18 @@ async def _reconcile_bootstrap_image_authority(
     service: OmnigentPolicyService,
     server_image: str | None,
     host_image: str | None,
+    live_server_image_resolver: LiveServerImageResolver,
 ) -> list[str]:
     """Advance bootstrap-owned defaults when their resolved images change."""
 
-    if not (
+    resolved_images_valid = bool(
         _DIGEST_IMAGE.fullmatch(server_image or "")
         and _DIGEST_IMAGE.fullmatch(host_image or "")
-    ):
-        return []
+    )
 
     reconciled: list[str] = []
+    live_server_checked = False
+    live_server_image: str | None = None
     for policy_id, *_ in _BOOTSTRAP_POLICY_DEFINITIONS:
         policy = await session.get(OmnigentPolicy, policy_id)
         if policy is None or policy.default_version is None:
@@ -879,34 +967,111 @@ async def _reconcile_bootstrap_image_authority(
         current_host = current.document_json.get("host")
         if not isinstance(current_host, Mapping):
             continue
+        versions = await service.versions(policy_id)
+        desired_server_image = (
+            server_image
+            if resolved_images_valid
+            else current_host.get("serverImageRef")
+        )
+        desired_host_image = (
+            host_image
+            if resolved_images_valid
+            else current_host.get("hostImageRef")
+        )
         if (
-            current_host.get("serverImageRef") == server_image
-            and current_host.get("hostImageRef") == host_image
+            resolved_images_valid
+            and current_host.get("serverImageRef") != server_image
         ):
+            if not live_server_checked:
+                live_server_image = await live_server_image_resolver(
+                    str(server_image)
+                )
+                live_server_checked = True
+            # A pulled tag is future deployment intent, not authority over the
+            # still-running server. Preserve the current authority until the
+            # live container objectively carries the new repository digest.
+            desired_server_image = (
+                live_server_image or current_host.get("serverImageRef")
+            )
+        current_ref = f"{policy_id}@{current.version}"
+        predecessor_refs = tuple(
+            f"{policy_id}@{version.version}"
+            for version in versions
+            if version.version != current.version
+            and version.created_by == "bootstrap"
+            and version.state == PolicyState.ACTIVE.value
+        )
+        if (
+            current_host.get("serverImageRef") == desired_server_image
+            and current_host.get("hostImageRef") == desired_host_image
+        ):
+            updated_binding_count, deferred_binding_count = (
+                await _cutover_inactive_bootstrap_bindings(
+                    session,
+                    previous_refs=predecessor_refs,
+                    policy_ref=current_ref,
+                )
+            )
+            if updated_binding_count:
+                service._event(
+                    policy_id,
+                    current.version,
+                    "bootstrap_image_authority_cutover",
+                    "bootstrap",
+                    {
+                        "previousRefs": list(predecessor_refs),
+                        "policyRef": current_ref,
+                        "serverImageRef": desired_server_image,
+                        "hostImageRef": desired_host_image,
+                        "updatedBindingCount": updated_binding_count,
+                        "deferredBindingCount": deferred_binding_count,
+                    },
+                )
+                await session.commit()
+                reconciled.append(policy_id)
             continue
 
-        current_ref = f"{policy_id}@{current.version}"
         desired_payload = copy.deepcopy(current.document_json)
-        desired_payload["host"]["serverImageRef"] = server_image
-        desired_payload["host"]["hostImageRef"] = host_image
+        desired_payload["host"]["serverImageRef"] = desired_server_image
+        desired_payload["host"]["hostImageRef"] = desired_host_image
         desired_document = PolicyDocument.model_validate(desired_payload)
         desired_digest = document_digest(normalize_document(desired_document))
-        latest = (await service.versions(policy_id))[0]
-        if latest.version == current.version:
+        later_versions = sorted(
+            (version for version in versions if version.version > current.version),
+            key=lambda version: version.version,
+        )
+        bootstrap_draft_chain = True
+        expected_parent_ref = current_ref
+        for version in later_versions:
+            if (
+                version.created_by != "bootstrap"
+                or version.state != PolicyState.DRAFT.value
+                or version.parent_ref != expected_parent_ref
+            ):
+                bootstrap_draft_chain = False
+                break
+            expected_parent_ref = f"{policy_id}@{version.version}"
+        if not later_versions:
             candidate = await service.new_version(
                 policy_id=policy_id,
                 document=desired_document,
                 actor="bootstrap",
                 expected_parent_ref=current_ref,
             )
-        elif (
-            latest.created_by == "bootstrap"
-            and latest.parent_ref == current_ref
-            and latest.digest == desired_digest
-        ):
+        elif bootstrap_draft_chain and later_versions[-1].digest == desired_digest:
             # Resume a startup interrupted between immutable version creation
             # and activation instead of creating parallel policy authority.
-            candidate = latest
+            candidate = later_versions[-1]
+        elif bootstrap_draft_chain:
+            # Tags may advance again after a prior startup persisted its draft.
+            # Preserve the immutable evidence and advance the bootstrap-owned
+            # lineage instead of letting an obsolete draft block reconciliation.
+            candidate = await service.new_version(
+                policy_id=policy_id,
+                document=desired_document,
+                actor="bootstrap",
+                expected_parent_ref=expected_parent_ref,
+            )
         else:
             logger.warning(
                 "Omnigent bootstrap image refresh for %s deferred because a "
@@ -935,10 +1100,18 @@ async def _reconcile_bootstrap_image_authority(
             )
 
         candidate_ref = f"{policy_id}@{candidate.version}"
+        candidate_versions = await service.versions(policy_id)
+        predecessor_refs = tuple(
+            f"{policy_id}@{version.version}"
+            for version in candidate_versions
+            if version.version != candidate.version
+            and version.created_by == "bootstrap"
+            and version.state == PolicyState.ACTIVE.value
+        )
         updated_binding_count, deferred_binding_count = (
             await _cutover_inactive_bootstrap_bindings(
                 session,
-                previous_ref=current_ref,
+                previous_refs=predecessor_refs,
                 policy_ref=candidate_ref,
             )
         )
@@ -948,10 +1121,10 @@ async def _reconcile_bootstrap_image_authority(
             "bootstrap_image_authority_cutover",
             "bootstrap",
             {
-                "previousRef": current_ref,
+                "previousRefs": list(predecessor_refs),
                 "policyRef": candidate_ref,
-                "serverImageRef": server_image,
-                "hostImageRef": host_image,
+                "serverImageRef": desired_server_image,
+                "hostImageRef": desired_host_image,
                 "updatedBindingCount": updated_binding_count,
                 "deferredBindingCount": deferred_binding_count,
             },
@@ -966,6 +1139,7 @@ async def seed_bootstrap_policies(
     *,
     env: Mapping[str, str] | None = None,
     image_resolver: ImageResolver = resolve_bootstrap_image_ref,
+    live_server_image_resolver: LiveServerImageResolver = resolve_live_server_image_ref,
 ) -> list[str]:
     """Idempotently persist and refresh the built-in image authorities."""
 
@@ -1025,12 +1199,28 @@ async def seed_bootstrap_policies(
     server_image, host_image = await resolve_bootstrap_image_refs(
         env=env, image_resolver=image_resolver
     )
+    if not (
+        _DIGEST_IMAGE.fullmatch(server_image or "")
+        and _DIGEST_IMAGE.fullmatch(host_image or "")
+    ):
+        # Readiness-local inspection may find no cached images on a first boot.
+        # Do not persist placeholder drafts; the background acquisition pass
+        # will seed once both immutable authorities exist. Existing active
+        # policies can still finish deferred binding cutovers meanwhile.
+        return await _reconcile_bootstrap_image_authority(
+            session,
+            service=service,
+            server_image=server_image,
+            host_image=host_image,
+            live_server_image_resolver=live_server_image_resolver,
+        )
     if not reconciliation_required:
         return await _reconcile_bootstrap_image_authority(
             session,
             service=service,
             server_image=server_image,
             host_image=host_image,
+            live_server_image_resolver=live_server_image_resolver,
         )
     for policy_id, name, host_mode, profile_ref in _BOOTSTRAP_POLICY_DEFINITIONS:
         document = bootstrap_document(
@@ -1181,6 +1371,7 @@ async def seed_bootstrap_policies(
         service=service,
         server_image=server_image,
         host_image=host_image,
+        live_server_image_resolver=live_server_image_resolver,
     )
     seeded.extend(item for item in image_reconciled if item not in seeded)
     return seeded

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
       # (terminal exec, OAuth auth-runner teardown). SYSTEM_DOCKER_HOST is a
       # trusted-worker-only backend selector and is not read by the API service.
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      - MOONMIND_DEPLOYMENT_PROJECT_NAME=${MOONMIND_DEPLOYMENT_PROJECT_NAME:-moonmind}
       - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
       - MOONMIND_DEPLOYMENT_DESIRED_STATE_JSON_FILE=${MOONMIND_DEPLOYMENT_DESIRED_STATE_JSON_FILE:-/workspace/deployment_state/desired-state.json}

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -14,7 +14,7 @@ with the run rather than rewriting it after registry or credential changes.
 **Document Class:** Canonical declarative  
 **Status:** Current  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-08-13
+**Last updated:** 2026-08-14
 **Authority:** Unified Temporal lifecycle and ownership model for true agent execution, including profile-bound Codex execution through Omnigent hosts
 
 Implementation progress belongs in the roadmap, issues, and pull requests. This document defines durable product and runtime contracts.
@@ -314,10 +314,16 @@ and `OMNIGENT_HOST_IMAGE_REF` values explicitly.
 
 Bootstrap-owned policy defaults advance through a new immutable version when
 those resolved repository digests move; operator-authored defaults are never
-rewritten by bootstrap. Live server attestation resolves the running
-container's image identity and requires the selected policy reference to appear
-in that image's observed repository digests. The mutable Compose input recorded
-in `Config.Image` is diagnostic configuration, not runtime image authority.
+rewritten by bootstrap. Registry refresh runs in the lifespan-owned background
+reconciler; API startup readiness performs only bounded local inspection. A
+server policy cutover uses the running Compose container's observed repository
+digest, never a newly pulled tag whose container is not running yet. Bindings
+with active host leases remain on their immutable prior authority and are
+revisited after the lease drains. Binding cutover and lease acquisition lock the
+same durable binding row. Live launch attestation requires the selected policy
+reference to appear in the running image's observed repository digests. The
+mutable Compose input recorded in `Config.Image` remains diagnostic
+configuration, not runtime image authority.
 
 ---
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -14,7 +14,7 @@ with the run rather than rewriting it after registry or credential changes.
 **Document Class:** Canonical declarative  
 **Status:** Current  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-08-07
+**Last updated:** 2026-08-13
 **Authority:** Unified Temporal lifecycle and ownership model for true agent execution, including profile-bound Codex execution through Omnigent hosts
 
 Implementation progress belongs in the roadmap, issues, and pull requests. This document defines durable product and runtime contracts.
@@ -311,6 +311,13 @@ If a tag cannot be resolved and no safe local repository digest exists, policy
 activation fails closed with image readiness evidence. Credentialed conformance
 and release manifests still name the resolved immutable `OMNIGENT_IMAGE_REF`
 and `OMNIGENT_HOST_IMAGE_REF` values explicitly.
+
+Bootstrap-owned policy defaults advance through a new immutable version when
+those resolved repository digests move; operator-authored defaults are never
+rewritten by bootstrap. Live server attestation resolves the running
+container's image identity and requires the selected policy reference to appear
+in that image's observed repository digests. The mutable Compose input recorded
+in `Config.Image` is diagnostic configuration, not runtime image authority.
 
 ---
 

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -1047,43 +1047,55 @@ class OmnigentOAuthHostRuntime:
                 code="OMNIGENT_SERVER_IMAGE_UNATTESTED",
             ) from exc
         declared_ref = str(launch.get("serverImageRef") or "").strip()
-        if configured[0] != 0 or observed[0] != 0 or configured_ref != declared_ref:
-            raise OmnigentOAuthHostError(
-                "live Omnigent server image does not match launch authority",
-                code="OMNIGENT_SERVER_IMAGE_MISMATCH",
-            )
-        if not re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest):
+        if (
+            configured[0] != 0
+            or observed[0] != 0
+            or not configured_ref
+            or not re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest)
+        ):
             raise OmnigentOAuthHostError(
                 "live Omnigent server digest is unavailable",
                 code="OMNIGENT_SERVER_IMAGE_UNATTESTED",
             )
-        architecture_result = await self._run(
+        image_metadata_result = await self._run(
             "docker",
             "image",
             "inspect",
             "--format",
-            "{{json .Architecture}}",
+            (
+                '{"repoDigests":{{json .RepoDigests}},'
+                '"architecture":{{json .Architecture}}}'
+            ),
             image_digest,
             check=False,
         )
         try:
-            architecture = str(json.loads(architecture_result[1])).strip()
-        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            image_metadata = json.loads(image_metadata_result[1])
+            repo_digests = {
+                str(item).strip()
+                for item in image_metadata["repoDigests"]
+                if str(item).strip()
+            }
+            architecture = str(image_metadata["architecture"]).strip()
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
             raise OmnigentOAuthHostError(
-                "live Omnigent server architecture is unavailable",
+                "live Omnigent server image metadata is unavailable",
                 code="OMNIGENT_SERVER_IMAGE_UNATTESTED",
             ) from exc
+        if image_metadata_result[0] != 0 or declared_ref not in repo_digests:
+            raise OmnigentOAuthHostError(
+                "live Omnigent server image does not match launch authority",
+                code="OMNIGENT_SERVER_IMAGE_MISMATCH",
+            )
         released_architectures = set(launch.get("architectures") or ())
-        if architecture_result[0] != 0 or (
-            released_architectures and architecture not in released_architectures
-        ):
+        if released_architectures and architecture not in released_architectures:
             raise OmnigentOAuthHostError(
                 "live Omnigent server architecture is not released",
                 code="OMNIGENT_SERVER_ARCHITECTURE_MISMATCH",
             )
         return {
             "serverAttachmentIdentity": container_id,
-            "serverImageRefObserved": configured_ref,
+            "serverImageRefObserved": declared_ref,
             "serverImageDigest": image_digest,
             "serverArchitecture": architecture,
         }

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -329,8 +329,38 @@ class OmnigentOAuthHostRepository:
     ) -> OmnigentHostLease:
         now = datetime.now(UTC)
         lease_id = deterministic_host_lease_id(provider_lease_id)
-        mount = binding.credential_mount_ref
         async with self._session_factory() as session:
+            locked_row = (
+                await session.execute(
+                    select(
+                        OmnigentOAuthHostBindingRecord,
+                        ManagedAgentProviderProfile,
+                    )
+                    .join(
+                        ManagedAgentProviderProfile,
+                        ManagedAgentProviderProfile.profile_id
+                        == OmnigentOAuthHostBindingRecord.provider_profile_id,
+                    )
+                    .where(
+                        OmnigentOAuthHostBindingRecord.binding_ref
+                        == binding.binding_ref
+                    )
+                    .with_for_update()
+                )
+            ).first()
+            if locked_row is None:
+                raise OmnigentOAuthHostError("host binding does not exist")
+            locked_binding = self._binding_model(locked_row[0], locked_row[1])
+            if locked_binding != binding:
+                # Bootstrap cutover and lease creation share this binding-row
+                # serialization boundary. A caller that compiled against the
+                # previous immutable authority must restart resolution; never
+                # create a lease carrying a stale launch snapshot.
+                raise OmnigentOAuthHostError(
+                    "host binding changed before lease acquisition",
+                    code="OMNIGENT_LAUNCH_SNAPSHOT_CONFLICT",
+                )
+            mount = locked_binding.credential_mount_ref
             existing = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
             if existing is None:
                 existing = (
@@ -343,14 +373,18 @@ class OmnigentOAuthHostRepository:
                 ).scalar_one_or_none()
             if existing is not None:
                 if (
-                    existing.provider_profile_id != binding.provider_profile_id
+                    existing.provider_profile_id
+                    != locked_binding.provider_profile_id
                     or existing.provider_lease_id != provider_lease_id
-                    or existing.binding_ref != binding.binding_ref
+                    or existing.binding_ref != locked_binding.binding_ref
                 ):
                     raise OmnigentOAuthHostError(
                         "idempotency key is already bound to another host lease"
                     )
-                if existing.effective_launch_snapshot_json != binding.effective_launch_snapshot:
+                if (
+                    existing.effective_launch_snapshot_json
+                    != locked_binding.effective_launch_snapshot
+                ):
                     raise OmnigentOAuthHostError(
                         "retry launch snapshot does not match the durable host lease",
                         code="OMNIGENT_LAUNCH_SNAPSHOT_CONFLICT",
@@ -358,18 +392,20 @@ class OmnigentOAuthHostRepository:
                 return self._lease_model(existing)
             record = OmnigentOAuthHostLeaseRecord(
                 lease_id=lease_id,
-                provider_profile_id=binding.provider_profile_id,
+                provider_profile_id=locked_binding.provider_profile_id,
                 provider_lease_id=provider_lease_id,
-                binding_ref=binding.binding_ref,
+                binding_ref=locked_binding.binding_ref,
                 credential_generation=mount.auth_volume_ref.credential_generation,
                 holder_workflow_id=holder_workflow_id,
                 agent_run_id=agent_run_id,
                 idempotency_key=idempotency_key,
                 lease_purpose=lease_purpose,
-                effective_launch_snapshot_json=binding.effective_launch_snapshot,
+                effective_launch_snapshot_json=(
+                    locked_binding.effective_launch_snapshot
+                ),
                 container_name=(
                     deterministic_host_container_name(lease_id)
-                    if binding.host_launch_profile_ref
+                    if locked_binding.host_launch_profile_ref
                     else None
                 ),
                 status="allocating",
@@ -395,7 +431,7 @@ class OmnigentOAuthHostRepository:
                         await session.execute(
                             select(OmnigentOAuthHostLeaseRecord).where(
                                 OmnigentOAuthHostLeaseRecord.provider_profile_id
-                                == binding.provider_profile_id,
+                                == locked_binding.provider_profile_id,
                                 OmnigentOAuthHostLeaseRecord.status.in_(
                                     ACTIVE_HOST_STATES
                                 ),

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -599,6 +599,17 @@ async def test_remediation_continuation_janitor_uses_real_authority_chain(
                 return (0, "true\n" if container_running else "false\n", "")
             raise AssertionError(f"unexpected Docker inspect: {args}")
         if args[:2] == ("docker", "image") and args[2] == "inspect":
+            if args[4].startswith('{"repoDigests"'):
+                return (
+                    0,
+                    json.dumps(
+                        {
+                            "repoDigests": [immutable_server],
+                            "architecture": observed_architecture,
+                        }
+                    ),
+                    "",
+                )
             return (0, json.dumps(observed_architecture), "")
         if args[:3] == (
             "docker",

--- a/tests/integration/reliability/replays/omnigent-server-image-authority-drift/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-server-image-authority-drift/expected-outcome.json
@@ -1,0 +1,11 @@
+{
+  "invariant": "a bootstrap-owned default policy advances through an immutable version when stock image inputs move, and live server attestation binds actual repository-digest evidence rather than mutable configured tag text",
+  "reconciledPolicyIds": [
+    "codex-on-demand",
+    "codex-static",
+    "omnigent-codex"
+  ],
+  "defaultPolicyVersion": 2,
+  "serverImageRefObserved": "ghcr.io/omnigent-ai/omnigent-server@sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "serverArchitecture": "arm64"
+}

--- a/tests/integration/reliability/replays/omnigent-server-image-authority-drift/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-server-image-authority-drift/manifest.json
@@ -1,0 +1,25 @@
+{
+  "incidentWorkflowId": "mm:5a7916f9-8cea-478e-b270-ae2c5860d5aa",
+  "incidentRunId": "019ffefc-6c94-7eb2-ae8f-a455f9c6298a",
+  "failedChildWorkflowId": "mm:5a7916f9-8cea-478e-b270-ae2c5860d5aa:agent:node-1",
+  "failedChildRunId": "019ffefc-824f-7990-b3e5-00613e348f72",
+  "runtime": "omnigent",
+  "protocol": "profile-bound-codex",
+  "failureCode": "OMNIGENT_SERVER_IMAGE_MISMATCH",
+  "failureShape": "the mutable default Omnigent server tag advanced while the bootstrap-owned active policy retained the previous repository digest, and runtime attestation compared the container's configured tag text to immutable policy authority instead of binding the actual live image repository digest",
+  "launchPolicyRef": "codex-on-demand@2",
+  "configuredServerImageRef": "ghcr.io/omnigent-ai/omnigent-server:latest",
+  "persistedServerImageRef": "ghcr.io/omnigent-ai/omnigent-server@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "persistedHostImageRef": "ghcr.io/omnigent-ai/omnigent-host@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "observedServerImageRef": "ghcr.io/omnigent-ai/omnigent-server@sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "observedHostImageRef": "ghcr.io/omnigent-ai/omnigent-host@sha256:4444444444444444444444444444444444444444444444444444444444444444",
+  "observedServerImageId": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+  "architecture": "arm64",
+  "eventScript": [
+    "bootstrap resolves mutable deployment image inputs",
+    "bootstrap creates a new immutable policy version and selects it as default",
+    "runtime resolves the live container image id and repository digests",
+    "runtime accepts only the repository digest authorized by the selected policy"
+  ],
+  "workspaceArtifacts": []
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -16,12 +16,16 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 import yaml
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from temporalio import activity
 from temporalio.testing import ActivityEnvironment
 
-from api_service.db.models import Base
-from api_service.services.omnigent_policies import bootstrap_document
+from api_service.db.models import Base, OmnigentPolicy, OmnigentPolicyVersion
+from api_service.services.omnigent_policies import (
+    bootstrap_document,
+    seed_bootstrap_policies,
+)
 from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
 from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
 from moonmind.omnigent.bridge_store import (
@@ -183,6 +187,80 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+async def test_omnigent_server_image_authority_drift_reconciles_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replay_id = "omnigent-server-image-authority-drift"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    resolved = {
+        "server": manifest["persistedServerImageRef"],
+        "host": manifest["persistedHostImageRef"],
+    }
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'policy.db'}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    async with sessions() as session:
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+        resolved.update(
+            server=manifest["observedServerImageRef"],
+            host=manifest["observedHostImageRef"],
+        )
+
+        reconciled = await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+        )
+
+        assert sorted(reconciled) == expected["reconciledPolicyIds"]
+        policy = await session.get(OmnigentPolicy, "codex-on-demand")
+        assert policy.default_version == expected["defaultPolicyVersion"]
+        version = await session.scalar(
+            select(OmnigentPolicyVersion).where(
+                OmnigentPolicyVersion.policy_id == "codex-on-demand",
+                OmnigentPolicyVersion.version == policy.default_version,
+            )
+        )
+        assert version.document_json["host"]["serverImageRef"] == resolved["server"]
+        assert version.document_json["host"]["hostImageRef"] == resolved["host"]
+    await engine.dispose()
+
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    runtime._run = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            (0, "omnigent-container-id\n", ""),
+            (0, json.dumps(manifest["configuredServerImageRef"]), ""),
+            (0, json.dumps(manifest["observedServerImageId"]), ""),
+            (
+                0,
+                json.dumps(
+                    {
+                        "repoDigests": [manifest["observedServerImageRef"]],
+                        "architecture": manifest["architecture"],
+                    }
+                ),
+                "",
+            ),
+        ]
+    )
+    evidence = await runtime._attest_server_image(
+        {
+            "serverImageRef": manifest["observedServerImageRef"],
+            "architectures": [manifest["architecture"]],
+        }
+    )
+
+    assert evidence["serverImageRefObserved"] == expected["serverImageRefObserved"]
+    assert evidence["serverArchitecture"] == expected["serverArchitecture"]
 
 
 def _egress_attestation() -> EgressAttestation:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -205,12 +205,19 @@ async def test_omnigent_server_image_authority_drift_reconciles_before_launch(
     async def resolver(image_ref: str) -> str:
         return resolved["host" if "host" in image_ref else "server"]
 
+    async def live_server(_image_ref: str) -> str:
+        return resolved["server"]
+
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'policy.db'}")
     sessions = async_sessionmaker(engine, expire_on_commit=False)
     async with engine.begin() as connection:
         await connection.run_sync(Base.metadata.create_all)
     async with sessions() as session:
-        await seed_bootstrap_policies(session, image_resolver=resolver)
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
         resolved.update(
             server=manifest["observedServerImageRef"],
             host=manifest["observedHostImageRef"],
@@ -219,6 +226,7 @@ async def test_omnigent_server_image_authority_drift_reconciles_before_launch(
         reconciled = await seed_bootstrap_policies(
             session,
             image_resolver=resolver,
+            live_server_image_resolver=live_server,
         )
 
         assert sorted(reconciled) == expected["reconciledPolicyIds"]

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -266,6 +266,9 @@ def test_api_host_port_mapping_and_optional_env_file_for_mm_969():
     assert api_env["OMNIGENT_HOST_IMAGE_TAG"] == (
         "${OMNIGENT_HOST_IMAGE_TAG:-latest}"
     )
+    assert api_env["MOONMIND_DEPLOYMENT_PROJECT_NAME"] == (
+        "${MOONMIND_DEPLOYMENT_PROJECT_NAME:-moonmind}"
+    )
     assert api_env["MOONMIND_OMNIGENT_REMEDIATION_RELEASE_EVIDENCE_REF"] == (
         "${MOONMIND_OMNIGENT_REMEDIATION_RELEASE_EVIDENCE_REF:-"
         "/workspace/cutover/remediation-release.json}"

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -25,6 +25,7 @@ from api_service.services.omnigent_policies import (
     bootstrap_document,
     configured_bootstrap_image_refs,
     resolve_bootstrap_image_ref,
+    resolve_live_server_image_ref,
     seed_bootstrap_policies,
 )
 from moonmind.omnigent.policies import PolicyDocument, PolicyState, document_digest
@@ -608,8 +609,15 @@ async def test_bootstrap_advances_image_authority_when_mutable_inputs_move(
     async def resolver(image_ref: str) -> str:
         return resolved["host" if "host" in image_ref else "server"]
 
+    async def live_server(_image_ref: str) -> str:
+        return resolved["server"]
+
     async with policy_db(tmp_path) as sessions, sessions() as session:
-        await seed_bootstrap_policies(session, image_resolver=resolver)
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
         session.add(
             OmnigentOAuthHostBindingRecord(
                 binding_ref="bootstrap-binding",
@@ -640,6 +648,7 @@ async def test_bootstrap_advances_image_authority_when_mutable_inputs_move(
         reconciled = await seed_bootstrap_policies(
             session,
             image_resolver=resolver,
+            live_server_image_resolver=live_server,
         )
 
         assert set(reconciled) == {
@@ -726,6 +735,248 @@ async def test_bootstrap_does_not_rewrite_operator_owned_default_images(
         assert versions[0].created_by == "operator"
         assert versions[0].document_json["host"]["serverImageRef"] == first_server
         assert versions[0].document_json["host"]["hostImageRef"] == first_host
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_revisits_image_binding_after_active_lease_drains(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    first_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    first_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    next_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "3" * 64
+    next_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "4" * 64
+    resolved = {"server": first_server, "host": first_host}
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    async def live_server(_image_ref: str) -> str:
+        return resolved["server"]
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+        session.add(
+            OmnigentOAuthHostBindingRecord(
+                binding_ref="deferred-image-binding",
+                provider_profile_id="profile",
+                endpoint_ref="default",
+                harness="codex-native",
+                credential_mount_template_json={
+                    "authVolumeRef": {
+                        "providerProfileId": "profile",
+                        "runtimeId": "codex_cli",
+                        "providerId": "openai",
+                        "volumeRef": "codex_auth_volume",
+                        "credentialGeneration": 1,
+                        "ownerUserId": "user-1",
+                    },
+                    "targetPath": "/home/app/.codex",
+                    "accessMode": "read_write",
+                    "runtimeUid": 1000,
+                    "runtimeGid": 1000,
+                },
+                launch_policy_ref="codex-on-demand@1",
+                effective_launch_snapshot_json={"snapshotRef": "active"},
+            )
+        )
+        now = datetime.now(UTC)
+        await session.execute(
+            OmnigentOAuthHostLeaseRecord.__table__.insert().values(
+                lease_id="deferred-image-lease",
+                provider_profile_id="profile",
+                provider_lease_id="provider-lease",
+                binding_ref="deferred-image-binding",
+                credential_generation=1,
+                holder_workflow_id="workflow-active",
+                idempotency_key="workflow-active:step-1",
+                lease_purpose="execution",
+                status="assigned",
+                acquired_at=now,
+                last_heartbeat_at=now,
+                host_capabilities_json={},
+                expires_at=now + timedelta(hours=1),
+            )
+        )
+        await session.commit()
+        resolved.update(server=next_server, host=next_host)
+
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+        binding = await session.get(
+            OmnigentOAuthHostBindingRecord,
+            "deferred-image-binding",
+        )
+        assert binding.launch_policy_ref == "codex-on-demand@1"
+        await session.execute(
+            OmnigentOAuthHostLeaseRecord.__table__
+            .update()
+            .where(
+                OmnigentOAuthHostLeaseRecord.lease_id
+                == "deferred-image-lease"
+            )
+            .values(status="stopped", stopped_at=datetime.now(UTC))
+        )
+        await session.commit()
+
+        reconciled = await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+
+        await session.refresh(binding)
+        assert reconciled == ["codex-on-demand"]
+        assert binding.launch_policy_ref == "codex-on-demand@2"
+        assert binding.effective_launch_snapshot_json is None
+        versions = await OmnigentPolicyService(session).versions("codex-on-demand")
+        assert len(versions) == 2
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_server_authority_follows_live_container_before_tag(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    first_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    first_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    next_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "3" * 64
+    next_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "4" * 64
+    resolved = {"server": first_server, "host": first_host}
+    live = {"server": first_server}
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    async def live_server(_image_ref: str) -> str:
+        return live["server"]
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+        resolved.update(server=next_server, host=next_host)
+
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+
+        policy = await session.get(OmnigentPolicy, "codex-on-demand")
+        current = await OmnigentPolicyService(session).get_version(
+            "codex-on-demand",
+            policy.default_version,
+        )
+        assert current.document_json["host"]["serverImageRef"] == first_server
+        assert current.document_json["host"]["hostImageRef"] == next_host
+
+        live["server"] = next_server
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+
+        await session.refresh(policy)
+        current = await OmnigentPolicyService(session).get_version(
+            "codex-on-demand",
+            policy.default_version,
+        )
+        assert policy.default_version == 3
+        assert current.document_json["host"]["serverImageRef"] == next_server
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_advances_stale_interrupted_draft_lineage(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    first_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    first_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    stale_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "3" * 64
+    stale_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "4" * 64
+    next_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "5" * 64
+    next_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "6" * 64
+    resolved = {"server": first_server, "host": first_host}
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    async def live_server(_image_ref: str) -> str:
+        return resolved["server"]
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+        service = OmnigentPolicyService(session)
+        current = await service.get_version("codex-on-demand", 1)
+        stale_payload = deepcopy(current.document_json)
+        stale_payload["host"]["serverImageRef"] = stale_server
+        stale_payload["host"]["hostImageRef"] = stale_host
+        stale = await service.new_version(
+            policy_id="codex-on-demand",
+            document=PolicyDocument.model_validate(stale_payload),
+            actor="bootstrap",
+            expected_parent_ref="codex-on-demand@1",
+        )
+        assert stale.state == PolicyState.DRAFT.value
+        resolved.update(server=next_server, host=next_host)
+
+        reconciled = await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+
+        policy = await session.get(OmnigentPolicy, "codex-on-demand")
+        latest = await service.get_version("codex-on-demand", 3)
+        assert "codex-on-demand" in reconciled
+        assert policy.default_version == 3
+        assert latest.parent_ref == "codex-on-demand@2"
+        assert latest.state == PolicyState.ACTIVE.value
+        assert latest.document_json["host"]["serverImageRef"] == next_server
+        assert latest.document_json["host"]["hostImageRef"] == next_host
+
+
+@pytest.mark.asyncio
+async def test_live_server_image_resolver_reads_running_compose_image(monkeypatch):
+    digest_ref = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "a" * 64
+    image_id = "sha256:" + "b" * 64
+    calls: list[tuple[str, ...]] = []
+
+    async def command(argv, **_kwargs):
+        calls.append(tuple(argv))
+        if argv[1] == "ps":
+            return 0, b"container-id\n", b""
+        if argv[1:3] == ("inspect", "--format"):
+            return 0, f"{image_id}\n".encode(), b""
+        if argv[1:3] == ("image", "inspect"):
+            return 0, f"{image_id}\t{digest_ref}\n".encode(), b""
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_policies.run_runtime_command", command
+    )
+
+    assert await resolve_live_server_image_ref(digest_ref) == digest_ref
+    assert any(
+        "com.docker.compose.service=omnigent" in argument
+        for call in calls
+        for argument in call
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -591,7 +591,141 @@ async def test_bootstrap_policies_activate_with_resolved_latest_images(
         assert await seed_bootstrap_policies(
             session, env={}, image_resolver=resolver
         ) == []
-        assert len(resolution_calls) == 2
+        assert len(resolution_calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_advances_image_authority_when_mutable_inputs_move(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    first_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    first_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    next_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "3" * 64
+    next_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "4" * 64
+    resolved = {"server": first_server, "host": first_host}
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+        session.add(
+            OmnigentOAuthHostBindingRecord(
+                binding_ref="bootstrap-binding",
+                provider_profile_id="profile",
+                endpoint_ref="default",
+                harness="codex-native",
+                credential_mount_template_json={
+                    "authVolumeRef": {
+                        "providerProfileId": "profile",
+                        "runtimeId": "codex_cli",
+                        "providerId": "openai",
+                        "volumeRef": "codex_auth_volume",
+                        "credentialGeneration": 1,
+                        "ownerUserId": "user-1",
+                    },
+                    "targetPath": "/home/app/.codex",
+                    "accessMode": "read_write",
+                    "runtimeUid": 1000,
+                    "runtimeGid": 1000,
+                },
+                launch_policy_ref="codex-on-demand@1",
+                effective_launch_snapshot_json={"snapshotRef": "stale"},
+            )
+        )
+        await session.commit()
+        resolved.update(server=next_server, host=next_host)
+
+        reconciled = await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+        )
+
+        assert set(reconciled) == {
+            "omnigent-codex",
+            "codex-static",
+            "codex-on-demand",
+        }
+        policies = list((await session.execute(select(OmnigentPolicy))).scalars())
+        assert all(policy.default_version == 2 for policy in policies)
+        defaults = list(
+            (
+                await session.execute(
+                    select(OmnigentPolicyVersion).where(
+                        OmnigentPolicyVersion.version == 2
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(defaults) == 3
+        assert all(
+            row.document_json["host"]["serverImageRef"] == next_server
+            for row in defaults
+        )
+        assert all(
+            row.document_json["host"]["hostImageRef"] == next_host
+            for row in defaults
+        )
+        binding = await session.get(
+            OmnigentOAuthHostBindingRecord,
+            "bootstrap-binding",
+        )
+        assert binding.launch_policy_ref == "codex-on-demand@2"
+        assert binding.effective_launch_snapshot_json is None
+        event_types = set(
+            (await session.execute(select(OmnigentPolicyEvent.event_type))).scalars()
+        )
+        assert "bootstrap_image_authority_cutover" in event_types
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_does_not_rewrite_operator_owned_default_images(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    first_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    first_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    next_server = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "3" * 64
+    next_host = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "4" * 64
+    resolved = {"server": first_server, "host": first_host}
+
+    async def resolver(image_ref: str) -> str:
+        return resolved["host" if "host" in image_ref else "server"]
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+        service = OmnigentPolicyService(session)
+        current = await service.get_version("codex-on-demand", 1)
+        operator_document = PolicyDocument.model_validate(
+            deepcopy(current.document_json)
+        )
+        operator_version = await service.new_version(
+            policy_id="codex-on-demand",
+            document=operator_document,
+            actor="operator",
+            expected_parent_ref="codex-on-demand@1",
+        )
+        await service.transition(
+            policy_id="codex-on-demand",
+            version=operator_version.version,
+            state=PolicyState.ACTIVE,
+            actor="operator",
+            make_default=True,
+        )
+        resolved.update(server=next_server, host=next_host)
+
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+
+        policy = await session.get(OmnigentPolicy, "codex-on-demand")
+        assert policy.default_version == operator_version.version
+        versions = await service.versions("codex-on-demand")
+        assert len(versions) == 2
+        assert versions[0].created_by == "operator"
+        assert versions[0].document_json["host"]["serverImageRef"] == first_server
+        assert versions[0].document_json["host"]["hostImageRef"] == first_host
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -21,8 +22,8 @@ async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inve
         if len(delays) == 4:
             raise asyncio.CancelledError
 
-    async def reconcile_once() -> bool:
-        reconciliations.append(True)
+    async def reconcile_once(*, refresh_images: bool) -> bool:
+        reconciliations.append(refresh_images)
         return len(reconciliations) > 1
 
     async def refresh_inventory() -> bool:
@@ -43,8 +44,37 @@ async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inve
         )
 
     assert delays == [5, 10, 120, 120]
-    assert len(reconciliations) == 2
-    assert len(inventory_refreshes) == 1
+    assert reconciliations == [True, True, False]
+    assert inventory_refreshes == []
+
+
+@pytest.mark.asyncio
+async def test_api_startup_bootstrap_uses_only_local_image_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api_service.services import omnigent_policies
+
+    observed_resolver = None
+
+    @asynccontextmanager
+    async def session_context():
+        yield object()
+
+    async def seed(_session, *, image_resolver):
+        nonlocal observed_resolver
+        observed_resolver = image_resolver
+
+    async def ready(_session) -> bool:
+        return True
+
+    monkeypatch.setattr(api_main, "get_async_session_context", session_context)
+    monkeypatch.setattr(omnigent_policies, "seed_bootstrap_policies", seed)
+    monkeypatch.setattr(omnigent_policies, "bootstrap_policies_ready", ready)
+
+    assert await api_main._sync_omnigent_bootstrap_policies(
+        refresh_images=False
+    )
+    assert observed_resolver is omnigent_policies.resolve_local_bootstrap_image_ref
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1441,9 +1441,18 @@ async def test_server_image_attestation_records_live_digest_and_architecture() -
     runtime._run = AsyncMock(  # type: ignore[method-assign]
         side_effect=[
             (0, "omnigent-container-id\n", ""),
-            (0, json.dumps(declared_ref), ""),
+            (0, json.dumps("ghcr.io/omnigent-ai/omnigent-server:latest"), ""),
             (0, json.dumps(image_digest), ""),
-            (0, json.dumps("amd64"), ""),
+            (
+                0,
+                json.dumps(
+                    {
+                        "repoDigests": [declared_ref],
+                        "architecture": "amd64",
+                    }
+                ),
+                "",
+            ),
         ]
     )
 
@@ -1468,8 +1477,18 @@ async def test_server_image_attestation_rejects_declared_digest_mismatch() -> No
     runtime._run = AsyncMock(  # type: ignore[method-assign]
         side_effect=[
             (0, "omnigent-container-id\n", ""),
-            (0, json.dumps("server@sha256:" + "0" * 64), ""),
+            (0, json.dumps("server:latest"), ""),
             (0, json.dumps("sha256:" + "9" * 64), ""),
+            (
+                0,
+                json.dumps(
+                    {
+                        "repoDigests": ["server@sha256:" + "0" * 64],
+                        "architecture": "amd64",
+                    }
+                ),
+                "",
+            ),
         ]
     )
 
@@ -1494,7 +1513,16 @@ async def test_server_image_attestation_rejects_unreleased_architecture() -> Non
             (0, "omnigent-container-id\n", ""),
             (0, json.dumps(launch["serverImageRef"]), ""),
             (0, json.dumps(image_digest), ""),
-            (0, json.dumps("amd64"), ""),
+            (
+                0,
+                json.dumps(
+                    {
+                        "repoDigests": [launch["serverImageRef"]],
+                        "architecture": "amd64",
+                    }
+                ),
+                "",
+            ),
         ]
     )
 

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import (
     Base,
     ManagedAgentProviderProfile,
+    OmnigentOAuthHostBindingRecord,
     ProviderCredentialSource,
     ProviderProfileAuthMethod,
     ProviderProfileAuthState,
@@ -3113,6 +3114,65 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
             new_status="starting",
         )
         assert starting.status == "starting"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_host_lease_rejects_binding_changed_before_serialized_acquisition(
+    tmp_path,
+) -> None:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/host-lock.db")
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    try:
+        async with factory() as session:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex",
+                    runtime_id="codex_cli",
+                    provider_id="openai",
+                    credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                    runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                    volume_ref="codex_auth_volume",
+                    volume_mount_path="/home/app/.codex",
+                    max_parallel_runs=1,
+                    credential_generation=3,
+                    enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
+                )
+            )
+            await session.commit()
+        repository = OmnigentOAuthHostRepository(factory)
+        stale_binding = await repository.create_or_update_static_binding(
+            profile_id="codex",
+            endpoint_ref="default",
+            static_host_id="host-1",
+            execution_profile_ref="omnigent-codex@1",
+            launch_policy_ref="codex-static@1",
+            effective_launch_snapshot={"snapshotRef": "old"},
+        )
+        async with factory() as session:
+            record = await session.get(
+                OmnigentOAuthHostBindingRecord,
+                stale_binding.binding_ref,
+            )
+            record.launch_policy_ref = "codex-static@2"
+            record.effective_launch_snapshot_json = None
+            await session.commit()
+
+        with pytest.raises(OmnigentOAuthHostError) as conflict:
+            await repository.create_or_get_host_lease(
+                binding=stale_binding,
+                provider_lease_id="provider-lease-1",
+                holder_workflow_id="workflow-1",
+                agent_run_id="step-1",
+                idempotency_key="idem-1",
+            )
+
+        assert conflict.value.code == "OMNIGENT_LAUNCH_SNAPSHOT_CONFLICT"
     finally:
         await engine.dispose()
 

--- a/tests/unit/omnigent/test_remediation_matrix.py
+++ b/tests/unit/omnigent/test_remediation_matrix.py
@@ -1331,6 +1331,16 @@ def test_release_builder_cli_stages_nested_evidence_for_post_cleanup_validation(
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    build_release_evidence = module.build_remediation_release_evidence
+
+    def build_release_evidence_at_fixture_time(**kwargs):
+        return build_release_evidence(**kwargs, generated_at=NOW)
+
+    monkeypatch.setattr(
+        module,
+        "build_remediation_release_evidence",
+        build_release_evidence_at_fixture_time,
+    )
     argv = [
         str(script),
         "--release",


### PR DESCRIPTION
## Summary

- advance bootstrap-owned Omnigent policies through a new immutable version when resolved stock server or host image digests move
- preserve operator-authored defaults and active host-lease authority while cutting idle bindings over to the new policy
- attest the live Omnigent server from its observed repository digests instead of comparing the immutable policy ref to mutable `Config.Image` text
- add a redacted reliability replay for workflow `mm:5a7916f9-8cea-478e-b270-ae2c5860d5aa`

## Root cause

The active `codex-on-demand@2` policy still authorized the prior Omnigent server digest while the Compose server had advanced to the image currently selected by `latest`. Bootstrap skipped image resolution whenever existing policies were already active and valid, so durable authority could not follow the default deployment image. Runtime attestation also compared the container's configured tag string directly with the policy's digest-pinned ref, which made the normal tag-based Compose input incompatible even when the running image content was correct.

## Impact

Default Omnigent workflows recover automatically on API startup through a reviewable immutable policy cutover. Runtime execution remains fail-closed: the live image must expose the exact repository digest selected by the policy, and architecture checks are unchanged.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/api/test_omnigent_policy_service.py tests/unit/omnigent/test_oauth_profile_lifecycle.py` — 185 passed
- focused hermetic remediation/reliability replay — 3 passed
- `python3 tools/check_documentation_architecture.py` — no advisory findings
- read-only live Compose attestation against the current Omnigent server — passed