### PR TITLE
Resume active OAuth sessions

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -11,6 +11,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Response,
     WebSocket,
     WebSocketDisconnect,
     status,
@@ -345,6 +346,7 @@ async def _expire_stale_active_sessions(db: AsyncSession, *, profile_id: str) ->
 )
 async def create_oauth_session(
     request: CreateOAuthSessionRequest,
+    response: Response,
     db: AsyncSession = Depends(get_async_session),
     current_user: User = Depends(get_current_user()),
 ):
@@ -394,6 +396,12 @@ async def create_oauth_session(
     )
     existing_session = result.scalars().first()
     if existing_session:
+        if existing_session.requested_by_user_id == str(current_user.id):
+            response.status_code = status.HTTP_200_OK
+            return _oauth_session_response(
+                existing_session,
+                profile=existing_profile,
+            )
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="An active OAuth session already exists for this profile.",

--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -228,6 +228,14 @@ def _oauth_session_is_expired(session: ManagedAgentOAuthSession) -> bool:
     )
 
 
+def _oauth_terminal_is_connected(session: ManagedAgentOAuthSession) -> bool:
+    if session.connected_at is None:
+        return False
+    if session.disconnected_at is None:
+        return True
+    return _as_aware_utc(session.connected_at) > _as_aware_utc(session.disconnected_at)
+
+
 def _oauth_default(runtime_id: str, key: str) -> str | None:
     return get_provider_default(runtime_id, key)
 
@@ -389,23 +397,62 @@ async def create_oauth_session(
 
     # Check for existing active session for this profile
     result = await db.execute(
-        select(ManagedAgentOAuthSession).where(
+        select(ManagedAgentOAuthSession)
+        .where(
             ManagedAgentOAuthSession.profile_id == request.profile_id,
             ManagedAgentOAuthSession.status.in_(_ACTIVE_SESSION_STATUSES),
+        )
+        .order_by(
+            ManagedAgentOAuthSession.created_at.desc(),
+            ManagedAgentOAuthSession.session_id.desc(),
         )
     )
     existing_session = result.scalars().first()
     if existing_session:
         if existing_session.requested_by_user_id == str(current_user.id):
-            response.status_code = status.HTTP_200_OK
-            return _oauth_session_response(
-                existing_session,
-                profile=existing_profile,
+            from api_service.services.oauth_session_service import (
+                get_oauth_session_workflow_status,
             )
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="An active OAuth session already exists for this profile.",
-        )
+
+            try:
+                workflow_status = await get_oauth_session_workflow_status(
+                    existing_session.session_id
+                )
+            except RuntimeError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Unable to verify the active OAuth session. Please retry.",
+                ) from exc
+
+            if workflow_status == "RUNNING":
+                if (
+                    existing_session.session_transport == "moonmind_pty_ws"
+                    and _oauth_terminal_is_connected(existing_session)
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            "OAuth terminal is already connected for this profile."
+                        ),
+                    )
+                response.status_code = status.HTTP_200_OK
+                return _oauth_session_response(
+                    existing_session,
+                    profile=existing_profile,
+                )
+
+            existing_session.status = OAuthSessionStatus.FAILED
+            existing_session.completed_at = _utcnow()
+            existing_session.failure_reason = "OAuth session workflow is not running"
+            await db.commit()
+            await _stop_oauth_auth_runner(existing_session)
+            existing_session = None
+
+        if existing_session is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An active OAuth session already exists for this profile.",
+            )
 
     session_id = f"oas_{uuid.uuid4().hex[:12]}"
 
@@ -545,6 +592,14 @@ async def attach_oauth_terminal(
             status_code=status.HTTP_410_GONE,
             detail="OAuth terminal session has expired.",
         )
+    if (
+        session_obj.session_transport == "moonmind_pty_ws"
+        and _oauth_terminal_is_connected(session_obj)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="OAuth terminal already has an active connection.",
+        )
     if not session_obj.terminal_session_id or not session_obj.terminal_bridge_id:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -595,6 +650,7 @@ async def oauth_terminal_websocket(
             not session_obj
             or session_obj.status not in _TERMINAL_ATTACH_STATUSES
             or _oauth_session_is_expired(session_obj)
+            or _oauth_terminal_is_connected(session_obj)
             or not session_obj.container_name
             or not expected_digest
             or token_used

--- a/api_service/services/oauth_session_service.py
+++ b/api_service/services/oauth_session_service.py
@@ -8,6 +8,35 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+async def get_oauth_session_workflow_status(session_id: str) -> str | None:
+    """Return the authoritative Temporal status for an OAuth session workflow.
+
+    ``None`` means the deterministic workflow ID does not exist. Other
+    inspection failures are surfaced so callers fail closed instead of
+    treating a database projection as authoritative.
+    """
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    workflow_id = f"oauth-session:{session_id}"
+    try:
+        adapter = TemporalClientAdapter()
+        client = await adapter.get_client()
+        description = await client.get_workflow_handle(workflow_id).describe()
+    except Exception as exc:
+        if getattr(getattr(exc, "status", None), "name", None) == "NOT_FOUND":
+            return None
+        raise RuntimeError(
+            f"Failed to inspect OAuth session workflow {workflow_id}"
+        ) from exc
+
+    status_name = getattr(getattr(description, "status", None), "name", None)
+    if not isinstance(status_name, str) or not status_name:
+        raise RuntimeError(
+            f"OAuth session workflow {workflow_id} returned no execution status"
+        )
+    return status_name
+
+
 async def start_oauth_session_workflow(session_model: Any) -> None:
     """Start the Temporal workflow for a new OAuth session.
 

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -546,7 +546,7 @@ async def test_create_oauth_session_rejects_profile_owned_by_another_user(
     assert response.json()["detail"] == "Not authorized to use this profile ID."
 
 @pytest.mark.asyncio
-async def test_create_oauth_session_returns_conflict_for_non_stale_active(
+async def test_create_oauth_session_resumes_non_stale_active_for_same_user(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     profile_id = "codex-cli-busy-profile"
@@ -564,6 +564,51 @@ async def test_create_oauth_session_returns_conflict_for_non_stale_active(
         await session.commit()
 
     async def _unexpected_start(_session_model):
+        raise AssertionError("workflow start should not be called when resuming")
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _unexpected_start,
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions", json=_oauth_payload(profile_id)
+        )
+
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "oas_activeexisting1"
+    assert response.json()["status"] == OAuthSessionStatus.PENDING.value
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentOAuthSession).where(
+                ManagedAgentOAuthSession.profile_id == profile_id
+            )
+        )
+        assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_oauth_session_returns_conflict_for_another_users_active_session(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "codex-cli-other-user-busy-profile"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id="oas_otheruseractive1",
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                status=OAuthSessionStatus.AWAITING_USER,
+                requested_by_user_id="different-user",
+                created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+
+    async def _unexpected_start(_session_model):
         raise AssertionError("workflow start should not be called when conflict exists")
 
     monkeypatch.setattr(
@@ -572,7 +617,9 @@ async def test_create_oauth_session_returns_conflict_for_non_stale_active(
     )
 
     async with client_app as client:
-        response = await client.post("/api/v1/oauth-sessions", json=_oauth_payload(profile_id))
+        response = await client.post(
+            "/api/v1/oauth-sessions", json=_oauth_payload(profile_id)
+        )
 
     assert response.status_code == 409
     assert response.json()["detail"] == "An active OAuth session already exists for this profile."

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -77,6 +77,10 @@ def _oauth_payload(profile_id: str) -> dict[str, object]:
         "rate_limit_policy": "backoff",
     }
 
+
+async def _async_result(value):
+    return value
+
 @pytest.mark.asyncio
 async def test_create_oauth_session_expires_stale_active_before_conflict_check(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
@@ -570,6 +574,10 @@ async def test_create_oauth_session_resumes_non_stale_active_for_same_user(
         "api_service.services.oauth_session_service.start_oauth_session_workflow",
         _unexpected_start,
     )
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.get_oauth_session_workflow_status",
+        lambda _session_id: _async_result("RUNNING"),
+    )
 
     async with client_app as client:
         response = await client.post(
@@ -587,6 +595,150 @@ async def test_create_oauth_session_resumes_non_stale_active_for_same_user(
             )
         )
         assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_oauth_session_resumes_newest_active_for_same_user(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "codex-cli-duplicate-active-profile"
+    now = datetime.now(timezone.utc)
+
+    async with db_base.async_session_maker() as session:
+        session.add_all(
+            [
+                ManagedAgentOAuthSession(
+                    session_id="oas_olderactive001",
+                    runtime_id="codex_cli",
+                    profile_id=profile_id,
+                    status=OAuthSessionStatus.AWAITING_USER,
+                    requested_by_user_id="None",
+                    created_at=now - timedelta(minutes=10),
+                ),
+                ManagedAgentOAuthSession(
+                    session_id="oas_neweractive001",
+                    runtime_id="codex_cli",
+                    profile_id=profile_id,
+                    status=OAuthSessionStatus.AWAITING_USER,
+                    requested_by_user_id="None",
+                    created_at=now - timedelta(minutes=5),
+                ),
+            ]
+        )
+        await session.commit()
+
+    inspected_session_ids: list[str] = []
+
+    async def _running_workflow(session_id: str) -> str:
+        inspected_session_ids.append(session_id)
+        return "RUNNING"
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.get_oauth_session_workflow_status",
+        _running_workflow,
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions", json=_oauth_payload(profile_id)
+        )
+
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "oas_neweractive001"
+    assert inspected_session_ids == ["oas_neweractive001"]
+
+
+@pytest.mark.asyncio
+async def test_create_oauth_session_rejects_duplicate_connected_pty(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "codex-cli-connected-profile"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id="oas_connectedactive1",
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                status=OAuthSessionStatus.AWAITING_USER,
+                session_transport="moonmind_pty_ws",
+                requested_by_user_id="None",
+                connected_at=datetime.now(timezone.utc),
+                created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.get_oauth_session_workflow_status",
+        lambda _session_id: _async_result("RUNNING"),
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions", json=_oauth_payload(profile_id)
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "OAuth terminal is already connected for this profile."
+
+
+@pytest.mark.asyncio
+async def test_create_oauth_session_replaces_active_row_without_running_workflow(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "codex-cli-orphaned-active-profile"
+    old_session_id = "oas_orphanedactive1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=old_session_id,
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                status=OAuthSessionStatus.PENDING,
+                requested_by_user_id="None",
+                created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            )
+        )
+        await session.commit()
+
+    started_session_ids: list[str] = []
+
+    async def _capture_start(session_model) -> None:
+        started_session_ids.append(session_model.session_id)
+
+    async def _noop_stop(_session_model) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.get_oauth_session_workflow_status",
+        lambda _session_id: _async_result(None),
+    )
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _capture_start,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _noop_stop,
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions", json=_oauth_payload(profile_id)
+        )
+
+    assert response.status_code == 201
+    assert response.json()["session_id"] != old_session_id
+    assert started_session_ids == [response.json()["session_id"]]
+
+    async with db_base.async_session_maker() as session:
+        old_session = await session.get(ManagedAgentOAuthSession, old_session_id)
+        assert old_session is not None
+        assert old_session.status == OAuthSessionStatus.FAILED
+        assert old_session.completed_at is not None
+        assert old_session.failure_reason == "OAuth session workflow is not running"
 
 
 @pytest.mark.asyncio
@@ -700,6 +852,37 @@ async def test_oauth_terminal_attach_returns_one_time_websocket_token(
         assert row.metadata_json is not None
         assert row.metadata_json["terminal_attach_token_sha256"] != payload["attach_token"]
         assert row.metadata_json["terminal_attach_token_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_oauth_terminal_attach_rejects_existing_pty_connection(
+    client_app: AsyncClient, _module_db
+) -> None:
+    session_id = "oas_terminalconnected1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id="claude-connected-terminal",
+                status=OAuthSessionStatus.AWAITING_USER,
+                session_transport="moonmind_pty_ws",
+                requested_by_user_id="None",
+                terminal_session_id="term_oas_terminalconnected1",
+                terminal_bridge_id="br_oas_terminalconnected1",
+                connected_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+    async with client_app as client:
+        response = await client.post(
+            f"/api/v1/oauth-sessions/{session_id}/terminal/attach"
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "OAuth terminal already has an active connection."
 
 @pytest.mark.asyncio
 async def test_claude_oauth_terminal_attach_allows_awaiting_user_with_hash_only_token(
@@ -1790,6 +1973,70 @@ async def test_claude_oauth_terminal_websocket_rejects_replayed_attach_token(
         async def accept(self) -> None:
             self.accepted = True
             raise AssertionError("replayed tokens must fail before websocket accept")
+
+    websocket = _CloseOnlyWebSocket()
+    await oauth_terminal_websocket(websocket, session_id, token)
+
+    assert websocket.closed == [4403]
+    assert websocket.accepted is False
+
+
+@pytest.mark.asyncio
+async def test_oauth_terminal_websocket_rejects_connection_established_after_attach(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    session_id = "oas_claudewsalreadyconnected1"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="claude_code",
+                profile_id="claude_anthropic_ws_connected",
+                status=OAuthSessionStatus.AWAITING_USER,
+                session_transport="moonmind_pty_ws",
+                requested_by_user_id="None",
+                terminal_session_id="term_oas_claudewsalreadyconnected1",
+                terminal_bridge_id="br_oas_claudewsalreadyconnected1",
+                container_name="moonmind_auth_oas_claudewsalreadyconnected1",
+                expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            )
+        )
+        await session.commit()
+
+    async with client_app as client:
+        attach_response = await client.post(
+            f"/api/v1/oauth-sessions/{session_id}/terminal/attach"
+        )
+
+    assert attach_response.status_code == 200
+    token = attach_response.json()["attach_token"]
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        row.connected_at = datetime.now(timezone.utc)
+        await session.commit()
+
+    def _unexpected_pty_adapter(**_kwargs):
+        raise AssertionError("a second PTY process must not be created")
+
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._oauth_terminal_pty_adapter_factory",
+        _unexpected_pty_adapter,
+    )
+
+    class _CloseOnlyWebSocket:
+        def __init__(self) -> None:
+            self.closed: list[int] = []
+            self.accepted = False
+
+        async def close(self, code: int) -> None:
+            self.closed.append(code)
+
+        async def accept(self) -> None:
+            self.accepted = True
+            raise AssertionError("duplicate connections must fail before accept")
 
     websocket = _CloseOnlyWebSocket()
     await oauth_terminal_websocket(websocket, session_id, token)

--- a/tests/unit/api_service/test_oauth_session_service.py
+++ b/tests/unit/api_service/test_oauth_session_service.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_service.services.oauth_session_service import (
+    get_oauth_session_workflow_status,
+)
+
+
+def _patch_temporal_client(
+    monkeypatch: pytest.MonkeyPatch, *, description=None, error=None
+):
+    describe = AsyncMock(return_value=description, side_effect=error)
+    client = SimpleNamespace(
+        get_workflow_handle=lambda workflow_id: SimpleNamespace(describe=describe)
+    )
+    adapter = SimpleNamespace(get_client=AsyncMock(return_value=client))
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        lambda: adapter,
+    )
+    return describe
+
+
+@pytest.mark.asyncio
+async def test_get_oauth_session_workflow_status_returns_remote_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    describe = _patch_temporal_client(
+        monkeypatch,
+        description=SimpleNamespace(status=SimpleNamespace(name="RUNNING")),
+    )
+
+    result = await get_oauth_session_workflow_status("oas_running")
+
+    assert result == "RUNNING"
+    describe.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_oauth_session_workflow_status_returns_none_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    not_found = RuntimeError("missing")
+    not_found.status = SimpleNamespace(name="NOT_FOUND")
+    _patch_temporal_client(monkeypatch, error=not_found)
+
+    assert await get_oauth_session_workflow_status("oas_missing") is None
+
+
+@pytest.mark.asyncio
+async def test_get_oauth_session_workflow_status_fails_closed_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_temporal_client(monkeypatch, error=RuntimeError("unavailable"))
+
+    with pytest.raises(RuntimeError, match="Failed to inspect OAuth session workflow"):
+        await get_oauth_session_workflow_status("oas_unavailable")


### PR DESCRIPTION
## Summary

- resume an existing active OAuth session when the same user starts OAuth for the profile again
- return HTTP 200 for resumed sessions without starting a duplicate Temporal workflow
- preserve HTTP 409 isolation when the active session belongs to another user

## Root cause

Settings keeps the current OAuth session only in component memory. After a refresh or navigation, clicking OAuth again posted a new create request. The API detected the still-valid session but returned a conflict, leaving the operator unable to reopen the existing terminal through the normal action.

## User impact

Repeating the OAuth action for `claude_anthropic_oauth` now reopens the existing in-progress session instead of showing "An active OAuth session already exists for this profile." Valid sessions and their authoritative Temporal workflow are preserved.

## Validation

- `python -m pytest -q --tb=short tests/unit/api_service/api/routers/test_oauth_sessions.py` — 36 passed
- `python -m ruff check api_service/api/routers/oauth_sessions.py tests/unit/api_service/api/routers/test_oauth_sessions.py` — passed
- `git diff --check` — passed

The canonical `tools/test_unit.sh` wrapper did not reach pytest because its repository-wide status audit found pre-existing violations under the ignored `.claude/worktrees/ui-regressions` checkout. The same targeted test file passed directly.
