### PR TITLE
Fix Omnigent AgentRun metadata overflow

### DIFF
--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -1763,7 +1763,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                 "effectiveLaunchRef": effective_launch["snapshotRef"],
                 "executionProfileRef": effective_launch["executionProfileRef"],
                 "launchPolicyRef": effective_launch["launchPolicyRef"],
-                "egressAttestation": dict(preflight.get("egressAttestation") or {}),
+                # The full attestation includes the compiled launch-policy
+                # boundary and is already durable behind this reference. Keep
+                # the workflow result plane reference-only so terminal evidence
+                # enrichment cannot overflow AgentRunResult metadata.
                 "egressEvidenceRef": preflight.get("egressEvidenceRef"),
                 # Stamp the immutable policy-authority evidence resolved for this
                 # launch so the Step Execution checkpoint can prove which compiled

--- a/moonmind/workflows/temporal/agent_result_payloads.py
+++ b/moonmind/workflows/temporal/agent_result_payloads.py
@@ -135,6 +135,25 @@ def _compact_moonspec_verify_for_workflow_history(
     return compact
 
 
+def _compact_omnigent_checkpoint_capture_for_workflow_history(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Keep referenced egress evidence out of replay-sensitive metadata.
+
+    Omnigent launch evidence is durably stored behind ``egressEvidenceRef``.
+    Older histories may also contain the full inline attestation, including the
+    compiled launch-policy boundary. Once the reference exists, retaining that
+    duplicate object in an ``AgentRunResult`` only consumes workflow-history
+    budget and can prevent a terminal result from being decoded on replay.
+    """
+
+    compact = dict(value)
+    egress_evidence_ref = compact.get("egressEvidenceRef")
+    if isinstance(egress_evidence_ref, str) and egress_evidence_ref.strip():
+        compact.pop("egressAttestation", None)
+    return compact
+
+
 def compact_agent_run_result_payload_for_workflow_history(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -184,6 +203,14 @@ def compact_agent_run_result_payload_for_workflow_history(
             if compact_child:
                 compact_children.append(compact_child)
         compact_metadata["queuedChildren"] = compact_children
+
+    omnigent_capture = compact_metadata.get("omnigentCheckpointCapture")
+    if isinstance(omnigent_capture, Mapping):
+        compact_metadata["omnigentCheckpointCapture"] = (
+            _compact_omnigent_checkpoint_capture_for_workflow_history(
+                omnigent_capture
+            )
+        )
     compact_payload["metadata"] = compact_metadata
     return compact_payload
 

--- a/tests/integration/reliability/replays/omnigent-agent-run-metadata-overflow/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-agent-run-metadata-overflow/expected-outcome.json
@@ -1,0 +1,10 @@
+{
+  "childState": "completed",
+  "terminalOutcome": "terminal_failure",
+  "failureCode": "MALFORMED_TERMINAL_EVIDENCE",
+  "preservedEgressEvidenceRef": "art_01REPLAYEGRESSEVIDENCE0001",
+  "removedInlineFields": [
+    "egressAttestation"
+  ],
+  "maxMetadataBytes": 16384
+}

--- a/tests/integration/reliability/replays/omnigent-agent-run-metadata-overflow/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-agent-run-metadata-overflow/manifest.json
@@ -1,0 +1,51 @@
+{
+  "failureShapeId": "omnigent-agent-run-metadata-overflow",
+  "incidentWorkflowId": "mm:25e93f42-a88e-4bae-b2c9-bf8bdd9977d0",
+  "incidentChildWorkflowId": "mm:25e93f42-a88e-4bae-b2c9-bf8bdd9977d0:agent:node-1",
+  "runtime": {
+    "runtimeId": "omnigent",
+    "executionLane": "profile_bound_omnigent"
+  },
+  "activityName": "agent_runtime.publish_artifacts",
+  "expectedTaskQueue": "mm.activity.agent_runtime",
+  "eventScript": [
+    {
+      "event": "integration.omnigent.profile_bound_execute",
+      "metadataBytes": 15700,
+      "outcome": "completed"
+    },
+    {
+      "event": "agent_runtime.evaluate_terminal_evidence",
+      "metadataBytes": 16176,
+      "outcome": "terminal_failure"
+    },
+    {
+      "event": "MoonMind.AgentRun.enrich_result_metadata",
+      "outcome": "workflow_task_failed_before_fix"
+    }
+  ],
+  "request": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "executionProfileRef": "codex_openai_oauth",
+    "correlationId": "mm:25e93f42-a88e-4bae-b2c9-bf8bdd9977d0",
+    "idempotencyKey": "replay-omnigent-agent-run-metadata-overflow:1",
+    "instructionRef": "artifact:replay-instructions",
+    "resolvedSkillsetRef": "art_01REPLAYRESOLVEDSKILLSET001",
+    "workspaceSpec": {
+      "repository": "owner/repository",
+      "repo": "owner/repository",
+      "branch": "feature/replay"
+    },
+    "parameters": {
+      "publishMode": "auto",
+      "repository": "owner/repository"
+    }
+  },
+  "resultShape": {
+    "policyBoundariesChars": 6500,
+    "authorityObservationChars": 2400,
+    "terminalOutcome": "terminal_failure",
+    "failureCode": "MALFORMED_TERMINAL_EVIDENCE"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -1321,6 +1321,160 @@ async def test_successful_batch_fanout_is_compacted_before_publish_activity_deco
     )
 
 
+async def test_omnigent_terminal_result_replays_after_metadata_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:25e93f42 after its completed Omnigent activity overflowed."""
+
+    replay_id = "omnigent-agent-run-metadata-overflow"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    shape = manifest["resultShape"]
+    request = AgentExecutionRequest.model_validate(manifest["request"])
+    egress_ref = expected["preservedEgressEvidenceRef"]
+    provider_metadata = {
+        "providerName": "omnigent",
+        "normalizedStatus": "completed",
+        "captureManifestRef": "artifact://omnigent/replay/capture.json",
+        "externalStateRef": "artifact://omnigent/replay/checkpoint.json",
+        "omnigentCheckpointCapture": {
+            "bridgeSessionId": "bridge-replay",
+            "effectiveLaunchRef": "omnigent-launch:sha256:" + "1" * 64,
+            "egressEvidenceRef": egress_ref,
+            "egressAttestation": {
+                "profileRef": "moonmind-omnigent-egress@1",
+                "profileDigest": "sha256:" + "2" * 64,
+                "appliedRuleDigest": "sha256:" + "3" * 64,
+                "policyAuthority": {
+                    "policyRef": "codex-on-demand@3",
+                    "policyDigest": "sha256:" + "4" * 64,
+                    "snapshotRef": "omnigent-policy:sha256:" + "5" * 64,
+                    "boundaries": {
+                        "approvalMatrix": "x" * shape["policyBoundariesChars"]
+                    },
+                },
+            },
+            "terminalRef": "artifact://omnigent/replay/final.json",
+        },
+        "authorityChain": {
+            "schemaVersion": "omnigent-authority-chain-v1",
+            "runtime": {
+                "observation": "y" * shape["authorityObservationChars"]
+            },
+            "terminal": {
+                "cleanupCompleted": True,
+                "leaseReleased": True,
+            },
+        },
+        "terminalContractAuthority": "MoonMind.AgentRun",
+        "terminalContractEvidencePath": "artifacts/publish_result.json",
+        "terminalContractEvidenceRef": "art_terminal_evidence",
+        "terminalContractId": "auto_publish_terminal.v1",
+        "terminalContractOutcome": shape["terminalOutcome"],
+        "terminalContractSatisfied": False,
+        "failureCode": shape["failureCode"],
+    }
+    replay_runtime = provider_metadata["authorityChain"]["runtime"]
+    replay_runtime["recordedEventPadding"] = ""
+    recorded_metadata_bytes = manifest["eventScript"][1]["metadataBytes"]
+    current_metadata_bytes = len(
+        json.dumps(
+            provider_metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    replay_padding_chars = recorded_metadata_bytes - current_metadata_bytes
+    assert 0 < replay_padding_chars <= 8192
+    replay_runtime["recordedEventPadding"] = "z" * replay_padding_chars
+    assert (
+        len(
+            json.dumps(
+                provider_metadata,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        == recorded_metadata_bytes
+    )
+    provider_result = AgentRunResult(
+        summary="Agent completed without required terminal evidence",
+        failureClass="execution_error",
+        metadata=provider_metadata,
+    )
+    agent_run = MoonMindAgentRun()
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": manifest["incidentChildWorkflowId"],
+            "run_id": "01a002c0-2468-70a7-a4fe-084afc817977",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch: True)
+
+    replayed_metadata = dict(provider_result.metadata)
+    replayed_metadata["resiliencyPolicy"] = {
+        "noProgressTimeoutSeconds": 1800,
+        "retryPolicy": {},
+        "runtime": "omnigent",
+        "stuckAction": "request_intervention",
+    }
+    replayed_result = provider_result.model_copy(
+        update={"metadata": replayed_metadata}
+    )
+    with pytest.raises(ValueError, match="metadata must serialize"):
+        AgentRunResult.model_validate(
+            agent_run._enrich_result_metadata(
+                request=request,
+                result=replayed_result,
+            ).model_dump(mode="json", by_alias=True)
+        )
+
+    published_payloads: list[AgentRunResult] = []
+
+    async def execute_activity(
+        name: str,
+        payload: AgentRunResult,
+        **kwargs: object,
+    ) -> dict:
+        assert name == manifest["activityName"]
+        assert kwargs["task_queue"] == manifest["expectedTaskQueue"]
+        validated = AgentRunResult.model_validate(
+            payload.model_dump(mode="json", by_alias=True)
+        )
+        metadata_bytes = len(
+            json.dumps(
+                validated.metadata,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        assert metadata_bytes <= expected["maxMetadataBytes"]
+        published_payloads.append(validated)
+        return validated.model_dump(mode="json", by_alias=True)
+
+    monkeypatch.setattr(agent_run_module, "execute_typed_activity", execute_activity)
+
+    result = await agent_run._publish_terminal_result(
+        request=request,
+        result=replayed_result,
+    )
+
+    assert len(published_payloads) == 1
+    capture = published_payloads[0].metadata["omnigentCheckpointCapture"]
+    assert capture["egressEvidenceRef"] == egress_ref
+    for field in expected["removedInlineFields"]:
+        assert field not in capture
+    assert result.metadata["terminalContractOutcome"] == expected["terminalOutcome"]
+    assert result.metadata["failureCode"] == expected["failureCode"]
+    assert expected["childState"] == "completed"
+
+
 async def test_dependabot_build_titles_replay_through_portable_skill_classifier() -> (
     None
 ):

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -3699,12 +3699,9 @@ async def test_coordinator_emits_bounded_authority_chain_before_terminal() -> No
     assert chain["runtime"]["hostMode"] == "on_demand_docker"
     assert chain["runtime"]["egress"]["validationState"] == "attested"
     assert chain["runtime"]["egress"]["attachmentRef"] == "container:host-1"
-    checkpoint_egress = result_metadata["omnigentCheckpointCapture"][
-        "egressAttestation"
-    ]
-    assert checkpoint_egress["profileRef"] == "omnigent-egress@1"
-    assert checkpoint_egress["appliedRuleDigest"] == "sha256:" + "2" * 64
-    assert checkpoint_egress["attachmentRef"] == "container:host-1"
+    checkpoint_capture = result_metadata["omnigentCheckpointCapture"]
+    assert checkpoint_capture["egressEvidenceRef"] == "artifact://launch-egress"
+    assert "egressAttestation" not in checkpoint_capture
     assert chain["terminal"]["cleanupMode"] == "on_demand_remove"
     # No credential material or raw daemon path anywhere in the projection.
     flat = repr(chain)


### PR DESCRIPTION
## Related issue

N/A — production incident workflow `mm:25e93f42-a88e-4bae-b2c9-bf8bdd9977d0`.

## Summary

- Stop copying the full Omnigent egress attestation into `AgentRunResult.metadata`; the durable `egressEvidenceRef` remains the authority.
- Compact inline egress attestations from older recorded histories when their durable ref exists, allowing already-running workflows to replay safely.
- Add a minimized incident replay at the recorded 16,176-byte activity-result boundary.

Root cause: Omnigent returned valid metadata just below the 16 KiB limit. AgentRun terminal enrichment added resiliency metadata, exceeded the limit, and the existing compactor did not recognize the authority-chain-heavy Omnigent checkpoint shape. Pydantic validation then failed every workflow task after the provider activity had already completed.

ELI5: the workflow carried both a receipt and the full package contents. A small final annotation made the package too large to pass through Temporal. This keeps the receipt and stores the contents only in the referenced artifact.

## Test Plan

```bash
./tools/test_unit.sh --python-only tests/unit/omnigent/test_oauth_profile_lifecycle.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/test_terminal_evidence.py

python -m pytest tests/integration/reliability -m reliability_journey -q --durations=25

./tools/test_unit.sh --python-only --no-xdist   tests/unit/omnigent/test_oauth_profile_lifecycle.py::test_coordinator_emits_bounded_authority_chain_before_terminal   tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py::test_publish_terminal_result_compacts_replayed_moonspec_verify_metadata   tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py::test_publish_terminal_result_compacts_large_fanout_before_activity_decode   tests/integration/reliability/test_escaped_failure_journeys.py::test_successful_batch_fanout_is_compacted_before_publish_activity_decode   tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_terminal_result_replays_after_metadata_overflow

python -m ruff check moonmind/omnigent/profile_bound_execution.py moonmind/workflows/temporal/agent_result_payloads.py tests/unit/omnigent/test_oauth_profile_lifecycle.py tests/integration/reliability/test_escaped_failure_journeys.py
python tools/verify_test_shard_ownership.py
```

Results:

- 240 impacted unit tests passed.
- 99 reliability journeys passed.
- Incident replay and four adjacent terminal-publication cases passed.
- Ruff and test-shard ownership passed.
- The selector-equivalent fast-unit shard had 5,971 passes and 9 unrelated local failures from the pre-existing modified submodules plus macOS `/tmp`/read-only-directory behavior.
- The Temporal-boundary shard had 3,416 passes and one unrelated stale assertion expecting `fail` while the current default is `draft_pr`.
- Compose integration was not selector-required.

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Codex
- What the AI helped with: Temporal incident tracing, implementation, replay fixture, tests, and PR preparation.
- What I manually reviewed: The scoped diff, authoritative evidence path, workflow history failure, and staged file set.
- What I verified independently: Live Temporal history, targeted tests, selector-owned suites, lint, and shard ownership.

I understand that I am responsible for the final submitted change.

## Risk notes

This changes a replay-visible workflow result projection. Old histories remain supported: compaction removes the inline attestation only when `egressEvidenceRef` proves the full durable evidence exists. Provider profile, credential, network policy, billing-relevant selection, and cleanup authority are unchanged. After workers roll out this code, the stuck AgentRun can replay its recorded activity result and terminalize.

## Coverage notes

Manual verification inspected the parent workflow, deepest child, activity completions, exact WorkflowTask failure stack, recorded metadata sizes, and top-level payload contributors.

## Changelog

Fix Omnigent workflows getting stuck after successful agent execution when terminal metadata exceeds Temporal's compact-result limit.
