### PR TITLE
Prevent cleanup from starving agent runtime polling

### DIFF
--- a/docs/ManagedAgents/ManagedRuntimeCleanup.md
+++ b/docs/ManagedAgents/ManagedRuntimeCleanup.md
@@ -604,7 +604,11 @@ report must use an artifact reference.
 The retained-state filesystem pass runs off the agent-runtime worker's async
 event loop. The Activity owner emits bounded timer-driven heartbeats while that
 pass runs so recursive scanning or deletion cannot starve live runtime status,
-control, or result Activities that share the worker fleet.
+control, or result Activities that share the worker fleet. Activity cancellation
+sets a cooperative stop signal, and the Activity retains ownership until the
+janitor thread exits and releases its process lock. Cleanup errors remain complete
+in the in-process result and are bounded exactly once when projected into the
+Temporal result, preserving an accurate omitted-error count.
 
 ---
 
@@ -681,8 +685,9 @@ The implementation should include tests for:
 8b. an owner record that no longer satisfies its current model protects the paths
    it names, is reported in the pass result, and is itself reclaimed only once
    those paths are gone;
-8c. filesystem cleanup runs off the shared async worker loop and emits bounded
-   timer-driven heartbeats without per-path heartbeat traffic;
+8c. filesystem cleanup runs off the shared async worker loop, emits bounded
+   timer-driven heartbeats without per-path heartbeat traffic, and retains
+   Activity ownership through cooperative cancellation until the janitor exits;
 9. paths outside `/work/agent_jobs` are skipped;
 10. symlink candidates are skipped;
 11. precise live Docker owner references and candidate-scoped mounts protect

--- a/docs/ManagedAgents/ManagedRuntimeCleanup.md
+++ b/docs/ManagedAgents/ManagedRuntimeCleanup.md
@@ -594,6 +594,18 @@ class ManagedRuntimeCleanupResult:
     errors: tuple[str, ...]
 ```
 
+The Temporal-facing result contains aggregate counters, bounded errors, and
+bounded candidate/deletion samples only. The janitor may retain complete
+per-candidate decisions in process while calculating the summary, but it must
+not serialize that unbounded list into Activity results, Workflow results, or a
+later scheduled run's `lastCompletionResult`. A future need for the complete
+report must use an artifact reference.
+
+The retained-state filesystem pass runs off the agent-runtime worker's async
+event loop. The Activity owner emits bounded timer-driven heartbeats while that
+pass runs so recursive scanning or deletion cannot starve live runtime status,
+control, or result Activities that share the worker fleet.
+
 ---
 
 ## 9. State and path classification
@@ -669,7 +681,8 @@ The implementation should include tests for:
 8b. an owner record that no longer satisfies its current model protects the paths
    it names, is reported in the pass result, and is itself reclaimed only once
    those paths are gone;
-8c. filesystem progress reporting cannot exhaust the activity heartbeat queue;
+8c. filesystem cleanup runs off the shared async worker loop and emits bounded
+   timer-driven heartbeats without per-path heartbeat traffic;
 9. paths outside `/work/agent_jobs` are skipped;
 10. symlink candidates are skipped;
 11. precise live Docker owner references and candidate-scoped mounts protect
@@ -677,6 +690,8 @@ The implementation should include tests for:
     every retained child;
 12. second scan prevents deletion if a new active owner appears;
 13. delete path and byte budgets stop a pass cleanly;
+13b. candidates encountered after the delete-path cap do not receive recursive
+   size walks;
 14. artifact directories are retained longer than workspace roots;
 15. record deletion is disabled when record retention is unset.
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2100,42 +2100,6 @@ async def _maybe_call_heartbeat(
     if inspect.isawaitable(result):
         await result
 
-_CLEANUP_HEARTBEAT_MIN_INTERVAL_SECONDS = 5.0
-
-
-def _throttled_cleanup_heartbeat(
-    *,
-    min_interval_seconds: float = _CLEANUP_HEARTBEAT_MIN_INTERVAL_SECONDS,
-    monotonic: Callable[[], float] = time.monotonic,
-) -> Callable[[Mapping[str, Any]], None]:
-    """Return a rate-limited heartbeat sink for managed-runtime cleanup progress.
-
-    The janitor reports progress per filesystem path. Forwarding each one is a
-    heartbeat storm that overflows the SDK's bounded pending-heartbeat queue and
-    fails the activity with ``QueueFull``, so liveness is reported at most once
-    per interval instead of once per path.
-    """
-
-    state = {"last": None}
-
-    def _emit(progress: Mapping[str, Any]) -> None:
-        if not temporal_activity.in_activity():
-            return
-        now = monotonic()
-        last = state["last"]
-        if last is not None and now - last < min_interval_seconds:
-            return
-        state["last"] = now
-        temporal_activity.heartbeat(
-            {
-                "activityType": "agent_runtime.cleanup_managed_runtime_files",
-                **dict(progress),
-            }
-        )
-
-    return _emit
-
-
 async def _await_with_activity_heartbeats(
     awaitable: Awaitable[Any],
     *,
@@ -11794,14 +11758,24 @@ class TemporalAgentRuntimeActivities:
                 failed=True,
                 reason="docker reference scan unavailable",
             )
-        result = cleanup_managed_runtime_files(
-            run_store=self._run_store,
-            session_store=session_store,
-            config=config,
-            docker_reference_provider=(
-                None if docker_state is None else lambda: docker_state
+        # The janitor performs recursive synchronous filesystem work. Keep it
+        # off this fleet's async loop so live status/control Activities remain
+        # serviceable, and own heartbeats from the event-loop side.
+        result = await _await_with_activity_heartbeats(
+            asyncio.to_thread(
+                cleanup_managed_runtime_files,
+                run_store=self._run_store,
+                session_store=session_store,
+                config=config,
+                docker_reference_provider=(
+                    None if docker_state is None else lambda: docker_state
+                ),
+                progress_callback=None,
             ),
-            progress_callback=_throttled_cleanup_heartbeat(),
+            heartbeat_payload={
+                "activityType": "agent_runtime.cleanup_managed_runtime_files",
+                "phase": "filesystem_cleanup",
+            },
         )
         result_payload = result.to_dict()
         if action_kind:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import fcntl
+import functools
 import gzip
 from email.message import EmailMessage
 import hashlib
@@ -20,6 +21,7 @@ import shutil
 import smtplib
 import stat
 import tempfile
+import threading
 import time
 import tarfile
 from dataclasses import dataclass
@@ -2135,6 +2137,30 @@ async def _await_with_activity_heartbeats(
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+
+
+async def _run_sync_call_until_stopped(
+    call: Callable[[], Any],
+    *,
+    cancellation_requested: threading.Event,
+) -> Any:
+    """Keep ownership of a sync worker until it exits after cancellation."""
+
+    worker = asyncio.get_running_loop().run_in_executor(None, call)
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        cancellation_requested.set()
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                # Repeated Activity cancellation must not orphan the worker.
+                continue
+        with contextlib.suppress(BaseException):
+            worker.result()
+        raise
+
 
 class TemporalPlanActivities:
     """Implementation helpers for ``plan.*`` activities."""
@@ -11760,17 +11786,28 @@ class TemporalAgentRuntimeActivities:
             )
         # The janitor performs recursive synchronous filesystem work. Keep it
         # off this fleet's async loop so live status/control Activities remain
-        # serviceable, and own heartbeats from the event-loop side.
+        # serviceable, and own heartbeats from the event-loop side. Cancellation
+        # is cooperative, and the Activity does not release ownership until the
+        # janitor has stopped and released its process lock.
+        cancellation_requested = threading.Event()
+
+        def _check_cleanup_cancellation(_progress: Mapping[str, object]) -> None:
+            if cancellation_requested.is_set():
+                raise asyncio.CancelledError
+
         result = await _await_with_activity_heartbeats(
-            asyncio.to_thread(
-                cleanup_managed_runtime_files,
-                run_store=self._run_store,
-                session_store=session_store,
-                config=config,
-                docker_reference_provider=(
-                    None if docker_state is None else lambda: docker_state
+            _run_sync_call_until_stopped(
+                functools.partial(
+                    cleanup_managed_runtime_files,
+                    run_store=self._run_store,
+                    session_store=session_store,
+                    config=config,
+                    docker_reference_provider=(
+                        None if docker_state is None else lambda: docker_state
+                    ),
+                    progress_callback=_check_cleanup_cancellation,
                 ),
-                progress_callback=None,
+                cancellation_requested=cancellation_requested,
             ),
             heartbeat_payload={
                 "activityType": "agent_runtime.cleanup_managed_runtime_files",

--- a/moonmind/workflows/temporal/runtime/cleanup.py
+++ b/moonmind/workflows/temporal/runtime/cleanup.py
@@ -73,8 +73,17 @@ _RAW_ARTIFACT_REF_KEYS = (
     "latest_checkpoint_ref",
 )
 _MAX_REPORTED_UNREADABLE_RECORDS = 20
+_MAX_REPORTED_CLEANUP_ERRORS = 20
 
 _FALSEY = frozenset({"", "0", "false", "no", "off"})
+
+
+def _bounded_cleanup_errors(errors: Sequence[str]) -> tuple[str, ...]:
+    bounded = tuple(errors[:_MAX_REPORTED_CLEANUP_ERRORS])
+    omitted = len(errors) - len(bounded)
+    if omitted <= 0:
+        return bounded
+    return (*bounded, f"{omitted} additional cleanup errors")
 
 
 @dataclass(frozen=True)
@@ -244,28 +253,12 @@ class ManagedRuntimeCleanupResult:
             "skippedUnreadableOwner": self.skipped_unreadable_owner,
             "unreadableOwnerRecords": self.unreadable_owner_records,
             "deleteBudgetExhausted": self.delete_budget_exhausted,
-            "errors": list(self.errors),
+            "errors": list(_bounded_cleanup_errors(self.errors)),
             "metrics": dict(self.metrics),
             "candidateSamples": [
                 sample.to_dict() for sample in self.candidate_samples
             ],
             "deletedSamples": [sample.to_dict() for sample in self.deleted_samples],
-            "decisions": [
-                {
-                    "kind": decision.kind,
-                    "path": decision.path,
-                    "ownershipRoot": decision.ownership_root,
-                    "classification": decision.classification,
-                    "reason": decision.reason,
-                    "newestActivityAt": (
-                        decision.newest_activity_at.isoformat()
-                        if decision.newest_activity_at
-                        else None
-                    ),
-                    "estimatedBytes": decision.estimated_bytes,
-                }
-                for decision in self.decisions
-            ],
         }
 
 
@@ -844,16 +837,15 @@ class ManagedRuntimeWorkspaceJanitor:
                 return self._decision(
                     candidate, "protected_recent", "grace window has not elapsed", newest
                 )
-            self._emit_progress("size", candidate)
-            estimated_bytes = _path_size(path, progress_callback=self._progress_callback)
             if budget.deleted_paths >= self._config.max_delete_paths:
                 return self._decision(
                     candidate,
                     "budget_exhausted",
                     "delete path cap reached",
                     newest,
-                    estimated_bytes,
                 )
+            self._emit_progress("size", candidate)
+            estimated_bytes = _path_size(path, progress_callback=self._progress_callback)
             max_bytes = self._config.max_delete_bytes
             if max_bytes is not None and budget.deleted_bytes + estimated_bytes > max_bytes:
                 return self._decision(
@@ -1135,6 +1127,7 @@ class ManagedRuntimeWorkspaceJanitor:
             for decision in decisions
             if decision.classification == "error"
         )
+        all_errors = list(_bounded_cleanup_errors(all_errors))
         metrics: dict[str, int] = {}
         for decision in decisions:
             key = f"resource.{decision.kind}.{decision.classification}"

--- a/moonmind/workflows/temporal/runtime/cleanup.py
+++ b/moonmind/workflows/temporal/runtime/cleanup.py
@@ -1127,7 +1127,6 @@ class ManagedRuntimeWorkspaceJanitor:
             for decision in decisions
             if decision.classification == "error"
         )
-        all_errors = list(_bounded_cleanup_errors(all_errors))
         metrics: dict[str, int] = {}
         for decision in decisions:
             key = f"resource.{decision.kind}.{decision.classification}"

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -649,7 +649,11 @@ def test_mm_949_enabled_delete_uses_rescan_and_deletes_records_after_retention(
     assert session_store.load("sess-1") is None
 
 
-def test_mm_951_delete_budget_exhaustion_is_visible(tmp_path: Path) -> None:
+def test_mm_951_delete_budget_exhaustion_skips_size_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from moonmind.workflows.temporal.runtime import cleanup
+
     root = tmp_path / "agent_jobs"
     run_root = root / "run-1"
     _touch_old(run_root)
@@ -670,6 +674,13 @@ def test_mm_951_delete_budget_exhaustion_is_visible(tmp_path: Path) -> None:
         artifact_root=config.artifact_root,
     )
 
+    monkeypatch.setattr(
+        cleanup,
+        "_path_size",
+        lambda *_args, **_kwargs: pytest.fail(
+            "path budget must be checked before recursive size walks"
+        ),
+    )
     result = ManagedRuntimeWorkspaceJanitor(
         run_store=run_store,
         session_store=session_store,
@@ -681,7 +692,32 @@ def test_mm_951_delete_budget_exhaustion_is_visible(tmp_path: Path) -> None:
     assert workspace_decision.classification == "budget_exhausted"
     assert result.delete_budget_exhausted == 1
     assert result.metrics["resource.workspace.budget_exhausted"] == 1
+    assert workspace_decision.estimated_bytes == 0
     assert run_root.exists()
+
+
+def test_mm_949_temporal_result_uses_bounded_samples(tmp_path: Path) -> None:
+    root = tmp_path / "agent_jobs"
+    run_store, session_store = _stores(root)
+    for index in range(100):
+        run_id = f"run-{index:03d}"
+        _touch_old(root / run_id)
+        run_store.save(_run(run_id, "completed", root=root))
+
+    result = _janitor(root, run_store, session_store).run()
+    payload = result.to_dict()
+
+    assert len(result.decisions) > 20
+    assert "decisions" not in payload
+    assert len(payload["candidateSamples"]) == 20
+    assert len(json.dumps(payload)) < 20_000
+
+    error_payload = replace(
+        result,
+        errors=tuple(f"cleanup error {index}" for index in range(100)),
+    ).to_dict()
+    assert len(error_payload["errors"]) == 21
+    assert error_payload["errors"][-1] == "80 additional cleanup errors"
 
 
 def test_mm_949_config_from_env_normalizes_artifact_root_and_caps() -> None:

--- a/tests/unit/services/temporal/runtime/test_cleanup.py
+++ b/tests/unit/services/temporal/runtime/test_cleanup.py
@@ -13,6 +13,7 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 from moonmind.workflows.temporal.runtime.cleanup import (
     DockerReferenceState,
     ManagedRuntimeCleanupConfig,
+    ManagedRuntimeCleanupDecision,
     ManagedRuntimeWorkspaceJanitor,
 )
 from moonmind.workflows.temporal.runtime.managed_session_store import (
@@ -718,6 +719,41 @@ def test_mm_949_temporal_result_uses_bounded_samples(tmp_path: Path) -> None:
     ).to_dict()
     assert len(error_payload["errors"]) == 21
     assert error_payload["errors"][-1] == "80 additional cleanup errors"
+
+
+def test_mm_949_cleanup_summary_only_bounds_errors_at_temporal_projection(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "agent_jobs"
+    run_store, session_store = _stores(root)
+    janitor = ManagedRuntimeWorkspaceJanitor(
+        run_store=run_store,
+        session_store=session_store,
+        config=_config(root),
+        now=lambda: NOW,
+    )
+    decisions = tuple(
+        ManagedRuntimeCleanupDecision(
+            kind="workspace",
+            path=f"store:workspaces/run-{index:03d}",
+            ownership_root=None,
+            classification="error",
+            reason=f"cleanup error {index}",
+        )
+        for index in range(100)
+    )
+
+    result = janitor._summarize(
+        decisions,
+        scanned_run_records=0,
+        scanned_session_records=0,
+        errors=(),
+    )
+    payload = result.to_dict()
+
+    assert len(result.errors) == 100
+    assert len(payload["errors"]) == 21
+    assert payload["errors"][-1] == "80 additional cleanup errors"
 
 
 def test_mm_949_config_from_env_normalizes_artifact_root_and_caps() -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -5803,9 +5803,74 @@ async def test_cleanup_filesystem_pass_does_not_block_shared_activity_loop(
             }
         }
     )
-    await loop_task
+    await asyncio.wait_for(loop_task, timeout=1.0)
 
     assert result["eventLoopRemainedResponsive"] is True
+
+
+async def test_cleanup_cancellation_waits_for_janitor_thread_to_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation must retain Activity ownership until the janitor exits."""
+
+    from moonmind.workflows.temporal.runtime import cleanup as cleanup_module
+
+    cleanup_started = Event()
+    cancellation_seen = Event()
+    release_cleanup = Event()
+    cleanup_finished = Event()
+
+    class _CleanupResult:
+        def to_dict(self) -> dict[str, object]:
+            return {"errors": []}
+
+    def _blocking_cleanup(*, progress_callback: Any, **_kwargs: object) -> _CleanupResult:
+        cleanup_started.set()
+        try:
+            while True:
+                try:
+                    progress_callback({"phase": "size_walk"})
+                except asyncio.CancelledError:
+                    cancellation_seen.set()
+                    release_cleanup.wait(timeout=1.0)
+                    raise
+                if release_cleanup.wait(timeout=0.01):
+                    return _CleanupResult()
+        finally:
+            cleanup_finished.set()
+
+    monkeypatch.setattr(
+        cleanup_module,
+        "cleanup_managed_runtime_files",
+        _blocking_cleanup,
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=ManagedRunStore(tmp_path / "managed_runs")
+    )
+    cleanup_task = asyncio.create_task(
+        activities.agent_runtime_cleanup_managed_runtime_files(
+            {
+                "config": {
+                    "dryRun": True,
+                    "runtimeStoreRoot": str(tmp_path),
+                    "artifactRoot": str(tmp_path / "artifacts"),
+                    "lockPath": str(tmp_path / ".janitor.lock"),
+                }
+            }
+        )
+    )
+
+    assert await asyncio.to_thread(cleanup_started.wait, 1.0)
+    cleanup_task.cancel()
+    assert await asyncio.to_thread(cancellation_seen.wait, 1.0)
+    await asyncio.sleep(0.05)
+    assert cleanup_task.done() is False
+
+    release_cleanup.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(cleanup_task, timeout=1.0)
+    assert cleanup_finished.is_set()
 
 
 async def test_agent_runtime_cleanup_managed_runtime_files_activity_boundary(
@@ -6103,15 +6168,13 @@ async def test_agent_runtime_cleanup_managed_runtime_files_returns_observability
         }
     )
 
-    assert cleanup_calls == [
-        {
-            "run_store": run_store,
-            "session_store_root": tmp_path / "managed_sessions",
-            "runtime_store_root": tmp_path,
-            "docker_reference_provider": None,
-            "progress_callback": None,
-        }
-    ]
+    assert len(cleanup_calls) == 1
+    cleanup_call = cleanup_calls[0]
+    assert cleanup_call["run_store"] is run_store
+    assert cleanup_call["session_store_root"] == tmp_path / "managed_sessions"
+    assert cleanup_call["runtime_store_root"] == tmp_path
+    assert cleanup_call["docker_reference_provider"] is None
+    assert callable(cleanup_call["progress_callback"])
     assert heartbeat_payloads == [
         {
             "activityType": "agent_runtime.cleanup_managed_runtime_files",

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -11,8 +11,10 @@ import asyncio
 import hashlib
 import json
 import os
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from threading import Event
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -5755,41 +5757,55 @@ async def test_agent_runtime_reconcile_orphan_reap_failure_is_best_effort() -> N
     assert result["orphanVolumesScanned"] == 0
     assert result["orphanVolumesReaped"] == 0
 
-async def test_cleanup_progress_heartbeats_are_rate_limited(
+async def test_cleanup_filesystem_pass_does_not_block_shared_activity_loop(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A per-path heartbeat storm overflows the SDK queue and fails the pass."""
+    """A long janitor pass must not starve status Activities on this worker."""
 
-    from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
+    from moonmind.workflows.temporal.runtime import cleanup as cleanup_module
 
-    sent: list[dict[str, object]] = []
-    clock = {"now": 100.0}
+    cleanup_started = Event()
+    event_loop_advanced = Event()
+
+    class _CleanupResult:
+        def __init__(self, responsive: bool) -> None:
+            self._responsive = responsive
+
+        def to_dict(self) -> dict[str, object]:
+            return {"eventLoopRemainedResponsive": self._responsive, "errors": []}
+
+    def _blocking_cleanup(**_kwargs: object) -> _CleanupResult:
+        cleanup_started.set()
+        return _CleanupResult(event_loop_advanced.wait(timeout=1.0))
+
+    async def _advance_event_loop() -> None:
+        while not cleanup_started.is_set():
+            await asyncio.sleep(0)
+        event_loop_advanced.set()
+
     monkeypatch.setattr(
-        activity_runtime_module.temporal_activity,
-        "in_activity",
-        lambda: True,
+        cleanup_module,
+        "cleanup_managed_runtime_files",
+        _blocking_cleanup,
     )
-    monkeypatch.setattr(
-        activity_runtime_module.temporal_activity,
-        "heartbeat",
-        lambda payload: sent.append(dict(payload)),
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    loop_task = asyncio.create_task(_advance_event_loop())
+
+    result = await activities.agent_runtime_cleanup_managed_runtime_files(
+        {
+            "config": {
+                "dryRun": True,
+                "runtimeStoreRoot": str(tmp_path),
+                "artifactRoot": str(tmp_path / "artifacts"),
+                "lockPath": str(tmp_path / ".janitor.lock"),
+            }
+        }
     )
+    await loop_task
 
-    emit = activity_runtime_module._throttled_cleanup_heartbeat(
-        min_interval_seconds=5.0,
-        monotonic=lambda: clock["now"],
-    )
-    for index in range(2000):
-        emit({"phase": "size_walk", "path": f"/work/agent_jobs/mm:{index}/repo"})
-
-    assert len(sent) == 1
-    assert sent[0]["activityType"] == "agent_runtime.cleanup_managed_runtime_files"
-    assert sent[0]["phase"] == "size_walk"
-
-    clock["now"] += 5.0
-    emit({"phase": "delete", "path": "/work/agent_jobs/mm:old"})
-    assert len(sent) == 2
-    assert sent[1]["phase"] == "delete"
+    assert result["eventLoopRemainedResponsive"] is True
 
 
 async def test_agent_runtime_cleanup_managed_runtime_files_activity_boundary(
@@ -5842,8 +5858,8 @@ async def test_agent_runtime_cleanup_managed_runtime_files_activity_boundary(
     assert result["disabled"] is False
     assert result["dryRun"] is True
     assert result["scannedRunRecords"] == 1
-    assert result["decisions"][0]["classification"] == "eligible"
-    assert result["decisions"][0]["reason"] == "dry-run would delete"
+    assert result["candidateSamples"][0]["classification"] == "eligible"
+    assert result["candidateSamples"][0]["reason"] == "dry-run would delete"
 
 
 async def test_agent_runtime_cleanup_managed_runtime_files_uses_docker_references(
@@ -5899,8 +5915,8 @@ async def test_agent_runtime_cleanup_managed_runtime_files_uses_docker_reference
         }
     )
 
-    assert result["decisions"][0]["classification"] == "protected_active"
-    assert result["decisions"][0]["reason"] == "live Docker reference"
+    assert result["candidateSamples"][0]["classification"] == "protected_active"
+    assert result["candidateSamples"][0]["reason"] == "live Docker reference"
     assert run_root.exists()
 
 
@@ -5947,8 +5963,11 @@ async def test_agent_runtime_cleanup_managed_runtime_files_fails_closed_without_
         }
     )
 
-    assert result["decisions"][0]["classification"] == "protected_active"
-    assert result["decisions"][0]["reason"] == "docker reference scan unavailable"
+    assert result["candidateSamples"][0]["classification"] == "protected_active"
+    assert (
+        result["candidateSamples"][0]["reason"]
+        == "docker reference scan unavailable"
+    )
     assert result["errors"] == ["docker reference scan unavailable"]
     assert run_root.exists()
 
@@ -6008,6 +6027,7 @@ async def test_agent_runtime_cleanup_managed_runtime_files_returns_observability
 
     run_store = ManagedRunStore(tmp_path / "managed_runs")
     cleanup_calls: list[dict[str, object]] = []
+    heartbeat_payloads: list[dict[str, object]] = []
 
     class _CleanupResult:
         def to_dict(self) -> dict[str, Any]:
@@ -6041,15 +6061,30 @@ async def test_agent_runtime_cleanup_managed_runtime_files_returns_observability
                 "session_store_root": session_store.store_root,
                 "runtime_store_root": config.runtime_store_root,
                 "docker_reference_provider": docker_reference_provider,
-                "progress_callback": callable(progress_callback),
+                "progress_callback": progress_callback,
             }
         )
         return _CleanupResult()
+
+    async def _fake_await_with_activity_heartbeats(
+        awaitable: Any,
+        *,
+        heartbeat_payload: Mapping[str, object],
+        interval_seconds: float | None = None,
+    ) -> Any:
+        del interval_seconds
+        heartbeat_payloads.append(dict(heartbeat_payload))
+        return await awaitable
 
     monkeypatch.setattr(
         cleanup_module,
         "cleanup_managed_runtime_files",
         _fake_cleanup_managed_runtime_files,
+    )
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_await_with_activity_heartbeats",
+        _fake_await_with_activity_heartbeats,
     )
 
     activities = TemporalAgentRuntimeActivities(
@@ -6074,7 +6109,13 @@ async def test_agent_runtime_cleanup_managed_runtime_files_returns_observability
             "session_store_root": tmp_path / "managed_sessions",
             "runtime_store_root": tmp_path,
             "docker_reference_provider": None,
-            "progress_callback": True,
+            "progress_callback": None,
+        }
+    ]
+    assert heartbeat_payloads == [
+        {
+            "activityType": "agent_runtime.cleanup_managed_runtime_files",
+            "phase": "filesystem_cleanup",
         }
     ]
     assert result["eligibleRoots"] == 1


### PR DESCRIPTION
## Summary

- run retained managed-runtime filesystem cleanup off the shared async activity loop
- emit bounded timer-driven heartbeats while cleanup is running
- stop recursive size walks after the delete-path budget is exhausted
- keep cleanup Activity and Workflow results compact by returning bounded samples and errors instead of every candidate decision

## Root cause

Workflow `mm:9c83d9d2-d8ee-4a15-9674-4bc81a1d5092` failed when its `MoonMind.AgentRun` child lost an `agent_runtime.status` heartbeat. At 02:00 UTC, the hourly `agent_runtime.cleanup_managed_runtime_files` Activity began synchronous recursive filesystem work on the same async agent-runtime worker. The janitor also calculated directory sizes after its 100-path delete budget had already been exhausted, so it recursively walked thousands of candidates while blocking the worker event loop.

The status Activity was polled by Temporal but could not execute or heartbeat on the blocked Python loop. It timed out after 30 seconds, causing the child and parent workflows to fail even though managed run `73bed670-68e7-44ce-b447-a1a135d8b040` continued and completed successfully nine minutes later. The cleanup Activity itself also timed out while its blocked loop prevented queued heartbeats from being delivered.

The previous cleanup result additionally serialized thousands of per-candidate decisions, producing a 1.75 MB workflow history payload that was carried into the next scheduled run as `lastCompletionResult`.

## Impact

Broad retained-state maintenance can no longer starve live runtime status, control, or result Activities on the shared worker. Cleanup converges faster after reaching its delete budget, and scheduled workflow histories remain bounded.

## Validation

- 81 targeted unit and documentation-architecture tests passed in the isolated `moonmind-test` Compose project
- regression coverage proves the filesystem pass leaves the async activity loop responsive
- regression coverage proves over-budget candidates skip recursive size walks
- regression coverage proves Temporal-facing cleanup results omit full decisions and bound samples and errors
- `git diff --check` passed
