### PR TITLE
Fix automatic Omnigent readiness recovery

### DIFF
--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -187,6 +187,14 @@ def _reason(code: str) -> GateReason:
     return GateReason(code=code, message=message, remediationHref=href)
 
 
+def _valid_server_url(value: str) -> bool:
+    try:
+        url = httpx.URL(value)
+    except (TypeError, ValueError):
+        return False
+    return url.scheme in {"http", "https"} and bool(url.host)
+
+
 def _deployment_reasons(config: Any, bridge: dict[str, Any]) -> list[GateReason]:
     reasons: list[GateReason] = []
     if not config.enabled:
@@ -196,9 +204,8 @@ def _deployment_reasons(config: Any, bridge: dict[str, Any]) -> list[GateReason]
     runtime_gate = build_omnigent_gate()
     if not runtime_gate.enabled:
         reasons.append(_reason("rollout_gate_disabled"))
-    if (
-        config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED
-        and not resolved_server_url()
+    if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED and not _valid_server_url(
+        resolved_server_url()
     ):
         reasons.append(_reason("bridge_endpoint_unavailable"))
     if os.getenv("MOONMIND_WORKSPACE_RESOLVER_ENABLED", "true").lower() not in {
@@ -246,7 +253,7 @@ async def _live_deployment_readiness() -> LiveDeploymentReadiness:
 
     endpoint = resolved_server_url()
     endpoint_ready = False
-    if endpoint:
+    if _valid_server_url(endpoint):
         try:
             async with httpx.AsyncClient(timeout=2.0) as client:
                 response = await client.get(endpoint.rstrip("/") + "/health")
@@ -369,7 +376,7 @@ async def get_omnigent_codex_catalog_readiness(
     if (
         config.enabled
         and config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED
-        and resolved_server_url()
+        and _valid_server_url(resolved_server_url())
         and not live_readiness.endpoint_ready
     ):
         deployment_reasons.append(_reason("bridge_endpoint_not_ready"))

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -161,6 +161,11 @@ _REASONS: dict[str, tuple[str, str]] = {
     "bridge_disabled": ("Enable the Omnigent bridge in deployment settings.", "/settings#omnigent"),
     "bridge_conformance_gated": ("Complete Omnigent bridge conformance checks.", "/settings#omnigent"),
     "bridge_endpoint_unavailable": ("Configure the selected Omnigent endpoint.", "/settings#omnigent"),
+    "bridge_endpoint_not_ready": (
+        "The configured Omnigent endpoint is starting or temporarily unavailable. "
+        "MoonMind will retry automatically.",
+        "/settings#omnigent",
+    ),
     "rollout_gate_disabled": ("Enable the Omnigent runtime rollout gate.", "/settings#omnigent"),
     "host_auth_unavailable": ("Configure or rotate Omnigent bridge credentials.", "/settings#omnigent"),
     "no_eligible_codex_oauth_profile": ("Connect and validate a compatible OAuth Provider Profile for the selected execution target.", "/settings#provider-profiles"),
@@ -367,7 +372,7 @@ async def get_omnigent_codex_catalog_readiness(
         and resolved_server_url()
         and not live_readiness.endpoint_ready
     ):
-        deployment_reasons.append(_reason("bridge_endpoint_unavailable"))
+        deployment_reasons.append(_reason("bridge_endpoint_not_ready"))
     auth: dict[str, Any] | None = None
     if config.enabled and config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
         try:

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -28,7 +28,9 @@ import {
   CAPABILITY_CATALOG,
   capabilityChipProvenanceLabel,
   LIQUID_GL_OPTIONS,
+  OMNIGENT_READINESS_REFRESH_MS,
   buildEditParametersPatch,
+  omnigentReadinessRefetchInterval,
   preferredTemplate,
   previewModelTier,
   deriveExplicitWorkflowTitle,
@@ -685,6 +687,79 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       validationResult: { ready: true },
     }],
   }];
+
+  it("polls recoverable readiness gates and stops after recovery", () => {
+    const startingCatalog = {
+      ...readyOmnigentCatalog,
+      available: false,
+      gateReasons: [{
+        code: "bridge_endpoint_not_ready",
+        message: "The configured Omnigent endpoint is starting.",
+        remediationHref: "/settings#omnigent",
+      }],
+    };
+
+    expect(omnigentReadinessRefetchInterval(startingCatalog)).toBe(
+      OMNIGENT_READINESS_REFRESH_MS,
+    );
+    expect(omnigentReadinessRefetchInterval(readyOmnigentCatalog)).toBe(false);
+    expect(omnigentReadinessRefetchInterval({
+      ...startingCatalog,
+      gateReasons: [{
+        code: "bridge_endpoint_unavailable",
+        message: "Configure the selected Omnigent endpoint.",
+        remediationHref: "/settings#omnigent",
+      }],
+    })).toBe(false);
+  });
+
+  it("automatically clears a transient endpoint startup gate", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        readinessRequests += 1;
+        const body = readinessRequests === 1
+          ? {
+              ...readyOmnigentCatalog,
+              available: false,
+              gateReasons: [{
+                code: "bridge_endpoint_not_ready",
+                message: "The configured Omnigent endpoint is starting.",
+                remediationHref: "/settings#omnigent",
+              }],
+            }
+          : readyOmnigentCatalog;
+        return Promise.resolve({ ok: true, json: async () => body } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), {
+      target: { value: "omnigent" },
+    });
+
+    expect((await screen.findAllByText(/endpoint is starting/)).length).toBeGreaterThan(0);
+    await waitFor(
+      () => expect(readinessRequests).toBeGreaterThanOrEqual(2),
+      { timeout: OMNIGENT_READINESS_REFRESH_MS + 1_500 },
+    );
+    await waitFor(() => {
+      expect(screen.queryAllByText(/endpoint is starting/)).toHaveLength(0);
+      expect(
+        screen.queryByText(/Codex via Omnigent cannot be submitted/),
+      ).toBeNull();
+    });
+  });
 
   it("keeps an unready runtime selectable and explicitly revalidates stale readiness", async () => {
     renderWorkflowStartPage(mockPayload);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -689,28 +689,87 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
   }];
 
   it("polls recoverable readiness gates and stops after recovery", () => {
+    const endpointStartingReason = {
+      code: "bridge_endpoint_not_ready",
+      message: "The configured Omnigent endpoint is starting.",
+      remediationHref: "/settings#omnigent",
+    };
     const startingCatalog = {
       ...readyOmnigentCatalog,
       available: false,
-      gateReasons: [{
-        code: "bridge_endpoint_not_ready",
-        message: "The configured Omnigent endpoint is starting.",
-        remediationHref: "/settings#omnigent",
-      }],
+      executionProfiles: readyOmnigentCatalog.executionProfiles.map((profile) => ({
+        ...profile,
+        available: false,
+        gateReasons: [endpointStartingReason],
+      })),
+      gateReasons: [endpointStartingReason],
     };
 
     expect(omnigentReadinessRefetchInterval(startingCatalog)).toBe(
       OMNIGENT_READINESS_REFRESH_MS,
     );
     expect(omnigentReadinessRefetchInterval(readyOmnigentCatalog)).toBe(false);
+    const endpointUnconfiguredReason = {
+      code: "bridge_endpoint_unavailable",
+      message: "Configure the selected Omnigent endpoint.",
+      remediationHref: "/settings#omnigent",
+    };
     expect(omnigentReadinessRefetchInterval({
       ...startingCatalog,
-      gateReasons: [{
-        code: "bridge_endpoint_unavailable",
-        message: "Configure the selected Omnigent endpoint.",
-        remediationHref: "/settings#omnigent",
-      }],
+      gateReasons: [endpointUnconfiguredReason],
+      executionProfiles: startingCatalog.executionProfiles.map((profile) => ({
+        ...profile,
+        gateReasons: [endpointUnconfiguredReason],
+      })),
     })).toBe(false);
+    expect(omnigentReadinessRefetchInterval({
+      ...startingCatalog,
+      gateReasons: [
+        endpointStartingReason,
+        {
+          code: "rollout_gate_disabled",
+          message: "Enable the Omnigent runtime rollout gate.",
+          remediationHref: "/settings#omnigent",
+        },
+      ],
+      executionProfiles: startingCatalog.executionProfiles.map((profile) => ({
+        ...profile,
+        gateReasons: [
+          endpointStartingReason,
+          {
+            code: "rollout_gate_disabled",
+            message: "Enable the Omnigent runtime rollout gate.",
+            remediationHref: "/settings#omnigent",
+          },
+        ],
+      })),
+    })).toBe(false);
+  });
+
+  it("polls a recoverable selected target when another target is available", () => {
+    const selectedTargetRef = "omnigent-claude-static";
+    const catalog = {
+      ...readyOmnigentCatalog,
+      available: true,
+      executionProfiles: [
+        ...readyOmnigentCatalog.executionProfiles,
+        {
+          ref: selectedTargetRef,
+          displayName: "Claude static",
+          available: false,
+          launchPolicies: [],
+          gateReasons: [{
+            code: "static_host_not_ready",
+            message: "Start and validate the selected static Omnigent host.",
+            remediationHref: "/settings#omnigent",
+          }],
+        },
+      ],
+    };
+
+    expect(omnigentReadinessRefetchInterval(catalog, {
+      executionTargetRef: selectedTargetRef,
+    })).toBe(OMNIGENT_READINESS_REFRESH_MS);
   });
 
   it("automatically clears a transient endpoint startup gate", async () => {
@@ -718,15 +777,23 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       const url = String(input);
       if (url === "/api/omnigent/codex-catalog-readiness") {
         readinessRequests += 1;
+        const endpointStartingReason = {
+          code: "bridge_endpoint_not_ready",
+          message: "The configured Omnigent endpoint is starting.",
+          remediationHref: "/settings#omnigent",
+        };
         const body = readinessRequests === 1
           ? {
               ...readyOmnigentCatalog,
               available: false,
-              gateReasons: [{
-                code: "bridge_endpoint_not_ready",
-                message: "The configured Omnigent endpoint is starting.",
-                remediationHref: "/settings#omnigent",
-              }],
+              executionProfiles: readyOmnigentCatalog.executionProfiles.map(
+                (profile) => ({
+                  ...profile,
+                  available: false,
+                  gateReasons: [endpointStartingReason],
+                }),
+              ),
+              gateReasons: [endpointStartingReason],
             }
           : readyOmnigentCatalog;
         return Promise.resolve({ ok: true, json: async () => body } as Response);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -663,16 +663,37 @@ const OMNIGENT_RECOVERABLE_GATE_CODES = new Set([
   "static_host_not_ready",
 ]);
 
+interface OmnigentReadinessSelection {
+  executionTargetRef?: string;
+  providerProfileRef?: string;
+}
+
 export function omnigentReadinessRefetchInterval(
   catalog: OmnigentCodexCatalogReadiness | undefined,
+  selection: OmnigentReadinessSelection = {},
 ): number | false {
-  if (!catalog || catalog.available) return false;
+  if (!catalog) return false;
+  const executionTargetRef =
+    selection.executionTargetRef || catalog.defaultExecutionProfileRef;
+  const selectedExecutionProfile = (catalog.executionProfiles || []).find(
+    (profile) => profile.ref === executionTargetRef,
+  );
+  const selectedIneligibleProviderProfile = (
+    catalog.ineligibleProviderProfiles || []
+  ).find((profile) => profile.profileId === selection.providerProfileRef);
+  if (
+    selectedExecutionProfile?.available !== false &&
+    !selectedIneligibleProviderProfile &&
+    catalog.available
+  ) {
+    return false;
+  }
   const reasons = [
-    ...(catalog.gateReasons || []),
-    ...(catalog.executionProfiles || []).flatMap((profile) => profile.gateReasons),
-    ...(catalog.ineligibleProviderProfiles || []).flatMap((profile) => profile.gateReasons),
+    ...(selectedExecutionProfile?.gateReasons || catalog.gateReasons || []),
+    ...(selectedIneligibleProviderProfile?.gateReasons || []),
   ];
-  return reasons.some((reason) => OMNIGENT_RECOVERABLE_GATE_CODES.has(reason.code))
+  return reasons.length > 0 &&
+    reasons.every((reason) => OMNIGENT_RECOVERABLE_GATE_CODES.has(reason.code))
     ? OMNIGENT_READINESS_REFRESH_MS
     : false;
 }
@@ -6275,7 +6296,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     refetchOnWindowFocus: true,
     refetchInterval: (query) =>
       runtime === "omnigent"
-        ? omnigentReadinessRefetchInterval(query.state.data)
+        ? omnigentReadinessRefetchInterval(query.state.data, {
+            executionTargetRef: omnigentExecutionTargetRef,
+            providerProfileRef: providerProfile,
+          })
         : false,
   });
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -651,6 +651,32 @@ interface OmnigentCodexCatalogReadiness {
   };
 }
 
+export const OMNIGENT_READINESS_REFRESH_MS = 2_000;
+
+const OMNIGENT_RECOVERABLE_GATE_CODES = new Set([
+  "bridge_conformance_gated",
+  "bridge_endpoint_not_ready",
+  "immutable_image_unavailable",
+  "no_eligible_codex_oauth_profile",
+  "on_demand_backend_unavailable",
+  "profile_capacity_unavailable",
+  "static_host_not_ready",
+]);
+
+export function omnigentReadinessRefetchInterval(
+  catalog: OmnigentCodexCatalogReadiness | undefined,
+): number | false {
+  if (!catalog || catalog.available) return false;
+  const reasons = [
+    ...(catalog.gateReasons || []),
+    ...(catalog.executionProfiles || []).flatMap((profile) => profile.gateReasons),
+    ...(catalog.ineligibleProviderProfiles || []).flatMap((profile) => profile.gateReasons),
+  ];
+  return reasons.some((reason) => OMNIGENT_RECOVERABLE_GATE_CODES.has(reason.code))
+    ? OMNIGENT_READINESS_REFRESH_MS
+    : false;
+}
+
 interface ProviderModelEffortTier {
   label?: string | null;
   model?: string | null;
@@ -6247,6 +6273,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     },
     staleTime: 0,
     refetchOnWindowFocus: true,
+    refetchInterval: (query) =>
+      runtime === "omnigent"
+        ? omnigentReadinessRefetchInterval(query.state.data)
+        : false,
   });
 
   const activeProviderProfiles: ProviderProfile[] = runtime === "omnigent"

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -372,6 +372,7 @@ def test_busy_profile_is_eligible_when_queueing_is_permitted(monkeypatch):
     [
         ({"OMNIGENT_ENABLED": "false"}, "rollout_gate_disabled"),
         ({"OMNIGENT_SERVER_URL": ""}, "bridge_endpoint_unavailable"),
+        ({"OMNIGENT_SERVER_URL": "omnigent:8000"}, "bridge_endpoint_unavailable"),
         ({"MOONMIND_WORKSPACE_RESOLVER_ENABLED": "false"}, "workspace_resolver_unavailable"),
         ({"OMNIGENT_IMAGE_REF": "mutable:latest"}, "immutable_image_unavailable"),
     ],

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -615,7 +615,7 @@ def test_catalog_filters_profiles_not_visible_to_caller(monkeypatch):
                     {OMNIGENT_EGRESS_PROFILE.ref}
                 ),
             ),
-            "bridge_endpoint_unavailable",
+            "bridge_endpoint_not_ready",
         ),
         (
             catalog.LiveDeploymentReadiness(endpoint_ready=True, backend_ready=True),


### PR DESCRIPTION
## What changed

- distinguish a configured-but-starting Omnigent endpoint from a genuinely missing endpoint configuration
- automatically refresh recoverable Omnigent readiness gates every two seconds while the runtime is selected
- stop polling once readiness recovers and preserve fail-fast behavior for non-recoverable configuration gates
- add API and Workflow Create regression coverage for the startup race

## Why

Compose starts MoonMind API and Omnigent concurrently. Workflow Create could read readiness before Omnigent's health endpoint was ready, mislabel the transient state as missing configuration, and disable submission without automatically checking again.

## Impact

The default Codex-via-Omnigent path now recovers automatically when the configured endpoint or another recoverable readiness dependency finishes starting. A genuinely missing endpoint still requires explicit configuration.

## Validation

- 26 Omnigent catalog API tests passed
- focused Workflow Create recovery tests passed
- TypeScript typecheck passed
- targeted ESLint passed
- production UI build and Vite manifest verification passed
- deployed dashboard asset coherence check passed

The full local Workflow Create test file reached 132 passing tests before an unrelated timezone-sensitive schedule assertion expected 12:00Z while the America/Los_Angeles environment correctly produced 20:00Z.
