### PR TITLE
Recover managed workflows across runtime ownership handoffs

### DIFF
--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -14,7 +14,7 @@ with the run rather than rewriting it after registry or credential changes.
 **Document Class:** Canonical declarative  
 **Status:** Current  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-08-14
+**Last updated:** 2026-08-17
 **Authority:** Unified Temporal lifecycle and ownership model for true agent execution, including profile-bound Codex execution through Omnigent hosts
 
 Implementation progress belongs in the roadmap, issues, and pull requests. This document defines durable product and runtime contracts.
@@ -384,6 +384,7 @@ Rules:
 - a managed-runtime locator must match the current runtime and AgentRun store identity;
 - legacy `workspacePath` fields are compatibility inputs during the replay window and cannot create new authority;
 - a provider/session workspace string is derived from the trusted resolution result;
+- host-side Git commands trust only the exact resolved workspace for that command, so a repository handed between the worker and runtime UIDs remains usable without a global trust exemption;
 - arbitrary absolute paths from workflow parameters are rejected;
 - cleanup removes only state owned by the matching run or lease.
 
@@ -534,6 +535,12 @@ Each lane reconciles its own side effects:
 - Omnigent reconciles bridge attempts, first-message markers, profile bindings, host leases, deterministic containers, registered hosts, sessions, credential generations, and janitor work.
 
 No lane silently creates replacement authority while the original may still be active.
+When direct-runtime startup reconciliation proves that the recorded PID no
+longer exists, the result carries a typed process-loss code. A one-shot lane may
+perform one replacement attempt with the same immutable request, Provider
+Profile, idempotency key, and authoritative workspace. The replacement inspects
+local and remotely visible side effects before repeating work. A second process
+loss is terminal and retains the workspace for checkpoint or operator recovery.
 
 ---
 

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -30,6 +30,9 @@ ExternalExecutionStyle = Literal["polling", "streaming_gateway"]
 # ``auto`` selects the run's runtime (and skill) at planning time. It is never a
 # runtime identity: an execution request must always name the resolved runtime.
 AUTO_RUNTIME_SENTINEL = "auto"
+MANAGED_PROCESS_LOST_DURING_RECONCILIATION = (
+    "MANAGED_PROCESS_LOST_DURING_RECONCILIATION"
+)
 AgentRunState = Literal[
     "queued",
     "awaiting_slot",
@@ -1975,6 +1978,7 @@ __all__ = [
     "ManagedRunRecord",
     "ManagedRuntimeProfile",
     "ManagedRuntimeWorkloadMode",
+    "MANAGED_PROCESS_LOST_DURING_RECONCILIATION",
     "MoonMindOpsRuntime",
     "MoonMindOpsRuntimeOperation",
     "OmnigentHostLease",

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -1036,18 +1036,33 @@ class ManagedRuntimeLauncher:
 
         if branch:
             checkout_ok = await self._run_git_command(
-                ["-C", str(run_workspace), "checkout", branch],
+                self._workspace_git_command(
+                    run_workspace,
+                    "checkout",
+                    branch,
+                )[1:],
                 allow_failure=True,
                 env=command_env,
             )
             if not checkout_ok:
                 await self._run_git_command(
-                    ["-C", str(run_workspace), "fetch", "origin", branch],
+                    self._workspace_git_command(
+                        run_workspace,
+                        "fetch",
+                        "origin",
+                        branch,
+                    )[1:],
                     allow_failure=True,
                     env=command_env,
                 )
                 await self._run_git_command(
-                    ["-C", str(run_workspace), "checkout", "-B", branch, f"origin/{branch}"],
+                    self._workspace_git_command(
+                        run_workspace,
+                        "checkout",
+                        "-B",
+                        branch,
+                        f"origin/{branch}",
+                    )[1:],
                     allow_failure=True,
                     env=command_env,
                 )
@@ -1128,6 +1143,23 @@ class ManagedRuntimeLauncher:
         raise RuntimeError(
             f"Command failed with exit code {returncode}: {rendered_cmd}; {detail}"
         )
+
+    @staticmethod
+    def _workspace_git_command(
+        workspace_path: Path,
+        *args: str,
+    ) -> list[str]:
+        """Build a Git command that trusts only the resolved owned workspace."""
+
+        resolved_workspace = str(workspace_path.resolve())
+        return [
+            "git",
+            "-c",
+            f"safe.directory={resolved_workspace}",
+            "-C",
+            resolved_workspace,
+            *args,
+        ]
 
     async def _ensure_claude_workspace_trust_config(
         self,
@@ -1369,12 +1401,13 @@ class ManagedRuntimeLauncher:
 
         new_branch = str(workspace_spec.get("targetBranch") or "").strip()
         if new_branch:
-            returncode, stdout_text, stderr_text = await self._run_command(
-                "git",
-                "-C",
-                str(repo_path),
+            checkout_command = self._workspace_git_command(
+                repo_path,
                 "checkout",
                 new_branch,
+            )
+            returncode, stdout_text, stderr_text = await self._run_command(
+                *checkout_command,
                 env=command_env,
             )
             if returncode != 0:
@@ -1391,26 +1424,19 @@ class ManagedRuntimeLauncher:
                     )
                     detail = redactor.scrub(stderr_text or stdout_text or "no output")
                     rendered_cmd = " ".join(
-                        shlex.quote(part)
-                        for part in [
-                            "git",
-                            "-C",
-                            str(repo_path),
-                            "checkout",
-                            new_branch,
-                        ]
+                        shlex.quote(part) for part in checkout_command
                     )
                     rendered_cmd = redactor.scrub(rendered_cmd)
                     raise RuntimeError(
                         f"Command failed with exit code {returncode}: {rendered_cmd}; {detail}"
                     )
                 await self._run_checked_command(
-                    "git",
-                    "-C",
-                    str(repo_path),
-                    "checkout",
-                    "-b",
-                    new_branch,
+                    *self._workspace_git_command(
+                        repo_path,
+                        "checkout",
+                        "-b",
+                        new_branch,
+                    ),
                     env=command_env,
                 )
 
@@ -1440,7 +1466,7 @@ class ManagedRuntimeLauncher:
         target_branch = self._normalize_clone_branch(
             str(workspace_spec.get("targetBranch") or "")
         )
-        checkout_args = ["git", "-C", str(repo_path), "checkout"]
+        checkout_args = self._workspace_git_command(repo_path, "checkout")
         if target_branch:
             checkout_args.extend(["-B", target_branch, commit_sha])
         else:
@@ -1450,7 +1476,8 @@ class ManagedRuntimeLauncher:
             env=dict(git_env) if git_env is not None else None,
         )
         returncode, stdout_text, _stderr_text = await self._run_command(
-            "git", "-C", str(repo_path), "rev-parse", "HEAD"
+            *self._workspace_git_command(repo_path, "rev-parse", "HEAD"),
+            env=dict(git_env) if git_env is not None else None,
         )
         observed_sha = stdout_text.strip()
         if returncode != 0 or not observed_sha.startswith(commit_sha):

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 CompletionCallback = Callable[[dict[str, Any]], Awaitable[None]]
 
 from moonmind.schemas.agent_runtime_models import (
+    MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
     ManagedRunRecord,
 )
 
@@ -740,6 +741,9 @@ class ManagedRunSupervisor:
                     "failed",
                     finished_at=datetime.now(tz=UTC),
                     failure_class="system_error",
+                    provider_error_code=(
+                        MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+                    ),
                     error_message=(
                         f"Process {record.pid} not found during reconciliation"
                     ),

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
 
     from moonmind.schemas.agent_runtime_models import (
         AUTO_RUNTIME_SENTINEL,
+        MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
         AgentExecutionRequest,
         AgentRunHandle,
         AgentRunResult,
@@ -89,6 +90,9 @@ TERMINAL_CONTRACT_CHECKPOINT_ON_FAILURE_PATCH_ID = (
 TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID = (
     "agent-run-terminal-contract-runtime-failure-authority-v1"
 )
+MANAGED_PROCESS_LOSS_RECOVERY_PATCH_ID = (
+    "agent-run-managed-process-loss-recovery-v1"
+)
 CODEX_TURN_RUNTIME_SELECTION_PATCH_ID = (
     "agent-run-codex-turn-runtime-selection-v1"
 )
@@ -101,6 +105,7 @@ PARENT_EXECUTION_ARTIFACT_HANDOFF_PATCH_ID = (
     "agent-run-parent-execution-artifact-handoff-v1"
 )
 _MAX_TERMINAL_CONTRACT_CONTINUATIONS = 2
+_MAX_MANAGED_PROCESS_LOSS_RECOVERIES = 1
 _RETRYABLE_TERMINAL_CONTRACT_FAILURE_CODES = frozenset(
     {
         "INCOMPLETE_TERMINAL_CONTRACT",
@@ -128,6 +133,17 @@ def _terminal_contract_fresh_process_instruction(missing: list[str]) -> str:
         + " The prior one-shot process exited, so continue in this replacement "
         "process using the existing authoritative workspace. Finish all work in "
         "this process; do not schedule a wake-up or other deferred callback."
+    )
+
+
+def _managed_process_loss_recovery_instruction() -> str:
+    return (
+        "The prior managed process was lost when its worker restarted before "
+        "MoonMind received authoritative terminal evidence. Continue in this "
+        "replacement process using the existing authoritative workspace. "
+        "Inspect the workspace and remotely visible side effects first, and "
+        "reuse completed work instead of duplicating it. Finish all remaining "
+        "work in this process; do not schedule a wake-up or deferred callback."
     )
 
 # Map canonical AgentRunState literals to workflow-usable status constants.
@@ -549,6 +565,7 @@ class MoonMindAgentRun:
         self._provider_cooldown_retry_counts: dict[str, int] = {}
         self._terminal_result_payload_compacted_for_history: bool = False
         self._terminal_contract_fresh_process_history: list[dict[str, Any]] = []
+        self._managed_process_loss_recovery_history: list[dict[str, Any]] = []
         self.runtime_selection_updated_event = asyncio.Event()
         self._pending_runtime_selection_update: dict[str, Any] | None = None
         self._managed_session_detached_for_runtime_selection: bool = False
@@ -2403,6 +2420,101 @@ class MoonMindAgentRun:
             }
         )
         return evaluated.model_copy(update={"metadata": metadata})
+
+    def _managed_process_loss_recovery_request(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        result: AgentRunResult,
+    ) -> AgentExecutionRequest | None:
+        """Build one bounded replacement after startup reconciliation loses a PID."""
+
+        if (
+            request.agent_kind != "managed"
+            or request.managed_session is not None
+            or not self.run_id
+            or result.failure_class != "system_error"
+            or result.provider_error_code
+            != MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+            or len(self._managed_process_loss_recovery_history)
+            >= _MAX_MANAGED_PROCESS_LOSS_RECOVERIES
+        ):
+            return None
+
+        runtime_id = self._managed_runtime_id(request.agent_id)
+        capabilities = resolve_runtime_execution_capabilities(runtime_id)
+        if capabilities.workspace_authority != "managed_runtime":
+            return None
+
+        attempt = len(self._managed_process_loss_recovery_history) + 1
+        self._managed_process_loss_recovery_history.append(
+            {
+                "attempt": attempt,
+                "mode": "fresh_process",
+                "reason": "process_lost_during_reconciliation",
+                "outcome": "requested",
+            }
+        )
+        workspace_spec = dict(request.workspace_spec or {})
+        workspace_spec["workspaceLocator"] = {
+            "kind": "managed_runtime",
+            "runtimeId": capabilities.runtime_id,
+            "agentRunId": self.run_id,
+            "relativePath": "repo",
+        }
+        instruction = str(request.instruction_ref or "").rstrip()
+        recovery_instruction = _managed_process_loss_recovery_instruction()
+        if instruction:
+            instruction = f"{instruction}\n\n{recovery_instruction}"
+        else:
+            instruction = recovery_instruction
+        return request.model_copy(
+            update={
+                "instruction_ref": instruction,
+                "workspace_spec": workspace_spec,
+            }
+        )
+
+    def _with_managed_process_loss_recovery_history(
+        self,
+        result: AgentRunResult,
+    ) -> AgentRunResult:
+        if not self._managed_process_loss_recovery_history:
+            return result
+
+        history = [
+            dict(item) for item in self._managed_process_loss_recovery_history
+        ]
+        if history[-1]["outcome"] == "requested":
+            if result.failure_class is None:
+                history[-1]["outcome"] = "recovered"
+                self._managed_process_loss_recovery_history[-1]["outcome"] = (
+                    "recovered"
+                )
+            elif (
+                result.provider_error_code
+                == MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+            ):
+                history[-1]["outcome"] = "process_lost_again"
+            else:
+                history[-1]["outcome"] = "replacement_failed"
+
+        recovery_outcome = history[-1]["outcome"]
+        if (
+            recovery_outcome == "process_lost_again"
+            and len(history) >= _MAX_MANAGED_PROCESS_LOSS_RECOVERIES
+        ):
+            recovery_outcome = "exhausted"
+
+        metadata = dict(result.metadata or {})
+        metadata.update(
+            {
+                "managedProcessLossRecoveryCount": len(history),
+                "managedProcessLossRecoveryHistory": history,
+                "managedProcessLossRecoveryOutcome": recovery_outcome,
+            }
+        )
+        return result.model_copy(update={"metadata": metadata})
 
     def _fresh_process_terminal_contract_request(
         self,
@@ -5352,6 +5464,40 @@ class MoonMindAgentRun:
                                 )
 
                 if self.final_result is not None:
+                    if workflow.patched(
+                        MANAGED_PROCESS_LOSS_RECOVERY_PATCH_ID
+                    ):
+                        self.final_result = (
+                            self._with_managed_process_loss_recovery_history(
+                                self.final_result
+                            )
+                        )
+                        recovery_request = (
+                            self._managed_process_loss_recovery_request(
+                                request=request,
+                                result=self.final_result,
+                            )
+                        )
+                        if recovery_request is not None:
+                            active_profile_id = str(
+                                request.execution_profile_ref
+                                or self._assigned_profile_id
+                                or ""
+                            ).strip()
+                            if manager_handle and active_profile_id:
+                                await manager_handle.signal(
+                                    "release_slot",
+                                    self._release_slot_payload(
+                                        profile_id=active_profile_id,
+                                        request=request,
+                                    ),
+                                )
+                            request = recovery_request
+                            self.completion_event.clear()
+                            self.final_result = None
+                            self._assigned_profile_id = None
+                            self.run_status = RunStatus.launching
+                            continue
                     self.final_result = await self._evaluate_terminal_contract(
                         request=request,
                         result=self.final_result,

--- a/tests/integration/reliability/replays/managed-launcher-reused-workspace-git-ownership/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-launcher-reused-workspace-git-ownership/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "safeDirectoryScope": "exact_reused_workspace",
+  "checkoutMode": "pinned_branch_reset",
+  "workspaceReused": true
+}

--- a/tests/integration/reliability/replays/managed-launcher-reused-workspace-git-ownership/manifest.json
+++ b/tests/integration/reliability/replays/managed-launcher-reused-workspace-git-ownership/manifest.json
@@ -1,0 +1,11 @@
+{
+  "failureShapeId": "managed-launcher-reused-workspace-git-ownership",
+  "incidentWorkflowId": "mm:921a8a3b-d2eb-5e00-99dc-c01a676783b9",
+  "runtime": "claude_code",
+  "repository": "MoonLadderStudios/MoonMind",
+  "repositoryOwnerUid": 1000,
+  "launcherUid": 0,
+  "targetBranch": "github-issue-implement-moonladderstudios-97b98c29",
+  "preparedCommitSha": "49ed3d9af7e54e047a47bc9a0e3be8b8c33284d0",
+  "observedFailure": "fatal: detected dubious ownership in repository"
+}

--- a/tests/integration/reliability/replays/managed-process-lost-during-reconciliation/expected-outcome.json
+++ b/tests/integration/reliability/replays/managed-process-lost-during-reconciliation/expected-outcome.json
@@ -1,0 +1,8 @@
+{
+  "recoveryMode": "fresh_process",
+  "recoveryReason": "process_lost_during_reconciliation",
+  "maxRecoveries": 1,
+  "workspaceKind": "managed_runtime",
+  "sameExecutionProfile": true,
+  "sameIdempotencyKey": true
+}

--- a/tests/integration/reliability/replays/managed-process-lost-during-reconciliation/manifest.json
+++ b/tests/integration/reliability/replays/managed-process-lost-during-reconciliation/manifest.json
@@ -1,0 +1,12 @@
+{
+  "failureShapeId": "managed-process-lost-during-reconciliation",
+  "incidentWorkflowId": "mm:e5ff4c80-c9c4-5e26-83f7-3fe5cc2f894a",
+  "agentRunId": "08fd02d1-f242-4dba-86d5-6646d8617a43",
+  "runtime": "claude_code",
+  "executionProfileRef": "claude_anthropic_oauth",
+  "lostPid": 36009,
+  "priorProviderCooldowns": 4,
+  "failureClass": "system_error",
+  "providerErrorCode": "MANAGED_PROCESS_LOST_DURING_RECONCILIATION",
+  "workspaceDirty": true
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -68,6 +68,7 @@ from moonmind.schemas.managed_session_models import (
     SendCodexManagedSessionTurnRequest,
 )
 from moonmind.schemas.agent_runtime_models import (
+    MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
     AgentExecutionRequest,
     AgentRunResult,
     AgentRuntimeStepExecutionLaunch,
@@ -103,6 +104,7 @@ from moonmind.workflows.temporal.activity_catalog import build_default_activity_
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
+from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
@@ -189,6 +191,128 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+async def test_managed_launcher_reuses_runtime_owned_workspace_with_exact_git_trust(
+    tmp_path: Path,
+) -> None:
+    replay_id = "managed-launcher-reused-workspace-git-ownership"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    run_id = "reused-workspace"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(run_store)
+    repo_path = (tmp_path / "workspaces" / run_id / "repo").resolve()
+    repo_path.mkdir(parents=True)
+    commands: list[tuple[object, ...]] = []
+    safe_prefix = (
+        "git",
+        "-c",
+        f"safe.directory={repo_path}",
+        "-C",
+        str(repo_path),
+    )
+
+    async def checked_command(*command: object, **_kwargs: object) -> None:
+        commands.append(command)
+        if command[: len(safe_prefix)] != safe_prefix:
+            raise RuntimeError(manifest["observedFailure"])
+
+    async def command_result(
+        *command: object, **_kwargs: object
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[: len(safe_prefix)] != safe_prefix:
+            raise RuntimeError(manifest["observedFailure"])
+        return 0, manifest["preparedCommitSha"], ""
+
+    launcher._run_checked_command = checked_command  # type: ignore[method-assign]
+    launcher._run_command = command_result  # type: ignore[method-assign]
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId=manifest["runtime"],
+        executionProfileRef="claude_anthropic_oauth",
+        correlationId="replay-correlation",
+        idempotencyKey=f"{manifest['incidentWorkflowId']}:step-6",
+        workspaceSpec={
+            "repository": manifest["repository"],
+            "targetBranch": manifest["targetBranch"],
+            "resolvedRepositoryTarget": {
+                "remoteTipExpectation": {"kind": "read_only"},
+                "preparedRevision": {
+                    "kind": "git_commit",
+                    "commitSha": manifest["preparedCommitSha"],
+                },
+            },
+        },
+    )
+
+    resolved = await launcher._prepare_workspace_path(
+        run_id=run_id,
+        request=request,
+        workspace_path=None,
+    )
+
+    assert expected["safeDirectoryScope"] == "exact_reused_workspace"
+    assert expected["checkoutMode"] == "pinned_branch_reset"
+    assert expected["workspaceReused"] is True
+    assert resolved == str(repo_path)
+    assert all(command[: len(safe_prefix)] == safe_prefix for command in commands)
+
+
+async def test_lost_managed_process_retries_once_over_authoritative_workspace() -> None:
+    replay_id = "managed-process-lost-during-reconciliation"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    agent_run = MoonMindAgentRun()
+    agent_run.run_id = manifest["agentRunId"]
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId=manifest["runtime"],
+        executionProfileRef=manifest["executionProfileRef"],
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=f"{manifest['incidentWorkflowId']}:implement",
+        instructionRef="Implement the selected issue and publish the result.",
+        workspaceSpec={"repository": "MoonLadderStudios/MoonMind"},
+    )
+    failure = AgentRunResult(
+        summary=f"Process {manifest['lostPid']} not found during reconciliation",
+        failureClass=manifest["failureClass"],
+        providerErrorCode=MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    )
+
+    recovery = agent_run._managed_process_loss_recovery_request(
+        request=request,
+        result=failure,
+    )
+
+    assert recovery is not None
+    assert expected["recoveryMode"] == "fresh_process"
+    assert expected["maxRecoveries"] == 1
+    assert recovery.workspace_spec["workspaceLocator"]["kind"] == expected[
+        "workspaceKind"
+    ]
+    assert (
+        recovery.execution_profile_ref == request.execution_profile_ref
+    ) is expected["sameExecutionProfile"]
+    assert (
+        recovery.idempotency_key == request.idempotency_key
+    ) is expected["sameIdempotencyKey"]
+    assert agent_run._managed_process_loss_recovery_history == [
+        {
+            "attempt": 1,
+            "mode": expected["recoveryMode"],
+            "reason": expected["recoveryReason"],
+            "outcome": "requested",
+        }
+    ]
+    assert (
+        agent_run._managed_process_loss_recovery_request(
+            request=recovery,
+            result=failure,
+        )
+        is None
+    )
 
 
 async def test_omnigent_server_image_authority_drift_reconciles_before_launch(

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -11,7 +11,13 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, Worker, UnsandboxedWorkflowRunner
 from temporalio.client import WorkflowFailureError
 from temporalio.service import RPCError
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult, AgentRunStatus, ProfileSelector
+from moonmind.schemas.agent_runtime_models import (
+    MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    AgentExecutionRequest,
+    AgentRunResult,
+    AgentRunStatus,
+    ProfileSelector,
+)
 from moonmind.schemas.workload_models import WorkloadRequest
 from moonmind.workloads.docker_launcher import DockerWorkloadLauncher
 from moonmind.workloads.registry import RunnerProfileRegistry
@@ -288,6 +294,23 @@ async def mock_agent_runtime_status(request: dict) -> dict:
             "status": status,
             "metadata": metadata,
         }
+    if _managed_status_mode == "process_lost_then_completed":
+        status = "failed" if len(_managed_launch_requests) == 1 else "completed"
+        return {
+            "runId": request.get("runId")
+            or request.get("run_id")
+            or "test-managed-run",
+            "agentKind": "managed",
+            "agentId": request.get("agentId")
+            or request.get("agent_id")
+            or "claude_code",
+            "status": status,
+            "metadata": {
+                "runtimeId": "claude_code",
+                "finishedAt": datetime.now(tz=UTC).isoformat(),
+                "exitCode": 0 if status == "completed" else None,
+            },
+        }
     return {
         "status": "running",
         "container_id": request.get("container_id", "test-container-001"),
@@ -333,6 +356,28 @@ async def mock_agent_runtime_fetch_result(request: dict) -> dict:
                         "after a profile cooldown."
                     ),
                 },
+            },
+        }
+    if _managed_status_mode == "process_lost_then_completed":
+        if _managed_fetch_result_count == 1:
+            return {
+                "summary": "Managed worker restarted while the process was running.",
+                "failureClass": "system_error",
+                "providerErrorCode": (
+                    MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+                ),
+                "metadata": {
+                    "normalizedStatus": "failed",
+                    "fetchRunId": request.get("runId")
+                    or request.get("run_id"),
+                },
+            }
+        return {
+            "summary": "Replacement process recovered the durable workspace.",
+            "metadata": {
+                "normalizedStatus": "completed",
+                "fetchRunId": request.get("runId")
+                or request.get("run_id"),
             },
         }
     return {
@@ -1934,6 +1979,94 @@ async def test_agent_run_reconciles_managed_completion_during_no_progress_grace(
         )
     finally:
         _managed_status_mode = "default"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_relaunches_lost_managed_process_in_same_workspace():
+    global _managed_status_mode, _managed_status_poll_count, _managed_fetch_result_count
+    _managed_launch_requests.clear()
+    _managed_status_mode = "process_lost_then_completed"
+    _managed_status_poll_count = 0
+    _managed_fetch_result_count = 0
+
+    try:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with (
+                Worker(
+                    env.client,
+                    task_queue="agent-run-task-queue",
+                    workflows=[MoonMindAgentRun, MockProviderProfileManager],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.artifacts",
+                    activities=[
+                        mock_provider_profile_list,
+                        mock_provider_profile_ensure_manager,
+                        mock_provider_profile_reset_manager,
+                        mock_provider_profile_manager_state,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="mm.activity.agent_runtime",
+                    activities=[
+                        mock_agent_runtime_build_launch_context,
+                        mock_agent_runtime_launch,
+                        mock_agent_runtime_status,
+                        mock_agent_runtime_fetch_result,
+                        mock_publish_artifacts,
+                        mock_cancel,
+                    ],
+                ),
+            ):
+                manager_id = "provider-profile-manager:claude_code"
+                await env.client.start_workflow(
+                    MockProviderProfileManager.run,
+                    {"runtime_id": "claude_code"},
+                    id=manager_id,
+                    task_queue="agent-run-task-queue",
+                )
+
+                handle = await env.client.start_workflow(
+                    MoonMindAgentRun.run,
+                    AgentExecutionRequest(
+                        agent_kind="managed",
+                        agent_id="claude_code",
+                        execution_profile_ref="default-managed",
+                        instruction_ref="Implement the requested change.",
+                        correlation_id="managed-process-loss:corr",
+                        idempotency_key="managed-process-loss:idem",
+                        parameters={"model": "test-model"},
+                    ),
+                    id="test-agent-managed-process-loss-recovery",
+                    task_queue="agent-run-task-queue",
+                )
+                result = await asyncio.wait_for(handle.result(), timeout=15)
+
+        assert result.failure_class is None
+        assert result.summary == (
+            "Replacement process recovered the durable workspace."
+        )
+        assert result.metadata["managedProcessLossRecoveryOutcome"] == "recovered"
+        assert result.metadata["managedProcessLossRecoveryCount"] == 1
+        assert len(_managed_launch_requests) == 2
+        first_launch = _managed_launch_requests[0]
+        first = first_launch["request"]
+        replacement = _managed_launch_requests[1]["request"]
+        assert replacement["executionProfileRef"] == first["executionProfileRef"]
+        assert replacement["parameters"] == first["parameters"]
+        assert replacement["idempotencyKey"] == first["idempotencyKey"]
+        assert replacement["workspaceSpec"]["workspaceLocator"] == {
+            "kind": "managed_runtime",
+            "runtimeId": "claude_code",
+            "agentRunId": first_launch["run_id"],
+            "relativePath": "repo",
+        }
+    finally:
+        _managed_status_mode = "default"
+
 
 @pytest.mark.asyncio
 async def test_agent_run_reconciles_managed_quota_after_no_progress_cancel(

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -131,6 +131,66 @@ async def test_prepare_workspace_clones_candidate_and_checks_out_pinned_revision
 
 
 @pytest.mark.asyncio
+async def test_prepare_workspace_trusts_reused_runtime_owned_repository(tmp_path):
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    launcher = ManagedRuntimeLauncher(store)
+    run_id = "reused-workspace"
+    repo_path = (tmp_path / "workspaces" / run_id / "repo").resolve()
+    repo_path.mkdir(parents=True)
+    head_sha = "49ed3d9af7e54e047a47bc9a0e3be8b8c33284d0"
+    checked_calls: list[tuple[object, ...]] = []
+    run_calls: list[tuple[object, ...]] = []
+
+    async def fake_checked(*args, **_kwargs):
+        checked_calls.append(args)
+
+    async def fake_run(*args, **_kwargs):
+        run_calls.append(args)
+        return 0, f"{head_sha}\n", ""
+
+    launcher._run_checked_command = fake_checked
+    launcher._run_command = fake_run
+    request = _make_request(
+        workspace_spec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "github-issue-implement-moonladderstudios-97b98c29",
+            "resolvedRepositoryTarget": {
+                "remoteTipExpectation": {"kind": "read_only"},
+                "preparedRevision": {
+                    "kind": "git_commit",
+                    "commitSha": head_sha,
+                },
+            },
+        }
+    )
+
+    resolved = await launcher._prepare_workspace_path(
+        run_id=run_id,
+        request=request,
+        workspace_path=None,
+    )
+
+    safe_prefix = (
+        "git",
+        "-c",
+        f"safe.directory={repo_path}",
+        "-C",
+        str(repo_path),
+    )
+    assert checked_calls == [
+        (
+            *safe_prefix,
+            "checkout",
+            "-B",
+            "github-issue-implement-moonladderstudios-97b98c29",
+            head_sha,
+        )
+    ]
+    assert run_calls == [(*safe_prefix, "rev-parse", "HEAD")]
+    assert resolved == str(repo_path)
+
+
+@pytest.mark.asyncio
 async def test_repository_readiness_blocks_before_workspace_mutation(tmp_path):
     store = ManagedRunStore(tmp_path / "managed_runs")
     readiness = AsyncMock(
@@ -2213,6 +2273,16 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
         async def communicate(self) -> tuple[bytes, bytes]:
             return self._stdout_bytes, self._stderr_bytes
 
+    expected_workspace = str(
+        (tmp_path / "workspaces" / "workspace-run-1" / "repo").resolve()
+    )
+    safe_prefix = (
+        "git",
+        "-c",
+        f"safe.directory={expected_workspace}",
+        "-C",
+        expected_workspace,
+    )
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     async def _fake_create_subprocess_exec(*args, **kwargs):
@@ -2221,7 +2291,7 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
             repo_path = Path(str(args[-1]))
             repo_path.mkdir(parents=True, exist_ok=True)
             return _FakeProcess(pid=1001)
-        if args[:2] == ("git", "-C") and args[3:] == (
+        if args[: len(safe_prefix)] == safe_prefix and args[len(safe_prefix):] == (
             "checkout",
             "feature/test",
         ):
@@ -2233,7 +2303,7 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
                     b"file(s) known to git"
                 ),
             )
-        if args[:2] == ("git", "-C") and args[3:] == (
+        if args[: len(safe_prefix)] == safe_prefix and args[len(safe_prefix):] == (
             "checkout",
             "-b",
             "feature/test",
@@ -2255,9 +2325,6 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
     )
     await process.wait()
 
-    expected_workspace = str(
-        (tmp_path / "workspaces" / "workspace-run-1" / "repo").resolve()
-    )
     assert record.workspace_path == expected_workspace
     assert record.live_stream_capable is True
     assert process.pid == 2001
@@ -2271,8 +2338,8 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
     checkout_call = next(
         args
         for args, _ in calls
-        if args[:2] == ("git", "-C")
-        and args[3:] == ("checkout", "-b", "feature/test")
+        if args[: len(safe_prefix)] == safe_prefix
+        and args[len(safe_prefix):] == ("checkout", "-b", "feature/test")
     )
     assert checkout_call[-2:] == ("-b", "feature/test")
 
@@ -2444,6 +2511,21 @@ async def test_launch_reuses_existing_new_branch_when_present(tmp_path, monkeypa
         async def communicate(self) -> tuple[bytes, bytes]:
             return self._stdout_bytes, self._stderr_bytes
 
+    expected_workspace = str(
+        (
+            tmp_path
+            / "workspaces"
+            / "workspace-run-existing-branch"
+            / "repo"
+        ).resolve()
+    )
+    safe_prefix = (
+        "git",
+        "-c",
+        f"safe.directory={expected_workspace}",
+        "-C",
+        expected_workspace,
+    )
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     async def _fake_create_subprocess_exec(*args, **kwargs):
@@ -2452,7 +2534,7 @@ async def test_launch_reuses_existing_new_branch_when_present(tmp_path, monkeypa
             repo_path = Path(str(args[-1]))
             repo_path.mkdir(parents=True, exist_ok=True)
             return _FakeProcess(pid=1001)
-        if args[:2] == ("git", "-C") and args[3:] == (
+        if args[: len(safe_prefix)] == safe_prefix and args[len(safe_prefix):] == (
             "checkout",
             "main",
         ):
@@ -2476,7 +2558,8 @@ async def test_launch_reuses_existing_new_branch_when_present(tmp_path, monkeypa
     checkout_call = next(
         args
         for args, _ in calls
-        if args[:2] == ("git", "-C") and args[3:] == ("checkout", "main")
+        if args[: len(safe_prefix)] == safe_prefix
+        and args[len(safe_prefix):] == ("checkout", "main")
     )
     assert checkout_call[-1] == "main"
     assert "-b" not in checkout_call

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 import signal
 import sys
 
-from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.agent_runtime_models import (
+    MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    ManagedRunRecord,
+)
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
@@ -645,6 +648,15 @@ async def test_reconcile_dead_pids(supervisor_env):
     assert reconciled[0].run_id == "run-1"
     assert reconciled[0].status == "failed"
     assert reconciled[0].failure_class == "system_error"
+    assert (
+        reconciled[0].provider_error_code
+        == MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+    )
+    completion = supervisor._build_completion_payload(reconciled[0], {})
+    assert (
+        completion["provider_error_code"]
+        == MANAGED_PROCESS_LOST_DURING_RECONCILIATION
+    )
 
 @pytest.mark.asyncio
 async def test_reconcile_skips_alive_pids(supervisor_env):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -8,6 +8,7 @@ import pytest
 from temporalio.exceptions import ApplicationError
 
 from moonmind.schemas.agent_runtime_models import (
+    MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
     AgentExecutionRequest,
     AgentRuntimeStepExecutionLaunch,
     AgentTerminalContract,
@@ -367,6 +368,122 @@ async def test_terminal_contract_uses_fresh_process_when_session_cannot_continue
         "relativePath": "repo",
     }
     assert "do not schedule a wake-up" in continuation.instruction_ref
+
+
+async def test_lost_managed_process_gets_one_workspace_preserving_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    run.run_id = "run-claude-lost-process"
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        executionProfileRef="claude-anthropic-oauth",
+        correlationId="mm:lost-process-workflow",
+        idempotencyKey="mm:lost-process-workflow:implement",
+        instructionRef="Implement the requested issue and publish the result.",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "github-issue-implement-moonladderstudios-9eea789f",
+        },
+        parameters={"model": "claude-opus-4-8", "publishMode": "auto"},
+    )
+    lost = AgentRunResult(
+        summary="Process 36009 not found during reconciliation",
+        failureClass="system_error",
+        providerErrorCode=MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    )
+
+    recovery = run._managed_process_loss_recovery_request(
+        request=request,
+        result=lost,
+    )
+
+    assert recovery is not None
+    assert recovery.execution_profile_ref == request.execution_profile_ref
+    assert recovery.parameters == request.parameters
+    assert recovery.idempotency_key == request.idempotency_key
+    assert recovery.workspace_spec["workspaceLocator"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "claude_code",
+        "agentRunId": "run-claude-lost-process",
+        "relativePath": "repo",
+    }
+    assert "reuse completed work instead of duplicating it" in (
+        recovery.instruction_ref
+    )
+
+    recovered = run._with_managed_process_loss_recovery_history(
+        AgentRunResult(summary="Published the requested pull request.")
+    )
+    assert recovered.metadata["managedProcessLossRecoveryOutcome"] == "recovered"
+    assert recovered.metadata["managedProcessLossRecoveryHistory"] == [
+        {
+            "attempt": 1,
+            "mode": "fresh_process",
+            "reason": "process_lost_during_reconciliation",
+            "outcome": "recovered",
+        }
+    ]
+
+
+async def test_lost_managed_process_recovery_is_bounded_and_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    run.run_id = "run-claude-lost-twice"
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        executionProfileRef="claude-anthropic-oauth",
+        correlationId="mm:lost-process-twice",
+        idempotencyKey="mm:lost-process-twice:implement",
+        workspaceSpec={"repository": "MoonLadderStudios/MoonMind"},
+    )
+    unrelated = AgentRunResult(
+        summary="Managed runtime unavailable",
+        failureClass="system_error",
+        providerErrorCode="MANAGED_RUNTIME_UNAVAILABLE",
+    )
+    legacy_untyped = AgentRunResult(
+        summary="Process not found during reconciliation",
+        failureClass="system_error",
+    )
+    assert (
+        run._managed_process_loss_recovery_request(
+            request=request,
+            result=unrelated,
+        )
+        is None
+    )
+    assert (
+        run._managed_process_loss_recovery_request(
+            request=request,
+            result=legacy_untyped,
+        )
+        is None
+    )
+
+    lost = AgentRunResult(
+        summary="Process not found during reconciliation",
+        failureClass="system_error",
+        providerErrorCode=MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    )
+    assert run._managed_process_loss_recovery_request(
+        request=request,
+        result=lost,
+    )
+    exhausted = run._with_managed_process_loss_recovery_history(lost)
+    assert exhausted.metadata["managedProcessLossRecoveryOutcome"] == "exhausted"
+    assert (
+        run._managed_process_loss_recovery_request(
+            request=request,
+            result=exhausted,
+        )
+        is None
+    )
 
 
 async def test_terminal_checkpoint_activity_failure_preserves_primary_result(


### PR DESCRIPTION
## Summary

Seven `MoonMind.UserWorkflow` runs failed in the reviewed eight-hour window:

- Issues #3702-#3707 reached a later managed step that reused a repository prepared by an earlier runtime process. The launcher then ran Git as a different UID and failed with `fatal: detected dubious ownership in repository`.
- Issue #3708 exhausted four provider-rate-limit attempts, then made progress on its fifth attempt. The agent-runtime worker restarted while that process was active; startup reconciliation could no longer find the container-local PID and converted the run to an untyped terminal `system_error`, even though the durable workspace and partial work survived.

## Changes

- Give every host-side Git command an exact, per-command `safe.directory` for the resolved managed workspace. No global trust exemption is added.
- Emit a typed `MANAGED_PROCESS_LOST_DURING_RECONCILIATION` result when startup reconciliation proves the recorded PID is gone.
- Allow one bounded one-shot managed replacement for that exact failure. It retains the runtime profile, request parameters, idempotency key, and authoritative workspace, and instructs the replacement to inspect existing local and remote side effects before continuing.
- Keep unrelated system errors, legacy untyped results, managed sessions, and a second process loss terminal.
- Add minimized production replay fixtures, unit coverage, a real Temporal workflow-boundary test, and update the canonical runtime document.

## Verification

- `179 passed` across the affected launcher, supervisor, and AgentRun unit modules.
- `2 passed` for the two minimized escaped-failure replays.
- `1 passed` for the time-skipping Temporal activity/workflow boundary recovery test.
- `git diff --check` and replay JSON validation passed.

The repository-wide capability/status audit scripts could not complete in this Windows workspace because an existing inaccessible `model_data/models--ByteDance-Seed--UI-TARS-1.5-7B/.../added_tokens.json` cache path raises WinError 1920 / invalid-argument errors before the audits evaluate this change.