### PR TITLE
Use schema-driven Skill input disclosure

### DIFF
--- a/docs/Steps/SkillInputSchemaUIGeneration.md
+++ b/docs/Steps/SkillInputSchemaUIGeneration.md
@@ -405,9 +405,11 @@ When a user selects `Skill` as the Step Type:
 3. The step editor passes `inputSchema`, `uiSchema`, `defaults`, current draft
    values, workflow context, and deployment policy into the shared schema-form
    renderer.
-4. The renderer generates visible fields for required inputs and default-visible
-   optional inputs.
-5. Advanced optional fields may be collapsed but remain discoverable.
+4. In guided mode, the renderer shows root `required` fields plus every field
+   participating in a root `oneOf` / `anyOf` required alternative.
+5. Other Skill properties are available when the user enables Advanced mode;
+   field selection is schema-derived and must not use Skill-name allowlists or
+   bespoke Skill layouts in the frontend.
 6. Local validation runs on change/blur and before Start Workflow.
 7. The draft stores values under `step.skill.inputs`.
 8. The backend validates the values against the same Skill input contract before

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -166,6 +166,13 @@ The frontend renders fields by reading `inputSchema`, optional `uiSchema`, and e
 
 The Create page must not hard-code a form for each preset or skill. New presets should be able to add new fields by updating their manifest, provided the fields use standard schema constructs or already-registered widgets.
 
+For Skill steps, guided mode shows fields named by the root `required` contract
+and every field participating in a root `oneOf` / `anyOf` required alternative,
+so the user can satisfy the contract without opening advanced controls. Other
+Skill properties remain available only in Advanced mode. This disclosure rule is
+derived from the selected Skill schema and must not use Skill-name allowlists or
+capability-specific frontend layouts.
+
 ## UI Schema and Widget Hints
 
 Validation belongs in `inputSchema`. Presentation belongs in `uiSchema` or namespaced schema hints.

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18398,7 +18398,7 @@ describe("Task Create schema-driven capability inputs", () => {
     expect(within(step).queryByDisplayValue("token=raw-secret")).toBeNull();
   });
 
-  it("renders direct skill inputs through the same schema behavior", async () => {
+  it("shows required Skill inputs by default and reveals optional schema fields in Advanced mode", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
     const step = (await screen.findByText("Step 1")).closest("section") as HTMLElement;
     selectStepType(step, "Skill");
@@ -18407,7 +18407,17 @@ describe("Task Create schema-driven capability inputs", () => {
     });
 
     expect(await within(step).findByLabelText("Repository name")).toBeTruthy();
-    expect(within(step).getByLabelText("Branch")).toBeTruthy();
+    expect(within(step).queryByLabelText("Branch")).toBeNull();
+    expect(
+      within(step).getByTestId("skill-optional-inputs-notice-0").textContent,
+    ).toContain("Advanced mode");
+
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+
+    expect(await within(step).findByLabelText("Branch")).toBeTruthy();
+    expect(
+      within(step).queryByTestId("skill-optional-inputs-notice-0"),
+    ).toBeNull();
     expect(within(step).getByLabelText("Notes").tagName).toBe("TEXTAREA");
     expect(within(step).getByLabelText("Markdown").tagName).toBe("TEXTAREA");
     expect((within(step).getByLabelText("Effort") as HTMLInputElement).type).toBe("number");
@@ -18488,6 +18498,11 @@ describe("Task Create schema-driven capability inputs", () => {
     fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
       target: { value: "schema.skill" },
     });
+    expect(
+      await within(step).findByTestId("skill-optional-inputs-notice-0"),
+    ).toBeTruthy();
+    expect(within(step).queryByTestId("skill-schema-fallback-0")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
 
     fireEvent.change(await within(step).findByLabelText("Repository name"), {
       target: { value: "MoonLadderStudios/MoonMind" },
@@ -18620,6 +18635,11 @@ describe("Task Create schema-driven capability inputs", () => {
     fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
       target: { value: "schema.skill" },
     });
+    expect(
+      await within(step).findByTestId("skill-optional-inputs-notice-0"),
+    ).toBeTruthy();
+    expect(within(step).queryByTestId("skill-schema-fallback-0")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
 
     const unsupported = (await waitFor(() => {
       const input = step.querySelector<HTMLInputElement>(
@@ -18662,6 +18682,7 @@ describe("Task Create schema-driven capability inputs", () => {
                 id: "deployment.skill",
                 inputSchema: {
                   type: "object",
+                  required: ["repository"],
                   properties: {
                     repository: { type: "string", title: "Deployment repository" },
                   },
@@ -18743,6 +18764,7 @@ describe("Task Create schema-driven capability inputs", () => {
     fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
       target: { value: "schema.skill" },
     });
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
 
     fireEvent.change(await within(step).findByLabelText("Repository name"), {
       target: { value: "MoonLadderStudios/SavedSchemaRepo" },
@@ -18841,6 +18863,7 @@ describe("Task Create schema-driven capability inputs", () => {
     fireEvent.change(within(step).getByLabelText("Skill (optional)"), {
       target: { value: "schema.skill" },
     });
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
 
     const effortInput = (await within(step).findByLabelText("Effort")) as HTMLInputElement;
     expect(effortInput.value).toBe("2");

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3535,6 +3535,18 @@ function schemaAlternativeRequiredGroups(
     .filter((group) => group.length > 0);
 }
 
+function schemaGuidedInputNames(
+  schema: Record<string, unknown> | undefined,
+): Set<string> {
+  const names = schemaRequired(schema);
+  for (const group of schemaAlternativeRequiredGroups(schema)) {
+    for (const name of group) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 function capabilityFieldLabel(name: string, schema: Record<string, unknown>): string {
   return String(schema.title || name)
     .trim()
@@ -12161,11 +12173,34 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   step.skillInputContractDigest,
                   selectedSkillDetail?.contractDigest,
                 ) || step.skillInputContractNotice;
-              const visibleSkillSchemaFields = schemaContractHasFields(
+              const selectedSkillHasInputFields = schemaContractHasFields(
                 selectedSkillDetail,
-              )
-                ? Object.entries(schemaProperties(selectedSkillDetail?.inputSchema))
+              );
+              const availableSkillSchemaFields = selectedSkillHasInputFields
+                ? Object.entries(
+                    schemaProperties(selectedSkillDetail?.inputSchema),
+                  ).filter(([name]) => {
+                    const uiSchema = capabilityFieldUiSchema(
+                      selectedSkillDetail?.uiSchema,
+                      name,
+                    );
+                    return capabilityFieldVisible(
+                      uiSchema,
+                      step.presetInputValues,
+                      selectedSkillDetail?.defaults,
+                    );
+                  })
                 : [];
+              const guidedSkillInputNames = schemaGuidedInputNames(
+                selectedSkillDetail?.inputSchema,
+              );
+              const visibleSkillSchemaFields = showAdvancedStepOptions
+                ? availableSkillSchemaFields
+                : availableSkillSchemaFields.filter(([name]) =>
+                    guidedSkillInputNames.has(name),
+                  );
+              const hiddenOptionalSkillInputCount =
+                availableSkillSchemaFields.length - visibleSkillSchemaFields.length;
               const toolSearchText = toolSearchTextByStep[step.localId] || "";
               const trustedToolDefinitions = trustedToolsQuery.data || [];
               const toolChoiceGroups = groupedToolChoices(
@@ -12645,7 +12680,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                           </span>
                         )}
                       </div>
-                      {selectedSkillDetail && visibleSkillSchemaFields.length === 0 ? (
+                      {selectedSkillDetail && !selectedSkillHasInputFields ? (
                         <div
                           className="notice small"
                           data-testid={`skill-schema-fallback-${index}`}
@@ -12659,6 +12694,18 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                             This Skill does not publish structured input fields.
                           </span>
                         </div>
+                      ) : null}
+
+                      {selectedSkillHasInputFields &&
+                      !showAdvancedStepOptions &&
+                      hiddenOptionalSkillInputCount > 0 ? (
+                        <p
+                          className="small"
+                          data-testid={`skill-optional-inputs-notice-${index}`}
+                        >
+                          Optional Skill inputs are hidden. Advanced mode shows
+                          customization fields.
+                        </p>
                       ) : null}
 
                       {showSkillArgsField ? (
@@ -13522,9 +13569,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             role="note"
           >
             <p className="small">
-              Adds skill args and required capabilities to each step. Optional
-              worker routing overrides; runtime, publish mode, skills, and
-              presets already add the common capabilities automatically.
+              Shows optional Skill inputs, skill args, required capabilities,
+              and worker routing overrides. Runtime, publish mode, skills, and
+              presets already add common capabilities automatically.
             </p>
           </div>
         ) : null}


### PR DESCRIPTION
## Summary

- Derive guided-mode Skill fields from root JSON Schema requirements and required `oneOf` / `anyOf` alternatives.
- Hide optional Skill inputs until Advanced mode, while honoring schema visibility rules and preserving schema-less fallback behavior.
- Update regression coverage and canonical Create-page documentation.

## Why

Schema-backed Skills previously rendered every declared property immediately, so operational defaults and runtime overrides overwhelmed users. The frontend now applies one generic schema rule instead of maintaining Skill-specific layouts or allowlists.

## Validation

- `npm run ui:typecheck`
- ESLint on the changed frontend files
- Schema-driven capability input tests: 17 passed
- Full workflow-start test file with `TZ=UTC`: 134 passed, 238 skipped
