### PR TITLE
Fix Omnigent host retry authority handoff

### DIFF
--- a/docs/Omnigent/OmnigentHostOAuth.md
+++ b/docs/Omnigent/OmnigentHostOAuth.md
@@ -256,7 +256,7 @@ On-demand mode starts a lease-owned container only after profile capacity is acq
 
 The host uses the published image selection and explicit image/tag overrides, runs as UID/GID `1000:1000` from `/home/app`, attaches to the configured MoonMind/Omnigent network, and registers with the selected Omnigent endpoint.
 
-A retry inspects the deterministic container and lease before creating anything. It removes a stopped same-lease container only as part of retry-safe replacement and never removes an unrelated container.
+A retry inspects the deterministic container and lease before creating anything. It removes a stopped same-lease container only as part of retry-safe replacement and never removes an unrelated container. After terminal cleanup is proven, MoonMind retires the prior live cleanup authority before restarting the lease; the replacement must publish a fresh endpoint attestation while an unexplained live identity change still fails closed.
 
 ### 8.3 Product selection authority
 

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 import secrets
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -853,24 +853,60 @@ class OmnigentBridgeSessionStore:
                     # only generation-scoped routing/capture fields.  Existing
                     # lifecycle events remain immutable evidence and the next
                     # attempt appends its own attempt-qualified transitions.
-                    prior_attempts = list(
-                        (row.metadata_ or {}).get("unpostedAttemptHistory") or []
-                    )
-                    prior_attempts.append(
-                        {
-                            "status": row.status,
-                            "terminalRefs": dict(row.terminal_refs or {}),
-                            "rawEventsRef": row.raw_events_ref,
-                            "normalizedEventsRef": row.normalized_events_ref,
-                            "initialSnapshotRef": row.initial_snapshot_ref,
-                            "finalSnapshotRef": row.final_snapshot_ref,
-                            "captureManifestRef": row.capture_manifest_ref,
-                            "diagnosticsRef": row.diagnostics_ref,
-                            "externalStateRef": row.external_state_ref,
-                            "recordedAt": datetime.now(tz=UTC).isoformat(),
-                        }
-                    )
                     reset_metadata = dict(row.metadata_ or {})
+                    journal = list(reset_metadata.get(BRIDGE_EVENT_JOURNAL_KEY) or [])
+                    terminal_event = next(
+                        (
+                            entry
+                            for entry in reversed(journal)
+                            if isinstance(entry, dict)
+                            and entry.get("type") == "terminal"
+                        ),
+                        {},
+                    )
+                    terminal_metadata = (
+                        terminal_event.get("metadata")
+                        if isinstance(terminal_event, dict)
+                        else None
+                    )
+                    cleanup_complete = bool(
+                        isinstance(terminal_metadata, dict)
+                        and terminal_metadata.get("cleanupCompleted") is True
+                        and terminal_metadata.get("leaseReleased") is True
+                    )
+                    cleanup_authority = reset_metadata.get(EGRESS_CLEANUP_AUTHORITY_KEY)
+                    prior_attempts = list(
+                        reset_metadata.get("unpostedAttemptHistory") or []
+                    )
+                    prior_attempt = {
+                        "status": row.status,
+                        "terminalRefs": dict(row.terminal_refs or {}),
+                        "rawEventsRef": row.raw_events_ref,
+                        "normalizedEventsRef": row.normalized_events_ref,
+                        "initialSnapshotRef": row.initial_snapshot_ref,
+                        "finalSnapshotRef": row.final_snapshot_ref,
+                        "captureManifestRef": row.capture_manifest_ref,
+                        "diagnosticsRef": row.diagnostics_ref,
+                        "externalStateRef": row.external_state_ref,
+                        "recordedAt": datetime.now(tz=UTC).isoformat(),
+                    }
+                    if cleanup_complete and isinstance(cleanup_authority, dict):
+                        # The terminal lifecycle event is the objective handoff
+                        # proving that the old endpoint no longer exists and its
+                        # provider capacity was released. Preserve only compact
+                        # artifact/identity refs for history, then require the
+                        # replacement host to bind fresh live authority.
+                        prior_attempt["egressCleanupAuthority"] = {
+                            key: cleanup_authority.get(key)
+                            for key in (
+                                "hostLeaseRef",
+                                "effectiveLaunchRef",
+                                "launchEvidenceRef",
+                                "phase",
+                            )
+                        }
+                        reset_metadata.pop(EGRESS_CLEANUP_AUTHORITY_KEY, None)
+                    prior_attempts.append(prior_attempt)
                     reset_metadata["unpostedAttemptHistory"] = prior_attempts[-10:]
                     reset_metadata.pop("initialRetrieval", None)
                     row.metadata_ = reset_metadata

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -869,10 +869,17 @@ class OmnigentBridgeSessionStore:
                         if isinstance(terminal_event, dict)
                         else None
                     )
+                    terminal_refs = dict(row.terminal_refs or {})
                     cleanup_complete = bool(
-                        isinstance(terminal_metadata, dict)
-                        and terminal_metadata.get("cleanupCompleted") is True
-                        and terminal_metadata.get("leaseReleased") is True
+                        (
+                            isinstance(terminal_metadata, dict)
+                            and terminal_metadata.get("cleanupCompleted") is True
+                            and terminal_metadata.get("leaseReleased") is True
+                        )
+                        or (
+                            terminal_refs.get("cleanupState") == "completed"
+                            and terminal_refs.get("leaseReleaseState") == "released"
+                        )
                     )
                     cleanup_authority = reset_metadata.get(EGRESS_CLEANUP_AUTHORITY_KEY)
                     prior_attempts = list(
@@ -891,11 +898,11 @@ class OmnigentBridgeSessionStore:
                         "recordedAt": datetime.now(tz=UTC).isoformat(),
                     }
                     if cleanup_complete and isinstance(cleanup_authority, dict):
-                        # The terminal lifecycle event is the objective handoff
-                        # proving that the old endpoint no longer exists and its
-                        # provider capacity was released. Preserve only compact
-                        # artifact/identity refs for history, then require the
-                        # replacement host to bind fresh live authority.
+                        # The terminal lifecycle event or host-scoped janitor
+                        # result is the objective handoff proving that the old
+                        # endpoint no longer exists and provider capacity was
+                        # released. Preserve only compact artifact/identity refs
+                        # for history, then require fresh live authority.
                         prior_attempt["egressCleanupAuthority"] = {
                             key: cleanup_authority.get(key)
                             for key in (

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -187,6 +187,8 @@ _MAX_RESTORE_TOTAL_BYTES = 256 * 1024 * 1024
 # keep the wait bounded but large enough for that authoritative online edge.
 _HOST_REGISTRATION_ATTEMPTS = 91
 _HOST_REGISTRATION_INTERVAL_SECONDS = 2
+_HOST_EXEC_PREFLIGHT_ATTEMPTS = 11
+_HOST_EXEC_PREFLIGHT_INTERVAL_SECONDS = 1
 _DEFAULT_PUBLISH_GIT_USER_NAME = "MoonMind Worker"
 _DEFAULT_PUBLISH_GIT_USER_EMAIL = "moonmind-worker@users.noreply.github.com"
 # Restore payloads are read through the durable artifact contract as raw bytes,
@@ -3435,18 +3437,37 @@ class OmnigentOAuthHostRuntime:
         )
 
     async def _exec_check(self, container_name: str) -> None:
-        await self._run(
-            "docker", "exec", container_name, "/opt/moonmind/check-runner-projections.sh"
-        )
-        await self._run(
-            "docker",
-            "exec",
-            container_name,
-            "git",
-            "-C",
-            "/workspaces/run",
-            "status",
-            "--porcelain",
+        # ``docker run -d`` returns before the container is guaranteed to
+        # accept ``docker exec``. Keep this readiness check local to the live
+        # container so a short startup race does not tear down an otherwise
+        # valid host and consume the activity-level retry budget.
+        for attempt in range(_HOST_EXEC_PREFLIGHT_ATTEMPTS):
+            projections = await self._run(
+                "docker",
+                "exec",
+                container_name,
+                "/opt/moonmind/check-runner-projections.sh",
+                check=False,
+            )
+            if projections[0] == 0:
+                workspace = await self._run(
+                    "docker",
+                    "exec",
+                    container_name,
+                    "git",
+                    "-C",
+                    "/workspaces/run",
+                    "status",
+                    "--porcelain",
+                    check=False,
+                )
+                if workspace[0] == 0:
+                    return
+            if attempt + 1 < _HOST_EXEC_PREFLIGHT_ATTEMPTS:
+                await asyncio.sleep(_HOST_EXEC_PREFLIGHT_INTERVAL_SECONDS)
+        raise OmnigentOAuthHostError(
+            "OAuth host runtime command failed",
+            code=HostPreflightFailure.LOGIN_STATUS_FAILED.value,
         )
 
     async def _resolve_exact_host(

--- a/tests/integration/reliability/replays/omnigent-cleanup-authority-retry/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-cleanup-authority-retry/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "preflightAttemptCount": 3,
+  "preflightSleepCount": 2,
+  "reopenedStatus": "declared",
+  "archivedAuthorityPhase": "attested",
+  "activeEndpointIdentity": "b63dfa7b7f0c58c88b837991666991983455b75bb1320fc2b14f85392dbf91d7"
+}

--- a/tests/integration/reliability/replays/omnigent-cleanup-authority-retry/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-cleanup-authority-retry/manifest.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "escaped-failure-replay/v1",
+  "incidentWorkflowId": "mm:4e1c43a5-650f-4ec8-bc6b-b53ed427c770",
+  "childWorkflowId": "mm:4e1c43a5-650f-4ec8-bc6b-b53ed427c770:agent:node-1",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "failureCode": "CODEX_OAUTH_LOGIN_STATUS_FAILED",
+  "retryFailure": "live host identity changed from durable cleanup authority",
+  "failureShape": "docker exec raced on-demand host readiness; after successful cleanup, the Temporal retry reopened the unposted bridge while retaining the stopped host endpoint as live cleanup authority",
+  "idempotencyKey": "replay-cleanup-authority-retry",
+  "firstEndpointIdentity": "4bdad87bfcdfbfb790a0cd5a48cff5cd89364b53e2b8e3a7f9dbce5fb401d9bd",
+  "replacementEndpointIdentity": "b63dfa7b7f0c58c88b837991666991983455b75bb1320fc2b14f85392dbf91d7"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -2812,6 +2812,136 @@ async def test_unposted_terminal_bridge_reopens_for_temporal_activity_retry(
     ]
 
 
+async def test_cleaned_up_host_retry_rebinds_fresh_endpoint_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:4e1c43a5 at host readiness and cleanup-authority handoffs."""
+
+    replay_id = "omnigent-cleanup-authority-retry"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime._run = AsyncMock(
+        side_effect=[
+            (1, "", "container is not running"),
+            (1, "", "container is restarting"),
+            (0, "", ""),
+            (0, "", ""),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(oauth_host_runtime_module.asyncio, "sleep", sleep)
+
+    await runtime._exec_check("mm-host-replay")
+
+    assert runtime._run.await_count == expected["preflightAttemptCount"] + 1
+    assert sleep.await_count == expected["preflightSleepCount"]
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    store = OmnigentBridgeSessionStore(sessions)
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey=manifest["idempotencyKey"],
+    )
+    policy_authority = {
+        "policyId": "codex-static",
+        "policyVersion": 1,
+        "policyRef": "codex-static@1",
+        "policyDigest": "sha256:" + "1" * 64,
+        "snapshotRef": "policy:sha256:" + "2" * 64,
+        "validation": {"valid": True},
+    }
+    launch = {
+        "snapshotRef": "omnigent-launch:sha256:" + "3" * 64,
+        "launchPolicyRef": "codex-static@1",
+        "policyAuthority": policy_authority,
+        "enforcedEgress": True,
+    }
+    try:
+        await store.bind_profile_authorization(
+            request=request,
+            endpoint_ref="embedded",
+            provider_profile_id="profile-replay",
+            provider_lease_id="provider-lease-1",
+            credential_generation=1,
+            host_binding_ref="binding-replay",
+            host_lease_ref="host-lease-replay",
+            omnigent_host_id="host-1",
+            effective_launch_snapshot=launch,
+        )
+        await store.bind_egress_cleanup_authority(
+            request=request,
+            host_lease_ref="host-lease-replay",
+            egress_evidence={
+                "attachmentIdentity": "host-container-replay",
+                "endpointIdentity": manifest["firstEndpointIdentity"],
+                "validationResult": "passed",
+            },
+            launch_evidence_ref="artifact://launch-1",
+        )
+        await store.record_lifecycle_event(
+            request.idempotency_key,
+            event_type="terminal",
+            status="failed",
+            metadata={"cleanupCompleted": True, "leaseReleased": True},
+        )
+
+        reopened = await store.get_or_create(
+            request=request,
+            endpoint_ref="embedded",
+            agent_id=None,
+            agent_name=None,
+            target_metadata={},
+        )
+        await store.bind_profile_authorization(
+            request=request,
+            endpoint_ref="embedded",
+            provider_profile_id="profile-replay",
+            provider_lease_id="provider-lease-1",
+            credential_generation=1,
+            host_binding_ref="binding-replay",
+            host_lease_ref="host-lease-replay",
+            omnigent_host_id="host-2",
+            effective_launch_snapshot=launch,
+        )
+        await store.bind_egress_cleanup_authority(
+            request=request,
+            host_lease_ref="host-lease-replay",
+            egress_evidence={
+                "attachmentIdentity": "host-container-replay",
+                "endpointIdentity": manifest["replacementEndpointIdentity"],
+                "validationResult": "passed",
+            },
+            launch_evidence_ref="artifact://launch-2",
+        )
+        active = await store.get_egress_cleanup_authority(
+            host_lease_ref="host-lease-replay"
+        )
+    finally:
+        await engine.dispose()
+
+    assert reopened.status == expected["reopenedStatus"]
+    archived = reopened.metadata_["unpostedAttemptHistory"][-1]
+    assert archived["egressCleanupAuthority"]["phase"] == expected[
+        "archivedAuthorityPhase"
+    ]
+    assert active is not None
+    assert active["egressEvidence"]["endpointIdentity"] == expected[
+        "activeEndpointIdentity"
+    ]
+
+
 async def test_abandoned_omnigent_host_cleanup_releases_provider_capacity() -> None:
     """Replay mm:651a14f6 after cancellation killed its coordinator Activity."""
 

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -108,6 +108,169 @@ def _request(idempotency_key: str = "idem-1", *, with_step: bool = False):
     )
 
 
+def _effective_launch() -> dict:
+    return {
+        "snapshotRef": "omnigent-launch:sha256:" + "3" * 64,
+        "launchPolicyRef": "codex-static@1",
+        "policyAuthority": {
+            "policyId": "codex-static",
+            "policyVersion": 1,
+            "policyRef": "codex-static@1",
+            "policyDigest": "sha256:" + "1" * 64,
+            "snapshotRef": "policy:sha256:" + "2" * 64,
+            "validation": {"valid": True},
+        },
+        "enforcedEgress": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stopped_lease_retry_retires_and_rebinds_cleanup_authority(
+    store,
+) -> None:
+    request = _request("stopped-lease-retry")
+    launch = _effective_launch()
+    await store.bind_profile_authorization(
+        request=request,
+        endpoint_ref="embedded",
+        provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
+        credential_generation=4,
+        host_binding_ref="binding-1",
+        host_lease_ref="lease-1",
+        omnigent_host_id="host-1",
+        effective_launch_snapshot=launch,
+    )
+    await store.bind_egress_cleanup_authority(
+        request=request,
+        host_lease_ref="lease-1",
+        egress_evidence={
+            "attachmentIdentity": "host-container-1",
+            "endpointIdentity": "endpoint-1",
+            "validationResult": "passed",
+        },
+        launch_evidence_ref="artifact://launch-egress-1",
+    )
+    await store.record_lifecycle_event(
+        request.idempotency_key,
+        event_type="terminal",
+        status="failed",
+        metadata={"cleanupCompleted": True, "leaseReleased": True},
+    )
+
+    reopened = await store.get_or_create(
+        request=request,
+        endpoint_ref="embedded",
+        agent_id=None,
+        agent_name=None,
+        target_metadata={},
+    )
+
+    assert reopened.status == STATUS_DECLARED
+    history = reopened.metadata_["unpostedAttemptHistory"][-1]
+    assert history["egressCleanupAuthority"] == {
+        "hostLeaseRef": "lease-1",
+        "effectiveLaunchRef": launch["snapshotRef"],
+        "launchEvidenceRef": "artifact://launch-egress-1",
+        "phase": "attested",
+    }
+
+    await store.bind_profile_authorization(
+        request=request,
+        endpoint_ref="embedded",
+        provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
+        credential_generation=4,
+        host_binding_ref="binding-1",
+        host_lease_ref="lease-1",
+        omnigent_host_id="host-2",
+        effective_launch_snapshot=launch,
+    )
+    assert await store.get_egress_cleanup_authority(host_lease_ref="lease-1") is None
+
+    await store.bind_egress_cleanup_authority(
+        request=request,
+        host_lease_ref="lease-1",
+        egress_evidence={
+            "attachmentIdentity": "host-container-2",
+            "endpointIdentity": "endpoint-2",
+            "validationResult": "passed",
+        },
+        launch_evidence_ref="artifact://launch-egress-2",
+    )
+    rebound = await store.get_egress_cleanup_authority(host_lease_ref="lease-1")
+    assert rebound is not None
+    assert rebound["egressEvidence"]["endpointIdentity"] == "endpoint-2"
+
+
+@pytest.mark.asyncio
+async def test_unposted_retry_preserves_live_cleanup_authority_without_cleanup_proof(
+    store,
+) -> None:
+    request = _request("ambiguous-cleanup-retry")
+    launch = _effective_launch()
+    await store.bind_profile_authorization(
+        request=request,
+        endpoint_ref="embedded",
+        provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
+        credential_generation=4,
+        host_binding_ref="binding-1",
+        host_lease_ref="lease-1",
+        omnigent_host_id="host-1",
+        effective_launch_snapshot=launch,
+    )
+    await store.bind_egress_cleanup_authority(
+        request=request,
+        host_lease_ref="lease-1",
+        egress_evidence={
+            "attachmentIdentity": "host-container-1",
+            "endpointIdentity": "endpoint-1",
+            "validationResult": "passed",
+        },
+        launch_evidence_ref="artifact://launch-egress-1",
+    )
+    await store.record_lifecycle_event(
+        request.idempotency_key,
+        event_type="terminal",
+        status="failed",
+        metadata={"cleanupCompleted": False, "leaseReleased": False},
+    )
+    await store.get_or_create(
+        request=request,
+        endpoint_ref="embedded",
+        agent_id=None,
+        agent_name=None,
+        target_metadata={},
+    )
+    await store.bind_profile_authorization(
+        request=request,
+        endpoint_ref="embedded",
+        provider_profile_id="profile-1",
+        provider_lease_id="provider-lease-1",
+        credential_generation=4,
+        host_binding_ref="binding-1",
+        host_lease_ref="lease-1",
+        omnigent_host_id="host-2",
+        effective_launch_snapshot=launch,
+    )
+
+    authority = await store.get_egress_cleanup_authority(host_lease_ref="lease-1")
+    assert authority is not None
+    assert authority["egressEvidence"]["endpointIdentity"] == "endpoint-1"
+    with pytest.raises(OmnigentIdempotencyError):
+        await store.bind_egress_cleanup_authority(
+            request=request,
+            host_lease_ref="lease-1",
+            egress_evidence={
+                "attachmentIdentity": "host-container-2",
+                "endpointIdentity": "endpoint-2",
+                "validationResult": "passed",
+            },
+            launch_evidence_ref="artifact://launch-egress-2",
+        )
+
+
 @pytest.mark.asyncio
 async def test_egress_cleanup_authority_round_trips_and_terminal_refs_persist(
     store,

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -155,7 +155,14 @@ async def test_stopped_lease_retry_retires_and_rebinds_cleanup_authority(
         request.idempotency_key,
         event_type="terminal",
         status="failed",
-        metadata={"cleanupCompleted": True, "leaseReleased": True},
+        metadata={"cleanupCompleted": False, "leaseReleased": False},
+    )
+    await store.record_terminal_cleanup(
+        host_lease_ref="lease-1",
+        completed=True,
+        egress_evidence_ref="artifact://terminal-egress-1",
+        launch_evidence_ref="artifact://launch-egress-1",
+        lease_released=True,
     )
 
     reopened = await store.get_or_create(

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -2242,24 +2242,62 @@ async def test_host_preflight_rejects_git_workspace_ownership_mismatch(tmp_path)
 
     await runtime._exec_check("mm-host-lease-1")
 
-    assert [call.args for call in runtime._run.await_args_list] == [
+    assert [
+        (call.args, call.kwargs) for call in runtime._run.await_args_list
+    ] == [
         (
-            "docker",
-            "exec",
-            "mm-host-lease-1",
-            "/opt/moonmind/check-runner-projections.sh",
+            (
+                "docker",
+                "exec",
+                "mm-host-lease-1",
+                "/opt/moonmind/check-runner-projections.sh",
+            ),
+            {"check": False},
         ),
         (
-            "docker",
-            "exec",
-            "mm-host-lease-1",
-            "git",
-            "-C",
-            "/workspaces/run",
-            "status",
-            "--porcelain",
+            (
+                "docker",
+                "exec",
+                "mm-host-lease-1",
+                "git",
+                "-C",
+                "/workspaces/run",
+                "status",
+                "--porcelain",
+            ),
+            {"check": False},
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_host_preflight_waits_for_container_exec_readiness(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+    runtime._run = AsyncMock(
+        side_effect=[
+            (1, "", "container is not running"),
+            (1, "", "container is restarting"),
+            (0, "", ""),
+            (0, "", ""),
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime.asyncio.sleep",
+        sleep,
+    )
+
+    await runtime._exec_check("mm-host-lease-1")
+
+    assert runtime._run.await_count == 4
+    assert sleep.await_count == 2
 
 
 def test_github_write_probe_uses_publish_or_skill_side_effect() -> None:


### PR DESCRIPTION
## Summary

- retry on-demand host preflight while Docker is still making the container exec-ready
- retire stopped-host cleanup authority only after terminal cleanup and lease release are durably proven
- preserve fail-closed behavior when cleanup is incomplete or ambiguous
- add unit coverage and an escaped-production replay for workflow `mm:4e1c43a5-650f-4ec8-bc6b-b53ed427c770`

## Root cause

The first activity attempt raced `docker exec` against container startup. Cleanup then correctly removed the host, but the reopened bridge retained the stopped endpoint as live cleanup authority. The Temporal retry created a fresh Docker endpoint and incorrectly rejected that expected identity change.

## Impact

Transient host startup races no longer consume the activity-level retry immediately. A retry after proven cleanup can bind the replacement endpoint, while unexplained live identity changes continue to fail closed.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/omnigent/test_bridge_store.py tests/unit/omnigent/test_oauth_profile_lifecycle.py` (250 passed)
- escaped-failure replay `test_cleaned_up_host_retry_rebinds_fresh_endpoint_authority` (passed)
- Ruff and `git diff --check` (passed)
- restarted the bind-mounted agent-runtime worker and confirmed it is healthy and polling `mm.activity.agent_runtime`