### PR TITLE
Fix Omnigent MoonMind environment handoff

### DIFF
--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -167,6 +167,24 @@ _RUNNER_GITHUB_ENV_NAMES = (
     "GH_NO_UPDATE_NOTIFIER",
     "GH_NO_EXTENSION_UPDATE_NOTIFIER",
 )
+# Omnigent deliberately filters the environment again when its runner launches
+# a provider harness.  Codex tool shells are login shells, so this exact
+# non-secret subset is also materialized through the lease-owned profile under
+# ``/etc/profile.d``.  Keep credential-bearing values (notably the scoped
+# container-job bearer) out of the generated file.
+_RUNTIME_EXECUTION_PROFILE_ENV_NAMES = (
+    "MOONMIND_URL",
+    "MOONMIND_AGENT_RUN_ID",
+    "MOONMIND_TASK_WORKFLOW_ID",
+    "MOONMIND_STEP_ID",
+    "MOONMIND_RUNTIME_ID",
+    "MOONMIND_CONTAINER_JOBS_MCP_URL",
+    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
+    "MOONMIND_CONTAINER_JOBS_SESSION_ID",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH",
+)
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
@@ -456,6 +474,7 @@ class OmnigentOAuthHostRuntime:
             daemon_runtime_scripts = self._prepare_daemon_runtime_scripts(
                 workspace_key,
                 current_step_execution_id=current_step_execution_id,
+                runtime_environment=container_job_environment,
                 daemon_workspace_root=daemon_workspace_root,
             )
             if "gh" in {item.strip().lower() for item in required_capabilities}:
@@ -1596,6 +1615,7 @@ class OmnigentOAuthHostRuntime:
         workspace_key: str,
         *,
         current_step_execution_id: str,
+        runtime_environment: Mapping[str, str] | None = None,
     ) -> Path:
         """Snapshot MoonMind host scripts under the daemon-mapped run root."""
 
@@ -1628,9 +1648,31 @@ class OmnigentOAuthHostRuntime:
                 "Omnigent step execution identity is missing or unsafe",
                 code="OMNIGENT_STEP_EXECUTION_ID_INVALID",
             )
+        profile_environment = {
+            "MOONMIND_STEP_EXECUTION_ID": execution_id,
+            "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
+        }
+        supplied_environment = dict(runtime_environment or {})
+        for name in _RUNTIME_EXECUTION_PROFILE_ENV_NAMES:
+            value = str(supplied_environment.get(name) or "").strip()
+            if value:
+                profile_environment[name] = value
+        for value in profile_environment.values():
+            if any(character in value for character in ("\0", "\r", "\n")):
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime execution profile contains an unsafe value",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                )
+
+        def shell_single_quote(value: str) -> str:
+            return "'" + value.replace("'", "'\"'\"'") + "'"
+
         execution_profile_payload = (
             "# Generated for one MoonMind-owned Omnigent host lease.\n"
-            f"export MOONMIND_STEP_EXECUTION_ID='{execution_id}'\n"
+            + "".join(
+                f"export {name}={shell_single_quote(value)}\n"
+                for name, value in profile_environment.items()
+            )
         )
 
         digest = hashlib.sha256(workspace_key.encode("utf-8")).hexdigest()[:24]
@@ -1698,12 +1740,14 @@ class OmnigentOAuthHostRuntime:
         workspace_key: str,
         *,
         current_step_execution_id: str,
+        runtime_environment: Mapping[str, str] | None = None,
         daemon_workspace_root: Path | str | None = None,
     ) -> Path:
         return daemon_visible_workspace_path(
             self._prepare_runtime_scripts(
                 workspace_key,
                 current_step_execution_id=current_step_execution_id,
+                runtime_environment=runtime_environment,
             ),
             daemon_root=daemon_workspace_root,
         )

--- a/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/expected-outcome.json
@@ -1,0 +1,19 @@
+{
+  "invariant": "the lease-owned Codex tool-shell profile restores non-secret MoonMind API and execution identity after Omnigent harness filtering without persisting scoped bearer credentials",
+  "toolShellEnvironmentNames": [
+    "MOONMIND_STEP_EXECUTION_ID",
+    "MOONMIND_ACTIVE_SKILLS_DIR",
+    "MOONMIND_URL",
+    "MOONMIND_AGENT_RUN_ID",
+    "MOONMIND_TASK_WORKFLOW_ID",
+    "MOONMIND_STEP_ID",
+    "MOONMIND_RUNTIME_ID",
+    "MOONMIND_CONTAINER_JOBS_MCP_URL",
+    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
+    "MOONMIND_CONTAINER_JOBS_SESSION_ID",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH"
+  ],
+  "excludedSecretName": "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"
+}

--- a/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/manifest.json
@@ -1,0 +1,13 @@
+{
+  "incidentWorkflowId": "mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0-2026-08-17T17:24:13Z",
+  "stepExecutionId": "mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0:node-1:execution:4",
+  "moonmindUrl": "http://api:8000",
+  "workspaceLocator": {
+    "kind": "sandbox",
+    "workspaceId": "3ed3af7e63985a76afeae4ab",
+    "relativePath": "repo"
+  },
+  "terminalFailureCode": "CHILD_WORKFLOW_QUEUE_FAILED",
+  "failureShape": "the on-demand host and Omnigent runner received MoonMind execution variables, but the Codex harness filtered them before the skill helper ran; all matched child workflow submissions failed because MOONMIND_URL was missing",
+  "boundary": "MoonMind on-demand host to Omnigent runner to Codex tool login shell"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -26,6 +26,7 @@ from api_service.services.omnigent_policies import (
     bootstrap_document,
     seed_bootstrap_policies,
 )
+from moonmind.config.settings import settings
 from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
 from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
 from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
@@ -3321,6 +3322,56 @@ async def test_omnigent_on_demand_runner_inherits_enforced_proxy_environment(
         if value.startswith("OMNIGENT_RUNNER_ENV_PASSTHROUGH=")
     )
     assert passthrough.split(",") == expected["passthroughNames"]
+
+
+async def test_omnigent_codex_tool_shell_receives_moonmind_execution_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:2d8480da at the Omnigent runner-to-Codex shell boundary."""
+
+    replay_id = "omnigent-codex-moonmind-env-handoff"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setenv("MOONMIND_URL", manifest["moonmindUrl"])
+    monkeypatch.setattr(
+        settings.security,
+        "JWT_SECRET_KEY",
+        "replay-container-capability-key",
+    )
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=REPO_ROOT / "services" / "omnigent" / "scripts",
+        workspace_root=tmp_path,
+    )
+    runtime_environment = runtime._container_job_environment(
+        binding=_oauth_binding().model_copy(
+            update={
+                "static_host_id": None,
+                "host_launch_profile_ref": "codex-oauth-v1",
+            }
+        ),
+        host_lease=_oauth_host_lease(),
+        workspace_locator=manifest["workspaceLocator"],
+        current_workflow_id=manifest["incidentWorkflowId"],
+        current_step_execution_id=manifest["stepExecutionId"],
+        timeout_seconds=3600,
+    )
+    runtime_scripts = runtime._prepare_runtime_scripts(
+        manifest["incidentWorkflowId"],
+        current_step_execution_id=manifest["stepExecutionId"],
+        runtime_environment=runtime_environment,
+    )
+    profile = (runtime_scripts / "moonmind-execution.sh").read_text(
+        encoding="utf-8"
+    )
+
+    for name in expected["toolShellEnvironmentNames"]:
+        assert f"export {name}=" in profile
+    assert f"'{manifest['moonmindUrl']}'" in profile
+    assert f"'{manifest['incidentWorkflowId']}'" in profile
+    assert expected["excludedSecretName"] not in profile
+    assert runtime_environment[expected["excludedSecretName"]] not in profile
 
 
 async def test_omnigent_codex_remote_bridge_has_loopback_only_proxy_bypass() -> None:

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1066,12 +1066,28 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
     target = runtime._prepare_runtime_scripts(
         "workspace-key",
         current_step_execution_id=execution_id,
+        runtime_environment={
+            "MOONMIND_URL": "http://api:8000",
+            "MOONMIND_AGENT_RUN_ID": execution_id,
+            "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+            "MOONMIND_RUNTIME_ID": "codex_cli",
+            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "must-not-be-persisted",
+        },
     )
 
     profile = target / "moonmind-execution.sh"
     assert profile.read_text(encoding="utf-8") == (
         "# Generated for one MoonMind-owned Omnigent host lease.\n"
         f"export MOONMIND_STEP_EXECUTION_ID='{execution_id}'\n"
+        "export MOONMIND_ACTIVE_SKILLS_DIR='/opt/moonmind-skills'\n"
+        "export MOONMIND_URL='http://api:8000'\n"
+        f"export MOONMIND_AGENT_RUN_ID='{execution_id}'\n"
+        "export MOONMIND_TASK_WORKFLOW_ID='workflow-1'\n"
+        "export MOONMIND_RUNTIME_ID='codex_cli'\n"
+    )
+    assert "must-not-be-persisted" not in profile.read_text(encoding="utf-8")
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in profile.read_text(
+        encoding="utf-8"
     )
     assert profile.stat().st_mode & 0o777 == 0o444
     with pytest.raises(OmnigentOAuthHostError) as mismatch:
@@ -1391,6 +1407,15 @@ async def test_prepare_host_retry_preserves_manifest_at_docker_mount_seam(
     assert cleanup_authority_store.bind_calls[1]["launch_evidence_ref"] == first[
         "egressEvidenceRef"
     ]
+    runtime_profile_environment = (
+        runtime._prepare_daemon_runtime_scripts.call_args.kwargs[
+            "runtime_environment"
+        ]
+    )
+    assert runtime_profile_environment["MOONMIND_URL"] == "http://api:8000"
+    assert runtime_profile_environment["MOONMIND_TASK_WORKFLOW_ID"] == "workflow-1"
+    assert runtime_profile_environment["MOONMIND_AGENT_RUN_ID"] == "step-1"
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" in runtime_profile_environment
     assert state["launches"] == 1
     assert state["manifest_checks"] == 2
 


### PR DESCRIPTION
## Summary

- restore the non-secret MoonMind API and execution environment through the lease-owned Codex login profile after Omnigent harness filtering
- keep the scoped container-job bearer ephemeral instead of persisting it in `/etc/profile.d`
- add unit coverage plus an escaped-failure replay for workflow `mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0-2026-08-17T17:24:13Z`

## Root cause

All four child attempts ran to a durable terminal artifact, but each Dependabot child-workflow submission failed because the skill process could not see `MOONMIND_URL`. MoonMind supplied the environment to the on-demand host and Omnigent runner, then Omnigent's Codex harness rebuilt a filtered environment. The stock Codex agent did not declare these names for passthrough, while MoonMind's mounted login profile restored only the step-execution ID.

The adapter now writes the exact non-secret execution subset into that immutable per-lease profile. This preserves the portable skill contract without duplicating skill semantics or modifying the upstream Omnigent bundle.

## Validation

- `170 passed`: full Omnigent OAuth profile lifecycle unit file plus the incident replay
- `103 passed`: selector-equivalent `reliability_journey` suite
- repository impact selector: `unit_fast=true`, `reliability_journey=true`, `integration_ci=false`
- staged diff and replay JSON validation passed
