### PR TITLE
Classify expired Claude OAuth sessions

### DIFF
--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -80,6 +80,7 @@ _AUTH_FAILURE_MARKERS = (
     "invalid token",
     "expired token",
     "access token could not be refreshed",
+    "oauth session expired",
     "authentication failed",
     "not logged in",
     "please run /login",

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -360,6 +360,42 @@ async def test_supervise_classifies_claude_not_logged_in_as_auth_failure(
         "Provider authentication required; reauthenticate the selected provider profile"
     )
 
+
+@pytest.mark.asyncio
+async def test_supervise_classifies_claude_expired_oauth_session_as_auth_failure(
+    tmp_path: Path,
+) -> None:
+    """Replay the escaped Claude OAuth failure as an actionable auth error."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+    run_id = "run-claude-expired-oauth"
+    _save_record(store, run_id, runtime_id="claude_code")
+
+    process = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        (
+            "print('Failed to authenticate: OAuth session expired and could not be "
+            "refreshed'); raise SystemExit(1)"
+        ),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    result = await supervisor.supervise(
+        run_id=run_id,
+        process=process,
+        timeout_seconds=10,
+    )
+
+    assert result.status == "failed"
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.error_message == (
+        "Provider authentication required; reauthenticate the selected provider profile"
+    )
+
+
 @pytest.mark.asyncio
 async def test_supervise_allows_successful_claude_output_with_auth_text(
     tmp_path: Path,

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -74,6 +74,7 @@ def test_provider_failure_search_markers_cover_classification_markers() -> None:
         "usage_limit_reached",
         "hit your weekly limit",
         "http 401",
+        "oauth session expired",
         "http 403",
         "insufficient scope",
     ):
@@ -120,6 +121,17 @@ def test_classifies_http_401_as_auth_user_error() -> None:
 
 def test_classifies_claude_not_logged_in_as_auth_user_error() -> None:
     result = classify_provider_failure("Not logged in. Please run /login")
+
+    assert result is not None
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
+
+
+def test_classifies_claude_expired_oauth_session_as_auth_user_error() -> None:
+    result = classify_provider_failure(
+        "Failed to authenticate: OAuth session expired and could not be refreshed"
+    )
 
     assert result is not None
     assert result.failure_class == "user_error"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Classify Claude Code's `OAuth session expired` process output as a provider authentication failure instead of a generic execution error.
- Preserve the existing canonical `user_error` / `401` handling so operators receive an actionable reauthentication message.
- Add classifier and managed-runtime supervisor regression coverage using the escaped production wording.

ELI5: Claude said its saved login had expired, but MoonMind did not recognize that exact sentence. This change teaches the shared classifier that wording so the failure points operators to reconnect the selected profile.

## Test Plan

```bash
./tools/test_unit.sh --python-only tests/unit/workflows/test_provider_failures.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py
TZ=UTC npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx -t 'preserves canonical Omnigent refs in once schedule submissions'
```

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Codex
- What the AI helped with: Temporal and artifact diagnosis, implementation, regression tests, and PR preparation.
- What I manually reviewed: The focused diff, exact classifier behavior, and managed supervisor result contract.
- What I verified independently: The escaped message now produces `user_error`, provider code `401`, and the reauthentication summary in the managed-runtime boundary test.

I understand that I am responsible for the final submitted change.

## Risk notes

This changes provider-auth text classification only. It does not alter credentials, profile selection, billing-relevant values, cooldown policy, retry authority, or Temporal payload shapes. An expired OAuth session still fails closed and requires the operator to reconnect the selected profile.

## Coverage notes

Temporal history, the completed child result, and managed runtime stdout/diagnostics were inspected to confirm that the worker and workflow scheduling were healthy and that the exact Claude OAuth wording was the unclassified signal.

## Changelog

Claude Code OAuth expiry failures now surface as actionable reauthentication errors.
