### PR TITLE
Add Omnigent semantic telemetry, operator session timeline, and stuck-state reconciliation (MoonLadderStudios/MoonMind#3708)

### DIFF
--- a/api_service/api/routers/omnigent_session_timeline.py
+++ b/api_service/api/routers/omnigent_session_timeline.py
@@ -1,0 +1,170 @@
+"""Authorized operator session-timeline diagnostic API.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+Exposes one authorized, machine-readable diagnostic projection for a single
+canonical Omnigent session, derived entirely from durable control-plane records
+(canonical session, turn attempts, observations, commands, decisions, and
+cleanup authority). The endpoint is a **projection, not a second lifecycle
+authority**: it only reads durable records, so it keeps explaining a session
+after its live provider/host/workspace resources are cleaned up.
+
+Access requires the ``operations.read`` operator permission. Every emitted field
+is bounded and secret-free (see
+:mod:`moonmind.omnigent.control_plane.timeline`): no provider credential,
+internal token, raw host path, or unbounded payload is ever surfaced.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
+from api_service.db.models import User
+from api_service.services.settings_catalog import has_settings_permission
+from moonmind.omnigent.control_plane.repositories import ControlPlaneRepositories
+from moonmind.omnigent.control_plane.stuck_state import (
+    SessionSignals,
+    detect_stuck_state,
+    plan_response,
+)
+from moonmind.omnigent.control_plane.timeline import build_timeline
+
+router = APIRouter(prefix="/api/omnigent/sessions", tags=["Omnigent Session Timeline"])
+
+_DIAGNOSTIC_PERMISSION = "operations.read"
+
+
+def _require_diagnostic_read(user: User) -> None:
+    if not has_settings_permission(user, _DIAGNOSTIC_PERMISSION):
+        raise HTTPException(
+            403,
+            f"Missing required operator permission: {_DIAGNOSTIC_PERMISSION}.",
+        )
+
+
+def _signals_from_records(session, observations, commands) -> SessionSignals:
+    """Derive bounded stuck-state signals from durable records only.
+
+    Provider/host/lease flags stay ``None`` (not observed) because durable
+    records alone are not an independent provider observation — the detector must
+    not treat an absent observation as an observed negative.
+    """
+
+    last_event_at = None
+    last_snapshot_at = None
+    for observation in observations:
+        if observation.observation_type in {"event", "event_frontier", "event_batch"}:
+            if last_event_at is None or observation.observed_at > last_event_at:
+                last_event_at = observation.observed_at
+        if observation.observation_type in {"snapshot", "provider_snapshot"}:
+            if last_snapshot_at is None or observation.observed_at > last_snapshot_at:
+                last_snapshot_at = observation.observed_at
+
+    active_command = None
+    active_command_since = None
+    for command in commands:
+        if command.status in {"claimed", "delivery_unknown"}:
+            active_command = command
+            active_command_since = command.updated_at or command.created_at
+            if command.status == "delivery_unknown":
+                break
+
+    return SessionSignals(
+        last_event_at=last_event_at,
+        last_snapshot_at=last_snapshot_at,
+        active_command=active_command,
+        active_command_since=active_command_since,
+    )
+
+
+@router.get("/{session_id}/timeline")
+async def get_session_timeline(
+    session_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> dict:
+    """Return the machine-readable operator timeline for one canonical session."""
+
+    _require_diagnostic_read(user)
+    repos = ControlPlaneRepositories.bind(db)
+
+    session = await repos.sessions.get(session_id)
+    if session is None:
+        raise HTTPException(404, "Session not found")
+
+    turn_attempts = await repos.turn_attempts.list_for_session(session_id)
+    observations = await repos.observations.list_for_session(session_id)
+    commands = await repos.commands.list_for_session(session_id)
+    decisions = await repos.decisions.list_for_session(session_id)
+    cleanup = await repos.cleanup.get(session_id)
+
+    timeline = build_timeline(
+        session=session,
+        turn_attempts=turn_attempts,
+        observations=observations,
+        commands=commands,
+        decisions=decisions,
+        cleanup=cleanup,
+    )
+    return timeline.to_dict()
+
+
+@router.get("/{session_id}/stuck-state")
+async def get_session_stuck_state(
+    session_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_session),
+) -> dict:
+    """Return bounded stuck-state findings and the safe automated response.
+
+    Uses server time (``now``) via the control-plane clock; the response is a
+    fenced reconcile recommendation or a quarantine escalation. This endpoint
+    never mutates state — it surfaces the recommendation for the reconciliation
+    workflow and operators to act on.
+    """
+
+    _require_diagnostic_read(user)
+    repos = ControlPlaneRepositories.bind(db)
+
+    session = await repos.sessions.get(session_id)
+    if session is None:
+        raise HTTPException(404, "Session not found")
+
+    observations = await repos.observations.list_for_session(session_id)
+    commands = await repos.commands.list_for_session(session_id)
+
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    signals = _signals_from_records(session, observations, commands)
+    findings = detect_stuck_state(session=session, signals=signals, now=now)
+    response = plan_response(session=session, findings=findings)
+
+    return {
+        "sessionId": session_id,
+        "findings": [
+            {
+                "reason": f.reason.value,
+                "action": f.action.value,
+                "detail": f.detail,
+                "remediation": f.remediation,
+            }
+            for f in findings
+        ],
+        "response": None
+        if response is None
+        else {
+            "reconcile": response.reconcile,
+            "quarantine": response.quarantine,
+            "expectedRevision": response.expected_revision,
+            "expectedFencingGeneration": response.expected_fencing_generation,
+            "reasons": [r.value for r in response.reasons],
+            "remediation": response.remediation,
+        },
+    }
+
+
+__all__ = ["router"]

--- a/api_service/api/routers/omnigent_session_timeline.py
+++ b/api_service/api/routers/omnigent_session_timeline.py
@@ -24,6 +24,7 @@ from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from api_service.db.models import User
 from api_service.services.settings_catalog import has_settings_permission
+from moonmind.omnigent.control_plane.records import CLEANUP_STATE_CLAIMED
 from moonmind.omnigent.control_plane.repositories import ControlPlaneRepositories
 from moonmind.omnigent.control_plane.stuck_state import (
     SessionSignals,
@@ -36,6 +37,11 @@ router = APIRouter(prefix="/api/omnigent/sessions", tags=["Omnigent Session Time
 
 _DIAGNOSTIC_PERMISSION = "operations.read"
 
+#: Observation types classified as substantive provider events / snapshots (kept
+#: in sync with the timeline projection so both endpoints read the same signal).
+_EVENT_OBSERVATION_TYPES = ("event", "event_frontier", "event_batch")
+_SNAPSHOT_OBSERVATION_TYPES = ("snapshot", "provider_snapshot")
+
 
 def _require_diagnostic_read(user: User) -> None:
     if not has_settings_permission(user, _DIAGNOSTIC_PERMISSION):
@@ -45,38 +51,48 @@ def _require_diagnostic_read(user: User) -> None:
         )
 
 
-def _signals_from_records(session, observations, commands) -> SessionSignals:
-    """Derive bounded stuck-state signals from durable records only.
+def _signals_from_durable(
+    session,
+    *,
+    active_turn,
+    latest_event,
+    latest_snapshot,
+    active_command,
+    cleanup,
+) -> SessionSignals:
+    """Map the durable evidence required by the stuck-state detectors.
 
-    Provider/host/lease flags stay ``None`` (not observed) because durable
-    records alone are not an independent provider observation — the detector must
-    not treat an absent observation as an observed negative.
+    Every signal that a durable record can authoritatively express is derived:
+    freshness (latest event/snapshot), the active turn's durable start (so
+    absence is aged rather than tripping immediately), the active/ambiguous
+    command, cleanup progress, admission, and compatibility resolution.
+
+    Signals that would require an *independent provider observation* the read
+    boundary does not own (``provider_terminal``/``provider_active``) or a
+    cross-aggregate lease reconciliation (host/profile lease ownership) stay
+    ``None`` (not observed): the detector must never treat an absent observation
+    as an observed negative, and this endpoint must not fabricate one. Those are
+    stamped by the reconciler at its own boundary.
     """
 
-    last_event_at = None
-    last_snapshot_at = None
-    for observation in observations:
-        if observation.observation_type in {"event", "event_frontier", "event_batch"}:
-            if last_event_at is None or observation.observed_at > last_event_at:
-                last_event_at = observation.observed_at
-        if observation.observation_type in {"snapshot", "provider_snapshot"}:
-            if last_snapshot_at is None or observation.observed_at > last_snapshot_at:
-                last_snapshot_at = observation.observed_at
-
-    active_command = None
-    active_command_since = None
-    for command in commands:
-        if command.status in {"claimed", "delivery_unknown"}:
-            active_command = command
-            active_command_since = command.updated_at or command.created_at
-            if command.status == "delivery_unknown":
-                break
+    cleanup_started_at = None
+    if cleanup is not None and cleanup.state == CLEANUP_STATE_CLAIMED:
+        cleanup_started_at = cleanup.updated_at or cleanup.created_at
 
     return SessionSignals(
-        last_event_at=last_event_at,
-        last_snapshot_at=last_snapshot_at,
+        last_event_at=latest_event.observed_at if latest_event is not None else None,
+        last_snapshot_at=latest_snapshot.observed_at if latest_snapshot is not None else None,
+        active_turn_started_at=active_turn.created_at if active_turn is not None else None,
         active_command=active_command,
-        active_command_since=active_command_since,
+        active_command_since=(
+            (active_command.updated_at or active_command.created_at)
+            if active_command is not None
+            else None
+        ),
+        cleanup_started_at=cleanup_started_at,
+        # Admission and compatibility are durable session facts.
+        admitted=session.provider_session_ref is not None,
+        compatibility_known=True if session.compatibility_ref is not None else None,
     )
 
 
@@ -95,19 +111,32 @@ async def get_session_timeline(
     if session is None:
         raise HTTPException(404, "Session not found")
 
-    turn_attempts = await repos.turn_attempts.list_for_session(session_id)
-    observations = await repos.observations.list_for_session(session_id)
-    commands = await repos.commands.list_for_session(session_id)
-    decisions = await repos.decisions.list_for_session(session_id)
+    # Bounded latest/active queries plus a count, so an operator diagnostic never
+    # materializes the full append-only history of a long-running session.
+    active_turn = (
+        await repos.turn_attempts.get(session.active_turn_attempt_id)
+        if session.active_turn_attempt_id is not None
+        else None
+    )
+    turn_attempt_count = await repos.turn_attempts.count_for_session(session_id)
+    latest_snapshot = await repos.observations.latest_for_session(
+        session_id, observation_types=_SNAPSHOT_OBSERVATION_TYPES
+    )
+    latest_event = await repos.observations.latest_for_session(
+        session_id, observation_types=_EVENT_OBSERVATION_TYPES
+    )
+    active_command = await repos.commands.active_for_session(session_id)
+    latest_decision = await repos.decisions.latest_for_session(session_id)
     cleanup = await repos.cleanup.get(session_id)
 
     timeline = build_timeline(
         session=session,
-        turn_attempts=turn_attempts,
-        observations=observations,
-        commands=commands,
-        decisions=decisions,
+        turn_attempts=[active_turn] if active_turn is not None else (),
+        observations=[o for o in (latest_snapshot, latest_event) if o is not None],
+        commands=[active_command] if active_command is not None else (),
+        decisions=[latest_decision] if latest_decision is not None else (),
         cleanup=cleanup,
+        turn_attempt_count=turn_attempt_count,
     )
     return timeline.to_dict()
 
@@ -133,15 +162,50 @@ async def get_session_stuck_state(
     if session is None:
         raise HTTPException(404, "Session not found")
 
-    observations = await repos.observations.list_for_session(session_id)
-    commands = await repos.commands.list_for_session(session_id)
+    # Bounded latest/active queries only; the detectors need the freshest signal
+    # on each channel, not the full observation/command history.
+    active_turn = (
+        await repos.turn_attempts.get(session.active_turn_attempt_id)
+        if session.active_turn_attempt_id is not None
+        else None
+    )
+    latest_event = await repos.observations.latest_for_session(
+        session_id, observation_types=_EVENT_OBSERVATION_TYPES
+    )
+    latest_snapshot = await repos.observations.latest_for_session(
+        session_id, observation_types=_SNAPSHOT_OBSERVATION_TYPES
+    )
+    active_command = await repos.commands.active_for_session(session_id)
+    cleanup = await repos.cleanup.get(session_id)
 
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    signals = _signals_from_records(session, observations, commands)
+    signals = _signals_from_durable(
+        session,
+        active_turn=active_turn,
+        latest_event=latest_event,
+        latest_snapshot=latest_snapshot,
+        active_command=active_command,
+        cleanup=cleanup,
+    )
     findings = detect_stuck_state(session=session, signals=signals, now=now)
-    response = plan_response(session=session, findings=findings)
+
+    # Bounded reconciliation-to-quarantine policy: escalation is driven by the
+    # durable per-session/per-reason detection count. The decision journal is the
+    # persistence — count prior decisions recorded under the dominant finding's
+    # reason so repeated inspections of the same unresolved condition can reach
+    # persistent_ambiguity_max and quarantine instead of recommending reconcile
+    # forever.
+    prior_detection_count = 0
+    if findings:
+        dominant_reason = findings[0].reason.value
+        prior_detection_count = await repos.decisions.count_for_session_reason(
+            session_id, dominant_reason
+        )
+    response = plan_response(
+        session=session, findings=findings, prior_detection_count=prior_detection_count
+    )
 
     return {
         "sessionId": session_id,

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -67,6 +67,9 @@ from api_service.api.routers.omnigent_native_ui import (
 )
 from api_service.api.routers.omnigent_catalog import router as omnigent_catalog_router
 from api_service.api.routers.omnigent_policies import router as omnigent_policies_router
+from api_service.api.routers.omnigent_session_timeline import (
+    router as omnigent_session_timeline_router,
+)
 from api_service.api.routers.workflow_proposals import router as workflow_proposals_router
 from api_service.api.routers.presets import (
     router as presets_router,
@@ -493,6 +496,7 @@ app.include_router(
 app.include_router(native_ui_router, prefix=NATIVE_UI_MOUNT_PATH)
 app.include_router(omnigent_catalog_router)
 app.include_router(omnigent_policies_router)
+app.include_router(omnigent_session_timeline_router)
 app.include_router(workflow_console_router)
 app.include_router(presets_router)
 app.include_router(temporal_artifacts_router)

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,82 @@
 [
   {
-    "id": 3807043073,
-    "disposition": "addressed",
-    "rationale": "Heartbeat renewal now uses a conditional SQL update over heartbeat-owning states, making it mutually exclusive with the cleanup claim CAS."
-  },
-  {
-    "id": 3807043083,
-    "disposition": "addressed",
-    "rationale": "Cleanup claims now renew expires_at for the bounded cleanup ownership window in the same atomic update."
-  },
-  {
-    "id": 3807043091,
-    "disposition": "addressed",
-    "rationale": "A typed cleanup-ownership loss now routes coordinator finalization to janitor-required waiting without host stop or Provider Profile release."
-  },
-  {
-    "id": 3807043093,
-    "disposition": "addressed",
-    "rationale": "Lease-scoped drain, stop, remove, eviction, and stale-reconciliation actions now share the atomic cleanup claim before side effects."
-  },
-  {
-    "id": 3807043100,
-    "disposition": "addressed",
-    "rationale": "Orphan cleanup now reloads the host lease identified by the container label and leaves lease-owned containers to the fenced cleanup path."
-  },
-  {
-    "id": 4964716657,
+    "id": 3806823435,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review envelope; its five child threads contain the complete actionable feedback."
+    "rationale": "False positive from static analysis: DecisionKind is an Enum subclass, which is iterable; `for kind in DecisionKind` is valid."
+  },
+  {
+    "id": 3806823446,
+    "disposition": "addressed",
+    "rationale": "Removed the unused CleanupAuthorityRecord import from stuck_state.py."
+  },
+  {
+    "id": 3806823458,
+    "disposition": "addressed",
+    "rationale": "Added an explanatory comment to the attribute-set except clause in omnigent_span (setting a bounded attribute must never fail the wrapped work)."
+  },
+  {
+    "id": 3806823471,
+    "disposition": "addressed",
+    "rationale": "The span-close except clause now carries an explanatory comment and closes the span with the real exception tuple (see 3806845213)."
+  },
+  {
+    "id": 3806845154,
+    "disposition": "not-applicable",
+    "rationale": "Deferred to a later phase: this is Omnigent control plane 7/11 and the reconciler-based session-admission boundary that evaluate_admission_readiness gates does not exist in production yet (the reducer has zero production consumers; the only live session-start path is the legacy bridge architecture, which does not gather reconciler capability signals). readiness.py intentionally lands as a pure, tested projection; wiring it into an admission boundary that does not exist would be premature and out of scope. Reject-future-dated-evidence hardening from the sibling thread (3806845183) was applied."
+  },
+  {
+    "id": 3806845160,
+    "disposition": "not-applicable",
+    "rationale": "Deferred to a later phase: the reconciler lifecycle/activity boundaries these spans and metrics instrument are test-only in this phase (the reducer has no production consumers), and no host exporter consumes control_plane.metrics.snapshot() yet. The module intentionally lands as a pure building block; instrumenting boundaries that do not exist would be premature. Correctness hardening of the primitives themselves (fallback label declaration 3806845223, credential sanitizer 3806845188, span exception handling 3806845213) was applied."
+  },
+  {
+    "id": 3806845166,
+    "disposition": "addressed",
+    "rationale": "The stuck-state endpoint now derives every durable signal it can authoritatively express: latest event/snapshot freshness, the active turn's durable start (so absence is aged), the active/ambiguous command, cleanup progress (loads the cleanup authority), admission, and compatibility resolution. Signals requiring an independent provider observation or cross-aggregate lease reconciliation stay None (not observed) rather than being fabricated at a read boundary, preserving the detector's tri-state invariant."
+  },
+  {
+    "id": 3806845173,
+    "disposition": "addressed",
+    "rationale": "_safe_link now emits only registered routes: artifact/intent refs use the registered /api/artifacts/{id} route, and the trace link (no registered destination this phase) is omitted rather than pointed at a nonexistent /api/omnigent/traces route."
+  },
+  {
+    "id": 3806845180,
+    "disposition": "addressed",
+    "rationale": "The active-no-recent-evidence finding now ages absence from a durable start timestamp (active_turn_started_at) and is suppressed when either channel has fresh evidence, so a freshly activated or actively progressing turn no longer trips immediately."
+  },
+  {
+    "id": 3806845183,
+    "disposition": "addressed",
+    "rationale": "_fresh_state now rejects negative ages (future-dated evidence from clock skew or malformed evidence) as UNKNOWN, so future-dated evidence can no longer bypass the fail-closed admission gate."
+  },
+  {
+    "id": 4964479580,
+    "disposition": "not-applicable",
+    "rationale": "Informational Codex review envelope (review body from a bot); its child review threads carry the actionable feedback."
+  },
+  {
+    "id": 3806845188,
+    "disposition": "addressed",
+    "rationale": "The span value sanitizer now matches credential assignments and auth headers (token=, password:, secret=, api_key=, authorization:, bearer <value>, etc.) independently of URL-query punctuation."
+  },
+  {
+    "id": 3806845194,
+    "disposition": "addressed",
+    "rationale": "Added bounded latest/active repository queries plus a turn-attempt count; both timeline endpoints now fetch only the freshest/active rows and a count instead of materializing the full append-only history."
+  },
+  {
+    "id": 3806845206,
+    "disposition": "addressed",
+    "rationale": "prior_detection_count is now derived from the durable decision journal (count_for_session_reason on the dominant finding's reason) and passed to plan_response, so the bounded reconciliation-to-quarantine policy can terminate instead of always passing 0."
+  },
+  {
+    "id": 3806845213,
+    "disposition": "addressed",
+    "rationale": "omnigent_span now captures the real exception (including cancellations that bypass Exception) and passes the exc_info tuple to the context manager's __exit__, so failed spans record an error status instead of a normal completion."
+  },
+  {
+    "id": 3806845223,
+    "disposition": "addressed",
+    "rationale": "The 'other' and 'unknown' fallback label values are now declared members of every bounded label vocabulary, so exporters can enumerate every value the recorder can emit."
   }
 ]

--- a/docs/Omnigent/OmnigentSemanticTelemetryAndTimeline.md
+++ b/docs/Omnigent/OmnigentSemanticTelemetryAndTimeline.md
@@ -1,0 +1,157 @@
+# Omnigent Semantic Telemetry, Operator Session Timeline, and Stuck-State Reconciliation
+
+Status: Proposed design
+Document Class: System / Feature Design View
+Owners: MoonMind Platform
+Last updated: 2026-08-18
+
+**Issue:** [MoonLadderStudios/MoonMind#3708](https://github.com/MoonLadderStudios/MoonMind/issues/3708) ([Omnigent control plane 7/11]).
+
+**Implementation tracking:** rollout notes and temporary handoffs belong under `docs/tmp/` or gitignored local-only artifacts, not in this canonical design document.
+
+## Related docs
+
+- [`docs/Omnigent/ControlPlaneAggregates.md`](./ControlPlaneAggregates.md) — the durable aggregates this telemetry and timeline project.
+- [`docs/Omnigent/ControlPlaneConcurrencyAndFencing.md`](./ControlPlaneConcurrencyAndFencing.md) — the revision/fencing authority the automated response is bound to.
+- [`docs/Omnigent/OmnigentLifecycleReconciler.md`](./OmnigentLifecycleReconciler.md) — the pure reducer whose decisions the timeline and stuck-state response derive from.
+
+## Why
+
+OpenTelemetry and Temporal Visibility remain the operational telemetry and
+durable orchestration planes. Temporal, canonical session state, decision
+journals, and artifacts remain the durable sources of lifecycle truth. This
+feature does not replace them: it makes Omnigent lifecycle behavior directly
+observable through a stable domain telemetry convention, one durable
+operator-facing session timeline, and a bounded stuck-state detector that
+requests a **fenced** reconciliation before a six-hour timeout or a user report.
+
+## Semantic trace convention
+
+Span names and bounded attributes are the closed vocabulary in
+`moonmind/omnigent/control_plane/spans.py`. Instrumentation wraps the
+infrastructure and activity boundaries **around** the domain decisions; the pure
+reducer never performs exporter I/O.
+
+Span names (closed set `OMNIGENT_SPANS`):
+
+```
+omnigent.intent.compile
+omnigent.session.reconcile
+omnigent.observation.load
+omnigent.provider.observe_snapshot
+omnigent.provider.read_event_batch
+omnigent.turn.submit
+omnigent.command.execute
+omnigent.profile_lease.ensure
+omnigent.host.ensure
+omnigent.session.ensure_provider_attachment
+omnigent.evidence.harvest
+omnigent.workspace.publish
+omnigent.cleanup.execute
+omnigent.compatibility.verify
+omnigent.stuck_state.inspect
+```
+
+Bounded span attributes (closed set `SAFE_SPAN_ATTRIBUTES`) carry only runtime,
+harness, host mode, command/decision class, desired/durable/observed/resulting
+state, reason code, expected/resulting revision, fencing generation class or
+ordinal, attempt ordinal, provider status vocabulary value, observation source
+and schema version, terminal evidence kind, compatibility/image-manifest
+digests, and retry/delivery-unknown/cleanup outcomes.
+
+`omnigent_span` fails safe: an unknown span name degrades to a no-op, unknown or
+oversized/secret-like attribute values are dropped, and a missing tracer or a
+failing exporter is swallowed. Prompts, transcripts, diffs, terminal input,
+credentials, presigned URLs, host paths, and unbounded provider payloads can
+never be emitted. **Exporter or backend failure cannot change execution
+correctness.**
+
+## Metric families
+
+Low-cardinality metric families live in
+`moonmind/omnigent/control_plane/metrics.py`; the concurrency *conflict* counters
+(revision/fencing conflicts, duplicate-command suppression, delivery-unknown
+created/reconciled, stale observation retained, cleanup-claim conflicts) remain
+in `telemetry.py` (#3704) and are not duplicated. The added families cover:
+
+- **Reconciliation:** decisions by decision/reason class, convergence latency,
+  repeated no-progress decisions, quarantined ambiguity, snapshot-recovered
+  terminal transitions.
+- **Provider and transport:** event-batch disconnects/reconnects, liveness-only
+  duration, snapshot latency/errors, provider-terminal-to-MoonMind-terminal
+  latency, unknown provider status/schema values, HTTP/SSE/WebSocket readiness
+  and failure classes.
+- **Resources and cleanup:** lease acquisition latency, lease renewal/fencing
+  conflicts, cleanup lag, orphaned lease count, janitor claim/success/conflict/
+  failure, evidence harvest/publication latency.
+- **Compatibility and verification:** deployed-build compatibility, runtime
+  capability readiness, exact-image conformance, protected-live evidence age,
+  provider verification runner health.
+
+Every label key is declared per-metric with a closed bounded value vocabulary,
+and `FORBIDDEN_LABEL_KEYS` rejects any Workflow, run, user, session, binding,
+provider-session, host, runner, profile, credential, repository, or workspace
+identity at registration and at record time. **Metric labels are low cardinality
+and never carry identity.**
+
+## Durable operator session timeline
+
+`moonmind/omnigent/control_plane/timeline.py` projects one bounded, safe
+`SessionTimeline` for a single canonical session from its durable records. It is
+a projection, not a second lifecycle authority: it reads only durable records
+and performs no live-resource I/O, so it **survives provider/host/workspace
+cleanup**. The timeline surfaces the difference among desired, durable, observed,
+and reconciled state and explains why a session is launching, running,
+delivery-unknown, awaiting observation, retrying, terminal, cleanup-incomplete,
+or quarantined. Refs/digests pass through a secret-free guard and links are
+server-authored relative URLs built from opaque validated ids.
+
+The authorized machine-readable endpoint is
+`GET /api/omnigent/sessions/{session_id}/timeline` (operator permission
+`operations.read`). A Workflow Detail or operator UI projection may consume it
+without becoming a second lifecycle authority.
+
+## Stuck-state detector and automated response
+
+`moonmind/omnigent/control_plane/stuck_state.py` is a pure, bounded detector over
+durable records plus tri-state observation signals (`None` = not observed, so a
+missing observation is never treated as an observed negative). It detects at
+least: MoonMind active with no recent event/snapshot; provider-terminal vs
+MoonMind-nonterminal (and the reverse); active turn with only liveness
+observations; repeated no-progress reconciliation; orphaned host lease; profile
+lease without a consumer; cleanup incomplete past deadline; compatibility unknown
+after admission; command stuck claimed/delivery-unknown; stale live-conformance
+evidence.
+
+Automated response policy (`plan_response`):
+
+1. Record a stuck-state finding and stable reason code.
+2. The **first automated response is a fenced reconciliation** bound to the
+   durable session's current revision and fencing generation — never a blind
+   duplicate provider mutation and never a heuristic lease release. There is no
+   resubmit/release response action in the detector at all.
+3. Only decisions the pure reconciler authorizes under current fencing apply.
+4. Persistent ambiguity (beyond policy) escalates to **quarantine plus a
+   redacted diagnostics payload** rather than a fabricated success.
+5. Product reads and evidence stay available even when interactive mutation is
+   disabled.
+
+## New-admission readiness
+
+`moonmind/omnigent/control_plane/readiness.py` computes a bounded
+`AdmissionReadiness` over actual runtime capability and evidence freshness:
+reconciler/session-workflow generation, schema/repository compatibility, provider
+endpoint and snapshot capability, event transport, server/UI/host build
+manifests, WebSocket availability, worker/container backend, observation
+freshness, janitor health, and the last exact-image and protected-live evidence.
+Admission **fails closed**: a capability is ready only when explicitly observed
+ready; unknown or negative signals block new admission. Historical reads and
+cleanup for existing sessions stay available regardless.
+
+## Non-goals
+
+- Replacing Temporal Visibility, Workflow Detail, or the artifact system with
+  OpenTelemetry.
+- Exporting raw provider transcripts or terminal input.
+- Automatically repairing arbitrary deployment configuration without reconciler
+  authority.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3839,6 +3839,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/omnigent/sessions/{session_id}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Session Timeline
+         * @description Return the machine-readable operator timeline for one canonical session.
+         */
+        get: operations["get_session_timeline_api_omnigent_sessions__session_id__timeline_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/omnigent/sessions/{session_id}/stuck-state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Session Stuck State
+         * @description Return bounded stuck-state findings and the safe automated response.
+         *
+         *     Uses server time (``now``) via the control-plane clock; the response is a
+         *     fenced reconcile recommendation or a quarantine escalation. This endpoint
+         *     never mutates state — it surfaces the recommendation for the reconciliation
+         *     workflow and operators to act on.
+         */
+        get: operations["get_session_stuck_state_api_omnigent_sessions__session_id__stuck_state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/secrets": {
         parameters: {
             query?: never;
@@ -22899,6 +22944,72 @@ export interface operations {
             header?: never;
             path: {
                 policy_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_timeline_api_omnigent_sessions__session_id__timeline_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_session_stuck_state_api_omnigent_sessions__session_id__stuck_state_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
             };
             cookie?: never;
         };

--- a/moonmind/omnigent/control_plane/__init__.py
+++ b/moonmind/omnigent/control_plane/__init__.py
@@ -10,12 +10,41 @@ SQLAlchemy from domain and application code.
 
 from __future__ import annotations
 
-from . import telemetry
+from . import metrics, spans, telemetry
 from .backfill import (
     BackfillPlan,
     BackfillReport,
     plan_backfill,
     run_backfill,
+)
+from .readiness import (
+    AdmissionReadiness,
+    CapabilityReadiness,
+    ReadinessCapability,
+    ReadinessInputs,
+    ReadinessState,
+    evaluate_admission_readiness,
+)
+from .spans import (
+    OMNIGENT_SPANS,
+    SAFE_SPAN_ATTRIBUTES,
+    omnigent_span,
+    sanitize_span_attributes,
+)
+from .stuck_state import (
+    AutomatedResponse,
+    ResponseAction,
+    SessionSignals,
+    StuckStateFinding,
+    StuckStatePolicy,
+    StuckStateReason,
+    detect_stuck_state,
+    plan_response,
+)
+from .timeline import (
+    SessionTimeline,
+    TimelineStatus,
+    build_timeline,
 )
 from .records import (
     ALIAS_STATE_ACTIVE,
@@ -140,4 +169,31 @@ __all__ = [
     "plan_backfill",
     "run_backfill",
     "telemetry",
+    "metrics",
+    "spans",
+    # semantic spans
+    "OMNIGENT_SPANS",
+    "SAFE_SPAN_ATTRIBUTES",
+    "omnigent_span",
+    "sanitize_span_attributes",
+    # operator timeline
+    "SessionTimeline",
+    "TimelineStatus",
+    "build_timeline",
+    # stuck-state detector + automated response
+    "AutomatedResponse",
+    "ResponseAction",
+    "SessionSignals",
+    "StuckStateFinding",
+    "StuckStatePolicy",
+    "StuckStateReason",
+    "detect_stuck_state",
+    "plan_response",
+    # new-admission readiness
+    "AdmissionReadiness",
+    "CapabilityReadiness",
+    "ReadinessCapability",
+    "ReadinessInputs",
+    "ReadinessState",
+    "evaluate_admission_readiness",
 ]

--- a/moonmind/omnigent/control_plane/metrics.py
+++ b/moonmind/omnigent/control_plane/metrics.py
@@ -132,6 +132,18 @@ BOUNDED_LABEL_VALUES: dict[str, frozenset[str]] = {
     "readiness": frozenset({"ready", "not_ready", "unknown"}),
 }
 
+#: Fallback label values emitted by :func:`_normalize_labels`: an
+#: out-of-vocabulary value collapses to ``"other"`` and an omitted label to
+#: ``"unknown"``. Both are declared members of *every* bounded vocabulary so an
+#: exporter or dashboard reading the registry can enumerate every value this
+#: recorder can actually produce (no undeclared value ever reaches the backend).
+LABEL_FALLBACK_OTHER = "other"
+LABEL_FALLBACK_UNKNOWN = "unknown"
+BOUNDED_LABEL_VALUES = {
+    key: values | {LABEL_FALLBACK_OTHER, LABEL_FALLBACK_UNKNOWN}
+    for key, values in BOUNDED_LABEL_VALUES.items()
+}
+
 
 COUNTER = "counter"
 OBSERVATION = "observation"
@@ -336,6 +348,8 @@ def reset() -> None:
 __all__ = [
     "FORBIDDEN_LABEL_KEYS",
     "BOUNDED_LABEL_VALUES",
+    "LABEL_FALLBACK_OTHER",
+    "LABEL_FALLBACK_UNKNOWN",
     "METRICS",
     "MetricDefinition",
     "COUNTER",

--- a/moonmind/omnigent/control_plane/metrics.py
+++ b/moonmind/omnigent/control_plane/metrics.py
@@ -1,0 +1,374 @@
+"""Low-cardinality Omnigent lifecycle metric families.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+This module adds the reconciliation (non-conflict), provider/transport,
+resource/cleanup, and compatibility/verification metric families required by the
+issue. The concurrency *conflict* counters (revision/fencing conflicts,
+duplicate-command suppression, delivery-unknown created/reconciled, stale
+observation retained, cleanup-claim conflicts) already live in
+:mod:`moonmind.omnigent.control_plane.telemetry` (from #3704) and are **not**
+duplicated here (Simplicity Gate).
+
+Cardinality discipline (issue acceptance criterion):
+
+* Every metric name is drawn from the closed :data:`METRICS` registry.
+* Every label key is declared per-metric and every label value is drawn from a
+  closed bounded vocabulary; an unknown value collapses to ``"other"`` rather
+  than entering the label space.
+* No Workflow, run, user, session, binding, provider-session, host, runner,
+  profile, credential, repository, or workspace identity may ever be a label:
+  :data:`FORBIDDEN_LABEL_KEYS` is rejected at registration and at record time,
+  so a high-cardinality identity can never enter the metric label space.
+
+The registry is process-local and additive; a host exporter reads
+:func:`snapshot` and maps the bounded names/labels onto its metric backend.
+Recording never performs exporter I/O and never raises on a bounded input, so a
+telemetry backend failure cannot change application correctness.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Mapping
+
+logger = logging.getLogger("moonmind.omnigent.control_plane.metrics")
+
+#: Identity labels that must never appear on any Omnigent metric. Registering or
+#: recording one fails closed (programming error), so identity can never leak
+#: into the metric label space through a new metric or a stray keyword.
+FORBIDDEN_LABEL_KEYS: frozenset[str] = frozenset(
+    {
+        "workflow",
+        "workflow_id",
+        "run",
+        "run_id",
+        "user",
+        "user_id",
+        "session",
+        "session_id",
+        "binding",
+        "chat_binding_id",
+        "provider_session",
+        "provider_session_id",
+        "host",
+        "host_id",
+        "runner",
+        "runner_id",
+        "profile",
+        "profile_id",
+        "credential",
+        "credential_id",
+        "repository",
+        "repo",
+        "workspace",
+        "workspace_id",
+    }
+)
+
+
+# --- Bounded label vocabularies ---------------------------------------------
+
+# Every label key used by any metric maps to a closed value set. An out-of-set
+# value collapses to "other"; a missing value collapses to "unknown".
+BOUNDED_LABEL_VALUES: dict[str, frozenset[str]] = {
+    "decision_class": frozenset(
+        {
+            "no_op",
+            "await_observation",
+            "ensure_profile_lease",
+            "ensure_host",
+            "ensure_provider_session",
+            "submit_turn",
+            "record_provider_terminal",
+            "synthesize_terminal_from_snapshot",
+            "harvest_evidence",
+            "begin_cleanup",
+            "release_leases",
+            "retry_transient_observation",
+            "quarantine_ambiguous_state",
+            "fail_nonretryable",
+        }
+    ),
+    # Coarse reason *class* (not the full reason-code vocabulary) to stay low
+    # cardinality: the timeline/decision journal carries the exact reason code.
+    "reason_class": frozenset(
+        {
+            "provisioning",
+            "awaiting",
+            "terminal",
+            "cleanup",
+            "ambiguous",
+            "failed",
+            "compatibility",
+        }
+    ),
+    "lease_scope": frozenset({"provider_profile", "host"}),
+    "transport": frozenset({"http", "sse", "websocket"}),
+    "transport_outcome": frozenset({"ready", "disconnect", "reconnect", "failure"}),
+    "janitor_outcome": frozenset({"claim", "success", "conflict", "failure"}),
+    "status": frozenset({"ok", "degraded", "unknown", "drift"}),
+    "capability": frozenset(
+        {
+            "reconciler_generation",
+            "schema",
+            "provider_snapshot",
+            "event_transport",
+            "server_build",
+            "ui_build",
+            "host_build",
+            "websocket",
+            "worker_backend",
+            "container_backend",
+            "observation_freshness",
+            "janitor",
+            "exact_image",
+            "protected_live_evidence",
+        }
+    ),
+    "readiness": frozenset({"ready", "not_ready", "unknown"}),
+}
+
+
+COUNTER = "counter"
+OBSERVATION = "observation"
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    name: str
+    kind: str
+    labels: tuple[str, ...]
+    unit: str = "1"
+
+
+def _def(name: str, kind: str, labels: tuple[str, ...] = (), unit: str = "1") -> MetricDefinition:
+    forbidden = set(labels) & FORBIDDEN_LABEL_KEYS
+    if forbidden:  # pragma: no cover - registry programming error
+        raise ValueError(f"metric {name!r} declares forbidden identity labels: {sorted(forbidden)}")
+    for key in labels:
+        if key not in BOUNDED_LABEL_VALUES:  # pragma: no cover - registry programming error
+            raise ValueError(f"metric {name!r} label {key!r} has no bounded value vocabulary")
+    return MetricDefinition(name, kind, labels, unit)
+
+
+# --- Reconciliation (non-conflict) ------------------------------------------
+
+RECONCILIATION_DECISIONS = "omnigent_reconciliation_decisions"
+RECONCILIATION_CONVERGENCE_LATENCY = "omnigent_reconciliation_convergence_latency_seconds"
+REPEATED_NO_PROGRESS_DECISIONS = "omnigent_reconciliation_repeated_no_progress"
+QUARANTINED_AMBIGUITY = "omnigent_reconciliation_quarantined_ambiguity"
+SNAPSHOT_RECOVERED_TERMINAL = "omnigent_reconciliation_snapshot_recovered_terminal"
+
+# --- Provider & transport ---------------------------------------------------
+
+TRANSPORT_EVENTS = "omnigent_provider_transport_events"
+LIVENESS_ONLY_DURATION = "omnigent_provider_liveness_only_seconds"
+SNAPSHOT_LATENCY = "omnigent_provider_snapshot_latency_seconds"
+SNAPSHOT_ERRORS = "omnigent_provider_snapshot_errors"
+PROVIDER_TERMINAL_TO_MOONMIND_TERMINAL_LATENCY = (
+    "omnigent_provider_terminal_to_moonmind_terminal_seconds"
+)
+UNKNOWN_PROVIDER_STATUS = "omnigent_provider_unknown_status"
+UNKNOWN_SCHEMA_VALUE = "omnigent_provider_unknown_schema_value"
+TRANSPORT_READINESS = "omnigent_provider_transport_readiness"
+
+# --- Resources & cleanup ----------------------------------------------------
+
+LEASE_ACQUIRE_LATENCY = "omnigent_lease_acquire_latency_seconds"
+LEASE_RENEWAL_CONFLICTS = "omnigent_lease_renewal_conflicts"
+CLEANUP_LAG = "omnigent_cleanup_lag_seconds"
+ORPHANED_LEASES = "omnigent_orphaned_leases"
+JANITOR_OPERATIONS = "omnigent_janitor_operations"
+EVIDENCE_HARVEST_LATENCY = "omnigent_evidence_harvest_latency_seconds"
+EVIDENCE_PUBLICATION_LATENCY = "omnigent_evidence_publication_latency_seconds"
+
+# --- Compatibility & verification -------------------------------------------
+
+DEPLOYED_BUILD_COMPATIBILITY = "omnigent_deployed_build_compatibility"
+RUNTIME_CAPABILITY_READINESS = "omnigent_runtime_capability_readiness"
+EXACT_IMAGE_CONFORMANCE = "omnigent_exact_image_conformance"
+PROTECTED_LIVE_EVIDENCE_AGE = "omnigent_protected_live_evidence_age_seconds"
+PROVIDER_VERIFICATION_RUNNER_HEALTH = "omnigent_provider_verification_runner_health"
+
+
+METRICS: dict[str, MetricDefinition] = {
+    m.name: m
+    for m in (
+        # Reconciliation
+        _def(RECONCILIATION_DECISIONS, COUNTER, ("decision_class", "reason_class")),
+        _def(RECONCILIATION_CONVERGENCE_LATENCY, OBSERVATION, (), "seconds"),
+        _def(REPEATED_NO_PROGRESS_DECISIONS, COUNTER),
+        _def(QUARANTINED_AMBIGUITY, COUNTER),
+        _def(SNAPSHOT_RECOVERED_TERMINAL, COUNTER),
+        # Provider & transport
+        _def(TRANSPORT_EVENTS, COUNTER, ("transport", "transport_outcome")),
+        _def(LIVENESS_ONLY_DURATION, OBSERVATION, (), "seconds"),
+        _def(SNAPSHOT_LATENCY, OBSERVATION, (), "seconds"),
+        _def(SNAPSHOT_ERRORS, COUNTER),
+        _def(PROVIDER_TERMINAL_TO_MOONMIND_TERMINAL_LATENCY, OBSERVATION, (), "seconds"),
+        _def(UNKNOWN_PROVIDER_STATUS, COUNTER),
+        _def(UNKNOWN_SCHEMA_VALUE, COUNTER),
+        _def(TRANSPORT_READINESS, COUNTER, ("transport", "readiness")),
+        # Resources & cleanup
+        _def(LEASE_ACQUIRE_LATENCY, OBSERVATION, ("lease_scope",), "seconds"),
+        _def(LEASE_RENEWAL_CONFLICTS, COUNTER, ("lease_scope",)),
+        _def(CLEANUP_LAG, OBSERVATION, (), "seconds"),
+        _def(ORPHANED_LEASES, COUNTER, ("lease_scope",)),
+        _def(JANITOR_OPERATIONS, COUNTER, ("janitor_outcome",)),
+        _def(EVIDENCE_HARVEST_LATENCY, OBSERVATION, (), "seconds"),
+        _def(EVIDENCE_PUBLICATION_LATENCY, OBSERVATION, (), "seconds"),
+        # Compatibility & verification
+        _def(DEPLOYED_BUILD_COMPATIBILITY, COUNTER, ("status",)),
+        _def(RUNTIME_CAPABILITY_READINESS, COUNTER, ("capability", "readiness")),
+        _def(EXACT_IMAGE_CONFORMANCE, COUNTER, ("status",)),
+        _def(PROTECTED_LIVE_EVIDENCE_AGE, OBSERVATION, (), "seconds"),
+        _def(PROVIDER_VERIFICATION_RUNNER_HEALTH, COUNTER, ("status",)),
+    )
+}
+
+
+@dataclass
+class _ObservationAggregate:
+    count: int = 0
+    total: float = 0.0
+    last: float = 0.0
+
+
+_lock = threading.Lock()
+_counters: defaultdict[tuple[str, tuple[tuple[str, str], ...]], int] = defaultdict(int)
+_observations: dict[tuple[str, tuple[tuple[str, str], ...]], _ObservationAggregate] = {}
+
+
+def _normalize_labels(metric: MetricDefinition, labels: Mapping[str, object]) -> tuple[tuple[str, str], ...]:
+    forbidden = set(labels) & FORBIDDEN_LABEL_KEYS
+    if forbidden:
+        raise ValueError(
+            f"forbidden identity labels for {metric.name!r}: {sorted(forbidden)}"
+        )
+    unknown = set(labels) - set(metric.labels)
+    if unknown:
+        raise ValueError(f"unknown labels for {metric.name!r}: {sorted(unknown)}")
+    normalized: list[tuple[str, str]] = []
+    for key in metric.labels:
+        allowed = BOUNDED_LABEL_VALUES[key]
+        raw = labels.get(key, "unknown")
+        value = raw.value if hasattr(raw, "value") else str(raw)
+        if value not in allowed:
+            value = "unknown" if key not in labels else "other"
+        normalized.append((key, value))
+    return tuple(normalized)
+
+
+def _definition(name: str) -> MetricDefinition:
+    try:
+        return METRICS[name]
+    except KeyError:  # pragma: no cover - programming error
+        raise KeyError(f"unknown Omnigent control-plane metric: {name!r}")
+
+
+def increment(name: str, *, amount: int = 1, **labels: object) -> None:
+    """Increment a bounded counter metric.
+
+    Fails closed on an unknown metric name, an unknown/forbidden label key, or a
+    non-counter metric — those are programming errors, not runtime inputs. A
+    bounded but out-of-vocabulary label value collapses to ``"other"`` rather
+    than raising, so untrusted classification input can never crash a caller.
+    """
+
+    metric = _definition(name)
+    if metric.kind != COUNTER:  # pragma: no cover - programming error
+        raise TypeError(f"metric {name!r} is not a counter")
+    key = _normalize_labels(metric, labels)
+    with _lock:
+        _counters[(name, key)] += amount
+    logger.info("omnigent.control_plane.metric", extra={"metric": name, "kind": COUNTER})
+
+
+def observe(name: str, value: float, **labels: object) -> None:
+    """Record one observation (latency/age/duration) into a bounded aggregate."""
+
+    metric = _definition(name)
+    if metric.kind != OBSERVATION:  # pragma: no cover - programming error
+        raise TypeError(f"metric {name!r} is not an observation metric")
+    key = _normalize_labels(metric, labels)
+    numeric = float(value)
+    with _lock:
+        agg = _observations.get((name, key))
+        if agg is None:
+            agg = _ObservationAggregate()
+            _observations[(name, key)] = agg
+        agg.count += 1
+        agg.total += numeric
+        agg.last = numeric
+    logger.info("omnigent.control_plane.metric", extra={"metric": name, "kind": OBSERVATION})
+
+
+def snapshot() -> dict[str, object]:
+    """Return a copy of current counters and observation aggregates."""
+
+    with _lock:
+        counters = {f"{name}{list(labels)}": count for (name, labels), count in _counters.items()}
+        observations = {
+            f"{name}{list(labels)}": {"count": agg.count, "total": agg.total, "last": agg.last}
+            for (name, labels), agg in _observations.items()
+        }
+    return {"counters": counters, "observations": observations}
+
+
+def label_inventory() -> dict[str, tuple[str, ...]]:
+    """Return the declared label keys for every metric (for contract tests)."""
+
+    return {name: metric.labels for name, metric in METRICS.items()}
+
+
+def reset() -> None:
+    """Reset all aggregates. Test-only; production metrics are monotonic."""
+
+    with _lock:
+        _counters.clear()
+        _observations.clear()
+
+
+__all__ = [
+    "FORBIDDEN_LABEL_KEYS",
+    "BOUNDED_LABEL_VALUES",
+    "METRICS",
+    "MetricDefinition",
+    "COUNTER",
+    "OBSERVATION",
+    "increment",
+    "observe",
+    "snapshot",
+    "label_inventory",
+    "reset",
+    # names
+    "RECONCILIATION_DECISIONS",
+    "RECONCILIATION_CONVERGENCE_LATENCY",
+    "REPEATED_NO_PROGRESS_DECISIONS",
+    "QUARANTINED_AMBIGUITY",
+    "SNAPSHOT_RECOVERED_TERMINAL",
+    "TRANSPORT_EVENTS",
+    "LIVENESS_ONLY_DURATION",
+    "SNAPSHOT_LATENCY",
+    "SNAPSHOT_ERRORS",
+    "PROVIDER_TERMINAL_TO_MOONMIND_TERMINAL_LATENCY",
+    "UNKNOWN_PROVIDER_STATUS",
+    "UNKNOWN_SCHEMA_VALUE",
+    "TRANSPORT_READINESS",
+    "LEASE_ACQUIRE_LATENCY",
+    "LEASE_RENEWAL_CONFLICTS",
+    "CLEANUP_LAG",
+    "ORPHANED_LEASES",
+    "JANITOR_OPERATIONS",
+    "EVIDENCE_HARVEST_LATENCY",
+    "EVIDENCE_PUBLICATION_LATENCY",
+    "DEPLOYED_BUILD_COMPATIBILITY",
+    "RUNTIME_CAPABILITY_READINESS",
+    "EXACT_IMAGE_CONFORMANCE",
+    "PROTECTED_LIVE_EVIDENCE_AGE",
+    "PROVIDER_VERIFICATION_RUNNER_HEALTH",
+]

--- a/moonmind/omnigent/control_plane/readiness.py
+++ b/moonmind/omnigent/control_plane/readiness.py
@@ -1,0 +1,224 @@
+"""Bounded new-admission readiness surface for the Omnigent control plane.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+:func:`evaluate_admission_readiness` computes one bounded readiness projection
+for admitting a *new* Omnigent session. It is a pure function over capability
+signals; it performs no probing I/O itself (the caller supplies observed
+capability results).
+
+Two issue invariants are structural:
+
+* **Fail closed for new admission.** A capability is ``READY`` only when it is
+  explicitly observed ready. An unknown (``None``) or negative signal makes the
+  session inadmissible — admission never proceeds on absent evidence
+  (acceptance criterion "new-admission readiness includes actual runtime
+  capability and evidence freshness").
+* **Historical reads and cleanup stay available.** Inadmissibility only gates
+  *new* work; :attr:`AdmissionReadiness.allow_historical_reads` and
+  :attr:`AdmissionReadiness.allow_cleanup` remain ``True`` so existing sessions
+  can still be inspected and cleaned up safely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Optional
+
+
+class ReadinessState(str, Enum):
+    READY = "ready"
+    NOT_READY = "not_ready"
+    UNKNOWN = "unknown"
+
+
+class ReadinessCapability(str, Enum):
+    """Closed capability vocabulary mirrored by the metrics ``capability`` label."""
+
+    RECONCILER_GENERATION = "reconciler_generation"
+    SCHEMA = "schema"
+    PROVIDER_SNAPSHOT = "provider_snapshot"
+    EVENT_TRANSPORT = "event_transport"
+    SERVER_BUILD = "server_build"
+    UI_BUILD = "ui_build"
+    HOST_BUILD = "host_build"
+    WEBSOCKET = "websocket"
+    WORKER_BACKEND = "worker_backend"
+    CONTAINER_BACKEND = "container_backend"
+    OBSERVATION_FRESHNESS = "observation_freshness"
+    JANITOR = "janitor"
+    EXACT_IMAGE = "exact_image"
+    PROTECTED_LIVE_EVIDENCE = "protected_live_evidence"
+
+
+#: Capabilities required before a *new* session may be admitted. Every declared
+#: capability is required: admission fails closed unless all are READY.
+REQUIRED_FOR_ADMISSION: frozenset[ReadinessCapability] = frozenset(ReadinessCapability)
+
+
+@dataclass(frozen=True)
+class CapabilityReadiness:
+    capability: ReadinessCapability
+    state: ReadinessState
+    detail: Optional[str] = None
+
+    @property
+    def ready(self) -> bool:
+        return self.state is ReadinessState.READY
+
+
+@dataclass(frozen=True)
+class ReadinessInputs:
+    """Observed capability signals. ``None`` means *unknown* (fails closed).
+
+    Boolean capability flags: ``True`` ready, ``False`` not ready, ``None``
+    unknown. Evidence freshness is expressed as an age plus a max age; a missing
+    age is unknown.
+    """
+
+    reconciler_generation_ready: Optional[bool] = None
+    schema_compatible: Optional[bool] = None
+    provider_snapshot_ready: Optional[bool] = None
+    event_transport_ready: Optional[bool] = None
+    server_build_ready: Optional[bool] = None
+    ui_build_ready: Optional[bool] = None
+    host_build_ready: Optional[bool] = None
+    websocket_available: Optional[bool] = None
+    worker_backend_ready: Optional[bool] = None
+    container_backend_ready: Optional[bool] = None
+    observation_age: Optional[timedelta] = None
+    observation_max_age: timedelta = timedelta(minutes=10)
+    janitor_healthy: Optional[bool] = None
+    exact_image_conformant: Optional[bool] = None
+    protected_live_evidence_age: Optional[timedelta] = None
+    protected_live_evidence_max_age: timedelta = timedelta(hours=24)
+
+
+@dataclass(frozen=True)
+class AdmissionReadiness:
+    """Overall bounded readiness projection for new admission."""
+
+    admit_new: bool
+    capabilities: tuple[CapabilityReadiness, ...]
+    #: Historical reads and cleanup for existing sessions are always safe.
+    allow_historical_reads: bool = True
+    allow_cleanup: bool = True
+
+    def capability(self, capability: ReadinessCapability) -> CapabilityReadiness:
+        for entry in self.capabilities:
+            if entry.capability is capability:
+                return entry
+        raise KeyError(capability)
+
+    @property
+    def blocking(self) -> tuple[ReadinessCapability, ...]:
+        """Capabilities that are not READY and therefore block admission."""
+
+        return tuple(
+            entry.capability
+            for entry in self.capabilities
+            if entry.capability in REQUIRED_FOR_ADMISSION and not entry.ready
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "admitNew": self.admit_new,
+            "allowHistoricalReads": self.allow_historical_reads,
+            "allowCleanup": self.allow_cleanup,
+            "blocking": [c.value for c in self.blocking],
+            "capabilities": [
+                {
+                    "capability": e.capability.value,
+                    "state": e.state.value,
+                    "detail": e.detail,
+                }
+                for e in self.capabilities
+            ],
+        }
+
+
+def _flag_state(value: Optional[bool]) -> ReadinessState:
+    if value is True:
+        return ReadinessState.READY
+    if value is False:
+        return ReadinessState.NOT_READY
+    return ReadinessState.UNKNOWN
+
+
+def _fresh_state(age: Optional[timedelta], max_age: timedelta) -> ReadinessState:
+    if age is None:
+        return ReadinessState.UNKNOWN
+    return ReadinessState.READY if age <= max_age else ReadinessState.NOT_READY
+
+
+def evaluate_admission_readiness(
+    inputs: ReadinessInputs, *, now: Optional[datetime] = None
+) -> AdmissionReadiness:
+    """Compute the bounded admission-readiness projection, failing closed.
+
+    ``now`` is accepted for signature symmetry with the rest of the control
+    plane; freshness is passed in as an age so this function stays pure and
+    deterministic.
+    """
+
+    capabilities = (
+        CapabilityReadiness(
+            ReadinessCapability.RECONCILER_GENERATION,
+            _flag_state(inputs.reconciler_generation_ready),
+        ),
+        CapabilityReadiness(ReadinessCapability.SCHEMA, _flag_state(inputs.schema_compatible)),
+        CapabilityReadiness(
+            ReadinessCapability.PROVIDER_SNAPSHOT, _flag_state(inputs.provider_snapshot_ready)
+        ),
+        CapabilityReadiness(
+            ReadinessCapability.EVENT_TRANSPORT, _flag_state(inputs.event_transport_ready)
+        ),
+        CapabilityReadiness(ReadinessCapability.SERVER_BUILD, _flag_state(inputs.server_build_ready)),
+        CapabilityReadiness(ReadinessCapability.UI_BUILD, _flag_state(inputs.ui_build_ready)),
+        CapabilityReadiness(ReadinessCapability.HOST_BUILD, _flag_state(inputs.host_build_ready)),
+        CapabilityReadiness(
+            ReadinessCapability.WEBSOCKET,
+            _flag_state(inputs.websocket_available),
+            None if inputs.websocket_available else "WebSocket runtime capability unavailable",
+        ),
+        CapabilityReadiness(
+            ReadinessCapability.WORKER_BACKEND, _flag_state(inputs.worker_backend_ready)
+        ),
+        CapabilityReadiness(
+            ReadinessCapability.CONTAINER_BACKEND, _flag_state(inputs.container_backend_ready)
+        ),
+        CapabilityReadiness(
+            ReadinessCapability.OBSERVATION_FRESHNESS,
+            _fresh_state(inputs.observation_age, inputs.observation_max_age),
+        ),
+        CapabilityReadiness(ReadinessCapability.JANITOR, _flag_state(inputs.janitor_healthy)),
+        CapabilityReadiness(
+            ReadinessCapability.EXACT_IMAGE,
+            _flag_state(inputs.exact_image_conformant),
+            None if inputs.exact_image_conformant else "exact-image conformance not confirmed",
+        ),
+        CapabilityReadiness(
+            ReadinessCapability.PROTECTED_LIVE_EVIDENCE,
+            _fresh_state(
+                inputs.protected_live_evidence_age, inputs.protected_live_evidence_max_age
+            ),
+        ),
+    )
+
+    admit_new = all(
+        entry.ready for entry in capabilities if entry.capability in REQUIRED_FOR_ADMISSION
+    )
+    return AdmissionReadiness(admit_new=admit_new, capabilities=capabilities)
+
+
+__all__ = [
+    "ReadinessState",
+    "ReadinessCapability",
+    "REQUIRED_FOR_ADMISSION",
+    "CapabilityReadiness",
+    "ReadinessInputs",
+    "AdmissionReadiness",
+    "evaluate_admission_readiness",
+]

--- a/moonmind/omnigent/control_plane/readiness.py
+++ b/moonmind/omnigent/control_plane/readiness.py
@@ -150,6 +150,12 @@ def _flag_state(value: Optional[bool]) -> ReadinessState:
 def _fresh_state(age: Optional[timedelta], max_age: timedelta) -> ReadinessState:
     if age is None:
         return ReadinessState.UNKNOWN
+    # A negative age means the evidence is timestamped in the future (clock skew
+    # or malformed evidence). Treat it as unknown rather than fresh so a
+    # future-dated capability probe or conformance artifact can never bypass the
+    # fail-closed admission gate.
+    if age < timedelta(0):
+        return ReadinessState.UNKNOWN
     return ReadinessState.READY if age <= max_age else ReadinessState.NOT_READY
 
 

--- a/moonmind/omnigent/control_plane/repositories.py
+++ b/moonmind/omnigent/control_plane/repositories.py
@@ -15,9 +15,9 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Callable, Optional, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -873,6 +873,16 @@ class TurnAttemptRepository(_RepositoryBase):
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_turn_record(r) for r in rows]
 
+    async def count_for_session(self, session_id: str) -> int:
+        """Return the number of turn attempts without materializing the rows."""
+
+        stmt = (
+            select(func.count())
+            .select_from(OmnigentTurnAttempt)
+            .where(OmnigentTurnAttempt.session_id == session_id)
+        )
+        return int((await self._session.execute(stmt)).scalar_one())
+
     async def _load_turn_for_update(
         self, turn_attempt_id: str
     ) -> OmnigentTurnAttempt:
@@ -1130,6 +1140,32 @@ class ObservationRepository(_RepositoryBase):
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_observation_record(r) for r in rows]
 
+    async def latest_for_session(
+        self,
+        session_id: str,
+        *,
+        observation_types: Optional[Sequence[str]] = None,
+    ) -> Optional[ObservationRecord]:
+        """Return the most recent observation, optionally filtered by type.
+
+        Bounded (``LIMIT 1``) so an operator diagnostic never materializes the
+        full append-only observation history for a long-running session.
+        """
+
+        stmt = select(OmnigentObservation).where(
+            OmnigentObservation.session_id == session_id
+        )
+        if observation_types is not None:
+            stmt = stmt.where(
+                OmnigentObservation.observation_type.in_(list(observation_types))
+            )
+        stmt = stmt.order_by(
+            OmnigentObservation.observed_at.desc(),
+            OmnigentObservation.observation_id.desc(),
+        ).limit(1)
+        row = (await self._session.execute(stmt)).scalars().first()
+        return _observation_record(row) if row is not None else None
+
 
 # --- CommandRepository -------------------------------------------------------
 
@@ -1257,6 +1293,32 @@ class CommandRepository(_RepositoryBase):
         )
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_command_record(r) for r in rows]
+
+    async def active_for_session(self, session_id: str) -> Optional[CommandRecord]:
+        """Return the single active command, delivery-ambiguity taking precedence.
+
+        Bounded (``LIMIT 1``): a ``delivery_unknown`` command outranks a merely
+        ``claimed`` one, matching the timeline projection's precedence, without
+        loading the full command journal.
+        """
+
+        precedence = case(
+            (OmnigentCommand.status == COMMAND_STATE_DELIVERY_UNKNOWN, 0),
+            else_=1,
+        )
+        stmt = (
+            select(OmnigentCommand)
+            .where(
+                OmnigentCommand.session_id == session_id,
+                OmnigentCommand.status.in_(
+                    [COMMAND_STATE_DELIVERY_UNKNOWN, COMMAND_STATE_CLAIMED]
+                ),
+            )
+            .order_by(precedence, OmnigentCommand.updated_at.desc(), OmnigentCommand.command_id)
+            .limit(1)
+        )
+        row = (await self._session.execute(stmt)).scalars().first()
+        return _command_record(row) if row is not None else None
 
     async def _load_command_for_update(self, command_id: str) -> OmnigentCommand:
         row = await self._session.get(
@@ -1479,6 +1541,40 @@ class DecisionRepository(_RepositoryBase):
         )
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_decision_record(r) for r in rows]
+
+    async def latest_for_session(self, session_id: str) -> Optional[DecisionRecord]:
+        """Return the most recent reconciliation decision (bounded ``LIMIT 1``)."""
+
+        stmt = (
+            select(OmnigentReconciliationDecision)
+            .where(OmnigentReconciliationDecision.session_id == session_id)
+            .order_by(
+                OmnigentReconciliationDecision.created_at.desc(),
+                OmnigentReconciliationDecision.decision_id.desc(),
+            )
+            .limit(1)
+        )
+        row = (await self._session.execute(stmt)).scalars().first()
+        return _decision_record(row) if row is not None else None
+
+    async def count_for_session_reason(self, session_id: str, reason_code: str) -> int:
+        """Count durable decisions recorded for a session under one reason code.
+
+        This is the per-session/per-reason detection count the stuck-state
+        response policy uses to escalate persistent ambiguity to quarantine; the
+        durable decision journal *is* the persistence, so no separate counter is
+        introduced.
+        """
+
+        stmt = (
+            select(func.count())
+            .select_from(OmnigentReconciliationDecision)
+            .where(
+                OmnigentReconciliationDecision.session_id == session_id,
+                OmnigentReconciliationDecision.reason_code == reason_code,
+            )
+        )
+        return int((await self._session.execute(stmt)).scalar_one())
 
 
 # --- ChatBindingAliasRepository ----------------------------------------------

--- a/moonmind/omnigent/control_plane/repositories.py
+++ b/moonmind/omnigent/control_plane/repositories.py
@@ -1243,6 +1243,21 @@ class CommandRepository(_RepositoryBase):
         row = (await self._session.execute(stmt)).scalar_one_or_none()
         return _command_record(row) if row is not None else None
 
+    async def list_for_session(self, session_id: str) -> list[CommandRecord]:
+        """Return this session's commands in creation order (read-only).
+
+        Used by the operator session-timeline projection (#3708) to surface the
+        active or delivery-unknown command; it never claims or mutates a command.
+        """
+
+        stmt = (
+            select(OmnigentCommand)
+            .where(OmnigentCommand.session_id == session_id)
+            .order_by(OmnigentCommand.created_at, OmnigentCommand.command_id)
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+        return [_command_record(r) for r in rows]
+
     async def _load_command_for_update(self, command_id: str) -> OmnigentCommand:
         row = await self._session.get(
             OmnigentCommand, command_id, with_for_update=True

--- a/moonmind/omnigent/control_plane/spans.py
+++ b/moonmind/omnigent/control_plane/spans.py
@@ -1,0 +1,263 @@
+"""Semantic trace convention for the Omnigent control plane.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+This module documents-in-code the Omnigent semantic trace convention and gives
+infrastructure/activity boundaries one safe way to emit it. It defines:
+
+* the closed set of ``omnigent.*`` span names (:data:`OMNIGENT_SPANS`);
+* the closed set of bounded span attribute keys (:data:`SAFE_SPAN_ATTRIBUTES`);
+* a value sanitizer that refuses forbidden content (prompts, transcripts,
+  diffs, terminal input, credentials, presigned URLs, host paths, or unbounded
+  provider payloads) so a span can never carry a secret or an unbounded payload.
+
+Two hard boundaries from the issue are enforced here:
+
+* **No exporter I/O from deterministic workflow code.** :func:`omnigent_span` is
+  meant to wrap the *infrastructure and activity boundaries around* the domain
+  decisions, not the pure reducer. It also never raises: a missing tracer or a
+  failing exporter is swallowed so telemetry can never change application
+  correctness (acceptance criterion "exporter/backend failure cannot alter
+  execution correctness").
+* **Bounded, secret-free attributes only.** Unknown attribute keys and
+  forbidden/oversized values fail closed (dropped, never emitted). The span name
+  vocabulary is closed so an ad-hoc span name cannot leak identity through a
+  free-text name.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional
+
+logger = logging.getLogger("moonmind.omnigent.control_plane.spans")
+
+# --- Closed span-name vocabulary --------------------------------------------
+
+INTENT_COMPILE = "omnigent.intent.compile"
+SESSION_RECONCILE = "omnigent.session.reconcile"
+OBSERVATION_LOAD = "omnigent.observation.load"
+PROVIDER_OBSERVE_SNAPSHOT = "omnigent.provider.observe_snapshot"
+PROVIDER_READ_EVENT_BATCH = "omnigent.provider.read_event_batch"
+TURN_SUBMIT = "omnigent.turn.submit"
+COMMAND_EXECUTE = "omnigent.command.execute"
+PROFILE_LEASE_ENSURE = "omnigent.profile_lease.ensure"
+HOST_ENSURE = "omnigent.host.ensure"
+SESSION_ENSURE_PROVIDER_ATTACHMENT = "omnigent.session.ensure_provider_attachment"
+EVIDENCE_HARVEST = "omnigent.evidence.harvest"
+WORKSPACE_PUBLISH = "omnigent.workspace.publish"
+CLEANUP_EXECUTE = "omnigent.cleanup.execute"
+COMPATIBILITY_VERIFY = "omnigent.compatibility.verify"
+STUCK_STATE_INSPECT = "omnigent.stuck_state.inspect"
+
+OMNIGENT_SPANS: frozenset[str] = frozenset(
+    {
+        INTENT_COMPILE,
+        SESSION_RECONCILE,
+        OBSERVATION_LOAD,
+        PROVIDER_OBSERVE_SNAPSHOT,
+        PROVIDER_READ_EVENT_BATCH,
+        TURN_SUBMIT,
+        COMMAND_EXECUTE,
+        PROFILE_LEASE_ENSURE,
+        HOST_ENSURE,
+        SESSION_ENSURE_PROVIDER_ATTACHMENT,
+        EVIDENCE_HARVEST,
+        WORKSPACE_PUBLISH,
+        CLEANUP_EXECUTE,
+        COMPATIBILITY_VERIFY,
+        STUCK_STATE_INSPECT,
+    }
+)
+
+
+# --- Closed bounded-attribute vocabulary ------------------------------------
+
+# Every attribute key an Omnigent span may carry. The set is closed so an
+# instrumentation site cannot introduce an unbounded/identity attribute by
+# passing an arbitrary key. Values are additionally range-checked by
+# :func:`sanitize_span_attributes`.
+SAFE_SPAN_ATTRIBUTES: frozenset[str] = frozenset(
+    {
+        "runtime",
+        "harness",
+        "host_mode",
+        "command_class",
+        "decision_class",
+        "desired_state",
+        "durable_state",
+        "observed_state",
+        "resulting_state",
+        "reason_code",
+        "expected_revision",
+        "resulting_revision",
+        "fencing_generation_class",
+        "fencing_generation_ordinal",
+        "attempt_ordinal",
+        "provider_status_class",
+        "observation_source",
+        "observation_schema_version",
+        "terminal_evidence_kind",
+        "compatibility_digest",
+        "image_manifest_digest",
+        "retry_outcome",
+        "delivery_unknown_outcome",
+        "cleanup_outcome",
+    }
+)
+
+# Maximum length of a string attribute value. A digest (sha256 hex) is 64 chars;
+# anything materially longer than that is treated as a potential unbounded
+# payload and dropped rather than emitted.
+MAX_ATTRIBUTE_VALUE_LEN = 96
+
+# Secret-like / forbidden-content markers. A value matching any of these is
+# dropped: it may be a credential, a presigned URL, a host path, or an
+# unbounded provider payload rather than a bounded classification code.
+_FORBIDDEN_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"ghp_|github_pat_|AKIA|AIza|ATATT"),  # credential prefixes
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),  # private key block
+    re.compile(r"[?&](?:x-amz-|sig=|signature=|token=|password=)", re.IGNORECASE),  # presigned/secret query
+    re.compile(r"https?://"),  # any URL (links belong in server-authored refs, not span attrs)
+    re.compile(r"(?:^|[\s\"'])/(?:home|root|work|var|tmp|etc|mnt|usr)/"),  # host filesystem path
+    re.compile(r"\n"),  # multi-line values are transcripts/diffs, not bounded codes
+)
+
+
+def is_omnigent_span(name: str) -> bool:
+    """True when ``name`` is a recognized Omnigent span name."""
+
+    return name in OMNIGENT_SPANS
+
+
+def _safe_attribute_value(value: Any) -> Optional[Any]:
+    """Return a bounded, secret-free attribute value, or ``None`` to drop it."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if value is None:
+        return None
+    text = value.value if hasattr(value, "value") and isinstance(value.value, str) else str(value)
+    if len(text) > MAX_ATTRIBUTE_VALUE_LEN:
+        return None
+    for pattern in _FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(text):
+            return None
+    return text
+
+
+def sanitize_span_attributes(attributes: Mapping[str, Any]) -> dict[str, Any]:
+    """Filter ``attributes`` to the closed, bounded, secret-free vocabulary.
+
+    Unknown keys are dropped (closed vocabulary); forbidden or oversized values
+    are dropped (fail closed). The function never raises so an instrumentation
+    site can pass raw values without a correctness risk.
+    """
+
+    safe: dict[str, Any] = {}
+    for key, raw in attributes.items():
+        if key not in SAFE_SPAN_ATTRIBUTES:
+            continue
+        value = _safe_attribute_value(raw)
+        if value is None:
+            continue
+        safe[key] = value
+    return safe
+
+
+def _tracer() -> Any:
+    """Return the OpenTelemetry tracer, or ``None`` when unavailable.
+
+    Importing/using OpenTelemetry is optional: if the package is not installed
+    or not initialized, spans degrade to no-ops so telemetry can never be a
+    hard dependency of the control plane.
+    """
+
+    try:  # pragma: no cover - exercised indirectly
+        from opentelemetry import trace  # type: ignore
+
+        return trace.get_tracer("moonmind.omnigent.control_plane")
+    except Exception:  # pragma: no cover - defensive; telemetry must not fail hard
+        return None
+
+
+@contextmanager
+def omnigent_span(name: str, /, **attributes: Any) -> Iterator[None]:
+    """Emit one bounded Omnigent span around an infrastructure/activity boundary.
+
+    ``name`` must be a member of :data:`OMNIGENT_SPANS`; an unknown name fails
+    closed to a no-op (and is logged) rather than emitting an ad-hoc span. All
+    attributes are sanitized through :func:`sanitize_span_attributes`.
+
+    The context manager never raises from telemetry: a missing tracer or an
+    exporter error is swallowed, so wrapping a boundary in ``omnigent_span``
+    cannot change the boundary's success or failure. The wrapped block's own
+    exceptions still propagate (and are recorded on the span when possible).
+    """
+
+    if name not in OMNIGENT_SPANS:
+        logger.warning("omnigent.span.unknown_name", extra={"span_name_rejected": True})
+        yield
+        return
+
+    safe = sanitize_span_attributes(attributes)
+    tracer = _tracer()
+    if tracer is None:
+        # No exporter plane: still yield so the wrapped work runs unchanged.
+        yield
+        return
+
+    try:  # pragma: no cover - depends on OTel runtime
+        span_cm = tracer.start_as_current_span(name)
+        span = span_cm.__enter__()
+    except Exception:  # pragma: no cover - telemetry must not fail hard
+        yield
+        return
+
+    try:
+        try:
+            for key, value in safe.items():
+                span.set_attribute(f"omnigent.{key}", value)
+        except Exception:  # pragma: no cover - defensive
+            pass
+        yield
+    except Exception as exc:  # record then re-raise: the work's error is real
+        try:  # pragma: no cover - telemetry must not fail hard
+            span.record_exception(exc)
+        except Exception:
+            pass
+        raise
+    finally:
+        try:  # pragma: no cover - telemetry must not fail hard
+            span_cm.__exit__(None, None, None)
+        except Exception:
+            pass
+
+
+__all__ = [
+    "OMNIGENT_SPANS",
+    "SAFE_SPAN_ATTRIBUTES",
+    "MAX_ATTRIBUTE_VALUE_LEN",
+    "INTENT_COMPILE",
+    "SESSION_RECONCILE",
+    "OBSERVATION_LOAD",
+    "PROVIDER_OBSERVE_SNAPSHOT",
+    "PROVIDER_READ_EVENT_BATCH",
+    "TURN_SUBMIT",
+    "COMMAND_EXECUTE",
+    "PROFILE_LEASE_ENSURE",
+    "HOST_ENSURE",
+    "SESSION_ENSURE_PROVIDER_ATTACHMENT",
+    "EVIDENCE_HARVEST",
+    "WORKSPACE_PUBLISH",
+    "CLEANUP_EXECUTE",
+    "COMPATIBILITY_VERIFY",
+    "STUCK_STATE_INSPECT",
+    "is_omnigent_span",
+    "sanitize_span_attributes",
+    "omnigent_span",
+]

--- a/moonmind/omnigent/control_plane/spans.py
+++ b/moonmind/omnigent/control_plane/spans.py
@@ -119,7 +119,18 @@ MAX_ATTRIBUTE_VALUE_LEN = 96
 _FORBIDDEN_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"ghp_|github_pat_|AKIA|AIza|ATATT"),  # credential prefixes
     re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),  # private key block
-    re.compile(r"[?&](?:x-amz-|sig=|signature=|token=|password=)", re.IGNORECASE),  # presigned/secret query
+    re.compile(r"[?&](?:x-amz-|sig=|signature=)", re.IGNORECASE),  # presigned URL query params
+    # Credential assignments and auth headers, matched independently of URL-query
+    # punctuation: ``token=secret``, ``password: secret``, ``api_key=...``, an
+    # ``Authorization:`` header, etc. are all dropped whether or not they follow
+    # a ``?``/``&``. A bounded classification code never contains one of these.
+    re.compile(
+        r"(?:token|password|passwd|pwd|secret|api[_-]?key|apikey|access[_-]?key|"
+        r"client[_-]?secret|private[_-]?key|authorization|session[_-]?id)"
+        r"\s*[=:]",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?:^|[\s\"'=:])[Bb]earer\s+\S"),  # bearer token value
     re.compile(r"https?://"),  # any URL (links belong in server-authored refs, not span attrs)
     re.compile(r"(?:^|[\s\"'])/(?:home|root|work|var|tmp|etc|mnt|usr)/"),  # host filesystem path
     re.compile(r"\n"),  # multi-line values are transcripts/diffs, not bounded codes
@@ -218,23 +229,32 @@ def omnigent_span(name: str, /, **attributes: Any) -> Iterator[None]:
         yield
         return
 
+    exc_info: tuple[Any, Any, Any] = (None, None, None)
     try:
         try:
             for key, value in safe.items():
                 span.set_attribute(f"omnigent.{key}", value)
         except Exception:  # pragma: no cover - defensive
+            # Setting a bounded attribute must never fail the wrapped work.
             pass
         yield
-    except Exception as exc:  # record then re-raise: the work's error is real
+    except BaseException as exc:  # record then re-raise: the work's error is real
+        # Capture the real exception (including cancellations that bypass the
+        # ``Exception`` hierarchy) so the span is closed with the actual error
+        # tuple below and OpenTelemetry records its error status instead of a
+        # normal, successful completion.
+        exc_info = (type(exc), exc, exc.__traceback__)
         try:  # pragma: no cover - telemetry must not fail hard
             span.record_exception(exc)
         except Exception:
+            # Recording the exception on the span is best-effort telemetry.
             pass
         raise
     finally:
         try:  # pragma: no cover - telemetry must not fail hard
-            span_cm.__exit__(None, None, None)
+            span_cm.__exit__(*exc_info)
         except Exception:
+            # Closing the span/exporter is best-effort and must not fail hard.
             pass
 
 

--- a/moonmind/omnigent/control_plane/stuck_state.py
+++ b/moonmind/omnigent/control_plane/stuck_state.py
@@ -30,7 +30,6 @@ from enum import Enum
 from typing import Optional
 
 from .records import (
-    CleanupAuthorityRecord,
     CommandRecord,
     SessionRecord,
     COMMAND_STATE_CLAIMED,
@@ -95,6 +94,10 @@ class SessionSignals:
 
     last_event_at: Optional[datetime] = None
     last_snapshot_at: Optional[datetime] = None
+    #: Durable start of the active turn attempt. Absence of any observation is
+    #: aged from this timestamp so a freshly activated turn with no observations
+    #: yet does not immediately trip the freshness finding.
+    active_turn_started_at: Optional[datetime] = None
     #: An active turn produced only liveness/heartbeat observations since this
     #: time (``None`` when the turn is producing substantive observations).
     liveness_only_since: Optional[datetime] = None
@@ -176,10 +179,26 @@ def detect_stuck_state(
 
     # 1. MoonMind active with no recent event or snapshot.
     if nonterminal and session.active_turn_attempt_id is not None:
-        no_recent_event = _stale(signals.last_event_at, now, policy.event_staleness)
-        no_recent_snapshot = _stale(signals.last_snapshot_at, now, policy.snapshot_staleness)
-        never_observed = signals.last_event_at is None and signals.last_snapshot_at is None
-        if no_recent_event or no_recent_snapshot or never_observed:
+        # Fresh evidence from *either* channel means the turn is progressing;
+        # never fire the freshness finding while one channel is reporting, even
+        # if the other channel is stale.
+        fresh_event = signals.last_event_at is not None and not _stale(
+            signals.last_event_at, now, policy.event_staleness
+        )
+        fresh_snapshot = signals.last_snapshot_at is not None and not _stale(
+            signals.last_snapshot_at, now, policy.snapshot_staleness
+        )
+        # Age the absence from the most recent durable timestamp available: the
+        # latest observation on either channel, else the turn's durable start.
+        # A brand-new turn with no observations must not trip immediately, and
+        # without any durable timestamp the finding stays conservative (no fire).
+        reference = (
+            signals.last_event_at
+            or signals.last_snapshot_at
+            or signals.active_turn_started_at
+        )
+        aged_out = _stale(reference, now, min(policy.event_staleness, policy.snapshot_staleness))
+        if not (fresh_event or fresh_snapshot) and aged_out:
             findings.append(
                 StuckStateFinding(
                     reason=StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE,

--- a/moonmind/omnigent/control_plane/stuck_state.py
+++ b/moonmind/omnigent/control_plane/stuck_state.py
@@ -1,0 +1,381 @@
+"""Bounded Omnigent stuck-state detector and automated response policy.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+:func:`detect_stuck_state` is a *pure* function over durable records, bounded
+observation-derived signals, a policy, and ``now``. It returns stable
+:class:`StuckStateFinding` values; it performs no I/O and never mutates state.
+
+Two issue invariants are structural here:
+
+* **Lack of evidence is not a negative observation.** Signals are tri-state
+  (``None`` = not observed, ``True``/``False`` = observed). The detector never
+  asserts "provider is terminal" from an *absent* observation; it distinguishes
+  a missing observation (which may itself trip a freshness finding) from an
+  observed negative.
+* **The detector never authorizes a provider mutation.** Every finding's
+  :class:`ResponseAction` is one of ``RECONCILE`` (ask the canonical session
+  workflow to reconcile under current fencing), ``QUARANTINE``, or ``OBSERVE``.
+  There is intentionally no ``RESUBMIT_TURN`` / ``RELEASE_LEASE`` action: the
+  first automated response is always a fenced reconciliation, never a blind
+  duplicate provider mutation or a heuristic lease release
+  (:func:`plan_response`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Optional
+
+from .records import (
+    CleanupAuthorityRecord,
+    CommandRecord,
+    SessionRecord,
+    COMMAND_STATE_CLAIMED,
+    COMMAND_STATE_DELIVERY_UNKNOWN,
+)
+
+
+class StuckStateReason(str, Enum):
+    """Stable, low-cardinality reason code for each detectable stuck state."""
+
+    MOONMIND_ACTIVE_NO_RECENT_EVIDENCE = "moonmind_active_no_recent_evidence"
+    PROVIDER_TERMINAL_MOONMIND_NONTERMINAL = "provider_terminal_moonmind_nonterminal"
+    MOONMIND_TERMINAL_PROVIDER_ACTIVE = "moonmind_terminal_provider_active"
+    ACTIVE_TURN_LIVENESS_ONLY = "active_turn_liveness_only"
+    REPEATED_RECONCILIATION_NO_PROGRESS = "repeated_reconciliation_no_progress"
+    HOST_LEASE_WITHOUT_SESSION_AUTHORITY = "host_lease_without_session_authority"
+    PROFILE_LEASE_WITHOUT_CONSUMER = "profile_lease_without_consumer"
+    CLEANUP_INCOMPLETE_PAST_DEADLINE = "cleanup_incomplete_past_deadline"
+    COMPATIBILITY_UNKNOWN_AFTER_ADMISSION = "compatibility_unknown_after_admission"
+    COMMAND_STUCK_CLAIMED_OR_DELIVERY_UNKNOWN = "command_stuck_claimed_or_delivery_unknown"
+    LIVE_CONFORMANCE_EVIDENCE_STALE = "live_conformance_evidence_stale"
+
+
+class ResponseAction(str, Enum):
+    """The only responses the detector may authorize.
+
+    ``RECONCILE`` requests a fenced reconciliation of the canonical session
+    workflow; ``QUARANTINE`` parks the session and publishes redacted
+    diagnostics; ``OBSERVE`` records the finding and surfaces remediation without
+    any mutation. There is deliberately no direct provider-mutation action.
+    """
+
+    RECONCILE = "reconcile"
+    QUARANTINE = "quarantine"
+    OBSERVE = "observe"
+
+
+@dataclass(frozen=True)
+class StuckStatePolicy:
+    """Bounded deadlines governing detection (all safely below a 6h timeout)."""
+
+    event_staleness: timedelta = timedelta(minutes=10)
+    snapshot_staleness: timedelta = timedelta(minutes=10)
+    liveness_only_max: timedelta = timedelta(minutes=15)
+    cleanup_deadline: timedelta = timedelta(minutes=30)
+    conformance_max_age: timedelta = timedelta(hours=24)
+    command_stuck_max: timedelta = timedelta(minutes=10)
+    #: Consecutive no-progress reconciliations before the no-progress finding.
+    no_progress_max: int = 3
+    #: After this many detections of the same reason, ambiguity is persistent and
+    #: the response escalates from RECONCILE to QUARANTINE.
+    persistent_ambiguity_max: int = 3
+
+
+@dataclass(frozen=True)
+class SessionSignals:
+    """Bounded observation-derived inputs. ``None`` means *not observed*.
+
+    Every provider/host/lease flag is tri-state so the detector can distinguish
+    a missing observation from an observed negative.
+    """
+
+    last_event_at: Optional[datetime] = None
+    last_snapshot_at: Optional[datetime] = None
+    #: An active turn produced only liveness/heartbeat observations since this
+    #: time (``None`` when the turn is producing substantive observations).
+    liveness_only_since: Optional[datetime] = None
+    provider_terminal: Optional[bool] = None
+    provider_active: Optional[bool] = None
+    host_lease_active: Optional[bool] = None
+    host_lease_owns_session_authority: Optional[bool] = None
+    profile_lease_active: Optional[bool] = None
+    profile_lease_has_consumer: Optional[bool] = None
+    #: Compatibility/actual-build state resolved after admission (``None`` =
+    #: unknown, which after admission is itself a finding).
+    compatibility_known: Optional[bool] = None
+    admitted: bool = False
+    active_command: Optional[CommandRecord] = None
+    active_command_since: Optional[datetime] = None
+    cleanup_started_at: Optional[datetime] = None
+    conformance_evidence_at: Optional[datetime] = None
+    conformance_runner_available: Optional[bool] = None
+    #: Consecutive reconciliations without a revision or observation advance.
+    consecutive_no_progress: int = 0
+    #: How many times this session has already been found stuck for the same
+    #: dominant reason (drives RECONCILE -> QUARANTINE escalation).
+    prior_detection_count: int = 0
+
+
+@dataclass(frozen=True)
+class StuckStateFinding:
+    """One detected stuck state with a stable reason and a safe response."""
+
+    reason: StuckStateReason
+    action: ResponseAction
+    detail: str
+    remediation: str
+
+
+@dataclass(frozen=True)
+class AutomatedResponse:
+    """The single automated response derived from a set of findings.
+
+    The first automated response is always a fenced reconciliation:
+    ``expected_revision`` / ``expected_fencing_generation`` are copied from the
+    durable session so the executor can only apply a decision authorized by the
+    pure reconciler under current fencing. Persistent ambiguity escalates to a
+    quarantine plus a redacted diagnostics payload; product reads and evidence
+    stay available regardless.
+    """
+
+    reconcile: bool
+    quarantine: bool
+    expected_revision: int
+    expected_fencing_generation: int
+    reasons: tuple[StuckStateReason, ...]
+    diagnostics: dict[str, object] = field(default_factory=dict)
+    remediation: Optional[str] = None
+
+
+def _stale(reference: Optional[datetime], now: datetime, budget: timedelta) -> bool:
+    """True when ``reference`` is present and older than ``budget`` before now."""
+
+    return reference is not None and (now - reference) >= budget
+
+
+def detect_stuck_state(
+    *,
+    session: SessionRecord,
+    signals: SessionSignals,
+    now: datetime,
+    policy: StuckStatePolicy = StuckStatePolicy(),
+) -> list[StuckStateFinding]:
+    """Return the stuck-state findings for one session, in priority order.
+
+    Detection is bounded and conservative: it fires at the configured deadline
+    and never while progress is occurring (fresh observations or an advancing
+    revision suppress the freshness/no-progress findings).
+    """
+
+    findings: list[StuckStateFinding] = []
+    nonterminal = session.terminal_state is None
+
+    # 1. MoonMind active with no recent event or snapshot.
+    if nonterminal and session.active_turn_attempt_id is not None:
+        no_recent_event = _stale(signals.last_event_at, now, policy.event_staleness)
+        no_recent_snapshot = _stale(signals.last_snapshot_at, now, policy.snapshot_staleness)
+        never_observed = signals.last_event_at is None and signals.last_snapshot_at is None
+        if no_recent_event or no_recent_snapshot or never_observed:
+            findings.append(
+                StuckStateFinding(
+                    reason=StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE,
+                    action=ResponseAction.RECONCILE,
+                    detail="active session has no recent provider event or snapshot",
+                    remediation="request a fenced reconcile to re-observe the provider snapshot",
+                )
+            )
+
+    # 2. Provider terminal while MoonMind nonterminal (observed-positive only).
+    if nonterminal and signals.provider_terminal is True:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.PROVIDER_TERMINAL_MOONMIND_NONTERMINAL,
+                action=ResponseAction.RECONCILE,
+                detail="provider reports terminal but canonical session is nonterminal",
+                remediation="reconcile to synthesize the missed terminal from snapshot evidence",
+            )
+        )
+
+    # 3. MoonMind terminal while provider active (observed-positive only).
+    if session.terminal_state is not None and signals.provider_active is True:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.MOONMIND_TERMINAL_PROVIDER_ACTIVE,
+                action=ResponseAction.RECONCILE,
+                detail="canonical session terminal but provider still reports active",
+                remediation="reconcile to confirm provider terminal and drive cleanup",
+            )
+        )
+
+    # 4. Active turn with only liveness observations beyond policy.
+    if nonterminal and _stale(signals.liveness_only_since, now, policy.liveness_only_max):
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.ACTIVE_TURN_LIVENESS_ONLY,
+                action=ResponseAction.RECONCILE,
+                detail="active turn has produced only liveness observations beyond policy",
+                remediation="reconcile to re-observe substantive turn progress",
+            )
+        )
+
+    # 5. Repeated reconciliation without revision or observation progress.
+    if signals.consecutive_no_progress >= policy.no_progress_max:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.REPEATED_RECONCILIATION_NO_PROGRESS,
+                action=ResponseAction.RECONCILE,
+                detail="reconciliation repeated without a revision or observation advance",
+                remediation="reconcile once more; escalate to quarantine if still no progress",
+            )
+        )
+
+    # 6. Host lease active without owning session authority (observed-positive).
+    if signals.host_lease_active is True and signals.host_lease_owns_session_authority is False:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.HOST_LEASE_WITHOUT_SESSION_AUTHORITY,
+                action=ResponseAction.RECONCILE,
+                detail="host lease is active but does not own current session authority",
+                remediation="reconcile so the fenced cleanup authority reclaims the orphaned host lease",
+            )
+        )
+
+    # 7. Provider Profile lease active without a credential consumer.
+    if signals.profile_lease_active is True and signals.profile_lease_has_consumer is False:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.PROFILE_LEASE_WITHOUT_CONSUMER,
+                action=ResponseAction.RECONCILE,
+                detail="Provider Profile lease is active with no credential consumer",
+                remediation="reconcile so the fenced cleanup authority releases the orphaned profile lease",
+            )
+        )
+
+    # 8. Cleanup started but not completed by deadline.
+    cleanup_incomplete = (
+        signals.cleanup_started_at is not None
+        and _stale(signals.cleanup_started_at, now, policy.cleanup_deadline)
+        and session.cleanup_state not in {"complete", "closed"}
+    )
+    if cleanup_incomplete:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.CLEANUP_INCOMPLETE_PAST_DEADLINE,
+                action=ResponseAction.RECONCILE,
+                detail="cleanup started but did not complete by the deadline",
+                remediation="reconcile so the janitor re-claims and completes cleanup under current fencing",
+            )
+        )
+
+    # 9. Compatibility / actual-build state unknown after admission.
+    if signals.admitted and signals.compatibility_known is None:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.COMPATIBILITY_UNKNOWN_AFTER_ADMISSION,
+                action=ResponseAction.RECONCILE,
+                detail="compatibility/actual-build state is unknown after admission",
+                remediation="reconcile to re-verify deployed-build compatibility",
+            )
+        )
+
+    # 10. Command stuck in claimed or delivery-unknown state past policy.
+    command = signals.active_command
+    if command is not None and command.status in {
+        COMMAND_STATE_CLAIMED,
+        COMMAND_STATE_DELIVERY_UNKNOWN,
+    }:
+        if _stale(signals.active_command_since, now, policy.command_stuck_max):
+            findings.append(
+                StuckStateFinding(
+                    reason=StuckStateReason.COMMAND_STUCK_CLAIMED_OR_DELIVERY_UNKNOWN,
+                    action=ResponseAction.RECONCILE,
+                    detail=f"command stuck in {command.status} state beyond policy",
+                    remediation=(
+                        "reconcile to confirm delivery at the authoritative boundary; "
+                        "never blind-resubmit"
+                    ),
+                )
+            )
+
+    # 11. Live-conformance evidence expired or runner unavailable.
+    conformance_stale = _stale(signals.conformance_evidence_at, now, policy.conformance_max_age)
+    runner_down = signals.conformance_runner_available is False
+    if conformance_stale or runner_down:
+        findings.append(
+            StuckStateFinding(
+                reason=StuckStateReason.LIVE_CONFORMANCE_EVIDENCE_STALE,
+                action=ResponseAction.OBSERVE,
+                detail="live-conformance evidence is expired or its runner is unavailable",
+                remediation="refresh protected-live conformance evidence or restore the verification runner",
+            )
+        )
+
+    return findings
+
+
+def plan_response(
+    *,
+    session: SessionRecord,
+    findings: list[StuckStateFinding],
+    prior_detection_count: int = 0,
+    policy: StuckStatePolicy = StuckStatePolicy(),
+) -> Optional[AutomatedResponse]:
+    """Derive the single fenced automated response for a set of findings.
+
+    Returns ``None`` when there is nothing to do. When findings exist, the first
+    automated response is a fenced reconcile bound to the durable session's
+    current revision and fencing generation. If the same ambiguity has persisted
+    beyond ``policy.persistent_ambiguity_max`` detections, the response escalates
+    to a quarantine plus redacted diagnostics. Findings whose only action is
+    ``OBSERVE`` never mutate state — they surface remediation only.
+    """
+
+    if not findings:
+        return None
+
+    actionable = [f for f in findings if f.action != ResponseAction.OBSERVE]
+    reasons = tuple(f.reason for f in findings)
+    diagnostics: dict[str, object] = {
+        "reasons": [f.reason.value for f in findings],
+        "detection_count": prior_detection_count + 1,
+    }
+    remediation = findings[0].remediation
+
+    if not actionable:
+        # Only OBSERVE-class findings: surface remediation, mutate nothing.
+        return AutomatedResponse(
+            reconcile=False,
+            quarantine=False,
+            expected_revision=session.revision,
+            expected_fencing_generation=session.fencing_generation,
+            reasons=reasons,
+            diagnostics=diagnostics,
+            remediation=remediation,
+        )
+
+    escalate = prior_detection_count + 1 > policy.persistent_ambiguity_max
+    return AutomatedResponse(
+        reconcile=not escalate,
+        quarantine=escalate,
+        expected_revision=session.revision,
+        expected_fencing_generation=session.fencing_generation,
+        reasons=reasons,
+        diagnostics=diagnostics,
+        remediation=remediation,
+    )
+
+
+__all__ = [
+    "StuckStateReason",
+    "ResponseAction",
+    "StuckStatePolicy",
+    "SessionSignals",
+    "StuckStateFinding",
+    "AutomatedResponse",
+    "detect_stuck_state",
+    "plan_response",
+]

--- a/moonmind/omnigent/control_plane/timeline.py
+++ b/moonmind/omnigent/control_plane/timeline.py
@@ -81,17 +81,21 @@ def _safe_ref(value: Optional[str]) -> Optional[str]:
 
 
 def _safe_link(kind: str, ref: Optional[str]) -> Optional[str]:
-    """Build a server-authored relative URL from an opaque, validated id."""
+    """Build a server-authored relative URL from an opaque, validated id.
+
+    Only links to routes that are actually registered are emitted; an operator
+    link must never resolve to a 404. Artifact and intent refs map to the
+    registered artifact metadata route ``/api/artifacts/{artifact_id}`` (see
+    :mod:`api_service.api.routers.temporal_artifacts`). ``trace`` refs have no
+    registered destination in this phase, so the link is omitted rather than
+    pointed at a nonexistent ``/api/omnigent/traces`` route.
+    """
 
     safe = _safe_ref(ref)
     if safe is None or not _SAFE_ID.match(safe):
         return None
-    if kind == "trace":
-        return f"/api/omnigent/traces/{safe}"
-    if kind == "artifact":
-        return f"/api/v1/artifacts/{safe}"
-    if kind == "intent":
-        return f"/api/v1/artifacts/{safe}"
+    if kind in {"artifact", "intent"}:
+        return f"/api/artifacts/{safe}"
     return None
 
 
@@ -330,6 +334,7 @@ def build_timeline(
     commands: Sequence[CommandRecord] = (),
     decisions: Sequence[DecisionRecord] = (),
     cleanup: Optional[CleanupAuthorityRecord] = None,
+    turn_attempt_count: Optional[int] = None,
 ) -> SessionTimeline:
     """Project one bounded operator session timeline from durable records.
 
@@ -338,6 +343,11 @@ def build_timeline(
     passed through :func:`_safe_ref`, and trace/artifact links are built only
     from opaque validated ids, so no credential, presigned URL, host path, or
     unbounded payload can appear.
+
+    ``turn_attempt_count`` lets a caller supply an authoritative database count
+    when it only fetched the active turn attempt (bounded query) rather than the
+    full turn-attempt history; when omitted the count falls back to the length of
+    the passed ``turn_attempts`` sequence.
     """
 
     # Active turn attempt.
@@ -411,7 +421,9 @@ def build_timeline(
         revision=session.revision,
         fencing_generation=session.fencing_generation,
         active_turn_attempt_state=active_turn.state if active_turn is not None else None,
-        turn_attempt_count=len(turn_attempts),
+        turn_attempt_count=(
+            turn_attempt_count if turn_attempt_count is not None else len(turn_attempts)
+        ),
         provider_event_cursor=_safe_ref(session.provider_event_cursor),
         snapshot_frontier=_safe_ref(session.snapshot_frontier),
         last_snapshot_at=getattr(snapshot_obs, "observed_at", None),

--- a/moonmind/omnigent/control_plane/timeline.py
+++ b/moonmind/omnigent/control_plane/timeline.py
@@ -1,0 +1,451 @@
+"""Durable operator session timeline projection for the Omnigent control plane.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+:func:`build_timeline` derives one authorized, bounded, secret-free diagnostic
+projection for a single canonical session from its durable records
+(:class:`SessionRecord`, turn attempts, observations, commands, and decisions,
+plus optional cleanup authority). It is a **projection, not a second lifecycle
+authority**: it only reads durable records and never mutates state or calls a
+live provider/host/workspace resource, so the timeline still explains a session
+after its live resources are cleaned up (issue acceptance criterion "timeline
+data remains available after live resources are removed").
+
+Every emitted field is bounded and safe: refs and digests are passed through a
+guard that drops anything resembling a credential, presigned URL, or host path
+(:func:`_safe_ref`), and no prompt, transcript, diff, or provider credential is
+ever included. Trace/artifact links are server-authored relative URLs built from
+opaque, validated ids.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional, Sequence
+
+from .records import (
+    CleanupAuthorityRecord,
+    CommandRecord,
+    DecisionRecord,
+    ObservationRecord,
+    SessionRecord,
+    TurnAttemptRecord,
+    COMMAND_STATE_CLAIMED,
+    COMMAND_STATE_DELIVERY_UNKNOWN,
+)
+from .spans import _FORBIDDEN_VALUE_PATTERNS, MAX_ATTRIBUTE_VALUE_LEN
+
+# Opaque identifiers safe to embed in a server-authored URL path segment.
+_SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class TimelineStatus(str, Enum):
+    """Bounded, operator-facing explanation class for the session's state.
+
+    This is *why* the session is where it is, derived from durable records — not
+    a second lifecycle vocabulary. It answers the issue requirement to explain
+    why a session is waiting, retrying, quarantined, terminal, or
+    cleanup-incomplete.
+    """
+
+    LAUNCHING = "launching"
+    RUNNING = "running"
+    DELIVERY_UNKNOWN = "delivery_unknown"
+    AWAITING_OBSERVATION = "awaiting_observation"
+    RETRYING = "retrying"
+    TERMINAL = "terminal"
+    CLEANUP_INCOMPLETE = "cleanup_incomplete"
+    QUARANTINED = "quarantined"
+    CLOSED = "closed"
+
+
+def _safe_ref(value: Optional[str]) -> Optional[str]:
+    """Return ``value`` if it is a bounded, secret-free ref, else ``None``.
+
+    A ref that looks like a credential, presigned URL, host path, or unbounded
+    payload is dropped rather than surfaced to an operator browser.
+    """
+
+    if value is None:
+        return None
+    text = str(value)
+    if len(text) > MAX_ATTRIBUTE_VALUE_LEN:
+        return None
+    for pattern in _FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(text):
+            return None
+    return text
+
+
+def _safe_link(kind: str, ref: Optional[str]) -> Optional[str]:
+    """Build a server-authored relative URL from an opaque, validated id."""
+
+    safe = _safe_ref(ref)
+    if safe is None or not _SAFE_ID.match(safe):
+        return None
+    if kind == "trace":
+        return f"/api/omnigent/traces/{safe}"
+    if kind == "artifact":
+        return f"/api/v1/artifacts/{safe}"
+    if kind == "intent":
+        return f"/api/v1/artifacts/{safe}"
+    return None
+
+
+@dataclass(frozen=True)
+class LeaseObservationSummary:
+    """Bounded durable-lease authority summary (no profile/host identity)."""
+
+    profile_generation: Optional[int] = None
+    host_lease_generation: Optional[int] = None
+    credential_generation: Optional[int] = None
+    host_bound: bool = False
+
+
+@dataclass(frozen=True)
+class DecisionSummary:
+    """Bounded summary of the most recent reconciliation decision."""
+
+    decision_code: str
+    reason_code: Optional[str]
+    fencing_generation: int
+    next_deadline: Optional[datetime]
+    product_visible_transition: Optional[str]
+    trace_link: Optional[str] = None
+    diagnostics_link: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CommandSummary:
+    """Bounded summary of the active or delivery-unknown command, if any."""
+
+    command_type: str
+    status: str
+    delivery_ambiguous: bool
+    fencing_generation: int
+
+
+@dataclass(frozen=True)
+class SessionTimeline:
+    """One bounded, durable operator-facing session timeline projection."""
+
+    session_id: str
+    provider: str
+
+    # compiled intent
+    intent_ref: Optional[str]
+    intent_digest: Optional[str]
+
+    # canonical session state / authority
+    desired_state: str
+    durable_state: str
+    observed_state: Optional[str]
+    reconciled_state: Optional[str]
+    revision: int
+    fencing_generation: int
+
+    # turn attempt
+    active_turn_attempt_state: Optional[str]
+    turn_attempt_count: int
+
+    # provider frontier / snapshot
+    provider_event_cursor: Optional[str]
+    snapshot_frontier: Optional[str]
+    last_snapshot_at: Optional[datetime]
+    last_snapshot_digest: Optional[str]
+    last_event_at: Optional[datetime]
+
+    # leases / host
+    leases: LeaseObservationSummary
+
+    # reconciliation
+    last_decision: Optional[DecisionSummary]
+    next_reconciliation_deadline: Optional[datetime]
+
+    # command
+    active_command: Optional[CommandSummary]
+
+    # terminal / cleanup
+    terminal_state: Optional[str]
+    terminal_evidence_ref: Optional[str]
+    cleanup_state: str
+    janitor_state: Optional[str]
+    workspace_publication_state: Optional[str]
+
+    # compatibility
+    compatibility_ref: Optional[str]
+    image_manifest_ref: Optional[str]
+
+    # explanation
+    status: TimelineStatus
+    status_detail: Optional[str]
+
+    # safe links
+    trace_link: Optional[str]
+    terminal_evidence_link: Optional[str]
+    intent_link: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the machine-readable, JSON-safe timeline document."""
+
+        def _iso(value: Optional[datetime]) -> Optional[str]:
+            return value.isoformat() if value is not None else None
+
+        decision: Optional[dict[str, Any]] = None
+        if self.last_decision is not None:
+            decision = {
+                "decisionCode": self.last_decision.decision_code,
+                "reasonCode": self.last_decision.reason_code,
+                "fencingGeneration": self.last_decision.fencing_generation,
+                "nextDeadline": _iso(self.last_decision.next_deadline),
+                "productVisibleTransition": self.last_decision.product_visible_transition,
+                "traceLink": self.last_decision.trace_link,
+                "diagnosticsLink": self.last_decision.diagnostics_link,
+            }
+        command: Optional[dict[str, Any]] = None
+        if self.active_command is not None:
+            command = {
+                "commandType": self.active_command.command_type,
+                "status": self.active_command.status,
+                "deliveryAmbiguous": self.active_command.delivery_ambiguous,
+                "fencingGeneration": self.active_command.fencing_generation,
+            }
+        return {
+            "sessionId": self.session_id,
+            "provider": self.provider,
+            "intent": {"ref": self.intent_ref, "digest": self.intent_digest, "link": self.intent_link},
+            "state": {
+                "desired": self.desired_state,
+                "durable": self.durable_state,
+                "observed": self.observed_state,
+                "reconciled": self.reconciled_state,
+                "revision": self.revision,
+                "fencingGeneration": self.fencing_generation,
+            },
+            "turnAttempt": {
+                "state": self.active_turn_attempt_state,
+                "count": self.turn_attempt_count,
+            },
+            "provider_frontier": {
+                "eventCursor": self.provider_event_cursor,
+                "snapshotFrontier": self.snapshot_frontier,
+                "lastSnapshotAt": _iso(self.last_snapshot_at),
+                "lastSnapshotDigest": self.last_snapshot_digest,
+                "lastEventAt": _iso(self.last_event_at),
+            },
+            "leases": {
+                "profileGeneration": self.leases.profile_generation,
+                "hostLeaseGeneration": self.leases.host_lease_generation,
+                "credentialGeneration": self.leases.credential_generation,
+                "hostBound": self.leases.host_bound,
+            },
+            "lastDecision": decision,
+            "nextReconciliationDeadline": _iso(self.next_reconciliation_deadline),
+            "activeCommand": command,
+            "terminal": {
+                "state": self.terminal_state,
+                "evidenceRef": self.terminal_evidence_ref,
+                "evidenceLink": self.terminal_evidence_link,
+            },
+            "cleanup": {"state": self.cleanup_state, "janitorState": self.janitor_state},
+            "workspacePublicationState": self.workspace_publication_state,
+            "compatibility": {
+                "ref": self.compatibility_ref,
+                "imageManifestRef": self.image_manifest_ref,
+            },
+            "explanation": {"status": self.status.value, "detail": self.status_detail},
+            "links": {"trace": self.trace_link},
+        }
+
+
+def _latest(records: Sequence[Any], key: str) -> Optional[Any]:
+    """Return the record with the greatest ``key`` timestamp, or ``None``."""
+
+    best = None
+    best_ts: Optional[datetime] = None
+    for record in records:
+        ts = getattr(record, key, None)
+        if ts is None:
+            continue
+        if best_ts is None or ts > best_ts:
+            best, best_ts = record, ts
+    return best
+
+
+def _classify_status(
+    session: SessionRecord,
+    active_command: Optional[CommandRecord],
+    cleanup: Optional[CleanupAuthorityRecord],
+) -> tuple[TimelineStatus, Optional[str]]:
+    """Explain the session's current state from durable records only."""
+
+    meta = session.metadata or {}
+    if meta.get("quarantined") or session.historical_read_state == "quarantined":
+        return TimelineStatus.QUARANTINED, "session quarantined pending operator remediation"
+
+    if active_command is not None and active_command.status == COMMAND_STATE_DELIVERY_UNKNOWN:
+        return (
+            TimelineStatus.DELIVERY_UNKNOWN,
+            "a provider side effect may have occurred; awaiting reconciliation confirmation",
+        )
+
+    if session.terminal_state is not None:
+        cleanup_done = session.cleanup_state in {"complete", "closed"}
+        if cleanup is not None and cleanup.state != "complete":
+            return (
+                TimelineStatus.CLEANUP_INCOMPLETE,
+                "session terminal but cleanup authority has not completed",
+            )
+        if not cleanup_done:
+            return (
+                TimelineStatus.CLEANUP_INCOMPLETE,
+                "session terminal but cleanup is not marked complete",
+            )
+        return TimelineStatus.CLOSED, "session terminal and cleanup complete"
+
+    if active_command is not None and active_command.status == COMMAND_STATE_CLAIMED:
+        return TimelineStatus.RUNNING, "command claimed and executing"
+
+    prior = (session.metadata or {}).get("last_reason_code")
+    if isinstance(prior, str) and prior.startswith("retry"):
+        return TimelineStatus.RETRYING, "reconciler is retrying a transient observation"
+
+    if session.active_turn_attempt_id is None and session.provider_session_ref is None:
+        return TimelineStatus.LAUNCHING, "session provisioning provider/host authority"
+
+    if session.observed_state is None:
+        return TimelineStatus.AWAITING_OBSERVATION, "no independent provider observation yet"
+
+    return TimelineStatus.RUNNING, "turn in flight"
+
+
+def build_timeline(
+    *,
+    session: SessionRecord,
+    turn_attempts: Sequence[TurnAttemptRecord] = (),
+    observations: Sequence[ObservationRecord] = (),
+    commands: Sequence[CommandRecord] = (),
+    decisions: Sequence[DecisionRecord] = (),
+    cleanup: Optional[CleanupAuthorityRecord] = None,
+) -> SessionTimeline:
+    """Project one bounded operator session timeline from durable records.
+
+    The projection reads only the passed records; it performs no live-resource
+    I/O, so it survives provider/host/workspace cleanup. Every ref/digest is
+    passed through :func:`_safe_ref`, and trace/artifact links are built only
+    from opaque validated ids, so no credential, presigned URL, host path, or
+    unbounded payload can appear.
+    """
+
+    # Active turn attempt.
+    active_turn: Optional[TurnAttemptRecord] = None
+    if session.active_turn_attempt_id is not None:
+        for turn in turn_attempts:
+            if turn.turn_attempt_id == session.active_turn_attempt_id:
+                active_turn = turn
+                break
+
+    # Latest snapshot and event observations (bounded, source-typed).
+    snapshot_obs = _latest(
+        [o for o in observations if o.observation_type in {"snapshot", "provider_snapshot"}],
+        "observed_at",
+    )
+    event_obs = _latest(
+        [o for o in observations if o.observation_type in {"event", "event_frontier", "event_batch"}],
+        "observed_at",
+    )
+
+    # Active / delivery-unknown command (delivery-ambiguity takes precedence).
+    active_command: Optional[CommandRecord] = None
+    for command in commands:
+        if command.status == COMMAND_STATE_DELIVERY_UNKNOWN:
+            active_command = command
+            break
+    if active_command is None:
+        for command in commands:
+            if command.status == COMMAND_STATE_CLAIMED:
+                active_command = command
+                break
+
+    # Most recent decision.
+    last_decision_record = _latest(list(decisions), "created_at")
+    decision_summary: Optional[DecisionSummary] = None
+    if last_decision_record is not None:
+        decision_summary = DecisionSummary(
+            decision_code=last_decision_record.decision_code,
+            reason_code=last_decision_record.reason_code,
+            fencing_generation=last_decision_record.fencing_generation,
+            next_deadline=last_decision_record.next_deadline,
+            product_visible_transition=last_decision_record.product_visible_transition,
+            trace_link=_safe_link("trace", last_decision_record.trace_ref),
+            diagnostics_link=_safe_link("artifact", last_decision_record.diagnostics_ref),
+        )
+
+    command_summary: Optional[CommandSummary] = None
+    if active_command is not None:
+        command_summary = CommandSummary(
+            command_type=active_command.command_type,
+            status=active_command.status,
+            delivery_ambiguous=active_command.delivery_ambiguous,
+            fencing_generation=active_command.fencing_generation,
+        )
+
+    status, detail = _classify_status(session, active_command, cleanup)
+
+    meta = session.metadata or {}
+    workspace_state = meta.get("workspace_publication_state")
+    janitor_state = cleanup.state if cleanup is not None else None
+
+    return SessionTimeline(
+        session_id=session.session_id,
+        provider=session.provider,
+        intent_ref=_safe_ref(session.intent_ref),
+        intent_digest=_safe_ref(session.intent_digest),
+        desired_state=session.desired_state,
+        durable_state=session.reconciled_state or session.desired_state,
+        observed_state=session.observed_state,
+        reconciled_state=session.reconciled_state,
+        revision=session.revision,
+        fencing_generation=session.fencing_generation,
+        active_turn_attempt_state=active_turn.state if active_turn is not None else None,
+        turn_attempt_count=len(turn_attempts),
+        provider_event_cursor=_safe_ref(session.provider_event_cursor),
+        snapshot_frontier=_safe_ref(session.snapshot_frontier),
+        last_snapshot_at=getattr(snapshot_obs, "observed_at", None),
+        last_snapshot_digest=_safe_ref(getattr(snapshot_obs, "source_digest", None)),
+        last_event_at=getattr(event_obs, "observed_at", None),
+        leases=LeaseObservationSummary(
+            profile_generation=session.provider_profile_generation,
+            host_lease_generation=session.host_lease_generation,
+            credential_generation=session.credential_generation,
+            host_bound=session.host_binding_ref is not None,
+        ),
+        last_decision=decision_summary,
+        next_reconciliation_deadline=session.next_reconciliation_deadline,
+        active_command=command_summary,
+        terminal_state=session.terminal_state,
+        terminal_evidence_ref=_safe_ref(session.terminal_evidence_ref),
+        cleanup_state=session.cleanup_state,
+        janitor_state=janitor_state,
+        workspace_publication_state=workspace_state if isinstance(workspace_state, str) else None,
+        compatibility_ref=_safe_ref(session.compatibility_ref),
+        image_manifest_ref=_safe_ref(session.image_manifest_ref),
+        status=status,
+        status_detail=detail,
+        trace_link=_safe_link("trace", last_decision_record.trace_ref if last_decision_record else None),
+        terminal_evidence_link=_safe_link("artifact", session.terminal_evidence_ref),
+        intent_link=_safe_link("intent", session.intent_ref),
+    )
+
+
+__all__ = [
+    "TimelineStatus",
+    "LeaseObservationSummary",
+    "DecisionSummary",
+    "CommandSummary",
+    "SessionTimeline",
+    "build_timeline",
+]

--- a/tests/unit/omnigent/test_control_plane_aggregates.py
+++ b/tests/unit/omnigent/test_control_plane_aggregates.py
@@ -792,3 +792,94 @@ async def test_chat_binding_resolution_uses_canonical_aggregate(session_factory)
     assert session.provider_session_ref == "psess-1"
     # Historical evidence remains readable after provider resources are gone.
     assert observations[0].bounded_index["external_state_ref"] == "art://state-1"
+
+
+@pytest.mark.asyncio
+async def test_bounded_diagnostic_queries(store) -> None:
+    """Bounded latest/active/count queries backing the operator session-timeline
+    endpoints return the freshest/active row and a count without materializing the
+    full append-only history (#3708)."""
+    from datetime import timedelta
+
+    from moonmind.omnigent.control_plane import ControlPlaneOutcome
+
+    base = datetime(2026, 8, 18, 12, 0, 0, tzinfo=UTC)
+    async with store.transaction() as repos:
+        await repos.sessions.create(
+            session_id="s1", moonmind_workflow_id="wf-1", provider="codex"
+        )
+        await repos.turn_attempts.create(
+            turn_attempt_id="t1", session_id="s1", idempotency_key="idem-1"
+        )
+        await repos.turn_attempts.create(
+            turn_attempt_id="t2", session_id="s1", idempotency_key="idem-2"
+        )
+        # Two event observations and one snapshot; latest_for_session must return
+        # the newest row of the requested channel.
+        await repos.observations.append(
+            observation_id="o1", session_id="s1", observation_type="event",
+            source="provider", observed_at=base, deduplication_key="d1",
+        )
+        await repos.observations.append(
+            observation_id="o2", session_id="s1", observation_type="event",
+            source="provider", observed_at=base + timedelta(minutes=5), deduplication_key="d2",
+        )
+        await repos.observations.append(
+            observation_id="o3", session_id="s1", observation_type="snapshot",
+            source="provider", observed_at=base + timedelta(minutes=1), deduplication_key="d3",
+        )
+        # Two active commands: a claimed one and a delivery-unknown one.
+        await repos.commands.record(
+            command_id="c1", session_id="s1", command_type="ensure_host",
+            idempotency_key="cmd-1", payload_digest="pd1", fencing_generation=0,
+        )
+        await repos.commands.claim_command(
+            "c1", owner_class="session_supervisor", claim_token="worker-a"
+        )
+        await repos.commands.record(
+            command_id="c2", session_id="s1", command_type="submit_turn",
+            idempotency_key="cmd-2", payload_digest="pd2", fencing_generation=0,
+        )
+        await repos.commands.claim_command(
+            "c2", owner_class="session_supervisor", claim_token="worker-b"
+        )
+        await repos.commands.record_command_delivery(
+            "c2", owner_class="session_supervisor", claim_token="worker-b",
+            outcome=ControlPlaneOutcome.DELIVERY_UNKNOWN, provider_receipt_id="rcpt-1",
+        )
+        # Decisions under two reason codes.
+        await repos.decisions.append(
+            decision_id="dec-1", session_id="s1", decision_code="await_observation",
+            reason_code="awaiting_provider",
+        )
+        await repos.decisions.append(
+            decision_id="dec-2", session_id="s1", decision_code="quarantine_ambiguous_state",
+            reason_code="moonmind_active_no_recent_evidence",
+        )
+        await repos.decisions.append(
+            decision_id="dec-3", session_id="s1", decision_code="quarantine_ambiguous_state",
+            reason_code="moonmind_active_no_recent_evidence",
+        )
+
+    async with store.transaction() as repos:
+        latest_event = await repos.observations.latest_for_session(
+            "s1", observation_types=("event", "event_frontier", "event_batch")
+        )
+        latest_snapshot = await repos.observations.latest_for_session(
+            "s1", observation_types=("snapshot", "provider_snapshot")
+        )
+        turn_count = await repos.turn_attempts.count_for_session("s1")
+        active_command = await repos.commands.active_for_session("s1")
+        latest_decision = await repos.decisions.latest_for_session("s1")
+        no_progress = await repos.decisions.count_for_session_reason(
+            "s1", "moonmind_active_no_recent_evidence"
+        )
+
+    assert latest_event.observation_id == "o2"  # newest event, not o1
+    assert latest_snapshot.observation_id == "o3"
+    assert turn_count == 2
+    # Delivery-ambiguity outranks a merely claimed command.
+    assert active_command.command_id == "c2"
+    assert active_command.status == "delivery_unknown"
+    assert latest_decision.decision_id == "dec-3"
+    assert no_progress == 2

--- a/tests/unit/omnigent/test_control_plane_readiness.py
+++ b/tests/unit/omnigent/test_control_plane_readiness.py
@@ -1,0 +1,102 @@
+"""New-admission readiness tests, including incident visibility cases.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+Covers fail-closed admission, the requirement that historical reads and cleanup
+stay available, and the incident cases where a missing WebSocket runtime
+capability and image-compatibility drift must be visible before admission.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from moonmind.omnigent.control_plane.readiness import (
+    ReadinessCapability,
+    ReadinessInputs,
+    ReadinessState,
+    evaluate_admission_readiness,
+)
+
+
+def _all_ready_inputs(**overrides) -> ReadinessInputs:
+    base = dict(
+        reconciler_generation_ready=True,
+        schema_compatible=True,
+        provider_snapshot_ready=True,
+        event_transport_ready=True,
+        server_build_ready=True,
+        ui_build_ready=True,
+        host_build_ready=True,
+        websocket_available=True,
+        worker_backend_ready=True,
+        container_backend_ready=True,
+        observation_age=timedelta(seconds=30),
+        janitor_healthy=True,
+        exact_image_conformant=True,
+        protected_live_evidence_age=timedelta(hours=1),
+    )
+    base.update(overrides)
+    return ReadinessInputs(**base)
+
+
+def test_all_capabilities_ready_admits_new():
+    readiness = evaluate_admission_readiness(_all_ready_inputs())
+    assert readiness.admit_new is True
+    assert readiness.blocking == ()
+
+
+def test_unknown_capability_fails_closed():
+    # A completely unspecified input set is unknown across the board -> not admitted.
+    readiness = evaluate_admission_readiness(ReadinessInputs())
+    assert readiness.admit_new is False
+    assert readiness.blocking  # non-empty
+
+
+def test_historical_reads_and_cleanup_stay_available_even_when_blocked():
+    readiness = evaluate_admission_readiness(ReadinessInputs())
+    assert readiness.admit_new is False
+    assert readiness.allow_historical_reads is True
+    assert readiness.allow_cleanup is True
+
+
+def test_missing_websocket_capability_visible_and_blocks_admission():
+    readiness = evaluate_admission_readiness(_all_ready_inputs(websocket_available=False))
+    assert readiness.admit_new is False
+    assert ReadinessCapability.WEBSOCKET in readiness.blocking
+    ws = readiness.capability(ReadinessCapability.WEBSOCKET)
+    assert ws.state is ReadinessState.NOT_READY
+    assert ws.detail  # actionable detail present
+
+
+def test_image_compatibility_drift_visible_before_admission():
+    readiness = evaluate_admission_readiness(_all_ready_inputs(exact_image_conformant=False))
+    assert readiness.admit_new is False
+    assert ReadinessCapability.EXACT_IMAGE in readiness.blocking
+
+
+def test_stale_protected_live_evidence_blocks_admission():
+    readiness = evaluate_admission_readiness(
+        _all_ready_inputs(protected_live_evidence_age=timedelta(hours=48))
+    )
+    assert readiness.admit_new is False
+    assert ReadinessCapability.PROTECTED_LIVE_EVIDENCE in readiness.blocking
+
+
+def test_stale_observation_freshness_blocks_admission():
+    readiness = evaluate_admission_readiness(
+        _all_ready_inputs(observation_age=timedelta(hours=1))
+    )
+    assert readiness.admit_new is False
+    assert ReadinessCapability.OBSERVATION_FRESHNESS in readiness.blocking
+
+
+def test_readiness_to_dict_is_bounded_and_serializable():
+    doc = evaluate_admission_readiness(_all_ready_inputs()).to_dict()
+    assert doc["admitNew"] is True
+    assert isinstance(doc["capabilities"], list)
+    # Every capability value is from the closed vocabulary.
+    allowed = {c.value for c in ReadinessCapability}
+    for entry in doc["capabilities"]:
+        assert entry["capability"] in allowed
+        assert entry["state"] in {"ready", "not_ready", "unknown"}

--- a/tests/unit/omnigent/test_control_plane_semantic_telemetry.py
+++ b/tests/unit/omnigent/test_control_plane_semantic_telemetry.py
@@ -1,0 +1,164 @@
+"""Telemetry contract tests for Omnigent semantic spans and metric families.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+Covers the issue's telemetry contract requirements:
+- every domain decision/command maps to a bounded semantic field;
+- no secret-like or forbidden large payload appears in span/metric data;
+- metric label inventories remain low cardinality and identity-free;
+- exporter failure cannot alter application correctness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.control_plane import metrics, spans
+from moonmind.omnigent.reconciler import DecisionKind
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+# --- Spans ------------------------------------------------------------------
+
+
+def test_span_names_are_closed_and_prefixed():
+    assert spans.OMNIGENT_SPANS
+    for name in spans.OMNIGENT_SPANS:
+        assert name.startswith("omnigent.")
+    # A recommended-but-unknown name is rejected.
+    assert not spans.is_omnigent_span("omnigent.not.a.real.span")
+
+
+def test_sanitize_drops_unknown_keys_and_keeps_bounded_values():
+    safe = spans.sanitize_span_attributes(
+        {
+            "decision_class": DecisionKind.SUBMIT_TURN.value,
+            "expected_revision": 7,
+            "attempt_ordinal": 2,
+            "workflow_id": "wf-secret-identity",  # unknown key -> dropped
+            "session_id": "sess-123",  # unknown key -> dropped
+        }
+    )
+    assert safe == {
+        "decision_class": "submit_turn",
+        "expected_revision": 7,
+        "attempt_ordinal": 2,
+    }
+
+
+@pytest.mark.parametrize(
+    "forbidden_value",
+    [
+        "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+        "https://bucket.s3.amazonaws.com/x?X-Amz-Signature=deadbeef",
+        "/home/app/secrets/token",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "line one\nline two transcript",
+        "x" * (spans.MAX_ATTRIBUTE_VALUE_LEN + 1),
+    ],
+)
+def test_sanitize_drops_secret_like_and_oversized_values(forbidden_value):
+    safe = spans.sanitize_span_attributes({"reason_code": forbidden_value})
+    assert "reason_code" not in safe
+
+
+def test_omnigent_span_never_raises_and_runs_body_without_tracer():
+    ran = []
+    with spans.omnigent_span(spans.TURN_SUBMIT, decision_class="submit_turn"):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_omnigent_span_unknown_name_is_noop_but_runs_body():
+    ran = []
+    with spans.omnigent_span("omnigent.bogus", decision_class="submit_turn"):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_span_exporter_failure_cannot_change_correctness(monkeypatch):
+    class _Boom:
+        def start_as_current_span(self, name):
+            raise RuntimeError("exporter down")
+
+    monkeypatch.setattr(spans, "_tracer", lambda: _Boom())
+    result = []
+    with spans.omnigent_span(spans.SESSION_RECONCILE, reason_code="provider_running"):
+        result.append("work-did-run")
+    assert result == ["work-did-run"]
+
+
+# --- Metrics ----------------------------------------------------------------
+
+
+def test_every_decision_kind_maps_to_a_bounded_decision_class():
+    allowed = metrics.BOUNDED_LABEL_VALUES["decision_class"]
+    for kind in DecisionKind:
+        assert kind.value in allowed
+
+
+def test_metric_labels_are_low_cardinality_and_identity_free():
+    inventory = metrics.label_inventory()
+    assert inventory  # non-empty
+    for name, labels in inventory.items():
+        assert not (set(labels) & metrics.FORBIDDEN_LABEL_KEYS), name
+        for label in labels:
+            # Every declared label has a closed bounded value vocabulary.
+            assert label in metrics.BOUNDED_LABEL_VALUES, (name, label)
+
+
+def test_forbidden_identity_label_is_rejected_at_record_time():
+    with pytest.raises(ValueError):
+        metrics.increment(
+            metrics.RECONCILIATION_DECISIONS,
+            decision_class="submit_turn",
+            reason_class="awaiting",
+            session_id="sess-1",  # identity label -> rejected
+        )
+
+
+def test_out_of_vocabulary_label_value_collapses_to_other():
+    metrics.increment(
+        metrics.RECONCILIATION_DECISIONS,
+        decision_class="not_a_real_decision",
+        reason_class="awaiting",
+    )
+    counters = metrics.snapshot()["counters"]
+    assert any("'other'" in key and "'awaiting'" in key for key in counters), counters
+
+
+def test_observation_metric_aggregates_count_total_last():
+    metrics.observe(metrics.SNAPSHOT_LATENCY, 0.5)
+    metrics.observe(metrics.SNAPSHOT_LATENCY, 1.5)
+    obs = metrics.snapshot()["observations"]
+    key = next(iter(obs))
+    assert obs[key]["count"] == 2
+    assert obs[key]["total"] == 2.0
+    assert obs[key]["last"] == 1.5
+
+
+def test_counter_and_observation_kinds_are_enforced():
+    with pytest.raises(TypeError):
+        metrics.observe(metrics.RECONCILIATION_DECISIONS, 1.0, decision_class="no_op", reason_class="awaiting")
+    with pytest.raises(TypeError):
+        metrics.increment(metrics.SNAPSHOT_LATENCY)
+
+
+def test_unknown_metric_name_fails_closed():
+    with pytest.raises(KeyError):
+        metrics.increment("omnigent_not_a_metric")
+
+
+def test_all_required_metric_families_present():
+    names = set(metrics.METRICS)
+    # A representative from each of the four required families.
+    assert metrics.RECONCILIATION_DECISIONS in names
+    assert metrics.TRANSPORT_READINESS in names
+    assert metrics.JANITOR_OPERATIONS in names
+    assert metrics.EXACT_IMAGE_CONFORMANCE in names

--- a/tests/unit/omnigent/test_control_plane_stuck_state.py
+++ b/tests/unit/omnigent/test_control_plane_stuck_state.py
@@ -60,12 +60,39 @@ def test_active_no_recent_evidence_detected_at_deadline():
 
 
 def test_never_observed_counts_as_no_recent_evidence():
-    # Absent observations (lack of evidence) trips the freshness finding, but is
-    # not treated as an observed provider-terminal/active negative.
-    signals = SessionSignals(last_event_at=None, last_snapshot_at=None)
+    # Absent observations aged past the deadline from the durable turn start trip
+    # the freshness finding, but are not treated as an observed
+    # provider-terminal/active negative.
+    signals = SessionSignals(
+        last_event_at=None,
+        last_snapshot_at=None,
+        active_turn_started_at=NOW - POLICY.event_staleness,
+    )
     findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
     assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE in _reasons(findings)
     assert StuckStateReason.PROVIDER_TERMINAL_MOONMIND_NONTERMINAL not in _reasons(findings)
+
+
+def test_fresh_turn_with_no_observations_does_not_trip_freshness():
+    # A turn that has just started with no observations yet must not immediately
+    # trip the freshness finding; absence is aged from the durable start.
+    signals = SessionSignals(
+        last_event_at=None,
+        last_snapshot_at=None,
+        active_turn_started_at=NOW - timedelta(seconds=5),
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE not in _reasons(findings)
+
+
+def test_fresh_evidence_on_one_channel_suppresses_freshness_finding():
+    # One channel is stale, but the other just reported progress => suppressed.
+    signals = SessionSignals(
+        last_event_at=NOW - POLICY.event_staleness,  # stale
+        last_snapshot_at=NOW - timedelta(seconds=5),  # fresh
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE not in _reasons(findings)
 
 
 def test_absent_provider_observation_is_not_a_negative():

--- a/tests/unit/omnigent/test_control_plane_stuck_state.py
+++ b/tests/unit/omnigent/test_control_plane_stuck_state.py
@@ -1,0 +1,234 @@
+"""Stuck-state detector and automated-response tests.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+For the listed conditions: detect at the correct deadline, avoid false positives
+while progress is occurring, trigger one idempotent fenced reconcile request,
+never duplicate a turn or release authority, and quarantine persistent ambiguity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from moonmind.omnigent.control_plane.records import CommandRecord, SessionRecord
+from moonmind.omnigent.control_plane.stuck_state import (
+    ResponseAction,
+    SessionSignals,
+    StuckStatePolicy,
+    StuckStateReason,
+    detect_stuck_state,
+    plan_response,
+)
+
+NOW = datetime(2026, 8, 18, 12, 0, 0, tzinfo=timezone.utc)
+POLICY = StuckStatePolicy()
+
+
+def _session(**overrides) -> SessionRecord:
+    base = dict(
+        session_id="sess-1",
+        moonmind_workflow_id="wf-1",
+        provider="codex",
+        revision=5,
+        fencing_generation=2,
+        active_turn_attempt_id="turn-1",
+    )
+    base.update(overrides)
+    return SessionRecord(**base)
+
+
+def _reasons(findings):
+    return {f.reason for f in findings}
+
+
+def test_no_findings_when_progress_is_fresh():
+    signals = SessionSignals(
+        last_event_at=NOW - timedelta(seconds=5),
+        last_snapshot_at=NOW - timedelta(seconds=5),
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert findings == []
+    assert plan_response(session=_session(), findings=findings) is None
+
+
+def test_active_no_recent_evidence_detected_at_deadline():
+    stale = NOW - POLICY.event_staleness
+    signals = SessionSignals(last_event_at=stale, last_snapshot_at=stale)
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE in _reasons(findings)
+
+
+def test_never_observed_counts_as_no_recent_evidence():
+    # Absent observations (lack of evidence) trips the freshness finding, but is
+    # not treated as an observed provider-terminal/active negative.
+    signals = SessionSignals(last_event_at=None, last_snapshot_at=None)
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE in _reasons(findings)
+    assert StuckStateReason.PROVIDER_TERMINAL_MOONMIND_NONTERMINAL not in _reasons(findings)
+
+
+def test_absent_provider_observation_is_not_a_negative():
+    # provider_terminal is None (not observed) => no divergence finding.
+    signals = SessionSignals(
+        last_event_at=NOW, last_snapshot_at=NOW, provider_terminal=None, provider_active=None
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.PROVIDER_TERMINAL_MOONMIND_NONTERMINAL not in _reasons(findings)
+
+
+def test_provider_terminal_moonmind_nonterminal():
+    signals = SessionSignals(last_event_at=NOW, last_snapshot_at=NOW, provider_terminal=True)
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    reasons = _reasons(findings)
+    assert StuckStateReason.PROVIDER_TERMINAL_MOONMIND_NONTERMINAL in reasons
+
+
+def test_moonmind_terminal_provider_active():
+    session = _session(terminal_state="success")
+    signals = SessionSignals(provider_active=True)
+    findings = detect_stuck_state(session=session, signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_TERMINAL_PROVIDER_ACTIVE in _reasons(findings)
+
+
+def test_active_turn_liveness_only():
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        liveness_only_since=NOW - POLICY.liveness_only_max,
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.ACTIVE_TURN_LIVENESS_ONLY in _reasons(findings)
+
+
+def test_repeated_no_progress():
+    signals = SessionSignals(
+        last_event_at=NOW, last_snapshot_at=NOW, consecutive_no_progress=POLICY.no_progress_max
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.REPEATED_RECONCILIATION_NO_PROGRESS in _reasons(findings)
+
+
+def test_orphan_host_lease():
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        host_lease_active=True,
+        host_lease_owns_session_authority=False,
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.HOST_LEASE_WITHOUT_SESSION_AUTHORITY in _reasons(findings)
+
+
+def test_profile_lease_without_consumer():
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        profile_lease_active=True,
+        profile_lease_has_consumer=False,
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.PROFILE_LEASE_WITHOUT_CONSUMER in _reasons(findings)
+
+
+def test_cleanup_incomplete_past_deadline():
+    session = _session(terminal_state="success", cleanup_state="claimed", active_turn_attempt_id=None)
+    signals = SessionSignals(cleanup_started_at=NOW - POLICY.cleanup_deadline)
+    findings = detect_stuck_state(session=session, signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.CLEANUP_INCOMPLETE_PAST_DEADLINE in _reasons(findings)
+
+
+def test_compatibility_unknown_after_admission():
+    signals = SessionSignals(
+        last_event_at=NOW, last_snapshot_at=NOW, admitted=True, compatibility_known=None
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.COMPATIBILITY_UNKNOWN_AFTER_ADMISSION in _reasons(findings)
+
+
+def test_command_stuck_claimed():
+    command = CommandRecord(
+        command_id="cmd-1",
+        session_id="sess-1",
+        command_type="submit_turn",
+        idempotency_key="ik",
+        payload_digest="pd",
+        status="claimed",
+    )
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        active_command=command,
+        active_command_since=NOW - POLICY.command_stuck_max,
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.COMMAND_STUCK_CLAIMED_OR_DELIVERY_UNKNOWN in _reasons(findings)
+
+
+def test_live_conformance_evidence_stale_is_observe_only():
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        conformance_evidence_at=NOW - POLICY.conformance_max_age,
+    )
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    conformance = [f for f in findings if f.reason is StuckStateReason.LIVE_CONFORMANCE_EVIDENCE_STALE]
+    assert conformance and conformance[0].action is ResponseAction.OBSERVE
+
+
+def test_no_false_positive_just_before_deadline():
+    just_fresh = NOW - POLICY.event_staleness + timedelta(seconds=1)
+    signals = SessionSignals(last_event_at=just_fresh, last_snapshot_at=just_fresh)
+    findings = detect_stuck_state(session=_session(), signals=signals, now=NOW, policy=POLICY)
+    assert StuckStateReason.MOONMIND_ACTIVE_NO_RECENT_EVIDENCE not in _reasons(findings)
+
+
+# --- Automated response policy ----------------------------------------------
+
+
+def test_first_response_is_a_fenced_reconcile_bound_to_current_authority():
+    session = _session(revision=9, fencing_generation=4)
+    signals = SessionSignals(provider_terminal=True, last_event_at=NOW, last_snapshot_at=NOW)
+    findings = detect_stuck_state(session=session, signals=signals, now=NOW, policy=POLICY)
+    response = plan_response(session=session, findings=findings)
+    assert response is not None
+    assert response.reconcile is True
+    assert response.quarantine is False
+    assert response.expected_revision == 9
+    assert response.expected_fencing_generation == 4
+
+
+def test_detector_never_authorizes_a_provider_mutation():
+    # No action across the entire ResponseAction vocabulary is a resubmit/release.
+    assert {a.value for a in ResponseAction} == {"reconcile", "quarantine", "observe"}
+
+
+def test_persistent_ambiguity_escalates_to_quarantine():
+    session = _session()
+    signals = SessionSignals(provider_terminal=True, last_event_at=NOW, last_snapshot_at=NOW)
+    findings = detect_stuck_state(session=session, signals=signals, now=NOW, policy=POLICY)
+    response = plan_response(
+        session=session,
+        findings=findings,
+        prior_detection_count=POLICY.persistent_ambiguity_max,
+        policy=POLICY,
+    )
+    assert response is not None
+    assert response.quarantine is True
+    assert response.reconcile is False
+    assert "reasons" in response.diagnostics
+
+
+def test_observe_only_findings_do_not_reconcile_or_quarantine():
+    session = _session()
+    signals = SessionSignals(
+        last_event_at=NOW,
+        last_snapshot_at=NOW,
+        conformance_evidence_at=NOW - POLICY.conformance_max_age,
+    )
+    findings = detect_stuck_state(session=session, signals=signals, now=NOW, policy=POLICY)
+    response = plan_response(session=session, findings=findings)
+    assert response is not None
+    assert response.reconcile is False
+    assert response.quarantine is False
+    assert response.remediation is not None

--- a/tests/unit/omnigent/test_control_plane_timeline.py
+++ b/tests/unit/omnigent/test_control_plane_timeline.py
@@ -48,6 +48,22 @@ def test_launching_session_explained_from_records():
     assert doc["state"]["revision"] == 3
 
 
+def test_turn_attempt_count_uses_explicit_count_when_supplied():
+    # A caller that fetched only the active turn attempt (bounded query) supplies
+    # the authoritative database count instead of len(turn_attempts).
+    session = _session(active_turn_attempt_id="turn-1", provider_session_ref="psr-1")
+    active = TurnAttemptRecord(
+        turn_attempt_id="turn-1", session_id="sess-1", idempotency_key="k1", state="running"
+    )
+    timeline = build_timeline(
+        session=session, turn_attempts=[active], turn_attempt_count=42
+    )
+    assert timeline.turn_attempt_count == 42
+    assert timeline.active_turn_attempt_state == "running"
+    # Falls back to the sequence length when no explicit count is given.
+    assert build_timeline(session=session, turn_attempts=[active]).turn_attempt_count == 1
+
+
 def test_awaiting_observation_status():
     session = _session(active_turn_attempt_id="turn-1", provider_session_ref="psr-1")
     timeline = build_timeline(
@@ -132,8 +148,12 @@ def test_timeline_survives_live_resource_deletion():
     assert doc["terminal"]["state"] == "success"
     assert doc["terminal"]["evidenceRef"] == "evidence-xyz"
     assert doc["lastDecision"]["decisionCode"] == "record_provider_terminal"
-    assert doc["lastDecision"]["traceLink"] == "/api/omnigent/traces/trace123"
-    assert doc["links"]["trace"] == "/api/omnigent/traces/trace123"
+    # Trace has no registered route in this phase, so the link is omitted rather
+    # than pointed at a nonexistent /api/omnigent/traces route (would 404).
+    assert doc["lastDecision"]["traceLink"] is None
+    assert doc["links"]["trace"] is None
+    # Artifact-backed diagnostics link uses the registered /api/artifacts route.
+    assert doc["lastDecision"]["diagnosticsLink"] == "/api/artifacts/artifact456"
 
 
 def test_timeline_drops_secret_like_refs_and_host_paths():

--- a/tests/unit/omnigent/test_control_plane_timeline.py
+++ b/tests/unit/omnigent/test_control_plane_timeline.py
@@ -1,0 +1,190 @@
+"""Operator session-timeline projection tests.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+Constructs sessions in launching, running, delivery-unknown, awaiting-observation,
+terminal, cleanup-incomplete, and quarantined states and verifies the timeline
+explains the state from durable records and survives live-resource deletion.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from moonmind.omnigent.control_plane import build_timeline
+from moonmind.omnigent.control_plane.records import (
+    CleanupAuthorityRecord,
+    CommandRecord,
+    DecisionRecord,
+    ObservationRecord,
+    SessionRecord,
+    TurnAttemptRecord,
+)
+from moonmind.omnigent.control_plane.timeline import TimelineStatus
+
+NOW = datetime(2026, 8, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _session(**overrides) -> SessionRecord:
+    base = dict(
+        session_id="sess-1",
+        moonmind_workflow_id="wf-1",
+        provider="codex",
+        intent_ref="intent-abc",
+        intent_digest="deadbeef",
+        desired_state="run",
+        revision=3,
+        fencing_generation=1,
+    )
+    base.update(overrides)
+    return SessionRecord(**base)
+
+
+def test_launching_session_explained_from_records():
+    timeline = build_timeline(session=_session())
+    assert timeline.status is TimelineStatus.LAUNCHING
+    doc = timeline.to_dict()
+    assert doc["state"]["desired"] == "run"
+    assert doc["state"]["revision"] == 3
+
+
+def test_awaiting_observation_status():
+    session = _session(active_turn_attempt_id="turn-1", provider_session_ref="psr-1")
+    timeline = build_timeline(
+        session=session,
+        turn_attempts=[
+            TurnAttemptRecord(
+                turn_attempt_id="turn-1", session_id="sess-1", idempotency_key="k1", state="running"
+            )
+        ],
+    )
+    assert timeline.status is TimelineStatus.AWAITING_OBSERVATION
+    assert timeline.active_turn_attempt_state == "running"
+
+
+def test_running_status_with_observed_state():
+    session = _session(
+        active_turn_attempt_id="turn-1", provider_session_ref="psr-1", observed_state="active"
+    )
+    timeline = build_timeline(session=session)
+    assert timeline.status is TimelineStatus.RUNNING
+
+
+def test_delivery_unknown_status_takes_precedence():
+    command = CommandRecord(
+        command_id="cmd-1",
+        session_id="sess-1",
+        command_type="submit_turn",
+        idempotency_key="ik-1",
+        payload_digest="pd-1",
+        status="delivery_unknown",
+        delivery_ambiguous=True,
+    )
+    timeline = build_timeline(session=_session(observed_state="active"), commands=[command])
+    assert timeline.status is TimelineStatus.DELIVERY_UNKNOWN
+    assert timeline.active_command is not None
+    assert timeline.active_command.delivery_ambiguous is True
+
+
+def test_terminal_with_incomplete_cleanup():
+    session = _session(terminal_state="success", cleanup_state="pending")
+    cleanup = CleanupAuthorityRecord(session_id="sess-1", state="claimed")
+    timeline = build_timeline(session=session, cleanup=cleanup)
+    assert timeline.status is TimelineStatus.CLEANUP_INCOMPLETE
+    assert timeline.janitor_state == "claimed"
+
+
+def test_terminal_closed_when_cleanup_complete():
+    session = _session(terminal_state="success", cleanup_state="complete")
+    cleanup = CleanupAuthorityRecord(session_id="sess-1", state="complete")
+    timeline = build_timeline(session=session, cleanup=cleanup)
+    assert timeline.status is TimelineStatus.CLOSED
+
+
+def test_quarantined_status_from_metadata():
+    session = _session(metadata={"quarantined": True})
+    timeline = build_timeline(session=session)
+    assert timeline.status is TimelineStatus.QUARANTINED
+
+
+def test_timeline_survives_live_resource_deletion():
+    # Terminal session whose live provider/host/workspace observations and
+    # commands have been cleaned up: only durable session + decision remain.
+    session = _session(
+        terminal_state="success",
+        terminal_evidence_ref="evidence-xyz",
+        cleanup_state="complete",
+        observed_state="terminal_success",
+        reconciled_state="closed",
+    )
+    decision = DecisionRecord(
+        decision_id="dec-1",
+        session_id="sess-1",
+        decision_code="record_provider_terminal",
+        reason_code="terminal_event_observed",
+        created_at=NOW,
+        trace_ref="trace123",
+        diagnostics_ref="artifact456",
+    )
+    timeline = build_timeline(session=session, observations=[], commands=[], decisions=[decision])
+    doc = timeline.to_dict()
+    # The durable evidence and last decision are still explained after cleanup.
+    assert doc["terminal"]["state"] == "success"
+    assert doc["terminal"]["evidenceRef"] == "evidence-xyz"
+    assert doc["lastDecision"]["decisionCode"] == "record_provider_terminal"
+    assert doc["lastDecision"]["traceLink"] == "/api/omnigent/traces/trace123"
+    assert doc["links"]["trace"] == "/api/omnigent/traces/trace123"
+
+
+def test_timeline_drops_secret_like_refs_and_host_paths():
+    session = _session(
+        intent_ref="/home/app/secret/intent.json",  # host path -> dropped
+        terminal_evidence_ref="ghp_" + "a" * 36,  # credential -> dropped
+        compatibility_ref="compat-ok",
+        image_manifest_ref="sha256digest",
+    )
+    timeline = build_timeline(session=session)
+    doc = timeline.to_dict()
+    assert doc["intent"]["ref"] is None
+    assert doc["terminal"]["evidenceRef"] is None
+    assert doc["compatibility"]["ref"] == "compat-ok"
+    assert doc["compatibility"]["imageManifestRef"] == "sha256digest"
+
+
+def test_timeline_shows_desired_durable_observed_reconciled_difference():
+    session = _session(
+        desired_state="run",
+        observed_state="active",
+        reconciled_state="running",
+    )
+    doc = build_timeline(session=session).to_dict()
+    state = doc["state"]
+    assert state["desired"] == "run"
+    assert state["observed"] == "active"
+    assert state["reconciled"] == "running"
+    assert state["durable"] == "running"
+
+
+def test_last_snapshot_derived_from_observations():
+    session = _session(active_turn_attempt_id="turn-1", provider_session_ref="psr-1")
+    older = ObservationRecord(
+        observation_id="o1",
+        session_id="sess-1",
+        observation_type="snapshot",
+        source="provider",
+        observed_at=datetime(2026, 8, 18, 11, 0, tzinfo=timezone.utc),
+        deduplication_key="d1",
+        source_digest="digest-old",
+    )
+    newer = ObservationRecord(
+        observation_id="o2",
+        session_id="sess-1",
+        observation_type="snapshot",
+        source="provider",
+        observed_at=NOW,
+        deduplication_key="d2",
+        source_digest="digest-new",
+    )
+    timeline = build_timeline(session=session, observations=[older, newer])
+    assert timeline.last_snapshot_at == NOW
+    assert timeline.last_snapshot_digest == "digest-new"

--- a/tests/unit/omnigent/test_omnigent_session_timeline_api.py
+++ b/tests/unit/omnigent/test_omnigent_session_timeline_api.py
@@ -1,0 +1,147 @@
+"""API boundary tests for the operator session-timeline endpoints.
+
+Source: MoonLadderStudios/MoonMind#3708 ([Omnigent control plane 7/11]).
+
+Exercises the authorized machine-readable timeline endpoint and the stuck-state
+endpoint through the real FastAPI route + auth boundary, with the control-plane
+repositories faked so the test stays hermetic (no database).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import api_service.api.routers.omnigent_session_timeline as timeline_api
+from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
+from moonmind.omnigent.control_plane.records import SessionRecord
+
+NOW = datetime(2026, 8, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class _FakeUser:
+    id: str = "op-1"
+    is_superuser: bool = True
+    settings_permissions: set = field(default_factory=set)
+
+
+class _FakeRepo:
+    def __init__(self, session):
+        self._session = session
+
+    async def get(self, session_id):
+        if session_id != self._session.session_id:
+            return None
+        return self._session
+
+    async def list_for_session(self, session_id, **_kwargs):
+        return []
+
+
+class _FakeRepos:
+    def __init__(self, session_record):
+        self.sessions = _FakeRepo(session_record)
+        self.turn_attempts = _FakeRepo(session_record)
+        self.observations = _FakeRepo(session_record)
+        self.commands = _FakeRepo(session_record)
+        self.decisions = _FakeRepo(session_record)
+
+        class _Cleanup:
+            async def get(self, _sid):
+                return None
+
+        self.cleanup = _Cleanup()
+
+
+def _build_app(session_record, user):
+    app = FastAPI()
+    app.include_router(timeline_api.router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_async_session] = lambda: iter([object()])
+    return app
+
+
+@pytest.fixture()
+def session_record():
+    return SessionRecord(
+        session_id="sess-1",
+        moonmind_workflow_id="wf-1",
+        provider="codex",
+        terminal_state="success",
+        cleanup_state="complete",
+        revision=4,
+        fencing_generation=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeline_endpoint_returns_projection(monkeypatch, session_record):
+    monkeypatch.setattr(
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+    )
+    app = _build_app(session_record, _FakeUser())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/omnigent/sessions/sess-1/timeline")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sessionId"] == "sess-1"
+    assert body["state"]["revision"] == 4
+    assert body["explanation"]["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_timeline_endpoint_404_for_unknown_session(monkeypatch, session_record):
+    monkeypatch.setattr(
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+    )
+    app = _build_app(session_record, _FakeUser())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/omnigent/sessions/does-not-exist/timeline")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_timeline_endpoint_requires_operator_permission(monkeypatch, session_record):
+    monkeypatch.setattr(
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+    )
+    unauthorized = _FakeUser(is_superuser=False, settings_permissions=set())
+    app = _build_app(session_record, unauthorized)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/omnigent/sessions/sess-1/timeline")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stuck_state_endpoint_returns_findings_and_response(monkeypatch):
+    active = SessionRecord(
+        session_id="sess-1",
+        moonmind_workflow_id="wf-1",
+        provider="codex",
+        active_turn_attempt_id="turn-1",
+        revision=7,
+        fencing_generation=3,
+    )
+    monkeypatch.setattr(
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(active))
+    )
+    app = _build_app(active, _FakeUser())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/omnigent/sessions/sess-1/stuck-state")
+    assert resp.status_code == 200
+    body = resp.json()
+    # No observations at all -> active-with-no-recent-evidence -> fenced reconcile.
+    assert any(f["reason"] == "moonmind_active_no_recent_evidence" for f in body["findings"])
+    assert body["response"]["reconcile"] is True
+    assert body["response"]["expectedRevision"] == 7
+    assert body["response"]["expectedFencingGeneration"] == 3

--- a/tests/unit/omnigent/test_omnigent_session_timeline_api.py
+++ b/tests/unit/omnigent/test_omnigent_session_timeline_api.py
@@ -19,7 +19,7 @@ from httpx import ASGITransport, AsyncClient
 import api_service.api.routers.omnigent_session_timeline as timeline_api
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
-from moonmind.omnigent.control_plane.records import SessionRecord
+from moonmind.omnigent.control_plane.records import SessionRecord, TurnAttemptRecord
 
 NOW = datetime(2026, 8, 18, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -31,7 +31,7 @@ class _FakeUser:
     settings_permissions: set = field(default_factory=set)
 
 
-class _FakeRepo:
+class _FakeSessions:
     def __init__(self, session):
         self._session = session
 
@@ -40,23 +40,81 @@ class _FakeRepo:
             return None
         return self._session
 
-    async def list_for_session(self, session_id, **_kwargs):
-        return []
+
+class _FakeTurnAttempts:
+    def __init__(self, active_turn=None, count=0):
+        self._active = active_turn
+        self._count = count
+
+    async def get(self, turn_attempt_id):
+        if self._active is not None and self._active.turn_attempt_id == turn_attempt_id:
+            return self._active
+        return None
+
+    async def count_for_session(self, _session_id):
+        return self._count
+
+
+class _FakeObservations:
+    def __init__(self, latest_event=None, latest_snapshot=None):
+        self._event = latest_event
+        self._snapshot = latest_snapshot
+
+    async def latest_for_session(self, _session_id, *, observation_types=None):
+        types = set(observation_types or ())
+        if types & {"snapshot", "provider_snapshot"}:
+            return self._snapshot
+        return self._event
+
+
+class _FakeCommands:
+    def __init__(self, active=None):
+        self._active = active
+
+    async def active_for_session(self, _session_id):
+        return self._active
+
+
+class _FakeDecisions:
+    def __init__(self, latest=None, reason_counts=None):
+        self._latest = latest
+        self._reason_counts = reason_counts or {}
+
+    async def latest_for_session(self, _session_id):
+        return self._latest
+
+    async def count_for_session_reason(self, _session_id, reason_code):
+        return self._reason_counts.get(reason_code, 0)
+
+
+class _FakeCleanup:
+    def __init__(self, cleanup=None):
+        self._cleanup = cleanup
+
+    async def get(self, _session_id):
+        return self._cleanup
 
 
 class _FakeRepos:
-    def __init__(self, session_record):
-        self.sessions = _FakeRepo(session_record)
-        self.turn_attempts = _FakeRepo(session_record)
-        self.observations = _FakeRepo(session_record)
-        self.commands = _FakeRepo(session_record)
-        self.decisions = _FakeRepo(session_record)
-
-        class _Cleanup:
-            async def get(self, _sid):
-                return None
-
-        self.cleanup = _Cleanup()
+    def __init__(
+        self,
+        session_record,
+        *,
+        active_turn=None,
+        turn_count=0,
+        latest_event=None,
+        latest_snapshot=None,
+        active_command=None,
+        latest_decision=None,
+        reason_counts=None,
+        cleanup=None,
+    ):
+        self.sessions = _FakeSessions(session_record)
+        self.turn_attempts = _FakeTurnAttempts(active_turn, turn_count)
+        self.observations = _FakeObservations(latest_event, latest_snapshot)
+        self.commands = _FakeCommands(active_command)
+        self.decisions = _FakeDecisions(latest_decision, reason_counts)
+        self.cleanup = _FakeCleanup(cleanup)
 
 
 def _build_app(session_record, user):
@@ -121,6 +179,20 @@ async def test_timeline_endpoint_requires_operator_permission(monkeypatch, sessi
     assert resp.status_code == 403
 
 
+#: A durably-old turn start so the absence of observations is aged past the
+#: staleness deadline regardless of the wall-clock ``now`` the endpoint reads.
+_LONG_AGO = datetime(2000, 1, 1, tzinfo=timezone.utc)
+
+
+def _active_turn(turn_attempt_id="turn-1", *, created_at=_LONG_AGO):
+    return TurnAttemptRecord(
+        turn_attempt_id=turn_attempt_id,
+        session_id="sess-1",
+        idempotency_key="k1",
+        created_at=created_at,
+    )
+
+
 @pytest.mark.asyncio
 async def test_stuck_state_endpoint_returns_findings_and_response(monkeypatch):
     active = SessionRecord(
@@ -131,8 +203,9 @@ async def test_stuck_state_endpoint_returns_findings_and_response(monkeypatch):
         revision=7,
         fencing_generation=3,
     )
+    repos = _FakeRepos(active, active_turn=_active_turn(), turn_count=1)
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(active))
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
     )
     app = _build_app(active, _FakeUser())
     transport = ASGITransport(app=app)
@@ -140,8 +213,41 @@ async def test_stuck_state_endpoint_returns_findings_and_response(monkeypatch):
         resp = await client.get("/api/omnigent/sessions/sess-1/stuck-state")
     assert resp.status_code == 200
     body = resp.json()
-    # No observations at all -> active-with-no-recent-evidence -> fenced reconcile.
+    # No observations, but the turn started long ago -> absence is aged out ->
+    # active-with-no-recent-evidence -> fenced reconcile.
     assert any(f["reason"] == "moonmind_active_no_recent_evidence" for f in body["findings"])
     assert body["response"]["reconcile"] is True
     assert body["response"]["expectedRevision"] == 7
     assert body["response"]["expectedFencingGeneration"] == 3
+
+
+@pytest.mark.asyncio
+async def test_stuck_state_endpoint_escalates_with_durable_detection_count(monkeypatch):
+    # When the durable decision journal already records the dominant reason at or
+    # beyond the persistent-ambiguity threshold, the endpoint escalates to
+    # quarantine instead of recommending reconcile forever.
+    active = SessionRecord(
+        session_id="sess-1",
+        moonmind_workflow_id="wf-1",
+        provider="codex",
+        active_turn_attempt_id="turn-1",
+        revision=7,
+        fencing_generation=3,
+    )
+    repos = _FakeRepos(
+        active,
+        active_turn=_active_turn(),
+        turn_count=1,
+        reason_counts={"moonmind_active_no_recent_evidence": 3},
+    )
+    monkeypatch.setattr(
+        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
+    )
+    app = _build_app(active, _FakeUser())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/omnigent/sessions/sess-1/stuck-state")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["response"]["quarantine"] is True
+    assert body["response"]["reconcile"] is False


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3708 — [Omnigent control plane 7/11] Add semantic telemetry, an operator session timeline, and automated stuck-state reconciliation

Closes MoonLadderStudios/MoonMind#3708

## Summary

Adds the Omnigent lifecycle observability and reconciliation layer described in #3708, built on the existing OpenTelemetry and canonical session-state foundations delivered by #3702/#3703/#3704.

- **Semantic trace model** (`moonmind/omnigent/control_plane/spans.py`): a closed `omnigent.*` span vocabulary with bounded, secret-free attributes. `omnigent_span` instruments infra/activity boundaries only (no exporter I/O in deterministic workflow code), swallows tracer/exporter errors so telemetry failure cannot change execution correctness, and sanitizes attribute values (drops credentials, presigned URLs, host paths, oversized values).
- **Metrics** (`moonmind/omnigent/control_plane/metrics.py`): the four required low-cardinality metric families (reconciliation non-conflict, provider/transport, resources/cleanup, compatibility/verification). Labels are validated at record time against a forbidden-identity list and a bounded value vocabulary (out-of-vocab collapses to `other`). The #3704 conflict counters are intentionally not duplicated (Simplicity Gate).
- **Durable operator session timeline** (`moonmind/omnigent/control_plane/timeline.py` + `api_service/api/routers/omnigent_session_timeline.py`, wired in `api_service/main.py`): a machine-readable projection derived solely from canonical session/turn/observation/command/decision records. It shows the difference among desired/durable/observed/reconciled state, explains why a session is waiting/retrying/quarantined/terminal/cleanup-incomplete, exposes safe server-authored links, and survives provider/host/workspace cleanup. The authorized `GET /api/omnigent/sessions/{id}/timeline` endpoint requires `operations.read`.
- **Stuck-state detector** (`moonmind/omnigent/control_plane/stuck_state.py`): a bounded detector covering all 11 listed conditions using tri-state signals that distinguish lack-of-evidence from an observed negative. The first automated response is always a fenced reconciliation bound to the current revision and fencing generation — never a blind duplicate provider mutation (the response vocabulary contains no provider-mutation action). Persistent ambiguity escalates to quarantine with redacted durable diagnostics.
- **New-admission readiness** (`moonmind/omnigent/control_plane/readiness.py`): a fail-closed admission surface over 14 runtime capabilities and evidence-freshness signals (incl. WebSocket availability, exact-image conformance, protected-live evidence age). Unknown/negative signals block new admission while historical reads and cleanup remain available.
- **Canonical design doc**: `docs/Omnigent/OmnigentSemanticTelemetryAndTimeline.md`.

## Tests run

- `python -m pytest tests/unit/omnigent/test_control_plane_readiness.py tests/unit/omnigent/test_control_plane_semantic_telemetry.py tests/unit/omnigent/test_control_plane_stuck_state.py tests/unit/omnigent/test_control_plane_timeline.py tests/unit/omnigent/test_omnigent_session_timeline_api.py -q` → **61 passed** (hermetic, no external credentials/services).

Coverage includes: closed span vocabulary + bounded attributes, exporter-failure-does-not-alter-correctness, low-cardinality/identity-free metric labels + all required families, timeline lifecycle states + desired/durable/observed/reconciled differencing + survival after live-resource deletion + secret/host-path redaction, stuck detector for every listed condition (at deadline, no false positive just-before-deadline, absent observation not treated as negative), fenced-reconcile-first / never-blind-mutation / quarantine escalation, fail-closed readiness with historical reads/cleanup preserved, and the authorized API boundary (permission enforcement + 404).

## Remaining risks

- OpenTelemetry exporter wiring to a live collector/backend and end-to-end trace emission are not exercised in the hermetic runtime; the control plane treats the tracer as optional and fails safe, and the bounded/secret-free/exporter-failure-safe contract is verified by unit tests without a live exporter.
- `#3642` and `#3508` acceptance artifacts are separate issues outside this change's repository scope; this change provides the referenceable readiness/telemetry/timeline evidence surfaces they depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
