### PR TITLE
Fence Omnigent host cleanup authority

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 3803594905,
+    "id": 3807043073,
     "disposition": "addressed",
-    "rationale": "Updated PINNED_OMNIGENT_COMMIT to the PR submodule commit and refreshed the native compatibility fixture hashes anchored to that pinned source for contract verification."
+    "rationale": "Heartbeat renewal now uses a conditional SQL update over heartbeat-owning states, making it mutually exclusive with the cleanup claim CAS."
   },
   {
-    "id": 4960451954,
+    "id": 3807043083,
+    "disposition": "addressed",
+    "rationale": "Cleanup claims now renew expires_at for the bounded cleanup ownership window in the same atomic update."
+  },
+  {
+    "id": 3807043091,
+    "disposition": "addressed",
+    "rationale": "A typed cleanup-ownership loss now routes coordinator finalization to janitor-required waiting without host stop or Provider Profile release."
+  },
+  {
+    "id": 3807043093,
+    "disposition": "addressed",
+    "rationale": "Lease-scoped drain, stop, remove, eviction, and stale-reconciliation actions now share the atomic cleanup claim before side effects."
+  },
+  {
+    "id": 3807043100,
+    "disposition": "addressed",
+    "rationale": "Orphan cleanup now reloads the host lease identified by the container label and leaves lease-owned containers to the fenced cleanup path."
+  },
+  {
+    "id": 4964716657,
     "disposition": "not-applicable",
-    "rationale": "Informational bot review summary comment with no standalone code or test action required."
+    "rationale": "Informational Codex review envelope; its five child threads contain the complete actionable feedback."
   }
 ]

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -354,6 +354,13 @@ Cleanup is idempotent across activity retry and worker failure:
   the observed lease status and heartbeat and moves it to `draining`; a
   concurrent heartbeat or state transition defeats the claim and defers cleanup
   to a later reconciliation pass;
+- heartbeat renewal is itself conditional on a heartbeat-owning state, so a
+  cleanup claim and heartbeat cannot both succeed; the claim renews a bounded
+  cleanup-ownership expiry, and the coordinator relinquishes cleanup and
+  Provider Profile release when that authority is lost;
+- orphan discovery resolves the container's durable host-lease label and reloads
+  that lease before removal; any lease-owned container stays on the fenced lease
+  cleanup path even when it appeared after the janitor's initial snapshot;
 - expired, missing-after-materialization, orphaned, and stale-generation hosts
   are reconciled by the host janitor;
 - cleanup failure leaves explicit `janitorRequired` evidence and does not falsely release credential capacity;

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -346,7 +346,16 @@ Cleanup is idempotent across activity retry and worker failure:
 
 - on-demand cleanup stops and removes the deterministic container and its lease-owned Omnigent state volume;
 - static cleanup stops or drains the dedicated Codex host according to policy;
-- expired, missing, orphaned, and stale-generation hosts are reconciled by the host janitor;
+- container absence is cleanup evidence only after the lease crosses the
+  materialization boundary into `ready` or `assigned`; an `allocating` or
+  `starting` lease is cleanup-eligible only when it is expired, stale, or named
+  by explicit durable reconciliation evidence;
+- before stopping a host or releasing capacity, the janitor atomically claims
+  the observed lease status and heartbeat and moves it to `draining`; a
+  concurrent heartbeat or state transition defeats the claim and defers cleanup
+  to a later reconciliation pass;
+- expired, missing-after-materialization, orphaned, and stale-generation hosts
+  are reconciled by the host janitor;
 - cleanup failure leaves explicit `janitorRequired` evidence and does not falsely release credential capacity;
 - Provider Profile release is the final lifecycle action.
 

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -9,7 +9,10 @@ from moonmind.omnigent.oauth_host_runtime import (
     OmnigentEgressEvidenceRequestIdentity,
     OmnigentOAuthHostRuntime,
 )
-from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostRepository
+from moonmind.omnigent.oauth_hosts import (
+    CLEANUP_CLAIMABLE_HOST_STATES,
+    OmnigentOAuthHostRepository,
+)
 from moonmind.provider_profiles.lease_client import (
     CredentialLease,
     CredentialLeasePurpose,
@@ -368,16 +371,47 @@ class OmnigentOAuthHostJanitor:
                 lease.container_name
                 and not await self._runtime.container_exists(lease.container_name)
             )
+            # ``allocating`` and ``starting`` precede the container
+            # materialization authority handoff. A deterministic container name
+            # exists on the lease during that window, but the container is not
+            # required to exist yet. Absence alone is therefore not cleanup
+            # evidence until the coordinator crosses into ready/assigned. A
+            # stale/expired lease or an explicit durable reconciliation signal
+            # still permits cleanup of an abandoned launch.
+            missing_requires_cleanup = bool(
+                missing and lease.status not in {"allocating", "starting"}
+            )
             if (
                 not force
                 and not expired
-                and not missing
+                and not missing_requires_cleanup
                 and not stale
                 and not terminal_cleanup
                 and not terminal_provider_cleanup
                 and not reconciliation_action
             ):
                 continue
+            # A fresh draining lease already has a cleanup owner. Let that owner
+            # finish; only a stale/expired pass may recover an abandoned drain.
+            if (
+                lease.status == "draining"
+                and not force
+                and not expired
+                and not stale
+            ):
+                continue
+            if lease.status in CLEANUP_CLAIMABLE_HOST_STATES:
+                claimed = await self._repository.claim_host_lease_cleanup(
+                    lease.lease_id,
+                    expected_status=lease.status,
+                    expected_last_heartbeat_at=lease.last_heartbeat_at,
+                )
+                if claimed is None:
+                    # The coordinator advanced state or heartbeat authority
+                    # after this janitor pass observed it. Reconcile from the
+                    # next durable scan; never clean from the stale snapshot.
+                    continue
+                lease = claimed
             binding = await self._repository.validate_binding(lease.binding_ref)
             if lease.omnigent_session_id:
                 try:

--- a/moonmind/omnigent/oauth_host_janitor.py
+++ b/moonmind/omnigent/oauth_host_janitor.py
@@ -11,6 +11,7 @@ from moonmind.omnigent.oauth_host_runtime import (
 )
 from moonmind.omnigent.oauth_hosts import (
     CLEANUP_CLAIMABLE_HOST_STATES,
+    OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
 )
 from moonmind.provider_profiles.lease_client import (
@@ -41,6 +42,18 @@ class OmnigentOAuthHostJanitor:
         self._artifact_gateway = artifact_gateway
         self._heartbeat_timeout = timedelta(
             seconds=max(30, heartbeat_timeout_seconds)
+        )
+
+    async def _claim_cleanup(self, lease: Any) -> Any | None:
+        """Claim the observed lease generation before cleanup side effects."""
+
+        if lease.status not in CLEANUP_CLAIMABLE_HOST_STATES:
+            return lease
+        return await self._repository.claim_host_lease_cleanup(
+            lease.lease_id,
+            expected_status=lease.status,
+            expected_last_heartbeat_at=lease.last_heartbeat_at,
+            ttl_seconds=int(self._heartbeat_timeout.total_seconds()),
         )
 
     async def _release_provider_lease(self, *, binding: Any, lease: Any) -> bool:
@@ -218,9 +231,12 @@ class OmnigentOAuthHostJanitor:
                 return self._action_result(
                     action_kind, request_id, profile_id, lease, before_state
                 )
-            lease = await self._repository.transition_host_lease(
-                lease.lease_id, expected_status=before_state, new_status="draining"
-            )
+            claimed = await self._claim_cleanup(lease)
+            if claimed is None:
+                raise OmnigentOAuthHostError(
+                    "host lease changed concurrently before cleanup claim"
+                )
+            lease = claimed
         elif action_kind == "host.restart":
             raise ValueError(
                 "host.restart is unsupported until the owning launch path can "
@@ -241,6 +257,16 @@ class OmnigentOAuthHostJanitor:
             "provider_profile.evict_stale_lease",
             "host_lease.reconcile_stale",
         }:
+            if lease.status == "draining" and not stale:
+                raise OmnigentOAuthHostError(
+                    "host lease cleanup is already owned by another worker"
+                )
+            claimed = await self._claim_cleanup(lease)
+            if claimed is None:
+                raise OmnigentOAuthHostError(
+                    "host lease changed concurrently before cleanup claim"
+                )
+            lease = claimed
             try:
                 # Even an already-absent attachment crosses ``stop_host``: that
                 # owner publishes independently resolvable terminal evidence
@@ -401,11 +427,7 @@ class OmnigentOAuthHostJanitor:
             ):
                 continue
             if lease.status in CLEANUP_CLAIMABLE_HOST_STATES:
-                claimed = await self._repository.claim_host_lease_cleanup(
-                    lease.lease_id,
-                    expected_status=lease.status,
-                    expected_last_heartbeat_at=lease.last_heartbeat_at,
-                )
+                claimed = await self._claim_cleanup(lease)
                 if claimed is None:
                     # The coordinator advanced state or heartbeat authority
                     # after this janitor pass observed it. Reconcile from the
@@ -484,10 +506,20 @@ class OmnigentOAuthHostJanitor:
         for container_name in await self._runtime.list_managed_containers():
             if container_name in known_containers:
                 continue
-            # No lease can resume or publish authority for an orphan. The runtime
-            # revalidates the deployment ownership label and objective absence,
-            # so remove the credential-bearing resource instead of repeatedly
-            # reporting an action that has no durable consumer.
+            host_lease_ref = await self._runtime.managed_container_host_lease_ref(
+                container_name
+            )
+            if host_lease_ref:
+                live_lease = await self._repository.get_host_lease(host_lease_ref)
+                if live_lease is not None:
+                    # The lease may have been created after the initial scan.
+                    # Leave every lease-owned container to the claimed cleanup
+                    # path on the next pass; raw orphan removal has no authority
+                    # to race a coordinator or cleanup owner.
+                    continue
+            # No durable lease can resume or publish authority for a true orphan.
+            # The runtime revalidates the deployment ownership label before
+            # removing the credential-bearing resource.
             await self._runtime.remove_container(container_name)
             actions.append(
                 {

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -2035,6 +2035,29 @@ class OmnigentOAuthHostRuntime:
             return []
         return [line.strip() for line in result[1].splitlines() if line.strip()]
 
+    async def managed_container_host_lease_ref(
+        self, container_name: str
+    ) -> str | None:
+        """Return the durable lease identity carried by a managed container."""
+
+        result = await self._run(
+            "docker", "inspect", "--format",
+            (
+                '{{index .Config.Labels "moonmind.kind"}}|'
+                '{{index .Config.Labels "moonmind.host_lease_id"}}'
+            ),
+            container_name, check=False,
+        )
+        if result[0] != 0:
+            return None
+        kind, separator, lease_ref = result[1].strip().partition("|")
+        if not separator or kind != "omnigent-oauth-host":
+            raise OmnigentOAuthHostError(
+                "refusing to inspect a container outside Omnigent ownership",
+                code="OMNIGENT_HOST_OWNERSHIP_MISMATCH",
+            )
+        return lease_ref.strip() or None
+
     async def remove_container(self, container_name: str) -> None:
         # Janitor discovery is label-scoped; never accept an arbitrary name.
         result = await self._run(

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -39,6 +39,8 @@ from moonmind.utils.logging import redact_sensitive_text
 ACTIVE_HOST_STATES = frozenset(
     {"allocating", "starting", "ready", "assigned", "draining"}
 )
+HEARTBEAT_HOST_STATES = ACTIVE_HOST_STATES - {"draining"}
+CLEANUP_CLAIMABLE_HOST_STATES = HEARTBEAT_HOST_STATES
 TERMINAL_HOST_STATES = frozenset({"stopped", "failed"})
 HOST_PROFILE_BUSY_ERROR_CODE = "OMNIGENT_OAUTH_HOST_PROFILE_BUSY"
 
@@ -530,12 +532,55 @@ class OmnigentOAuthHostRepository:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
-            if record is None or record.status not in ACTIVE_HOST_STATES:
+            if record is None or record.status not in HEARTBEAT_HOST_STATES:
                 raise OmnigentOAuthHostError("active host lease does not exist")
             record.last_heartbeat_at = now
             record.expires_at = now + timedelta(seconds=max(60, ttl_seconds))
             await session.commit()
             await session.refresh(record)
+            return self._lease_model(record)
+
+    async def claim_host_lease_cleanup(
+        self,
+        lease_id: str,
+        *,
+        expected_status: str,
+        expected_last_heartbeat_at: datetime,
+    ) -> OmnigentHostLease | None:
+        """Fence a janitor cleanup against a concurrently live lease owner.
+
+        The heartbeat timestamp is part of the compare-and-swap because status
+        alone cannot distinguish a genuinely stale lease from one heartbeated
+        after the janitor observed it. Returning ``None`` tells the caller to
+        reload and reconcile instead of executing cleanup from stale evidence.
+        """
+
+        if expected_status not in CLEANUP_CLAIMABLE_HOST_STATES:
+            raise ValueError(
+                f"host lease status {expected_status!r} cannot be claimed for cleanup"
+            )
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            result = await session.execute(
+                update(OmnigentOAuthHostLeaseRecord)
+                .where(
+                    OmnigentOAuthHostLeaseRecord.lease_id == lease_id,
+                    OmnigentOAuthHostLeaseRecord.status == expected_status,
+                    OmnigentOAuthHostLeaseRecord.last_heartbeat_at
+                    == expected_last_heartbeat_at,
+                )
+                .values(
+                    status="draining",
+                    last_heartbeat_at=now,
+                    draining_at=now,
+                )
+            )
+            if result.rowcount != 1:
+                await session.rollback()
+                return None
+            await session.commit()
+            record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
+            assert record is not None
             return self._lease_model(record)
 
     async def restart_host_lease(
@@ -742,6 +787,8 @@ def validate_preflight_result(
 
 __all__ = [
     "ACTIVE_HOST_STATES",
+    "CLEANUP_CLAIMABLE_HOST_STATES",
+    "HEARTBEAT_HOST_STATES",
     "HOST_PROFILE_BUSY_ERROR_CODE",
     "HostPreflightFailure",
     "OmnigentOAuthHostError",

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -40,9 +40,10 @@ ACTIVE_HOST_STATES = frozenset(
     {"allocating", "starting", "ready", "assigned", "draining"}
 )
 HEARTBEAT_HOST_STATES = ACTIVE_HOST_STATES - {"draining"}
-CLEANUP_CLAIMABLE_HOST_STATES = HEARTBEAT_HOST_STATES
+CLEANUP_CLAIMABLE_HOST_STATES = ACTIVE_HOST_STATES
 TERMINAL_HOST_STATES = frozenset({"stopped", "failed"})
 HOST_PROFILE_BUSY_ERROR_CODE = "OMNIGENT_OAUTH_HOST_PROFILE_BUSY"
+HOST_CLEANUP_CLAIMED_ERROR_CODE = "OMNIGENT_HOST_CLEANUP_CLAIMED"
 
 
 class OmnigentOAuthHostError(RuntimeError):
@@ -531,13 +532,31 @@ class OmnigentOAuthHostRepository:
     ) -> OmnigentHostLease:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
-            record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
-            if record is None or record.status not in HEARTBEAT_HOST_STATES:
+            result = await session.execute(
+                update(OmnigentOAuthHostLeaseRecord)
+                .where(
+                    OmnigentOAuthHostLeaseRecord.lease_id == lease_id,
+                    OmnigentOAuthHostLeaseRecord.status.in_(HEARTBEAT_HOST_STATES),
+                )
+                .values(
+                    last_heartbeat_at=now,
+                    expires_at=now + timedelta(seconds=max(60, ttl_seconds)),
+                )
+            )
+            if result.rowcount != 1:
+                await session.rollback()
+                record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
+                if record is not None and record.status in {
+                    "draining", "stopped", "failed",
+                }:
+                    raise OmnigentOAuthHostError(
+                        "host lease cleanup is owned by the janitor",
+                        code=HOST_CLEANUP_CLAIMED_ERROR_CODE,
+                    )
                 raise OmnigentOAuthHostError("active host lease does not exist")
-            record.last_heartbeat_at = now
-            record.expires_at = now + timedelta(seconds=max(60, ttl_seconds))
             await session.commit()
-            await session.refresh(record)
+            record = await session.get(OmnigentOAuthHostLeaseRecord, lease_id)
+            assert record is not None
             return self._lease_model(record)
 
     async def claim_host_lease_cleanup(
@@ -546,6 +565,7 @@ class OmnigentOAuthHostRepository:
         *,
         expected_status: str,
         expected_last_heartbeat_at: datetime,
+        ttl_seconds: int = 90,
     ) -> OmnigentHostLease | None:
         """Fence a janitor cleanup against a concurrently live lease owner.
 
@@ -572,6 +592,7 @@ class OmnigentOAuthHostRepository:
                 .values(
                     status="draining",
                     last_heartbeat_at=now,
+                    expires_at=now + timedelta(seconds=max(60, ttl_seconds)),
                     draining_at=now,
                 )
             )
@@ -789,6 +810,7 @@ __all__ = [
     "ACTIVE_HOST_STATES",
     "CLEANUP_CLAIMABLE_HOST_STATES",
     "HEARTBEAT_HOST_STATES",
+    "HOST_CLEANUP_CLAIMED_ERROR_CODE",
     "HOST_PROFILE_BUSY_ERROR_CODE",
     "HostPreflightFailure",
     "OmnigentOAuthHostError",

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -47,6 +47,8 @@ from moonmind.omnigent.execution_profiles import (
 )
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.oauth_hosts import (
+    HEARTBEAT_HOST_STATES,
+    HOST_CLEANUP_CLAIMED_ERROR_CODE,
     HOST_PROFILE_BUSY_ERROR_CODE,
     OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
@@ -707,6 +709,28 @@ class OmnigentProfileBoundExecutionCoordinator:
                 heartbeat_task,
                 return_exceptions=True,
             )
+
+    async def _claim_host_cleanup(
+        self, host_lease_ref: str
+    ) -> OmnigentHostLease | None:
+        """Acquire cleanup authority after the final operation heartbeat."""
+
+        for _attempt in range(3):
+            current = await self._hosts.get_host_lease(host_lease_ref)
+            if current is None:
+                raise OmnigentOAuthHostError("host lease does not exist")
+            if current.status not in HEARTBEAT_HOST_STATES:
+                return None
+            claimed = await self._hosts.claim_host_lease_cleanup(
+                current.lease_id,
+                expected_status=current.status,
+                expected_last_heartbeat_at=current.last_heartbeat_at,
+                ttl_seconds=90,
+            )
+            if claimed is not None:
+                return claimed
+            await asyncio.sleep(0)
+        return None
 
     async def _create_host_lease_after_profile_idle(
         self,
@@ -1877,6 +1901,14 @@ class OmnigentProfileBoundExecutionCoordinator:
                 attempt_cleanup_deferred_code = "activity_cancelled"
             elif isinstance(exc, OmnigentSessionStillRunningError):
                 attempt_cleanup_deferred_code = "ambiguous_terminal_state"
+            elif (
+                isinstance(exc, OmnigentOAuthHostError)
+                and exc.code == HOST_CLEANUP_CLAIMED_ERROR_CODE
+            ):
+                # The janitor won the durable cleanup claim. Its draining lease
+                # and Provider Profile release are now one authority chain; the
+                # coordinator must not enter a second finally-cleanup path.
+                attempt_cleanup_deferred_code = HOST_CLEANUP_CLAIMED_ERROR_CODE
             terminal_status = "failed"
             if bridge_ready:
                 code, failure_class, remediation = _failure_evidence(exc)
@@ -1932,6 +1964,20 @@ class OmnigentProfileBoundExecutionCoordinator:
         finally:
             safe_to_release_provider = host_lease is None
             if host_lease is not None and binding is not None:
+                if attempt_cleanup_deferred_code is None:
+                    try:
+                        claimed_cleanup_lease = await self._claim_host_cleanup(
+                            host_lease.lease_id
+                        )
+                    except Exception as claim_exc:
+                        attempt_cleanup_deferred_code = type(claim_exc).__name__
+                    else:
+                        if claimed_cleanup_lease is None:
+                            attempt_cleanup_deferred_code = (
+                                HOST_CLEANUP_CLAIMED_ERROR_CODE
+                            )
+                        else:
+                            host_lease = claimed_cleanup_lease
                 if attempt_cleanup_deferred_code is not None:
                     # A Temporal timeout or ambiguous terminal observation can
                     # schedule a retry against the same durable bridge. Leave the

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -8,7 +8,7 @@ import json
 import math
 import os
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any
+from typing import Any, TypeVar
 
 from sqlalchemy import select
 from temporalio import activity
@@ -88,6 +88,7 @@ from moonmind.workflows.executions.runtime_capabilities import (
 
 
 ExecutionRunner = Callable[..., Awaitable[AgentRunResult]]
+HeartbeatResult = TypeVar("HeartbeatResult")
 HOST_LEASE_HEARTBEAT_INTERVAL_SECONDS = 30.0
 # The deployment janitor reconciles abandoned OAuth hosts on a five-minute
 # cadence.  Cover one complete cadence plus scheduling slack so an exact rerun
@@ -668,12 +669,12 @@ class OmnigentProfileBoundExecutionCoordinator:
 
     async def _execute_with_host_lease_heartbeat(
         self,
-        execution: Awaitable[AgentRunResult],
+        execution: Awaitable[HeartbeatResult],
         *,
         host_lease_ref: str,
         ttl_seconds: int,
-    ) -> AgentRunResult:
-        """Keep the durable host lease live for the full provider execution."""
+    ) -> HeartbeatResult:
+        """Keep the durable host lease live for one owned runtime operation."""
 
         async def heartbeat() -> None:
             while True:
@@ -1243,7 +1244,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                 if remediation_resolution is not None
                 else workspace_intent.workspace_locator_payload()
             )
-            preflight = await self._runtime.prepare_host(
+            preflight_operation = self._runtime.prepare_host(
                 binding=binding,
                 host_lease=host_lease,
                 workspace_key=(
@@ -1321,6 +1322,11 @@ class OmnigentProfileBoundExecutionCoordinator:
                     if remediation_resolution is not None
                     else self._attachment_refs(request)
                 ),
+            )
+            preflight = await self._execute_with_host_lease_heartbeat(
+                preflight_operation,
+                host_lease_ref=host_lease.lease_id,
+                ttl_seconds=int(effective_launch["limits"]["timeoutSeconds"]),
             )
             await emit(current_stage, "completed")
             workspace_resolution = preflight.get("workspaceResolution")

--- a/tests/helpers/checkpoint_branch_turn_runtime.py
+++ b/tests/helpers/checkpoint_branch_turn_runtime.py
@@ -348,6 +348,34 @@ async def execute_checkpoint_branch_request(
             ledger._host_leases[key] = lease
             return lease
 
+        async def get_host_lease(self, _lease_id):
+            return ledger._host_leases.get(key)
+
+        async def claim_host_lease_cleanup(
+            self,
+            _lease_id,
+            *,
+            expected_status,
+            expected_last_heartbeat_at,
+            ttl_seconds,
+        ):
+            lease = ledger._host_leases[key]
+            if (
+                lease.status != expected_status
+                or lease.last_heartbeat_at != expected_last_heartbeat_at
+            ):
+                return None
+            now = datetime.now(UTC)
+            lease = lease.model_copy(
+                update={
+                    "status": "draining",
+                    "last_heartbeat_at": now,
+                    "expires_at": now + timedelta(seconds=ttl_seconds),
+                }
+            )
+            ledger._host_leases[key] = lease
+            return lease
+
         async def transition_host_lease(
             self, _lease_id, *, expected_status, new_status, fields=None
         ):

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -238,7 +238,24 @@ async def test_runner_crash_disconnected_cleanup_survives_restart_and_drives_jan
                 binding_ref="binding-1", container_name="host-1",
                 omnigent_session_id=None, last_heartbeat_at=now,
                 expires_at=now + timedelta(hours=1),
+                status="ready",
             )]
+
+        async def claim_host_lease_cleanup(
+            self, lease_id, *, expected_status, expected_last_heartbeat_at
+        ):
+            assert lease_id == "host-lease-1"
+            assert expected_status == "ready"
+            return SimpleNamespace(
+                lease_id=lease_id,
+                provider_profile_id="profile-1",
+                binding_ref="binding-1",
+                container_name="host-1",
+                omnigent_session_id=None,
+                last_heartbeat_at=expected_last_heartbeat_at,
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+                status="draining",
+            )
 
         async def validate_binding(self, _binding_ref):
             return SimpleNamespace()

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -242,10 +242,12 @@ async def test_runner_crash_disconnected_cleanup_survives_restart_and_drives_jan
             )]
 
         async def claim_host_lease_cleanup(
-            self, lease_id, *, expected_status, expected_last_heartbeat_at
+            self, lease_id, *, expected_status, expected_last_heartbeat_at,
+            ttl_seconds,
         ):
             assert lease_id == "host-lease-1"
             assert expected_status == "ready"
+            assert ttl_seconds == 90
             return SimpleNamespace(
                 lease_id=lease_id,
                 provider_profile_id="profile-1",

--- a/tests/integration/reliability/replays/omnigent-fresh-launch-janitor-race/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-fresh-launch-janitor-race/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "janitorActionCount": 0,
+  "cleanupClaimCount": 0,
+  "hostStopCount": 0,
+  "providerLeaseReleaseCount": 0,
+  "durableCleanupFailureRecorded": false
+}

--- a/tests/integration/reliability/replays/omnigent-fresh-launch-janitor-race/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-fresh-launch-janitor-race/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "escaped-failure-replay/v1",
+  "incidentWorkflowId": "mm:4ce41531-205c-4b9a-aa90-33ae8396e17c",
+  "childWorkflowId": "mm:4ce41531-205c-4b9a-aa90-33ae8396e17c:agent:node-1:execution2:retry1",
+  "janitorWorkflowId": "omnigent-oauth-host-janitor-run-2026-08-18T16:25:00Z",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "failureCode": "OMNIGENT_EGRESS_CLEANUP_AUTHORITY_MISMATCH",
+  "failureShape": "the scheduled janitor treated the deterministic container as missing while the fresh starting lease was still materializing it, stopped the active owner, and caused an activity retry to encounter the stopped generation's cleanup authority",
+  "leaseStatusAtJanitorScan": "starting",
+  "containerStateAtJanitorScan": "not_yet_materialized",
+  "heartbeatAgeSeconds": 5,
+  "heartbeatTimeoutSeconds": 90,
+  "observedRetryFailure": "live host identity changed from durable cleanup authority"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -9,7 +9,7 @@ import sqlite3
 import subprocess
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -2942,6 +2942,93 @@ async def test_cleaned_up_host_retry_rebinds_fresh_endpoint_authority(
     assert active["egressEvidence"]["endpointIdentity"] == expected[
         "activeEndpointIdentity"
     ]
+
+
+async def test_fresh_omnigent_launch_is_not_reaped_before_materialization() -> None:
+    """Replay mm:4ce41531 at the coordinator-to-janitor authority handoff."""
+
+    replay_id = "omnigent-fresh-launch-janitor-race"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    now = datetime.now(timezone.utc)
+    lease = SimpleNamespace(
+        lease_id="host-lease-fresh-launch",
+        provider_profile_id="profile-replay",
+        provider_lease_id="provider-lease-fresh-launch",
+        binding_ref="binding-replay",
+        container_name="host-container-fresh-launch",
+        omnigent_session_id=None,
+        last_heartbeat_at=now
+        - timedelta(seconds=manifest["heartbeatAgeSeconds"]),
+        expires_at=now + timedelta(hours=1),
+        status=manifest["leaseStatusAtJanitorScan"],
+    )
+    cleanup_claims: list[str] = []
+    stopped: list[str] = []
+    released: list[str] = []
+    cleanup_records: list[dict] = []
+
+    class Repository:
+        async def list_active_host_leases(self):
+            return [lease]
+
+        async def list_terminal_host_leases_with_active_provider_capacity(self):
+            return []
+
+        async def get_binding_for_profile(self, _profile_id):
+            return None
+
+        async def claim_host_lease_cleanup(self, lease_id, **_kwargs):
+            cleanup_claims.append(lease_id)
+            return lease
+
+        async def validate_binding(self, _binding_ref):
+            raise AssertionError("fresh launch must not enter cleanup")
+
+        async def mark_host_lease_stopped(self, lease_id):
+            stopped.append(lease_id)
+            return lease
+
+    class Runtime:
+        async def container_exists(self, name):
+            assert name == lease.container_name
+            return False
+
+        async def list_managed_containers(self):
+            return []
+
+        async def stop_host(self, **_kwargs):
+            stopped.append(lease.lease_id)
+            return {}
+
+    class LeaseClient:
+        async def release_lease(self, provider_lease):
+            released.append(provider_lease.lease_id)
+
+    class RunStore:
+        async def cleanup_required_host_lease_refs(self):
+            return set()
+
+        async def embedded_reconciliation_host_lease_refs(self, **_kwargs):
+            return {}
+
+        async def record_terminal_cleanup(self, **kwargs):
+            cleanup_records.append(kwargs)
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=Repository(),
+        runtime=Runtime(),
+        client=SimpleNamespace(),
+        run_store=RunStore(),
+        lease_client=LeaseClient(),
+        heartbeat_timeout_seconds=manifest["heartbeatTimeoutSeconds"],
+    ).run()
+
+    assert result["count"] == expected["janitorActionCount"]
+    assert len(cleanup_claims) == expected["cleanupClaimCount"]
+    assert len(stopped) == expected["hostStopCount"]
+    assert len(released) == expected["providerLeaseReleaseCount"]
+    assert bool(cleanup_records) is expected["durableCleanupFailureRecorded"]
 
 
 async def test_abandoned_omnigent_host_cleanup_releases_provider_capacity() -> None:

--- a/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
@@ -763,6 +763,42 @@ async def _drive_coordinator_materialization_to_cleanup(
         async def create_or_get_host_lease(self, **_kwargs):
             return self.lease
 
+        async def get_host_lease(self, _lease_id):
+            return self.lease
+
+        async def heartbeat_host_lease(self, _lease_id, *, ttl_seconds):
+            now = datetime.now(UTC)
+            self.lease = self.lease.model_copy(
+                update={
+                    "last_heartbeat_at": now,
+                    "expires_at": now + timedelta(seconds=ttl_seconds),
+                }
+            )
+            return self.lease
+
+        async def claim_host_lease_cleanup(
+            self,
+            _lease_id,
+            *,
+            expected_status,
+            expected_last_heartbeat_at,
+            ttl_seconds,
+        ):
+            if (
+                self.lease.status != expected_status
+                or self.lease.last_heartbeat_at != expected_last_heartbeat_at
+            ):
+                return None
+            now = datetime.now(UTC)
+            self.lease = self.lease.model_copy(
+                update={
+                    "status": "draining",
+                    "last_heartbeat_at": now,
+                    "expires_at": now + timedelta(seconds=ttl_seconds),
+                }
+            )
+            return self.lease
+
         async def restart_host_lease(self, _lease_id):
             self.lease = self.lease.model_copy(update={"status": "allocating"})
             return self.lease

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -10,6 +10,7 @@ from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
 class _Repository:
     def __init__(self, lease):
         self.lease = lease
+        self.cleanup_claims: list[str] = []
         self.stopped: list[str] = []
         self.order: list[str] = []
 
@@ -36,6 +37,21 @@ class _Repository:
         self.order.append("lease_released")
         self.stopped.append(lease_id)
         self.lease.status = "stopped"
+        return self.lease
+
+    async def claim_host_lease_cleanup(
+        self, lease_id, *, expected_status, expected_last_heartbeat_at
+    ):
+        assert lease_id == self.lease.lease_id
+        if (
+            self.lease.status != expected_status
+            or self.lease.last_heartbeat_at != expected_last_heartbeat_at
+        ):
+            return None
+        self.order.append("cleanup_claimed")
+        self.cleanup_claims.append(lease_id)
+        self.lease.status = "draining"
+        self.lease.last_heartbeat_at = datetime.now(UTC)
         return self.lease
 
     async def transition_host_lease(
@@ -326,7 +342,7 @@ async def test_stale_lease_eviction_rejects_fresh_lease() -> None:
 @pytest.mark.asyncio
 async def test_janitor_reconciles_stale_heartbeat_after_restart() -> None:
     repository = _Repository(_lease(heartbeat_age=121))
-    runtime = _Runtime()
+    runtime = _Runtime(repository.order)
 
     result = await OmnigentOAuthHostJanitor(
         repository=repository,
@@ -338,6 +354,77 @@ async def test_janitor_reconciles_stale_heartbeat_after_restart() -> None:
     assert result["actions"][-1]["action"] == "stale_heartbeat_cleanup"
     assert repository.stopped == ["lease-1"]
     assert runtime.stopped == 1
+    assert repository.order[:2] == ["cleanup_claimed", "host_stopped"]
+
+
+@pytest.mark.asyncio
+async def test_janitor_ignores_missing_container_during_fresh_launch() -> None:
+    lease = _lease()
+    lease.status = "starting"
+    lease.omnigent_session_id = None
+    repository = _Repository(lease)
+    runtime = _Runtime(repository.order)
+
+    async def missing_container(_name):
+        return False
+
+    runtime.container_exists = missing_container
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository,
+        runtime=runtime,
+        client=_Client(),
+        heartbeat_timeout_seconds=90,
+    ).run()
+
+    assert result == {"status": "completed", "actions": [], "count": 0}
+    assert repository.cleanup_claims == []
+    assert repository.stopped == []
+    assert runtime.stopped == 0
+
+
+@pytest.mark.asyncio
+async def test_janitor_claims_missing_container_after_launch_boundary() -> None:
+    repository = _Repository(_lease())
+    runtime = _Runtime(repository.order)
+
+    async def missing_container(_name):
+        return False
+
+    runtime.container_exists = missing_container
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository,
+        runtime=runtime,
+        client=_Client(),
+    ).run()
+
+    assert result["actions"][-1]["action"] == "missing_container_repair"
+    assert repository.cleanup_claims == ["lease-1"]
+    assert repository.order[:2] == ["cleanup_claimed", "host_stopped"]
+
+
+@pytest.mark.asyncio
+async def test_janitor_reloads_after_cleanup_claim_conflict() -> None:
+    repository = _Repository(_lease(heartbeat_age=121))
+    runtime = _Runtime(repository.order)
+
+    async def lost_claim(*_args, **_kwargs):
+        repository.lease.last_heartbeat_at = datetime.now(UTC)
+        return None
+
+    repository.claim_host_lease_cleanup = lost_claim
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository,
+        runtime=runtime,
+        client=_Client(),
+        heartbeat_timeout_seconds=90,
+    ).run()
+
+    assert result == {"status": "completed", "actions": [], "count": 0}
+    assert repository.stopped == []
+    assert runtime.stopped == 0
 
 
 @pytest.mark.asyncio
@@ -367,6 +454,7 @@ async def test_janitor_consumes_durable_runner_exit_cleanup_handoff() -> None:
     assert lease_client.released[0].owner_id == "provider-lease-1"
     assert lease_client.released[0].runtime_id == "codex_cli"
     assert repository.order == [
+        "cleanup_claimed",
         "host_stopped",
         "lease_released",
         "provider_released",
@@ -455,7 +543,11 @@ async def test_janitor_reconciles_each_durable_embedded_abandonment_class(
     ).run()
 
     assert result["actions"][-1]["action"] == action
-    assert repository.order == ["host_stopped", "lease_released"]
+    assert repository.order == [
+        "cleanup_claimed",
+        "host_stopped",
+        "lease_released",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_host_janitor.py
+++ b/tests/unit/omnigent/test_oauth_host_janitor.py
@@ -40,7 +40,8 @@ class _Repository:
         return self.lease
 
     async def claim_host_lease_cleanup(
-        self, lease_id, *, expected_status, expected_last_heartbeat_at
+        self, lease_id, *, expected_status, expected_last_heartbeat_at,
+        ttl_seconds=90,
     ):
         assert lease_id == self.lease.lease_id
         if (
@@ -52,6 +53,9 @@ class _Repository:
         self.cleanup_claims.append(lease_id)
         self.lease.status = "draining"
         self.lease.last_heartbeat_at = datetime.now(UTC)
+        self.lease.expires_at = self.lease.last_heartbeat_at + timedelta(
+            seconds=ttl_seconds
+        )
         return self.lease
 
     async def transition_host_lease(
@@ -76,6 +80,7 @@ class _Runtime:
         self.stop_kwargs: list[dict] = []
         self.static_stops = 0
         self.managed_containers: list[str] = []
+        self.container_lease_refs: dict[str, str | None] = {}
 
     async def container_exists(self, _name):
         return True
@@ -93,6 +98,9 @@ class _Runtime:
 
     async def list_managed_containers(self):
         return list(self.managed_containers)
+
+    async def managed_container_host_lease_ref(self, name):
+        return self.container_lease_refs.get(name)
 
     async def stop_static_host(self, **_kwargs):
         self.static_stops += 1
@@ -238,6 +246,7 @@ async def test_action_reuses_durable_launch_authority_and_binds_terminal_evidenc
         "artifact://terminal-egress"
     )
     assert repository.order == [
+        "cleanup_claimed",
         "host_stopped",
         "lease_released",
         "provider_released",
@@ -581,6 +590,7 @@ async def test_pre_upgrade_restricted_lease_uses_bounded_cleanup_cutover() -> No
 
     assert runtime.stop_kwargs[0].get("effective_launch") is None
     assert repository.order == [
+        "cleanup_claimed",
         "host_stopped",
         "lease_released",
         "provider_released",
@@ -674,3 +684,58 @@ async def test_janitor_removes_label_owned_orphan_instead_of_repeating_report() 
             "providerLeaseReleased": False,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_janitor_reloads_container_lease_before_orphan_removal() -> None:
+    initial_lease = _lease()
+    new_lease = _lease()
+    new_lease.lease_id = "lease-created-after-scan"
+    new_lease.container_name = "new-host"
+    repository = _Repository(initial_lease)
+
+    async def get_host_lease(lease_id):
+        if lease_id == new_lease.lease_id:
+            return new_lease
+        return initial_lease if lease_id == initial_lease.lease_id else None
+
+    repository.get_host_lease = get_host_lease
+    runtime = _Runtime()
+    runtime.managed_containers = ["new-host"]
+    runtime.container_lease_refs["new-host"] = new_lease.lease_id
+
+    result = await OmnigentOAuthHostJanitor(
+        repository=repository, runtime=runtime, client=_Client(),
+    ).run()
+
+    assert result == {"status": "completed", "actions": [], "count": 0}
+    assert runtime.removed == []
+
+
+@pytest.mark.asyncio
+async def test_stale_remediation_claim_conflict_prevents_cleanup() -> None:
+    repository = _Repository(_lease(heartbeat_age=121))
+    runtime = _Runtime()
+
+    async def lost_claim(*_args, **_kwargs):
+        repository.lease.last_heartbeat_at = datetime.now(UTC)
+        return None
+
+    repository.claim_host_lease_cleanup = lost_claim
+
+    with pytest.raises(OmnigentOAuthHostError, match="changed concurrently"):
+        await OmnigentOAuthHostJanitor(
+            repository=repository,
+            runtime=runtime,
+            client=_Client(),
+            heartbeat_timeout_seconds=90,
+        ).run_action(
+            action_kind="host_lease.reconcile_stale",
+            profile_id="profile-1",
+            host_lease_ref="lease-1",
+            expected_host_state="ready",
+            request_id="stale-race",
+        )
+
+    assert runtime.stopped == 0
+    assert repository.stopped == []

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -50,6 +50,7 @@ from moonmind.omnigent.execution_profiles import (
 from moonmind.omnigent.mounted_tool_preflight import MountedToolPreflightError
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.oauth_hosts import (
+    HOST_CLEANUP_CLAIMED_ERROR_CODE,
     HOST_PROFILE_BUSY_ERROR_CODE,
     OmnigentOAuthHostError,
     OmnigentOAuthHostRepository,
@@ -3206,6 +3207,9 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
         )
         assert claimed is not None
         assert claimed.status == "draining"
+        assert 89 <= (
+            claimed.expires_at - claimed.last_heartbeat_at
+        ).total_seconds() <= 90
         assert (
             await repository.claim_host_lease_cleanup(
                 first.lease_id,
@@ -3214,8 +3218,27 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
             )
             is None
         )
-        with pytest.raises(OmnigentOAuthHostError, match="active host lease"):
+        with pytest.raises(OmnigentOAuthHostError) as heartbeat_error:
             await repository.heartbeat_host_lease(first.lease_id)
+        assert heartbeat_error.value.code == HOST_CLEANUP_CLAIMED_ERROR_CODE
+
+        await repository.mark_host_lease_stopped(first.lease_id)
+        restarted = await repository.restart_host_lease(first.lease_id)
+        heartbeat_result, cleanup_result = await asyncio.gather(
+            repository.heartbeat_host_lease(first.lease_id),
+            repository.claim_host_lease_cleanup(
+                first.lease_id,
+                expected_status="starting",
+                expected_last_heartbeat_at=restarted.last_heartbeat_at,
+            ),
+            return_exceptions=True,
+        )
+        heartbeat_won = not isinstance(heartbeat_result, BaseException)
+        cleanup_won = (
+            not isinstance(cleanup_result, BaseException)
+            and cleanup_result is not None
+        )
+        assert heartbeat_won is not cleanup_won
     finally:
         await engine.dispose()
 
@@ -3380,6 +3403,14 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
 
         async def create_or_get_host_lease(self, **_kwargs):
             actions.append("host_lease_created")
+            return self.lease
+
+        async def get_host_lease(self, _lease_id):
+            return self.lease
+
+        async def claim_host_lease_cleanup(self, _lease_id, **_kwargs):
+            self.lease = self.lease.model_copy(update={"status": "draining"})
+            actions.append("host_draining")
             return self.lease
 
         async def transition_host_lease(
@@ -3593,6 +3624,13 @@ async def _drive_authority_chain_coordinator(
             })
 
         async def create_or_get_host_lease(self, **_kwargs):
+            return self.lease
+
+        async def get_host_lease(self, _lease_id):
+            return self.lease
+
+        async def claim_host_lease_cleanup(self, _lease_id, **_kwargs):
+            self.lease = self.lease.model_copy(update={"status": "draining"})
             return self.lease
 
         async def transition_host_lease(
@@ -4199,6 +4237,13 @@ async def test_coordinator_records_runner_preflight_block_before_execution() -> 
         async def create_or_get_host_lease(self, **_kwargs):
             return self.lease
 
+        async def get_host_lease(self, _lease_id):
+            return self.lease
+
+        async def claim_host_lease_cleanup(self, _lease_id, **_kwargs):
+            self.lease = self.lease.model_copy(update={"status": "draining"})
+            return self.lease
+
         async def transition_host_lease(
             self, _lease_id, *, expected_status, new_status, fields=None
         ):
@@ -4744,6 +4789,13 @@ async def _run_coordinator_failure_case(
                 raise error
             return self.lease
 
+        async def get_host_lease(self, _lease_id):
+            return self.lease
+
+        async def claim_host_lease_cleanup(self, _lease_id, **_kwargs):
+            self.lease = self.lease.model_copy(update={"status": "draining"})
+            return self.lease
+
         async def transition_host_lease(
             self, _lease_id, *, expected_status, new_status, fields=None
         ):
@@ -4992,6 +5044,29 @@ async def test_cancelled_attempt_defers_host_and_profile_cleanup_to_retry_or_jan
         and payload["status"] == "waiting"
         for event_type, payload in events
     )
+
+
+@pytest.mark.asyncio
+async def test_janitor_cleanup_claim_relinquishes_coordinator_cleanup() -> None:
+    events, actions, owner_calls = await _run_coordinator_failure_case(
+        fail_at="session_create",
+        code=HOST_CLEANUP_CLAIMED_ERROR_CODE,
+        injected_error=OmnigentOAuthHostError(
+            "host lease cleanup is owned by the janitor",
+            code=HOST_CLEANUP_CLAIMED_ERROR_CODE,
+        ),
+    )
+
+    cleanup_event = next(
+        payload
+        for event_type, payload in events
+        if event_type == "host_cleanup" and payload["status"] == "waiting"
+    )
+    assert cleanup_event["code"] == HOST_CLEANUP_CLAIMED_ERROR_CODE
+    assert cleanup_event["metadata"]["janitorRequired"] is True
+    assert "host_stop" not in owner_calls
+    assert "host_remove" not in owner_calls
+    assert "provider_released" not in actions
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -3198,6 +3198,23 @@ async def test_host_repository_creates_idempotent_binding_and_lease(tmp_path) ->
             new_status="starting",
         )
         assert starting.status == "starting"
+        claimed = await repository.claim_host_lease_cleanup(
+            first.lease_id,
+            expected_status="starting",
+            expected_last_heartbeat_at=starting.last_heartbeat_at,
+        )
+        assert claimed is not None
+        assert claimed.status == "draining"
+        assert (
+            await repository.claim_host_lease_cleanup(
+                first.lease_id,
+                expected_status="starting",
+                expected_last_heartbeat_at=starting.last_heartbeat_at,
+            )
+            is None
+        )
+        with pytest.raises(OmnigentOAuthHostError, match="active host lease"):
+            await repository.heartbeat_host_lease(first.lease_id)
     finally:
         await engine.dispose()
 
@@ -3323,6 +3340,8 @@ async def test_coordinator_waits_for_canceled_host_cleanup_before_rerun(
 async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
     actions: list[str] = []
     lifecycle: list[tuple[str, str | None]] = []
+    preflight_heartbeat_observed = asyncio.Event()
+    heartbeat_calls: list[str] = []
     provider_lease = SimpleNamespace(
         profile_id="codex",
         runtime_id="codex_cli",
@@ -3380,8 +3399,15 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
         async def mark_host_lease_failed(self, *_args, **_kwargs):
             actions.append("host_failed")
 
+        async def heartbeat_host_lease(self, lease_id, *, ttl_seconds):
+            assert ttl_seconds == 5400
+            heartbeat_calls.append(lease_id)
+            preflight_heartbeat_observed.set()
+            return self.lease
+
     class Runtime:
         async def prepare_host(self, **_kwargs):
+            await preflight_heartbeat_observed.wait()
             actions.append("preflight")
             return {
                 "hostId": "host-1",
@@ -3462,6 +3488,8 @@ async def test_coordinator_releases_provider_lease_after_host_cleanup() -> None:
         )
     )
     assert result.summary == "done"
+    assert heartbeat_calls
+    assert set(heartbeat_calls) == {"host-lease-1"}
     assert actions[0] == "bridge_envelope_created"
     assert actions[-1] == "terminal"
     assert actions.index("host_stopped") < actions.index("profile_lease_release")


### PR DESCRIPTION
## Summary

- distinguish a fresh pre-materialization host from a missing launched host
- heartbeat the durable host lease while host preparation is running
- compare-and-swap the observed lease status and heartbeat into `draining` before janitor cleanup side effects
- add a minimized replay fixture for workflow `mm:4ce41531-205c-4b9a-aa90-33ae8396e17c`

## Root cause

The scheduled janitor observed a deterministic container name on a fresh `starting` lease before `prepare_host` had materialized the container. It treated that temporary absence as cleanup evidence, stopped the active host generation, and released capacity. The activity retry then correctly failed closed because the live endpoint no longer matched the stopped generation's durable cleanup authority.

## Impact

Fresh Omnigent OAuth hosts cannot be reaped during normal startup. Cleanup still proceeds for stale, expired, explicitly reconciled, or missing-after-materialization hosts, and concurrent coordinator progress fences a stale janitor observation.

## Validation

- 191 targeted Omnigent unit tests
- 18 embedded-recovery integration tests
- 3 escaped-failure replay tests
- Python compilation, Ruff, and diff checks

The broader Omnigent unit run completed with 1,140 passes and four unrelated existing failures: one locally modified submodule pin mismatch and three parallel-test temporary-directory permission failures.
