### PR TITLE
Implement this recommendation for our docker compose: **Remove the externally managed network requirement, but keep an explicit named control-plane ne

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,6 +1,9 @@
 # Deployment Settings
 MOONMIND_IMAGE="ghcr.io/moonladderstudios/moonmind:latest"
 MOONMIND_API_HOST_PORT=7000
+# Stable Docker-level name for the Compose-managed application control plane.
+# Standalone managed-runtime containers use this network to reach API services.
+MOONMIND_CONTROL_PLANE_NETWORK="moonmind_control-plane-network"
 # Evidence-gated Codex-through-Omnigent rollout. Promotion is one phase at a
 # time: opt_in, create_default, schedule_default, broad_default,
 # direct_launch_disabled, direct_launch_removed.

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3807043073,
+    "id": 3808359979,
     "disposition": "addressed",
-    "rationale": "Heartbeat renewal now uses a conditional SQL update over heartbeat-owning states, making it mutually exclusive with the cleanup claim CAS."
+    "rationale": "Removed both legacy managed-session network aliases and updated every remaining test and caller to use MOONMIND_CONTROL_PLANE_NETWORK."
   },
   {
-    "id": 3807043083,
+    "id": 3808359988,
     "disposition": "addressed",
-    "rationale": "Cleanup claims now renew expires_at for the bounded cleanup ownership window in the same atomic update."
+    "rationale": "The lifecycle conformance now launches its health probe through DockerCodexManagedSessionController before testing API reachability from the resulting managed-session container."
   },
   {
-    "id": 3807043091,
+    "id": 3808359994,
     "disposition": "addressed",
-    "rationale": "A typed cleanup-ownership loss now routes coordinator finalization to janitor-required waiting without host stop or Provider Profile release."
+    "rationale": "The lifecycle conformance exports project-specific names for the control-plane, Docker-proxy, sandbox-egress, restricted-egress, and Omnigent-egress networks."
   },
   {
-    "id": 3807043093,
-    "disposition": "addressed",
-    "rationale": "Lease-scoped drain, stop, remove, eviction, and stale-reconciliation actions now share the atomic cleanup claim before side effects."
-  },
-  {
-    "id": 3807043100,
-    "disposition": "addressed",
-    "rationale": "Orphan cleanup now reloads the host lease identified by the container label and leaves lease-owned containers to the fenced cleanup path."
-  },
-  {
-    "id": 4964716657,
+    "id": 4966282554,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review envelope; its five child threads contain the complete actionable feedback."
+    "rationale": "This review body is an informational summary whose actionable findings are represented and addressed by the three linked review comments."
   }
 ]

--- a/config/workloads/default-runner-profiles.yaml
+++ b/config/workloads/default-runner-profiles.yaml
@@ -14,7 +14,7 @@ profiles:
     envAllowlist:
       - CI
       - DOCKER_HOST
-      - MOONMIND_DOCKER_NETWORK
+      - MOONMIND_CONTROL_PLANE_NETWORK
     networkPolicy: docker_proxy
     resources:
       cpu: "4"

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -9,7 +9,7 @@ services:
       - "9000"
       - "9001"
     networks:
-      local-network:
+      control-plane-network:
         aliases:
           # Keep test MinIO off the production artifact hostname. The test
           # compose stack uses its own isolated network, so this alias stays
@@ -54,7 +54,7 @@ services:
     depends_on:
       - minio
     networks:
-      - local-network
+      - control-plane-network
 
   cli-tooling-smoke:
     build:
@@ -68,7 +68,7 @@ services:
       - PYTHONPATH=/app:/app/moonmind
     command: ["bash", "-lc", "codex --version"]
     networks:
-      - local-network
+      - control-plane-network
 
 networks:
-  local-network:
+  control-plane-network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    networks: [local-network]
+    networks: [control-plane-network]
     restart: unless-stopped
 
   api:
@@ -76,6 +76,7 @@ services:
       # (terminal exec, OAuth auth-runner teardown). SYSTEM_DOCKER_HOST is a
       # trusted-worker-only backend selector and is not read by the API service.
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      - MOONMIND_CONTROL_PLANE_NETWORK=${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}
       - MOONMIND_DEPLOYMENT_PROJECT_NAME=${MOONMIND_DEPLOYMENT_PROJECT_NAME:-moonmind}
       - MOONMIND_OAUTH_RUNNER_IMAGE=${MOONMIND_OAUTH_RUNNER_IMAGE:-${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}}
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
@@ -119,7 +120,7 @@ services:
       - workflow_workspaces:/work/runs:ro
     command: sh /app/api_service/entrypoint.sh
     networks:
-      - local-network
+      - control-plane-network
       - docker-proxy-network
     healthcheck:
       test: [
@@ -163,7 +164,7 @@ services:
     expose:
       - "5432"
     networks:
-      local-network:
+      control-plane-network:
         aliases:
           - moonmind-api-db
           - temporal-db
@@ -201,7 +202,7 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      local-network:
+      control-plane-network:
         aliases:
           - temporal-internal
       sandbox-egress-network:
@@ -228,7 +229,7 @@ services:
     volumes:
       - minio-data:/data
     networks:
-      local-network:
+      control-plane-network:
         aliases:
           - moonmind-temporal-artifacts-s3
       sandbox-egress-network:
@@ -253,7 +254,7 @@ services:
       temporal:
         condition: service_started
     networks:
-      - local-network
+      - control-plane-network
     restart: "no"
 
   temporal-visibility-rehearsal:
@@ -279,7 +280,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: "no"
 
   temporal-admin-tools:
@@ -294,7 +295,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   temporal-ui:
@@ -310,7 +311,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   temporal-worker-workflow:
@@ -375,7 +376,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   temporal-worker-artifacts:
@@ -431,7 +432,7 @@ services:
       minio:
         condition: service_started
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   temporal-worker-llm:
@@ -489,7 +490,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   temporal-worker-sandbox:
@@ -617,6 +618,7 @@ services:
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
       - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      - MOONMIND_CONTROL_PLANE_NETWORK=${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}
       - MOONMIND_CONTAINER_BACKEND_ENABLED=${MOONMIND_CONTAINER_BACKEND_ENABLED:-true}
       - MOONMIND_CONTAINER_BACKEND_MAX_ACTIVE_MEMORY_MIB=${MOONMIND_CONTAINER_BACKEND_MAX_ACTIVE_MEMORY_MIB:-}
       - MOONMIND_CONTAINER_JOBS_ENABLED=${MOONMIND_CONTAINER_JOBS_ENABLED:-true}
@@ -713,7 +715,7 @@ services:
       docker-proxy:
         condition: service_started
     networks:
-      - local-network
+      - control-plane-network
       - docker-proxy-network
     restart: unless-stopped
 
@@ -739,6 +741,7 @@ services:
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
       - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
       - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      - MOONMIND_CONTROL_PLANE_NETWORK=${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}
       - MOONMIND_DEPLOYMENT_PROJECT_DIR=${MOONMIND_DEPLOYMENT_PROJECT_DIR:-}
       - MOONMIND_DEPLOYMENT_COMPOSE_FILE=${MOONMIND_DEPLOYMENT_COMPOSE_FILE:-}
       - MOONMIND_DEPLOYMENT_LOCAL_PROJECT_DIR=/workspace/host_project
@@ -783,7 +786,7 @@ services:
       docker-proxy:
         condition: service_started
     networks:
-      - local-network
+      - control-plane-network
       - docker-proxy-network
     restart: unless-stopped
 
@@ -843,7 +846,7 @@ services:
       temporal-namespace-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   qdrant:
@@ -854,7 +857,7 @@ services:
     volumes:
       - qdrant-storage:/qdrant/storage
     networks:
-      - local-network
+      - control-plane-network
 
   omnigent-tools-init:
     image: ${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}
@@ -900,7 +903,7 @@ services:
       omnigent-tools-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
     restart: unless-stopped
 
   omnigent-host-claude:
@@ -1140,7 +1143,7 @@ services:
       - ./init_db:/app/init_db
     command: sh /app/init_db/init_db_entrypoint.sh
     networks:
-      - local-network
+      - control-plane-network
     restart: "no"
     depends_on:
       postgres:
@@ -1190,7 +1193,7 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      - local-network
+      - control-plane-network
     restart: "no"
 
   omnigent:
@@ -1243,7 +1246,7 @@ services:
       omnigent-db-init:
         condition: service_completed_successfully
     networks:
-      - local-network
+      - control-plane-network
       - omnigent-egress-network
     restart: unless-stopped
 
@@ -1312,7 +1315,7 @@ services:
       - "3128"
       - "3129"
     networks:
-      local-network: {}
+      control-plane-network: {}
       sandbox-egress-network: {}
       restricted-egress-network: {}
       omnigent-egress-network:
@@ -1356,8 +1359,8 @@ volumes:
   omnigent-data:
 
 networks:
-  local-network:
-    external: true
+  control-plane-network:
+    name: ${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}
   docker-proxy-network:
     name: ${MOONMIND_DOCKER_PROXY_NETWORK:-moonmind_docker-proxy-network}
     internal: true

--- a/docs/Security/RestrictedEgress.md
+++ b/docs/Security/RestrictedEgress.md
@@ -27,8 +27,8 @@ secondary network or launch a helper outside the trusted backend. Static
 Compose and on-demand hosts use the same Omnigent profile, internal network,
 isolated listener, and gateway. Deployment-owned runner profiles select an
 explicit network policy: `restricted_egress` uses the provider profile,
-`docker_proxy` reaches only the trusted Docker proxy. Plain Docker `bridge`,
-`local-network`, and local application URL
+`docker_proxy` reaches only the trusted Docker proxy. Plain Docker `bridge`, the
+Compose-managed `control-plane-network`, and local application URL
 allowlists are non-enforcing development mechanisms and must never be reported
 in `enforcedNetworkRefs`.
 
@@ -36,6 +36,13 @@ The current implementation supports the deployment-selected daemon reached
 through MoonMind's restricted Docker proxy. Arbitrary remote daemon endpoints
 are not profile authority: the backend must find and attest the exact
 deployment-owned network and gateway on its selected daemon or startup fails.
+
+The ordinary application control plane uses the Compose key
+`control-plane-network`. Compose creates and owns it with the stable Docker-level
+name resolved from `MOONMIND_CONTROL_PLANE_NETWORK` (default
+`moonmind_control-plane-network`). Trusted workers pass that same resolved name
+to standalone managed sessions and gateway attestation. It remains a routable
+development/application network, not an enforced egress boundary.
 
 ## Profile and request controls
 
@@ -93,3 +100,10 @@ cleanup outcome. The production-shaped local
 conformance suite is `tests/integration/security/test_restricted_egress_live.py`;
 operators run it against the supported Compose topology with
 `MOONMIND_RUN_EGRESS_CONFORMANCE=1` before approving an external-target profile.
+The opt-in `tools/test_control_plane_network_lifecycle.sh` check starts an
+isolated `moonmind-test-*` project with no pre-existing control-plane network,
+proves standalone managed-session access to `http://api:8000`, observes worker
+egress attestations, verifies normal `compose down`, and exercises restart and
+cleanup while an interrupted owned container temporarily keeps the network
+attached. Run it only with the normal deployment stopped and
+`MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE=1`.

--- a/docs/tmp/UnrealRuntimeProofProvisioning.md
+++ b/docs/tmp/UnrealRuntimeProofProvisioning.md
@@ -65,7 +65,7 @@ These need real secret values / a verified digest and cannot be committed:
 
 3. If sidecars run on the locked-down `sandbox-egress-network`, also ensure the DinD
    daemon uses the egress proxy (the squid allowlist now permits `ghcr.io`, but the
-   daemon must be told to use it). On the default `local-network` (NAT egress) this is
+   daemon must be told to use it). On the default control-plane network (NAT egress) this is
    not required.
 
 ## Deferred (separate change, needs design + tests)

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -56,6 +56,7 @@ from moonmind.schemas.workspace_locator_models import (
 from moonmind.security.container_job_capabilities import (
     mint_container_job_session_capability,
 )
+from moonmind.security.docker_networks import resolve_control_plane_network
 from moonmind.security.execution_fanout_capabilities import (
     mint_execution_fanout_capability,
 )
@@ -292,8 +293,10 @@ class OmnigentOAuthHostRuntime:
             else:
                 tag = os.getenv("OMNIGENT_HOST_IMAGE_TAG", "latest")
                 self._image = f"{base_image}:{tag}"
-        self._network = network or os.getenv(
-            "OMNIGENT_HOST_NETWORK", "local-network"
+        self._network = (
+            network
+            or os.getenv("OMNIGENT_HOST_NETWORK")
+            or resolve_control_plane_network()
         )
         self._server_url = server_url or os.getenv(
             "OMNIGENT_SERVER_INTERNAL_URL", "http://omnigent:8000"

--- a/moonmind/security/docker_networks.py
+++ b/moonmind/security/docker_networks.py
@@ -1,0 +1,19 @@
+"""Canonical Docker network identities shared across runtime boundaries."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+CONTROL_PLANE_NETWORK_ENV = "MOONMIND_CONTROL_PLANE_NETWORK"
+DEFAULT_CONTROL_PLANE_NETWORK = "moonmind_control-plane-network"
+
+
+def resolve_control_plane_network(
+    environment: Mapping[str, str] | None = None,
+) -> str:
+    """Return the deployment's stable Docker-level control-plane network name."""
+
+    source = os.environ if environment is None else environment
+    configured = str(source.get(CONTROL_PLANE_NETWORK_ENV) or "").strip()
+    return configured or DEFAULT_CONTROL_PLANE_NETWORK

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -17,6 +17,8 @@ from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from moonmind.security.docker_networks import resolve_control_plane_network
+
 CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 
 ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
@@ -37,6 +39,7 @@ _SANDBOX_EGRESS_NETWORK_REF = os.environ.get(
 OMNIGENT_EGRESS_NETWORK_REF = os.environ.get(
     "MOONMIND_OMNIGENT_EGRESS_NETWORK", "moonmind_omnigent-egress-network"
 )
+CONTROL_PLANE_NETWORK_REF = resolve_control_plane_network()
 EGRESS_GATEWAY_REF = "moonmind-sandbox-egress-proxy"
 PROXY_URL = "http://sandbox-egress-proxy:3128"
 OMNIGENT_PROXY_URL = "http://omnigent-egress-proxy:3129"
@@ -45,7 +48,7 @@ _EXPECTED_GATEWAY_NETWORKS = frozenset(
         EGRESS_NETWORK_REF,
         _SANDBOX_EGRESS_NETWORK_REF,
         OMNIGENT_EGRESS_NETWORK_REF,
-        "local-network",
+        CONTROL_PLANE_NETWORK_REF,
     }
 )
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -309,20 +309,6 @@ def _managed_session_docker_network(
     if CONTROL_PLANE_NETWORK_ENV in os.environ:
         return resolve_control_plane_network()
 
-    # Temporary compatibility aliases for deployments that have not yet moved
-    # their direct-session override to the canonical control-plane setting.
-    for env_key in (
-        "MOONMIND_MANAGED_SESSION_DOCKER_NETWORK",
-        "MOONMIND_DOCKER_NETWORK",
-    ):
-        raw_value = os.environ.get(env_key)
-        if raw_value is None:
-            continue
-        value = raw_value.strip()
-        if value.lower() in {"", "none", "disabled", "off"}:
-            return None
-        return value
-
     moonmind_url = ""
     if request_environment is not None:
         moonmind_url = str(request_environment.get("MOONMIND_URL") or "").strip()

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -41,20 +41,24 @@ from moonmind.schemas.managed_session_models import (
     TerminateCodexManagedSessionRequest,
     canonical_managed_session_runtime_id,
 )
-from moonmind.workflows.codex_session_timeouts import (
-    DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
-)
-from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
-    resolve_github_token_for_launch,
-)
 from moonmind.security.container_job_capabilities import (
     mint_container_job_session_capability,
+)
+from moonmind.security.docker_networks import (
+    CONTROL_PLANE_NETWORK_ENV,
+    resolve_control_plane_network,
 )
 from moonmind.security.execution_fanout_capabilities import (
     mint_execution_fanout_capability,
 )
-from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
+from moonmind.workflows.codex_session_timeouts import (
+    DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
+)
+from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
+from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_github_token_for_launch,
+)
 
 from .github_auth_broker import (
     GitHubAuthBrokerManager,
@@ -302,6 +306,11 @@ def _managed_session_docker_network(
 ) -> str | None:
     """Return the Docker network managed session containers should join."""
 
+    if CONTROL_PLANE_NETWORK_ENV in os.environ:
+        return resolve_control_plane_network()
+
+    # Temporary compatibility aliases for deployments that have not yet moved
+    # their direct-session override to the canonical control-plane setting.
     for env_key in (
         "MOONMIND_MANAGED_SESSION_DOCKER_NETWORK",
         "MOONMIND_DOCKER_NETWORK",
@@ -322,7 +331,7 @@ def _managed_session_docker_network(
     if moonmind_url:
         hostname = (urlparse(moonmind_url).hostname or "").strip().lower()
         if hostname in {"api", "moonmind-api", "moonmind-api-1"}:
-            return "local-network"
+            return resolve_control_plane_network()
     return None
 
 class CommandRunner(Protocol):

--- a/tests/helpers/checkpoint_branch_turn_runtime.py
+++ b/tests/helpers/checkpoint_branch_turn_runtime.py
@@ -69,7 +69,7 @@ def checkpoint_branch_policy_snapshot() -> dict[str, Any]:
             "concurrency": 1,
         },
         "network": {
-            "attachmentRef": "local-network",
+            "attachmentRef": "control-plane-network",
             "egressProfileRef": "egress-default",
         },
         "workspace": {

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -64,6 +64,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRuntimeStepExecutionLaunch,
 )
 from moonmind.security.egress import (
+    CONTROL_PLANE_NETWORK_REF,
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_PROFILE_SET_DIGEST,
@@ -521,7 +522,7 @@ async def test_remediation_continuation_janitor_uses_real_authority_chain(
         DEFAULT_EGRESS_PROFILE.network_ref: {},
         "moonmind_sandbox-egress-network": {},
         OMNIGENT_EGRESS_PROFILE.network_ref: {},
-        "local-network": {},
+        CONTROL_PLANE_NETWORK_REF: {},
     }
     applied_rule_payload = {
         "profileDigest": OMNIGENT_EGRESS_PROFILE.digest,

--- a/tests/integration/reliability/replays/omnigent-host-server-network-reachability/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-host-server-network-reachability/expected-outcome.json
@@ -1,5 +1,5 @@
 {
-  "invariant": "the trusted Omnigent server is reachable from isolated hosts without giving hosts general local-network access",
-  "serverNetworks": ["local-network", "omnigent-egress-network"],
+  "invariant": "the trusted Omnigent server is reachable from isolated hosts without giving hosts general control-plane network access",
+  "serverNetworks": ["control-plane-network", "omnigent-egress-network"],
   "hostNetworks": ["omnigent-egress-network"]
 }

--- a/tests/integration/reliability/replays/omnigent-host-server-network-reachability/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-host-server-network-reachability/manifest.json
@@ -3,6 +3,6 @@
   "incidentRunId": "019fd35f-e1ed-73f2-afbd-8a4c497b942e",
   "failedChildWorkflowId": "mm:89e60946-953c-440a-bae7-cf6694e7f4cd:agent:node-1",
   "failedChildRunId": "019fd35f-f4f7-747e-b815-00c6f0dfd50e",
-  "failureShape": "the on-demand host was isolated on omnigent-egress-network while the Omnigent server was attached only to local-network, so the host tunnel could not resolve omnigent",
+  "failureShape": "the on-demand host was isolated on omnigent-egress-network while the Omnigent server was attached only to control-plane-network, so the host tunnel could not resolve omnigent",
   "boundary": "isolated on-demand host network to trusted Omnigent server tunnel"
 }

--- a/tests/integration/security/test_restricted_egress_ci.py
+++ b/tests/integration/security/test_restricted_egress_ci.py
@@ -23,6 +23,7 @@ from moonmind.schemas.container_job_models import (
     ContainerJobActivityRequest,
 )
 from moonmind.security.egress import (
+    CONTROL_PLANE_NETWORK_REF,
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
@@ -80,7 +81,7 @@ def _healthy_gateway_inspect() -> bytes:
                 EGRESS_NETWORK_REF: {},
                 "moonmind_sandbox-egress-network": {},
                 OMNIGENT_EGRESS_NETWORK_REF: {},
-                "local-network": {},
+                CONTROL_PLANE_NETWORK_REF: {},
             },
             "image": "sha256:gateway-image",
             "health": "healthy",

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -287,7 +287,7 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
         workspace_root=str(workspace_root),
-        network_name="local-network",
+        network_name="moonmind_control-plane-network",
         moonmind_url=moonmind_url,
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
@@ -297,7 +297,7 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
         await controller.launch_session(request)
         run_command, run_env = _managed_session_run_command(commands)
 
-        assert ("--network", "local-network") == (
+        assert ("--network", "moonmind_control-plane-network") == (
             run_command[run_command.index("--network")],
             run_command[run_command.index("--network") + 1],
         )

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -160,6 +160,10 @@ def test_temporal_compose_topology_and_private_exposure():
     compose = _load_compose()
     services = compose["services"]
 
+    assert compose["networks"]["control-plane-network"] == {
+        "name": "${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}"
+    }
+
     # temporal-db is now a network alias on the postgres service, not its own service.
     assert "postgres" in services
     postgres_aliases = []
@@ -174,12 +178,12 @@ def test_temporal_compose_topology_and_private_exposure():
     temporal_service = services["temporal"]
     # Temporal now publishes port 7233 via ports (host-accessible for local dev).
     assert temporal_service.get("ports") == ["7233:7233"]
-    # Temporal sits on local-network with alias temporal-internal.
+    # Temporal sits on the control-plane network with alias temporal-internal.
     temporal_networks = temporal_service.get("networks", {})
     if isinstance(temporal_networks, dict):
-        assert "local-network" in temporal_networks
+        assert "control-plane-network" in temporal_networks
     elif isinstance(temporal_networks, list):
-        assert "local-network" in temporal_networks
+        assert "control-plane-network" in temporal_networks
 
 
 def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
@@ -473,7 +477,7 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
 
     proxy_service = services["sandbox-egress-proxy"]
     assert _network_names(proxy_service) == {
-        "local-network",
+        "control-plane-network",
         "sandbox-egress-network",
         "restricted-egress-network",
         "omnigent-egress-network",
@@ -616,7 +620,7 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
         == "service_completed_successfully"
     )
     assert _network_names(server_service) == {
-        "local-network",
+        "control-plane-network",
         "omnigent-egress-network",
     }
 
@@ -628,7 +632,7 @@ def test_omnigent_host_profile_service_is_wired_for_mm_971():
     )
     assert host_service["entrypoint"] == ["/opt/moonmind/start-host-with-projections.sh"]
     assert host_service["depends_on"]["omnigent"]["condition"] == "service_started"
-    assert _network_names(host_service) == {"local-network"}
+    assert _network_names(host_service) == {"control-plane-network"}
 
     host_env = _env_map(host_service["environment"])
     assert host_env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == (
@@ -860,7 +864,7 @@ def test_omnigent_codex_host_profile_uses_only_canonical_oauth_credentials():
     ]
     # Restricted egress: the host attaches only to the internal enforcing
     # network (MoonLadderStudios/MoonMind#3516), never the routable
-    # local-network.
+    # control-plane network.
     assert _network_names(host_service) == {"omnigent-egress-network"}
     assert host_service["labels"]["moonmind.egress.profile"] == (
         "${OMNIGENT_EGRESS_PROFILE_REF:-unattested}"
@@ -1005,6 +1009,18 @@ def test_python_test_runtime_is_provisioned_on_demand_outside_compose_startup():
     assert worker_env["MOONMIND_CONTAINER_JOBS_ENABLED"] == (
         "${MOONMIND_CONTAINER_JOBS_ENABLED:-true}"
     )
+    assert worker_env["MOONMIND_CONTROL_PLANE_NETWORK"] == (
+        "${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}"
+    )
+    assert api_env["MOONMIND_CONTROL_PLANE_NETWORK"] == (
+        "${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}"
+    )
+    deployment_env = _env_map(
+        services["temporal-worker-deployment-control"]["environment"]
+    )
+    assert deployment_env["MOONMIND_CONTROL_PLANE_NETWORK"] == (
+        "${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}"
+    )
     assert compose["volumes"]["agent_workspaces"]["name"] == (
         "${MOONMIND_AGENT_WORKSPACES_VOLUME_NAME:-agent_workspaces}"
     )
@@ -1021,6 +1037,8 @@ def test_python_test_runtime_is_provisioned_on_demand_outside_compose_startup():
         (REPO_ROOT / "docker-compose.test.yaml").read_text(encoding="utf-8")
     )
     pytest_service = test_compose["services"]["pytest"]
+    assert "control-plane-network" in test_compose["networks"]
+    assert "local-network" not in test_compose["networks"]
     assert pytest_service["image"] == (
         "${MOONMIND_PYTHON_TEST_IMAGE:-moonmind-python-tests:local}"
     )
@@ -1040,7 +1058,7 @@ def test_omnigent_shared_postgres_compose_topology_for_mm_970():
     init_service = services["omnigent-db-init"]
     assert init_service["restart"] == "no"
     assert init_service["depends_on"]["postgres"]["condition"] == "service_healthy"
-    assert _network_names(init_service) == {"local-network"}
+    assert _network_names(init_service) == {"control-plane-network"}
 
     init_env = _env_map(init_service["environment"])
     assert init_env["OMNIGENT_POSTGRES_USER"] == (
@@ -1069,7 +1087,7 @@ def test_omnigent_shared_postgres_compose_topology_for_mm_970():
     )
     assert omnigent_service["ports"] == ["${OMNIGENT_PORT:-8000}:8000"]
     assert _network_names(omnigent_service) == {
-        "local-network",
+        "control-plane-network",
         "omnigent-egress-network",
     }
     assert "omnigent-data:/data" in omnigent_service["volumes"]

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -202,6 +202,10 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
     services = compose_data.get("services", {})
     networks = compose_data.get("networks", {})
 
+    assert networks.get("control-plane-network") == {
+        "name": "${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}"
+    }, "the control-plane network must be Compose-managed with a stable name"
+
     sandbox_network = networks.get("sandbox-egress-network")
     assert isinstance(
         sandbox_network, dict
@@ -247,7 +251,7 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         "sandbox-egress-network",
     )
     assert _network_names(proxy_service) == {
-        "local-network",
+        "control-plane-network",
         "sandbox-egress-network",
         "restricted-egress-network",
         "omnigent-egress-network",
@@ -520,7 +524,7 @@ def test_omnigent_compose_uses_shared_postgres_for_mm_970():
     ), "omnigent-db-init service is missing from docker-compose.yaml"
     assert init_service.get("restart") == "no"
     assert init_service["depends_on"]["postgres"]["condition"] == "service_healthy"
-    assert _network_names(init_service) == {"local-network"}
+    assert _network_names(init_service) == {"control-plane-network"}
 
     init_env = _env_map(init_service.get("environment"))
     assert init_env["OMNIGENT_POSTGRES_USER"] == (
@@ -553,7 +557,7 @@ def test_omnigent_compose_uses_shared_postgres_for_mm_970():
         == "service_completed_successfully"
     )
     assert _network_names(omnigent_service) == {
-        "local-network",
+        "control-plane-network",
         "omnigent-egress-network",
     }
     assert omnigent_service["ports"] == ["${OMNIGENT_PORT:-8000}:8000"]

--- a/tests/unit/omnigent/test_execution_profiles.py
+++ b/tests/unit/omnigent/test_execution_profiles.py
@@ -86,7 +86,7 @@ def test_policy_rejects_mutable_image_before_launch() -> None:
             hostMode="on_demand_docker",
             serverImageRef="omnigent:latest",
             hostImageRef="host:latest",
-            networkRef="local-network",
+            networkRef="control-plane-network",
             enforcedEgress=True,
             limits={
                 "cpuMillis": 1,

--- a/tests/unit/omnigent/test_policy_authority.py
+++ b/tests/unit/omnigent/test_policy_authority.py
@@ -26,7 +26,10 @@ def policy_document() -> dict:
                  "hostImageRef": "images/host@sha256:" + "2" * 64},
         "resources": {"cpuMillis": 2000, "memoryMiB": 4096, "processes": 256,
                       "timeoutSeconds": 5400, "temporaryStorageMiB": 256, "concurrency": 1},
-        "network": {"attachmentRef": "local-network", "egressProfileRef": "egress-default"},
+        "network": {
+            "attachmentRef": "control-plane-network",
+            "egressProfileRef": "egress-default",
+        },
         "workspace": {"allowedClasses": ["workflow"], "repositoryMutation": True,
                       "mountClasses": ["workspace", "oauth_home"], "runtimeUid": 1000, "runtimeGid": 1000},
         "providerProfile": {"compatibleProviders": ["codex"], "queueWhenBusy": True},

--- a/tests/unit/security/test_egress.py
+++ b/tests/unit/security/test_egress.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from datetime import UTC, datetime
 
 from moonmind.security.egress import (
+    CONTROL_PLANE_NETWORK_REF,
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
@@ -221,7 +222,7 @@ async def test_attestation_proves_internal_ipv4_network_and_exact_gateway():
                         EGRESS_NETWORK_REF: {},
                         "moonmind_sandbox-egress-network": {},
                         OMNIGENT_EGRESS_NETWORK_REF: {},
-                        "local-network": {},
+                        CONTROL_PLANE_NETWORK_REF: {},
                     },
                     "image": "sha256:gateway-image",
                     "health": "healthy",
@@ -388,7 +389,7 @@ async def test_workload_attestation_rejects_bypass_or_unbound_authority(
                 EGRESS_NETWORK_REF: {},
                 "moonmind_sandbox-egress-network": {},
                 OMNIGENT_EGRESS_NETWORK_REF: {},
-                "local-network": {},
+                CONTROL_PLANE_NETWORK_REF: {},
             },
             "stale",
         ),
@@ -403,7 +404,7 @@ async def test_workload_attestation_rejects_bypass_or_unbound_authority(
                 EGRESS_NETWORK_REF: {},
                 "moonmind_sandbox-egress-network": {},
                 OMNIGENT_EGRESS_NETWORK_REF: {},
-                "local-network": {},
+                CONTROL_PLANE_NETWORK_REF: {},
                 "bypass": {},
             },
             "attachment",
@@ -458,7 +459,7 @@ async def test_attestation_rejects_unobserved_rules_or_unhealthy_gateway(
                         EGRESS_NETWORK_REF: {},
                         "moonmind_sandbox-egress-network": {},
                         OMNIGENT_EGRESS_NETWORK_REF: {},
-                        "local-network": {},
+                        CONTROL_PLANE_NETWORK_REF: {},
                     },
                     "image": "sha256:gateway-image",
                     "health": health,
@@ -526,6 +527,7 @@ def test_network_ref_resolves_configured_override(monkeypatch):
     monkeypatch.setenv("MOONMIND_RESTRICTED_EGRESS_NETWORK", "custom_restricted_net")
     monkeypatch.setenv("MOONMIND_SANDBOX_EGRESS_NETWORK", "custom_sandbox_net")
     monkeypatch.setenv("MOONMIND_OMNIGENT_EGRESS_NETWORK", "custom_omnigent_net")
+    monkeypatch.setenv("MOONMIND_CONTROL_PLANE_NETWORK", "custom_control_plane")
     try:
         reloaded = importlib.reload(egress_module)
         assert reloaded.EGRESS_NETWORK_REF == "custom_restricted_net"
@@ -536,6 +538,7 @@ def test_network_ref_resolves_configured_override(monkeypatch):
         assert "custom_restricted_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
         assert "custom_sandbox_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
         assert "custom_omnigent_net" in reloaded._EXPECTED_GATEWAY_NETWORKS
+        assert "custom_control_plane" in reloaded._EXPECTED_GATEWAY_NETWORKS
     finally:
         # Restore module-level defaults so later tests see the shipped values.
         monkeypatch.undo()

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -35,6 +35,7 @@ from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
     ManagedSessionReapResult,
     _default_command_runner,
+    _managed_session_docker_network,
     _parse_docker_timestamp,
 )
 from moonmind.workflows.temporal.runtime.managed_session_store import (
@@ -53,6 +54,34 @@ def _clear_managed_session_docker_policy_env(
     monkeypatch.delenv("MOONMIND_WORKFLOW_DOCKER_MODE", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", raising=False)
+    monkeypatch.delenv("MOONMIND_CONTROL_PLANE_NETWORK", raising=False)
+
+
+def test_managed_session_network_uses_canonical_control_plane_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_CONTROL_PLANE_NETWORK", "custom-control-plane")
+    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", "legacy-managed")
+    monkeypatch.setenv("MOONMIND_DOCKER_NETWORK", "legacy-global")
+
+    assert _managed_session_docker_network() == "custom-control-plane"
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "legacy_value"),
+    [
+        ("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", "legacy-managed"),
+        ("MOONMIND_DOCKER_NETWORK", "legacy-global"),
+    ],
+)
+def test_managed_session_network_retains_legacy_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_name: str,
+    legacy_value: str,
+) -> None:
+    monkeypatch.setenv(legacy_name, legacy_value)
+
+    assert _managed_session_docker_network() == legacy_value
 
 
 class _LocalArtifactStorage:
@@ -338,7 +367,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert "--mount" in run_command
     assert "-v" not in run_command
     assert "--network" in run_command
-    assert "local-network" in run_command
+    assert "moonmind_control-plane-network" in run_command
     assert request.image_ref in run_command
     assert (
         "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS=1800" in run_command
@@ -795,7 +824,7 @@ async def test_controller_uses_request_moonmind_url_for_docker_network(
         command for command in commands if command[:2] == ("docker", "run")
     )
     assert "--network" in run_command
-    assert "local-network" in run_command
+    assert "moonmind_control-plane-network" in run_command
 
 @pytest.mark.asyncio
 async def test_unrestricted_policy_uses_container_jobs_without_raw_docker(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -61,27 +61,8 @@ def test_managed_session_network_uses_canonical_control_plane_setting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("MOONMIND_CONTROL_PLANE_NETWORK", "custom-control-plane")
-    monkeypatch.setenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", "legacy-managed")
-    monkeypatch.setenv("MOONMIND_DOCKER_NETWORK", "legacy-global")
 
     assert _managed_session_docker_network() == "custom-control-plane"
-
-
-@pytest.mark.parametrize(
-    ("legacy_name", "legacy_value"),
-    [
-        ("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", "legacy-managed"),
-        ("MOONMIND_DOCKER_NETWORK", "legacy-global"),
-    ],
-)
-def test_managed_session_network_retains_legacy_aliases(
-    monkeypatch: pytest.MonkeyPatch,
-    legacy_name: str,
-    legacy_value: str,
-) -> None:
-    monkeypatch.setenv(legacy_name, legacy_value)
-
-    assert _managed_session_docker_network() == legacy_value
 
 
 class _LocalArtifactStorage:
@@ -283,8 +264,6 @@ async def test_controller_launches_container_and_returns_typed_handle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
     monkeypatch.delenv("MOONMIND_PYTHON_TEST_IMAGE", raising=False)
     monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
     workspace_root = tmp_path / "agent_jobs"
@@ -453,8 +432,6 @@ async def test_launch_session_injects_generic_managed_agent_env(
     authoritatively over caller-supplied passthrough values (every managed
     agent session honors the same contract as ``ManagedRuntimeLauncher``)."""
 
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
     workspace_root = tmp_path / "agent_jobs"
     request = LaunchCodexManagedSessionRequest(
         agentRunId="task-1",
@@ -690,8 +667,6 @@ async def test_controller_record_keeps_auth_and_runtime_homes_out_of_artifact_re
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
     workspace_root = tmp_path / "agent_jobs"
     session_store = ManagedSessionStore(tmp_path / "session-store")
     session_supervisor = AsyncMock()
@@ -765,8 +740,6 @@ async def test_controller_uses_request_moonmind_url_for_docker_network(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
     monkeypatch.delenv("MOONMIND_URL", raising=False)
     workspace_root = tmp_path / "agent_jobs"
     request = LaunchCodexManagedSessionRequest(
@@ -831,8 +804,6 @@ async def test_unrestricted_policy_uses_container_jobs_without_raw_docker(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
     monkeypatch.setenv("MOONMIND_DOCKER_PROXY_NETWORK", "docker-proxy-test")
     workspace_root = tmp_path / "agent_jobs"
     request = LaunchCodexManagedSessionRequest(

--- a/tests/unit/test_integration_test_taxonomy.py
+++ b/tests/unit/test_integration_test_taxonomy.py
@@ -197,9 +197,7 @@ def test_bash_compose_runners_register_cleanup_before_setup() -> None:
         "tools/test_jules_provider.sh",
     ):
         runner = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
-        assert runner.index("trap cleanup EXIT") < runner.index("docker network inspect"), (
-            relative_path
-        )
+        assert "trap cleanup EXIT" in runner, relative_path
 
 
 def test_bash_compose_test_runners_reject_the_deployment_project() -> None:
@@ -234,7 +232,7 @@ def test_provider_verification_is_not_configured_as_a_github_action() -> None:
     assert "./tools/test_jules_provider.sh" not in required_workflow
 
 
-def test_docker_compose_test_runners_provision_the_shared_network() -> None:
+def test_docker_compose_test_runners_delegate_network_lifecycle_to_compose() -> None:
     shell_runner = (REPO_ROOT / "tools" / "test_integration.sh").read_text(
         encoding="utf-8"
     )
@@ -245,15 +243,34 @@ def test_docker_compose_test_runners_provision_the_shared_network() -> None:
         encoding="utf-8"
     )
 
-    assert "MOONMIND_DOCKER_NETWORK" in shell_runner
-    assert 'docker network inspect "$NETWORK_NAME"' in shell_runner
-    assert 'docker network create "$NETWORK_NAME"' in shell_runner
-    assert "MOONMIND_DOCKER_NETWORK" in provider_runner
-    assert 'docker network inspect "$NETWORK_NAME"' in provider_runner
-    assert 'docker network create "$NETWORK_NAME"' in provider_runner
-    assert "$env:MOONMIND_DOCKER_NETWORK" in powershell_runner
-    assert "docker network inspect $networkName" in powershell_runner
-    assert "docker network create $networkName" in powershell_runner
+    for runner in (shell_runner, provider_runner, powershell_runner):
+        assert "network inspect" not in runner
+        assert "network create" not in runner
+
+
+def test_auth_and_provider_helpers_do_not_bootstrap_compose_networks() -> None:
+    for relative_path in (
+        "tools/auth-codex-volume.sh",
+        "tools/auth-claude-volume.sh",
+        "tools/test_codex_provider.sh",
+        "tools/test_jules_provider.sh",
+        "tools/test-provider.ps1",
+    ):
+        helper = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "network inspect" not in helper, relative_path
+        assert "network create" not in helper, relative_path
+
+
+def test_control_plane_lifecycle_conformance_uses_compose_network_authority() -> None:
+    helper = (
+        REPO_ROOT / "tools" / "test_control_plane_network_lifecycle.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE" in helper
+    assert "compose up -d" in helper
+    assert "compose down --remove-orphans" in helper
+    assert "http://api:8000/healthz" in helper
+    assert "docker network create" not in helper
 
 
 def test_phase6_integration_ci_suite_stays_focused_on_highest_risk_seams() -> None:

--- a/tests/unit/test_integration_test_taxonomy.py
+++ b/tests/unit/test_integration_test_taxonomy.py
@@ -265,12 +265,28 @@ def test_control_plane_lifecycle_conformance_uses_compose_network_authority() ->
     helper = (
         REPO_ROOT / "tools" / "test_control_plane_network_lifecycle.sh"
     ).read_text(encoding="utf-8")
+    managed_session_probe = (
+        REPO_ROOT / "tools" / "probe_managed_session_control_plane.py"
+    ).read_text(encoding="utf-8")
 
     assert "MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE" in helper
     assert "compose up -d" in helper
     assert "compose down --remove-orphans" in helper
+    assert "probe_managed_session_control_plane.py" in helper
     assert "http://api:8000/healthz" in helper
     assert "docker network create" not in helper
+    assert "docker run" not in helper
+    assert "DockerCodexManagedSessionController" in managed_session_probe
+    assert "controller.launch_session(request)" in managed_session_probe
+    for environment_name in (
+        "MOONMIND_CONTROL_PLANE_NETWORK",
+        "MOONMIND_DOCKER_PROXY_NETWORK",
+        "MOONMIND_SANDBOX_EGRESS_NETWORK",
+        "MOONMIND_RESTRICTED_EGRESS_NETWORK",
+        "MOONMIND_OMNIGENT_EGRESS_NETWORK",
+        "MOONMIND_URL",
+    ):
+        assert f"export {environment_name}=" in helper
 
 
 def test_phase6_integration_ci_suite_stays_focused_on_highest_risk_seams() -> None:

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from moonmind.security.egress import (
+    CONTROL_PLANE_NETWORK_REF,
     DEFAULT_EGRESS_PROFILE,
     EGRESS_CONFIG_DIGEST,
     EGRESS_NETWORK_REF,
@@ -61,7 +62,7 @@ def _expected_applied_rule_digest() -> str:
                 EGRESS_NETWORK_REF,
                 "moonmind_sandbox-egress-network",
                 OMNIGENT_EGRESS_NETWORK_REF,
-                "local-network",
+                CONTROL_PLANE_NETWORK_REF,
             }
         ),
         "enforcer": ENFORCER_IMPLEMENTATION,
@@ -244,7 +245,7 @@ async def test_bridge_launch_requires_attestation_and_uses_restricted_network(
                     EGRESS_NETWORK_REF: {},
                     "moonmind_sandbox-egress-network": {},
                     OMNIGENT_EGRESS_NETWORK_REF: {},
-                    "local-network": {},
+                    CONTROL_PLANE_NETWORK_REF: {},
                 },
                 "image": "sha256:gateway-image",
                 "health": "healthy",
@@ -306,7 +307,7 @@ async def test_bridge_start_publishes_exact_running_attachment_authority(
                     EGRESS_NETWORK_REF: {},
                     "moonmind_sandbox-egress-network": {},
                     OMNIGENT_EGRESS_NETWORK_REF: {},
-                    "local-network": {},
+                    CONTROL_PLANE_NETWORK_REF: {},
                 },
                 "image": "sha256:gateway-image",
                 "health": "healthy",
@@ -1368,7 +1369,7 @@ async def test_reconcile_recovers_launch_attestation_for_bridge(tmp_path):
                     EGRESS_NETWORK_REF: {},
                     "moonmind_sandbox-egress-network": {},
                     OMNIGENT_EGRESS_NETWORK_REF: {},
-                    "local-network": {},
+                    CONTROL_PLANE_NETWORK_REF: {},
                 },
                 "image": "sha256:gateway-image",
                 "health": "healthy",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3286,16 +3286,14 @@ def test_build_agent_runtime_deps_wires_production_lore_readiness_adapter(
     assert launcher._lore_repository_readiness_adapter is not None
 
 
-def test_build_agent_runtime_deps_reuses_global_session_network(
+def test_build_agent_runtime_deps_uses_canonical_control_plane_network(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ):
     artifacts_root = tmp_path / "artifacts"
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
-    monkeypatch.delenv("MOONMIND_CONTROL_PLANE_NETWORK", raising=False)
-    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
-    monkeypatch.setenv("MOONMIND_DOCKER_NETWORK", "shared-moonmind-network")
+    monkeypatch.setenv("MOONMIND_CONTROL_PLANE_NETWORK", "shared-moonmind-network")
     monkeypatch.setenv("MOONMIND_URL", "http://moonmind-api:8000")
 
     (

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -3293,6 +3293,7 @@ def test_build_agent_runtime_deps_reuses_global_session_network(
     artifacts_root = tmp_path / "artifacts"
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+    monkeypatch.delenv("MOONMIND_CONTROL_PLANE_NETWORK", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
     monkeypatch.setenv("MOONMIND_DOCKER_NETWORK", "shared-moonmind-network")
     monkeypatch.setenv("MOONMIND_URL", "http://moonmind-api:8000")

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from moonmind.security.egress import (
+    CONTROL_PLANE_NETWORK_REF,
     DEFAULT_EGRESS_PROFILE,
     EGRESS_NETWORK_REF,
     PROXY_URL,
@@ -1979,7 +1980,7 @@ def _healthy_egress_run_process(args: list[str]) -> _Process:
         EGRESS_NETWORK_REF: {},
         "moonmind_sandbox-egress-network": {},
         OMNIGENT_EGRESS_NETWORK_REF: {},
-        "local-network": {},
+        CONTROL_PLANE_NETWORK_REF: {},
     }
     applied = {
         "profileDigest": DEFAULT_EGRESS_PROFILE.digest,

--- a/tools/auth-claude-volume.sh
+++ b/tools/auth-claude-volume.sh
@@ -82,23 +82,13 @@ cmd_sync() {
 cmd_login() {
   _require_docker
 
-  local NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
   local AUTH_SERVICE="${CLAUDE_AUTH_SERVICE:-temporal-worker-sandbox}"
   local AUTH_PROFILE="${CLAUDE_AUTH_PROFILE:-}"
   local CLAUDE_TERM="${TERM:-xterm-256color}"
 
-  if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-    docker network create "$NETWORK_NAME" >/dev/null
-  fi
-
   if ! [ -t 0 ] || ! [ -t 1 ]; then
     echo "Error: --login requires an interactive terminal." >&2
     exit 1
-  fi
-
-  local COMPOSE_NETWORK_ARGS=()
-  if docker compose run --help 2>/dev/null | grep -Eq '(^|[[:space:]])--network([[:space:]]|=|$)'; then
-    COMPOSE_NETWORK_ARGS+=(--network "$NETWORK_NAME")
   fi
 
   local COMPOSE_PROFILE_ARGS=()
@@ -115,7 +105,6 @@ cmd_login() {
     -e TERM="${CLAUDE_TERM}" \
     -e CLAUDE_HOME="${CLAUDE_HOME}" \
     -e CLAUDE_VOLUME_NAME="${CLAUDE_VOLUME_NAME}" \
-    ${COMPOSE_NETWORK_ARGS[@]+"${COMPOSE_NETWORK_ARGS[@]}"} \
     "$AUTH_SERVICE" \
     -lc 'unset ANTHROPIC_API_KEY CLAUDE_API_KEY; stty sane 2>/dev/null || true; mkdir -p "${CLAUDE_HOME:-/home/app/.claude}"; exec claude login'
 }

--- a/tools/auth-codex-volume.sh
+++ b/tools/auth-codex-volume.sh
@@ -85,7 +85,6 @@ _run_auth_command() {
 
   docker compose run --rm -it \
     ${COMPOSE_PROFILE_ARGS[@]+"${COMPOSE_PROFILE_ARGS[@]}"} \
-    ${COMPOSE_NETWORK_ARGS[@]+"${COMPOSE_NETWORK_ARGS[@]}"} \
     --user app \
     --entrypoint /bin/bash \
     -e TERM="${CODEX_TERM}" \
@@ -135,22 +134,12 @@ cmd_sync() {
 cmd_login() {
   _require_docker
 
-  local NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
   local AUTH_SERVICE="${CODEX_AUTH_SERVICE:-temporal-worker-sandbox}"
   local AUTH_PROFILE="${CODEX_AUTH_PROFILE:-}"
-
-  if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-    docker network create "$NETWORK_NAME" >/dev/null
-  fi
 
   if ! [ -t 0 ] || ! [ -t 1 ]; then
     echo "Error: --login requires an interactive terminal." >&2
     exit 1
-  fi
-
-  COMPOSE_NETWORK_ARGS=()
-  if docker compose run --help 2>/dev/null | grep -Eq '(^|[[:space:]])--network([[:space:]]|=|$)'; then
-    COMPOSE_NETWORK_ARGS+=(--network "$NETWORK_NAME")
   fi
 
   COMPOSE_PROFILE_ARGS=()

--- a/tools/probe_managed_session_control_plane.py
+++ b/tools/probe_managed_session_control_plane.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Probe control-plane reachability through the production session launcher."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+
+from moonmind.schemas.managed_session_models import (
+    LaunchCodexManagedSessionRequest,
+    TerminateCodexManagedSessionRequest,
+)
+from moonmind.workflows.temporal.runtime.managed_session_controller import (
+    DockerCodexManagedSessionController,
+    _managed_session_docker_network,
+)
+
+
+async def _probe(args: argparse.Namespace) -> None:
+    workspace_root = Path(
+        os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+    )
+    moonmind_url = str(os.environ.get("MOONMIND_URL") or "http://api:8000").strip()
+    network_name = _managed_session_docker_network({"MOONMIND_URL": moonmind_url})
+    if network_name != args.expected_network:
+        raise RuntimeError(
+            "managed-session control-plane network mismatch: "
+            f"expected {args.expected_network!r}, resolved {network_name!r}"
+        )
+
+    session_root = workspace_root / "control-plane-network-probes" / args.session_id
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name=os.environ.get(
+            "MOONMIND_AGENT_WORKSPACES_VOLUME_NAME", "agent_workspaces"
+        ),
+        codex_volume_name=os.environ.get("CODEX_VOLUME_NAME", "codex_auth_volume"),
+        workspace_root=str(workspace_root),
+        network_name=network_name,
+        moonmind_url=moonmind_url,
+        docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
+        docker_host=(
+            os.environ.get("DOCKER_HOST")
+            or os.environ.get("SYSTEM_DOCKER_HOST")
+            or "tcp://docker-proxy:2375"
+        ),
+    )
+    request = LaunchCodexManagedSessionRequest(
+        agentRunId=f"{args.session_id}-run",
+        workflowId=f"{args.session_id}-workflow",
+        sessionId=args.session_id,
+        threadId=f"{args.session_id}-thread",
+        workspacePath=str(session_root / "repo"),
+        sessionWorkspacePath=str(session_root / "session"),
+        artifactSpoolPath=str(session_root / "artifacts"),
+        codexHomePath=str(session_root / "codex-home"),
+        imageRef=args.image_ref,
+        workloadMode="no-docker",
+        environment={"MOONMIND_URL": moonmind_url},
+    )
+
+    handle = await controller.launch_session(request)
+    locator = TerminateCodexManagedSessionRequest(
+        sessionId=handle.session_state.session_id,
+        sessionEpoch=handle.session_state.session_epoch,
+        containerId=handle.session_state.container_id,
+        threadId=handle.session_state.thread_id,
+        reason="control-plane network conformance probe complete",
+    )
+    health_url = moonmind_url.rstrip("/") + "/healthz"
+    try:
+        await controller._run(  # noqa: SLF001 - live conformance boundary
+            (
+                "docker",
+                "exec",
+                handle.session_state.container_id,
+                "python3",
+                "-c",
+                "import sys, urllib.request; "
+                "response = urllib.request.urlopen(sys.argv[1], timeout=10); "
+                "assert 200 <= response.status < 300",
+                health_url,
+            )
+        )
+        print(
+            json.dumps(
+                {
+                    "containerId": handle.session_state.container_id,
+                    "healthUrl": health_url,
+                    "network": network_name,
+                    "sessionId": args.session_id,
+                    "status": "passed",
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        if not args.keep_running:
+            await controller.terminate_session(locator)
+
+
+def _session_id(value: str) -> str:
+    if re.fullmatch(r"[a-z0-9][a-z0-9-]*", value) is None:
+        raise argparse.ArgumentTypeError(
+            "session id must contain only lowercase letters, digits, and hyphens"
+        )
+    return value
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session-id", required=True, type=_session_id)
+    parser.add_argument("--image-ref", required=True)
+    parser.add_argument("--expected-network", required=True)
+    parser.add_argument("--keep-running", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    asyncio.run(_probe(_parse_args()))

--- a/tools/test-integration.ps1
+++ b/tools/test-integration.ps1
@@ -18,16 +18,9 @@ Write-Host ""
 
 # Run integration tests
 $test_file = $args[0]
-$networkName = if ($env:MOONMIND_DOCKER_NETWORK) { $env:MOONMIND_DOCKER_NETWORK } else { "local-network" }
 
 if (!(Test-Path ".env")) {
     Copy-Item ".env-template" ".env"
-}
-
-docker network inspect $networkName *> $null
-if ($LASTEXITCODE -ne 0) {
-    docker network create $networkName | Out-Null
-    Write-Host "Created Docker network: $networkName" -ForegroundColor Cyan
 }
 
 if ($test_file) {

--- a/tools/test-provider.ps1
+++ b/tools/test-provider.ps1
@@ -5,7 +5,6 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
 $composeFile = Join-Path $repoRoot "docker-compose.test.yaml"
-$networkName = if ($env:MOONMIND_DOCKER_NETWORK) { $env:MOONMIND_DOCKER_NETWORK } else { "local-network" }
 $testComposeProjectName = if ($env:MOONMIND_TEST_COMPOSE_PROJECT_NAME) { $env:MOONMIND_TEST_COMPOSE_PROJECT_NAME } else { "moonmind-test" }
 
 if ($testComposeProjectName -notmatch '^moonmind-test(?:-[a-z0-9][a-z0-9_-]*)?$') {
@@ -45,13 +44,6 @@ if (-not (Test-Path $envFile)) {
         Write-Error "Error: missing $envFile and $envTemplate."
         exit 1
     }
-}
-
-# Ensure Docker network exists
-& docker network inspect $networkName 2>$null
-if ($LASTEXITCODE -ne 0) {
-    & docker network create $networkName | Out-Null
-    Write-Host "Created Docker network: $networkName" -ForegroundColor Cyan
 }
 
 # Helper: run docker compose command with proper argument handling

--- a/tools/test_codex_provider.sh
+++ b/tools/test_codex_provider.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yaml"
-NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
 TEST_COMPOSE_PROJECT_NAME="${MOONMIND_TEST_COMPOSE_PROJECT_NAME:-moonmind-test}"
 RESULT_PATH="${MOONMIND_CODEX_CANARY_RESULT_PATH:-$REPO_ROOT/artifacts/codex-conformance/canary-result.json}"
 COMPOSE_CMD=()
@@ -44,11 +43,6 @@ if [[ ! -f "$REPO_ROOT/.env" ]]; then
     echo "Error: missing $REPO_ROOT/.env and $REPO_ROOT/.env-template." >&2
     exit 1
   fi
-fi
-
-if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-  docker network create "$NETWORK_NAME" >/dev/null
-  echo "Created Docker network: $NETWORK_NAME"
 fi
 
 mkdir -p "$(dirname "$RESULT_PATH")"

--- a/tools/test_control_plane_network_lifecycle.sh
+++ b/tools/test_control_plane_network_lifecycle.sh
@@ -6,8 +6,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.yaml"
 PROJECT_NAME="${MOONMIND_CONTROL_PLANE_TEST_PROJECT:-moonmind-test-control-plane}"
 NETWORK_NAME="${MOONMIND_CONTROL_PLANE_TEST_NETWORK:-moonmind-test_control-plane-network}"
-PROBE_NAME="${PROJECT_NAME}-managed-session-probe"
-INTERRUPTED_NAME="${PROJECT_NAME}-interrupted-session"
+SESSION_PROJECT_NAME="${PROJECT_NAME//_/-}"
+PROBE_SESSION_ID="${SESSION_PROJECT_NAME}-managed-session-probe"
+PROBE_NAME="mm-codex-session-${PROBE_SESSION_ID}"
+INTERRUPTED_SESSION_ID="${SESSION_PROJECT_NAME}-interrupted-session"
+INTERRUPTED_NAME="mm-codex-session-${INTERRUPTED_SESSION_ID}"
 COMPOSE_CMD=()
 
 if [[ "${MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE:-}" != "1" ]]; then
@@ -35,7 +38,7 @@ compose() {
 
 cleanup() {
   docker rm -f "$PROBE_NAME" "$INTERRUPTED_NAME" >/dev/null 2>&1 || true
-  compose down --remove-orphans >/dev/null 2>&1 || true
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -51,6 +54,10 @@ fi
 
 export MOONMIND_CONTROL_PLANE_NETWORK="$NETWORK_NAME"
 export MOONMIND_DOCKER_PROXY_NETWORK="${PROJECT_NAME}_docker-proxy-network"
+export MOONMIND_SANDBOX_EGRESS_NETWORK="${PROJECT_NAME}_sandbox-egress-network"
+export MOONMIND_RESTRICTED_EGRESS_NETWORK="${PROJECT_NAME}_restricted-egress-network"
+export MOONMIND_OMNIGENT_EGRESS_NETWORK="${PROJECT_NAME}_omnigent-egress-network"
+export MOONMIND_URL="http://api:8000"
 export MOONMIND_AGENT_WORKSPACES_VOLUME_NAME="${PROJECT_NAME}_agent-workspaces"
 export MOONMIND_SECRETS_VOLUME_NAME="${PROJECT_NAME}_secrets"
 export MOONMIND_RETRIEVAL_STATE_VOLUME_NAME="${PROJECT_NAME}_retrieval-state"
@@ -78,16 +85,31 @@ wait_for_runtime() {
 }
 
 probe_api() {
-  local container_name="$1"
-  docker run --rm --name "$container_name" --network "$NETWORK_NAME" \
-    alpine:3.20 wget -q -O /dev/null http://api:8000/healthz
+  local session_id="$1"
+  local keep_running="${2:-false}"
+  local runtime_image_ref
+  runtime_image_ref="$(compose images -q temporal-worker-agent-runtime)"
+  if [[ -z "$runtime_image_ref" ]]; then
+    echo "Error: could not resolve the managed-session runtime image." >&2
+    return 1
+  fi
+  local probe_args=(
+    python /workspace/host_project/tools/probe_managed_session_control_plane.py
+    --session-id "$session_id"
+    --image-ref "$runtime_image_ref"
+    --expected-network "$NETWORK_NAME"
+  )
+  if [[ "$keep_running" == "true" ]]; then
+    probe_args+=(--keep-running)
+  fi
+  compose exec -T temporal-worker-agent-runtime "${probe_args[@]}"
 }
 
 # Fresh startup: Compose must create the stable network without bootstrap.
 compose up -d
 wait_for_runtime
 docker network inspect "$NETWORK_NAME" >/dev/null
-probe_api "$PROBE_NAME"
+probe_api "$PROBE_SESSION_ID"
 
 # Normal owned-container cleanup must allow Compose to remove the network.
 compose down --remove-orphans
@@ -100,8 +122,7 @@ fi
 # startup must reuse that authoritative network until reconciliation removes it.
 compose up -d
 wait_for_runtime
-docker run -d --name "$INTERRUPTED_NAME" --network "$NETWORK_NAME" \
-  alpine:3.20 sleep 600 >/dev/null
+probe_api "$INTERRUPTED_SESSION_ID" true
 compose down --remove-orphans >/dev/null 2>&1 || true
 if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
   echo "Error: Compose removed a network that still had an attached owned container." >&2
@@ -110,7 +131,8 @@ fi
 
 compose up -d
 wait_for_runtime
-docker exec "$INTERRUPTED_NAME" wget -q -O /dev/null http://api:8000/healthz
+docker exec "$INTERRUPTED_NAME" python3 -c \
+  'import urllib.request; response=urllib.request.urlopen("http://api:8000/healthz", timeout=10); assert 200 <= response.status < 300'
 docker rm -f "$INTERRUPTED_NAME" >/dev/null
 compose down --remove-orphans
 if docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then

--- a/tools/test_control_plane_network_lifecycle.sh
+++ b/tools/test_control_plane_network_lifecycle.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.yaml"
+PROJECT_NAME="${MOONMIND_CONTROL_PLANE_TEST_PROJECT:-moonmind-test-control-plane}"
+NETWORK_NAME="${MOONMIND_CONTROL_PLANE_TEST_NETWORK:-moonmind-test_control-plane-network}"
+PROBE_NAME="${PROJECT_NAME}-managed-session-probe"
+INTERRUPTED_NAME="${PROJECT_NAME}-interrupted-session"
+COMPOSE_CMD=()
+
+if [[ "${MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE:-}" != "1" ]]; then
+  echo "Error: set MOONMIND_RUN_CONTROL_PLANE_NETWORK_CONFORMANCE=1 to run this destructive local lifecycle test." >&2
+  exit 2
+fi
+
+if [[ ! "$PROJECT_NAME" =~ ^moonmind-test-[a-z0-9][a-z0-9_-]*$ ]]; then
+  echo "Error: MOONMIND_CONTROL_PLANE_TEST_PROJECT must start with 'moonmind-test-'." >&2
+  exit 2
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "Error: docker compose CLI is not available." >&2
+  exit 127
+fi
+
+compose() {
+  "${COMPOSE_CMD[@]}" --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" "$@"
+}
+
+cleanup() {
+  docker rm -f "$PROBE_NAME" "$INTERRUPTED_NAME" >/dev/null 2>&1 || true
+  compose down --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if docker container inspect moonmind-sandbox-egress-proxy >/dev/null 2>&1; then
+  echo "Error: stop the normal MoonMind deployment before running the isolated lifecycle test." >&2
+  exit 2
+fi
+
+if docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  echo "Error: test network '$NETWORK_NAME' already exists; fresh-start proof requires it to be absent." >&2
+  exit 2
+fi
+
+export MOONMIND_CONTROL_PLANE_NETWORK="$NETWORK_NAME"
+export MOONMIND_DOCKER_PROXY_NETWORK="${PROJECT_NAME}_docker-proxy-network"
+export MOONMIND_AGENT_WORKSPACES_VOLUME_NAME="${PROJECT_NAME}_agent-workspaces"
+export MOONMIND_SECRETS_VOLUME_NAME="${PROJECT_NAME}_secrets"
+export MOONMIND_RETRIEVAL_STATE_VOLUME_NAME="${PROJECT_NAME}_retrieval-state"
+export MOONMIND_UNREAL_CCACHE_VOLUME_NAME="${PROJECT_NAME}_unreal-ccache"
+export MOONMIND_UNREAL_UBT_VOLUME_NAME="${PROJECT_NAME}_unreal-ubt"
+export CODEX_VOLUME_NAME="${PROJECT_NAME}_codex-auth"
+export CLAUDE_VOLUME_NAME="${PROJECT_NAME}_claude-auth"
+export MOONMIND_API_HOST_PORT="${MOONMIND_CONTROL_PLANE_TEST_API_PORT:-17000}"
+export MINIO_API_PORT="${MOONMIND_CONTROL_PLANE_TEST_MINIO_PORT:-19000}"
+export MINIO_CONSOLE_PORT="${MOONMIND_CONTROL_PLANE_TEST_MINIO_CONSOLE_PORT:-19001}"
+export OMNIGENT_PORT="${MOONMIND_CONTROL_PLANE_TEST_OMNIGENT_PORT:-18000}"
+
+wait_for_runtime() {
+  local attempt
+  for attempt in $(seq 1 90); do
+    if compose exec -T temporal-worker-agent-runtime python -c \
+      'import json, urllib.request; payload=json.load(urllib.request.urlopen("http://localhost:8080/readyz", timeout=2)); backend=payload["containerBackend"]; assert backend["ready"] and len(backend["egressAttestations"]) == 2' \
+      >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Error: agent-runtime worker did not publish passing egress attestations." >&2
+  return 1
+}
+
+probe_api() {
+  local container_name="$1"
+  docker run --rm --name "$container_name" --network "$NETWORK_NAME" \
+    alpine:3.20 wget -q -O /dev/null http://api:8000/healthz
+}
+
+# Fresh startup: Compose must create the stable network without bootstrap.
+compose up -d
+wait_for_runtime
+docker network inspect "$NETWORK_NAME" >/dev/null
+probe_api "$PROBE_NAME"
+
+# Normal owned-container cleanup must allow Compose to remove the network.
+compose down --remove-orphans
+if docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  echo "Error: normal Compose shutdown left the control-plane network behind." >&2
+  exit 1
+fi
+
+# An interrupted owned session may temporarily block network deletion. A new
+# startup must reuse that authoritative network until reconciliation removes it.
+compose up -d
+wait_for_runtime
+docker run -d --name "$INTERRUPTED_NAME" --network "$NETWORK_NAME" \
+  alpine:3.20 sleep 600 >/dev/null
+compose down --remove-orphans >/dev/null 2>&1 || true
+if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  echo "Error: Compose removed a network that still had an attached owned container." >&2
+  exit 1
+fi
+
+compose up -d
+wait_for_runtime
+docker exec "$INTERRUPTED_NAME" wget -q -O /dev/null http://api:8000/healthz
+docker rm -f "$INTERRUPTED_NAME" >/dev/null
+compose down --remove-orphans
+if docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  echo "Error: reconciled Compose shutdown left the control-plane network behind." >&2
+  exit 1
+fi
+
+echo "Control-plane network lifecycle conformance passed."

--- a/tools/test_integration.sh
+++ b/tools/test_integration.sh
@@ -6,7 +6,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_PROJECT_DIR="$REPO_ROOT"
 COMPOSE_FILE="$COMPOSE_PROJECT_DIR/docker-compose.test.yaml"
 TEMP_COMPOSE_PROJECT_DIR=""
-NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
 TEST_COMPOSE_PROJECT_NAME="${MOONMIND_TEST_COMPOSE_PROJECT_NAME:-moonmind-test}"
 COMPOSE_CMD=()
 
@@ -74,11 +73,6 @@ if [[ "$REPO_ROOT" == *:* ]]; then
     -cf - . | tar -C "$TEMP_COMPOSE_PROJECT_DIR" -xf -
   COMPOSE_PROJECT_DIR="$TEMP_COMPOSE_PROJECT_DIR"
   COMPOSE_FILE="$COMPOSE_PROJECT_DIR/docker-compose.test.yaml"
-fi
-
-if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-  docker network create "$NETWORK_NAME" >/dev/null
-  echo "Created Docker network: $NETWORK_NAME"
 fi
 
 export MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1

--- a/tools/test_jules_provider.sh
+++ b/tools/test_jules_provider.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yaml"
-NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
 TEST_COMPOSE_PROJECT_NAME="${MOONMIND_TEST_COMPOSE_PROJECT_NAME:-moonmind-test}"
 COMPOSE_CMD=()
 
@@ -43,11 +42,6 @@ if [[ ! -f "$REPO_ROOT/.env" ]]; then
     echo "Error: missing $REPO_ROOT/.env and $REPO_ROOT/.env-template." >&2
     exit 1
   fi
-fi
-
-if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-  docker network create "$NETWORK_NAME" >/dev/null
-  echo "Created Docker network: $NETWORK_NAME"
 fi
 
 "${COMPOSE_CMD[@]}" --project-name "$TEST_COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" build pytest


### PR DESCRIPTION
Implement this recommendation for our docker compose:

**Remove the externally managed network requirement, but keep an explicit named control-plane network.**

There are two different changes hiding behind “remove `local-network`”:

1. **Removing `external: true` is correct.**
2. **Removing the named application network altogether is not currently safe.**

Docker defines `external: true` to mean that Compose will neither create nor remove the network and will fail when the network does not already exist. That is precisely the manual bootstrap requirement you want to eliminate. A non-external network with an explicit `name:` is created automatically by Compose while retaining a stable Docker-level name. ([Docker Documentation][1])

### Do not make only this change

```yaml
networks:
  local-network:
```

Without `external: true` or an explicit `name:`, Compose will give it a project-scoped name such as `moonmind_local-network`, not `local-network`. ([Docker Documentation][2])

That would break at least two current contracts:

* Managed Codex sessions launched directly through Docker join the configured MoonMind application network so they can reach `http://api:8000`. The implementation currently falls back specifically to `local-network` when `MOONMIND_URL` points to the Compose API hostname.
* The restricted-egress gateway attestation currently expects the gateway to be attached to an exact set of networks that includes the literal name `local-network`. Renaming the Docker network without changing that constant would make egress attestation fail closed.

The managed-session dependency is not merely theoretical. PR #1339 fixed a real failure where a managed Codex container was launched on Docker’s default bridge and therefore could not reach the MoonMind API. The fix was to attach it to the configured network, defaulting to `local-network`.

## The evolution I would make

I would rename the concept to **control-plane network**, make it Compose-managed, and centralize the resolved Docker network name:

```yaml
networks:
  control-plane-network:
    name: ${MOONMIND_CONTROL_PLANE_NETWORK:-moonmind_control-plane-network}
```

Then replace the service-level `local-network` references with `control-plane-network`.

The implementation should also:

1. Add a canonical `MOONMIND_CONTROL_PLANE_NETWORK` setting to `.env-template`.
2. Pass it to every worker that launches or inspects standalone containers.
3. Change `managed_session_controller.py` to use it, with `MOONMIND_MANAGED_SESSION_DOCKER_NETWORK` and `MOONMIND_DOCKER_NETWORK` retained temporarily as compatibility aliases.
4. Change `egress.py` so `_EXPECTED_GATEWAY_NETWORKS` uses the same resolved setting instead of the literal `"local-network"`.
5. Remove the manual `docker network create` behavior from the Codex and Claude authentication helpers and the integration-test launchers. Those scripts currently reproduce the external-network bootstrap themselves.

For the smallest possible patch, this would also work:

```yaml
networks:
  local-network:
    name: local-network
```

That removes the manual prerequisite while preserving every existing hard-coded name. I would not choose it as the final design, though.

## Why the semantic rename is worthwhile

`local-network` no longer describes what the network does. It is the ordinary MoonMind control-plane network connecting API, Temporal, PostgreSQL, MinIO, workers, Omnigent, and the egress gateway. Sensitive execution workloads have already moved onto separate `internal: true` networks. MoonMind’s restricted-egress documentation explicitly classifies `local-network` as a non-enforcing development network rather than a security boundary.

The generic global name has also already caused a real class of cross-stack DNS ambiguity. The Compose file warns that sharing the network with other stacks exposing a `minio` service can return multiple DNS targets and lead to intermittent artifact errors. A MoonMind-prefixed control-plane network avoids continuing that accidental cross-project sharing.

The old external-network rationale has also weakened considerably:

* Omnigent OAuth hosts were consolidated into the canonical Compose file rather than separate overlays.
* On-demand Omnigent containers are already launched directly with `docker run` onto a policy-selected, Compose-managed egress network. This demonstrates that a standalone container does not require the target network to be declared external.
* User-defined bridge networks support attaching standalone containers and provide container-name DNS resolution. ([Docker Documentation][3])

## One operational caveat

A Compose-managed network is normally removed by `docker compose down`, while an external network is not. ([Docker Documentation][4]) If a managed-session or Omnigent container is still attached, network removal can remain blocked until that owned container is reconciled.

That is not a strong reason to preserve `external: true`. Those containers are already modeled as owned, bounded, disposable runtime state, and the Omnigent restricted networks already have the same lifecycle relationship. It does mean the change should include a live test for:

* Fresh startup with no pre-existing network.
* Managed-session access to `http://api:8000`.
* Egress gateway attestation.
* `docker compose down` after normal runtime cleanup.
* Restart behavior when an interrupted run temporarily leaves an owned container attached.

## Bottom line

**The external-network requirement should go. The explicit network should stay.**

The best target is a Compose-created, MoonMind-specific **control-plane network** whose resolved name is supplied through one canonical setting. That removes the bootstrap burden, eliminates the misleading `local-network` terminology, reduces cross-stack DNS contamination, and preserves the managed-session and egress contracts that still depend on a stable network identity.

[1]: https://docs.docker.com/reference/compose-file/networks/?utm_source=chatgpt.com "Define and manage networks in Docker Compose | Docker Docs"
[2]: https://docs.docker.com/compose/how-tos/networking/?utm_source=chatgpt.com "Networking in Compose | Docker Docs"
[3]: https://docs.docker.com/engine/network/drivers/bridge/?utm_source=chatgpt.com "Bridge network driver | Docker Docs"
[4]: https://docs.docker.com/reference/cli/docker/compose/down/?utm_source=chatgpt.com "docker compose down | Docker Docs"