### PR TITLE
Scope Omnigent workflow fanout permissions

### DIFF
--- a/.agents/skills/queue-moonmind-workflows/SKILL.md
+++ b/.agents/skills/queue-moonmind-workflows/SKILL.md
@@ -67,7 +67,8 @@ The helper supports both execution API shapes:
 - task-shaped wrapper: `{"type": "task", "payload": {...}}`
 - direct execution create body: `{"workflowType": "MoonMind.UserWorkflow", ...}`
 
-When `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN` is present, only the task-shaped
+When `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE` or the direct
+`MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN` value is present, only the task-shaped
 child form is accepted and the helper binds it to the caller with
 `runtimeInheritance="caller"`; direct create and schedule shapes remain available
 only to ordinary authenticated API users.
@@ -101,8 +102,11 @@ For direct create requests, idempotency is stored at `request.idempotencyKey`.
 `scripts/queue_moonmind_workflows.py`:
 
 - requires `MOONMIND_URL`;
-- prefers `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN` when present, sends it as a
-  bearer with the fan-out v1 marker, and never substitutes a broader API token;
+- reads `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE` when present and fails
+  closed if that lease-owned file is missing or empty; otherwise accepts the
+  direct `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN` value for portable hosts;
+- sends the scoped value as a bearer with the fan-out v1 marker and never
+  substitutes a broader API token when scoped authority is configured;
 - forwards supported API auth from `MOONMIND_AUTH_HEADER`,
   `MOONMIND_API_TOKEN`, `MOONMIND_AUTH_TOKEN`, `MOONMIND_BEARER_TOKEN`, or
   `MOONMIND_API_KEY` when present, and also forwards

--- a/.agents/skills/queue-moonmind-workflows/scripts/queue_moonmind_workflows.py
+++ b/.agents/skills/queue-moonmind-workflows/scripts/queue_moonmind_workflows.py
@@ -145,7 +145,7 @@ def _normalize_child_request(raw: Any) -> dict[str, Any]:
 def _bind_request_to_fanout_capability(request: dict[str, Any]) -> dict[str, Any]:
     """Make the portable child relationship explicit when MoonMind scopes it."""
 
-    if not _text(os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN")):
+    if not _read_execution_fanout_token():
         return request
     if not _request_is_task_shape(request):
         raise RuntimeError(
@@ -245,6 +245,19 @@ def _read_worker_token() -> str | None:
 
 
 def _read_execution_fanout_token() -> str | None:
+    token_file = _text(
+        os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE")
+    )
+    if token_file:
+        path = Path(token_file)
+        if not path.is_file():
+            raise RuntimeError(
+                "execution fan-out capability file is unavailable: " + token_file
+            )
+        token = path.read_text(encoding="utf-8").strip()
+        if not token:
+            raise RuntimeError("execution fan-out capability file is empty")
+        return token
     return _text(os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN")) or None
 
 

--- a/.agents/skills/tactics-test/SKILL.md
+++ b/.agents/skills/tactics-test/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: tactics-test
 description: Run Unreal Engine build and automation test workflows for Tactics through MoonMind's shared Docker backend, with a portable direct-Docker fallback outside MoonMind.
+metadata:
+  required-capabilities:
+    - docker
 ---
 
 # Dood Unreal Tactics Build Test
@@ -13,7 +16,7 @@ Run Linux Unreal build and targeted automation tests for `Tactics.uproject`. Ins
 
 - Repository path (defaults to the active managed workspace inside MoonMind and
   `/mnt/d/Unreal/Tactics` in the direct-Docker fallback)
-- Inside MoonMind: `containerJobs` capability and an operator-provisioned `tactics-unreal` image source
+- Inside MoonMind: `docker` capability and an operator-provisioned `tactics-unreal` image source
 - Outside MoonMind: Docker CLI access and a reachable daemon
 - Container image with the Unreal toolchain in the selected execution substrate
 

--- a/.env-template
+++ b/.env-template
@@ -125,7 +125,7 @@ MOONMIND_WORKDIR="/work/agent_jobs"
 MOONMIND_AGENT_WORKSPACES_VOLUME_NAME="agent_workspaces"
 CODEX_VOLUME_PATH="/home/app/.codex"
 CODEX_HOME="/home/app/.codex"
-MOONMIND_WORKER_CAPABILITIES="codex,git,gh,docker,proposals_write"
+MOONMIND_WORKER_CAPABILITIES="codex,git,gh,docker,proposals_write,execution.fanout"
 # Shared-host Unreal image used by imageSourceRef=tactics-unreal.
 # First use pulls a missing image through the trusted deployment daemon. Set
 # `never` only when policy requires an explicit operator prewarm.

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -8599,6 +8599,36 @@ async def _enrich_deployment_skill_metadata(
     return metadata_by_skill
 
 
+def _merge_deployment_skill_required_capabilities(
+    required_capabilities: list[str],
+    metadata_by_skill: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    """Flatten trusted deployment Skill requirements into the canonical plane."""
+
+    merged: list[str] = []
+    seen: set[str] = set()
+
+    def append(values: list[str]) -> None:
+        for value in values:
+            capability = value.strip().lower()
+            if capability and capability not in seen:
+                seen.add(capability)
+                merged.append(capability)
+
+    append(required_capabilities)
+    for skill_name in sorted(metadata_by_skill):
+        metadata = metadata_by_skill[skill_name]
+        append(
+            _coerce_string_list(
+                metadata.get("required_capabilities"),
+                field_name=(
+                    f"deployment skill '{skill_name}' metadata.required_capabilities"
+                ),
+            )
+        )
+    return merged
+
+
 async def _resolve_step_runtime_selections(
     *,
     steps: list[dict[str, Any]],
@@ -10743,6 +10773,10 @@ async def _create_execution_from_workflow_request(
         session=session,
         normalized_tool=normalized_tool,
         steps=normalized_steps,
+    )
+    required_capabilities = _merge_deployment_skill_required_capabilities(
+        required_capabilities,
+        deployment_skill_metadata,
     )
     publish_skill_id = _workflow_publish_skill_id(task_payload, normalized_tool)
     publish_skill_metadata = deployment_skill_metadata.get(

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,42 @@
 [
   {
-    "id": 3808359979,
+    "id": 3808837005,
     "disposition": "addressed",
-    "rationale": "Removed both legacy managed-session network aliases and updated every remaining test and caller to use MOONMIND_CONTROL_PLANE_NETWORK."
+    "rationale": "Both container CLIs now prefer the lease-owned bearer file, fail closed for missing or empty selected files, and retain inline fallback only when no selector exists."
   },
   {
-    "id": 3808359988,
+    "id": 3808837012,
     "disposition": "addressed",
-    "rationale": "The lifecycle conformance now launches its health probe through DockerCodexManagedSessionController before testing API reachability from the resulting managed-session container."
+    "rationale": "The tactics-test Skill now declares the canonical docker capability in its portable frontmatter and the real Skill parser test verifies it."
   },
   {
-    "id": 3808359994,
+    "id": 3808837016,
     "disposition": "addressed",
-    "rationale": "The lifecycle conformance exports project-specific names for the control-plane, Docker-proxy, sandbox-egress, restricted-egress, and Omnigent-egress networks."
+    "rationale": "Managed-session fanout minting is independent of container-job availability and the no-docker boundary test verifies fanout without container-job authority."
   },
   {
-    "id": 4966282554,
+    "id": 3808837020,
+    "disposition": "addressed",
+    "rationale": "Trusted deployment Skill artifact requirements are normalized, lowercased, deduplicated, and flattened into canonical top-level requiredCapabilities."
+  },
+  {
+    "id": 3808837024,
+    "disposition": "addressed",
+    "rationale": "The managed adapter preserves omitted requiredCapabilities as None for in-flight replay, preserves explicit empty lists, and rejects malformed present values."
+  },
+  {
+    "id": 3808837028,
+    "disposition": "addressed",
+    "rationale": "Same-lease retries atomically replace capability-file contents with freshly minted values while preserving the exact owned filename set and read-only final mode."
+  },
+  {
+    "id": 3808837030,
+    "disposition": "addressed",
+    "rationale": "Fanout minting now requires workflow-owned authorization derived from immutable built-in or deployment Skill provenance; repo/local and top-level-only declarations are denied."
+  },
+  {
+    "id": 4966913681,
     "disposition": "not-applicable",
-    "rationale": "This review body is an informational summary whose actionable findings are represented and addressed by the three linked review comments."
+    "rationale": "This review body is an informational summary whose seven actionable findings are separately classified and addressed above."
   }
 ]

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -1,10 +1,12 @@
 # Executions API Contract
 
+**Document Class:** Canonical declarative
+**Viewpoint:** Module Contract Specification
 **Project:** MoonMind 
 **Doc type:** API contract 
 **Status:** Draft 
 **Owner:** MoonMind Platform 
-**Last updated:** 2026-07-16 (UTC)
+**Last updated:** 2026-08-18 (UTC)
 **Audience:** backend, dashboard, integrations
 
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
@@ -152,7 +154,9 @@ External JSON fields use **camelCase**.
 
 ### 6.1 Authentication
 
-All `/api/executions` endpoints require an authenticated MoonMind user.
+All `/api/executions` endpoints require an authenticated MoonMind user except
+the exact create and describe operations admitted by the workflow-scoped
+execution fan-out capability in Section 6.5.
 
 ### 6.2 Ownership model
 
@@ -178,6 +182,28 @@ Rules:
 ### 6.4 Information disclosure posture
 
 For direct fetch/update/signal/cancel operations, non-admin callers receive `404 Not Found` for executions they do not own. This intentionally avoids confirming whether another user's execution exists.
+
+### 6.5 Workflow-scoped execution fan-out
+
+A managed runtime with the normalized `execution.fanout` requirement may receive
+a short-lived bearer plus `X-MoonMind-Execution-Fanout: v1`. This is an
+operation-specific capability, not a user session, worker token, container-job
+token, or general API credential.
+
+The capability is bound to one parent Workflow Execution, agent run, optional
+step, runtime session, runtime id, source kind, and expiry. The API resolves the
+parent's authoritative user owner and permits only:
+
+- `POST /api/executions` with exactly one task or workflow child,
+  `runtimeInheritance="caller"`, and a stable `idempotencyKey`; and
+- `GET /api/executions/{workflowId}` when the target is a child of that parent
+  and has the same owner.
+
+Fan-out authentication rejects schedules, direct-create payloads, source
+overrides, unrelated execution reads, and every other execution operation.
+Unauthorized or unrelated describe requests return `404` so the capability
+cannot probe execution existence. Runtime adapters mint and materialize this
+bearer only when policy authorizes the declared requirement.
 
 ---
 

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -283,7 +283,10 @@ Host registration credentials and OpenAI OAuth credentials remain separate. Neit
 
 The Omnigent network route to MoonMind is transport, not authority. The runtime
 adapter derives grants from the normalized Required Capabilities and policy
-snapshot. For `execution.fanout`, it mints a short-lived parent-scoped bearer,
+snapshot. For `execution.fanout`, the workflow must also attest that the
+immutable resolved Skill has built-in or deployment-managed provenance and the
+derived requirement; an authored capability string is never sufficient
+authority. The adapter then mints a short-lived parent-scoped bearer,
 writes it to the lease-owned read-only capability directory, and exposes only
 `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE` to the runner and login shell.
 Runs without that requirement receive neither the file nor its selector. Raw

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -268,6 +268,7 @@ The owning worker resolves and validates the locator, performs root-containment 
 | Workflow workspace | `/workspaces/run` for on-demand | Workflow-scoped, policy-resolved, daemon-visible |
 | Resolved skills | `/opt/moonmind-skills` | Immutable run snapshot, read-only |
 | Versioned tools | `/opt/moonmind-tools` | Pinned bundle, read-only |
+| Runtime capability files | `/opt/moonmind/capabilities` | Lease-owned, read-only, created only for policy-authorized requirements |
 | Artifact handoff | Policy-selected path or gateway | Never conflated with the OAuth or host-state volume |
 | Temporary storage | `/tmp` | Bounded, removable, and non-authoritative |
 | Optional caches | Policy-selected | Explicit owner, scope, retention, and invalidation |
@@ -279,6 +280,21 @@ The supported host user is UID/GID `1000:1000` with `HOME=/home/app`. On-demand 
 The host attaches only to the network selected by the effective deployment/policy snapshot and required for MoonMind/Omnigent communication. A network name is not itself an egress policy. Restricted egress requires an enforced network, proxy, or firewall boundary and must fail closed when a selected policy cannot be realized.
 
 Host registration credentials and OpenAI OAuth credentials remain separate. Neither may substitute for the other.
+
+The Omnigent network route to MoonMind is transport, not authority. The runtime
+adapter derives grants from the normalized Required Capabilities and policy
+snapshot. For `execution.fanout`, it mints a short-lived parent-scoped bearer,
+writes it to the lease-owned read-only capability directory, and exposes only
+`MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE` to the runner and login shell.
+Runs without that requirement receive neither the file nor its selector. Raw
+capability values must not be written to shell profiles, Docker arguments,
+durable artifacts, or diagnostics.
+
+The baseline file handoff requires a run-dedicated on-demand host. If an
+advanced static-host selection requests `execution.fanout`, preflight blocks
+before workspace or host mutation and directs the operator to the canonical
+on-demand profile; MoonMind does not place a run-scoped bearer into shared host
+state or silently broaden the selected policy.
 
 ---
 

--- a/docs/Omnigent/OmnigentHostMountedTools.md
+++ b/docs/Omnigent/OmnigentHostMountedTools.md
@@ -375,6 +375,12 @@ selector exists but the file is missing or empty. This preserves unchanged
 upstream host images and avoids a token broker, sidecar, broad API token, or
 operator-managed permission switch.
 
+The container-job bearer uses the same lease-owned file pattern. Both the
+projected dependency-free `moonmind` CLI and the shared Python CLI prefer
+`MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE`, fail closed when its selected file
+is missing or empty, and use the legacy inline value only when no selector is
+present. Same-lease retries atomically refresh file contents before launch.
+
 ---
 
 ## 9. Use for future tools

--- a/docs/Omnigent/OmnigentHostMountedTools.md
+++ b/docs/Omnigent/OmnigentHostMountedTools.md
@@ -1,8 +1,10 @@
 # Omnigent Host Mounted Runtime Tools
 
+**Document Class:** Canonical declarative
+**Viewpoint:** System / Feature Design View
 **Status:** Desired-state design  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-07-17
+**Last updated:** 2026-08-18
 
 **Implementation tracking:** rollout notes, spikes, migration checklists, and temporary handoffs belong under `docs/tmp/` or in issue/PR tracking. This document defines the durable target-state contract.
 
@@ -357,6 +359,21 @@ Mutation-capable workflows must also verify that the selected GitHub credential 
 If `gh` is missing, unauthenticated, or unauthorized for the target repository, MoonMind blocks before creating the Omnigent session and returns an actionable capability diagnostic.
 
 A host may contain `gh` even when a run does not require it. Mere executable presence does not cause MoonMind to inject GitHub credentials or imply permission to perform GitHub mutations.
+
+### 8.4 MoonMind runtime capabilities
+
+MoonMind-internal runtime capabilities are distinct from mounted CLIs. The
+transport route may exist for every compatible host, but the runtime adapter
+materializes operation-specific authority only when normalized
+`requiredCapabilities` and policy demand it.
+
+For `execution.fanout`, the bearer is stored in a lease-owned read-only file
+under `/opt/moonmind/capabilities`. The login-shell profile exports only
+`MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE`; it never contains the bearer
+value. The portable queue helper reads that file and fails closed when the
+selector exists but the file is missing or empty. This preserves unchanged
+upstream host images and avoids a token broker, sidecar, broad API token, or
+operator-managed permission switch.
 
 ---
 

--- a/docs/Security/RestrictedEgress.md
+++ b/docs/Security/RestrictedEgress.md
@@ -1,5 +1,9 @@
 # Restricted egress
 
+**Document Class:** Canonical declarative
+**Viewpoint:** Cross-Cutting Concept
+**Last updated:** 2026-08-18
+
 MoonLadderStudios/MoonMind#3516 defines the production restricted-egress
 boundary shared by Container Jobs, managed helper workloads, and static and
 on-demand Omnigent hosts.
@@ -57,10 +61,15 @@ without weakening CNAME, mixed-answer, rebinding, metadata, Docker/host gateway,
 or internal-service protections. IPv6 is disabled on workload networks and the
 gateway denies the entire IPv6 destination space on its external hop. The
 reviewed 300-second peer read timeout bounds idle CONNECT tunnels and is part of
-the attested profile/config digests. The single narrow exception is HTTP access
-through the Omnigent-only listener to the `omnigent:8000` control endpoint; no
-other workload network can reach that listener and no other control-plane
-destination is allowed.
+the attested profile/config digests. The Omnigent-only listener permits narrow
+HTTP control-plane exceptions to `omnigent:8000` and to `api:8000` for the
+container Tool call, execution creation, and child execution description paths.
+Execution routes require both the fan-out version marker and a bearer header;
+the API then verifies the workflow-scoped capability and child relationship.
+No other workload network can reach this listener, and all other MoonMind API
+paths, methods, and control-plane destinations are denied. The transport route
+is always available to compatible hosts but grants no authority without the
+operation-specific credential selected by normalized `requiredCapabilities`.
 
 ## Lifecycle and evidence
 

--- a/docs/Security/SecretsSystem.md
+++ b/docs/Security/SecretsSystem.md
@@ -1,15 +1,17 @@
 # Secrets System
 
+**Document Class:** Canonical declarative
+**Viewpoint:** Cross-Cutting Concept
 **Implementation tracking:** Rollout and backlog notes live under `docs/tmp/` or in gitignored local-only handoffs (for example `artifacts/`), not as migration checklists in canonical `docs/`.
 
 Status: **Design Draft**
 Owners: MoonMind Engineering
-Last Updated: 2026-06-11
+Last Updated: 2026-08-18
 
 > [!NOTE]
 > This document defines the desired-state MoonMind Secrets System.
 > It is a declarative contract for how secrets are referenced, stored, resolved, materialized, and audited.
-> Phase sequencing, migration work, and implementation checklists belong in .
+> Phase sequencing, migration work, and implementation checklists belong in `docs/tmp/`.
 
 ---
 
@@ -157,6 +159,13 @@ Secret values should be resolved as late as practical and exposed to as little c
 ### 4.5 Proxy First
 
 If MoonMind itself is making the provider or tool call, the preferred design is for the caller to use a MoonMind-issued capability or internal token rather than receiving the provider secret directly.
+
+Runtime capability values follow the same rule. For example, an Omnigent run
+with the policy-authorized `execution.fanout` requirement receives a
+short-lived, parent-scoped MoonMind capability through a lease-owned read-only
+file. The runtime environment contains only the file selector; runs without the
+requirement receive no capability. This avoids distributing a user API token or
+provider credential while keeping built-in batch Skills automatic by default.
 
 ### 4.6 Fail Fast
 

--- a/docs/Steps/SkillSystem.md
+++ b/docs/Steps/SkillSystem.md
@@ -1,8 +1,10 @@
 # Skill System
 
+**Document Class:** Canonical declarative
+**Viewpoint:** Module Architecture View
 Status: Desired State
 Owners: MoonMind Engineering
-Last Updated: 2026-07-11
+Last Updated: 2026-08-18
 Canonical for: agent skills, Skill steps, skill-set resolution, runtime skill materialization, `.agents/skills` path policy
 Related: `docs/Steps/StepTypes.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Workflows/WorkflowArchitecture.md`, `docs/Workflows/RequiredCapabilities.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/UI/WorkflowConsoleArchitecture.md`, `AGENTS.md`
 
@@ -1241,6 +1243,14 @@ Rules:
 4. A Tool invoked by an agent is still a Tool.
 5. Tool outputs remain Tool outputs and artifact refs.
 6. Agent decisions about which Tool to use belong to the Skill step/runtime policy, not to the Tool registry.
+
+Skill side-effect metadata may contribute a normalized Required Capability
+without becoming an authorization grant itself. Specifically,
+`sideEffect.kind: enqueue_children` derives `execution.fanout` during backend
+normalization. Policy must authorize and materialize the scoped runtime
+capability before launch; the Skill author and operator do not manage a separate
+permission checkbox. See
+[Required Capabilities](../Workflows/RequiredCapabilities.md#75-executionfanout).
 
 ---
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -398,8 +398,11 @@ The generic Container Jobs plane owns reusable workspace-resolution and daemon-t
 
 Direct managed runtimes receive a workflow-scoped workspace and artifact area, runtime-specific credential materialization, immutable Skill projection, and bounded temporary state. Runtime-owned environment values take precedence over untrusted passthrough values.
 
-Managed sessions and profile-bound Omnigent hosts that may queue child work
-receive a separate short-lived execution fan-out bearer. That bearer is bound
+Managed sessions and profile-bound Omnigent hosts whose normalized
+`requiredCapabilities` include `execution.fanout` receive a separate short-lived
+execution fan-out bearer after policy authorization. The requirement is derived
+automatically when a resolved Skill declares `sideEffect.kind: enqueue_children`,
+so the supported batch path requires no operator permission toggle. That bearer is bound
 to the parent Workflow Execution, agent run, runtime session, and runtime id; it
 is not interchangeable with the container-job bearer or a user API token. The
 execution API accepts the bearer only for idempotent task/workflow child
@@ -407,6 +410,10 @@ requests with `runtimeInheritance="caller"`, rejects schedule and direct-create
 shapes, records the authoritative `parentWorkflowId`, and limits describe calls
 to children of that parent. Restricted Omnigent egress additionally requires
 the fan-out marker and bearer on the exact create and child-describe paths.
+Profile-bound Omnigent hosts expose the bearer through a lease-owned read-only
+file and pass only its non-secret selector into runner and login-shell
+environments. Hosts without the requirement receive neither the bearer nor the
+selector.
 
 ### 11.2 Profile-bound Omnigent hosts
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -415,6 +415,18 @@ file and pass only its non-secret selector into runner and login-shell
 environments. Hosts without the requirement receive neither the bearer nor the
 selector.
 
+The Run workflow derives the mint authorization from immutable resolved-Skill
+provenance and carries it in `stepExecution.skillSourcePolicy.executionFanout`.
+Built-in and deployment-managed Skills are eligible; repo/local Skills and
+top-level-only declarations are denied before runtime launch. The absent field
+is a replay marker for already-scheduled launch payloads, not a current default.
+
+The Run workflow derives the mint authorization from immutable resolved-Skill
+provenance and carries it in `stepExecution.skillSourcePolicy.executionFanout`.
+Built-in and deployment-managed Skills are eligible; repo/local Skills and
+top-level-only declarations are denied before runtime launch. The absent field
+is a replay marker for already-scheduled launch payloads, not a current default.
+
 ### 11.2 Profile-bound Omnigent hosts
 
 The Codex host filesystem separates:

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -302,11 +302,9 @@ resolved Skill entry: only built-in or deployment-managed provenance with the
 derived requirement authorizes bearer minting. An authored top-level token is
 still only a requirement and cannot grant fan-out by itself. Missing attestation
 is reserved for replay of launches scheduled before this contract existed.
-The Run workflow records a compact allow/deny attestation from the immutable
-resolved Skill entry: only built-in or deployment-managed provenance with the
-derived requirement authorizes bearer minting. An authored top-level token is
-still only a requirement and cannot grant fan-out by itself. Missing attestation
-is reserved for replay of launches scheduled before this contract existed.
+Standard Codex and Claude workers advertise fan-out readiness so trusted batch
+Skills work by default. That readiness label is not authority: the attestation
+and launch-boundary policy check remain mandatory before bearer minting.
 
 Minimum readiness:
 

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -297,6 +297,16 @@ Skill metadata with `sideEffect.kind: enqueue_children` automatically contribute
 this requirement during trusted backend normalization. Built-in batch Skills
 therefore work without an operator permission toggle, while repo and local Skill
 metadata still passes through the normal untrusted-source policy checks.
+The Run workflow records a compact allow/deny attestation from the immutable
+resolved Skill entry: only built-in or deployment-managed provenance with the
+derived requirement authorizes bearer minting. An authored top-level token is
+still only a requirement and cannot grant fan-out by itself. Missing attestation
+is reserved for replay of launches scheduled before this contract existed.
+The Run workflow records a compact allow/deny attestation from the immutable
+resolved Skill entry: only built-in or deployment-managed provenance with the
+derived requirement authorizes bearer minting. An authored top-level token is
+still only a requirement and cannot grant fan-out by itself. Missing attestation
+is reserved for replay of launches scheduled before this contract existed.
 
 Minimum readiness:
 

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -1,8 +1,10 @@
 # Required Capabilities
 
+**Document Class:** Canonical declarative
+**Viewpoint:** Module Contract Specification
 Status: Desired State
 Owners: MoonMind Engineering
-Last Updated: 2026-06-17
+Last Updated: 2026-08-18
 Canonical for: `requiredCapabilities` declaration, derivation, normalization, readiness checks, and failure semantics
 Related: `docs/Workflows/WorkflowArchitecture.md`, `docs/Steps/StepTypes.md`, `docs/Steps/SkillSystem.md`, `docs/Workflows/SkillAndPlanContracts.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
 
@@ -285,7 +287,33 @@ Minimum readiness:
 3. resource and network policy are enforceable;
 4. publishable workspace contents are protected from container-only side effects unless explicitly intended.
 
-### 7.5 Runtime-mode capabilities
+### 7.5 `execution.fanout`
+
+`execution.fanout` means a runtime may create bounded child Workflow Executions
+under its current parent and inspect only those children. It does not grant
+general MoonMind API access.
+
+Skill metadata with `sideEffect.kind: enqueue_children` automatically contributes
+this requirement during trusted backend normalization. Built-in batch Skills
+therefore work without an operator permission toggle, while repo and local Skill
+metadata still passes through the normal untrusted-source policy checks.
+
+Minimum readiness:
+
+1. policy authorizes child execution fan-out for the resolved Skill and caller;
+2. the runtime adapter can materialize a short-lived bearer bound to the parent
+   Workflow Execution, agent run, step, runtime session, and runtime id;
+3. the runtime can reach only the exact execution-create and child-describe API
+   paths through its enforced network profile;
+4. for profile-bound Omnigent, the portable queue helper can read the
+   lease-owned capability file before the model begins work.
+
+The API accepts this authority only for idempotent task/workflow child requests
+with `runtimeInheritance="caller"`. It rejects schedules, unrelated execution
+reads, and broader API operations. A policy denial or materialization failure
+blocks before runtime launch with capability provenance and safe remediation.
+
+### 7.6 Runtime-mode capabilities
 
 Runtime tokens such as `codex_cli` or `claude_code` mean the selected runtime adapter is available and compatible with the workflow's Skill, Tool, policy, and provider profile requirements.
 
@@ -296,7 +324,7 @@ Minimum readiness:
 3. required model/provider profile constraints are satisfied;
 4. runtime-specific materialization, prompt, Skill bundle, and artifact contracts can be honored.
 
-### 7.6 Scoped future capabilities
+### 7.7 Scoped future capabilities
 
 Coarse names remain valid. Future scoped aliases may refine semantics:
 

--- a/moonmind/agents/codex_worker/cli.py
+++ b/moonmind/agents/codex_worker/cli.py
@@ -134,7 +134,7 @@ def _effective_worker_capabilities(
     if configured:
         return configured
     if runtime == "universal":
-        capabilities = ["codex", "claude", "git", "gh"]
+        capabilities = ["codex", "claude", "git", "gh", "execution.fanout"]
         if _jules_runtime_gate_from_env(source).enabled:
             capabilities.insert(2, "jules")
         return tuple(capabilities)
@@ -142,7 +142,10 @@ def _effective_worker_capabilities(
         "codex_cli": "codex",
         "claude_code": "claude",
     }.get(runtime, runtime)
-    return (normalized_runtime, "git", "gh")
+    capabilities = (normalized_runtime, "git", "gh")
+    if normalized_runtime in {"codex", "claude"}:
+        return (*capabilities, "execution.fanout")
+    return capabilities
 
 def _jules_runtime_gate_from_env(source: Mapping[str, str]):
     """Return Jules runtime gate state derived from worker environment."""

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -544,7 +544,12 @@ class CodexWorkerConfig:
     jules_retry_delay_seconds: float = 1.0
     jules_poll_interval_seconds: float = 10.0
     jules_max_inflight: int = 15
-    worker_capabilities: tuple[str, ...] = ("codex", "git", "gh")
+    worker_capabilities: tuple[str, ...] = (
+        "codex",
+        "git",
+        "gh",
+        "execution.fanout",
+    )
     docker_binary: str = "docker"
     container_workspace_volume: str | None = None
     container_default_timeout_seconds: int = 3600
@@ -859,13 +864,20 @@ class CodexWorkerConfig:
                 runtime_caps = ["codex", "claude"]
                 if jules_gate.enabled:
                     runtime_caps.append("jules")
-                worker_capabilities = tuple([*runtime_caps, "git", "gh"])
+                worker_capabilities = tuple(
+                    [*runtime_caps, "git", "gh", "execution.fanout"]
+                )
             else:
                 worker_capability_runtime = {
                     "codex_cli": "codex",
                     "claude_code": "claude",
                 }.get(worker_runtime, worker_runtime)
                 worker_capabilities = (worker_capability_runtime, "git", "gh")
+                if worker_capability_runtime in {"codex", "claude"}:
+                    worker_capabilities = (
+                        *worker_capabilities,
+                        "execution.fanout",
+                    )
 
         docker_binary = (
             str(source.get("MOONMIND_DOCKER_BINARY", "docker")).strip() or "docker"

--- a/moonmind/container_job_cli.py
+++ b/moonmind/container_job_cli.py
@@ -141,6 +141,21 @@ def _mcp_endpoint(source: Mapping[str, str]) -> str:
 
 
 def _mcp_bearer_token(source: Mapping[str, str]) -> str | None:
+    selector = str(
+        source.get("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE") or ""
+    ).strip()
+    if selector:
+        try:
+            value = Path(selector).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise ContainerJobCliError(
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE is unavailable"
+            ) from exc
+        if not value:
+            raise ContainerJobCliError(
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE is empty"
+            )
+        return value
     return (
         str(source.get("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN") or "").strip()
         or None

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -59,7 +59,9 @@ from moonmind.security.container_job_capabilities import (
 from moonmind.security.docker_networks import resolve_control_plane_network
 from moonmind.security.execution_fanout_capabilities import (
     EXECUTION_FANOUT_REQUIRED_CAPABILITY,
+    ExecutionFanoutCapabilityError,
     mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
 )
 from moonmind.security.egress import (
     EgressAttestation,
@@ -415,6 +417,7 @@ class OmnigentOAuthHostRuntime:
         cleanup_authority_store: Any | None = None,
         target_repository: str = "",
         required_capabilities: tuple[str, ...] = (),
+        execution_fanout_authorization: Mapping[str, Any] | None = None,
         github_token: str | None = None,
         github_mutation_required: bool = False,
         effective_launch: Mapping[str, Any] | None = None,
@@ -447,6 +450,15 @@ class OmnigentOAuthHostRuntime:
         normalized_capabilities = {
             str(item or "").strip().lower() for item in required_capabilities
         }
+        try:
+            require_execution_fanout_authorization(
+                required_capabilities,
+                execution_fanout_authorization,
+            )
+        except ExecutionFanoutCapabilityError as exc:
+            raise OmnigentOAuthHostError(
+                str(exc), code="authorization_denied"
+            ) from exc
         if (
             EXECUTION_FANOUT_REQUIRED_CAPABILITY in normalized_capabilities
             and not binding.host_launch_profile_ref
@@ -509,6 +521,7 @@ class OmnigentOAuthHostRuntime:
                 current_step_execution_id=current_step_execution_id,
                 timeout_seconds=int(launch["limits"]["timeoutSeconds"]),
                 required_capabilities=required_capabilities,
+                execution_fanout_authorization=execution_fanout_authorization,
             )
             daemon_runtime_scripts = self._prepare_daemon_runtime_scripts(
                 host_lease.lease_id,
@@ -1745,6 +1758,13 @@ class OmnigentOAuthHostRuntime:
                     code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
                 )
             capability_dir = target / "capabilities"
+            if capability_dir.is_dir() and any(
+                path.is_symlink() for path in capability_dir.iterdir()
+            ):
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime capability files do not match their owner",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                )
             existing_capability_files = (
                 {path.name for path in capability_dir.iterdir() if path.is_file()}
                 if capability_dir.is_dir()
@@ -1755,6 +1775,32 @@ class OmnigentOAuthHostRuntime:
                     "Omnigent runtime capability files do not match their owner",
                     code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
                 )
+            if capability_files:
+                try:
+                    capability_dir.chmod(0o700)
+                    for filename, secret_value in capability_files.items():
+                        descriptor, temporary_name = tempfile.mkstemp(
+                            prefix=f".{filename}-",
+                            dir=capability_dir,
+                        )
+                        os.close(descriptor)
+                        temporary = Path(temporary_name)
+                        try:
+                            temporary.write_text(
+                                secret_value + "\n", encoding="utf-8"
+                            )
+                            temporary.chmod(0o444)
+                            os.replace(temporary, capability_dir / filename)
+                        finally:
+                            if temporary.exists():
+                                temporary.unlink()
+                except OSError as exc:
+                    raise OmnigentOAuthHostError(
+                        "Omnigent runtime capability files could not be refreshed",
+                        code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                    ) from exc
+                finally:
+                    capability_dir.chmod(0o555)
             return target
 
         target_parent.mkdir(parents=True, exist_ok=True)
@@ -2453,6 +2499,7 @@ class OmnigentOAuthHostRuntime:
         current_step_execution_id: str,
         timeout_seconds: int,
         required_capabilities: Sequence[str] = (),
+        execution_fanout_authorization: Mapping[str, Any] | None = None,
     ) -> dict[str, str]:
         """Materialize only the runtime capabilities declared for this host lease."""
 
@@ -2484,6 +2531,15 @@ class OmnigentOAuthHostRuntime:
         normalized_capabilities = {
             str(item or "").strip().lower() for item in required_capabilities
         }
+        try:
+            require_execution_fanout_authorization(
+                required_capabilities,
+                execution_fanout_authorization,
+            )
+        except ExecutionFanoutCapabilityError as exc:
+            raise OmnigentOAuthHostError(
+                str(exc), code="authorization_denied"
+            ) from exc
         environment = {
             "MOONMIND_URL": moonmind_url,
             "MOONMIND_AGENT_RUN_ID": agent_run_id,

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import tarfile
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -56,6 +56,7 @@ from moonmind.security.container_job_capabilities import (
     mint_container_job_session_capability,
 )
 from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
     mint_execution_fanout_capability,
 )
 from moonmind.security.egress import (
@@ -187,6 +188,8 @@ _RUNTIME_EXECUTION_PROFILE_ENV_NAMES = (
     "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
     "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
     "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH",
+    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE",
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
 )
 _SECRET_RUNTIME_ENV_NAMES = frozenset(
     {
@@ -194,6 +197,17 @@ _SECRET_RUNTIME_ENV_NAMES = frozenset(
         "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN",
     }
 )
+_RUNTIME_CAPABILITY_FILE_ENV = {
+    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": (
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE",
+        "container-jobs",
+    ),
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": (
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        "execution-fanout",
+    ),
+}
+_RUNTIME_CAPABILITY_MOUNT_ROOT = "/opt/moonmind/capabilities"
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
@@ -426,6 +440,17 @@ class OmnigentOAuthHostRuntime:
                 "effective launch provider does not match the OAuth host binding",
                 code=HostPreflightFailure.BINDING_MISMATCH.value,
             )
+        normalized_capabilities = {
+            str(item or "").strip().lower() for item in required_capabilities
+        }
+        if (
+            EXECUTION_FANOUT_REQUIRED_CAPABILITY in normalized_capabilities
+            and not binding.host_launch_profile_ref
+        ):
+            raise OmnigentOAuthHostError(
+                "execution fan-out requires a run-dedicated Omnigent host",
+                code="OMNIGENT_RUNTIME_CAPABILITY_UNSUPPORTED",
+            )
         skill_projection = await self._prepare_skill_projection(
             workspace_key=workspace_key,
             resolved_skillset_ref=resolved_skillset_ref,
@@ -479,12 +504,16 @@ class OmnigentOAuthHostRuntime:
                 current_workflow_id=current_workflow_id,
                 current_step_execution_id=current_step_execution_id,
                 timeout_seconds=int(launch["limits"]["timeoutSeconds"]),
+                required_capabilities=required_capabilities,
             )
             daemon_runtime_scripts = self._prepare_daemon_runtime_scripts(
-                workspace_key,
+                host_lease.lease_id,
                 current_step_execution_id=current_step_execution_id,
                 runtime_environment=container_job_environment,
                 daemon_workspace_root=daemon_workspace_root,
+            )
+            host_runtime_environment = self._host_runtime_environment(
+                container_job_environment
             )
             if "gh" in {item.strip().lower() for item in required_capabilities}:
                 await self._initialize_required_tools()
@@ -502,7 +531,7 @@ class OmnigentOAuthHostRuntime:
                 runtime_scripts=daemon_runtime_scripts,
                 current_step_execution_id=current_step_execution_id,
                 github_token=github_token,
-                container_job_environment=container_job_environment,
+                container_job_environment=host_runtime_environment,
                 effective_launch=launch,
                 egress_attestation=egress_attestation,
             )
@@ -1621,7 +1650,7 @@ class OmnigentOAuthHostRuntime:
 
     def _prepare_runtime_scripts(
         self,
-        workspace_key: str,
+        owner_key: str,
         *,
         current_step_execution_id: str,
         runtime_environment: Mapping[str, str] | None = None,
@@ -1662,6 +1691,12 @@ class OmnigentOAuthHostRuntime:
             "MOONMIND_ACTIVE_SKILLS_DIR": "/opt/moonmind-skills",
         }
         supplied_environment = dict(runtime_environment or {})
+        capability_files: dict[str, str] = {}
+        for secret_name, (_, filename) in _RUNTIME_CAPABILITY_FILE_ENV.items():
+            secret_value = str(supplied_environment.get(secret_name) or "").strip()
+            if secret_value:
+                capability_files[filename] = secret_value
+        supplied_environment = self._host_runtime_environment(supplied_environment)
         for name in _RUNTIME_EXECUTION_PROFILE_ENV_NAMES:
             value = str(supplied_environment.get(name) or "").strip()
             if value:
@@ -1684,14 +1719,7 @@ class OmnigentOAuthHostRuntime:
             )
         )
 
-        digest = hashlib.sha256(workspace_key.encode("utf-8")).hexdigest()[:24]
-        target_parent = (self._workspace_root / ".omnigent-runtime-scripts").resolve()
-        target = (target_parent / digest).resolve()
-        if not target.is_relative_to(target_parent):
-            raise OmnigentOAuthHostError(
-                "Omnigent runtime script target escaped its owned root",
-                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
-            )
+        target_parent, target = self._runtime_scripts_target(owner_key)
         if target.is_dir():
             if any(not (target / name).is_file() for name in required_scripts):
                 raise OmnigentOAuthHostError(
@@ -1712,11 +1740,22 @@ class OmnigentOAuthHostRuntime:
                     "Omnigent runtime execution profile does not match its owner",
                     code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
                 )
+            capability_dir = target / "capabilities"
+            existing_capability_files = (
+                {path.name for path in capability_dir.iterdir() if path.is_file()}
+                if capability_dir.is_dir()
+                else set()
+            )
+            if existing_capability_files != set(capability_files):
+                raise OmnigentOAuthHostError(
+                    "Omnigent runtime capability files do not match their owner",
+                    code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+                )
             return target
 
         target_parent.mkdir(parents=True, exist_ok=True)
         staging = Path(
-            tempfile.mkdtemp(prefix=f".{digest}-", dir=target_parent)
+            tempfile.mkdtemp(prefix=f".{target.name}-", dir=target_parent)
         ).resolve()
         try:
             shutil.copytree(source, staging, dirs_exist_ok=True)
@@ -1726,6 +1765,14 @@ class OmnigentOAuthHostRuntime:
                 encoding="utf-8",
             )
             execution_profile.chmod(0o444)
+            if capability_files:
+                capability_dir = staging / "capabilities"
+                capability_dir.mkdir(mode=0o700)
+                for filename, secret_value in capability_files.items():
+                    capability_file = capability_dir / filename
+                    capability_file.write_text(secret_value + "\n", encoding="utf-8")
+                    capability_file.chmod(0o444)
+                capability_dir.chmod(0o555)
             try:
                 os.replace(staging, target)
             except FileExistsError:
@@ -1744,9 +1791,62 @@ class OmnigentOAuthHostRuntime:
             )
         return target
 
+    def _runtime_scripts_target(self, owner_key: str) -> tuple[Path, Path]:
+        normalized_owner = str(owner_key or "").strip()
+        if not normalized_owner:
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script owner is unavailable",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        digest = hashlib.sha256(normalized_owner.encode("utf-8")).hexdigest()[:24]
+        target_parent = (self._workspace_root / ".omnigent-runtime-scripts").resolve()
+        target = (target_parent / digest).resolve()
+        if not target.is_relative_to(target_parent):
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script target escaped its owned root",
+                code="OMNIGENT_RUNTIME_SCRIPTS_UNAVAILABLE",
+            )
+        return target_parent, target
+
+    def _remove_runtime_scripts(self, owner_key: str) -> bool:
+        """Remove one stopped lease's runtime scripts and capability files."""
+
+        _, target = self._runtime_scripts_target(owner_key)
+        if not target.exists():
+            return True
+        if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
+            raise OmnigentOAuthHostError(
+                "Omnigent runtime script cleanup found an unsupported symlink",
+                code="OMNIGENT_HOST_CLEANUP_INCOMPLETE",
+            )
+        for path in sorted(target.rglob("*"), reverse=True):
+            path.chmod(0o700 if path.is_dir() else 0o600)
+        target.chmod(0o700)
+        shutil.rmtree(target)
+        return not target.exists()
+
+    @staticmethod
+    def _host_runtime_environment(
+        runtime_environment: Mapping[str, str] | None,
+    ) -> dict[str, str]:
+        """Replace secret runtime values with lease-owned file selectors."""
+
+        supplied = dict(runtime_environment or {})
+        visible = {
+            key: value
+            for key, value in supplied.items()
+            if key not in _SECRET_RUNTIME_ENV_NAMES
+        }
+        for secret_name, (file_env_name, filename) in _RUNTIME_CAPABILITY_FILE_ENV.items():
+            if str(supplied.get(secret_name) or "").strip():
+                visible[file_env_name] = (
+                    f"{_RUNTIME_CAPABILITY_MOUNT_ROOT}/{filename}"
+                )
+        return visible
+
     def _prepare_daemon_runtime_scripts(
         self,
-        workspace_key: str,
+        owner_key: str,
         *,
         current_step_execution_id: str,
         runtime_environment: Mapping[str, str] | None = None,
@@ -1754,7 +1854,7 @@ class OmnigentOAuthHostRuntime:
     ) -> Path:
         return daemon_visible_workspace_path(
             self._prepare_runtime_scripts(
-                workspace_key,
+                owner_key,
                 current_step_execution_id=current_step_execution_id,
                 runtime_environment=runtime_environment,
             ),
@@ -1902,10 +2002,20 @@ class OmnigentOAuthHostRuntime:
                 name for name in volume_names if await self._volume_present(name)
             ]
             cleanup_ok = not container_present and not remaining_volumes
+            runtime_files_removed = False
+            if cleanup_ok:
+                try:
+                    runtime_files_removed = self._remove_runtime_scripts(
+                        host_lease.lease_id
+                    )
+                except (OSError, OmnigentOAuthHostError):
+                    runtime_files_removed = False
+                cleanup_ok = runtime_files_removed
             cleanup_result = "succeeded" if cleanup_ok else "failed"
             resource_cleanup = {
                 "containerPresent": container_present,
                 "remainingOwnedVolumes": remaining_volumes,
+                "runtimeCapabilityFilesRemoved": runtime_files_removed,
                 "mode": "on_demand_remove",
             }
 
@@ -2278,12 +2388,13 @@ class OmnigentOAuthHostRuntime:
                 ]
             )
         for key, value in sorted(dict(container_job_environment or {}).items()):
-            runner_env_passthrough.append(key)
             if key in _SECRET_RUNTIME_ENV_NAMES:
-                child_env[key] = value
-                args.extend(["--env", key])
-            else:
-                args.extend(["--env", f"{key}={value}"])
+                raise OmnigentOAuthHostError(
+                    "Omnigent host launch received a raw runtime capability",
+                    code="OMNIGENT_RUNTIME_CAPABILITY_EXPOSURE",
+                )
+            runner_env_passthrough.append(key)
+            args.extend(["--env", f"{key}={value}"])
         args.extend(
             [
                 "--env",
@@ -2310,8 +2421,9 @@ class OmnigentOAuthHostRuntime:
         current_workflow_id: str,
         current_step_execution_id: str,
         timeout_seconds: int,
+        required_capabilities: Sequence[str] = (),
     ) -> dict[str, str]:
-        """Mint one sandbox-scoped container-job capability for this host lease."""
+        """Materialize only the runtime capabilities declared for this host lease."""
 
         locator = WORKSPACE_LOCATOR_ADAPTER.validate_python(workspace_locator)
         if not isinstance(locator, SandboxWorkspaceLocator):
@@ -2338,52 +2450,64 @@ class OmnigentOAuthHostRuntime:
             )
         runtime_id = binding.credential_mount_ref.auth_volume_ref.runtime_id
         session_scope = host_lease.lease_id
-        token = mint_container_job_session_capability(
-            secret=str(settings.security.JWT_SECRET_KEY or ""),
-            owner=OwnerIdentity(
-                principalId=agent_run_id,
-                principalType="service",
-            ),
-            agent_run_id=agent_run_id,
-            workflow_id=current_workflow_id,
-            step_id=current_step_execution_id,
-            session_id=session_scope,
-            runtime_id=runtime_id,
-            source_kind="omnigent",
-            workspace_kind="sandbox",
-            workspace_id=locator.workspace_id,
-            workspace_relative_path=locator.relative_path,
-            lifetime_seconds=timeout_seconds,
-        )
-        execution_fanout_token = mint_execution_fanout_capability(
-            secret=str(settings.security.JWT_SECRET_KEY or ""),
-            parent_workflow_id=current_workflow_id,
-            agent_run_id=agent_run_id,
-            step_id=current_step_execution_id,
-            session_id=session_scope,
-            runtime_id=runtime_id,
-            source_kind="omnigent",
-            lifetime_seconds=timeout_seconds,
-        )
-        return {
+        normalized_capabilities = {
+            str(item or "").strip().lower() for item in required_capabilities
+        }
+        environment = {
             "MOONMIND_URL": moonmind_url,
             "MOONMIND_AGENT_RUN_ID": agent_run_id,
             "MOONMIND_TASK_WORKFLOW_ID": current_workflow_id,
             "MOONMIND_STEP_ID": current_step_execution_id,
             "MOONMIND_RUNTIME_ID": runtime_id,
-            "MOONMIND_CONTAINER_JOBS_MCP_URL": (
-                moonmind_url.rstrip("/") + "/mcp/container"
-            ),
-            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": token,
-            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": execution_fanout_token,
-            "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",
-            "MOONMIND_CONTAINER_JOBS_SESSION_ID": session_scope,
-            "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "sandbox",
-            "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": locator.workspace_id,
-            "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": (
-                locator.relative_path
-            ),
         }
+        if "docker" in normalized_capabilities:
+            environment.update(
+                {
+                    "MOONMIND_CONTAINER_JOBS_MCP_URL": (
+                        moonmind_url.rstrip("/") + "/mcp/container"
+                    ),
+                    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": (
+                        mint_container_job_session_capability(
+                            secret=str(settings.security.JWT_SECRET_KEY or ""),
+                            owner=OwnerIdentity(
+                                principalId=agent_run_id,
+                                principalType="service",
+                            ),
+                            agent_run_id=agent_run_id,
+                            workflow_id=current_workflow_id,
+                            step_id=current_step_execution_id,
+                            session_id=session_scope,
+                            runtime_id=runtime_id,
+                            source_kind="omnigent",
+                            workspace_kind="sandbox",
+                            workspace_id=locator.workspace_id,
+                            workspace_relative_path=locator.relative_path,
+                            lifetime_seconds=timeout_seconds,
+                        )
+                    ),
+                    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",
+                    "MOONMIND_CONTAINER_JOBS_SESSION_ID": session_scope,
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "sandbox",
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": locator.workspace_id,
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": (
+                        locator.relative_path
+                    ),
+                }
+            )
+        if EXECUTION_FANOUT_REQUIRED_CAPABILITY in normalized_capabilities:
+            environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"] = (
+                mint_execution_fanout_capability(
+                    secret=str(settings.security.JWT_SECRET_KEY or ""),
+                    parent_workflow_id=current_workflow_id,
+                    agent_run_id=agent_run_id,
+                    step_id=current_step_execution_id,
+                    session_id=session_scope,
+                    runtime_id=runtime_id,
+                    source_kind="omnigent",
+                    lifetime_seconds=timeout_seconds,
+                )
+            )
+        return environment
 
     async def _assert_container_owned(self, container_name: str, lease_id: str) -> None:
         result = await self._run(

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -83,6 +83,10 @@ from moonmind.schemas.agent_runtime_models import (
     RepositoryOutcomePolicy,
 )
 from moonmind.schemas.temporal_activity_models import AcceptedRepositoryEvidence
+from moonmind.security.execution_fanout_capabilities import (
+    ExecutionFanoutCapabilityError,
+    require_execution_fanout_authorization,
+)
 from moonmind.workflows.executions.runtime_capabilities import (
     RuntimeCapabilityError,
     resolve_runtime_execution_capabilities,
@@ -880,6 +884,16 @@ class OmnigentProfileBoundExecutionCoordinator:
         authority_reasons: list[dict[str, Any]] = []
         try:
             await emit("request_validated", "started")
+            fanout_authorization = self._execution_fanout_authorization(request)
+            try:
+                require_execution_fanout_authorization(
+                    self._required_capabilities(request),
+                    fanout_authorization,
+                )
+            except ExecutionFanoutCapabilityError as exc:
+                raise OmnigentOAuthHostError(
+                    str(exc), code="authorization_denied"
+                ) from exc
             if not profile_id:
                 raise OmnigentOAuthHostError(
                     "OAuth-backed Omnigent execution requires executionProfileRef",
@@ -1287,6 +1301,7 @@ class OmnigentProfileBoundExecutionCoordinator:
                     (request.parameters or {}).get("repository") or ""
                 ).strip(),
                 required_capabilities=self._required_capabilities(request),
+                execution_fanout_authorization=fanout_authorization,
                 github_token=github_token,
                 github_mutation_required=self._github_mutation_required(request),
                 effective_launch=effective_launch,
@@ -2596,6 +2611,24 @@ class OmnigentProfileBoundExecutionCoordinator:
     @staticmethod
     def _required_capabilities(request: AgentExecutionRequest) -> tuple[str, ...]:
         return authored_required_capabilities(request)
+
+    @staticmethod
+    def _execution_fanout_authorization(
+        request: AgentExecutionRequest,
+    ) -> Mapping[str, Any] | None:
+        step_execution = request.step_execution
+        if step_execution is None:
+            return None
+        policy = step_execution.skill_source_policy
+        if "executionFanout" not in policy:
+            return None
+        evidence = policy.get("executionFanout")
+        if not isinstance(evidence, Mapping):
+            raise OmnigentOAuthHostError(
+                "execution fan-out authorization evidence is malformed",
+                code="authorization_denied",
+            )
+        return evidence
 
     @classmethod
     async def _github_token(cls, request: AgentExecutionRequest) -> str | None:

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1173,6 +1173,10 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
     workload_mode: ManagedSessionWorkloadMode = Field(
         "container-jobs", alias="workloadMode"
     )
+    required_capabilities: tuple[NonBlankStr, ...] | None = Field(
+        None,
+        alias="requiredCapabilities",
+    )
     container_job_owner: OwnerIdentity | None = Field(
         None, alias="containerJobOwner"
     )

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1177,6 +1177,10 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
         None,
         alias="requiredCapabilities",
     )
+    execution_fanout_authorization: dict[str, Any] | None = Field(
+        None,
+        alias="executionFanoutAuthorization",
+    )
     container_job_owner: OwnerIdentity | None = Field(
         None, alias="containerJobOwner"
     )

--- a/moonmind/security/execution_fanout_capabilities.py
+++ b/moonmind/security/execution_fanout_capabilities.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 _AUDIENCE = "moonmind-execution-fanout"
 _VERSION = 1
+EXECUTION_FANOUT_REQUIRED_CAPABILITY = "execution.fanout"
 
 
 class ExecutionFanoutCapabilityError(ValueError):
@@ -159,6 +160,7 @@ def verify_execution_fanout_capability(
 
 
 __all__ = [
+    "EXECUTION_FANOUT_REQUIRED_CAPABILITY",
     "ExecutionFanoutCapability",
     "ExecutionFanoutCapabilityError",
     "mint_execution_fanout_capability",

--- a/moonmind/security/execution_fanout_capabilities.py
+++ b/moonmind/security/execution_fanout_capabilities.py
@@ -8,6 +8,7 @@ import hmac
 import json
 import time
 from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 _AUDIENCE = "moonmind-execution-fanout"
@@ -17,6 +18,30 @@ EXECUTION_FANOUT_REQUIRED_CAPABILITY = "execution.fanout"
 
 class ExecutionFanoutCapabilityError(ValueError):
     """Raised when an execution fan-out capability is invalid or expired."""
+
+
+def require_execution_fanout_authorization(
+    required_capabilities: Sequence[str] | None,
+    authorization: Mapping[str, Any] | None,
+) -> bool:
+    """Authorize minting from workflow-owned evidence, with a replay-only gap."""
+
+    required = {
+        str(value or "").strip().lower()
+        for value in (required_capabilities or ())
+    }
+    if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required:
+        return False
+    # Already-scheduled activity payloads predate the typed authorization field
+    # and retain their former launch semantics. Current workflows always write
+    # an explicit authorized/denied decision.
+    if authorization is None:
+        return True
+    if authorization.get("authorized") is True:
+        return True
+    raise ExecutionFanoutCapabilityError(
+        "execution fan-out is not authorized by the resolved Skill policy"
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,5 +189,6 @@ __all__ = [
     "ExecutionFanoutCapability",
     "ExecutionFanoutCapabilityError",
     "mint_execution_fanout_capability",
+    "require_execution_fanout_authorization",
     "verify_execution_fanout_capability",
 ]

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -11,6 +11,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from moonmind.config.settings import settings
+from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
+)
 from moonmind.schemas.agent_skill_models import (
     AgentSkillFormat,
     AgentSkillProvenance,
@@ -453,10 +456,20 @@ def _required_capabilities_from_frontmatter(
     metadata = frontmatter.get("metadata") or {}
     if not isinstance(metadata, dict):
         raise ValueError(f"skill '{owner}' metadata must be a mapping")
-    return _required_capabilities_from_metadata(
-        metadata.get(_REQUIRED_CAPABILITIES_METADATA_KEY),
-        owner=owner,
+    required = list(
+        _required_capabilities_from_metadata(
+            metadata.get(_REQUIRED_CAPABILITIES_METADATA_KEY),
+            owner=owner,
+        )
     )
+    side_effect = _side_effect_metadata_from_frontmatter(frontmatter, owner=owner)
+    side_effect_kind = str(side_effect.get("kind") or "").strip().lower()
+    if (
+        side_effect_kind == "enqueue_children"
+        and EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required
+    ):
+        required.append(EXECUTION_FANOUT_REQUIRED_CAPABILITY)
+    return tuple(required)
 
 
 def extract_required_capabilities_from_skill_markdown(

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -495,6 +495,36 @@ def _jira_skill_blocker_summary(
         )
     return None
 
+
+def _managed_session_required_capabilities(
+    parameters: Mapping[str, Any],
+) -> list[Any] | None:
+    """Preserve omission for already-scheduled launch compatibility."""
+
+    if "requiredCapabilities" not in parameters:
+        return None
+    raw = parameters.get("requiredCapabilities")
+    if isinstance(raw, (list, tuple)):
+        return list(raw)
+    raise ValueError(
+        "requiredCapabilities must be a list when present on an agent request"
+    )
+
+
+def _execution_fanout_authorization(
+    request: AgentExecutionRequest,
+) -> dict[str, Any] | None:
+    step_execution = request.step_execution
+    if step_execution is None:
+        return None
+    policy = step_execution.skill_source_policy
+    if "executionFanout" not in policy:
+        return None
+    evidence = policy.get("executionFanout")
+    if not isinstance(evidence, Mapping):
+        raise ValueError("executionFanout authorization evidence must be a mapping")
+    return dict(evidence)
+
 def _application_error_metadata(error: ApplicationError) -> dict[str, Any]:
     for detail in error.details:
         if isinstance(detail, Mapping):
@@ -1892,11 +1922,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             binding=active_binding,
             environment=environment,
         )
-        raw_required_capabilities = request.parameters.get("requiredCapabilities")
-        required_capabilities = (
-            list(raw_required_capabilities)
-            if isinstance(raw_required_capabilities, (list, tuple))
-            else []
+        required_capabilities = _managed_session_required_capabilities(
+            request.parameters
         )
         launch_request = LaunchCodexManagedSessionRequest(
             runtimeFamily=managed_session_runtime_family_for_runtime_id(
@@ -1915,6 +1942,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             imageRef=self._session_image_ref,
             workloadMode=workload_mode,
             requiredCapabilities=required_capabilities,
+            executionFanoutAuthorization=_execution_fanout_authorization(request),
             containerJobOwner=container_job_owner,
             turnCompletionTimeoutSeconds=turn_completion_timeout_seconds,
             environment=launch_environment,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1892,6 +1892,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             binding=active_binding,
             environment=environment,
         )
+        raw_required_capabilities = request.parameters.get("requiredCapabilities")
+        required_capabilities = (
+            list(raw_required_capabilities)
+            if isinstance(raw_required_capabilities, (list, tuple))
+            else []
+        )
         launch_request = LaunchCodexManagedSessionRequest(
             runtimeFamily=managed_session_runtime_family_for_runtime_id(
                 active_binding.runtime_id
@@ -1908,6 +1914,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             codexHomePath=str(self._session_root(binding) / ".moonmind" / "codex-home"),
             imageRef=self._session_image_ref,
             workloadMode=workload_mode,
+            requiredCapabilities=required_capabilities,
             containerJobOwner=container_job_owner,
             turnCompletionTimeoutSeconds=turn_completion_timeout_seconds,
             environment=launch_environment,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -51,6 +51,7 @@ from moonmind.security.docker_networks import (
 from moonmind.security.execution_fanout_capabilities import (
     EXECUTION_FANOUT_REQUIRED_CAPABILITY,
     mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
 )
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 from moonmind.workflows.codex_session_timeouts import (
@@ -2564,6 +2565,11 @@ class DockerCodexManagedSessionController:
             normalized_capabilities is None
             or EXECUTION_FANOUT_REQUIRED_CAPABILITY in normalized_capabilities
         )
+        if execution_fanout_required:
+            require_execution_fanout_authorization(
+                (EXECUTION_FANOUT_REQUIRED_CAPABILITY,),
+                request.execution_fanout_authorization,
+            )
         if container_jobs_available:
             owner = request.container_job_owner or OwnerIdentity(
                 principalId=request.agent_run_id,
@@ -2592,27 +2598,6 @@ class DockerCodexManagedSessionController:
             container_secret_environment[
                 "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"
             ] = capability_token
-            if execution_fanout_required:
-                container_secret_environment[
-                    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
-                ] = mint_execution_fanout_capability(
-                    secret=str(settings.security.JWT_SECRET_KEY or ""),
-                    parent_workflow_id=str(
-                        session_environment.get("MOONMIND_TASK_WORKFLOW_ID")
-                        or request.agent_run_id
-                    ),
-                    agent_run_id=request.agent_run_id,
-                    step_id=(
-                        str(
-                            session_environment.get("MOONMIND_STEP_ID") or ""
-                        ).strip()
-                        or None
-                    ),
-                    session_id=request.session_id,
-                    runtime_id=runtime_id,
-                    source_kind="managed_session",
-                    lifetime_seconds=int(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS),
-                )
             session_environment["MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND"] = (
                 "managed_runtime"
             )
@@ -2621,6 +2606,25 @@ class DockerCodexManagedSessionController:
             )
             session_environment["MOONMIND_CONTAINER_JOBS_SESSION_ID"] = (
                 request.session_id
+            )
+        if execution_fanout_required:
+            container_secret_environment[
+                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
+            ] = mint_execution_fanout_capability(
+                secret=str(settings.security.JWT_SECRET_KEY or ""),
+                parent_workflow_id=str(
+                    session_environment.get("MOONMIND_TASK_WORKFLOW_ID")
+                    or request.agent_run_id
+                ),
+                agent_run_id=request.agent_run_id,
+                step_id=(
+                    str(session_environment.get("MOONMIND_STEP_ID") or "").strip()
+                    or None
+                ),
+                session_id=request.session_id,
+                runtime_id=runtime_id,
+                source_kind="managed_session",
+                lifetime_seconds=int(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS),
             )
         # Managed sessions never receive a Docker endpoint. Repository container
         # work crosses the authenticated container-job service boundary above.

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -51,6 +51,7 @@ from moonmind.security.container_job_capabilities import (
     mint_container_job_session_capability,
 )
 from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
     mint_execution_fanout_capability,
 )
 from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
@@ -2554,6 +2555,20 @@ class DockerCodexManagedSessionController:
             request.workload_mode == "container-jobs"
             and session_environment.get("MOONMIND_URL")
         )
+        normalized_capabilities = (
+            None
+            if request.required_capabilities is None
+            else {
+                str(item or "").strip().lower()
+                for item in request.required_capabilities
+            }
+        )
+        # Omitted capabilities preserve already-scheduled launch Activity
+        # payloads. New adapters always send an explicit list, including empty.
+        execution_fanout_required = (
+            normalized_capabilities is None
+            or EXECUTION_FANOUT_REQUIRED_CAPABILITY in normalized_capabilities
+        )
         if container_jobs_available:
             owner = request.container_job_owner or OwnerIdentity(
                 principalId=request.agent_run_id,
@@ -2582,24 +2597,27 @@ class DockerCodexManagedSessionController:
             container_secret_environment[
                 "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"
             ] = capability_token
-            container_secret_environment[
-                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
-            ] = mint_execution_fanout_capability(
-                secret=str(settings.security.JWT_SECRET_KEY or ""),
-                parent_workflow_id=str(
-                    session_environment.get("MOONMIND_TASK_WORKFLOW_ID")
-                    or request.agent_run_id
-                ),
-                agent_run_id=request.agent_run_id,
-                step_id=(
-                    str(session_environment.get("MOONMIND_STEP_ID") or "").strip()
-                    or None
-                ),
-                session_id=request.session_id,
-                runtime_id=runtime_id,
-                source_kind="managed_session",
-                lifetime_seconds=int(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS),
-            )
+            if execution_fanout_required:
+                container_secret_environment[
+                    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
+                ] = mint_execution_fanout_capability(
+                    secret=str(settings.security.JWT_SECRET_KEY or ""),
+                    parent_workflow_id=str(
+                        session_environment.get("MOONMIND_TASK_WORKFLOW_ID")
+                        or request.agent_run_id
+                    ),
+                    agent_run_id=request.agent_run_id,
+                    step_id=(
+                        str(
+                            session_environment.get("MOONMIND_STEP_ID") or ""
+                        ).strip()
+                        or None
+                    ),
+                    session_id=request.session_id,
+                    runtime_id=runtime_id,
+                    source_kind="managed_session",
+                    lifetime_seconds=int(_DEFAULT_SESSION_REAP_MAX_AGE_SECONDS),
+                )
             session_environment["MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND"] = (
                 "managed_runtime"
             )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -729,6 +729,9 @@ RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH = (
 RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH = (
     "run-agent-required-capabilities-propagation-v1"
 )
+RUN_EXECUTION_FANOUT_AUTHORIZATION_PATCH = (
+    "run-execution-fanout-authorization-v1"
+)
 RUN_ALREADY_IMPLEMENTED_JIRA_COMPLETION_PATCH = (
     "run-already-implemented-jira-completion-v1"
 )
@@ -1547,6 +1550,9 @@ class MoonMindRunWorkflow:
         self._remediation_context: dict[str, Any] = {}
         self._remediation_policy: dict[str, Any] = {}
         self._native_skill_binding_by_step: dict[str, dict[str, Any]] = {}
+        self._execution_fanout_authorization_by_step: dict[
+            str, dict[str, Any]
+        ] = {}
         self._resolved_skill_terminal_contract_by_step: dict[
             str, dict[str, Any]
         ] = {}
@@ -18729,6 +18735,12 @@ class MoonMindRunWorkflow:
             resolved,
             normalized_skill,
         )
+        self._execution_fanout_authorization_by_step[node_id] = (
+            self._resolved_skill_execution_fanout_authorization(
+                selected_entry,
+                selected_skill=normalized_skill,
+            )
+        )
         if terminal_contract_enabled:
             terminal_contract = self._resolved_skill_terminal_contract(selected_entry)
             if terminal_contract is not None:
@@ -18818,6 +18830,54 @@ class MoonMindRunWorkflow:
             if str(raw_name or "").strip().lower() == normalized:
                 return entry
         return None
+
+    @staticmethod
+    def _resolved_skill_execution_fanout_authorization(
+        resolved_entry: Any,
+        *,
+        selected_skill: str,
+    ) -> dict[str, Any]:
+        if isinstance(resolved_entry, WorkflowMapping):
+            provenance = resolved_entry.get("provenance")
+            required = resolved_entry.get(
+                "required_capabilities",
+                resolved_entry.get("requiredCapabilities", ()),
+            )
+        else:
+            provenance = getattr(resolved_entry, "provenance", None)
+            required = getattr(resolved_entry, "required_capabilities", ())
+        if isinstance(provenance, WorkflowMapping):
+            raw_source_kind = provenance.get(
+                "source_kind", provenance.get("sourceKind")
+            )
+        else:
+            raw_source_kind = getattr(provenance, "source_kind", None)
+        source_kind = str(
+            getattr(raw_source_kind, "value", raw_source_kind) or ""
+        ).strip().lower()
+        capabilities = {
+            str(value or "").strip().lower()
+            for value in (
+                required
+                if isinstance(required, Iterable)
+                and not isinstance(required, (str, bytes))
+                else ()
+            )
+        }
+        authorized = bool(
+            source_kind in {"built_in", "deployment"}
+            and "execution.fanout" in capabilities
+        )
+        return {
+            "authorized": authorized,
+            "selectedSkill": str(selected_skill or "").strip().lower(),
+            "sourceKind": source_kind or "unresolved",
+            "reasonCode": (
+                "trusted_resolved_skill_requirement"
+                if authorized
+                else "resolved_skill_policy_denied"
+            ),
+        }
 
     @staticmethod
     def _resolved_skill_terminal_contract(
@@ -19684,6 +19744,23 @@ class MoonMindRunWorkflow:
             skill_source_policy["resolvedSkillsetRef"] = resolved_skillset_ref
         if selected_skill:
             skill_source_policy["selectedSkill"] = selected_skill
+        if self._workflow_patch_enabled(
+            RUN_EXECUTION_FANOUT_AUTHORIZATION_PATCH
+        ):
+            fanout_authorization = dict(
+                self._execution_fanout_authorization_by_step.get(
+                    node_id,
+                    {
+                        "authorized": False,
+                        "selectedSkill": selected_skill,
+                        "sourceKind": "unresolved",
+                        "reasonCode": "resolved_skill_evidence_unavailable",
+                    },
+                )
+            )
+            if resolved_skillset_ref:
+                fanout_authorization["resolvedSkillsetRef"] = resolved_skillset_ref
+            skill_source_policy["executionFanout"] = fanout_authorization
         execution_ordinal = step_execution or 1
         context_workspace = self._step_execution_workspace(
             node_id,

--- a/services/omnigent/scripts/moonmind-container-cli.py
+++ b/services/omnigent/scripts/moonmind-container-cli.py
@@ -38,6 +38,32 @@ def _required_env(name: str) -> str:
     return value
 
 
+def _container_jobs_bearer_token() -> str:
+    selector = str(
+        os.environ.get("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE") or ""
+    ).strip()
+    if selector:
+        try:
+            value = Path(selector).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise CliError(
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE is unavailable"
+            ) from exc
+        if not value:
+            raise CliError("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE is empty")
+        return value
+    inline = str(
+        os.environ.get("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN") or ""
+    ).strip()
+    if inline:
+        return inline
+    raise CliError(
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN or "
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE is required; run this "
+        "command inside a MoonMind managed workflow"
+    )
+
+
 def _workspace() -> dict[str, str]:
     kind = str(
         os.environ.get("MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND")
@@ -94,9 +120,7 @@ def _call(tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
         data=json.dumps({"tool": tool, "arguments": arguments}).encode("utf-8"),
         headers={
             "Accept": "application/json",
-            "Authorization": (
-                "Bearer " + _required_env("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN")
-            ),
+            "Authorization": "Bearer " + _container_jobs_bearer_token(),
             "Content-Type": "application/json",
         },
         method="POST",

--- a/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/expected-outcome.json
@@ -1,5 +1,5 @@
 {
-  "invariant": "the lease-owned Codex tool-shell profile restores non-secret MoonMind API and execution identity after Omnigent harness filtering without persisting scoped bearer credentials",
+  "invariant": "the lease-owned Codex tool-shell profile restores non-secret MoonMind API, execution identity, and a capability-file selector after Omnigent harness filtering without persisting scoped bearer values in the environment",
   "toolShellEnvironmentNames": [
     "MOONMIND_STEP_EXECUTION_ID",
     "MOONMIND_ACTIVE_SKILLS_DIR",
@@ -8,15 +8,9 @@
     "MOONMIND_TASK_WORKFLOW_ID",
     "MOONMIND_STEP_ID",
     "MOONMIND_RUNTIME_ID",
-    "MOONMIND_CONTAINER_JOBS_MCP_URL",
-    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
-    "MOONMIND_CONTAINER_JOBS_SESSION_ID",
-    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
-    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
-    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH"
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE"
   ],
   "excludedSecretNames": [
-    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN",
     "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
   ]
 }

--- a/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-codex-moonmind-env-handoff/manifest.json
@@ -2,12 +2,13 @@
   "incidentWorkflowId": "mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0-2026-08-17T17:24:13Z",
   "stepExecutionId": "mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0:node-1:execution:4",
   "moonmindUrl": "http://api:8000",
+  "requiredCapabilities": ["execution.fanout"],
   "workspaceLocator": {
     "kind": "sandbox",
     "workspaceId": "3ed3af7e63985a76afeae4ab",
     "relativePath": "repo"
   },
   "terminalFailureCode": "CHILD_WORKFLOW_QUEUE_FAILED",
-  "failureShape": "the on-demand host and Omnigent runner received MoonMind execution variables, but the Codex harness filtered them before the skill helper ran; all matched child workflow submissions failed because MOONMIND_URL was missing",
+  "failureShape": "the on-demand host and Omnigent runner received MoonMind execution variables, but the Codex harness filtered the scoped fan-out bearer before the skill helper ran; all matched child workflow submissions failed at the restricted proxy",
   "boundary": "MoonMind on-demand host to Omnigent runner to Codex tool login shell"
 }

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -3357,6 +3357,7 @@ async def test_omnigent_codex_tool_shell_receives_moonmind_execution_environment
         current_workflow_id=manifest["incidentWorkflowId"],
         current_step_execution_id=manifest["stepExecutionId"],
         timeout_seconds=3600,
+        required_capabilities=manifest["requiredCapabilities"],
     )
     runtime_scripts = runtime._prepare_runtime_scripts(
         manifest["incidentWorkflowId"],
@@ -3372,8 +3373,13 @@ async def test_omnigent_codex_tool_shell_receives_moonmind_execution_environment
     assert f"'{manifest['moonmindUrl']}'" in profile
     assert f"'{manifest['incidentWorkflowId']}'" in profile
     for secret_name in expected["excludedSecretNames"]:
-        assert secret_name not in profile
+        assert f"export {secret_name}=" not in profile
         assert runtime_environment[secret_name] not in profile
+    capability_file = runtime_scripts / "capabilities" / "execution-fanout"
+    assert capability_file.read_text(encoding="utf-8").strip() == (
+        runtime_environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"]
+    )
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in runtime_environment
 
 
 async def test_omnigent_batch_fanout_crosses_only_scoped_execution_proxy_routes(

--- a/tests/unit/agents/codex_worker/test_cli.py
+++ b/tests/unit/agents/codex_worker/test_cli.py
@@ -17,6 +17,24 @@ def _disable_rag_preflight_checks(monkeypatch) -> None:
 
     monkeypatch.setattr(cli, "ensure_rag_ready", lambda _settings: None)
 
+
+@pytest.mark.parametrize(
+    ("runtime", "expected"),
+    (
+        ("codex", ("codex", "git", "gh", "execution.fanout")),
+        (
+            "universal",
+            ("codex", "claude", "git", "gh", "execution.fanout"),
+        ),
+        ("jules", ("jules", "git", "gh")),
+    ),
+)
+def test_effective_worker_capabilities_include_supported_fanout_by_default(
+    runtime: str,
+    expected: tuple[str, ...],
+) -> None:
+    assert cli._effective_worker_capabilities({}, runtime) == expected
+
 def test_run_preflight_missing_codex_raises(monkeypatch) -> None:
     """Preflight should fail when codex binary is unavailable."""
 

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -1074,6 +1074,7 @@ async def test_run_once_passes_runtime_inheritance_args_to_batch_pr_resolver_ski
     processed = await worker.run_once()
 
     assert processed is True
+    assert queue.failed == []
     assert handler.calls == ["codex_skill:batch-pr-resolver:True"]
     payload = handler.skill_payloads[0]
     inputs = payload["inputs"]
@@ -7170,7 +7171,12 @@ async def test_config_from_env_uses_defaults(monkeypatch) -> None:
     assert config.legacy_job_types_enabled is True
     assert config.worker_runtime == "codex"
     assert config.allowed_types == ("task", "codex_exec", "codex_skill")
-    assert config.worker_capabilities == ("codex", "git", "gh")
+    assert config.worker_capabilities == (
+        "codex",
+        "git",
+        "gh",
+        "execution.fanout",
+    )
     assert config.docker_binary == "docker"
     assert config.container_workspace_volume is None
     assert config.container_default_timeout_seconds == 3600
@@ -7228,7 +7234,13 @@ async def test_config_from_env_runtime_mode_controls_default_capabilities(
     config = CodexWorkerConfig.from_env()
 
     assert config.worker_runtime == "universal"
-    assert config.worker_capabilities == ("codex", "claude", "git", "gh")
+    assert config.worker_capabilities == (
+        "codex",
+        "claude",
+        "git",
+        "gh",
+        "execution.fanout",
+    )
 
 async def test_config_from_env_rejects_jules_runtime_when_disabled(
     monkeypatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -120,6 +120,26 @@ from moonmind.workflows.executions.control_stop_continuation import (
 _TARGET_SEARCH_ATTRIBUTE_TYPE = int(IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 
 
+def test_deployment_skill_requirements_merge_into_canonical_capabilities() -> None:
+    assert executions_module._merge_deployment_skill_required_capabilities(
+        ["Git", "execution.fanout"],
+        {
+            "batch-skill": {
+                "required_capabilities": ["execution.fanout", "GH"]
+            },
+            "step-skill": {"required_capabilities": ["docker"]},
+        },
+    ) == ["git", "execution.fanout", "gh", "docker"]
+
+
+def test_deployment_skill_requirements_reject_malformed_trusted_metadata() -> None:
+    with pytest.raises(HTTPException, match="must be a JSON array of strings"):
+        executions_module._merge_deployment_skill_required_capabilities(
+            [],
+            {"batch-skill": {"required_capabilities": "execution.fanout"}},
+        )
+
+
 class _ScalarRows:
     def __init__(self, rows: list[object]) -> None:
         self._rows = rows

--- a/tests/unit/omnigent/test_mounted_container_cli.py
+++ b/tests/unit/omnigent/test_mounted_container_cli.py
@@ -45,6 +45,40 @@ def test_omitted_request_id_remains_unique(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
 
+def test_bearer_token_reads_omnigent_capability_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _load_cli()
+    capability_file = tmp_path / "container-jobs"
+    capability_file.write_text("scoped-file-token\n", encoding="utf-8")
+    monkeypatch.delenv("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE", str(capability_file)
+    )
+    monkeypatch.setenv(
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN", "stale-inline-token"
+    )
+
+    assert cli._container_jobs_bearer_token() == "scoped-file-token"
+
+
+def test_bearer_token_file_selector_fails_closed_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = _load_cli()
+    monkeypatch.setenv(
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE", str(tmp_path / "missing")
+    )
+    monkeypatch.setenv(
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN", "must-not-be-used"
+    )
+
+    with pytest.raises(cli.CliError, match="BEARER_TOKEN_FILE is unavailable"):
+        cli._container_jobs_bearer_token()
+
+
 def test_log_reader_follows_cursors_and_keeps_terminal_tail(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1108,6 +1108,25 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
         encoding="utf-8"
     ) == "also-must-not-be-persisted\n"
     assert profile.stat().st_mode & 0o777 == 0o444
+    retried = runtime._prepare_runtime_scripts(
+        "workspace-key",
+        current_step_execution_id=execution_id,
+        runtime_environment={
+            "MOONMIND_URL": "http://api:8000",
+            "MOONMIND_AGENT_RUN_ID": execution_id,
+            "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+            "MOONMIND_RUNTIME_ID": "codex_cli",
+            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "retry-container-capability",
+            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "retry-fanout-capability",
+        },
+    )
+    assert retried == target
+    assert (target / "capabilities" / "container-jobs").read_text(
+        encoding="utf-8"
+    ) == "retry-container-capability\n"
+    assert (target / "capabilities" / "execution-fanout").read_text(
+        encoding="utf-8"
+    ) == "retry-fanout-capability\n"
     with pytest.raises(OmnigentOAuthHostError) as mismatch:
         runtime._prepare_runtime_scripts(
             "workspace-key",
@@ -1817,6 +1836,10 @@ def test_omnigent_container_job_environment_is_sandbox_and_host_lease_scoped(
         current_step_execution_id="agent-run-1",
         timeout_seconds=3600,
         required_capabilities=("docker", "execution.fanout"),
+        execution_fanout_authorization={
+            "authorized": True,
+            "sourceKind": "built_in",
+        },
     )
 
     assert environment["MOONMIND_CONTAINER_JOBS_MCP_URL"] == (
@@ -1873,6 +1896,43 @@ def test_omnigent_runtime_authority_is_not_minted_without_required_capabilities(
     assert environment["MOONMIND_URL"] == "http://api:8000"
     assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in environment
     assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
+
+
+def test_omnigent_fanout_mint_rejects_denied_skill_authorization(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+
+    with pytest.raises(OmnigentOAuthHostError) as exc_info:
+        runtime._container_job_environment(
+            binding=_binding().model_copy(
+                update={
+                    "static_host_id": None,
+                    "host_launch_profile_ref": "codex-oauth-v1",
+                }
+            ),
+            host_lease=_host_lease(),
+            workspace_locator={
+                "kind": "sandbox",
+                "workspaceId": "sandbox-1",
+                "relativePath": "repo",
+            },
+            current_workflow_id="workflow-1",
+            current_step_execution_id="agent-run-1",
+            timeout_seconds=3600,
+            required_capabilities=("execution.fanout",),
+            execution_fanout_authorization={
+                "authorized": False,
+                "sourceKind": "repo",
+            },
+        )
+
+    assert exc_info.value.code == "authorization_denied"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1088,14 +1088,24 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
         f"export MOONMIND_AGENT_RUN_ID='{execution_id}'\n"
         "export MOONMIND_TASK_WORKFLOW_ID='workflow-1'\n"
         "export MOONMIND_RUNTIME_ID='codex_cli'\n"
+        "export MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE="
+        "'/opt/moonmind/capabilities/container-jobs'\n"
+        "export MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE="
+        "'/opt/moonmind/capabilities/execution-fanout'\n"
     )
     assert "must-not-be-persisted" not in profile.read_text(encoding="utf-8")
-    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in profile.read_text(
+    assert "export MOONMIND_CONTAINER_JOBS_BEARER_TOKEN=" not in profile.read_text(
         encoding="utf-8"
     )
-    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in profile.read_text(
+    assert "export MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=" not in profile.read_text(
         encoding="utf-8"
     )
+    assert (target / "capabilities" / "container-jobs").read_text(
+        encoding="utf-8"
+    ) == "must-not-be-persisted\n"
+    assert (target / "capabilities" / "execution-fanout").read_text(
+        encoding="utf-8"
+    ) == "also-must-not-be-persisted\n"
     assert profile.stat().st_mode & 0o777 == 0o444
     with pytest.raises(OmnigentOAuthHostError) as mismatch:
         runtime._prepare_runtime_scripts(
@@ -1422,8 +1432,8 @@ async def test_prepare_host_retry_preserves_manifest_at_docker_mount_seam(
     assert runtime_profile_environment["MOONMIND_URL"] == "http://api:8000"
     assert runtime_profile_environment["MOONMIND_TASK_WORKFLOW_ID"] == "workflow-1"
     assert runtime_profile_environment["MOONMIND_AGENT_RUN_ID"] == "step-1"
-    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" in runtime_profile_environment
-    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" in runtime_profile_environment
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in runtime_profile_environment
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in runtime_profile_environment
     assert state["launches"] == 1
     assert state["manifest_checks"] == 2
 
@@ -1460,6 +1470,36 @@ async def test_daemon_workspace_root_uses_selected_daemon_volume_mountpoint(
         "agent_workspaces",
         check=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_static_host_rejects_execution_fanout_before_materialization(
+    tmp_path,
+) -> None:
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace(), workspace_root=tmp_path)
+    runtime._prepare_skill_projection = AsyncMock()  # type: ignore[method-assign]
+    runtime._attest_egress = AsyncMock()  # type: ignore[method-assign]
+    launch = compile_effective_launch(
+        profile_ref="omnigent-codex@1",
+        policy_ref="codex-static@1",
+        provider_profile_id="codex",
+    )
+
+    with pytest.raises(OmnigentOAuthHostError) as exc_info:
+        await runtime.prepare_host(
+            binding=_binding(),
+            host_lease=_host_lease(),
+            workspace_key="workspace-1",
+            workspace_locator={"kind": "sandbox", "workspaceId": "sandbox-1"},
+            current_workflow_id="workflow-1",
+            current_step_execution_id="step-1",
+            required_capabilities=("execution.fanout",),
+            effective_launch=launch,
+        )
+
+    assert exc_info.value.code == "OMNIGENT_RUNTIME_CAPABILITY_UNSUPPORTED"
+    runtime._prepare_skill_projection.assert_not_awaited()
+    runtime._attest_egress.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1647,9 +1687,13 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
         runtime_scripts=tmp_path,
         current_step_execution_id="workflow:run:node-1:execution:1",
         container_job_environment={
-            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "scoped-test-token",
+            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE": (
+                "/opt/moonmind/capabilities/container-jobs"
+            ),
             "MOONMIND_CONTAINER_JOBS_MCP_URL": "http://api:8000/mcp/container",
-            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "fanout-test-token",
+            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": (
+                "/opt/moonmind/capabilities/execution-fanout"
+            ),
         },
         effective_launch=effective_launch,
         egress_attestation=_egress_attestation(),
@@ -1706,24 +1750,25 @@ async def test_on_demand_host_initializes_state_before_unprivileged_launch(
     assert (
         "OMNIGENT_RUNNER_ENV_PASSTHROUGH="
         "HTTP_PROXY,HTTPS_PROXY,http_proxy,https_proxy,NO_PROXY,no_proxy,"
-        "MOONMIND_STEP_EXECUTION_ID,MOONMIND_CONTAINER_JOBS_BEARER_TOKEN,"
+        "MOONMIND_STEP_EXECUTION_ID,MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE,"
         "MOONMIND_CONTAINER_JOBS_MCP_URL,"
-        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE"
     ) in commands[2]
-    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" in commands[2]
-    assert "scoped-test-token" not in commands[2]
-    assert "fanout-test-token" not in commands[2]
+    assert (
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE="
+        "/opt/moonmind/capabilities/container-jobs"
+    ) in commands[2]
+    assert (
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE="
+        "/opt/moonmind/capabilities/execution-fanout"
+    ) in commands[2]
     assert (
         "MOONMIND_CONTAINER_JOBS_MCP_URL=http://api:8000/mcp/container"
         in commands[2]
     )
     launch_environment = runtime._run.await_args_list[2].kwargs["env"]
-    assert launch_environment["MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"] == (
-        "scoped-test-token"
-    )
-    assert launch_environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"] == (
-        "fanout-test-token"
-    )
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in launch_environment
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in launch_environment
     assert "NO_PROXY=localhost,127.0.0.1" in commands[2]
     assert "no_proxy=localhost,127.0.0.1" in commands[2]
     assert commands[2][commands[2].index("--stop-timeout") + 1] == "20"
@@ -1769,6 +1814,7 @@ def test_omnigent_container_job_environment_is_sandbox_and_host_lease_scoped(
         current_workflow_id="workflow-1",
         current_step_execution_id="agent-run-1",
         timeout_seconds=3600,
+        required_capabilities=("docker", "execution.fanout"),
     )
 
     assert environment["MOONMIND_CONTAINER_JOBS_MCP_URL"] == (
@@ -1791,6 +1837,40 @@ def test_omnigent_container_job_environment_is_sandbox_and_host_lease_scoped(
     assert fanout.parent_workflow_id == "workflow-1"
     assert fanout.agent_run_id == "agent-run-1"
     assert fanout.session_id == "host-lease-1"
+
+
+def test_omnigent_runtime_authority_is_not_minted_without_required_capabilities(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    monkeypatch.setattr(
+        settings.security, "JWT_SECRET_KEY", "test-container-capability-secret"
+    )
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        scripts_dir=tmp_path,
+        workspace_root=tmp_path / "workspaces",
+    )
+
+    environment = runtime._container_job_environment(
+        binding=_binding().model_copy(
+            update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
+        ),
+        host_lease=_host_lease(),
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": "sandbox-1",
+            "relativePath": "repo",
+        },
+        current_workflow_id="workflow-1",
+        current_step_execution_id="agent-run-1",
+        timeout_seconds=3600,
+        required_capabilities=(),
+    )
+
+    assert environment["MOONMIND_URL"] == "http://api:8000"
+    assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in environment
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
 
 
 @pytest.mark.asyncio
@@ -2098,13 +2178,22 @@ async def test_stop_host_cleans_volumes_when_container_is_absent(tmp_path) -> No
         update={"static_host_id": None, "host_launch_profile_ref": "codex-oauth-v1"}
     )
     lease = _host_lease().model_copy(update={"container_name": "mm-host-lease-1"})
+    _, runtime_scripts = runtime._runtime_scripts_target(lease.lease_id)
+    capability_dir = runtime_scripts / "capabilities"
+    capability_dir.mkdir(parents=True)
+    (capability_dir / "execution-fanout").write_text(
+        "expired-test-capability\n",
+        encoding="utf-8",
+    )
 
-    await runtime.stop_host(binding=binding, host_lease=lease)
+    result = await runtime.stop_host(binding=binding, host_lease=lease)
 
     commands = [call.args for call in runtime._run.await_args_list]
     assert commands[0][:3] == ("docker", "inspect", "--format")
     assert ("docker", "volume", "rm", "-f", "mm-host-lease-1-artifacts") in commands
     assert ("docker", "volume", "rm", "-f", "mm-host-lease-1-cache") in commands
+    assert result["resourceCleanup"]["runtimeCapabilityFilesRemoved"] is True
+    assert not runtime_scripts.exists()
 
 
 @pytest.mark.asyncio
@@ -2171,6 +2260,7 @@ async def test_stop_host_publishes_resolvable_terminal_egress_and_cleanup_author
         "containerPresent": False,
         "mode": "on_demand_remove",
         "remainingOwnedVolumes": [],
+        "runtimeCapabilityFilesRemoved": True,
     }
     assert terminal["launchEvidenceRef"] == "artifact://omnigent/launch.json"
 

--- a/tests/unit/security/test_execution_fanout_capabilities.py
+++ b/tests/unit/security/test_execution_fanout_capabilities.py
@@ -9,6 +9,7 @@ from moonmind.security.container_job_capabilities import (
 from moonmind.security.execution_fanout_capabilities import (
     ExecutionFanoutCapabilityError,
     mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
     verify_execution_fanout_capability,
 )
 
@@ -64,4 +65,20 @@ def test_container_job_bearer_cannot_authorize_execution_fanout() -> None:
     with pytest.raises(ExecutionFanoutCapabilityError, match="unsupported"):
         verify_execution_fanout_capability(
             container_token, secret="test-secret", now=120
+        )
+
+
+def test_fanout_mint_requires_explicit_current_skill_authorization() -> None:
+    assert require_execution_fanout_authorization([], {"authorized": False}) is False
+    assert require_execution_fanout_authorization(
+        ["execution.fanout"], {"authorized": True, "sourceKind": "built_in"}
+    ) is True
+    assert require_execution_fanout_authorization(
+        ["execution.fanout"], None
+    ) is True
+
+    with pytest.raises(ExecutionFanoutCapabilityError, match="not authorized"):
+        require_execution_fanout_authorization(
+            ["execution.fanout"],
+            {"authorized": False, "sourceKind": "repo"},
         )

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -294,6 +294,11 @@ async def test_controller_launches_container_and_returns_typed_handle(
     )
     if required_capabilities is not None:
         request_payload["requiredCapabilities"] = list(required_capabilities)
+    if required_capabilities == ("execution.fanout",):
+        request_payload["executionFanoutAuthorization"] = {
+            "authorized": True,
+            "sourceKind": "built_in",
+        }
     request = LaunchCodexManagedSessionRequest(**request_payload)
     commands: list[tuple[str, ...]] = []
     docker_run_env: dict[str, str] = {}
@@ -914,10 +919,16 @@ async def test_no_docker_profile_does_not_advertise_container_jobs(
         codexHomePath="/home/app/.codex",
         imageRef="moonmind:latest",
         workloadMode="no-docker",
+        requiredCapabilities=["execution.fanout"],
+        executionFanoutAuthorization={
+            "authorized": True,
+            "sourceKind": "deployment",
+        },
         environment={"MOONMIND_URL": "http://api:8000"},
     )
     commands: list[tuple[str, ...]] = []
     launched_payload: dict[str, object] = {}
+    docker_run_env: dict[str, str] = {}
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -925,11 +936,11 @@ async def test_no_docker_profile_does_not_advertise_container_jobs(
         input_text: str | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        del env
         commands.append(command)
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
         if command[:2] == ("docker", "run"):
+            docker_run_env.update(env or {})
             return 0, "ctr-no-docker\n", ""
         if "ready" in command:
             return 0, '{"ready": true}\n', ""
@@ -967,6 +978,18 @@ async def test_no_docker_profile_does_not_advertise_container_jobs(
     assert not any(
         item.startswith("MOONMIND_CONTAINER_JOBS_") for item in run_command
     )
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" in run_command
+    assert not any(
+        item.startswith("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=")
+        for item in run_command
+    )
+    fanout = verify_execution_fanout_capability(
+        docker_run_env["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
+        secret="test_jwt_secret_key",
+    )
+    assert fanout.parent_workflow_id == "task-no-docker"
+    assert fanout.agent_run_id == "task-no-docker"
+    assert fanout.session_id == "sess-no-docker"
     metadata = launched_payload["metadata"]
     assert isinstance(metadata, dict)
     assert metadata["capabilities"]["containerJobs"] == {

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -250,9 +250,19 @@ async def test_default_command_runner_clears_supplemental_groups_when_uid_change
     assert "group" not in captured_kwargs
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("required_capabilities", "expects_fanout"),
+    [
+        (None, True),
+        ((), False),
+        (("execution.fanout",), True),
+    ],
+)
 async def test_controller_launches_container_and_returns_typed_handle(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    required_capabilities: tuple[str, ...] | None,
+    expects_fanout: bool,
 ) -> None:
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
     monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
@@ -262,7 +272,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     session_store = ManagedSessionStore(tmp_path / "session-store")
     session_supervisor = AsyncMock()
     session_supervisor.emit_session_event = Mock()
-    request = LaunchCodexManagedSessionRequest(
+    request_payload = dict(
         agentRunId="task-1",
         workflowId="wf-task-1",
         sessionId="sess-1",
@@ -274,6 +284,9 @@ async def test_controller_launches_container_and_returns_typed_handle(
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
         turnCompletionTimeoutSeconds=1800,
     )
+    if required_capabilities is not None:
+        request_payload["requiredCapabilities"] = list(required_capabilities)
+    request = LaunchCodexManagedSessionRequest(**request_payload)
     commands: list[tuple[str, ...]] = []
     docker_run_env: dict[str, str] = {}
 
@@ -367,18 +380,22 @@ async def test_controller_launches_container_and_returns_typed_handle(
     )
     assert capability.agent_run_id == "task-1"
     assert capability.session_id == "sess-1"
-    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" in run_command
-    assert not any(
-        item.startswith("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=")
-        for item in run_command
-    )
-    fanout = verify_execution_fanout_capability(
-        docker_run_env["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
-        secret="test_jwt_secret_key",
-    )
-    assert fanout.parent_workflow_id == "wf-task-1"
-    assert fanout.agent_run_id == "task-1"
-    assert fanout.session_id == "sess-1"
+    if expects_fanout:
+        assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" in run_command
+        assert not any(
+            item.startswith("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=")
+            for item in run_command
+        )
+        fanout = verify_execution_fanout_capability(
+            docker_run_env["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
+            secret="test_jwt_secret_key",
+        )
+        assert fanout.parent_workflow_id == "wf-task-1"
+        assert fanout.agent_run_id == "task-1"
+        assert fanout.session_id == "sess-1"
+    else:
+        assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in run_command
+        assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in docker_run_env
     assert not any(item.startswith("DOCKER_HOST=") for item in run_command)
     assert not any(item.startswith("SYSTEM_DOCKER_HOST=") for item in run_command)
     assert "python3" in run_command

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -16,6 +16,7 @@ from moonmind.services.skill_resolution import (
     RepoSkillLoader,
     DeploymentSkillLoader,
     _terminal_contract_from_side_effect,
+    extract_required_capabilities_from_skill_markdown,
     extract_side_effect_metadata_from_skill_markdown,
 )
 
@@ -42,6 +43,42 @@ metadata:
         "owner": "agent",
         "outcomeArtifact": "artifacts/result.json",
     }
+
+
+async def test_enqueue_children_derives_execution_fanout_capability() -> None:
+    markdown = """---
+name: batch-skill
+metadata:
+  required-capabilities:
+    - gh
+  sideEffect:
+    kind: enqueue_children
+---
+# Batch Skill
+"""
+
+    assert extract_required_capabilities_from_skill_markdown(
+        markdown,
+        skill_name="batch-skill",
+    ) == ("gh", "execution.fanout")
+
+
+async def test_explicit_execution_fanout_capability_is_not_duplicated() -> None:
+    markdown = """---
+name: batch-skill
+metadata:
+  required-capabilities:
+    - execution.fanout
+  sideEffect:
+    kind: enqueue_children
+---
+# Batch Skill
+"""
+
+    assert extract_required_capabilities_from_skill_markdown(
+        markdown,
+        skill_name="batch-skill",
+    ) == ("execution.fanout",)
 
 
 async def test_terminal_contract_rejects_rooted_posix_path() -> None:

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -79,6 +80,15 @@ metadata:
         markdown,
         skill_name="batch-skill",
     ) == ("execution.fanout",)
+
+
+async def test_tactics_test_declares_canonical_docker_capability() -> None:
+    skill_path = Path(__file__).parents[3] / ".agents" / "skills" / "tactics-test" / "SKILL.md"
+
+    assert extract_required_capabilities_from_skill_markdown(
+        skill_path.read_text(encoding="utf-8"),
+        skill_name="tactics-test",
+    ) == ("docker",)
 
 
 async def test_terminal_contract_rejects_rooted_posix_path() -> None:

--- a/tests/unit/test_container_job_cli.py
+++ b/tests/unit/test_container_job_cli.py
@@ -316,6 +316,57 @@ def test_run_python_tests_passes_scoped_bearer_token_to_transport(
     }
 
 
+def test_run_python_tests_reads_scoped_bearer_token_file(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+    fake_client = _FakeClient(["succeeded"])
+    capability_file = tmp_path / "container-jobs"
+    capability_file.write_text("scoped-file-token\n", encoding="utf-8")
+
+    def client_factory(*, endpoint: str, bearer_token: str | None):
+        captured["endpoint"] = endpoint
+        captured["bearer_token"] = bearer_token
+        return fake_client
+
+    monkeypatch.setattr(
+        "moonmind.container_job_cli.ContainerJobMcpClient", client_factory
+    )
+
+    result = run_python_tests(
+        [],
+        env={
+            **_ENV,
+            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "stale-inline-token",
+            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE": str(capability_file),
+        },
+        poll_seconds=0.001,
+    )
+
+    assert result.state == "succeeded"
+    assert captured == {
+        "endpoint": "http://api:8000/mcp",
+        "bearer_token": "scoped-file-token",
+    }
+
+
+def test_bearer_token_file_selector_fails_closed_when_empty(tmp_path) -> None:
+    capability_file = tmp_path / "container-jobs"
+    capability_file.write_text("\n", encoding="utf-8")
+
+    with pytest.raises(ContainerJobCliError, match="BEARER_TOKEN_FILE is empty"):
+        run_python_tests(
+            [],
+            env={
+                **_ENV,
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "must-not-be-used",
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE": str(capability_file),
+            },
+            poll_seconds=0.001,
+        )
+
+
 def test_run_python_tests_polls_to_authoritative_terminal_evidence() -> None:
     client = _FakeClient(["queued", "running", "succeeded"])
 

--- a/tests/unit/test_queue_moonmind_workflows.py
+++ b/tests/unit/test_queue_moonmind_workflows.py
@@ -211,6 +211,59 @@ def test_request_headers_prefer_scoped_execution_fanout_bearer(
     assert headers["X-MoonMind-Execution-Fanout"] == "v1"
 
 
+def test_request_headers_read_scoped_execution_fanout_bearer_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    capability_file = tmp_path / "execution-fanout"
+    capability_file.write_text("fanout-file-capability\n", encoding="utf-8")
+    monkeypatch.delenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        str(capability_file),
+    )
+
+    headers = module["_request_headers"]()
+
+    assert headers["Authorization"] == "Bearer fanout-file-capability"
+    assert headers["X-MoonMind-Execution-Fanout"] == "v1"
+
+
+def test_execution_fanout_capability_file_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    capability_file = tmp_path / "execution-fanout"
+    capability_file.write_text("file-capability\n", encoding="utf-8")
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        str(capability_file),
+    )
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN",
+        "environment-capability",
+    )
+
+    assert module["_read_execution_fanout_token"]() == "file-capability"
+
+
+def test_missing_execution_fanout_capability_file_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    monkeypatch.delenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        str(tmp_path / "missing"),
+    )
+
+    with pytest.raises(RuntimeError, match="capability file is unavailable"):
+        module["_request_headers"]()
+
+
 def test_manifest_binds_scoped_fanout_request_to_caller_runtime(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -40,7 +40,9 @@ from moonmind.workflows.codex_session_timeouts import (
 from moonmind.workflows.adapters.codex_session_adapter import (
     CodexSessionAdapter,
     CodexSessionRunFailedError,
+    _execution_fanout_authorization,
     _jira_skill_blocker_summary,
+    _managed_session_required_capabilities,
     _pr_resolver_terminal_contract,
 )
 from moonmind.workflows.temporal.workflows.agent_run import (
@@ -53,6 +55,49 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     _CODEX_PROVIDER_USAGE_LIMIT_REACHED_REASON,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+async def test_managed_session_required_capabilities_preserve_omitted_replay_shape() -> None:
+    assert _managed_session_required_capabilities({}) is None
+    assert _managed_session_required_capabilities(
+        {"requiredCapabilities": []}
+    ) == []
+    assert _managed_session_required_capabilities(
+        {"requiredCapabilities": ["execution.fanout"]}
+    ) == ["execution.fanout"]
+
+    with pytest.raises(ValueError, match="must be a list"):
+        _managed_session_required_capabilities(
+            {"requiredCapabilities": "execution.fanout"}
+        )
+
+
+async def test_execution_fanout_authorization_comes_from_step_policy() -> None:
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        stepExecution={
+            "workflowId": "wf-1",
+            "runId": "run-1",
+            "logicalStepId": "step-1",
+            "executionOrdinal": 1,
+            "stepExecutionId": "wf-1:run-1:step-1:execution:1",
+            "runtimeContextPolicy": "fresh_agent_run",
+            "skillSourcePolicy": {
+                "executionFanout": {
+                    "authorized": True,
+                    "sourceKind": "built_in",
+                }
+            },
+        },
+    )
+
+    assert _execution_fanout_authorization(request) == {
+        "authorized": True,
+        "sourceKind": "built_in",
+    }
 
 pytestmark = [pytest.mark.asyncio]
 

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -504,6 +504,7 @@ async def test_start_launches_missing_workflow_scoped_session_and_persists_resul
             "sessionContinuityCacheStatus": "advisory_only",
         }
     }
+    request.parameters["requiredCapabilities"] = ["execution.fanout"]
 
     handle = await adapter.start(request)
     status = await adapter.status(handle.run_id)
@@ -527,6 +528,7 @@ async def test_start_launches_missing_workflow_scoped_session_and_persists_resul
         == DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS
     )
     assert launch_request["workspaceSpec"] == {"workspacePath": str(workspace_path)}
+    assert launch_request["requiredCapabilities"] == ["execution.fanout"]
     assert launch_request["metadata"]["latestContextPackRef"] == "artifacts/context/rag-context-abc123.json"
     assert launch_request["metadata"]["retrievalDurabilityAuthority"] == "artifact_ref"
     assert send_turn_calls[0].instructions.startswith("artifact:instructions")

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1322,6 +1322,20 @@ def test_step_skill_metadata_required_capabilities_aggregate_into_canonical_requ
     assert set(result["requiredCapabilities"]) >= {"git", "gh", "jira"}
 
 
+def test_enqueue_children_skill_derives_execution_fanout_capability() -> None:
+    result = build_canonical_workflow_view(
+        job_type="task",
+        payload={
+            "task": {
+                "instructions": "Queue one resolver per pull request.",
+                "skill": {"id": "batch-pr-resolver"},
+            },
+        },
+    )
+
+    assert "execution.fanout" in result["requiredCapabilities"]
+
+
 def test_mm569_tool_validation_error_identifies_required_field_path() -> None:
     invalid = tool_step()
     invalid["tool"].pop("id")

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -1724,6 +1724,31 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
             "prohibited",
         )
 
+    def test_resolved_skill_fanout_authorization_requires_trusted_provenance(self) -> None:
+        authorize = MoonMindRunWorkflow._resolved_skill_execution_fanout_authorization
+
+        assert authorize(
+            {
+                "provenance": {"sourceKind": "built_in"},
+                "requiredCapabilities": ["execution.fanout"],
+            },
+            selected_skill="batch-workflows",
+        )["authorized"] is True
+        assert authorize(
+            {
+                "provenance": {"sourceKind": "repo"},
+                "requiredCapabilities": ["execution.fanout"],
+            },
+            selected_skill="untrusted-batch",
+        )["authorized"] is False
+        assert authorize(
+            {
+                "provenance": {"sourceKind": "deployment"},
+                "requiredCapabilities": [],
+            },
+            selected_skill="ordinary-skill",
+        )["authorized"] is False
+
     def test_build_agent_execution_request_compiles_trusted_remediation_authority(self) -> None:
         from unittest.mock import patch
 

--- a/tools/start-worker.sh
+++ b/tools/start-worker.sh
@@ -58,7 +58,7 @@ TOKEN_POLICY_PATH="${MOONMIND_WORKER_TOKEN_POLICY_FILE:-$TOKEN_POLICY_PATH_DEFAU
 BOOTSTRAP="$(lower "${MOONMIND_WORKER_BOOTSTRAP_TOKEN:-true}")"
 ENFORCE_TOKEN_POLICY="$(lower "${MOONMIND_WORKER_ENFORCE_TOKEN_POLICY:-false}")"
 ALLOWED_TYPES_RAW="${MOONMIND_WORKER_ALLOWED_TYPES:-task,codex_exec,codex_skill}"
-CAPABILITIES_RAW="${MOONMIND_WORKER_CAPABILITIES:-codex,git,gh,docker,proposals_write}"
+CAPABILITIES_RAW="${MOONMIND_WORKER_CAPABILITIES:-codex,git,gh,docker,proposals_write,execution.fanout}"
 normalize_csv() {
   printf '%s' "$1" | tr -d '[:space:]'
 }
@@ -300,7 +300,7 @@ allowed_types = [
 capabilities = [
     item.strip()
     for item in os.environ.get(
-        "MOONMIND_WORKER_CAPABILITIES", "codex,git,gh,docker,proposals_write"
+        "MOONMIND_WORKER_CAPABILITIES", "codex,git,gh,docker,proposals_write,execution.fanout"
     ).split(",")
     if item.strip()
 ]


### PR DESCRIPTION
## What changed

- derive the canonical `execution.fanout` requirement automatically from Skills that declare `sideEffect.kind: enqueue_children`
- mint fan-out authority only for runs that require it, including explicit propagation to direct managed-session launches
- deliver Omnigent capability bearers through lease-owned read-only files and expose only non-secret file selectors to runner/login shells
- remove capability files as part of verified host-lease cleanup and reject shared static-host fan-out before mutation
- retain exact proxy/API route restrictions and update the owning capability, API, egress, Skill, secrets, Temporal, and Omnigent docs

## Why

The existing fan-out route and API bearer were correctly scoped, but Omnigent minted authority for every on-demand host and passed the bearer through an environment path that the Codex harness filters. Batch Skills therefore reached the restricted proxy without usable authorization and failed after discovering work. The API contract and restricted-egress docs also did not describe the implemented fan-out exception.

This change makes the built-in batch path work automatically while preserving least authority: Skill intent derives the requirement, policy gates it, the runtime materializes a short-lived parent-scoped grant, and runs without the requirement receive no grant.

## Impact

Built-in batch Skills require no operator permission toggle. Unauthorized Skills cannot inherit generic MoonMind API access. Advanced static Omnigent profiles fail before mutation when they request run-scoped fan-out, directing operators to the run-dedicated on-demand path.

## Validation

- targeted Linux capability and Omnigent boundary suite: 29 passed
- managed-session adapter and compatibility suite: 4 passed
- portable helper and Skill derivation checks: 19 passed locally
- Python syntax checks for all changed Python files
- `python tools/check_documentation_architecture.py`: no advisory findings
- `git diff --check`: passed