### PR TITLE
Refresh recurring Omnigent launch authority

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -81,7 +81,7 @@ from api_service.db.models import (
 from api_service.services.checkpoint_branches import prepare_checkpoint_branch_workspace
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
-    refresh_managed_bootstrap_snapshot_for_rerun,
+    refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
 )
 from api_service.services.control_stop_continuation import (
@@ -17687,9 +17687,10 @@ async def rerun_execution(
     # task dependency edges and recovery metadata from a prior execution.
     initial_params = service._full_rerun_parameters(canonical.parameters or {})
     reserved_workflow_id = f"mm:{_uuid4()}"
-    initial_params = await refresh_managed_bootstrap_snapshot_for_rerun(
+    initial_params = await refresh_managed_bootstrap_snapshot(
         session,
         parameters=initial_params,
+        consumer_type="workflow",
         consumer_id=reserved_workflow_id,
         user=user,
     )

--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -24,6 +24,7 @@ from api_service.db.models import (
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
     RecurringWorkflowAuthorizationError,
+    RecurringWorkflowConflictError,
     RecurringWorkflowNotFoundError,
     RecurringWorkflowsService,
     RecurringWorkflowValidationError,
@@ -144,6 +145,7 @@ class UpdateRecurringWorkflowRequest(BaseModel):
     scope_ref: Optional[str] = Field(None, alias="scopeRef")
     target: Optional[dict[str, Any]] = Field(None, alias="target")
     policy: Optional[dict[str, Any]] = Field(None, alias="policy")
+    version: int = Field(..., ge=1, alias="version")
 
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 
@@ -531,6 +533,14 @@ def _map_error(exc: Exception) -> HTTPException:
                 "message": str(exc),
             },
         )
+    if isinstance(exc, RecurringWorkflowConflictError):
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "recurring_workflow_version_conflict",
+                "message": str(exc),
+            },
+        )
     if isinstance(exc, RecurringWorkflowValidationError):
         return HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -811,6 +821,7 @@ async def update_recurring_workflow(
             scope_ref=payload.scope_ref,
             target=payload.target,
             policy=payload.policy,
+            expected_version=payload.version,
         )
     except Exception as exc:  # pragma: no cover - thin mapping layer
         _log_route_exception(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -297,6 +297,32 @@ async def _sync_omnigent_bootstrap_policies(
         return False
 
 
+async def _sync_managed_bootstrap_recurring_schedules() -> bool:
+    """Advance recurring actions to the active managed bootstrap snapshot."""
+
+    try:
+        from api_service.services.recurring_workflows_service import (
+            RecurringWorkflowsService,
+        )
+
+        async with get_async_session_context() as session:
+            refreshed = await RecurringWorkflowsService(
+                session,
+            ).refresh_managed_bootstrap_schedules(limit=500)
+        if refreshed:
+            logger.info(
+                "Refreshed managed bootstrap recurring schedules: count=%s",
+                refreshed,
+            )
+        return True
+    except Exception:
+        logger.warning(
+            "Managed bootstrap recurring schedule refresh deferred",
+            exc_info=True,
+        )
+        return False
+
+
 async def _reconcile_omnigent_bootstrap_once(
     *,
     refresh_images: bool,
@@ -305,7 +331,12 @@ async def _reconcile_omnigent_bootstrap_once(
         refresh_images=refresh_images
     )
     agent_ready = await _sync_omnigent_bootstrap_agent_profile()
-    return policies_ready and agent_ready
+    schedules_ready = (
+        await _sync_managed_bootstrap_recurring_schedules()
+        if policies_ready and agent_ready
+        else False
+    )
+    return policies_ready and agent_ready and schedules_ready
 
 
 async def _maintain_omnigent_bootstrap_reconciliation(

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -160,7 +160,8 @@ async def resolve_agent_profile_snapshot(
     selection: Mapping[str, Any],
     consumer_type: str,
     consumer_id: str,
-    user: User,
+    user: User | None,
+    replace_existing_usage: bool = False,
 ) -> dict[str, Any]:
     """Validate, persist, and return one launch-authoritative profile snapshot.
 
@@ -171,7 +172,10 @@ async def resolve_agent_profile_snapshot(
     if not profile_id:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "agentProfile.profileId is required")
     profile = await session.get(OmnigentAgentProfile, profile_id)
-    if profile is None or (profile.visibility == "private" and profile.owner_id != user.id):
+    if profile is None or (
+        profile.visibility == "private"
+        and (user is None or profile.owner_id != user.id)
+    ):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent profile not found")
     if profile.state != "active":
         raise HTTPException(status.HTTP_409_CONFLICT, "agent profile is not active")
@@ -312,32 +316,52 @@ async def resolve_agent_profile_snapshot(
         "upstreamSnapshot": upstream_snapshot,
         "validationResult": version.validation_result,
     }
-    session.add(OmnigentAgentProfileUsage(
-        consumer_type=consumer_type,
-        consumer_id=consumer_id,
-        profile_id=profile_id,
-        version=version.version,
-        digest=version.digest,
-        effective_snapshot=snapshot,
-    ))
+    if replace_existing_usage:
+        usage = await session.scalar(
+            select(OmnigentAgentProfileUsage).where(
+                OmnigentAgentProfileUsage.consumer_type == consumer_type,
+                OmnigentAgentProfileUsage.consumer_id == consumer_id,
+            )
+        )
+        if usage is None:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "managed Agent Profile usage is unavailable for replacement",
+            )
+        usage.profile_id = profile_id
+        usage.version = version.version
+        usage.digest = version.digest
+        usage.effective_snapshot = snapshot
+    else:
+        session.add(OmnigentAgentProfileUsage(
+            consumer_type=consumer_type,
+            consumer_id=consumer_id,
+            profile_id=profile_id,
+            version=version.version,
+            digest=version.digest,
+            effective_snapshot=snapshot,
+        ))
     await session.flush()
     return snapshot
 
 
-async def refresh_managed_bootstrap_snapshot_for_rerun(
+async def refresh_managed_bootstrap_snapshot(
     session: AsyncSession,
     *,
     parameters: Mapping[str, Any],
+    consumer_type: str,
     consumer_id: str,
-    user: User,
+    user: User | None,
+    replace_existing_usage: bool = False,
 ) -> dict[str, Any]:
-    """Refresh product-managed launch authority while preserving run intent.
+    """Refresh product-managed launch authority while preserving consumer intent.
 
-    Exact reruns retain authored task inputs and operator-owned immutable profile
-    selections. The deployment-managed bootstrap profile is different: its
-    active version advances when MoonMind moves a built-in launch policy, so a
-    rerun must re-resolve that trusted snapshot rather than replaying an
-    authority version that the durable host binding no longer selects.
+    Operator-owned immutable profile selections are retained. The
+    deployment-managed bootstrap profile is different: its active version
+    advances when MoonMind moves a built-in launch policy, so long-lived
+    consumers such as reruns and recurring schedules must re-resolve that
+    trusted snapshot rather than replaying authority that the durable host
+    binding no longer selects.
     """
 
     from api_service.services.omnigent_agent_bootstrap_service import (
@@ -374,6 +398,24 @@ async def refresh_managed_bootstrap_snapshot_for_rerun(
             status.HTTP_409_CONFLICT,
             "managed bootstrap snapshot lineage does not match durable state",
         )
+    if replace_existing_usage:
+        existing_usage = await session.scalar(
+            select(OmnigentAgentProfileUsage).where(
+                OmnigentAgentProfileUsage.consumer_type == consumer_type,
+                OmnigentAgentProfileUsage.consumer_id == consumer_id,
+            )
+        )
+        if (
+            existing_usage is None
+            or existing_usage.profile_id != BOOTSTRAP_PROFILE_ID
+            or existing_usage.version != previous_version_number
+            or existing_usage.digest != previous_digest
+            or existing_usage.effective_snapshot != dict(previous)
+        ):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "managed bootstrap snapshot usage does not match durable state",
+            )
 
     selection: dict[str, Any] = {
         "profileId": BOOTSTRAP_PROFILE_ID,
@@ -411,9 +453,10 @@ async def refresh_managed_bootstrap_snapshot_for_rerun(
     refreshed = await resolve_agent_profile_snapshot(
         session,
         selection=selection,
-        consumer_type="workflow",
+        consumer_type=consumer_type,
         consumer_id=consumer_id,
         user=user,
+        replace_existing_usage=replace_existing_usage,
     )
     return compile_agent_profile_snapshot_parameters(
         compiled,
@@ -423,6 +466,6 @@ async def refresh_managed_bootstrap_snapshot_for_rerun(
 
 __all__ = [
     "compile_agent_profile_snapshot_parameters",
-    "refresh_managed_bootstrap_snapshot_for_rerun",
+    "refresh_managed_bootstrap_snapshot",
     "resolve_agent_profile_snapshot",
 ]

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload
 from api_service.db.models import (
     OmnigentAgentProfile,
     OmnigentAgentProfileVersion,
+    OmnigentOAuthHostBindingRecord,
     RecurringWorkflowDefinition,
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
@@ -58,6 +59,9 @@ _SUPPORTED_RECURRING_WORKFLOW_TYPES = (
 
 class RecurringWorkflowValidationError(ValueError):
     """Raised when recurring workflow inputs are invalid."""
+
+class RecurringWorkflowConflictError(RuntimeError):
+    """Raised when a recurring definition changed before an authored update."""
 
 class RecurringWorkflowNotFoundError(RuntimeError):
     """Raised when a recurring definition does not exist."""
@@ -402,6 +406,22 @@ class RecurringWorkflowsService:
         self._session = session
         self._adapter = temporal_client_adapter or TemporalClientAdapter()
 
+    async def _lock_definition_for_update(
+        self,
+        definition_id: UUID,
+    ) -> RecurringWorkflowDefinition:
+        definition = await self._session.scalar(
+            select(RecurringWorkflowDefinition)
+            .where(RecurringWorkflowDefinition.id == definition_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        if definition is None:
+            raise RecurringWorkflowNotFoundError(
+                f"Recurring workflow {definition_id} not found"
+            )
+        return definition
+
     async def list_definitions(
         self,
         *,
@@ -659,6 +679,34 @@ class RecurringWorkflowsService:
             raise RecurringWorkflowValidationError(
                 "managed bootstrap Agent Profile active version is unavailable"
             )
+        execution = (
+            active.document.get("execution")
+            if isinstance(active.document, Mapping)
+            else None
+        )
+        allowed_policy_refs = (
+            execution.get("allowedLaunchPolicyRefs")
+            if isinstance(execution, Mapping)
+            else None
+        )
+        selected_policy_ref = (
+            str(allowed_policy_refs[0]).strip()
+            if isinstance(allowed_policy_refs, list) and allowed_policy_refs
+            else ""
+        )
+        provider_profile_ref = str(previous.get("providerProfileRef") or "").strip()
+        if selected_policy_ref and provider_profile_ref:
+            host_binding = await self._session.scalar(
+                select(OmnigentOAuthHostBindingRecord).where(
+                    OmnigentOAuthHostBindingRecord.provider_profile_id
+                    == provider_profile_ref
+                )
+            )
+            if (
+                host_binding is not None
+                and host_binding.launch_policy_ref != selected_policy_ref
+            ):
+                return False
         if (
             previous.get("version") == active.version
             and previous.get("digest") == active.digest
@@ -718,15 +766,9 @@ class RecurringWorkflowsService:
                 break
 
         refreshed = 0
-        failures: list[str] = []
         for definition_id in definition_ids:
             try:
-                definition = await self._session.get(
-                    RecurringWorkflowDefinition,
-                    definition_id,
-                )
-                if definition is None:
-                    continue
+                definition = await self._lock_definition_for_update(definition_id)
                 if not await self._refresh_managed_bootstrap_target(definition):
                     continue
                 # Update Temporal before committing the corresponding DB
@@ -737,17 +779,11 @@ class RecurringWorkflowsService:
                 refreshed += 1
             except Exception as exc:
                 await self._session.rollback()
-                failures.append(str(definition_id))
                 logger.warning(
                     "Failed to refresh managed bootstrap schedule %s: %s",
                     definition_id,
                     exc,
                 )
-        if failures:
-            raise RecurringWorkflowValidationError(
-                "managed bootstrap schedule refresh failed for: "
-                + ", ".join(failures)
-            )
         return refreshed
 
     async def create_definition(
@@ -889,7 +925,15 @@ class RecurringWorkflowsService:
         target: Mapping[str, Any] | None = None,
         policy: Mapping[str, Any] | None = None,
         scope_ref: str | None = None,
+        expected_version: int | None = None,
     ) -> RecurringWorkflowDefinition:
+        definition = await self._lock_definition_for_update(definition.id)
+        if expected_version is not None and int(definition.version or 0) != int(
+            expected_version
+        ):
+            raise RecurringWorkflowConflictError(
+                "recurring workflow changed since it was loaded; refresh and retry"
+            )
         changed_schedule = False
         now = datetime.now(UTC)
 
@@ -1357,6 +1401,7 @@ class RecurringWorkflowsService:
 __all__ = [
     "RecurringScheduleRuntimeSummary",
     "RecurringWorkflowAuthorizationError",
+    "RecurringWorkflowConflictError",
     "RecurringWorkflowNotFoundError",
     "RecurringWorkflowValidationError",
     "RecurringWorkflowsService",

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -14,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from api_service.db.models import (
+    OmnigentAgentProfile,
+    OmnigentAgentProfileVersion,
     RecurringWorkflowDefinition,
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
@@ -24,6 +26,7 @@ from api_service.db.models import (
 )
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
+    refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
 )
 from moonmind.workflows.recurring.cron import (
@@ -614,6 +617,138 @@ class RecurringWorkflowsService:
                 definition.owner_user_id
             ),
         )
+
+    async def _refresh_managed_bootstrap_target(
+        self,
+        definition: RecurringWorkflowDefinition,
+    ) -> bool:
+        """Advance one schedule when deployment-managed launch authority moves."""
+
+        from api_service.services.omnigent_agent_bootstrap_service import (
+            BOOTSTRAP_PROFILE_ID,
+        )
+
+        target = dict(definition.target or {})
+        initial_parameters = dict(target.get("initialParameters") or {})
+        previous = initial_parameters.get("agentProfileSnapshot")
+        if (
+            not isinstance(previous, Mapping)
+            or previous.get("profileId") != BOOTSTRAP_PROFILE_ID
+        ):
+            return False
+        if target.get("agentProfileSnapshot") != previous:
+            raise RecurringWorkflowValidationError(
+                "managed schedule Agent Profile snapshot identities conflict"
+            )
+
+        profile = await self._session.get(
+            OmnigentAgentProfile,
+            BOOTSTRAP_PROFILE_ID,
+        )
+        if profile is None or profile.active_version is None:
+            raise RecurringWorkflowValidationError(
+                "managed bootstrap Agent Profile is unavailable"
+            )
+        active = await self._session.scalar(
+            select(OmnigentAgentProfileVersion).where(
+                OmnigentAgentProfileVersion.profile_id == BOOTSTRAP_PROFILE_ID,
+                OmnigentAgentProfileVersion.version == profile.active_version,
+            )
+        )
+        if active is None:
+            raise RecurringWorkflowValidationError(
+                "managed bootstrap Agent Profile active version is unavailable"
+            )
+        if (
+            previous.get("version") == active.version
+            and previous.get("digest") == active.digest
+        ):
+            return False
+
+        actor = (
+            await self._session.get(User, definition.owner_user_id)
+            if definition.owner_user_id is not None
+            else None
+        )
+        refreshed = await refresh_managed_bootstrap_snapshot(
+            self._session,
+            parameters=initial_parameters,
+            consumer_type="schedule",
+            consumer_id=str(definition.id),
+            user=actor,
+            replace_existing_usage=True,
+        )
+        target["initialParameters"] = refreshed
+        target["agentProfile"] = dict(refreshed["agentProfile"])
+        target["agentProfileSnapshot"] = dict(refreshed["agentProfileSnapshot"])
+        definition.target = target
+        definition.updated_at = datetime.now(UTC)
+        definition.version = int(definition.version or 0) + 1
+        await self._session.flush()
+        return True
+
+    async def refresh_managed_bootstrap_schedules(self, limit: int = 500) -> int:
+        """Refresh scheduled actions after a managed bootstrap policy cutover."""
+
+        batch_size = max(1, int(limit))
+        definition_ids: list[UUID] = []
+        last_definition_id: UUID | None = None
+        while True:
+            statement = select(RecurringWorkflowDefinition.id).where(
+                RecurringWorkflowDefinition.temporal_schedule_id.is_not(None),
+            )
+            if last_definition_id is not None:
+                statement = statement.where(
+                    RecurringWorkflowDefinition.id > last_definition_id
+                )
+            batch = list(
+                (
+                    await self._session.execute(
+                        statement.order_by(RecurringWorkflowDefinition.id).limit(
+                            batch_size
+                        )
+                    )
+                ).scalars()
+            )
+            if not batch:
+                break
+            definition_ids.extend(batch)
+            last_definition_id = batch[-1]
+            if len(batch) < batch_size:
+                break
+
+        refreshed = 0
+        failures: list[str] = []
+        for definition_id in definition_ids:
+            try:
+                definition = await self._session.get(
+                    RecurringWorkflowDefinition,
+                    definition_id,
+                )
+                if definition is None:
+                    continue
+                if not await self._refresh_managed_bootstrap_target(definition):
+                    continue
+                # Update Temporal before committing the corresponding DB
+                # authority. A crash between the two is repaired idempotently:
+                # the next pass observes the current action and commits the DB.
+                await self._ensure_schedule_action_current(definition)
+                await self._session.commit()
+                refreshed += 1
+            except Exception as exc:
+                await self._session.rollback()
+                failures.append(str(definition_id))
+                logger.warning(
+                    "Failed to refresh managed bootstrap schedule %s: %s",
+                    definition_id,
+                    exc,
+                )
+        if failures:
+            raise RecurringWorkflowValidationError(
+                "managed bootstrap schedule refresh failed for: "
+                + ", ".join(failures)
+            )
+        return refreshed
 
     async def create_definition(
         self,

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3812528685,
-    "disposition": "addressed",
-    "rationale": "Updated PINNED_OMNIGENT_COMMIT and refreshed pinned native UI compatibility evidence to the checked-out submodule commit to eliminate pin drift across auth and compatibility checks."
+    "id": 4974996686,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary only; the three concrete inline findings are classified separately."
   },
   {
-    "id": 4971576672,
-    "disposition": "not-applicable",
-    "rationale": "Non-actionable bot review summary comment excluded from review-gating."
+    "id": 3815293692,
+    "disposition": "addressed",
+    "rationale": "The refresh sweep now rolls back and logs a failed schedule while continuing with the remaining schedules, with regression coverage."
+  },
+  {
+    "id": 3815293719,
+    "disposition": "addressed",
+    "rationale": "Managed schedule authority now waits until the selected OAuth host binding references the active profile version's launch policy, with deferred-cutover coverage."
+  },
+  {
+    "id": 3815293738,
+    "disposition": "addressed",
+    "rationale": "Automatic refresh and authored updates now share a row lock, while PATCH requires the current schedule version and rejects stale target replacement with HTTP 409."
   }
 ]

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -775,6 +775,7 @@ describe('Dashboard shared entry', () => {
           json: async () => ({
             items: [{
               id: 'schedule-one',
+              version: 1,
               name: 'Daily recurring scan',
               enabled: true,
               cron: '0 9 * * *',
@@ -792,6 +793,7 @@ describe('Dashboard shared entry', () => {
           ok: true,
           json: async () => ({
             id: 'schedule-one',
+            version: 1,
             name: 'Daily recurring scan',
             description: 'Runs every morning.',
             enabled: true,
@@ -855,6 +857,7 @@ describe('Dashboard shared entry', () => {
           json: async () => ({
             items: [{
               id: 'schedule-one',
+              version: 1,
               name: 'Daily recurring scan',
               enabled: true,
               cron: '0 9 * * *',
@@ -904,6 +907,7 @@ describe('Dashboard shared entry', () => {
           json: async () => ({
             items: [{
               id: 'schedule-one',
+              version: 1,
               name: 'Daily recurring scan',
               enabled: true,
               cron: '0 9 * * *',
@@ -921,6 +925,7 @@ describe('Dashboard shared entry', () => {
           ok: true,
           json: async () => ({
             id: 'schedule-one',
+            version: 1,
             name: 'Daily recurring scan',
             description: 'Runs every morning.',
             enabled: true,
@@ -1153,6 +1158,7 @@ describe('Dashboard shared entry', () => {
           json: async () => ({
             items: [{
               id: 'schedule-one',
+              version: 1,
               name: 'Daily recurring scan',
               enabled: true,
               cron: '0 9 * * *',
@@ -1170,6 +1176,7 @@ describe('Dashboard shared entry', () => {
           ok: true,
           json: async () => ({
             id: 'schedule-one',
+            version: 1,
             name: 'Daily recurring scan',
             description: 'Runs every morning.',
             enabled: true,
@@ -1222,6 +1229,7 @@ describe('Dashboard shared entry', () => {
           json: async () => ({
             items: [{
               id: 'schedule-one',
+              version: 1,
               name: 'Daily recurring scan',
               enabled: true,
               cron: '0 9 * * *',
@@ -1239,6 +1247,7 @@ describe('Dashboard shared entry', () => {
           ok: true,
           json: async () => ({
             id: 'schedule-one',
+            version: 1,
             name: 'Daily recurring scan',
             description: 'Runs every morning.',
             enabled: true,
@@ -1316,6 +1325,7 @@ describe('Dashboard shared entry', () => {
   // `hidden` on a direct `/schedules/{definitionId}` visit.
   const recurringScheduleRow = (id: string, name: string) => ({
     id,
+    version: 1,
     name,
     enabled: true,
     cron: '0 9 * * *',

--- a/frontend/src/entrypoints/schedules.test.tsx
+++ b/frontend/src/entrypoints/schedules.test.tsx
@@ -162,6 +162,7 @@ describe("SchedulesPage", () => {
         items: [
           {
             id: "schedule-1",
+            version: 1,
             name: "Daily repository sweep",
             enabled: true,
             cron: "0 9 * * *",
@@ -187,6 +188,7 @@ describe("SchedulesPage", () => {
           },
           {
             id: "schedule-2",
+            version: 1,
             name: "Sparse schedule",
             enabled: false,
             cron: "15 * * * *",
@@ -200,6 +202,7 @@ describe("SchedulesPage", () => {
           },
           {
             id: "schedule-3",
+            version: 1,
             name: "Failing schedule",
             enabled: true,
             cron: "30 4 * * 1",
@@ -280,6 +283,7 @@ describe("SchedulesPage", () => {
         items: [
           {
             id: "schedule-error",
+            version: 1,
             name: "Error carrying schedule",
             enabled: true,
             cron: "0 12 * * *",
@@ -343,6 +347,7 @@ describe("SchedulesPage", () => {
       items: [
         {
           id: "schedule-1",
+          version: 1,
           name: "Daily repository sweep",
           enabled: true,
           cron: "0 9 * * *",
@@ -408,6 +413,7 @@ describe("SchedulesPage", () => {
       items: [
         {
           id: "schedule-1",
+          version: 1,
           name: "Daily repository sweep",
           enabled: true,
           cron: "0 9 * * *",
@@ -459,6 +465,7 @@ describe("SchedulesPage", () => {
       items: [
         {
           id: "schedule-1",
+          version: 1,
           name: "Daily repository sweep",
           enabled: true,
           cron: "0 9 * * *",
@@ -735,6 +742,7 @@ describe("SchedulesPage", () => {
           items: url.includes("cursor=cursor-2") ? [] : [
             {
               id: "schedule-page-1",
+              version: 1,
               name: "Page one schedule",
               enabled: true,
               cron: "0 9 * * *",
@@ -1084,6 +1092,7 @@ describe("SchedulesPage", () => {
       expect(updateCall).toBeDefined();
       expect(JSON.parse(String(updateCall?.[1]?.body || "{}"))).toEqual({
         name: "Nightly detail sweep updated",
+        version: 1,
       });
     });
     expect(screen.getAllByText("schedule-alpha").length).toBeGreaterThanOrEqual(1);
@@ -1107,6 +1116,7 @@ describe("SchedulesPage", () => {
       expect(updateCall).toBeDefined();
       expect(JSON.parse(String(updateCall?.[1]?.body || "{}"))).toEqual({
         description: "",
+        version: 1,
       });
     });
   });
@@ -1166,6 +1176,7 @@ describe("SchedulesPage", () => {
             branch: "release",
           },
         },
+        version: 1,
       });
     });
   });
@@ -1418,6 +1429,10 @@ describe("SchedulesPage", () => {
         && JSON.parse(String(init?.body || "{}")).enabled === false
       ));
       expect(pauseCall).toBeDefined();
+      expect(JSON.parse(String(pauseCall?.[1]?.body || "{}"))).toEqual({
+        enabled: false,
+        version: 1,
+      });
     });
   });
 
@@ -1436,6 +1451,10 @@ describe("SchedulesPage", () => {
         && JSON.parse(String(init?.body || "{}")).enabled === true
       ));
       expect(resumeCall).toBeDefined();
+      expect(JSON.parse(String(resumeCall?.[1]?.body || "{}"))).toEqual({
+        enabled: true,
+        version: 1,
+      });
     });
   });
 });

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -95,6 +95,7 @@ const ScheduleSchema = z.object({
   target: z.record(z.string(), z.unknown()).optional(),
   policy: z.record(z.string(), z.unknown()).optional(),
   temporalScheduleId: z.string().nullable().optional(),
+  version: z.number().int().positive(),
   updatedAt: z.string().optional(),
 }).passthrough();
 
@@ -874,6 +875,9 @@ function buildSchedulePatchPayload(schedule: Schedule, form: ScheduleEditForm): 
   if (stableJson(target) !== stableJson(schedule.target || {})) {
     payload.target = target;
   }
+  if (Object.keys(payload).length > 0) {
+    payload.version = schedule.version;
+  }
   return payload;
 }
 
@@ -1133,12 +1137,12 @@ function ScheduleDetailPage({
   });
 
   const pauseResumeMutation = useMutation({
-    mutationFn: async (enabled: boolean) => {
+    mutationFn: async ({ enabled, version }: { enabled: boolean; version: number }) => {
       const response = await fetch(updateEndpoint, {
         method: 'PATCH',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ enabled }),
+        body: JSON.stringify({ enabled, version }),
       });
       if (!response.ok) {
         throw new Error(`Failed to ${enabled ? 'resume' : 'pause'} schedule: ${response.statusText}`);
@@ -1304,7 +1308,10 @@ function ScheduleDetailPage({
           <button
             type="button"
             className="secondary"
-            onClick={() => pauseResumeMutation.mutate(!schedule.enabled)}
+            onClick={() => pauseResumeMutation.mutate({
+              enabled: !schedule.enabled,
+              version: schedule.version,
+            })}
             disabled={pauseResumeMutation.isPending || isEditing || updateMutation.isPending || !actions?.canEdit}
             title={!actions?.canEdit ? actions?.editReason : undefined}
           >
@@ -1833,7 +1840,7 @@ function ScheduleRowActions({
         method: 'PATCH',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ enabled }),
+        body: JSON.stringify({ enabled, version: schedule.version }),
       });
       if (!response.ok) {
         throw new Error(

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -13397,6 +13397,8 @@ export interface components {
             policy?: {
                 [key: string]: unknown;
             } | null;
+            /** Version */
+            version: number;
         };
         /** UserCreate */
         UserCreate: {

--- a/tests/integration/reliability/replays/recurring-managed-bootstrap-policy-cutover/expected-outcome.json
+++ b/tests/integration/reliability/replays/recurring-managed-bootstrap-policy-cutover/expected-outcome.json
@@ -1,0 +1,8 @@
+{
+  "invariant": "a recurring schedule using the deployment-managed bootstrap profile advances to the active immutable launch policy before its next Temporal occurrence",
+  "refreshedProfileVersion": 3,
+  "refreshedLaunchPolicyRef": "codex-on-demand@4",
+  "definitionVersion": 2,
+  "usageMode": "replace_existing_schedule_authority",
+  "temporalActionUpdated": true
+}

--- a/tests/integration/reliability/replays/recurring-managed-bootstrap-policy-cutover/manifest.json
+++ b/tests/integration/reliability/replays/recurring-managed-bootstrap-policy-cutover/manifest.json
@@ -1,0 +1,39 @@
+{
+  "incidentWorkflowId": "mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0-2026-08-19T13:00:00Z",
+  "incidentRunId": "01a01a1b-6cd7-7832-a6be-90792d80c8a4",
+  "definitionId": "2d8480da-045c-4569-81b3-5b0b0a0ee9a0",
+  "failureCode": "OMNIGENT_LAUNCH_POLICY_BINDING_CONFLICT",
+  "failureMessage": "explicit launch selection conflicts with the durable host binding",
+  "storedSnapshot": {
+    "profileId": "omnigent-bootstrap-default",
+    "version": 2,
+    "digest": "sha256:52a92c4e9786c566f253a48b9f45bf0770ac4ec2e76f46eb5ea363b2af54b61a",
+    "providerProfileRef": "codex_openai_oauth",
+    "executionProfileRef": "omnigent-codex@1",
+    "launchPolicyRef": "codex-on-demand@3",
+    "document": {
+      "model": {},
+      "capture": {},
+      "rag": {},
+      "publish": {}
+    }
+  },
+  "activeSnapshot": {
+    "profileId": "omnigent-bootstrap-default",
+    "version": 3,
+    "digest": "sha256:8f21b0a610ed9f7f0bb73de12e78a16e02bb6694fb288d8526348fa63145541a",
+    "providerProfileRef": "codex_openai_oauth",
+    "executionProfileRef": "omnigent-codex@1",
+    "launchPolicyRef": "codex-on-demand@4",
+    "document": {
+      "model": {},
+      "capture": {},
+      "rag": {},
+      "publish": {}
+    }
+  },
+  "durableHostBinding": {
+    "executionProfileRef": "omnigent-codex@1",
+    "launchPolicyRef": "codex-on-demand@4"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import httpx
 import pytest
@@ -22,11 +23,21 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from temporalio import activity
 from temporalio.testing import ActivityEnvironment
 
-from api_service.db.models import Base, OmnigentPolicy, OmnigentPolicyVersion
+from api_service.db.models import (
+    Base,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileVersion,
+    OmnigentPolicy,
+    OmnigentPolicyVersion,
+    RecurringWorkflowDefinition,
+    RecurringWorkflowScheduleType,
+    RecurringWorkflowScopeType,
+)
 from api_service.services.omnigent_policies import (
     bootstrap_document,
     seed_bootstrap_policies,
 )
+from api_service.services.recurring_workflows_service import RecurringWorkflowsService
 from moonmind.config.settings import settings
 from moonmind.omnigent import oauth_host_runtime as oauth_host_runtime_module
 from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
@@ -113,6 +124,9 @@ from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
     SandboxWorkspaceRecordStore,
+)
+from moonmind.workflows.temporal.schedule_mapping import (
+    make_scheduled_workflow_id_base,
 )
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows import (
@@ -962,6 +976,163 @@ async def test_pr_resolver_child_compiles_bindable_stock_agent_identity(
     )
     assert target.agent_id == expected["resolvedAgentId"]
     assert target.agent_name == expected["resolvedAgentName"]
+
+
+async def test_recurring_managed_bootstrap_policy_cutover_refreshes_temporal_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay the stale schedule action that conflicted with its host binding."""
+
+    replay_id = "recurring-managed-bootstrap-policy-cutover"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    definition_id = UUID(manifest["definitionId"])
+    old_snapshot = manifest["storedSnapshot"]
+    active_snapshot = manifest["activeSnapshot"]
+
+    async def refresh_snapshot(
+        session,
+        *,
+        parameters,
+        consumer_type,
+        consumer_id,
+        user,
+        replace_existing_usage,
+    ):
+        assert consumer_type == "schedule"
+        assert consumer_id == str(definition_id)
+        assert replace_existing_usage is True
+        return {
+            **dict(parameters),
+            "agentProfile": {
+                "profileId": active_snapshot["profileId"],
+                "version": active_snapshot["version"],
+                "digest": active_snapshot["digest"],
+            },
+            "agentProfileSnapshot": active_snapshot,
+            "omnigent": {
+                "executionTargetRef": active_snapshot["executionProfileRef"],
+                "launchPolicyRef": active_snapshot["launchPolicyRef"],
+            },
+        }
+
+    monkeypatch.setattr(
+        "api_service.services.recurring_workflows_service."
+        "refresh_managed_bootstrap_snapshot",
+        refresh_snapshot,
+    )
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'replay.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            definition = RecurringWorkflowDefinition(
+                id=definition_id,
+                name="Daily Dependabot Resolver",
+                enabled=True,
+                schedule_type=RecurringWorkflowScheduleType.CRON,
+                cron="0 13 * * *",
+                timezone="UTC",
+                temporal_schedule_id=f"mm-schedule:{definition_id}",
+                owner_user_id=UUID("00000000-0000-0000-0000-000000000000"),
+                scope_type=RecurringWorkflowScopeType.PERSONAL,
+                target={
+                    "workflowType": "MoonMind.UserWorkflow",
+                    "initialParameters": {
+                        "targetRuntime": "omnigent",
+                        "agentProfile": {
+                            "profileId": old_snapshot["profileId"],
+                            "version": old_snapshot["version"],
+                            "digest": old_snapshot["digest"],
+                        },
+                        "agentProfileSnapshot": old_snapshot,
+                        "omnigent": {
+                            "executionTargetRef": old_snapshot[
+                                "executionProfileRef"
+                            ],
+                            "launchPolicyRef": old_snapshot["launchPolicyRef"],
+                        },
+                    },
+                    "agentProfile": {
+                        "profileId": old_snapshot["profileId"],
+                        "version": old_snapshot["version"],
+                        "digest": old_snapshot["digest"],
+                    },
+                    "agentProfileSnapshot": old_snapshot,
+                },
+                policy={},
+                version=1,
+            )
+            session.add_all(
+                [
+                    definition,
+                    OmnigentAgentProfile(
+                        profile_id=active_snapshot["profileId"],
+                        display_name="Codex via Omnigent",
+                        visibility="workspace",
+                        state="active",
+                        active_version=active_snapshot["version"],
+                        default_for_runtime=True,
+                    ),
+                    OmnigentAgentProfileVersion(
+                        profile_id=active_snapshot["profileId"],
+                        version=active_snapshot["version"],
+                        digest=active_snapshot["digest"],
+                        document={},
+                        validation_result={"ready": True},
+                    ),
+                ]
+            )
+            await session.commit()
+
+            update_schedule = AsyncMock()
+            adapter = SimpleNamespace(
+                resolve_workflow_task_queue=lambda _workflow: "mm.workflow.user.v2",
+                describe_schedule=AsyncMock(),
+                update_schedule=update_schedule,
+            )
+            service = RecurringWorkflowsService(
+                session,
+                temporal_client_adapter=adapter,
+            )
+            old_workflow_type, old_workflow_input = (
+                service._workflow_bundle_for_definition(definition)
+            )
+            adapter.describe_schedule.return_value = SimpleNamespace(
+                schedule=SimpleNamespace(
+                    action=SimpleNamespace(
+                        workflow=old_workflow_type,
+                        id=make_scheduled_workflow_id_base(definition_id),
+                        args=[old_workflow_input],
+                        task_queue="mm.workflow.user.v2",
+                    )
+                )
+            )
+
+            assert await service.refresh_managed_bootstrap_schedules() == 1
+            await session.refresh(definition)
+
+            assert definition.version == expected["definitionVersion"]
+            assert definition.target["agentProfile"]["version"] == expected[
+                "refreshedProfileVersion"
+            ]
+            assert definition.target["initialParameters"]["omnigent"][
+                "launchPolicyRef"
+            ] == expected["refreshedLaunchPolicyRef"]
+            assert (
+                manifest["durableHostBinding"]["launchPolicyRef"]
+                == expected["refreshedLaunchPolicyRef"]
+            )
+            assert update_schedule.await_count == 1
+            update_input = update_schedule.await_args.kwargs["workflow_input"]
+            assert update_input["initial_parameters"]["omnigent"][
+                "launchPolicyRef"
+            ] == expected["refreshedLaunchPolicyRef"]
+    finally:
+        await engine.dispose()
 
 
 async def test_runtime_switch_rebinds_managed_session_authority_before_activity() -> (

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -19,6 +19,7 @@ from api_service.db.models import (
 )
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
+    RecurringWorkflowConflictError,
     RecurringWorkflowValidationError,
 )
 
@@ -101,6 +102,19 @@ def test_recurring_workflow_validation_error_maps_to_422() -> None:
         "code": "invalid_recurring_workflow",
         "message": "target.workflowType is required",
     }
+
+
+def test_recurring_workflow_version_conflict_maps_to_409() -> None:
+    exc = recurring_router._map_error(
+        RecurringWorkflowConflictError("refresh and retry")
+    )
+
+    assert exc.status_code == status.HTTP_409_CONFLICT
+    assert exc.detail == {
+        "code": "recurring_workflow_version_conflict",
+        "message": "refresh and retry",
+    }
+
 
 @pytest.mark.asyncio
 async def test_list_recurring_workflows_global_requires_operator() -> None:

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -78,6 +78,36 @@ async def test_api_startup_bootstrap_uses_only_local_image_evidence(
 
 
 @pytest.mark.asyncio
+async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def policies(*, refresh_images: bool) -> bool:
+        calls.append(f"policies:{refresh_images}")
+        return True
+
+    async def agent() -> bool:
+        calls.append("agent")
+        return True
+
+    async def schedules() -> bool:
+        calls.append("schedules")
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
+    monkeypatch.setattr(
+        api_main,
+        "_sync_managed_bootstrap_recurring_schedules",
+        schedules,
+    )
+
+    assert await api_main._reconcile_omnigent_bootstrap_once(refresh_images=True)
+    assert calls == ["policies:True", "agent", "schedules"]
+
+
+@pytest.mark.asyncio
 async def test_mm870_api_startup_ensures_managed_session_reconcile_schedule(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -16,7 +16,7 @@ from api_service.db.models import (
 )
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
-    refresh_managed_bootstrap_snapshot_for_rerun,
+    refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
 )
 
@@ -55,6 +55,7 @@ class _Session:
             volume_mount_path="/root/.codex", secret_refs={},
             credential_bindings=[], command_behavior={"auth_readiness": {"launch_ready": True}},
         )
+        self.usage = None
         self.added = []
 
     async def get(self, model, key):
@@ -66,6 +67,8 @@ class _Session:
             return self.version
         if entity is ManagedAgentProviderProfile:
             return self.provider
+        if entity is OmnigentAgentProfileUsage:
+            return self.usage
         return None
 
     def add(self, value):
@@ -153,6 +156,34 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
     assert isinstance(usage, OmnigentAgentProfileUsage)
     assert usage.consumer_type == "checkpoint"
     assert usage.effective_snapshot == snapshot
+
+
+@pytest.mark.asyncio
+async def test_resolver_replaces_managed_schedule_usage_in_place():
+    session = _Session()
+    session.usage = SimpleNamespace(
+        profile_id="team-codex",
+        version=1,
+        digest="sha256:" + "1" * 64,
+        effective_snapshot={"version": 1},
+    )
+
+    snapshot = await resolve_agent_profile_snapshot(
+        session,
+        selection={
+            "profileId": "team-codex",
+            "providerProfileRef": "oauth-team",
+        },
+        consumer_type="schedule",
+        consumer_id="schedule-1",
+        user=None,
+        replace_existing_usage=True,
+    )
+
+    assert session.added == []
+    assert session.usage.version == 2
+    assert session.usage.digest == "sha256:" + "a" * 64
+    assert session.usage.effective_snapshot == snapshot
 
 
 @pytest.mark.asyncio
@@ -249,7 +280,15 @@ async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
 
     captured = {}
 
-    async def _resolve(session, *, selection, consumer_type, consumer_id, user):
+    async def _resolve(
+        session,
+        *,
+        selection,
+        consumer_type,
+        consumer_id,
+        user,
+        replace_existing_usage=False,
+    ):
         captured.update(
             selection=selection,
             consumer_type=consumer_type,
@@ -278,7 +317,7 @@ async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
         "resolve_agent_profile_snapshot",
         _resolve,
     )
-    refreshed = await refresh_managed_bootstrap_snapshot_for_rerun(
+    refreshed = await refresh_managed_bootstrap_snapshot(
         _RerunSession(),
         parameters={
             "instructions": "keep the same task",
@@ -301,6 +340,7 @@ async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
                 "agent": {"agentId": "stale-agent-id"},
             },
         },
+        consumer_type="workflow",
         consumer_id="mm:rerun",
         user=SimpleNamespace(id=uuid4()),
     )
@@ -323,6 +363,82 @@ async def test_exact_rerun_refreshes_managed_bootstrap_authority(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_managed_schedule_refresh_requires_and_replaces_exact_usage(
+    monkeypatch,
+):
+    old_digest = "sha256:" + "1" * 64
+    previous = {
+        "profileId": "omnigent-bootstrap-default",
+        "version": 1,
+        "digest": old_digest,
+        "providerProfileRef": "codex_openai_oauth",
+        "document": {"model": {}, "capture": {}, "rag": {}, "publish": {}},
+    }
+    previous_version = SimpleNamespace(
+        digest=old_digest,
+        document=previous["document"],
+    )
+    usage = SimpleNamespace(
+        profile_id="omnigent-bootstrap-default",
+        version=1,
+        digest=old_digest,
+        effective_snapshot=previous,
+    )
+
+    class _ScheduleSession:
+        async def scalar(self, statement):
+            entity = statement.column_descriptions[0].get("entity")
+            if entity is OmnigentAgentProfileVersion:
+                return previous_version
+            if entity is OmnigentAgentProfileUsage:
+                return usage
+            return None
+
+    async def _resolve(
+        session,
+        *,
+        selection,
+        consumer_type,
+        consumer_id,
+        user,
+        replace_existing_usage,
+    ):
+        assert consumer_type == "schedule"
+        assert consumer_id == "schedule-1"
+        assert replace_existing_usage is True
+        return {
+            **previous,
+            "version": 2,
+            "digest": "sha256:" + "2" * 64,
+            "executionProfileRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@2",
+            "agentId": "codex-native-ui",
+            "document": {
+                **previous["document"],
+                "workspace": {},
+            },
+        }
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_agent_profile_selection."
+        "resolve_agent_profile_snapshot",
+        _resolve,
+    )
+
+    refreshed = await refresh_managed_bootstrap_snapshot(
+        _ScheduleSession(),
+        parameters={"agentProfileSnapshot": previous},
+        consumer_type="schedule",
+        consumer_id="schedule-1",
+        user=None,
+        replace_existing_usage=True,
+    )
+
+    assert refreshed["agentProfile"]["version"] == 2
+    assert refreshed["omnigent"]["launchPolicyRef"] == "codex-on-demand@2"
+
+
+@pytest.mark.asyncio
 async def test_exact_rerun_reconstructs_explicit_null_overrides(monkeypatch):
     old_digest = "sha256:" + "3" * 64
     previous_version = SimpleNamespace(
@@ -341,7 +457,15 @@ async def test_exact_rerun_reconstructs_explicit_null_overrides(monkeypatch):
 
     captured = {}
 
-    async def _resolve(session, *, selection, consumer_type, consumer_id, user):
+    async def _resolve(
+        session,
+        *,
+        selection,
+        consumer_type,
+        consumer_id,
+        user,
+        replace_existing_usage=False,
+    ):
         captured["selection"] = selection
         return {
             "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
@@ -367,7 +491,7 @@ async def test_exact_rerun_reconstructs_explicit_null_overrides(monkeypatch):
         _resolve,
     )
 
-    await refresh_managed_bootstrap_snapshot_for_rerun(
+    await refresh_managed_bootstrap_snapshot(
         _RerunSession(),
         parameters={
             "agentProfileSnapshot": {
@@ -385,6 +509,7 @@ async def test_exact_rerun_reconstructs_explicit_null_overrides(monkeypatch):
                 },
             }
         },
+        consumer_type="workflow",
         consumer_id="mm:rerun-null-overrides",
         user=SimpleNamespace(id=uuid4()),
     )
@@ -401,9 +526,10 @@ async def test_exact_rerun_preserves_operator_owned_profile_snapshot():
         "agentProfileSnapshot": {"profileId": "operator-profile"},
         "omnigent": {"launchPolicyRef": "operator-policy@7"},
     }
-    assert await refresh_managed_bootstrap_snapshot_for_rerun(
+    assert await refresh_managed_bootstrap_snapshot(
         SimpleNamespace(),
         parameters=parameters,
+        consumer_type="workflow",
         consumer_id="mm:rerun",
         user=SimpleNamespace(id=uuid4()),
     ) == parameters

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import (
     Base,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileVersion,
     RecurringWorkflowDefinition,
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
@@ -727,6 +729,165 @@ async def test_reconcile_repairs_existing_schedule_action_payload(
                 "MoonMind.UserWorkflow"
             )
             assert "workflowType" not in call_kwargs["workflow_input"]
+
+
+async def test_managed_bootstrap_policy_cutover_refreshes_schedule_action(
+    tmp_path: Path,
+    mock_temporal_adapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_digest = "sha256:" + "3" * 64
+    new_digest = "sha256:" + "4" * 64
+    old_snapshot = {
+        "profileId": "omnigent-bootstrap-default",
+        "version": 2,
+        "digest": old_digest,
+        "providerProfileRef": "codex_openai_oauth",
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@3",
+        "document": {"model": {}, "capture": {}, "rag": {}, "publish": {}},
+    }
+    new_snapshot = {
+        **old_snapshot,
+        "version": 3,
+        "digest": new_digest,
+        "launchPolicyRef": "codex-on-demand@4",
+    }
+    refresh_calls: list[dict[str, object]] = []
+
+    async def refresh_snapshot(
+        session,
+        *,
+        parameters,
+        consumer_type,
+        consumer_id,
+        user,
+        replace_existing_usage,
+    ):
+        refresh_calls.append(
+            {
+                "consumerType": consumer_type,
+                "consumerId": consumer_id,
+                "replaceExistingUsage": replace_existing_usage,
+            }
+        )
+        return {
+            **dict(parameters),
+            "agentProfile": {
+                "profileId": "omnigent-bootstrap-default",
+                "version": 3,
+                "digest": new_digest,
+            },
+            "agentProfileSnapshot": new_snapshot,
+            "omnigent": {
+                "executionTargetRef": "omnigent-codex@1",
+                "launchPolicyRef": "codex-on-demand@4",
+            },
+        }
+
+    monkeypatch.setattr(
+        "api_service.services.recurring_workflows_service."
+        "refresh_managed_bootstrap_snapshot",
+        refresh_snapshot,
+    )
+
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        service = RecurringWorkflowsService(
+            session,
+            temporal_client_adapter=mock_temporal_adapter,
+        )
+        definition = await service.create_definition(
+            name="Daily Dependabot Resolver",
+            description=None,
+            enabled=True,
+            schedule_type="cron",
+            cron="0 13 * * *",
+            timezone="UTC",
+            scope_type="personal",
+            scope_ref=None,
+            owner_user_id=uuid4(),
+            target={
+                "workflowType": "MoonMind.UserWorkflow",
+                "initialParameters": {
+                    "targetRuntime": "omnigent",
+                    "agentProfile": {
+                        "profileId": "omnigent-bootstrap-default",
+                        "version": 2,
+                        "digest": old_digest,
+                    },
+                    "agentProfileSnapshot": old_snapshot,
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-codex@1",
+                        "launchPolicyRef": "codex-on-demand@3",
+                    },
+                },
+                "agentProfile": {
+                    "profileId": "omnigent-bootstrap-default",
+                    "version": 2,
+                    "digest": old_digest,
+                },
+                "agentProfileSnapshot": old_snapshot,
+            },
+            policy={},
+        )
+        session.add(
+            OmnigentAgentProfile(
+                profile_id="omnigent-bootstrap-default",
+                display_name="Codex via Omnigent",
+                visibility="workspace",
+                state="active",
+                active_version=3,
+                default_for_runtime=True,
+            )
+        )
+        session.add(
+            OmnigentAgentProfileVersion(
+                profile_id="omnigent-bootstrap-default",
+                version=3,
+                digest=new_digest,
+                document={},
+                validation_result={"ready": True},
+            )
+        )
+        await session.commit()
+
+        old_workflow_type, old_workflow_input = (
+            service._workflow_bundle_for_definition(definition)
+        )
+        mock_temporal_adapter.create_schedule.reset_mock()
+        mock_temporal_adapter.update_schedule.reset_mock()
+        mock_temporal_adapter.describe_schedule.return_value = SimpleNamespace(
+            schedule=SimpleNamespace(
+                action=SimpleNamespace(
+                    workflow=old_workflow_type,
+                    id=make_scheduled_workflow_id_base(definition.id),
+                    args=[old_workflow_input],
+                    task_queue="mm.workflow.user.v2",
+                )
+            )
+        )
+
+        assert await service.refresh_managed_bootstrap_schedules() == 1
+
+        await session.refresh(definition)
+        assert definition.version == 2
+        assert definition.target["agentProfile"]["version"] == 3
+        assert definition.target["initialParameters"]["omnigent"] == {
+            "executionTargetRef": "omnigent-codex@1",
+            "launchPolicyRef": "codex-on-demand@4",
+        }
+        assert refresh_calls == [
+            {
+                "consumerType": "schedule",
+                "consumerId": str(definition.id),
+                "replaceExistingUsage": True,
+            }
+        ]
+        update = mock_temporal_adapter.update_schedule.call_args.kwargs
+        assert update["workflow_input"]["initial_parameters"]["omnigent"][
+            "launchPolicyRef"
+        ] == "codex-on-demand@4"
+
 
 async def test_reconcile_skips_update_when_metadata_and_action_match(
     tmp_path: Path, mock_temporal_adapter

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -18,12 +18,14 @@ from api_service.db.models import (
     Base,
     OmnigentAgentProfile,
     OmnigentAgentProfileVersion,
+    OmnigentOAuthHostBindingRecord,
     RecurringWorkflowDefinition,
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
 )
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
+    RecurringWorkflowConflictError,
     RecurringWorkflowsService,
     RecurringWorkflowValidationError,
 )
@@ -845,10 +847,36 @@ async def test_managed_bootstrap_policy_cutover_refreshes_schedule_action(
                 profile_id="omnigent-bootstrap-default",
                 version=3,
                 digest=new_digest,
-                document={},
+                document={
+                    "execution": {
+                        "allowedLaunchPolicyRefs": ["codex-on-demand@4"],
+                    }
+                },
                 validation_result={"ready": True},
             )
         )
+        binding = OmnigentOAuthHostBindingRecord(
+            binding_ref="codex-openai-oauth-host",
+            provider_profile_id="codex_openai_oauth",
+            endpoint_ref="default",
+            harness="codex-native",
+            credential_mount_template_json={
+                "authVolumeRef": {
+                    "providerProfileId": "codex_openai_oauth",
+                    "runtimeId": "codex_cli",
+                    "providerId": "openai",
+                    "volumeRef": "codex_auth_volume",
+                    "credentialGeneration": 1,
+                    "ownerUserId": "user-1",
+                },
+                "targetPath": "/home/app/.codex",
+                "accessMode": "read_write",
+                "runtimeUid": 1000,
+                "runtimeGid": 1000,
+            },
+            launch_policy_ref="codex-on-demand@3",
+        )
+        session.add(binding)
         await session.commit()
 
         old_workflow_type, old_workflow_input = (
@@ -866,6 +894,13 @@ async def test_managed_bootstrap_policy_cutover_refreshes_schedule_action(
                 )
             )
         )
+
+        assert await service.refresh_managed_bootstrap_schedules() == 0
+        mock_temporal_adapter.update_schedule.assert_not_called()
+        assert refresh_calls == []
+
+        binding.launch_policy_ref = "codex-on-demand@4"
+        await session.commit()
 
         assert await service.refresh_managed_bootstrap_schedules() == 1
 
@@ -887,6 +922,103 @@ async def test_managed_bootstrap_policy_cutover_refreshes_schedule_action(
         assert update["workflow_input"]["initial_parameters"]["omnigent"][
             "launchPolicyRef"
         ] == "codex-on-demand@4"
+
+
+async def test_managed_bootstrap_refresh_contains_individual_failures(
+    tmp_path: Path,
+    mock_temporal_adapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        service = RecurringWorkflowsService(
+            session,
+            temporal_client_adapter=mock_temporal_adapter,
+        )
+        definitions = []
+        for name in ("Broken", "Healthy"):
+            definitions.append(
+                await service.create_definition(
+                    name=name,
+                    description=None,
+                    enabled=True,
+                    schedule_type="cron",
+                    cron="0 13 * * *",
+                    timezone="UTC",
+                    scope_type="personal",
+                    scope_ref=None,
+                    owner_user_id=uuid4(),
+                    target={
+                        "workflowType": "MoonMind.UserWorkflow",
+                        "initialParameters": {"task": {"instructions": name}},
+                    },
+                    policy={},
+                )
+            )
+        definition_ids = [definition.id for definition in definitions]
+
+        visited: list[object] = []
+
+        async def refresh_target(definition):
+            visited.append(definition.id)
+            if definition.id == definition_ids[0]:
+                raise RecurringWorkflowValidationError("missing usage row")
+            return True
+
+        monkeypatch.setattr(service, "_refresh_managed_bootstrap_target", refresh_target)
+        monkeypatch.setattr(
+            service,
+            "_ensure_schedule_action_current",
+            AsyncMock(),
+        )
+
+        assert await service.refresh_managed_bootstrap_schedules() == 1
+        assert set(visited) == set(definition_ids)
+
+
+async def test_update_definition_rejects_stale_target_version(
+    tmp_path: Path,
+    mock_temporal_adapter,
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        service = RecurringWorkflowsService(
+            session,
+            temporal_client_adapter=mock_temporal_adapter,
+        )
+        original_target = {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {"omnigent": {"launchPolicyRef": "policy@1"}},
+        }
+        current_target = {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {"omnigent": {"launchPolicyRef": "policy@2"}},
+        }
+        definition = await service.create_definition(
+            name="Daily Resolver",
+            description=None,
+            enabled=True,
+            schedule_type="cron",
+            cron="0 13 * * *",
+            timezone="UTC",
+            scope_type="personal",
+            scope_ref=None,
+            owner_user_id=uuid4(),
+            target=original_target,
+            policy={},
+        )
+        definition.target = current_target
+        definition.version = 2
+        await session.commit()
+        mock_temporal_adapter.update_schedule.reset_mock()
+
+        with pytest.raises(RecurringWorkflowConflictError, match="refresh and retry"):
+            await service.update_definition(
+                definition,
+                target=original_target,
+                expected_version=1,
+            )
+
+        assert definition.target == current_target
+        mock_temporal_adapter.update_schedule.assert_not_called()
 
 
 async def test_reconcile_skips_update_when_metadata_and_action_match(


### PR DESCRIPTION
## Summary

- refresh deployment-managed Agent Profile snapshots held by recurring workflow definitions after a built-in launch-policy cutover
- update the Temporal schedule action before committing the corresponding database authority, with idempotent retry through the existing bootstrap reconciler
- generalize managed-bootstrap snapshot refresh for reruns and schedules, and add an escaped-incident replay fixture

## Root cause

Workflow `mm:2d8480da-045c-4569-81b3-5b0b0a0ee9a0-2026-08-19T13:00:00Z` retained Agent Profile v2 selecting `codex-on-demand@3`. Automatic bootstrap reconciliation had advanced the active Agent Profile and durable Omnigent host binding to v3 / `codex-on-demand@4`, but recurring definitions and their Temporal actions were not refreshed. Omnigent therefore correctly failed closed on the conflicting explicit launch selection.

## Validation

- `36 passed` in the focused service, startup-boundary, and incident-replay tests
- `605 passed, 1 skipped` in `tests/integration -m integration_ci`
- Python compile check and staged diff/secret checks passed

The maximum-parallel full unit attempt was not clean across unrelated areas. A serial rerun of the startup file passed 7 tests, including the new boundary test; its 2 remaining failures are existing cleanup-default assertions running under the Compose test environment's explicit `janitor_enabled=False` setting.