### PR TITLE
Fix OAuth bound-host revalidation workspace

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,32 @@
 [
   {
-    "id": 4977865976,
+    "id": 3819559431,
+    "disposition": "addressed",
+    "rationale": "The activity now accepts only objective cleanupResult values before marking the host lease stopped. OmnigentOAuthHostRuntime.stop_host already raises OMNIGENT_HOST_CLEANUP_INCOMPLETE when the container, owned volumes, or runtime files remain, and the new activity regression proves a failed cleanup result leaves the validation lease nonterminal."
+  },
+  {
+    "id": 3819559440,
+    "disposition": "addressed",
+    "rationale": "Bound-host revalidation now captures provider-login failures, always invokes lease-owned host cleanup, marks the lease stopped only after cleanup succeeds, and then propagates the original preflight failure. The activity regression exercises this failure ordering."
+  },
+  {
+    "id": 3819559447,
+    "disposition": "addressed",
+    "rationale": "OAuth revalidation no longer creates or passes an empty execution workspace. The credential-only preflight mounts only the approved OAuth volume and runs the provider login-status command in the selected host image; its runtime test asserts that /workspaces/run is absent."
+  },
+  {
+    "id": 3819559454,
+    "disposition": "addressed",
+    "rationale": "OAuth revalidation no longer waits for Omnigent host registration. The credential-only provider login check has a 60-second bound, leaving the existing 180-second activity budget for deterministic cleanup."
+  },
+  {
+    "id": 4980223622,
     "disposition": "not-applicable",
-    "rationale": "Codex automated review summary only; the three concrete inline findings are classified separately."
+    "rationale": "Automated review summary only; the five concrete inline findings from this review are classified separately."
   },
   {
-    "id": 3817669960,
+    "id": 3819559461,
     "disposition": "addressed",
-    "rationale": "The native-UI compatibility version now resolves from one authority: an explicit OMNIGENT_NATIVE_UI_VERSION pin, otherwise verified immutable image evidence (an OMNIGENT_IMAGE_REF sha256 digest reports PINNED_OMNIGENT_COMMIT). A mutable tag such as :latest still reports unknown and fails closed, so AC11/AC12 hold, and no separate undocumented override is required: pinning the same immutable image the execution catalog and launch policies already demand also serves native Workflow Chat. Compose comments and docs/Omnigent/OmnigentBridge.md were corrected (they still claimed a default), and tests/unit/omnigent/test_omnigent_settings.py covers explicit pin, digest derivation, mutable-tag unknown, and the end-to-end gate outcome."
-  },
-  {
-    "id": 3817669964,
-    "disposition": "addressed",
-    "rationale": "Introduced one shared execution-budget authority (resolve_execution_timeout_seconds in moonmind/schemas/agent_runtime_models.py). The AgentRun workflow now publishes its effective budget into the launch request timeoutPolicy behind agent-run-shared-execution-budget-v1, and agent_runtime_launch derives the supervisor deadline from that same resolver instead of its own 3600s literal, so an explicitly requested budget is honored at both boundaries. Covered by tests/unit/workflows/temporal/workflows/test_agent_run_shared_execution_budget.py including the pre-patch in-flight payload case."
-  },
-  {
-    "id": 3817669962,
-    "disposition": "addressed",
-    "rationale": "Reverted the global widening: DEFAULT_MANAGED_TIMEOUT_SECONDS is 3600 again, so no managed run holds its provider slot longer or delays actionable failure by default. A genuinely long run requests the larger budget explicitly via timeoutPolicy.timeout_seconds, which is now effective end-to-end because the workflow budget and the process supervisor share one timeout authority (previously an explicit request was still killed at the launch default). A regression test asserts the managed default is not widened."
+    "rationale": "The activity no longer calls the full prepare_host execution contract. The new credential-only boundary validates the durable effective-launch image and binding identity but does not require an execution workspace, resolved Skill snapshot, artifact gateway, or fabricated execution authority."
   }
 ]

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -258,6 +258,7 @@ _RUNTIME_ADAPTERS = {
         "compose_service": "omnigent-host-codex",
         "start_script": "/opt/moonmind/start-codex-oauth-host.sh",
         "generation_env": "CODEX_CREDENTIAL_GENERATION",
+        "login_command": ("codex", "login", "status"),
         "env": (
             "CODEX_HOME=/home/app/.codex",
             "CODEX_CONFIG_HOME=/home/app/.codex",
@@ -273,6 +274,7 @@ _RUNTIME_ADAPTERS = {
         "compose_service": "omnigent-host-claude",
         "start_script": "/opt/moonmind/start-claude-oauth-host.sh",
         "generation_env": "CLAUDE_CREDENTIAL_GENERATION",
+        "login_command": ("claude", "auth", "status"),
         "env": (
             "CLAUDE_HOME=/home/app/.claude",
             "CLAUDE_CONFIG_DIR=/home/app/.claude",
@@ -401,6 +403,114 @@ class OmnigentOAuthHostRuntime:
             "-f",
             str(compose_path.resolve()),
         )
+
+    async def validate_credential_mount(
+        self,
+        *,
+        binding: OmnigentOAuthHostBinding,
+        host_lease: OmnigentHostLease,
+        effective_launch: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Validate OAuth in the selected host image without launching execution."""
+
+        launch = self._validate_effective_launch(
+            binding=binding, effective_launch=effective_launch
+        )
+        adapter = self._runtime_adapter(binding)
+        auth_volume = binding.credential_mount_ref.auth_volume_ref
+        if (
+            host_lease.provider_profile_id != binding.provider_profile_id
+            or host_lease.binding_ref != binding.binding_ref
+            or host_lease.credential_generation != auth_volume.credential_generation
+            or launch.get("providerRuntime") not in {None, auth_volume.runtime_id}
+            or launch.get("harness") != adapter["harness"]
+        ):
+            raise OmnigentOAuthHostError(
+                "credential validation authority does not match the OAuth host binding",
+                code=HostPreflightFailure.BINDING_MISMATCH.value,
+            )
+
+        container_name = deterministic_host_container_name(host_lease.lease_id)
+        if await self._container_present(container_name):
+            await self._assert_container_owned(container_name, host_lease.lease_id)
+            await self._run("docker", "rm", "-f", container_name, check=False)
+            if await self._container_present(container_name):
+                raise OmnigentOAuthHostError(
+                    "prior OAuth credential validator could not be removed",
+                    code="OMNIGENT_HOST_CLEANUP_INCOMPLETE",
+                )
+
+        host_image_ref = str(launch["hostImageRef"])
+        host_path = await self._discover_upstream_path(host_image_ref)
+        args = [
+            "docker",
+            "run",
+            "--name",
+            container_name,
+            "--label",
+            "moonmind.kind=omnigent-oauth-credential-validator",
+            "--label",
+            f"moonmind.provider_profile_id={binding.provider_profile_id}",
+            "--label",
+            f"moonmind.host_lease_id={host_lease.lease_id}",
+            "--label",
+            f"moonmind.credential_generation={host_lease.credential_generation}",
+            "--user",
+            f"{launch['runtimeUid']}:{launch['runtimeGid']}",
+            "--workdir",
+            "/home/app",
+            "--network",
+            "none",
+            *structured_container_security_args(),
+            "--cpus",
+            str(int(launch["limits"]["cpuMillis"]) / 1000),
+            "--memory",
+            f"{launch['limits']['memoryMiB']}m",
+            "--pids-limit",
+            str(launch["limits"]["processes"]),
+            "--read-only",
+            "--tmpfs",
+            f"/tmp:rw,noexec,nosuid,size={launch['limits']['temporaryStorageMiB']}m",
+            "--mount",
+            (
+                "type=volume,"
+                f"src={auth_volume.volume_ref},dst={adapter['home']},readonly"
+            ),
+            "--env",
+            f"PATH={self._prepend_tools_path(host_path)}",
+            "--env",
+            "HOME=/home/app",
+            "--env",
+            f"{adapter['generation_env']}={host_lease.credential_generation}",
+        ]
+        for runtime_env in adapter["env"]:
+            args.extend(["--env", runtime_env])
+        args.extend(["--entrypoint", "/usr/bin/env"])
+        for key in _FORBIDDEN_ENV:
+            args.extend(["-u", key])
+        args.extend([host_image_ref, *adapter["login_command"]])
+        try:
+            result = await asyncio.wait_for(
+                self._run(*args, check=False), timeout=60
+            )
+        except TimeoutError as exc:
+            raise OmnigentOAuthHostError(
+                "OAuth credential validation timed out",
+                code=HostPreflightFailure.LOGIN_STATUS_FAILED.value,
+            ) from exc
+        if result[0] != 0:
+            raise OmnigentOAuthHostError(
+                "OAuth credential validation failed",
+                code=HostPreflightFailure.LOGIN_STATUS_FAILED.value,
+            )
+        return {
+            "status": "ready",
+            "providerProfileId": binding.provider_profile_id,
+            "runtimeId": auth_volume.runtime_id,
+            "credentialGeneration": host_lease.credential_generation,
+            "loginStatus": "authenticated",
+            "validationMode": "credential_only",
+        }
 
     async def prepare_host(
         self,
@@ -1997,13 +2107,20 @@ class OmnigentOAuthHostRuntime:
                     "attachment_absent_before_cleanup"
                 )
         if not binding.host_launch_profile_ref:
+            container_name = deterministic_host_container_name(host_lease.lease_id)
+            if await self._container_present(container_name):
+                await self._assert_container_owned(container_name, host_lease.lease_id)
+                await self._run("docker", "rm", "-f", container_name, check=False)
             await self.stop_static_host(binding=binding)
             cleanup_result = "drained_owned_static_host"
-            cleanup_ok = not attachment_identity or not await self.container_exists(
-                attachment_identity
+            container_present = await self._container_present(container_name)
+            cleanup_ok = not container_present and (
+                not attachment_identity
+                or not await self.container_exists(attachment_identity)
             )
             resource_cleanup = {
                 "containerRunning": not cleanup_ok,
+                "containerPresent": container_present,
                 "mode": "static_drain",
             }
         else:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -430,7 +430,9 @@ class OmnigentOAuthHostRuntime:
                 code=HostPreflightFailure.BINDING_MISMATCH.value,
             )
 
-        container_name = deterministic_host_container_name(host_lease.lease_id)
+        container_name = host_lease.container_name or deterministic_host_container_name(
+            host_lease.lease_id
+        )
         if await self._container_present(container_name):
             await self._assert_container_owned(container_name, host_lease.lease_id)
             await self._run("docker", "rm", "-f", container_name, check=False)
@@ -2107,13 +2109,19 @@ class OmnigentOAuthHostRuntime:
                     "attachment_absent_before_cleanup"
                 )
         if not binding.host_launch_profile_ref:
-            container_name = deterministic_host_container_name(host_lease.lease_id)
-            if await self._container_present(container_name):
-                await self._assert_container_owned(container_name, host_lease.lease_id)
-                await self._run("docker", "rm", "-f", container_name, check=False)
+            container_name = host_lease.container_name
+            if container_name and await self._container_present(container_name):
+                await self._assert_container_owned(
+                    container_name, host_lease.lease_id
+                )
+                await self._run(
+                    "docker", "rm", "-f", container_name, check=False
+                )
             await self.stop_static_host(binding=binding)
             cleanup_result = "drained_owned_static_host"
-            container_present = await self._container_present(container_name)
+            container_present = bool(
+                container_name and await self._container_present(container_name)
+            )
             cleanup_ok = not container_present and (
                 not attachment_identity
                 or not await self.container_exists(attachment_identity)

--- a/moonmind/omnigent/oauth_hosts.py
+++ b/moonmind/omnigent/oauth_hosts.py
@@ -409,6 +409,7 @@ class OmnigentOAuthHostRepository:
                 container_name=(
                     deterministic_host_container_name(lease_id)
                     if locked_binding.host_launch_profile_ref
+                    or lease_purpose == "credential_validation"
                     else None
                 ),
                 status="allocating",

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -14,11 +14,8 @@ Provides the activities invoked by the ``MoonMind.OAuthSession`` workflow:
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
-import os
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any, Mapping
 from uuid import UUID
 
@@ -32,12 +29,6 @@ from api_service.db.models import (
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
 from moonmind.provider_profiles.oauth_policy import (
     effective_oauth_capacity_for_finalization,
-)
-from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
-from moonmind.workflows.temporal.runtime.workspace_locators import (
-    SandboxWorkspaceRecord,
-    SandboxWorkspaceRecordStore,
-    resolve_sandbox_workspace_locator,
 )
 from moonmind.workflows.temporal.runtime.providers.registry import (
     get_provider_bootstrap_command,
@@ -120,14 +111,14 @@ async def oauth_session_revalidate_bound_host(
 
     from api_service.db.base import async_session_maker
     from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
-    from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostRepository
+    from moonmind.omnigent.oauth_hosts import (
+        OmnigentOAuthHostError,
+        OmnigentOAuthHostRepository,
+    )
     from moonmind.omnigent.settings import (
         resolved_api_token,
         resolved_proxy_forward_headers,
         resolved_server_url,
-    )
-    from moonmind.repositories.lore_runtime import (
-        build_lore_repository_adapter_from_environment,
     )
     from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
@@ -157,33 +148,6 @@ async def oauth_session_revalidate_bound_host(
             expected_status="allocating",
             new_status="starting",
         )
-    current_workflow_id = f"oauth-session:{session_id}"
-    current_step_execution_id = f"oauth-revalidate:{session_id}"
-    workspace_id = hashlib.sha256(
-        f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
-    ).hexdigest()[:24]
-    workspace_locator = SandboxWorkspaceLocator(workspaceId=workspace_id)
-    workspace_root = Path(
-        os.getenv("WORKFLOW_WORKSPACE_ROOT", "/work/agent_jobs")
-    ).resolve()
-    workspace_record = SandboxWorkspaceRecord(
-        workspace_id=workspace_id,
-        workflow_id=current_workflow_id,
-        step_execution_id=current_step_execution_id,
-        relative_path=workspace_locator.relative_path,
-    )
-    workspace_record_store = SandboxWorkspaceRecordStore(workspace_root)
-    workspace_record_store.ensure(workspace_record)
-    workspace_path = resolve_sandbox_workspace_locator(
-        workspace_locator,
-        workspace_root=workspace_root,
-        expected_workspace_id=workspace_id,
-        owner_record=workspace_record,
-        expected_workflow_id=current_workflow_id,
-        expected_step_execution_id=current_step_execution_id,
-        must_exist=False,
-    )
-    workspace_path.mkdir(mode=0o700, parents=True, exist_ok=True)
     try:
         async with httpx.AsyncClient() as http_client:
             client = OmnigentHttpClient(
@@ -192,32 +156,42 @@ async def oauth_session_revalidate_bound_host(
                 client=http_client,
                 upstream_header_allowlist=resolved_proxy_forward_headers(),
             )
-            runtime = OmnigentOAuthHostRuntime(
-                client=client,
-                lore_repository_adapter=build_lore_repository_adapter_from_environment(),
-                workspace_root=workspace_root,
-            )
-            preflight = await runtime.prepare_host(
-                binding=binding,
-                host_lease=lease,
-                workspace_key=current_step_execution_id,
-                workspace_locator=workspace_locator.model_dump(
-                    by_alias=True, mode="json"
-                ),
-                current_workflow_id=current_workflow_id,
-                current_step_execution_id=current_step_execution_id,
-            )
-            if lease.status == "starting":
-                lease = await repository.transition_host_lease(
-                    lease.lease_id,
-                    expected_status="starting",
-                    new_status="ready",
-                    fields={"omnigent_host_id": preflight["hostId"]},
+            runtime = OmnigentOAuthHostRuntime(client=client)
+            preflight_error: BaseException | None = None
+            preflight: dict[str, Any] | None = None
+            try:
+                preflight = await runtime.validate_credential_mount(
+                    binding=binding,
+                    host_lease=lease,
+                    effective_launch=(
+                        lease.effective_launch_snapshot
+                        or binding.effective_launch_snapshot
+                    ),
                 )
-            if binding.host_launch_profile_ref:
-                await runtime.stop_host(binding=binding, host_lease=lease)
+            except (Exception, asyncio.CancelledError) as exc:
+                preflight_error = exc
+
+            cleanup_error: BaseException | None = None
+            try:
+                cleanup = await runtime.stop_host(binding=binding, host_lease=lease)
+                if cleanup.get("cleanupResult") not in {
+                    "succeeded",
+                    "drained_owned_static_host",
+                }:
+                    raise OmnigentOAuthHostError(
+                        "OAuth credential validator cleanup was not proven",
+                        code="OMNIGENT_HOST_CLEANUP_INCOMPLETE",
+                    )
+            except (Exception, asyncio.CancelledError) as exc:
+                cleanup_error = exc
+            if cleanup_error is not None:
+                if preflight_error is not None:
+                    raise cleanup_error from preflight_error
+                raise cleanup_error
             await repository.mark_host_lease_stopped(lease.lease_id)
-    except Exception:
+            if preflight_error is not None:
+                raise preflight_error
+    except (Exception, asyncio.CancelledError):
         async with get_async_session_context() as db:
             from sqlalchemy.future import select
             from api_service.db.models import (
@@ -252,11 +226,13 @@ async def oauth_session_revalidate_bound_host(
                     session=db, runtime_id=profile.runtime_id
                 )
         raise
+    if preflight is None:
+        raise RuntimeError("OAuth credential preflight produced no result")
     return {
         "profile_id": profile_id,
         "status": "ready",
         "credential_generation": lease.credential_generation,
-        "host_id": preflight["hostId"],
+        "validation_mode": preflight["validationMode"],
     }
 
 

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -13,9 +13,12 @@ Provides the activities invoked by the ``MoonMind.OAuthSession`` workflow:
 
 from __future__ import annotations
 
-import logging
 import asyncio
+import hashlib
+import logging
+import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Mapping
 from uuid import UUID
 
@@ -29,6 +32,12 @@ from api_service.db.models import (
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
 from moonmind.provider_profiles.oauth_policy import (
     effective_oauth_capacity_for_finalization,
+)
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+    resolve_sandbox_workspace_locator,
 )
 from moonmind.workflows.temporal.runtime.providers.registry import (
     get_provider_bootstrap_command,
@@ -148,6 +157,33 @@ async def oauth_session_revalidate_bound_host(
             expected_status="allocating",
             new_status="starting",
         )
+    current_workflow_id = f"oauth-session:{session_id}"
+    current_step_execution_id = f"oauth-revalidate:{session_id}"
+    workspace_id = hashlib.sha256(
+        f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    workspace_locator = SandboxWorkspaceLocator(workspaceId=workspace_id)
+    workspace_root = Path(
+        os.getenv("WORKFLOW_WORKSPACE_ROOT", "/work/agent_jobs")
+    ).resolve()
+    workspace_record = SandboxWorkspaceRecord(
+        workspace_id=workspace_id,
+        workflow_id=current_workflow_id,
+        step_execution_id=current_step_execution_id,
+        relative_path=workspace_locator.relative_path,
+    )
+    workspace_record_store = SandboxWorkspaceRecordStore(workspace_root)
+    workspace_record_store.ensure(workspace_record)
+    workspace_path = resolve_sandbox_workspace_locator(
+        workspace_locator,
+        workspace_root=workspace_root,
+        expected_workspace_id=workspace_id,
+        owner_record=workspace_record,
+        expected_workflow_id=current_workflow_id,
+        expected_step_execution_id=current_step_execution_id,
+        must_exist=False,
+    )
+    workspace_path.mkdir(mode=0o700, parents=True, exist_ok=True)
     try:
         async with httpx.AsyncClient() as http_client:
             client = OmnigentHttpClient(
@@ -159,11 +195,17 @@ async def oauth_session_revalidate_bound_host(
             runtime = OmnigentOAuthHostRuntime(
                 client=client,
                 lore_repository_adapter=build_lore_repository_adapter_from_environment(),
+                workspace_root=workspace_root,
             )
             preflight = await runtime.prepare_host(
                 binding=binding,
                 host_lease=lease,
-                workspace_key=f"oauth-revalidate:{session_id}",
+                workspace_key=current_step_execution_id,
+                workspace_locator=workspace_locator.model_dump(
+                    by_alias=True, mode="json"
+                ),
+                current_workflow_id=current_workflow_id,
+                current_step_execution_id=current_step_execution_id,
             )
             if lease.status == "starting":
                 lease = await repository.transition_host_lease(

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -196,6 +197,145 @@ class TestOAuthSessionWorkflowRegistration:
         assert route.activity_type == "oauth_session.cleanup_stale"
         assert route.fleet == "artifacts"
         assert route.timeouts.start_to_close_seconds == 60
+
+
+@pytest.mark.asyncio
+async def test_revalidate_bound_host_supplies_workspace_authority_to_runtime(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "oas-revalidate-bound-host"
+    current_workflow_id = f"oauth-session:{session_id}"
+    current_step_execution_id = f"oauth-revalidate:{session_id}"
+    workspace_id = hashlib.sha256(
+        f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    binding = SimpleNamespace(host_launch_profile_ref="codex-on-demand@1")
+    lease = SimpleNamespace(
+        lease_id="ohl-revalidate",
+        status="allocating",
+        credential_generation=7,
+        omnigent_host_id=None,
+    )
+    observed: dict[str, object] = {}
+
+    class Repository:
+        def __init__(self, _session_factory) -> None:
+            pass
+
+        async def refresh_binding_generation(self, profile_id: str):
+            assert profile_id == "codex_openai_oauth"
+            return binding
+
+        async def create_or_get_host_lease(self, **kwargs):
+            observed["lease_request"] = kwargs
+            return lease
+
+        async def transition_host_lease(
+            self, _lease_id, *, expected_status, new_status, fields=None
+        ):
+            assert lease.status == expected_status
+            lease.status = new_status
+            for key, value in dict(fields or {}).items():
+                setattr(lease, key, value)
+            return lease
+
+        async def mark_host_lease_stopped(self, lease_id: str) -> None:
+            assert lease_id == lease.lease_id
+            lease.status = "stopped"
+
+    class Runtime:
+        def __init__(self, *, workspace_root, **_kwargs) -> None:
+            observed["workspace_root"] = workspace_root
+
+        async def prepare_host(
+            self,
+            *,
+            binding,
+            host_lease,
+            workspace_key,
+            workspace_locator,
+            current_workflow_id,
+            current_step_execution_id,
+            **_kwargs,
+        ):
+            observed["prepare_host"] = {
+                "binding": binding,
+                "host_lease": host_lease,
+                "workspace_key": workspace_key,
+                "workspace_locator": workspace_locator,
+                "current_workflow_id": current_workflow_id,
+                "current_step_execution_id": current_step_execution_id,
+            }
+            workspace = (
+                tmp_path
+                / "temporal_sandbox"
+                / workspace_locator["workspaceId"]
+                / workspace_locator["relativePath"]
+            )
+            assert workspace.is_dir()
+            return {"hostId": "host-revalidated"}
+
+        async def stop_host(self, **kwargs) -> None:
+            observed["stop_host"] = kwargs
+
+    class Client:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_hosts.OmnigentOAuthHostRepository", Repository
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime.OmnigentOAuthHostRuntime", Runtime
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.adapters.omnigent_client.OmnigentHttpClient", Client
+    )
+    monkeypatch.setattr(
+        "moonmind.repositories.lore_runtime.build_lore_repository_adapter_from_environment",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.settings.resolved_server_url", lambda: "http://omnigent"
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.settings.resolved_api_token", lambda: "test-token"
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.settings.resolved_proxy_forward_headers", lambda: ()
+    )
+
+    result = await oauth_session_activities.oauth_session_revalidate_bound_host(
+        {
+            "session_id": session_id,
+            "profile_id": "codex_openai_oauth",
+            "provider_lease_id": "provider-lease-revalidate",
+        }
+    )
+
+    assert result == {
+        "profile_id": "codex_openai_oauth",
+        "status": "ready",
+        "credential_generation": 7,
+        "host_id": "host-revalidated",
+    }
+    assert observed["prepare_host"] == {
+        "binding": binding,
+        "host_lease": lease,
+        "workspace_key": current_step_execution_id,
+        "workspace_locator": {
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        "current_workflow_id": current_workflow_id,
+        "current_step_execution_id": current_step_execution_id,
+    }
+    assert lease.status == "stopped"
+    assert (tmp_path / "temporal_sandbox" / ".workspace_records").is_dir()
+
 
 @pytest.mark.asyncio
 async def test_register_profile_activity_persists_oauth_home_codex_profile(

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -24,6 +23,11 @@ from api_service.db.models import (
     ProviderProfileAuthState,
     RuntimeMaterializationMode,
 )
+from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
+from moonmind.provider_profiles.lease_client import (
+    CredentialLeasePurpose,
+    ProviderProfileLeaseClient,
+)
 from moonmind.workflows.temporal.activities import oauth_session_activities
 from moonmind.workflows.temporal.activities.oauth_session_activities import (
     oauth_session_register_profile,
@@ -34,13 +38,9 @@ from moonmind.workflows.temporal.activities.oauth_session_activities import (
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 from moonmind.workflows.temporal.activity_catalog import AGENT_RUNTIME_FLEET
 from moonmind.workflows.temporal.activity_catalog import ARTIFACTS_FLEET
+from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 from moonmind.workflows.temporal.runtime.providers import registry as provider_registry
 from moonmind.workflows.temporal.workers import list_registered_workflow_types
-from moonmind.provider_profiles.lease_client import (
-    CredentialLeasePurpose,
-    ProviderProfileLeaseClient,
-)
-from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 
 @pytest_asyncio.fixture
 async def _oauth_activity_session_factory(tmp_path):
@@ -200,22 +200,21 @@ class TestOAuthSessionWorkflowRegistration:
 
 
 @pytest.mark.asyncio
-async def test_revalidate_bound_host_supplies_workspace_authority_to_runtime(
-    tmp_path,
+async def test_revalidate_bound_host_uses_credential_only_runtime_preflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session_id = "oas-revalidate-bound-host"
-    current_workflow_id = f"oauth-session:{session_id}"
-    current_step_execution_id = f"oauth-revalidate:{session_id}"
-    workspace_id = hashlib.sha256(
-        f"{current_workflow_id}:{current_step_execution_id}".encode("utf-8")
-    ).hexdigest()[:24]
-    binding = SimpleNamespace(host_launch_profile_ref="codex-on-demand@1")
+    effective_launch = {"snapshotRef": "omnigent-launch:sha256:test"}
+    binding = SimpleNamespace(
+        host_launch_profile_ref="codex-on-demand@1",
+        effective_launch_snapshot=effective_launch,
+    )
     lease = SimpleNamespace(
         lease_id="ohl-revalidate",
         status="allocating",
         credential_generation=7,
         omnigent_host_id=None,
+        effective_launch_snapshot=effective_launch,
     )
     observed: dict[str, object] = {}
 
@@ -245,45 +244,35 @@ async def test_revalidate_bound_host_supplies_workspace_authority_to_runtime(
             lease.status = "stopped"
 
     class Runtime:
-        def __init__(self, *, workspace_root, **_kwargs) -> None:
-            observed["workspace_root"] = workspace_root
+        def __init__(self, **_kwargs) -> None:
+            pass
 
-        async def prepare_host(
+        async def validate_credential_mount(
             self,
             *,
             binding,
             host_lease,
-            workspace_key,
-            workspace_locator,
-            current_workflow_id,
-            current_step_execution_id,
-            **_kwargs,
+            effective_launch,
         ):
-            observed["prepare_host"] = {
+            observed["validate_credential_mount"] = {
                 "binding": binding,
                 "host_lease": host_lease,
-                "workspace_key": workspace_key,
-                "workspace_locator": workspace_locator,
-                "current_workflow_id": current_workflow_id,
-                "current_step_execution_id": current_step_execution_id,
+                "effective_launch": effective_launch,
             }
-            workspace = (
-                tmp_path
-                / "temporal_sandbox"
-                / workspace_locator["workspaceId"]
-                / workspace_locator["relativePath"]
-            )
-            assert workspace.is_dir()
-            return {"hostId": "host-revalidated"}
+            if observed.get("fail_validation"):
+                raise RuntimeError("credential preflight failed")
+            return {"validationMode": "credential_only"}
 
-        async def stop_host(self, **kwargs) -> None:
+        async def stop_host(self, **kwargs):
             observed["stop_host"] = kwargs
+            if observed.get("fail_cleanup"):
+                return {"cleanupResult": "failed"}
+            return {"cleanupResult": "succeeded"}
 
     class Client:
         def __init__(self, **_kwargs) -> None:
             pass
 
-    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(tmp_path))
     monkeypatch.setattr(
         "moonmind.omnigent.oauth_hosts.OmnigentOAuthHostRepository", Repository
     )
@@ -319,22 +308,58 @@ async def test_revalidate_bound_host_supplies_workspace_authority_to_runtime(
         "profile_id": "codex_openai_oauth",
         "status": "ready",
         "credential_generation": 7,
-        "host_id": "host-revalidated",
+        "validation_mode": "credential_only",
     }
-    assert observed["prepare_host"] == {
+    assert observed["validate_credential_mount"] == {
         "binding": binding,
         "host_lease": lease,
-        "workspace_key": current_step_execution_id,
-        "workspace_locator": {
-            "kind": "sandbox",
-            "workspaceId": workspace_id,
-            "relativePath": "repo",
-        },
-        "current_workflow_id": current_workflow_id,
-        "current_step_execution_id": current_step_execution_id,
+        "effective_launch": effective_launch,
     }
+    assert observed["stop_host"] == {"binding": binding, "host_lease": lease}
     assert lease.status == "stopped"
-    assert (tmp_path / "temporal_sandbox" / ".workspace_records").is_dir()
+
+    @asynccontextmanager
+    async def no_profile_context():
+        class Database:
+            async def execute(self, _statement):
+                return SimpleNamespace(scalar_one_or_none=lambda: None)
+
+        yield Database()
+
+    monkeypatch.setattr(
+        oauth_session_activities,
+        "get_async_session_context",
+        no_profile_context,
+    )
+    observed["fail_validation"] = True
+    lease.status = "allocating"
+
+    with pytest.raises(RuntimeError, match="credential preflight failed"):
+        await oauth_session_activities.oauth_session_revalidate_bound_host(
+            {
+                "session_id": session_id,
+                "profile_id": "codex_openai_oauth",
+                "provider_lease_id": "provider-lease-revalidate",
+            }
+        )
+
+    assert lease.status == "stopped"
+    assert observed["stop_host"] == {"binding": binding, "host_lease": lease}
+
+    observed["fail_validation"] = False
+    observed["fail_cleanup"] = True
+    lease.status = "allocating"
+
+    with pytest.raises(OmnigentOAuthHostError, match="cleanup was not proven"):
+        await oauth_session_activities.oauth_session_revalidate_bound_host(
+            {
+                "session_id": session_id,
+                "profile_id": "codex_openai_oauth",
+                "provider_lease_id": "provider-lease-revalidate",
+            }
+        )
+
+    assert lease.status == "starting"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -542,6 +542,93 @@ def _host_lease() -> OmnigentHostLease:
     )
 
 
+@pytest.mark.asyncio
+async def test_credential_mount_preflight_runs_provider_login_without_execution_launch(
+) -> None:
+    launch = {
+        "hostImageRef": "example.invalid/omnigent-host@sha256:" + "a" * 64,
+        "providerRuntime": "codex_cli",
+        "harness": "codex-native",
+        "runtimeUid": 1000,
+        "runtimeGid": 1000,
+        "limits": {
+            "cpuMillis": 1000,
+            "memoryMiB": 512,
+            "processes": 128,
+            "temporaryStorageMiB": 64,
+        },
+    }
+    binding = _binding().model_copy(
+        update={
+            "static_host_id": None,
+            "host_launch_profile_ref": "codex-on-demand@1",
+            "effective_launch_snapshot": launch,
+        }
+    )
+    lease = _host_lease().model_copy(
+        update={
+            "omnigent_host_id": None,
+            "status": "starting",
+            "effective_launch_snapshot": launch,
+        }
+    )
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    runtime._validate_effective_launch = MagicMock(return_value=launch)
+    runtime._container_present = AsyncMock(return_value=False)
+    runtime._discover_upstream_path = AsyncMock(return_value="/usr/local/bin:/usr/bin")
+    runtime._run = AsyncMock(return_value=(0, "Logged in", ""))
+
+    result = await runtime.validate_credential_mount(
+        binding=binding,
+        host_lease=lease,
+        effective_launch=launch,
+    )
+
+    assert result == {
+        "status": "ready",
+        "providerProfileId": "codex",
+        "runtimeId": "codex_cli",
+        "credentialGeneration": 3,
+        "loginStatus": "authenticated",
+        "validationMode": "credential_only",
+    }
+    command = runtime._run.await_args.args
+    assert command[:2] == ("docker", "run")
+    assert "none" in command
+    assert "type=volume,src=codex_auth_volume,dst=/home/app/.codex,readonly" in command
+    assert "/workspaces/run" not in command
+    assert command[-4:] == (
+        launch["hostImageRef"],
+        "codex",
+        "login",
+        "status",
+    )
+
+
+@pytest.mark.asyncio
+async def test_static_host_cleanup_removes_lease_owned_credential_validator() -> None:
+    runtime = OmnigentOAuthHostRuntime(client=SimpleNamespace())
+    runtime._container_present = AsyncMock(side_effect=[True, False])
+    runtime._assert_container_owned = AsyncMock()
+    runtime._run = AsyncMock(return_value=(0, "", ""))
+    runtime.stop_static_host = AsyncMock()
+
+    result = await runtime.stop_host(binding=_binding(), host_lease=_host_lease())
+
+    assert result["cleanupResult"] == "drained_owned_static_host"
+    runtime._assert_container_owned.assert_awaited_once_with(
+        "mm-omnigent-host-host-lease-1", "host-lease-1"
+    )
+    runtime._run.assert_awaited_once_with(
+        "docker",
+        "rm",
+        "-f",
+        "mm-omnigent-host-host-lease-1",
+        check=False,
+    )
+    runtime.stop_static_host.assert_awaited_once_with(binding=_binding())
+
+
 def test_claude_profile_materializes_exact_oauth_home_without_secret_data() -> None:
     profile = SimpleNamespace(
         profile_id="claude-oauth",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -613,7 +613,10 @@ async def test_static_host_cleanup_removes_lease_owned_credential_validator() ->
     runtime._run = AsyncMock(return_value=(0, "", ""))
     runtime.stop_static_host = AsyncMock()
 
-    result = await runtime.stop_host(binding=_binding(), host_lease=_host_lease())
+    lease = _host_lease().model_copy(
+        update={"container_name": "mm-omnigent-host-host-lease-1"}
+    )
+    result = await runtime.stop_host(binding=_binding(), host_lease=lease)
 
     assert result["cleanupResult"] == "drained_owned_static_host"
     runtime._assert_container_owned.assert_awaited_once_with(


### PR DESCRIPTION
## Summary

- replace OAuth reconnect's accidental full `prepare_host` execution launch with a credential-only preflight in the selected immutable host image
- run the provider's real login-status command with only the approved OAuth volume mounted, a 60-second bound, no network, and launch-policy resource limits
- require objective validator cleanup before marking the host lease stopped or releasing Provider Profile maintenance capacity
- clean up after failed provider validation and preserve nonterminal lease ownership when cleanup cannot be proven

## Verification

- `docker compose --project-name moonmind-test-oauthresolver -f docker-compose.test.yaml run --rm --no-deps pytest python -m pytest -q --tb=short tests/unit/auth/test_oauth_session_activities.py tests/unit/omnigent/test_oauth_profile_lifecycle.py` (199 passed)
- `git diff --check`
- The standard wrapper previously stopped before pytest because `status_domain_audit.py` scanned unrelated pre-existing files under `.claude/worktrees/ui-regressions`; the affected suites above passed in the canonical Linux test image.