### PR TITLE
Bind native Workflow Chat acceptance evidence to every claimed support combination (MoonLadderStudios/MoonMind#3642)

### DIFF
--- a/.github/workflows/omnigent-live-conformance.yml
+++ b/.github/workflows/omnigent-live-conformance.yml
@@ -96,6 +96,7 @@ jobs:
           MOONMIND_OMNIGENT_TEST_BRANCH: ${{ vars.MOONMIND_OMNIGENT_TEST_BRANCH }}
           MOONMIND_OMNIGENT_BROWSER_STORAGE_STATE: ${{ runner.temp }}/moonmind-browser-state.json
           MOONMIND_OMNIGENT_ACCEPTANCE_CANARY_TOKEN: ${{ secrets.MOONMIND_OMNIGENT_ACCEPTANCE_CANARY_TOKEN }}
+          MOONMIND_OMNIGENT_WORKFLOW_CHAT_SUPERSEDED_REPORT: ${{ vars.MOONMIND_OMNIGENT_WORKFLOW_CHAT_SUPERSEDED_REPORT }}
         run: |
           python tools/run_omnigent_live_conformance.py \
             --mode "${{ matrix.mode }}" \
@@ -250,6 +251,22 @@ jobs:
               evidence_root=workflow_chat_path.parent,
               expected_commit=os.environ["GITHUB_SHA"],
           )
+          # #3712 retirement guards consume the acceptance report directly:
+          # the criterion is derived from the manifest, never asserted by hand.
+          from moonmind.omnigent.legacy_retirement import (
+              RetirementCriterion,
+              criteria_from_native_chat_acceptance,
+          )
+          native_chat_criteria = criteria_from_native_chat_acceptance(
+              workflow_chat,
+              evidence_root=workflow_chat_path.parent,
+              expected_commit=os.environ["GITHUB_SHA"],
+          )
+          if RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED not in native_chat_criteria:
+              raise SystemExit(
+                  "native Workflow Chat acceptance evidence does not satisfy its "
+                  "retirement criterion"
+              )
           authority_fields = {
               "authoredWorkflowRef", "taskInputSnapshotRef", "compiledRuntimeRequestRef",
               "executionProfileRef", "launchPolicyRef", "effectiveLaunchSnapshotRef",
@@ -411,6 +428,10 @@ jobs:
               "browserRows": rows,
               "cumulativeRemediationEvidence": str(cumulative_paths[0].relative_to(root)),
               "nativeWorkflowChatEvidence": str(workflow_chat_path.relative_to(root)),
+              "nativeWorkflowChatCombinations": sorted(workflow_chat["combinations"]),
+              "nativeWorkflowChatRetirementCriteria": sorted(
+                  criterion.value for criterion in native_chat_criteria
+              ),
               "productSchemaVersions": product["schemaVersions"],
               "selection": selection,
               "executionProfileRef": acceptance["executionProfileRef"],

--- a/.github/workflows/omnigent-live-conformance.yml
+++ b/.github/workflows/omnigent-live-conformance.yml
@@ -13,6 +13,10 @@ on:
         description: "Optional digest-pinned stock Omnigent host image override"
         required: false
         type: string
+      opencode_host_image:
+        description: "Optional digest-pinned dedicated OpenCode host image override"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -61,9 +65,12 @@ jobs:
           DISPATCH_HOST_IMAGE: ${{ inputs.host_image }}
           DEFAULT_SERVER_IMAGE: ${{ vars.OMNIGENT_CONFORMANCE_SERVER_IMAGE }}
           DEFAULT_HOST_IMAGE: ${{ vars.OMNIGENT_CONFORMANCE_HOST_IMAGE }}
+          DISPATCH_OPENCODE_HOST_IMAGE: ${{ inputs.opencode_host_image }}
+          DEFAULT_OPENCODE_HOST_IMAGE: ${{ vars.OMNIGENT_CONFORMANCE_OPENCODE_HOST_IMAGE }}
         run: |
           server_image="${DISPATCH_SERVER_IMAGE:-$DEFAULT_SERVER_IMAGE}"
           host_image="${DISPATCH_HOST_IMAGE:-$DEFAULT_HOST_IMAGE}"
+          opencode_host_image="${DISPATCH_OPENCODE_HOST_IMAGE:-$DEFAULT_OPENCODE_HOST_IMAGE}"
           if [[ ! "$server_image" =~ @sha256:[0-9a-fA-F]{64}$ ]]; then
             echo "::error::The Omnigent server image must be configured by immutable digest"
             exit 1
@@ -72,8 +79,18 @@ jobs:
             echo "::error::The Omnigent host image must be configured by immutable digest"
             exit 1
           fi
+          # The OpenCode combination runs the dedicated OpenCode host image, so
+          # workflow_chat cannot be qualified by the Codex host digest alone.
+          # Any configured value must be digest-pinned in every mode.
+          if [[ "${{ matrix.mode }}" == "workflow_chat" || -n "$opencode_host_image" ]]; then
+            if [[ ! "$opencode_host_image" =~ @sha256:[0-9a-fA-F]{64}$ ]]; then
+              echo "::error::The dedicated OpenCode host image must be configured by immutable digest"
+              exit 1
+            fi
+          fi
           echo "server=$server_image" >> "$GITHUB_OUTPUT"
           echo "host=$host_image" >> "$GITHUB_OUTPUT"
+          echo "opencode_host=$opencode_host_image" >> "$GITHUB_OUTPUT"
       - name: Record case start
         id: case_start
         shell: bash
@@ -102,6 +119,7 @@ jobs:
             --mode "${{ matrix.mode }}" \
             --server-image "${{ steps.images.outputs.server }}" \
             --host-image "${{ steps.images.outputs.host }}" \
+            --opencode-host-image "${{ steps.images.outputs.opencode_host }}" \
             --source-commit "${{ github.sha }}" \
             --output-dir "artifacts/omnigent-conformance/live/${{ matrix.mode }}"
       - name: Stage secret-safe case evidence

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,336 +1,57 @@
 [
   {
-    "id": 3813108025,
+    "id": 3828381449,
     "disposition": "addressed",
-    "rationale": "Added Protocol stub comment to ReconcileDispatcher.request_reconcile ellipsis (line 107) to clarify it is an intentional interface stub, not a no-effect statement."
+    "rationale": "Added a distinct digest-pinned --opencode-host-image input, exported OMNIGENT_OPENCODE_HOST_IMAGE_REF for the run, gave each combination a code-owned host_image_key, and required every claimed combination to publish hostImageRef equal to that pinned images entry."
   },
   {
-    "id": 3813108036,
+    "id": 3828381452,
     "disposition": "addressed",
-    "rationale": "Added Protocol stub comment to DiagnosticPublisher.publish ellipsis (line 119) for same reason."
+    "rationale": "Cleanup expectations are now derived from the launch policy cleanup mode: remove requires live_host_stopped with liveResourcesRemoved true, drain requires live_host_drained with liveResourcesRemoved false, at both the cleanupReceipt and manifest cleanupOutcome gates."
   },
   {
-    "id": 3813108054,
+    "id": 3828381455,
     "disposition": "addressed",
-    "rationale": "Added explanatory comment to empty except in bridge_proxy._metric_increment: telemetry failures are auxiliary and must not affect lifecycle authority."
+    "rationale": "The cleanup receipt now compares the ordered step list directly against the combination's required step tuple instead of comparing sets with a release-last check."
   },
   {
-    "id": 3813108065,
+    "id": 3828381462,
     "disposition": "addressed",
-    "rationale": "Added explanatory comment to empty except in bridge_proxy._metric_observe for same telemetry rationale."
+    "rationale": "Report cases must now equal the code-owned workflow_chat_case_id set for the combination's four rows and reference exactly that row's evidence refs; passed must equal the row count and skipped must be zero."
   },
   {
-    "id": 3813108078,
+    "id": 3828381466,
     "disposition": "addressed",
-    "rationale": "Added missing comment to second worker readiness except in omnigent_catalog._live_deployment_readiness: readiness is fail-closed, malformed worker metadata must not advertise launch authority."
+    "rationale": "action() takes a log_id and the workflow_chat controller passes the combination id, so each combination retains its own workflow_chat-<row>-<combination>.log."
   },
   {
-    "id": 3813108087,
+    "id": 3828381471,
     "disposition": "addressed",
-    "rationale": "Added comment to empty except in omnigent_catalog protected evidence observe: telemetry failures must not affect lifecycle authority."
+    "rationale": "providerProfileClass is now pinned by the claimed combination inventory (with the credential materializer ref required in bindingIdentity.materializerRefs), so evidence collected under one credential/provider authority class cannot qualify another."
   },
   {
-    "id": 3813108094,
+    "id": 3828381477,
     "disposition": "addressed",
-    "rationale": "Added comment to empty except in repositories SessionRepository.mark_terminal latency observe; telemetry failures are ignored."
+    "rationale": "executionCreation is cross-checked against the matching browser trace event's method and normalized path before created_through_public_executions_api is derived."
   },
   {
-    "id": 3813108101,
+    "id": 3828381485,
     "disposition": "addressed",
-    "rationale": "Added comment to empty except in repositories ObservationRepository schema value increment; telemetry failures are ignored."
+    "rationale": "Denied capability enforcement observations are propagated into expected_denial_statuses, and the unit fixture now uses an independent enforcement request id instead of reusing one from denialAudit."
   },
   {
-    "id": 3813108115,
-    "disposition": "addressed",
-    "rationale": "Added comment to stuck_state_reconciliation._increment_metric except: telemetry failures must not affect lifecycle authority."
-  },
-  {
-    "id": 3813108132,
-    "disposition": "addressed",
-    "rationale": "Added comment to stuck_state_reconciliation._observe_metric except: same telemetry rationale."
-  },
-  {
-    "id": 3813135896,
-    "disposition": "addressed",
-    "rationale": "Fixed TemporalOmnigentReconcileDispatcher to route to MoonMind.OmnigentSession workflow via omnigent-session:{session_id} and signal operator_reconcile_requested, instead of hard-coded wf:session:codex_cli which does not exist for external Omnigent sessions. Commit 9708607.. now routes correctly; test updated."
-  },
-  {
-    "id": 3813135902,
-    "disposition": "addressed",
-    "rationale": "Persist observation_frontier_digest on every decision via compute_digest of providerEventCursor/snapshotFrontier/revision in stuck_state_reconciliation._record_observation_and_decision, preventing false REPEATED_RECONCILIATION_NO_PROGRESS."
-  },
-  {
-    "id": 3813135905,
-    "disposition": "addressed",
-    "rationale": "Added rotation offset to list_reconciliation_candidates (offset param) and sweep now rotates by observed_now timestamp % 100, preventing same oldest rows from monopolizing bounded batch."
-  },
-  {
-    "id": 3813135910,
-    "disposition": "addressed",
-    "rationale": "Changed LIVE_CONFORMANCE_EVIDENCE_STALE detection in stuck_state.py to not fire on missing evidence alone when runner is unknown; only stale timestamp or explicit runner_down is actionable, matching durable wiring expectation."
-  },
-  {
-    "id": 3813135915,
-    "disposition": "addressed",
-    "rationale": "Modified omnigent_catalog snapshot_ready/event_transport_ready to treat missing observations as not-yet-observed rather than hard admission blocker, while support gate still surfaces missing protected evidence; provider observations are expected to be persisted at snapshot/event boundary."
-  },
-  {
-    "id": 3813135922,
-    "disposition": "addressed",
-    "rationale": "Fixed omnigent_session_timeline to prefer latest journal decision via latest_for_session instead of stale last_decision_ref, with fallback to pointer only when journal empty."
-  },
-  {
-    "id": 3813135931,
-    "disposition": "addressed",
-    "rationale": "Added SessionRepository.recover_from_quarantine fenced recovery method that restores historical_read_state from quarantined to live under current fencing, providing authorized operator remediation path."
-  },
-  {
-    "id": 3813135936,
-    "disposition": "addressed",
-    "rationale": "Fixed Depends(get_current_user) to Depends(get_current_user()) in all four timeline routes, resolving 403 for authorized operators."
-  },
-  {
-    "id": 3825494788,
-    "disposition": "addressed",
-    "rationale": "Same as 3813108094: added explanatory comment to repositories 963 empty except; duplicate bot finding on same line."
-  },
-  {
-    "id": 4972324465,
+    "id": 4990980963,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review summary with no specific requested change; individual findings are tracked as separate review comments."
+    "rationale": "Informational Codex review summary body; no action requested."
   },
   {
-    "id": 3825780392,
+    "id": 3828381491,
     "disposition": "addressed",
-    "rationale": "Changed ReconcileDispatcher Protocol stub from single-line ellipsis to pass with comment to satisfy linter while preserving Protocol semantics."
+    "rationale": "_write_workflow_chat_report takes an auth_mode; each per-combination report publishes the combination's code-owned auth mode (validated against the manifest) and the aggregate report names every mode it exercised."
   },
   {
-    "id": 3825780407,
+    "id": 3828381495,
     "disposition": "addressed",
-    "rationale": "Changed DiagnosticPublisher Protocol stub similarly from ellipsis to pass."
-  },
-  {
-    "id": 3825914206,
-    "disposition": "addressed",
-    "rationale": "Added explanatory comment to empty except in test helper _build_app: get_current_user may fail when auth settings not configured, override is best-effort."
-  },
-  {
-    "id": 3825741220,
-    "path": ".github/workflows/docker-publish-opencode-host.yml",
-    "line": 43,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Workflow lacked explicit permissions for GITHUB_TOKEN. Added top-level permissions: contents: read and job-level permissions for metadata/build/merge.",
-    "fix": "Added permissions: contents: read at workflow top and permissions: contents: read for metadata job; build/merge already had read+write but now consistent."
-  },
-  {
-    "id": 3825768389,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1743,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Unused local variable fake_home was assigned but never used. Removed and replaced ambient isolation with context manager.",
-    "fix": "Removed fake_home and subprocess version-check stub; replaced with isolated env context manager and live HTTP catalog validation."
-  },
-  {
-    "id": 3825768399,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 347,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort cleanup of stale tmp file' to OSError handler."
-  },
-  {
-    "id": 3825768413,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 356,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort ownership in non-root test containers' to OSError handler."
-  },
-  {
-    "id": 3825768422,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 368,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort ownership in non-root test containers' to tmp_path chown handler."
-  },
-  {
-    "id": 3825768429,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 533,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort parent cleanup' to OSError handler."
-  },
-  {
-    "id": 3825768436,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 540,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort tmp cleanup' to OSError handler."
-  },
-  {
-    "id": 3825768446,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 542,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Empty except clause without explanatory comment.",
-    "fix": "Added comment 'best-effort glob cleanup' to OSError handler."
-  },
-  {
-    "id": 3825780248,
-    "path": "moonmind/omnigent/harness_platform/host_classes.py",
-    "line": 191,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Host Class registration alone does not make OpenCode executable; no production call sites selected the class. Added Omnigent execution profile omnigent-opencode@1 and launch policies opencode-on-demand/static, wired via execution_profiles and omnigent_catalog eligibility, so Workflow Create can select opencode and planner can compile with omnigent-opencode@1.",
-    "fix": "Added execution_profiles entries for opencode-native harness, provider_runtime opencode, and updated catalog to include opencode runtime."
-  },
-  {
-    "id": 3825780254,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1768,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Validation only ran opencode --version and returned success even on missing binary or non-zero exit, so invalid keys were stored as connected.",
-    "fix": "Replaced stub validation with live authenticated model catalog query (GET https://api.opencode.ai/v1/models with Bearer key), requiring at least one opencode-go/ model. Missing binary, non-zero, or unavailable catalog now fails closed (422/401/502). Isolated ambient env and converted HarnessPlatformError to 422."
-  },
-  {
-    "id": 3825780258,
-    "path": "moonmind/omnigent/harness_platform/host_classes.py",
-    "line": 39,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Default path returned fabricated cccc digest and never consulted OMNIGENT_OPENCODE_HOST_IMAGE/TAG, so default launches pulled nonexistent digest.",
-    "fix": "Modified get_opencode_host_image_ref() to consult OMNIGENT_OPENCODE_HOST_IMAGE and TAG when REF omitted, synthesizing stable digest-pinned ref from image:tag via sha256. Also rejects c*64 placeholder when explicitly supplied. Updated tests to expect derived ref."
-  },
-  {
-    "id": 3825780262,
-    "path": "moonmind/omnigent/harness_platform/attestation.py",
-    "line": 303,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Branch for require_restricted_egress did nothing, so host without restricted-egress could pass preflight.",
-    "fix": "Now ensures 'restricted-egress' is added to caps when require_restricted_egress=True, and passes expectedVendorRuntimes to validate_exact_host_attestation so capability is actually enforced."
-  },
-  {
-    "id": 3825780265,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 498,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "verify_opencode_auth_file simply echoed expected_generation into return dict; file carries no generation, so stale auth.json passed after rotation.",
-    "fix": "Materializer now writes sidecar .opencode-auth-generation with generation; verifier reads sidecar and compares observed vs expected, failing with CREDENTIAL_GENERATION_FENCED on mismatch/missing, instead of echoing."
-  },
-  {
-    "id": 3825780269,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1447,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Introduced second provider identity opencode for canonical opencode-go, requiring every consumer to handle both IDs.",
-    "fix": "Removed compatibility alias entry ('opencode','opencode') from _API_KEY_MAPPINGS; now only canonical ('opencode','opencode-go') is supported. Updated error message and _apply logic to handle only canonical."
-  },
-  {
-    "id": 3825780275,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1553,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Stored file_templates with from_secret_ref/mode/provider_key and absolute path outside runtime_support_dir, which RuntimeFileTemplate forbids and materializer rejects.",
-    "fix": "Removed invalid file_templates storage for OpenCode; now relies solely on secret_refs + opencode-auth-json@1 trusted materializer. Cleans any prior invalid templates without re-adding."
-  },
-  {
-    "id": 3825780280,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1725,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Validation loop did not clear ambient FORBIDDEN_AMBIENT_ENV_KEYS; materializer's _assert_no_forbidden_ambient_env then raised HarnessPlatformError not converted to HTTPException, causing 500.",
-    "fix": "Added _isolated_forbidden_env context manager that temporarily pops FORBIDDEN_AMBIENT_ENV_KEYS and restores after; wrapped materialize call and converted HarnessPlatformError to HTTPException 422."
-  },
-  {
-    "id": 3825780288,
-    "path": ".github/workflows/docker-publish-opencode-host.yml",
-    "line": 68,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Base resolution passed mutable omnigent-host:latest tag directly to BuildKit without resolving digest, so rebuilds could produce different host contents and arch jobs could use different bases.",
-    "fix": "Reordered to login before resolve, added proper digest resolution via docker pull + inspect (fallback to buildx imagetools inspect), validating digest-pinned form for vars.ORG base and recording base_digest. Build args now receive pinned base_image."
-  },
-  {
-    "id": 3825780294,
-    "path": "moonmind/omnigent/harness_platform/attestation.py",
-    "line": 327,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Preflight only checked opencode version range, never passed Host Class's runtime dependency digest to validate_exact_host_attestation, so binary with any digest could pass.",
-    "fix": "Now resolves HostClass for expectedHostClassRef, extracts its declared runtimeDependencies for opencode-native, and passes as expectedVendorRuntimes to validate_exact_host_attestation, which validates version and digest."
-  },
-  {
-    "id": 3825780300,
-    "path": "moonmind/omnigent/harness_platform/attestation.py",
-    "line": 273,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "requiredSkillDeliveryRef param was never read, so any host passed even with missing/stale skills.",
-    "fix": "Added enforcement: validates format, requires mountedSkills capability, and if host attests a delivery ref in capabilities, calls assert_skill_delivery_attestation to compare required vs attested."
-  },
-  {
-    "id": 4987942615,
-    "path": "frontend/src/components/settings/ProviderProfilesManager.tsx",
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "OpenCode profiles used use_api_key action but manager only recognized it for claude_code/anthropic and sent it to /manual-auth/commit which rejects OpenCode.",
-    "fix": "Added Opencode provider auth model (isOpencodeGoProfile, opencodeCredentialActions, OPENCODE_AUTH_ACTION_LABELS), new enrollment state/mutation that POSTs to /credentials/api-key with api_key, and UI drawer/actions for 'Use OpenCode API key'. Now renders usable enrollment for opencode-go."
-  },
-  {
-    "id": 3825780307,
-    "path": "moonmind/omnigent/harness_platform/materializers.py",
-    "line": 567,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "clear_forbidden_ambient_env returned raw credential values in dict and was exported; diagnostic logging would expose API keys.",
-    "fix": "Changed to return list[str] of cleared key names only (no values). Kept export but now secret-free."
-  },
-  {
-    "id": 3825780311,
-    "path": "api_service/api/routers/provider_profiles.py",
-    "line": 1432,
-    "still_applies": true,
-    "should_address": true,
-    "disposition": "addressed",
-    "rationale": "Omnigent catalog queried only codex_cli/claude_code, schema restricted runtimeId, and predicate accepted only oauth_home, so even connected OpenCode profiles never appeared in eligibleProviderProfiles.",
-    "fix": "Updated omnigent_catalog models to allow runtimeId opencode, expanded query to include opencode, and updated compatibility predicate to accept secret_ref+composite for opencode-go. Also updated eligible/ineligible handling."
+    "rationale": "cross_user and cross_workflow denials must record authorized/attempted user and workflow identities, bind the authorized workflow to the session under test, and vary exactly the scope they claim to isolate."
   }
 ]

--- a/docs/Omnigent/ConformanceAndLiveSmoke.md
+++ b/docs/Omnigent/ConformanceAndLiveSmoke.md
@@ -134,14 +134,24 @@ before its evidence can enter the publication job. The final publication-tree
 scan runs after per-mode cleanup and final report generation, and therefore
 covers the cleanup logs and the exact report tree uploaded by the workflow.
 
+Host images are pinned per host class rather than shared: `--host-image` pins
+the Codex stock host and `--opencode-host-image` pins the dedicated OpenCode
+host, and each claimed combination publishes the digest-pinned image that
+actually executed it. Each per-combination report publishes that combination's
+own authentication mode and exactly the four case ids and row evidence refs of
+the combination it qualifies, so one passing report cannot cover another
+combination.
+
 Each passing combination binds its evidence to the exact support-combination
 identity that ran: Omnigent server and host build refs, harness implementation
 and vendor runtime refs, agent source, materializers, provider compatibility
 class, Host Class, architecture, launch policy, normalized model-configuration
 digest, execution realizer, required-capability digest, and the Provider Profile
-class. The recorded `supportCombinationKey` must recompute from those fields, so
-evidence for one combination can never qualify another. The manifest also
-carries the scenario and route-inventory versions, the deployed dashboard and
+class. The recorded `supportCombinationKey` must recompute from those fields,
+and the Provider Profile class, credential materializer, and authentication mode
+are pinned by the claimed inventory, so evidence for one combination can never
+qualify another. The manifest also carries the scenario and route-inventory
+versions, the deployed dashboard and
 Omnigent UI bundle digests, each case's measured duration, the durable operator
 timeline ref for the terminal cleaned-up session, the cleanup outcome, and the
 superseded report ref.
@@ -153,6 +163,12 @@ stop, and clear-context, capture gates evidence harvest, and only a `remove`
 cleanup mode advertises session cleanup. The `capabilitySnapshot` record must
 cover exactly that set and record one observed enforcement outcome per
 advertised capability that matches the effective intersection.
+
+Cleanup evidence is derived the same way. A `remove` cleanup mode must show the
+live host stopped and its live resources removed; a `drain` cleanup mode retires
+a static-connected host that keeps serving, so it shows a drain and retains its
+live resources. Both orders end with Provider Profile release, and the observed
+step order must match the required order exactly.
 
 `MOONMIND_OMNIGENT_WORKFLOW_CHAT_SUPERSEDED_REPORT` optionally names the report
 this run supersedes. When it is omitted the manifest records no superseded ref

--- a/docs/Omnigent/ConformanceAndLiveSmoke.md
+++ b/docs/Omnigent/ConformanceAndLiveSmoke.md
@@ -113,18 +113,56 @@ and cleanup-reconciliation rows. Every row resolves the full profile, policy,
 runtime, host, session, workspace, artifact, cleanup, janitor, and lease
 authority chain and fails on any direct-Codex or alternate-authority fallback.
 
-`--mode workflow_chat` is the #3642 protected controller. It runs the four
+`--mode workflow_chat` is the #3642 protected controller. It runs the complete
+matrix of native Workflow Chat support combinations declared by
+`moonmind.omnigent.workflow_chat_acceptance.WORKFLOW_CHAT_COMBINATIONS`: the
+Codex-through-Omnigent on-demand combination, the Codex static-connected host
+mode (whose transport and cleanup behavior differ materially), and OpenCode
+through `generic-omnigent-host@1`. For each claimed combination it runs the
 native-conversation, scoped-transport/resource, authority/security-denial, and
 terminal/evidence/continuation actions in order against the digest-pinned stock
-host. It resolves the typed source records returned by the live action adapter,
-derives assertions from those records, scans the logs, Temporal history,
-screenshots, and archives, builds and validates the commit-bound
-`moonmind.omnigent.workflow-chat-acceptance/v1` artifact, and then invokes the
-dedicated provider gate. A missing row, source record, raw evidence channel,
-digest correlation, or provider-test result fails the mode before its evidence
-can enter the publication job. The final publication-tree scan runs after
-per-mode cleanup and final report generation, and therefore covers the cleanup
-logs and the exact report tree uploaded by the workflow.
+host. A combination MoonMind does not claim for native chat is reported as
+`unsupported` with its stable code-owned reason; it is never silently omitted.
+
+The controller resolves the typed source records returned by the live action
+adapter, derives assertions from those records, scans the logs, Temporal
+history, screenshots, and archives, builds and validates the commit-bound
+`moonmind.omnigent.workflow-chat-acceptance/v2` artifact, and then invokes the
+dedicated provider gate. A missing combination, row, source record, raw
+evidence channel, digest correlation, or provider-test result fails the mode
+before its evidence can enter the publication job. The final publication-tree
+scan runs after per-mode cleanup and final report generation, and therefore
+covers the cleanup logs and the exact report tree uploaded by the workflow.
+
+Each passing combination binds its evidence to the exact support-combination
+identity that ran: Omnigent server and host build refs, harness implementation
+and vendor runtime refs, agent source, materializers, provider compatibility
+class, Host Class, architecture, launch policy, normalized model-configuration
+digest, execution realizer, required-capability digest, and the Provider Profile
+class. The recorded `supportCombinationKey` must recompute from those fields, so
+evidence for one combination can never qualify another. The manifest also
+carries the scenario and route-inventory versions, the deployed dashboard and
+Omnigent UI bundle digests, each case's measured duration, the durable operator
+timeline ref for the terminal cleaned-up session, the cleanup outcome, and the
+superseded report ref.
+
+The advertised capability contract for a combination is derived from declared
+authority rather than a constant: Host Class features gate terminal and
+workspace capabilities, Launch Policy control capabilities gate interrupt,
+stop, and clear-context, capture gates evidence harvest, and only a `remove`
+cleanup mode advertises session cleanup. The `capabilitySnapshot` record must
+cover exactly that set and record one observed enforcement outcome per
+advertised capability that matches the effective intersection.
+
+`MOONMIND_OMNIGENT_WORKFLOW_CHAT_SUPERSEDED_REPORT` optionally names the report
+this run supersedes. When it is omitted the manifest records no superseded ref
+and takes the same production path.
+
+`#3712` retirement guards consume the published manifest directly through
+`moonmind.omnigent.legacy_retirement.criteria_from_native_chat_acceptance`,
+which returns `native_chat_acceptance_passed` only for a manifest that
+revalidates against its evidence tree, so a missing, incomplete, failed, or
+expired report yields no criterion.
 
 `--mode static` covers restart and replay; `stock`, `product`, `cumulative`,
 `ondemand`, `failures`, and `workflow_chat` can be gated independently in

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -1091,7 +1091,11 @@ freshness window. Each combination binds its evidence to the exact
 support-combination identity — harness implementation, vendor runtime,
 materializers, Host Class, architecture, launch policy, normalized model
 configuration, execution realizer, required capabilities, and Provider Profile
-class — and the recorded `supportCombinationKey` must recompute from it.
+class — and the recorded `supportCombinationKey` must recompute from it. The
+Provider Profile class, credential materializer, authentication mode, and the
+digest-pinned host image that executed the combination are pinned by the claimed
+inventory, so evidence gathered under one credential authority or host image can
+never qualify another.
 
 Every source record carries an observation timestamp, immutable image digests,
 and one server-owned correlation envelope containing the Workflow, chat binding,
@@ -1109,16 +1113,16 @@ record-specific observed facts are:
 | `facadeRequests` | every compatibility route bound to an observed request path/method/transport, HTML/HTTP/SSE/WebSocket authorization, server-resolved binding/session, reconnect reauthorization |
 | `resourceInventory` | request-correlated approval/tool/file/terminal/agent/task resources |
 | `mutationReceipts` | exactly one receipt for every mutation derived from the compatibility map, including actor, idempotency, expected state, outcome, upstream correlation, and audit ref |
-| `denialAudit` | alternate-binding, provider-session, hidden-control, immutable-policy, cross-user, and cross-workflow denials before upstream forwarding |
-| `executionCreation` | the browser-originated `POST /api/executions` create, the Temporal workflow/run/task-queue routing it produced, the resolved Agent Profile snapshot, execution plan, and Provider Profile, and the live bridge session it resolved to |
-| `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs, their recomputed intersection digest over exactly the combination's advertised capability contract, and one observed enforcement outcome per advertised capability |
+| `denialAudit` | alternate-binding, provider-session, hidden-control, immutable-policy, cross-user, and cross-workflow denials before upstream forwarding; each cross-scope denial records the authorized and attempted user and Workflow identities and varies exactly the scope it claims to isolate |
+| `executionCreation` | the browser-originated `POST /api/executions` create — cross-checked against the matching browser trace event's method and normalized path — the Temporal workflow/run/task-queue routing it produced, the resolved Agent Profile snapshot, execution plan, and Provider Profile, and the live bridge session it resolved to |
+| `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs, their recomputed intersection digest over exactly the combination's advertised capability contract, and one observed enforcement outcome per advertised capability; a denied capability's enforcement request is expected to be denied in the browser trace |
 | `scanAudit` | blocked-content and unavailable-enforcement sends, neither forwarded |
 | `credentialBoundary` | every traced request verified to expose no upstream credential in the browser and forward no MoonMind credential upstream, plus a server-side credential injection ref |
 | `terminalSnapshot` | terminal state, read-only projection, denied mutation requests |
 | `capturedEvidence` | packaged MoonMind artifact and capture-manifest refs resolved and digest-bound into the acceptance manifest |
 | `continuationReceipt` | production destination-creation receipt, pinned source run, durable outbound `linked_continuation` relationship identity, idempotency, and matching source before/after digests |
 | `replaySnapshot` | host unavailable and replay resolved from the captured MoonMind artifacts |
-| `cleanupReceipt` | consecutively ordered live-host stop, provider-session removal, workspace publication, and Provider Profile release, with release last, plus the observed host mode, launch-policy cleanup mode, and cleanup state |
+| `cleanupReceipt` | the consecutively ordered cleanup steps the combination's cleanup mode can truthfully emit — live-host stop for `remove`, live-host drain for `drain` — then provider-session removal, workspace publication, and Provider Profile release last, plus the observed host mode, launch-policy cleanup mode, live-resource disposition, and cleanup state |
 
 ---
 

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -929,16 +929,19 @@ Rules:
 13. Embedded mode must pass stock-host auth conformance before production enablement.
 
 Native Workflow Chat rollout evidence uses
-`moonmind.omnigent.workflow-chat-acceptance/v1`. The controlling artifact is
-commit- and immutable-image-bound, covers every required browser-to-stock-host
-row, and contains SHA-256 bindings for independently resolvable case evidence,
-typed source records, conformance reports, and the logs, Temporal history,
-screenshot, and archive secret-scan results. The required source records bind
-browser traces to binding/capability snapshots, facade requests, resource and
-receipt inventories, denial/scan/credential audits, terminal evidence,
-continuation receipts, and replay snapshots. A bare pass flag, repository-only
-test result, unresolved artifact ref, mutable image tag, stale report, or
-self-asserted secret scan is not rollout evidence.
+`moonmind.omnigent.workflow-chat-acceptance/v2`. The controlling artifact is
+commit- and immutable-image-bound, covers every claimed native-chat support
+combination and every required browser-to-stock-host row within each of them,
+and contains SHA-256 bindings for independently resolvable case evidence, typed
+source records, per-combination conformance reports, the durable operator
+timeline, and the logs, Temporal history, screenshot, and archive secret-scan
+results. The required source records bind browser traces to the
+`/api/executions` creation receipt, binding/capability snapshots, facade
+requests, resource and receipt inventories, denial/scan/credential audits,
+terminal evidence, continuation receipts, replay snapshots, and the
+release-last cleanup receipt. A bare pass flag, repository-only test result,
+unresolved artifact ref, mutable image tag, stale report, self-asserted secret
+scan, or silently omitted support combination is not rollout evidence.
 `tools/build_omnigent_workflow_chat_acceptance.py` builds and validates the
 artifact produced by the protected controller against its required current
 `--expected-commit`; the provider gate independently requires the same commit
@@ -1071,14 +1074,24 @@ Verify host registration, heartbeat/capabilities, session creation, harness laun
 
 ### 20.5 Native Workflow Chat rollout gate
 
-The protected browser-to-stock-host matrix covers the live native conversation,
-scoped transports and resources, authority/security denials, and terminal
-evidence/linked continuation. Each row records browser-originated observations
-against an unchanged digest-pinned stock host and resolves its source evidence
-before the `moonmind.omnigent.workflow-chat-acceptance/v1` manifest can pass.
-Every raw evidence channel is secret-scanned, and the manifest is valid only for
-its recorded source commit, compatibility profile, image digests, and freshness
-window.
+The protected browser-to-stock-host matrix runs one journey per claimed native
+Workflow Chat support combination. Every combination MoonMind claims appears in
+the matrix; a combination it does not claim appears as `unsupported` with a
+stable code-owned reason. Each combination's journey covers the live native
+conversation (created through the normal `/api/executions` and Temporal path),
+scoped transports and resources, authority/security denials (including
+cross-user and cross-workflow denials), and terminal evidence, linked
+continuation, and release-last cleanup. Each row records browser-originated
+observations against an unchanged digest-pinned stock host and resolves its
+source evidence before the `moonmind.omnigent.workflow-chat-acceptance/v2`
+manifest can pass. Every raw evidence channel is secret-scanned, and the
+manifest is valid only for its recorded source commit, compatibility profile,
+image digests, bundle digests, scenario and route-inventory versions, and
+freshness window. Each combination binds its evidence to the exact
+support-combination identity — harness implementation, vendor runtime,
+materializers, Host Class, architecture, launch policy, normalized model
+configuration, execution realizer, required capabilities, and Provider Profile
+class — and the recorded `supportCombinationKey` must recompute from it.
 
 Every source record carries an observation timestamp, immutable image digests,
 and one server-owned correlation envelope containing the Workflow, chat binding,
@@ -1096,14 +1109,16 @@ record-specific observed facts are:
 | `facadeRequests` | every compatibility route bound to an observed request path/method/transport, HTML/HTTP/SSE/WebSocket authorization, server-resolved binding/session, reconnect reauthorization |
 | `resourceInventory` | request-correlated approval/tool/file/terminal/agent/task resources |
 | `mutationReceipts` | exactly one receipt for every mutation derived from the compatibility map, including actor, idempotency, expected state, outcome, upstream correlation, and audit ref |
-| `denialAudit` | alternate-binding, provider-session, hidden-control, and immutable-policy denials before upstream forwarding |
-| `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs and their recomputed intersection digest |
+| `denialAudit` | alternate-binding, provider-session, hidden-control, immutable-policy, cross-user, and cross-workflow denials before upstream forwarding |
+| `executionCreation` | the browser-originated `POST /api/executions` create, the Temporal workflow/run/task-queue routing it produced, the resolved Agent Profile snapshot, execution plan, and Provider Profile, and the live bridge session it resolved to |
+| `capabilitySnapshot` | upstream/profile/provider-policy/workflow/caller inputs, their recomputed intersection digest over exactly the combination's advertised capability contract, and one observed enforcement outcome per advertised capability |
 | `scanAudit` | blocked-content and unavailable-enforcement sends, neither forwarded |
 | `credentialBoundary` | every traced request verified to expose no upstream credential in the browser and forward no MoonMind credential upstream, plus a server-side credential injection ref |
 | `terminalSnapshot` | terminal state, read-only projection, denied mutation requests |
 | `capturedEvidence` | packaged MoonMind artifact and capture-manifest refs resolved and digest-bound into the acceptance manifest |
 | `continuationReceipt` | production destination-creation receipt, pinned source run, durable outbound `linked_continuation` relationship identity, idempotency, and matching source before/after digests |
 | `replaySnapshot` | host unavailable and replay resolved from the captured MoonMind artifacts |
+| `cleanupReceipt` | consecutively ordered live-host stop, provider-session removal, workspace publication, and Provider Profile release, with release last, plus the observed host mode, launch-policy cleanup mode, and cleanup state |
 
 ---
 

--- a/moonmind/omnigent/legacy_retirement.py
+++ b/moonmind/omnigent/legacy_retirement.py
@@ -21,9 +21,17 @@ architecture.
 from __future__ import annotations
 
 import importlib
+from datetime import datetime
 from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.workflow_chat_acceptance import (
+    validate_workflow_chat_acceptance_manifest,
+)
 
 RETIREMENT_CONTRACT_VERSION = "moonmind.omnigent-legacy-retirement/v1"
 
@@ -179,6 +187,35 @@ def evaluate_retirement(
     )
 
 
+def criteria_from_native_chat_acceptance(
+    manifest: Mapping[str, Any] | None,
+    *,
+    evidence_root: Path,
+    expected_commit: str | None = None,
+    now: datetime | None = None,
+) -> frozenset[RetirementCriterion]:
+    """Project a #3642 acceptance manifest into passing retirement criteria.
+
+    A retirement guard must be able to consume the published protected report
+    without a human asserting the criterion. A missing, incomplete, failed,
+    expired, or unresolvable manifest yields no criterion, so the guard stays
+    fail-closed instead of inheriting an operator's interpretation.
+    """
+
+    if manifest is None:
+        return frozenset()
+    try:
+        validate_workflow_chat_acceptance_manifest(
+            manifest,
+            evidence_root=evidence_root,
+            expected_commit=expected_commit,
+            now=now,
+        )
+    except (ConformanceContractError, ValueError):
+        return frozenset()
+    return frozenset({RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED})
+
+
 def _ref_resolves(ref: str) -> bool:
     """Whether a machine-checkable ``module:symbol`` reference still resolves.
 
@@ -253,6 +290,7 @@ __all__ = [
     "RETIREMENT_INVENTORY",
     "TEMPORARY_ROLLOUT_FLAGS",
     "LEGACY_RETIREMENT_COMPLETE",
+    "criteria_from_native_chat_acceptance",
     "evaluate_retirement",
     "assert_retirement_guard",
     "assert_temporary_flags_have_retirement",

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -16,6 +16,7 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -27,10 +28,22 @@ from moonmind.omnigent.conformance import (
     assert_secret_free,
     require_pinned_images,
 )
+from moonmind.omnigent.effective_capabilities import CAPABILITY_NAMES
+from moonmind.omnigent.harness_platform.host_classes import (
+    HostClass,
+    LaunchPolicy,
+    get_host_class,
+    get_launch_policy,
+)
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_support_combination_key,
+    validate_realizer,
+)
 from moonmind.omnigent.native_ui_compat import compatibility_map
 
 WORKFLOW_CHAT_ACCEPTANCE_VERSION = (
-    "moonmind.omnigent.workflow-chat-acceptance/v1"
+    "moonmind.omnigent.workflow-chat-acceptance/v2"
 )
 WORKFLOW_CHAT_CASE_EVIDENCE_VERSION = (
     "moonmind.omnigent.workflow-chat-case-evidence/v1"
@@ -38,14 +51,170 @@ WORKFLOW_CHAT_CASE_EVIDENCE_VERSION = (
 WORKFLOW_CHAT_SOURCE_RECORD_VERSION = (
     "moonmind.omnigent.workflow-chat-source-record/v1"
 )
+WORKFLOW_CHAT_COMBINATION_VERSION = (
+    "moonmind.omnigent.workflow-chat-combination/v1"
+)
+WORKFLOW_CHAT_SCENARIO_VERSION = "moonmind.omnigent.workflow-chat-scenario/v1"
 WORKFLOW_CHAT_ACCEPTANCE_ISSUE = "MoonLadderStudios/MoonMind#3642"
 WORKFLOW_CHAT_PARENT_ISSUE = "MoonLadderStudios/MoonMind#3632"
 WORKFLOW_CHAT_COMPATIBILITY_PROFILE = "omnigent.server.v1"
 MAX_ACCEPTANCE_AGE = timedelta(days=7)
 
+# The deployed bundles a browser actually loads. Image digests alone do not
+# identify the compiled dashboard or the stock Omnigent UI bundle served through
+# the binding-scoped route, so both are bound separately (issue #3642 AC8).
+REQUIRED_BUNDLE_DIGESTS = ("dashboard", "omnigentUi")
+
+# Capability groups whose advertisement is decided by declared Host Class
+# features or Launch Policy authority rather than by this module.
+_TERMINAL_CAPABILITIES = frozenset(
+    {
+        "createTerminal",
+        "attachTerminal",
+        "viewTerminal",
+        "writeTerminal",
+        "closeTerminal",
+    }
+)
+_WORKSPACE_CAPABILITIES = frozenset({"uploadFiles", "mutateWorkspace"})
+_CONTROL_CAPABILITY_REQUIREMENTS: Mapping[str, str] = {
+    "interruptTurn": "interrupt",
+    "stopSession": "terminate",
+    "replaceSession": "clear_context",
+}
+
+
+def advertised_native_chat_capabilities(
+    *, host_class: HostClass, launch_policy: LaunchPolicy
+) -> frozenset[str]:
+    """Derive the native-chat capability contract a combination advertises.
+
+    The set is computed from already-declared authority (Host Class features,
+    Launch Policy control capabilities, capture, and cleanup mode) so a
+    combination that advertises a different capability surface produces a
+    different required coverage set instead of silently reusing a constant.
+    """
+
+    advertised: set[str] = set()
+    features = host_class.features
+    controls = set(launch_policy.controlCapabilities)
+    for name in CAPABILITY_NAMES:
+        if name in _TERMINAL_CAPABILITIES and not features.get("tmux"):
+            continue
+        if name in _WORKSPACE_CAPABILITIES and not features.get("workspaceBind"):
+            continue
+        required_control = _CONTROL_CAPABILITY_REQUIREMENTS.get(name)
+        if required_control is not None and required_control not in controls:
+            continue
+        if name == "harvestEvidence" and launch_policy.capture.get("required") is not True:
+            continue
+        if name == "cleanupSession" and launch_policy.cleanup.get("mode") != "remove":
+            continue
+        advertised.add(name)
+    return frozenset(advertised)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowChatCombination:
+    """One combination MoonMind either claims or declines for native chat.
+
+    ``native_chat_claimed`` is code-owned release authority: a claimed
+    combination must appear in the protected matrix with its own live evidence,
+    and a declined combination must appear with a stable machine reason. Neither
+    may be silently omitted.
+    """
+
+    combination_id: str
+    harness_id: str
+    host_class_ref: str
+    launch_policy_ref: str
+    execution_realizer_ref: str
+    compose_profile: str
+    compose_services: tuple[str, ...]
+    native_chat_claimed: bool
+    unsupported_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.native_chat_claimed == bool(self.unsupported_reason):
+            raise ConformanceContractError(
+                "workflow Chat combination must either be claimed or carry one "
+                f"stable unsupported reason: {self.combination_id}"
+            )
+        validate_realizer(self.execution_realizer_ref)
+
+    @property
+    def host_class(self) -> HostClass:
+        return get_host_class(self.host_class_ref)
+
+    @property
+    def launch_policy(self) -> LaunchPolicy:
+        return get_launch_policy(self.launch_policy_ref)
+
+    @property
+    def host_mode(self) -> str:
+        return self.launch_policy.hostMode
+
+    @property
+    def advertised_capabilities(self) -> frozenset[str]:
+        return advertised_native_chat_capabilities(
+            host_class=self.host_class, launch_policy=self.launch_policy
+        )
+
+
+# Every combination MoonMind claims for native Workflow Chat, including the
+# host modes whose transport and cleanup behavior differ materially (on-demand
+# hosts are removed; static-connected hosts are drained and keep serving).
+WORKFLOW_CHAT_COMBINATIONS: tuple[WorkflowChatCombination, ...] = (
+    WorkflowChatCombination(
+        combination_id="codex-on-demand-through-omnigent",
+        harness_id="codex-native",
+        host_class_ref="omnigent-codex-current@1",
+        launch_policy_ref="codex-on-demand@1",
+        execution_realizer_ref="codex-profile-bound@1",
+        compose_profile="omnigent-host-codex",
+        compose_services=("omnigent",),
+        native_chat_claimed=True,
+    ),
+    WorkflowChatCombination(
+        combination_id="codex-static-connected-through-omnigent",
+        harness_id="codex-native",
+        host_class_ref="omnigent-codex-current@1",
+        launch_policy_ref="codex-static@1",
+        execution_realizer_ref="codex-profile-bound@1",
+        compose_profile="omnigent-host-codex",
+        compose_services=("omnigent", "omnigent-host-codex"),
+        native_chat_claimed=True,
+    ),
+    WorkflowChatCombination(
+        combination_id="opencode-through-generic-omnigent-host",
+        harness_id="opencode-native",
+        host_class_ref="omnigent-opencode@1",
+        launch_policy_ref="omnigent-on-demand@1",
+        execution_realizer_ref="generic-omnigent-host@1",
+        compose_profile="omnigent-host-codex",
+        compose_services=("omnigent",),
+        native_chat_claimed=True,
+    ),
+)
+
+
+def workflow_chat_combinations() -> dict[str, WorkflowChatCombination]:
+    """Return the claimed-combination inventory keyed by combination id."""
+
+    inventory: dict[str, WorkflowChatCombination] = {}
+    for combination in WORKFLOW_CHAT_COMBINATIONS:
+        if combination.combination_id in inventory:
+            raise ConformanceContractError(
+                "workflow Chat combination inventory has a duplicate id: "
+                f"{combination.combination_id}"
+            )
+        inventory[combination.combination_id] = combination
+    return inventory
+
 REQUIRED_WORKFLOW_CHAT_ROWS: Mapping[str, frozenset[str]] = {
     "native-live-conversation": frozenset(
         {
+            "created_through_public_executions_api",
             "workflow_chat_route_opened",
             "authoritative_binding_only",
             "native_transcript_composer_queue",
@@ -68,6 +237,9 @@ REQUIRED_WORKFLOW_CHAT_ROWS: Mapping[str, frozenset[str]] = {
             "provider_session_substitution_denied",
             "hidden_control_direct_invocation_denied",
             "immutable_policy_enforced",
+            "cross_user_denied",
+            "cross_workflow_denied",
+            "advertised_capabilities_enforced",
             "high_security_send_blocked",
             "scan_unavailable_failed_closed",
             "credentials_separated",
@@ -80,6 +252,7 @@ REQUIRED_WORKFLOW_CHAT_ROWS: Mapping[str, frozenset[str]] = {
             "linked_continuation_created",
             "source_workflow_unchanged",
             "replay_after_stock_host_unavailable",
+            "cleanup_completed_provider_profile_released_last",
         }
     ),
 }
@@ -87,6 +260,7 @@ REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS: Mapping[str, frozenset[str]] = {
     "native-live-conversation": frozenset(
         {
             "browserTrace",
+            "executionCreation",
             "bindingSnapshot",
             "nativeConversation",
             "nativeControls",
@@ -116,6 +290,7 @@ REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS: Mapping[str, frozenset[str]] = {
             "capturedEvidence",
             "continuationReceipt",
             "replaySnapshot",
+            "cleanupReceipt",
         }
     ),
 }
@@ -142,8 +317,20 @@ _DENIAL_KINDS = frozenset(
         "provider_session_substitution",
         "hidden_control",
         "immutable_policy",
+        "cross_user",
+        "cross_workflow",
     }
 )
+# Cleanup must finish with provider-profile release, after the live host and
+# provider session are gone and the workspace result is durable.
+_PROVIDER_PROFILE_RELEASE_STEP = "provider_profile_release"
+_REQUIRED_CLEANUP_STEPS = (
+    "live_host_stopped",
+    "provider_session_removed",
+    "workspace_published",
+    _PROVIDER_PROFILE_RELEASE_STEP,
+)
+_EXECUTIONS_CREATE_PATH = "/api/executions"
 _TERMINAL_STATES = frozenset(
     {"completed", "failed", "canceled", "cancelled", "timed_out", "stopped"}
 )
@@ -192,8 +379,15 @@ def _canonical_digest(value: Any) -> str:
     return "sha256:" + hashlib.sha256(raw).hexdigest()
 
 
-def _is_scoped_path(path: str, allowed_bases: tuple[str, ...]) -> bool:
+def _is_scoped_path(
+    path: str,
+    allowed_bases: tuple[str, ...],
+    *,
+    allowed_exact: tuple[str, ...] = (),
+) -> bool:
     parsed_path = urllib.parse.urlsplit(path).path
+    if parsed_path in allowed_exact:
+        return True
     return any(
         parsed_path == base or parsed_path.startswith(base + "/")
         for base in allowed_bases
@@ -234,6 +428,7 @@ def _validate_record_data(
     data: Mapping[str, Any],
     *,
     correlation: Mapping[str, str],
+    combination: WorkflowChatCombination,
 ) -> None:
     request_ids = _require_string_list(
         data.get("requestIds"), field=f"{record_type}.data.requestIds"
@@ -273,7 +468,11 @@ def _validate_record_data(
             if (
                 request_id in event_ids
                 or transport not in _TRANSPORTS
-                or not _is_scoped_path(path, allowed_prefixes)
+                or not _is_scoped_path(
+                    path,
+                    allowed_prefixes,
+                    allowed_exact=(_EXECUTIONS_CREATE_PATH,),
+                )
                 or not isinstance(status, int)
                 or not 100 <= status <= 599
                 or item.get("moonmindScoped") is not True
@@ -299,6 +498,39 @@ def _validate_record_data(
         _require_sha256_ref(
             data.get("screenshotSha256"), field="browserTrace.data.screenshotSha256"
         )
+        return
+
+    if record_type == "executionCreation":
+        create_request_id = data.get("createRequestId")
+        if (
+            create_request_id not in request_id_set
+            or data.get("method") != "POST"
+            or urllib.parse.urlsplit(str(data.get("path") or "")).path
+            != _EXECUTIONS_CREATE_PATH
+            or data.get("createdThroughPublicApi") is not True
+            or data.get("workflowId") != workflow_id
+            or data.get("resolvedBridgeSessionId")
+            != correlation["bridgeSessionId"]
+            or data.get("harnessId") != combination.harness_id
+            or data.get("executionRealizerRef")
+            != combination.execution_realizer_ref
+            or data.get("launchPolicyRef") != combination.launch_policy_ref
+        ):
+            raise ConformanceContractError(
+                "workflow Chat executionCreation does not prove the normal "
+                "/api/executions create path"
+            )
+        for field in (
+            "temporalWorkflowId",
+            "temporalRunId",
+            "temporalTaskQueue",
+            "agentProfileSnapshotRef",
+            "executionPlanRef",
+            "providerProfileRef",
+        ):
+            _require_string(
+                data.get(field), field=f"executionCreation.data.{field}"
+            )
         return
 
     if record_type == "bindingSnapshot":
@@ -567,14 +799,47 @@ def _validate_record_data(
             name: all(values.get(name) is True for values in typed_inputs)
             for name in capability_names
         }
-        digest_payload = {"inputs": inputs, "effective": computed}
+        advertised = combination.advertised_capabilities
+        declared = _require_string_list(
+            data.get("advertised"), field="capabilitySnapshot.data.advertised"
+        )
+        digest_payload = {
+            "inputs": inputs,
+            "effective": computed,
+            "advertised": sorted(advertised),
+        }
         if (
             dict(effective) != computed
+            or set(declared) != set(advertised)
+            or set(computed) != set(advertised)
             or data.get("snapshotDigest") != _canonical_digest(digest_payload)
         ):
             raise ConformanceContractError(
-                "workflow Chat capabilitySnapshot is not the effective intersection"
+                "workflow Chat capabilitySnapshot is not the effective "
+                "intersection of the advertised capability contract"
             )
+        enforcement = _require_mapping(
+            data.get("enforcement"), field="capabilitySnapshot.data.enforcement"
+        )
+        if set(enforcement) != set(advertised):
+            raise ConformanceContractError(
+                "workflow Chat capabilitySnapshot does not cover every "
+                "advertised capability"
+            )
+        for name in sorted(advertised):
+            observation = _require_mapping(
+                enforcement[name],
+                field=f"capabilitySnapshot.data.enforcement.{name}",
+            )
+            expected_outcome = "allowed" if computed[name] else "denied"
+            if (
+                observation.get("requestId") not in request_id_set
+                or observation.get("outcome") != expected_outcome
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat capability enforcement does not match the "
+                    f"effective decision: {name}"
+                )
         return
 
     if record_type == "scanAudit":
@@ -723,6 +988,53 @@ def _validate_record_data(
         )
         return
 
+    if record_type == "cleanupReceipt":
+        steps = data.get("steps")
+        if not isinstance(steps, list) or not steps:
+            raise ConformanceContractError(
+                "workflow Chat cleanupReceipt requires ordered cleanup steps"
+            )
+        observed: dict[int, str] = {}
+        for raw_step in steps:
+            step = _require_mapping(raw_step, field="cleanupReceipt.data.steps[]")
+            kind = _require_string(
+                step.get("kind"), field="cleanupReceipt.data.steps[].kind"
+            )
+            order = step.get("order")
+            if (
+                kind not in _REQUIRED_CLEANUP_STEPS
+                or not isinstance(order, int)
+                or isinstance(order, bool)
+                or order in observed
+                or step.get("outcome") != "completed"
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat cleanupReceipt step is malformed or incomplete"
+                )
+            _require_string(
+                step.get("auditRef"), field="cleanupReceipt.data.steps[].auditRef"
+            )
+            observed[order] = kind
+        ordered = [observed[key] for key in sorted(observed)]
+        if (
+            sorted(observed) != list(range(1, len(ordered) + 1))
+            or set(ordered) != set(_REQUIRED_CLEANUP_STEPS)
+            or ordered[-1] != _PROVIDER_PROFILE_RELEASE_STEP
+            or data.get("liveResourcesRemoved") is not True
+            or data.get("providerProfileReleasedLast") is not True
+            or data.get("outcome") != "released"
+            or data.get("hostMode") != combination.host_mode
+            or data.get("cleanupMode")
+            != combination.launch_policy.cleanup.get("mode")
+        ):
+            raise ConformanceContractError(
+                "workflow Chat cleanupReceipt does not prove release-last cleanup"
+            )
+        _require_string(
+            data.get("cleanupState"), field="cleanupReceipt.data.cleanupState"
+        )
+        return
+
     if record_type == "replaySnapshot":
         replay_refs = _require_string_list(
             data.get("artifactRefs"), field="replaySnapshot.data.artifactRefs"
@@ -752,6 +1064,7 @@ def validate_workflow_chat_source_records(
     source_commit: str,
     images: Mapping[str, Any],
     generated_at: datetime,
+    combination: WorkflowChatCombination,
     expected_correlation: Mapping[str, str] | None = None,
 ) -> tuple[dict[str, bool], dict[str, str]]:
     """Validate and correlate one row's production-owned source records.
@@ -805,8 +1118,15 @@ def validate_workflow_chat_source_records(
             raise ConformanceContractError(
                 f"workflow Chat source records are not correlated: {row_name}"
             )
+        if source.get("combination") != combination.combination_id:
+            raise ConformanceContractError(
+                "workflow Chat source record is not bound to the combination "
+                f"under test: {row_name}/{record_type}"
+            )
         data = _require_mapping(source.get("data"), field=f"{record_type}.data")
-        _validate_record_data(record_type, data, correlation=correlation)
+        _validate_record_data(
+            record_type, data, correlation=correlation, combination=combination
+        )
         request_ids_by_type[record_type] = set(data["requestIds"])
 
     assert row_correlation is not None
@@ -995,36 +1315,117 @@ def _resolve_json(ref: str, evidence_root: Path) -> dict[str, Any]:
     return value
 
 
+_BINDING_IDENTITY_FIELDS = (
+    "omnigentServerBuildRef",
+    "omnigentHostBuildRef",
+    "harnessImplementationRef",
+    "vendorRuntimeRefs",
+    "agentSourceRef",
+    "materializerRefs",
+    "providerCompatibilityClass",
+    "hostClassRef",
+    "architecture",
+    "launchPolicyRef",
+    "modelConfigDigest",
+    "executionRealizerRef",
+    "requiredCapabilitiesDigest",
+)
+
+
+def _validate_binding_identity(
+    identity: Any, *, combination: WorkflowChatCombination
+) -> None:
+    """Bind a combination's evidence to the exact support-combination identity.
+
+    The report is only usable as release evidence when it names the harness
+    implementation, vendor runtime, realizer, launch policy, normalized model
+    configuration, and Provider Profile class that actually ran, and when the
+    recomputed support-combination key agrees with the recorded one.
+    """
+
+    payload = _require_mapping(
+        identity, field=f"combinations.{combination.combination_id}.bindingIdentity"
+    )
+    expected_keys = set(_BINDING_IDENTITY_FIELDS) | {
+        "supportCombinationKey",
+        "providerProfileClass",
+    }
+    if set(payload) != expected_keys:
+        raise ConformanceContractError(
+            "workflow Chat acceptance binding identity is incomplete: "
+            f"{combination.combination_id}"
+        )
+    _require_string(
+        payload.get("providerProfileClass"),
+        field="bindingIdentity.providerProfileClass",
+    )
+    if (
+        payload.get("hostClassRef") != combination.host_class_ref
+        or payload.get("launchPolicyRef") != combination.launch_policy_ref
+        or payload.get("executionRealizerRef")
+        != combination.execution_realizer_ref
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance binding identity does not match the "
+            f"combination under test: {combination.combination_id}"
+        )
+    try:
+        support_payload = SupportKeyPayload.model_validate(
+            {field: payload[field] for field in _BINDING_IDENTITY_FIELDS}
+        )
+    except ValueError as exc:
+        raise ConformanceContractError(
+            "workflow Chat acceptance binding identity is not a valid support "
+            f"combination: {combination.combination_id}"
+        ) from exc
+    if payload.get("supportCombinationKey") != compute_support_combination_key(
+        support_payload
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance support combination key does not recompute: "
+            f"{combination.combination_id}"
+        )
+
+
 def build_workflow_chat_acceptance_manifest(
     source: Mapping[str, Any],
     *,
     evidence_root: Path,
 ) -> dict[str, Any]:
-    """Bind a protected-run matrix to immutable evidence digests.
+    """Bind a protected-run combination matrix to immutable evidence digests.
 
     ``source`` is the run-local matrix produced by the protected controller. It
-    carries rows and refs, never raw credentials.  This function resolves every
-    referenced file before emitting a candidate manifest; validation remains a
-    separate mandatory step.
+    carries combinations, rows, and refs, never raw credentials.  This function
+    resolves every referenced file before emitting a candidate manifest;
+    validation remains a separate mandatory step.
     """
 
-    rows = source.get("rows")
-    reports = source.get("reports")
+    combinations = source.get("combinations")
     scans = source.get("evidenceScans")
-    if not isinstance(rows, Mapping) or not isinstance(reports, list) or not isinstance(
-        scans, Mapping
-    ):
+    if not isinstance(combinations, Mapping) or not isinstance(scans, Mapping):
         raise ConformanceContractError(
-            "workflow Chat acceptance source lacks rows, reports, or evidence scans"
+            "workflow Chat acceptance source lacks combinations or evidence scans"
         )
     refs: list[str] = []
     case_refs: list[str] = []
-    for row in rows.values():
-        if isinstance(row, Mapping) and isinstance(row.get("evidenceRefs"), list):
-            row_refs = [str(ref) for ref in row["evidenceRefs"]]
-            refs.extend(row_refs)
-            case_refs.extend(row_refs)
-    refs.extend(str(ref) for ref in reports)
+    for combination in combinations.values():
+        if not isinstance(combination, Mapping):
+            raise ConformanceContractError(
+                "workflow Chat acceptance combination must be an object"
+            )
+        rows = combination.get("rows")
+        if isinstance(rows, Mapping):
+            for row in rows.values():
+                if isinstance(row, Mapping) and isinstance(
+                    row.get("evidenceRefs"), list
+                ):
+                    row_refs = [str(ref) for ref in row["evidenceRefs"]]
+                    refs.extend(row_refs)
+                    case_refs.extend(row_refs)
+        if isinstance(combination.get("reports"), list):
+            refs.extend(str(ref) for ref in combination["reports"])
+        if combination.get("timelineRef"):
+            refs.append(str(combination["timelineRef"]))
     scan_refs: list[str] = []
     for channel in REQUIRED_EVIDENCE_CHANNELS:
         scan = scans.get(channel)
@@ -1070,6 +1471,8 @@ def build_workflow_chat_acceptance_manifest(
         )
     manifest = {
         "schemaVersion": WORKFLOW_CHAT_ACCEPTANCE_VERSION,
+        "scenarioVersion": WORKFLOW_CHAT_SCENARIO_VERSION,
+        "routeInventoryVersion": compatibility_map()["version"],
         "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
         "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
         "status": "passed",
@@ -1078,8 +1481,13 @@ def build_workflow_chat_acceptance_manifest(
         "sourceCommit": source.get("sourceCommit"),
         "compatibilityProfile": source.get("compatibilityProfile"),
         "images": dict(source.get("images") or {}),
-        "rows": {str(key): dict(value) for key, value in rows.items()},
-        "reports": list(reports),
+        "bundleDigests": dict(source.get("bundleDigests") or {}),
+        "supersededReportRef": source.get("supersededReportRef"),
+        "combinations": {
+            str(key): dict(value)
+            for key, value in combinations.items()
+            if isinstance(value, Mapping)
+        },
         "evidenceScans": {
             str(key): dict(value)
             for key, value in scans.items()
@@ -1102,6 +1510,9 @@ def validate_workflow_chat_acceptance_manifest(
 
     if (
         manifest.get("schemaVersion") != WORKFLOW_CHAT_ACCEPTANCE_VERSION
+        or manifest.get("scenarioVersion") != WORKFLOW_CHAT_SCENARIO_VERSION
+        or manifest.get("routeInventoryVersion")
+        != compatibility_map()["version"]
         or manifest.get("issue") != WORKFLOW_CHAT_ACCEPTANCE_ISSUE
         or manifest.get("parentIssue") != WORKFLOW_CHAT_PARENT_ISSUE
         or manifest.get("status") != "passed"
@@ -1109,7 +1520,21 @@ def validate_workflow_chat_acceptance_manifest(
         != WORKFLOW_CHAT_COMPATIBILITY_PROFILE
     ):
         raise ConformanceContractError(
-            "workflow Chat acceptance identity or status is invalid"
+            "workflow Chat acceptance identity, scenario, or route-inventory "
+            "version is invalid"
+        )
+    superseded = manifest.get("supersededReportRef")
+    if superseded is not None and (
+        not isinstance(superseded, str)
+        or not superseded.strip()
+        or urllib.parse.urlparse(superseded).scheme not in {"", "https"}
+        or (
+            not urllib.parse.urlparse(superseded).scheme
+            and Path(superseded).is_absolute()
+        )
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance superseded report ref is not a bounded ref"
         )
     observed_at = now or datetime.now(timezone.utc)
     generated_at = _timestamp(manifest.get("generatedAt"), field="generatedAt")
@@ -1133,6 +1558,15 @@ def validate_workflow_chat_acceptance_manifest(
     if not isinstance(images, Mapping):
         raise ConformanceContractError("workflow Chat acceptance images are missing")
     require_pinned_images({str(key): str(value) for key, value in images.items()})
+    bundle_digests = manifest.get("bundleDigests")
+    if not isinstance(bundle_digests, Mapping) or set(bundle_digests) != set(
+        REQUIRED_BUNDLE_DIGESTS
+    ):
+        raise ConformanceContractError(
+            "workflow Chat acceptance bundle digests are incomplete"
+        )
+    for name in REQUIRED_BUNDLE_DIGESTS:
+        _require_sha256_ref(bundle_digests[name], field=f"bundleDigests.{name}")
 
     evidence_manifest = manifest.get("evidenceManifest")
     if not isinstance(evidence_manifest, list) or not evidence_manifest:
@@ -1169,225 +1603,347 @@ def validate_workflow_chat_acceptance_manifest(
         if isinstance(value, dict):
             resolved[ref] = value
 
-    rows = manifest.get("rows")
-    if not isinstance(rows, Mapping) or set(rows) != set(REQUIRED_WORKFLOW_CHAT_ROWS):
+    inventory = workflow_chat_combinations()
+    combinations = manifest.get("combinations")
+    if not isinstance(combinations, Mapping) or set(combinations) != set(inventory):
         raise ConformanceContractError(
-            "workflow Chat acceptance matrix coverage is incomplete"
+            "workflow Chat acceptance combination coverage is incomplete"
         )
     used_refs: set[str] = set()
     trace_screenshot_digests: set[str] = set()
-    global_correlation: dict[str, str] | None = None
-    for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
-        row = rows[row_name]
-        if not isinstance(row, Mapping) or row.get("status") != "passed":
+    for combination_id, combination in inventory.items():
+        entry = combinations[combination_id]
+        if not isinstance(entry, Mapping):
             raise ConformanceContractError(
-                f"workflow Chat acceptance row did not pass: {row_name}"
+                f"workflow Chat acceptance combination is malformed: {combination_id}"
             )
-        assertions = row.get("assertions")
-        refs = row.get("evidenceRefs")
         if (
-            not isinstance(assertions, Mapping)
-            or any(assertions.get(name) is not True for name in required_assertions)
-            or not isinstance(refs, list)
-            or not refs
+            entry.get("schemaVersion") != WORKFLOW_CHAT_COMBINATION_VERSION
+            or entry.get("combinationId") != combination_id
+            or entry.get("harnessId") != combination.harness_id
+            or entry.get("hostClassRef") != combination.host_class_ref
+            or entry.get("launchPolicyRef") != combination.launch_policy_ref
+            or entry.get("executionRealizerRef")
+            != combination.execution_realizer_ref
+            or entry.get("hostMode") != combination.host_mode
+            or set(
+                _require_string_list(
+                    entry.get("advertisedCapabilities"),
+                    field=f"combinations.{combination_id}.advertisedCapabilities",
+                )
+            )
+            != set(combination.advertised_capabilities)
         ):
             raise ConformanceContractError(
-                f"workflow Chat acceptance row lacks controlling evidence: {row_name}"
+                "workflow Chat acceptance combination identity does not match the "
+                f"claimed inventory: {combination_id}"
             )
-        for ref_value in refs:
-            ref = str(ref_value)
-            evidence = resolved.get(ref)
-            evidence_assertions = (
-                evidence.get("assertions")
-                if isinstance(evidence, Mapping)
-                else None
-            )
-            source_records = (
-                evidence.get("sourceRecords")
-                if isinstance(evidence, Mapping)
-                else None
-            )
+        if not combination.native_chat_claimed:
             if (
-                not isinstance(evidence, Mapping)
-                or evidence.get("schemaVersion")
-                != WORKFLOW_CHAT_CASE_EVIDENCE_VERSION
-                or evidence.get("issue") != WORKFLOW_CHAT_ACCEPTANCE_ISSUE
-                or evidence.get("parentIssue") != WORKFLOW_CHAT_PARENT_ISSUE
-                or evidence.get("row") != row_name
-                or evidence.get("status") != "passed"
-                or evidence.get("sourceCommit") != source_commit
-                or evidence.get("images") != images
-                or evidence.get("stockHostUnmodified") is not True
-                or evidence.get("browserOriginated") is not True
-                or evidence.get("moonmindScopedOnly") is not True
-                or not isinstance(evidence_assertions, Mapping)
-                or any(
-                    evidence_assertions.get(name) is not True
-                    for name in required_assertions
-                )
-                or not isinstance(source_records, list)
+                entry.get("status") != "unsupported"
+                or entry.get("unsupportedReason") != combination.unsupported_reason
+                or entry.get("rows")
+                or entry.get("reports")
+                or entry.get("bindingIdentity")
             ):
                 raise ConformanceContractError(
-                    f"workflow Chat acceptance case evidence is invalid: {row_name}"
+                    "workflow Chat acceptance must report an unclaimed combination "
+                    f"as unsupported with its stable reason: {combination_id}"
                 )
-            used_refs.add(ref)
-            sources_by_type: dict[str, Mapping[str, Any]] = {}
-            for record in source_records:
-                if not isinstance(record, Mapping):
-                    raise ConformanceContractError(
-                        f"workflow Chat source record is malformed: {row_name}"
-                    )
-                record_type = str(record.get("type") or "")
-                record_ref = str(record.get("ref") or "")
-                record_digest = str(record.get("sha256") or "")
-                if (
-                    not record_type
-                    or not record_ref
-                    or _SHA256.fullmatch(record_digest) is None
-                    or record_type in sources_by_type
-                ):
-                    raise ConformanceContractError(
-                        f"workflow Chat source record is malformed: {row_name}"
-                    )
-                source = resolved.get(record_ref)
-                manifest_digest = manifest_digests.get(record_ref, "")
-                if (
-                    not isinstance(source, Mapping)
-                    or manifest_digest != record_digest
-                ):
-                    raise ConformanceContractError(
-                        "workflow Chat source record is invalid: "
-                        f"{row_name}/{record_type}"
-                    )
-                sources_by_type[record_type] = source
-                used_refs.add(record_ref)
-            derived_assertions, correlation = validate_workflow_chat_source_records(
-                sources_by_type,
-                row_name=row_name,
-                source_commit=source_commit,
-                images=images,
-                generated_at=generated_at,
-                expected_correlation=global_correlation,
+            continue
+        if (
+            entry.get("status") != "passed"
+            or entry.get("unsupportedReason") is not None
+        ):
+            raise ConformanceContractError(
+                f"workflow Chat acceptance combination did not pass: {combination_id}"
             )
-            browser_data = sources_by_type["browserTrace"].get("data")
-            if isinstance(browser_data, Mapping):
-                trace_screenshot_digests.add(
-                    _require_sha256_ref(
-                        browser_data.get("screenshotSha256"),
-                        field="browserTrace.data.screenshotSha256",
-                    ).removeprefix("sha256:")
+        _validate_binding_identity(
+            entry.get("bindingIdentity"), combination=combination
+        )
+        cleanup_outcome = entry.get("cleanupOutcome")
+        if not isinstance(cleanup_outcome, Mapping) or any(
+            cleanup_outcome.get(field) is not True
+            for field in ("liveResourcesRemoved", "providerProfileReleasedLast")
+        ):
+            raise ConformanceContractError(
+                "workflow Chat acceptance combination lacks a complete cleanup "
+                f"outcome: {combination_id}"
+            )
+        _require_string(
+            cleanup_outcome.get("cleanupState"),
+            field=f"combinations.{combination_id}.cleanupOutcome.cleanupState",
+        )
+        rows = entry.get("rows")
+        if not isinstance(rows, Mapping) or set(rows) != set(
+            REQUIRED_WORKFLOW_CHAT_ROWS
+        ):
+            raise ConformanceContractError(
+                "workflow Chat acceptance journey coverage is incomplete: "
+                f"{combination_id}"
+            )
+        global_correlation: dict[str, str] | None = None
+        observed_cleanup_state: str | None = None
+        for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
+            row = rows[row_name]
+            if not isinstance(row, Mapping) or row.get("status") != "passed":
+                raise ConformanceContractError(
+                    f"workflow Chat acceptance row did not pass: {row_name}"
                 )
-            captured_source = sources_by_type.get("capturedEvidence")
-            if captured_source is not None:
-                captured_data = _require_mapping(
-                    captured_source.get("data"), field="capturedEvidence.data"
-                )
-                for artifact in _require_evidence_items(
-                    captured_data.get("artifacts"),
-                    field="capturedEvidence.data.artifacts",
-                ):
-                    if manifest_digests.get(artifact["ref"]) != artifact["sha256"]:
-                        raise ConformanceContractError(
-                            "workflow Chat capturedEvidence artifact is unresolved"
-                        )
-                    used_refs.add(artifact["ref"])
-            if any(
-                evidence_assertions.get(name) is not value
-                or assertions.get(name) is not value
-                for name, value in derived_assertions.items()
+            assertions = row.get("assertions")
+            refs = row.get("evidenceRefs")
+            if (
+                not isinstance(assertions, Mapping)
+                or any(assertions.get(name) is not True for name in required_assertions)
+                or not isinstance(refs, list)
+                or not refs
             ):
                 raise ConformanceContractError(
-                    "workflow Chat row assertions do not match typed source evidence: "
-                    f"{row_name}"
+                    f"workflow Chat acceptance row lacks controlling evidence: {row_name}"
                 )
-            if global_correlation is None:
-                global_correlation = correlation
-
-    reports = manifest.get("reports")
-    if not isinstance(reports, list) or not reports:
-        raise ConformanceContractError("workflow Chat acceptance report is missing")
-    for report_ref in reports:
-        ref = str(report_ref)
-        report = resolved.get(ref)
-        summary = report.get("summary") if isinstance(report, Mapping) else None
-        cases = report.get("cases") if isinstance(report, Mapping) else None
-        try:
-            failed = (
-                int(summary.get("failed", 1))
-                if isinstance(summary, Mapping)
-                else 1
-            )
-            passed = (
-                int(summary.get("passed", 0))
-                if isinstance(summary, Mapping)
-                else 0
-            )
-            skipped = (
-                int(summary.get("skipped", 0))
-                if isinstance(summary, Mapping)
-                else 0
-            )
-        except (TypeError, ValueError) as exc:
-            raise ConformanceContractError(
-                "workflow Chat acceptance report summary is malformed"
-            ) from exc
-        try:
-            report_generated_at = _timestamp(
-                report.get("generatedAt") if isinstance(report, Mapping) else None,
-                field="report.generatedAt",
-            )
-        except ConformanceContractError as exc:
-            raise ConformanceContractError(
-                "workflow Chat acceptance references a stale or malformed report"
-            ) from exc
-        case_statuses: list[str] = []
-        case_ids: set[str] = set()
-        if isinstance(cases, list):
-            for case in cases:
-                case_id = case.get("caseId") if isinstance(case, Mapping) else None
-                case_status = (
-                    case.get("status") if isinstance(case, Mapping) else None
+            for ref_value in refs:
+                ref = str(ref_value)
+                evidence = resolved.get(ref)
+                evidence_assertions = (
+                    evidence.get("assertions")
+                    if isinstance(evidence, Mapping)
+                    else None
                 )
-                case_refs = (
-                    case.get("evidenceRefs")
-                    if isinstance(case, Mapping)
+                source_records = (
+                    evidence.get("sourceRecords")
+                    if isinstance(evidence, Mapping)
                     else None
                 )
                 if (
-                    not isinstance(case_id, str)
-                    or not case_id
-                    or case_id in case_ids
-                    or case_status not in {"passed", "failed", "skipped"}
-                    or not isinstance(case_refs, list)
-                    or not case_refs
-                    or any(str(item) not in resolved_raw for item in case_refs)
+                    not isinstance(evidence, Mapping)
+                    or evidence.get("schemaVersion")
+                    != WORKFLOW_CHAT_CASE_EVIDENCE_VERSION
+                    or evidence.get("issue") != WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+                    or evidence.get("parentIssue") != WORKFLOW_CHAT_PARENT_ISSUE
+                    or evidence.get("row") != row_name
+                    or evidence.get("combination") != combination_id
+                    or evidence.get("status") != "passed"
+                    or evidence.get("sourceCommit") != source_commit
+                    or evidence.get("images") != images
+                    or evidence.get("stockHostUnmodified") is not True
+                    or evidence.get("browserOriginated") is not True
+                    or evidence.get("moonmindScopedOnly") is not True
+                    or not isinstance(evidence_assertions, Mapping)
+                    or any(
+                        evidence_assertions.get(name) is not True
+                        for name in required_assertions
+                    )
+                    or not isinstance(source_records, list)
                 ):
                     raise ConformanceContractError(
-                        "workflow Chat acceptance report cases are malformed"
+                        f"workflow Chat acceptance case evidence is invalid: {row_name}"
                     )
-                case_ids.add(case_id)
-                case_statuses.append(str(case_status))
-        computed_summary = {
-            status_name: sum(value == status_name for value in case_statuses)
-            for status_name in ("passed", "failed", "skipped")
-        }
+                used_refs.add(ref)
+                sources_by_type: dict[str, Mapping[str, Any]] = {}
+                for record in source_records:
+                    if not isinstance(record, Mapping):
+                        raise ConformanceContractError(
+                            f"workflow Chat source record is malformed: {row_name}"
+                        )
+                    record_type = str(record.get("type") or "")
+                    record_ref = str(record.get("ref") or "")
+                    record_digest = str(record.get("sha256") or "")
+                    if (
+                        not record_type
+                        or not record_ref
+                        or _SHA256.fullmatch(record_digest) is None
+                        or record_type in sources_by_type
+                    ):
+                        raise ConformanceContractError(
+                            f"workflow Chat source record is malformed: {row_name}"
+                        )
+                    source = resolved.get(record_ref)
+                    manifest_digest = manifest_digests.get(record_ref, "")
+                    if (
+                        not isinstance(source, Mapping)
+                        or manifest_digest != record_digest
+                    ):
+                        raise ConformanceContractError(
+                            "workflow Chat source record is invalid: "
+                            f"{row_name}/{record_type}"
+                        )
+                    sources_by_type[record_type] = source
+                    used_refs.add(record_ref)
+                derived_assertions, correlation = validate_workflow_chat_source_records(
+                    sources_by_type,
+                    row_name=row_name,
+                    source_commit=source_commit,
+                    images=images,
+                    generated_at=generated_at,
+                    combination=combination,
+                    expected_correlation=global_correlation,
+                )
+                browser_data = sources_by_type["browserTrace"].get("data")
+                if isinstance(browser_data, Mapping):
+                    trace_screenshot_digests.add(
+                        _require_sha256_ref(
+                            browser_data.get("screenshotSha256"),
+                            field="browserTrace.data.screenshotSha256",
+                        ).removeprefix("sha256:")
+                    )
+                captured_source = sources_by_type.get("capturedEvidence")
+                if captured_source is not None:
+                    captured_data = _require_mapping(
+                        captured_source.get("data"), field="capturedEvidence.data"
+                    )
+                    for artifact in _require_evidence_items(
+                        captured_data.get("artifacts"),
+                        field="capturedEvidence.data.artifacts",
+                    ):
+                        if manifest_digests.get(artifact["ref"]) != artifact["sha256"]:
+                            raise ConformanceContractError(
+                                "workflow Chat capturedEvidence artifact is unresolved"
+                            )
+                        used_refs.add(artifact["ref"])
+                if any(
+                    evidence_assertions.get(name) is not value
+                    or assertions.get(name) is not value
+                    for name, value in derived_assertions.items()
+                ):
+                    raise ConformanceContractError(
+                        "workflow Chat row assertions do not match typed source evidence: "
+                        f"{row_name}"
+                    )
+                cleanup_source = sources_by_type.get("cleanupReceipt")
+                if cleanup_source is not None:
+                    cleanup_data = _require_mapping(
+                        cleanup_source.get("data"), field="cleanupReceipt.data"
+                    )
+                    observed_cleanup_state = str(cleanup_data["cleanupState"])
+                if global_correlation is None:
+                    global_correlation = correlation
+
+        if observed_cleanup_state != cleanup_outcome["cleanupState"]:
+            raise ConformanceContractError(
+                "workflow Chat acceptance cleanup outcome does not match the "
+                f"typed cleanup receipt: {combination_id}"
+            )
+        if global_correlation is None:
+            raise ConformanceContractError(
+                "workflow Chat acceptance combination resolved no session "
+                f"correlation: {combination_id}"
+            )
+        timeline_ref = _require_string(
+            entry.get("timelineRef"),
+            field=f"combinations.{combination_id}.timelineRef",
+        )
+        timeline = resolved.get(timeline_ref)
+        terminal = timeline.get("terminal") if isinstance(timeline, Mapping) else None
+        timeline_cleanup = (
+            timeline.get("cleanup") if isinstance(timeline, Mapping) else None
+        )
         if (
-            not isinstance(report, Mapping)
-            or report.get("schemaVersion") != REPORT_VERSION
-            or report.get("images") != images
-            or not isinstance(summary, Mapping)
-            or not case_statuses
-            or computed_summary
-            != {"passed": passed, "failed": failed, "skipped": skipped}
-            or report_generated_at > generated_at
-            or generated_at - report_generated_at > timedelta(days=1)
-            or failed != 0
-            or passed < 1
+            not isinstance(timeline, Mapping)
+            or timeline.get("sessionId") != global_correlation["bridgeSessionId"]
+            or not isinstance(terminal, Mapping)
+            or terminal.get("state") not in _TERMINAL_STATES
+            or not isinstance(timeline_cleanup, Mapping)
+            or timeline_cleanup.get("state") != cleanup_outcome["cleanupState"]
         ):
             raise ConformanceContractError(
-                "workflow Chat acceptance references a non-passing report"
+                "workflow Chat acceptance operator timeline does not bind the "
+                f"terminal, cleaned-up session: {combination_id}"
             )
-        used_refs.add(ref)
+        used_refs.add(timeline_ref)
+        reports = entry.get("reports")
+        if not isinstance(reports, list) or not reports:
+            raise ConformanceContractError(
+                "workflow Chat acceptance report is missing: "
+                f"{combination_id}"
+            )
+        for report_ref in reports:
+            ref = str(report_ref)
+            report = resolved.get(ref)
+            summary = report.get("summary") if isinstance(report, Mapping) else None
+            cases = report.get("cases") if isinstance(report, Mapping) else None
+            try:
+                failed = (
+                    int(summary.get("failed", 1))
+                    if isinstance(summary, Mapping)
+                    else 1
+                )
+                passed = (
+                    int(summary.get("passed", 0))
+                    if isinstance(summary, Mapping)
+                    else 0
+                )
+                skipped = (
+                    int(summary.get("skipped", 0))
+                    if isinstance(summary, Mapping)
+                    else 0
+                )
+            except (TypeError, ValueError) as exc:
+                raise ConformanceContractError(
+                    "workflow Chat acceptance report summary is malformed"
+                ) from exc
+            try:
+                report_generated_at = _timestamp(
+                    report.get("generatedAt") if isinstance(report, Mapping) else None,
+                    field="report.generatedAt",
+                )
+            except ConformanceContractError as exc:
+                raise ConformanceContractError(
+                    "workflow Chat acceptance references a stale or malformed report"
+                ) from exc
+            case_statuses: list[str] = []
+            case_ids: set[str] = set()
+            if isinstance(cases, list):
+                for case in cases:
+                    case_id = case.get("caseId") if isinstance(case, Mapping) else None
+                    case_status = (
+                        case.get("status") if isinstance(case, Mapping) else None
+                    )
+                    case_refs = (
+                        case.get("evidenceRefs")
+                        if isinstance(case, Mapping)
+                        else None
+                    )
+                    duration_ms = (
+                        case.get("durationMs") if isinstance(case, Mapping) else None
+                    )
+                    if (
+                        not isinstance(case_id, str)
+                        or not case_id
+                        or case_id in case_ids
+                        or case_status not in {"passed", "failed", "skipped"}
+                        or not isinstance(duration_ms, int)
+                        or isinstance(duration_ms, bool)
+                        or duration_ms <= 0
+                        or not isinstance(case_refs, list)
+                        or not case_refs
+                        or any(str(item) not in resolved_raw for item in case_refs)
+                    ):
+                        raise ConformanceContractError(
+                            "workflow Chat acceptance report cases are malformed"
+                        )
+                    case_ids.add(case_id)
+                    case_statuses.append(str(case_status))
+            computed_summary = {
+                status_name: sum(value == status_name for value in case_statuses)
+                for status_name in ("passed", "failed", "skipped")
+            }
+            if (
+                not isinstance(report, Mapping)
+                or report.get("schemaVersion") != REPORT_VERSION
+                or report.get("images") != images
+                or not isinstance(summary, Mapping)
+                or not case_statuses
+                or computed_summary
+                != {"passed": passed, "failed": failed, "skipped": skipped}
+                or report_generated_at > generated_at
+                or generated_at - report_generated_at > timedelta(days=1)
+                or failed != 0
+                or passed < 1
+            ):
+                raise ConformanceContractError(
+                    "workflow Chat acceptance references a non-passing report"
+                )
+            used_refs.add(ref)
 
     scans = manifest.get("evidenceScans")
     if not isinstance(scans, Mapping) or set(scans) != set(
@@ -1448,15 +2004,22 @@ def validate_workflow_chat_acceptance_manifest(
 
 __all__ = [
     "MAX_ACCEPTANCE_AGE",
+    "REQUIRED_BUNDLE_DIGESTS",
     "REQUIRED_WORKFLOW_CHAT_ROWS",
     "REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS",
     "WORKFLOW_CHAT_ACCEPTANCE_ISSUE",
     "WORKFLOW_CHAT_ACCEPTANCE_VERSION",
     "WORKFLOW_CHAT_CASE_EVIDENCE_VERSION",
+    "WORKFLOW_CHAT_COMBINATIONS",
+    "WORKFLOW_CHAT_COMBINATION_VERSION",
     "WORKFLOW_CHAT_COMPATIBILITY_PROFILE",
     "WORKFLOW_CHAT_PARENT_ISSUE",
+    "WORKFLOW_CHAT_SCENARIO_VERSION",
     "WORKFLOW_CHAT_SOURCE_RECORD_VERSION",
+    "WorkflowChatCombination",
+    "advertised_native_chat_capabilities",
     "build_workflow_chat_acceptance_manifest",
     "validate_workflow_chat_source_records",
     "validate_workflow_chat_acceptance_manifest",
+    "workflow_chat_combinations",
 ]

--- a/moonmind/omnigent/workflow_chat_acceptance.py
+++ b/moonmind/omnigent/workflow_chat_acceptance.py
@@ -77,6 +77,12 @@ _TERMINAL_CAPABILITIES = frozenset(
     }
 )
 _WORKSPACE_CAPABILITIES = frozenset({"uploadFiles", "mutateWorkspace"})
+
+# Provider Profile classes are release identity: the credential and provider
+# authority a combination ran under is pinned by the claimed inventory, so
+# evidence gathered under one class can never qualify another.
+_CODEX_OAUTH_PROFILE_CLASS = "omnigent-codex-oauth-profile-class@1"
+_OPENCODE_API_KEY_PROFILE_CLASS = "omnigent-opencode-api-key-profile-class@1"
 _CONTROL_CAPABILITY_REQUIREMENTS: Mapping[str, str] = {
     "interruptTurn": "interrupt",
     "stopSession": "terminate",
@@ -132,6 +138,16 @@ class WorkflowChatCombination:
     compose_profile: str
     compose_services: tuple[str, ...]
     native_chat_claimed: bool
+    # Credential/provider authority identity is code-owned per combination:
+    # evidence collected under one Provider Profile class, credential
+    # materializer, or authentication mode never qualifies another.
+    provider_profile_class: str = ""
+    credential_materializer_ref: str = ""
+    auth_mode: str = ""
+    # The manifest ``images`` key that pins the host image which actually
+    # executes this combination. Distinct host classes ship distinct images, so
+    # a single shared ``host`` digest cannot qualify all of them.
+    host_image_key: str = "host"
     unsupported_reason: str | None = None
 
     def __post_init__(self) -> None:
@@ -139,6 +155,19 @@ class WorkflowChatCombination:
             raise ConformanceContractError(
                 "workflow Chat combination must either be claimed or carry one "
                 f"stable unsupported reason: {self.combination_id}"
+            )
+        if self.native_chat_claimed and not all(
+            (
+                self.provider_profile_class,
+                self.credential_materializer_ref,
+                self.auth_mode,
+                self.host_image_key,
+            )
+        ):
+            raise ConformanceContractError(
+                "workflow Chat claimed combination must name its Provider "
+                "Profile class, credential materializer, authentication mode, "
+                f"and pinned host image: {self.combination_id}"
             )
         validate_realizer(self.execution_realizer_ref)
 
@@ -153,6 +182,33 @@ class WorkflowChatCombination:
     @property
     def host_mode(self) -> str:
         return self.launch_policy.hostMode
+
+    @property
+    def cleanup_mode(self) -> str:
+        return str(self.launch_policy.cleanup.get("mode") or "")
+
+    @property
+    def required_cleanup_steps(self) -> tuple[str, ...]:
+        """Return the ordered cleanup steps this host mode can truthfully emit.
+
+        On-demand hosts are removed, so the live host stops. Static-connected
+        hosts are drained and keep serving the next run, so demanding a stopped
+        host would force the adapter to publish false evidence.
+        """
+
+        steps = _CLEANUP_STEPS_BY_MODE.get(self.cleanup_mode)
+        if steps is None:
+            raise ConformanceContractError(
+                "workflow Chat combination has no cleanup contract for mode "
+                f"{self.cleanup_mode!r}: {self.combination_id}"
+            )
+        return steps
+
+    @property
+    def live_resources_removed_expected(self) -> bool:
+        """Whether cleanup must report the live host's resources as removed."""
+
+        return self.cleanup_mode == "remove"
 
     @property
     def advertised_capabilities(self) -> frozenset[str]:
@@ -174,6 +230,10 @@ WORKFLOW_CHAT_COMBINATIONS: tuple[WorkflowChatCombination, ...] = (
         compose_profile="omnigent-host-codex",
         compose_services=("omnigent",),
         native_chat_claimed=True,
+        provider_profile_class=_CODEX_OAUTH_PROFILE_CLASS,
+        credential_materializer_ref="codex-oauth-home@1",
+        auth_mode="codex-oauth",
+        host_image_key="host",
     ),
     WorkflowChatCombination(
         combination_id="codex-static-connected-through-omnigent",
@@ -184,6 +244,10 @@ WORKFLOW_CHAT_COMBINATIONS: tuple[WorkflowChatCombination, ...] = (
         compose_profile="omnigent-host-codex",
         compose_services=("omnigent", "omnigent-host-codex"),
         native_chat_claimed=True,
+        provider_profile_class=_CODEX_OAUTH_PROFILE_CLASS,
+        credential_materializer_ref="codex-oauth-home@1",
+        auth_mode="codex-oauth",
+        host_image_key="host",
     ),
     WorkflowChatCombination(
         combination_id="opencode-through-generic-omnigent-host",
@@ -194,6 +258,12 @@ WORKFLOW_CHAT_COMBINATIONS: tuple[WorkflowChatCombination, ...] = (
         compose_profile="omnigent-host-codex",
         compose_services=("omnigent",),
         native_chat_claimed=True,
+        provider_profile_class=_OPENCODE_API_KEY_PROFILE_CLASS,
+        credential_materializer_ref="opencode-auth-json@1",
+        auth_mode="opencode-api-key",
+        # The OpenCode journey runs the dedicated OpenCode host image, which is
+        # pinned separately from the Codex host digest.
+        host_image_key="opencodeHost",
     ),
 )
 
@@ -210,6 +280,17 @@ def workflow_chat_combinations() -> dict[str, WorkflowChatCombination]:
             )
         inventory[combination.combination_id] = combination
     return inventory
+
+
+def workflow_chat_case_id(combination_id: str, row_name: str) -> str:
+    """Return the one canonical report case id for a combination's row.
+
+    The case id is code-owned so a report cannot satisfy one combination's
+    retirement coverage with another combination's passing cases.
+    """
+
+    return f"workflow-chat-{combination_id}-{row_name}"
+
 
 REQUIRED_WORKFLOW_CHAT_ROWS: Mapping[str, frozenset[str]] = {
     "native-live-conversation": frozenset(
@@ -297,6 +378,7 @@ REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS: Mapping[str, frozenset[str]] = {
 
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _SHA256_REF = re.compile(r"^sha256:[0-9a-f]{64}$")
+_IMAGE_DIGEST_REF = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _CORRELATION_FIELDS = (
     "workflowId",
     "chatBindingId",
@@ -321,8 +403,10 @@ _DENIAL_KINDS = frozenset(
         "cross_workflow",
     }
 )
-# Cleanup must finish with provider-profile release, after the live host and
-# provider session are gone and the workspace result is durable.
+# Cleanup must finish with provider-profile release, after the live host is
+# retired for its host mode, the provider session is gone, and the workspace
+# result is durable. On-demand hosts stop; static-connected hosts drain and keep
+# serving, so their truthful terminal step is a drain, not a stop.
 _PROVIDER_PROFILE_RELEASE_STEP = "provider_profile_release"
 _REQUIRED_CLEANUP_STEPS = (
     "live_host_stopped",
@@ -330,6 +414,28 @@ _REQUIRED_CLEANUP_STEPS = (
     "workspace_published",
     _PROVIDER_PROFILE_RELEASE_STEP,
 )
+_DRAIN_CLEANUP_STEPS = (
+    "live_host_drained",
+    "provider_session_removed",
+    "workspace_published",
+    _PROVIDER_PROFILE_RELEASE_STEP,
+)
+_CLEANUP_STEPS_BY_MODE: Mapping[str, tuple[str, ...]] = {
+    "remove": _REQUIRED_CLEANUP_STEPS,
+    "drain": _DRAIN_CLEANUP_STEPS,
+}
+_CLEANUP_STEP_KINDS = frozenset(_REQUIRED_CLEANUP_STEPS) | frozenset(
+    _DRAIN_CLEANUP_STEPS
+)
+# Cross-scope denials only prove isolation when they record the authorized and
+# attempted identities, so a relabelled ordinary 403 cannot satisfy them.
+_CROSS_SCOPE_IDENTITY_FIELDS = (
+    "authorizedUserId",
+    "attemptedUserId",
+    "authorizedWorkflowId",
+    "attemptedWorkflowId",
+)
+_CROSS_SCOPE_DENIAL_KINDS = frozenset({"cross_user", "cross_workflow"})
 _EXECUTIONS_CREATE_PATH = "/api/executions"
 _TERMINAL_STATES = frozenset(
     {"completed", "failed", "canceled", "cancelled", "timed_out", "stopped"}
@@ -421,6 +527,47 @@ def _require_evidence_items(value: Any, *, field: str) -> list[dict[str, str]]:
         seen.add(ref)
         result.append({"ref": ref, "sha256": digest})
     return result
+
+
+def _validate_cross_scope_denial(
+    denial: Mapping[str, Any], *, kind: str, workflow_id: str
+) -> None:
+    """Require the identities that make a cross-scope denial meaningful.
+
+    ``cross_user`` and ``cross_workflow`` are isolation claims, not labels: the
+    audit must name the authorized scope under test and the different scope the
+    attempt used, so an ordinary 403 cannot be relabelled as either check.
+    """
+
+    identity = _require_mapping(
+        denial.get("scopeIdentity"),
+        field="denialAudit.data.denials[].scopeIdentity",
+    )
+    if set(identity) != set(_CROSS_SCOPE_IDENTITY_FIELDS):
+        raise ConformanceContractError(
+            f"workflow Chat {kind} denial does not record both scope identities"
+        )
+    values = {
+        field: _require_string(
+            identity[field],
+            field=f"denialAudit.data.denials[].scopeIdentity.{field}",
+        )
+        for field in _CROSS_SCOPE_IDENTITY_FIELDS
+    }
+    if values["authorizedWorkflowId"] != workflow_id:
+        raise ConformanceContractError(
+            f"workflow Chat {kind} denial is not bound to the workflow under test"
+        )
+    same_user = values["attemptedUserId"] == values["authorizedUserId"]
+    same_workflow = values["attemptedWorkflowId"] == values["authorizedWorkflowId"]
+    # Exactly one scope may vary, otherwise the denial does not isolate the
+    # property it claims to prove.
+    if (kind == "cross_user" and (same_user or not same_workflow)) or (
+        kind == "cross_workflow" and (same_workflow or not same_user)
+    ):
+        raise ConformanceContractError(
+            f"workflow Chat {kind} denial does not vary exactly that scope"
+        )
 
 
 def _validate_record_data(
@@ -741,11 +888,10 @@ def _validate_record_data(
         denial_ids: set[str] = set()
         for denial in denials:
             item = _require_mapping(denial, field="denialAudit.data.denials[]")
-            kinds.add(
-                _require_string(
-                    item.get("kind"), field="denialAudit.data.denials[].kind"
-                )
+            kind = _require_string(
+                item.get("kind"), field="denialAudit.data.denials[].kind"
             )
+            kinds.add(kind)
             if (
                 item.get("requestId") not in request_id_set
                 or item.get("requestId") in denial_ids
@@ -758,6 +904,10 @@ def _validate_record_data(
             _require_string(
                 item.get("auditRef"), field="denialAudit.data.denials[].auditRef"
             )
+            if kind in _CROSS_SCOPE_DENIAL_KINDS:
+                _validate_cross_scope_denial(
+                    item, kind=kind, workflow_id=workflow_id
+                )
         if not _DENIAL_KINDS.issubset(kinds):
             raise ConformanceContractError(
                 "workflow Chat denialAudit coverage is incomplete"
@@ -994,6 +1144,7 @@ def _validate_record_data(
             raise ConformanceContractError(
                 "workflow Chat cleanupReceipt requires ordered cleanup steps"
             )
+        required_steps = combination.required_cleanup_steps
         observed: dict[int, str] = {}
         for raw_step in steps:
             step = _require_mapping(raw_step, field="cleanupReceipt.data.steps[]")
@@ -1002,7 +1153,7 @@ def _validate_record_data(
             )
             order = step.get("order")
             if (
-                kind not in _REQUIRED_CLEANUP_STEPS
+                kind not in _CLEANUP_STEP_KINDS
                 or not isinstance(order, int)
                 or isinstance(order, bool)
                 or order in observed
@@ -1018,14 +1169,15 @@ def _validate_record_data(
         ordered = [observed[key] for key in sorted(observed)]
         if (
             sorted(observed) != list(range(1, len(ordered) + 1))
-            or set(ordered) != set(_REQUIRED_CLEANUP_STEPS)
-            or ordered[-1] != _PROVIDER_PROFILE_RELEASE_STEP
-            or data.get("liveResourcesRemoved") is not True
+            # The documented contract is an order, not a set: publishing the
+            # workspace before removing the provider session is not equivalent.
+            or tuple(ordered) != required_steps
+            or data.get("liveResourcesRemoved")
+            is not combination.live_resources_removed_expected
             or data.get("providerProfileReleasedLast") is not True
             or data.get("outcome") != "released"
             or data.get("hostMode") != combination.host_mode
-            or data.get("cleanupMode")
-            != combination.launch_policy.cleanup.get("mode")
+            or data.get("cleanupMode") != combination.cleanup_mode
         ):
             raise ConformanceContractError(
                 "workflow Chat cleanupReceipt does not prove release-last cleanup"
@@ -1149,7 +1301,33 @@ def validate_workflow_chat_source_records(
         str(item["requestId"]): item
         for item in sources["browserTrace"]["data"]["networkEvents"]
     }
+    creation_source = sources.get("executionCreation")
+    if creation_source is not None:
+        creation_data = creation_source["data"]
+        create_event = browser_events[str(creation_data["createRequestId"])]
+        # The record must describe the same observed call the browser made, not
+        # merely reuse a request ID seen somewhere in the trace.
+        if str(create_event["method"]) != "POST" or urllib.parse.urlsplit(
+            str(create_event["path"])
+        ).path != _EXECUTIONS_CREATE_PATH:
+            raise ConformanceContractError(
+                "workflow Chat executionCreation does not match the observed "
+                "browser create request"
+            )
     expected_denial_statuses: dict[str, int] = {}
+    capability_source = sources.get("capabilitySnapshot")
+    if capability_source is not None:
+        # A capability that evaluates false is enforced with a real denial, so
+        # its browser event is a 403 rather than an unsuccessful positive.
+        expected_denial_statuses.update(
+            {
+                str(observation["requestId"]): 403
+                for observation in capability_source["data"][
+                    "enforcement"
+                ].values()
+                if observation.get("outcome") == "denied"
+            }
+        )
     denial_source = sources.get("denialAudit")
     if denial_source is not None:
         expected_denial_statuses.update(
@@ -1355,15 +1533,20 @@ def _validate_binding_identity(
             "workflow Chat acceptance binding identity is incomplete: "
             f"{combination.combination_id}"
         )
-    _require_string(
-        payload.get("providerProfileClass"),
-        field="bindingIdentity.providerProfileClass",
+    materializer_refs = _require_string_list(
+        payload.get("materializerRefs"), field="bindingIdentity.materializerRefs"
     )
     if (
         payload.get("hostClassRef") != combination.host_class_ref
         or payload.get("launchPolicyRef") != combination.launch_policy_ref
         or payload.get("executionRealizerRef")
         != combination.execution_realizer_ref
+        # The Provider Profile class is not part of the canonical support-key
+        # payload, so it is pinned by the claimed inventory instead: evidence
+        # collected under one credential authority class cannot qualify another.
+        or payload.get("providerProfileClass")
+        != combination.provider_profile_class
+        or combination.credential_materializer_ref not in materializer_refs
     ):
         raise ConformanceContractError(
             "workflow Chat acceptance binding identity does not match the "
@@ -1645,6 +1828,7 @@ def validate_workflow_chat_acceptance_manifest(
                 or entry.get("rows")
                 or entry.get("reports")
                 or entry.get("bindingIdentity")
+                or entry.get("hostImageRef")
             ):
                 raise ConformanceContractError(
                     "workflow Chat acceptance must report an unclaimed combination "
@@ -1661,10 +1845,23 @@ def validate_workflow_chat_acceptance_manifest(
         _validate_binding_identity(
             entry.get("bindingIdentity"), combination=combination
         )
+        # A combination is only qualified by the host image that actually ran
+        # it, so the digest is pinned per host class instead of sharing one
+        # ``host`` entry across materially different images.
+        host_image_ref = images.get(combination.host_image_key)
+        if entry.get("hostImageRef") != host_image_ref or _IMAGE_DIGEST_REF.fullmatch(
+            str(host_image_ref or "")
+        ) is None:
+            raise ConformanceContractError(
+                "workflow Chat acceptance combination does not pin the host "
+                f"image digest that executed it: {combination_id}"
+            )
         cleanup_outcome = entry.get("cleanupOutcome")
-        if not isinstance(cleanup_outcome, Mapping) or any(
-            cleanup_outcome.get(field) is not True
-            for field in ("liveResourcesRemoved", "providerProfileReleasedLast")
+        if (
+            not isinstance(cleanup_outcome, Mapping)
+            or cleanup_outcome.get("providerProfileReleasedLast") is not True
+            or cleanup_outcome.get("liveResourcesRemoved")
+            is not combination.live_resources_removed_expected
         ):
             raise ConformanceContractError(
                 "workflow Chat acceptance combination lacks a complete cleanup "
@@ -1684,6 +1881,7 @@ def validate_workflow_chat_acceptance_manifest(
             )
         global_correlation: dict[str, str] | None = None
         observed_cleanup_state: str | None = None
+        row_evidence_refs: dict[str, set[str]] = {}
         for row_name, required_assertions in REQUIRED_WORKFLOW_CHAT_ROWS.items():
             row = rows[row_name]
             if not isinstance(row, Mapping) or row.get("status") != "passed":
@@ -1701,6 +1899,7 @@ def validate_workflow_chat_acceptance_manifest(
                 raise ConformanceContractError(
                     f"workflow Chat acceptance row lacks controlling evidence: {row_name}"
                 )
+            row_evidence_refs[row_name] = {str(ref_value) for ref_value in refs}
             for ref_value in refs:
                 ref = str(ref_value)
                 evidence = resolved.get(ref)
@@ -1892,6 +2091,7 @@ def validate_workflow_chat_acceptance_manifest(
                 ) from exc
             case_statuses: list[str] = []
             case_ids: set[str] = set()
+            case_refs_by_id: dict[str, set[str]] = {}
             if isinstance(cases, list):
                 for case in cases:
                     case_id = case.get("caseId") if isinstance(case, Mapping) else None
@@ -1922,6 +2122,7 @@ def validate_workflow_chat_acceptance_manifest(
                             "workflow Chat acceptance report cases are malformed"
                         )
                     case_ids.add(case_id)
+                    case_refs_by_id[case_id] = {str(item) for item in case_refs}
                     case_statuses.append(str(case_status))
             computed_summary = {
                 status_name: sum(value == status_name for value in case_statuses)
@@ -1938,10 +2139,26 @@ def validate_workflow_chat_acceptance_manifest(
                 or report_generated_at > generated_at
                 or generated_at - report_generated_at > timedelta(days=1)
                 or failed != 0
-                or passed < 1
+                or skipped != 0
+                or passed != len(REQUIRED_WORKFLOW_CHAT_ROWS)
             ):
                 raise ConformanceContractError(
                     "workflow Chat acceptance references a non-passing report"
+                )
+            # A report only qualifies this combination when its cases name this
+            # combination's rows and reference exactly that row's evidence.
+            if case_refs_by_id != {
+                workflow_chat_case_id(combination_id, row_name): refs
+                for row_name, refs in row_evidence_refs.items()
+            }:
+                raise ConformanceContractError(
+                    "workflow Chat acceptance report does not cover this "
+                    f"combination's row evidence: {combination_id}"
+                )
+            if report.get("authMode") != combination.auth_mode:
+                raise ConformanceContractError(
+                    "workflow Chat acceptance report publishes the wrong "
+                    f"authentication mode: {combination_id}"
                 )
             used_refs.add(ref)
 
@@ -2021,5 +2238,6 @@ __all__ = [
     "build_workflow_chat_acceptance_manifest",
     "validate_workflow_chat_source_records",
     "validate_workflow_chat_acceptance_manifest",
+    "workflow_chat_case_id",
     "workflow_chat_combinations",
 ]

--- a/tests/provider/omnigent/test_omnigent_smoke.py
+++ b/tests/provider/omnigent/test_omnigent_smoke.py
@@ -342,6 +342,10 @@ async def test_live_native_workflow_chat_release_matrix(bridge_store) -> None:
             continue
         assert entry.get("status") == "passed"
         assert set(entry.get("rows") or {}) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
+        # The combination is only qualified by the host image that ran it.
+        assert entry.get("hostImageRef") == (payload.get("images") or {}).get(
+            combination.host_image_key
+        )
 
 
 async def test_live_cumulative_remediation_journey(bridge_store) -> None:

--- a/tests/provider/omnigent/test_omnigent_smoke.py
+++ b/tests/provider/omnigent/test_omnigent_smoke.py
@@ -38,6 +38,7 @@ from moonmind.omnigent.workflow_chat_acceptance import (
     REQUIRED_WORKFLOW_CHAT_ROWS,
     WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
     validate_workflow_chat_acceptance_manifest,
+    workflow_chat_combinations,
 )
 from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
 
@@ -331,7 +332,16 @@ async def test_live_native_workflow_chat_release_matrix(bridge_store) -> None:
         expected_commit=expected_commit,
     )
     assert payload.get("issue") == WORKFLOW_CHAT_ACCEPTANCE_ISSUE
-    assert set(payload.get("rows") or {}) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
+    combinations = payload.get("combinations") or {}
+    assert set(combinations) == set(workflow_chat_combinations())
+    for combination_id, combination in workflow_chat_combinations().items():
+        entry = combinations[combination_id]
+        if not combination.native_chat_claimed:
+            assert entry.get("status") == "unsupported"
+            assert entry.get("unsupportedReason")
+            continue
+        assert entry.get("status") == "passed"
+        assert set(entry.get("rows") or {}) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
 
 
 async def test_live_cumulative_remediation_journey(bridge_store) -> None:

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -29,6 +29,7 @@ from moonmind.omnigent.workflow_chat_acceptance import (
     WorkflowChatCombination,
     build_workflow_chat_acceptance_manifest,
     validate_workflow_chat_acceptance_manifest,
+    workflow_chat_case_id,
     workflow_chat_combinations,
 )
 
@@ -36,6 +37,7 @@ NOW = datetime(2026, 8, 13, tzinfo=timezone.utc)
 IMAGES = {
     "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
     "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
+    "opencodeHost": "ghcr.io/omnigent/host-opencode@sha256:" + "3" * 64,
 }
 BUNDLE_DIGESTS = {
     "dashboard": "sha256:" + "7" * 64,
@@ -89,7 +91,7 @@ def _binding_identity(combination: WorkflowChatCombination) -> dict[str, object]
         ),
         "vendorRuntimeRefs": ["opencode@1.18.11#sha256:" + "d" * 64],
         "agentSourceRef": "agent-source:sha256:" + "c" * 64,
-        "materializerRefs": ["codex-oauth-home@1"],
+        "materializerRefs": [combination.credential_materializer_ref],
         "providerCompatibilityClass": "omnigent-provider-binding-set@1",
         "hostClassRef": combination.host_class_ref,
         "architecture": "linux/amd64",
@@ -103,7 +105,7 @@ def _binding_identity(combination: WorkflowChatCombination) -> dict[str, object]
         "supportCombinationKey": compute_support_combination_key(
             SupportKeyPayload.model_validate(fields)
         ),
-        "providerProfileClass": "omnigent-codex-oauth-profile-class@1",
+        "providerProfileClass": combination.provider_profile_class,
     }
 
 
@@ -113,7 +115,9 @@ def _request_ids(
     if row_name == "scoped-transports-and-resources":
         count = len(compatibility_map()["routes"]) + 1
     elif row_name == "authority-and-security-denials":
-        count = 8 + capability_count
+        # 8 scoped denial/scan requests, one independent capability-enforcement
+        # denial, then one allowed observation per advertised capability.
+        count = 9 + capability_count
     else:
         count = 6
     return [f"request-{combination_id}-{row_name}-{item}" for item in range(count)]
@@ -150,7 +154,7 @@ def _browser_events(
                         for item in range(len(request_ids))]
         elif row_name == "authority-and-security-denials":
             statuses = [
-                403 if item <= 6 else 503 if item == 7 else 200
+                403 if item <= 6 or item == 8 else 503 if item == 7 else 200
                 for item in range(len(request_ids))
             ]
         else:
@@ -328,6 +332,19 @@ def _record_data(
             "cross_user",
             "cross_workflow",
         ]
+        authorized_scope = {
+            "authorizedUserId": "user-1",
+            "attemptedUserId": "user-1",
+            "authorizedWorkflowId": correlation["workflowId"],
+            "attemptedWorkflowId": correlation["workflowId"],
+        }
+        cross_scope = {
+            "cross_user": {**authorized_scope, "attemptedUserId": "user-2"},
+            "cross_workflow": {
+                **authorized_scope,
+                "attemptedWorkflowId": f"other-{correlation['workflowId']}",
+            },
+        }
         return {
             "requestIds": request_ids[: len(kinds)],
             "denials": [
@@ -336,6 +353,11 @@ def _record_data(
                     "kind": kind,
                     "upstreamForwarded": False,
                     "auditRef": f"artifact://denial-{item}",
+                    **(
+                        {"scopeIdentity": cross_scope[kind]}
+                        if kind in cross_scope
+                        else {}
+                    ),
                 }
                 for item, kind in enumerate(kinds)
             ],
@@ -361,13 +383,16 @@ def _record_data(
         enforcement = {}
         for item, capability in enumerate(advertised):
             if capability == "changeModel":
+                # An independent enforcement request, not a request id already
+                # present in denialAudit, so the denied status is derived from
+                # the capability observation itself.
                 enforcement[capability] = {
-                    "requestId": request_ids[2],
+                    "requestId": request_ids[8],
                     "outcome": "denied",
                 }
             else:
                 enforcement[capability] = {
-                    "requestId": request_ids[8 + item],
+                    "requestId": request_ids[9 + item],
                     "outcome": "allowed",
                 }
         return {
@@ -476,20 +501,13 @@ def _record_data(
                     "outcome": "completed",
                     "auditRef": f"artifact://cleanup-{item}",
                 }
-                for item, kind in enumerate(
-                    (
-                        "live_host_stopped",
-                        "provider_session_removed",
-                        "workspace_published",
-                        "provider_profile_release",
-                    )
-                )
+                for item, kind in enumerate(combination.required_cleanup_steps)
             ],
-            "liveResourcesRemoved": True,
+            "liveResourcesRemoved": combination.live_resources_removed_expected,
             "providerProfileReleasedLast": True,
             "outcome": "released",
             "hostMode": combination.host_mode,
-            "cleanupMode": combination.launch_policy.cleanup.get("mode"),
+            "cleanupMode": combination.cleanup_mode,
             "cleanupState": "cleaned",
         }
     raise AssertionError(f"missing test source record: {record_type}")
@@ -590,7 +608,7 @@ def _matrix(root: Path) -> dict[str, object]:
             }
             cases.append(
                 {
-                    "caseId": f"workflow-chat-{combination_id}-{row_name}",
+                    "caseId": workflow_chat_case_id(combination_id, row_name),
                     "status": "passed",
                     "durationMs": 1000 + row_index,
                     "evidenceRefs": [case_ref],
@@ -603,6 +621,7 @@ def _matrix(root: Path) -> dict[str, object]:
                 "schemaVersion": "moonmind.omnigent.conformance-report/v1",
                 "generatedAt": NOW.isoformat(),
                 "images": IMAGES,
+                "authMode": combination.auth_mode,
                 "cases": cases,
                 "summary": {"passed": len(cases), "failed": 0, "skipped": 0},
             },
@@ -620,12 +639,15 @@ def _matrix(root: Path) -> dict[str, object]:
             **declared,
             "status": "passed",
             "unsupportedReason": None,
+            "hostImageRef": IMAGES[combination.host_image_key],
             "bindingIdentity": _binding_identity(combination),
             "rows": rows,
             "reports": [report_ref],
             "timelineRef": timeline_ref,
             "cleanupOutcome": {
-                "liveResourcesRemoved": True,
+                "liveResourcesRemoved": (
+                    combination.live_resources_removed_expected
+                ),
                 "providerProfileReleasedLast": True,
                 "cleanupState": "cleaned",
             },
@@ -1667,3 +1689,296 @@ def test_cleanup_outcome_must_match_the_typed_cleanup_receipt(tmp_path: Path) ->
         validate_workflow_chat_acceptance_manifest(
             manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
         )
+
+
+STATIC_COMBINATION = "codex-static-connected-through-omnigent"
+OPENCODE_COMBINATION = "opencode-through-generic-omnigent-host"
+
+
+def _validate(manifest: dict, root: Path) -> None:
+    validate_workflow_chat_acceptance_manifest(
+        manifest, evidence_root=root, expected_commit="abc123", now=NOW
+    )
+
+
+def test_cross_scope_denial_without_identities_fails_closed(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def drop_identity(payload: dict) -> None:
+        for denial in payload["data"]["denials"]:
+            denial.pop("scopeIdentity", None)
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="denialAudit",
+        update=drop_identity,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="scopeIdentity"):
+        _validate(manifest, tmp_path)
+
+
+def test_relabelled_cross_scope_denial_fails_closed(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def reuse_authorized_scope(payload: dict) -> None:
+        for denial in payload["data"]["denials"]:
+            if denial["kind"] == "cross_user":
+                # A denial that never left the authorized user proves nothing
+                # about user isolation.
+                denial["scopeIdentity"]["attemptedUserId"] = denial[
+                    "scopeIdentity"
+                ]["authorizedUserId"]
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="denialAudit",
+        update=reuse_authorized_scope,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="vary exactly that scope"):
+        _validate(manifest, tmp_path)
+
+
+def test_cross_scope_denial_must_bind_the_workflow_under_test(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def borrow_another_session(payload: dict) -> None:
+        for denial in payload["data"]["denials"]:
+            if denial["kind"] == "cross_workflow":
+                denial["scopeIdentity"]["authorizedWorkflowId"] = "other-workflow"
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="denialAudit",
+        update=borrow_another_session,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="workflow under test"):
+        _validate(manifest, tmp_path)
+
+
+def test_denied_capability_enforcement_expects_a_denied_browser_status(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+    row_index = ROW_NAMES.index("authority-and-security-denials")
+    snapshot = json.loads(
+        (
+            tmp_path
+            / _source_ref(PRIMARY_COMBINATION, row_index, "capabilitySnapshot")
+        ).read_text(encoding="utf-8")
+    )
+    denied_request_id = next(
+        observation["requestId"]
+        for observation in snapshot["data"]["enforcement"].values()
+        if observation["outcome"] == "denied"
+    )
+    # An independent enforcement request, not one already listed in denialAudit.
+    assert denied_request_id not in {
+        item["requestId"]
+        for item in json.loads(
+            (
+                tmp_path / _source_ref(PRIMARY_COMBINATION, row_index, "denialAudit")
+            ).read_text(encoding="utf-8")
+        )["data"]["denials"]
+    }
+
+    def succeed_denied_enforcement(payload: dict) -> None:
+        for event in payload["data"]["networkEvents"]:
+            if event["requestId"] == denied_request_id:
+                event["responseStatus"] = 200
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="browserTrace",
+        update=succeed_denied_enforcement,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="unexpected response status"):
+        _validate(manifest, tmp_path)
+
+
+def test_execution_creation_must_match_the_observed_browser_call(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def rewrite_create_event(payload: dict) -> None:
+        create_event = payload["data"]["networkEvents"][1]
+        create_event["method"] = "GET"
+        create_event["path"] = f"/api/executions/workflow-{PRIMARY_COMBINATION}"
+
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="browserTrace",
+        update=rewrite_create_event,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(
+        ConformanceContractError, match="observed browser create request"
+    ):
+        _validate(manifest, tmp_path)
+
+
+def test_cleanup_step_order_is_enforced(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def swap_middle_steps(payload: dict) -> None:
+        steps = payload["data"]["steps"]
+        steps[1]["order"], steps[2]["order"] = steps[2]["order"], steps[1]["order"]
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="cleanupReceipt",
+        update=swap_middle_steps,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="release-last cleanup"):
+        _validate(manifest, tmp_path)
+
+
+def test_static_connected_cleanup_is_a_drain_not_a_stop() -> None:
+    inventory = workflow_chat_combinations()
+    static = inventory[STATIC_COMBINATION]
+    on_demand = inventory[PRIMARY_COMBINATION]
+
+    assert static.required_cleanup_steps[0] == "live_host_drained"
+    assert static.live_resources_removed_expected is False
+    assert on_demand.required_cleanup_steps[0] == "live_host_stopped"
+    assert on_demand.live_resources_removed_expected is True
+
+
+def test_static_connected_host_may_not_claim_a_stopped_host(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def claim_a_stopped_host(payload: dict) -> None:
+        payload["data"]["steps"][0]["kind"] = "live_host_stopped"
+        payload["data"]["liveResourcesRemoved"] = True
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="cleanupReceipt",
+        update=claim_a_stopped_host,
+        combination_id=STATIC_COMBINATION,
+    )
+    source["combinations"][STATIC_COMBINATION]["cleanupOutcome"][
+        "liveResourcesRemoved"
+    ] = True
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="cleanup outcome"):
+        _validate(manifest, tmp_path)
+
+
+def test_provider_profile_class_is_pinned_by_the_claimed_inventory(
+    tmp_path: Path,
+) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][OPENCODE_COMBINATION]["bindingIdentity"][
+        "providerProfileClass"
+    ] = workflow_chat_combinations()[PRIMARY_COMBINATION].provider_profile_class
+
+    with pytest.raises(ConformanceContractError, match="combination under test"):
+        _validate(manifest, tmp_path)
+
+
+def test_credential_materializer_must_match_the_combination(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][OPENCODE_COMBINATION]["bindingIdentity"][
+        "materializerRefs"
+    ] = ["codex-oauth-home@1"]
+
+    with pytest.raises(ConformanceContractError, match="combination under test"):
+        _validate(manifest, tmp_path)
+
+
+def test_opencode_combination_pins_its_own_host_image(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][OPENCODE_COMBINATION]["hostImageRef"] = manifest[
+        "images"
+    ]["host"]
+
+    with pytest.raises(ConformanceContractError, match="host image digest"):
+        _validate(manifest, tmp_path)
+
+
+def test_report_from_another_combination_cannot_qualify_this_one(
+    tmp_path: Path,
+) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][OPENCODE_COMBINATION]["reports"] = [
+        f"report-{PRIMARY_COMBINATION}.json"
+    ]
+
+    with pytest.raises(ConformanceContractError, match="row evidence"):
+        _validate(manifest, tmp_path)
+
+
+def test_report_case_must_reference_its_own_row_evidence(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+    report_path = tmp_path / f"report-{PRIMARY_COMBINATION}.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["cases"][0]["evidenceRefs"] = report["cases"][1]["evidenceRefs"]
+    _write(report_path, report)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="row evidence"):
+        _validate(manifest, tmp_path)
+
+
+def test_report_must_publish_the_combination_auth_mode(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+    report_path = tmp_path / f"report-{OPENCODE_COMBINATION}.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["authMode"] = workflow_chat_combinations()[
+        PRIMARY_COMBINATION
+    ].auth_mode
+    _write(report_path, report)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="authentication mode"):
+        _validate(manifest, tmp_path)

--- a/tests/unit/omnigent/test_workflow_chat_acceptance.py
+++ b/tests/unit/omnigent/test_workflow_chat_acceptance.py
@@ -10,17 +10,26 @@ from pathlib import Path
 import pytest
 
 from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_support_combination_key,
+)
 from moonmind.omnigent.native_ui_compat import compatibility_map
 from moonmind.omnigent.workflow_chat_acceptance import (
+    REQUIRED_BUNDLE_DIGESTS,
     REQUIRED_WORKFLOW_CHAT_ROWS,
     REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS,
     WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
     WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+    WORKFLOW_CHAT_COMBINATION_VERSION,
     WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
     WORKFLOW_CHAT_PARENT_ISSUE,
+    WORKFLOW_CHAT_SCENARIO_VERSION,
     WORKFLOW_CHAT_SOURCE_RECORD_VERSION,
+    WorkflowChatCombination,
     build_workflow_chat_acceptance_manifest,
     validate_workflow_chat_acceptance_manifest,
+    workflow_chat_combinations,
 )
 
 NOW = datetime(2026, 8, 13, tzinfo=timezone.utc)
@@ -28,7 +37,13 @@ IMAGES = {
     "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
     "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
 }
+BUNDLE_DIGESTS = {
+    "dashboard": "sha256:" + "7" * 64,
+    "omnigentUi": "sha256:" + "8" * 64,
+}
 SCREENSHOT_EVIDENCE = b"secret-free protected screenshot evidence"
+ROW_NAMES = list(REQUIRED_WORKFLOW_CHAT_ROWS)
+PRIMARY_COMBINATION = "codex-on-demand-through-omnigent"
 
 
 def _write(path: Path, value: object) -> None:
@@ -55,87 +70,157 @@ def _route_path(route: dict[str, object]) -> str:
     return path
 
 
-def _request_ids(row_name: str, index: int) -> list[str]:
-    count = (
-        len(compatibility_map()["routes"]) + 1
-        if row_name == "scoped-transports-and-resources"
-        else 6
-    )
-    return [f"request-{index}-{item}" for item in range(count)]
+def _correlation(combination_id: str, row_index: int) -> dict[str, str]:
+    return {
+        "workflowId": f"workflow-{combination_id}",
+        "chatBindingId": f"binding-{combination_id}",
+        "bridgeSessionId": f"bridge-{combination_id}",
+        "providerSessionId": "provider-session-1",
+        "browserTraceId": f"browser-trace-{combination_id}-{row_index}",
+    }
+
+
+def _binding_identity(combination: WorkflowChatCombination) -> dict[str, object]:
+    fields: dict[str, object] = {
+        "omnigentServerBuildRef": "sha256:" + "b" * 64,
+        "omnigentHostBuildRef": "sha256:" + "b" * 64,
+        "harnessImplementationRef": (
+            "omnigent-harness-implementation:sha256:" + "a" * 64
+        ),
+        "vendorRuntimeRefs": ["opencode@1.18.11#sha256:" + "d" * 64],
+        "agentSourceRef": "agent-source:sha256:" + "c" * 64,
+        "materializerRefs": ["codex-oauth-home@1"],
+        "providerCompatibilityClass": "omnigent-provider-binding-set@1",
+        "hostClassRef": combination.host_class_ref,
+        "architecture": "linux/amd64",
+        "launchPolicyRef": combination.launch_policy_ref,
+        "modelConfigDigest": "sha256:" + "e" * 64,
+        "executionRealizerRef": combination.execution_realizer_ref,
+        "requiredCapabilitiesDigest": "sha256:" + "f" * 64,
+    }
+    return {
+        **fields,
+        "supportCombinationKey": compute_support_combination_key(
+            SupportKeyPayload.model_validate(fields)
+        ),
+        "providerProfileClass": "omnigent-codex-oauth-profile-class@1",
+    }
+
+
+def _request_ids(
+    row_name: str, combination_id: str, capability_count: int
+) -> list[str]:
+    if row_name == "scoped-transports-and-resources":
+        count = len(compatibility_map()["routes"]) + 1
+    elif row_name == "authority-and-security-denials":
+        count = 8 + capability_count
+    else:
+        count = 6
+    return [f"request-{combination_id}-{row_name}-{item}" for item in range(count)]
+
+
+def _browser_events(
+    row_name: str, combination_id: str, request_ids: list[str]
+) -> list[dict[str, object]]:
+    binding_id = f"binding-{combination_id}"
+    routes = compatibility_map()["routes"]
+    if row_name == "scoped-transports-and-resources":
+        transports = ["html"] + [str(route["transport"]) for route in routes]
+        paths = [f"/omnigent-ui/workflow-chat/{binding_id}"] + [
+            f"/api/workflow-chat-bindings/{binding_id}/omnigent/" + _route_path(route)
+            for route in routes
+        ]
+        methods = ["GET"] + [str(route["methods"][0]) for route in routes]
+        statuses = [200] + [
+            101 if str(route["transport"]) == "websocket" else 200 for route in routes
+        ]
+    else:
+        transports = ["html", "http", "sse", "websocket"] + [
+            "http" for _ in request_ids[4:]
+        ]
+        paths = [f"/omnigent-ui/workflow-chat/{binding_id}"] + [
+            f"/api/workflow-chat-bindings/{binding_id}/omnigent/health"
+            for _ in request_ids[1:]
+        ]
+        methods = ["GET"] * len(request_ids)
+        if row_name == "native-live-conversation":
+            paths[1] = "/api/executions"
+            methods[1] = "POST"
+            statuses = [201 if item == 1 else 101 if item == 3 else 200
+                        for item in range(len(request_ids))]
+        elif row_name == "authority-and-security-denials":
+            statuses = [
+                403 if item <= 6 else 503 if item == 7 else 200
+                for item in range(len(request_ids))
+            ]
+        else:
+            statuses = [
+                403 if item == 0 else 101 if item == 3 else 200
+                for item in range(len(request_ids))
+            ]
+    return [
+        {
+            "requestId": request_id,
+            "transport": transports[item],
+            "method": methods[item],
+            "path": paths[item],
+            "responseStatus": statuses[item],
+            "moonmindScoped": True,
+            "browserOriginated": True,
+        }
+        for item, request_id in enumerate(request_ids)
+    ]
 
 
 def _record_data(
-    record_type: str, row_name: str, index: int, root: Path
+    record_type: str,
+    row_name: str,
+    row_index: int,
+    combination: WorkflowChatCombination,
+    root: Path,
 ) -> dict[str, object]:
-    request_ids = _request_ids(row_name, index)
+    combination_id = combination.combination_id
+    correlation = _correlation(combination_id, row_index)
+    binding_id = correlation["chatBindingId"]
+    advertised = sorted(combination.advertised_capabilities)
+    request_ids = _request_ids(row_name, combination_id, len(advertised))
     common: dict[str, object] = {"requestIds": [request_ids[0]]}
     if record_type == "browserTrace":
-        if row_name == "scoped-transports-and-resources":
-            transports = ["html"] + [
-                str(route["transport"])
-                for route in compatibility_map()["routes"]
-            ]
-            route_paths = [
-                "/omnigent-ui/workflow-chat/binding-1"
-            ] + [
-                "/api/workflow-chat-bindings/binding-1/omnigent/"
-                + _route_path(route)
-                for route in compatibility_map()["routes"]
-            ]
-            methods = ["GET"] + [
-                str(route["methods"][0])
-                for route in compatibility_map()["routes"]
-            ]
-        else:
-            transports = ["html", "http", "sse", "websocket", "http", "http"]
-            route_paths = [
-                "/omnigent-ui/workflow-chat/binding-1"
-                if item == 0
-                else "/api/workflow-chat-bindings/binding-1/omnigent/health"
-                for item in range(len(request_ids))
-            ]
-            methods = ["GET"] * len(request_ids)
-        events = []
-        for item, (request_id, transport) in enumerate(
-            zip(request_ids, transports, strict=True)
-        ):
-            events.append(
-                {
-                    "requestId": request_id,
-                    "transport": transport,
-                    "method": methods[item],
-                    "path": route_paths[item],
-                    "responseStatus": (
-                        503
-                        if row_name == "authority-and-security-denials" and item == 5
-                        else 403
-                        if row_name == "authority-and-security-denials"
-                        or row_name == "terminal-evidence-and-continuation"
-                        and item == 0
-                        else 101
-                        if transport == "websocket"
-                        else 200
-                    ),
-                    "moonmindScoped": True,
-                    "browserOriginated": True,
-                }
-            )
         return {
             "requestIds": request_ids,
-            "route": "/workflows/workflow-1/chat",
-            "traceId": f"browser-trace-{index}",
+            "route": f"/workflows/{correlation['workflowId']}/chat",
+            "traceId": correlation["browserTraceId"],
             "directUpstreamRequestCount": 0,
             "exposedProviderFields": [],
             "screenshotSha256": "sha256:"
             + hashlib.sha256(SCREENSHOT_EVIDENCE).hexdigest(),
-            "networkEvents": events,
+            "networkEvents": _browser_events(row_name, combination_id, request_ids),
+        }
+    if record_type == "executionCreation":
+        return {
+            "requestIds": [request_ids[1]],
+            "createRequestId": request_ids[1],
+            "method": "POST",
+            "path": "/api/executions",
+            "createdThroughPublicApi": True,
+            "workflowId": correlation["workflowId"],
+            "resolvedBridgeSessionId": correlation["bridgeSessionId"],
+            "harnessId": combination.harness_id,
+            "executionRealizerRef": combination.execution_realizer_ref,
+            "launchPolicyRef": combination.launch_policy_ref,
+            "temporalWorkflowId": f"temporal-{combination_id}",
+            "temporalRunId": f"temporal-run-{combination_id}",
+            "temporalTaskQueue": "moonmind-omnigent",
+            "agentProfileSnapshotRef": "agent-profile-snapshot:sha256:" + "3" * 64,
+            "executionPlanRef": "omnigent-execution-plan:sha256:" + "4" * 64,
+            "providerProfileRef": "provider-profile:omnigent-codex",
         }
     if record_type == "bindingSnapshot":
         return {
             **common,
             "authoritative": True,
-            "resolvedBindingId": "binding-1",
-            "runId": "run-1",
+            "resolvedBindingId": binding_id,
+            "runId": f"run-{combination_id}",
             "state": "available",
             "readOnly": False,
             "capabilitiesDigest": "sha256:" + "4" * 64,
@@ -163,7 +248,7 @@ def _record_data(
                 "routeName": "native_ui_document",
                 "transport": "html",
                 "method": "GET",
-                "routePath": "omnigent-ui/workflow-chat/binding-1",
+                "routePath": f"omnigent-ui/workflow-chat/{binding_id}",
             }
         ] + [
             {
@@ -188,8 +273,8 @@ def _record_data(
                 {
                     **route,
                     "requestId": request_id,
-                    "bindingId": "binding-1",
-                    "providerSessionId": "provider-session-1",
+                    "bindingId": binding_id,
+                    "providerSessionId": correlation["providerSessionId"],
                     "authorized": True,
                     "serverResolvedTarget": True,
                     "reauthorized": request_id == reconnect_id,
@@ -213,15 +298,11 @@ def _record_data(
             ],
         }
     if record_type == "mutationReceipts":
-        mutating_route_names = {
-            str(route["name"])
-            for route in compatibility_map()["routes"]
-            if route["mutation"] is True
-        }
+        routes = compatibility_map()["routes"]
         mutation_ids = [
             request_ids[item + 1]
-            for item, route in enumerate(compatibility_map()["routes"])
-            if route["name"] in mutating_route_names
+            for item, route in enumerate(routes)
+            if route["mutation"] is True
         ]
         return {
             "requestIds": mutation_ids,
@@ -244,9 +325,11 @@ def _record_data(
             "provider_session_substitution",
             "hidden_control",
             "immutable_policy",
+            "cross_user",
+            "cross_workflow",
         ]
         return {
-            "requestIds": request_ids[:4],
+            "requestIds": request_ids[: len(kinds)],
             "denials": [
                 {
                     "requestId": request_ids[item],
@@ -258,33 +341,61 @@ def _record_data(
             ],
         }
     if record_type == "capabilitySnapshot":
+        sources = (
+            "upstream",
+            "agentProfile",
+            "providerPolicy",
+            "workflowState",
+            "callerPermission",
+        )
         inputs = {
-            "upstream": {"sendMessage": True, "changeModel": True},
-            "agentProfile": {"sendMessage": True, "changeModel": False},
-            "providerPolicy": {"sendMessage": True, "changeModel": True},
-            "workflowState": {"sendMessage": True, "changeModel": True},
-            "callerPermission": {"sendMessage": True, "changeModel": True},
+            name: {
+                capability: not (name == "agentProfile" and capability == "changeModel")
+                for capability in advertised
+            }
+            for name in sources
         }
-        effective = {"sendMessage": True, "changeModel": False}
+        effective = {
+            capability: capability != "changeModel" for capability in advertised
+        }
+        enforcement = {}
+        for item, capability in enumerate(advertised):
+            if capability == "changeModel":
+                enforcement[capability] = {
+                    "requestId": request_ids[2],
+                    "outcome": "denied",
+                }
+            else:
+                enforcement[capability] = {
+                    "requestId": request_ids[8 + item],
+                    "outcome": "allowed",
+                }
         return {
-            **common,
+            "requestIds": request_ids,
             "inputs": inputs,
             "effective": effective,
-            "snapshotDigest": _digest({"inputs": inputs, "effective": effective}),
+            "advertised": advertised,
+            "enforcement": enforcement,
+            "snapshotDigest": _digest(
+                {
+                    "inputs": inputs,
+                    "effective": effective,
+                    "advertised": advertised,
+                }
+            ),
         }
     if record_type == "scanAudit":
-        scan_ids = request_ids[4:]
         return {
-            "requestIds": scan_ids,
+            "requestIds": request_ids[6:8],
             "attempts": [
                 {
-                    "requestId": scan_ids[0],
+                    "requestId": request_ids[6],
                     "outcome": "blocked",
                     "forwarded": False,
                     "auditRef": "artifact://scan-blocked",
                 },
                 {
-                    "requestId": scan_ids[1],
+                    "requestId": request_ids[7],
                     "outcome": "enforcement_unavailable",
                     "forwarded": False,
                     "auditRef": "artifact://scan-unavailable",
@@ -307,14 +418,13 @@ def _record_data(
             "deniedMutationRequestIds": [request_ids[0]],
         }
     if record_type == "capturedEvidence":
-        artifacts = []
-        for ref in ("capture-manifest.json", "captured-final.json"):
-            artifacts.append(
-                {
-                    "ref": ref,
-                    "sha256": hashlib.sha256((root / ref).read_bytes()).hexdigest(),
-                }
-            )
+        artifacts = [
+            {
+                "ref": ref,
+                "sha256": hashlib.sha256((root / ref).read_bytes()).hexdigest(),
+            }
+            for ref in ("capture-manifest.json", "captured-final.json")
+        ]
         return {
             **common,
             "artifacts": artifacts,
@@ -323,10 +433,10 @@ def _record_data(
     if record_type == "continuationReceipt":
         relationship_identity = {
             "relationshipType": "linked_continuation",
-            "sourceWorkflowId": "workflow-1",
-            "sourceRunId": "run-1",
-            "destinationWorkflowId": "workflow-2",
-            "destinationRunId": "run-2",
+            "sourceWorkflowId": correlation["workflowId"],
+            "sourceRunId": f"run-{combination_id}",
+            "destinationWorkflowId": f"continuation-{combination_id}",
+            "destinationRunId": f"continuation-run-{combination_id}",
         }
         return {
             "requestIds": request_ids[1:3],
@@ -337,9 +447,9 @@ def _record_data(
                 "requestId": request_ids[1],
                 "created": True,
                 "relationshipType": "linked_continuation",
-                "sourceWorkflowId": "workflow-1",
-                "sourceRunId": "run-1",
-                "destinationWorkflowId": "workflow-2",
+                "sourceWorkflowId": correlation["workflowId"],
+                "sourceRunId": f"run-{combination_id}",
+                "destinationWorkflowId": f"continuation-{combination_id}",
             },
             "durableRelationship": {
                 **relationship_identity,
@@ -356,7 +466,41 @@ def _record_data(
             "replayedFromMoonMindArtifacts": True,
             "artifactRefs": ["captured-final.json"],
         }
+    if record_type == "cleanupReceipt":
+        return {
+            **common,
+            "steps": [
+                {
+                    "order": item + 1,
+                    "kind": kind,
+                    "outcome": "completed",
+                    "auditRef": f"artifact://cleanup-{item}",
+                }
+                for item, kind in enumerate(
+                    (
+                        "live_host_stopped",
+                        "provider_session_removed",
+                        "workspace_published",
+                        "provider_profile_release",
+                    )
+                )
+            ],
+            "liveResourcesRemoved": True,
+            "providerProfileReleasedLast": True,
+            "outcome": "released",
+            "hostMode": combination.host_mode,
+            "cleanupMode": combination.launch_policy.cleanup.get("mode"),
+            "cleanupState": "cleaned",
+        }
     raise AssertionError(f"missing test source record: {record_type}")
+
+
+def _source_ref(combination_id: str, row_index: int, record_type: str) -> str:
+    return f"source-{combination_id}-{row_index}-{record_type}.json"
+
+
+def _case_ref(combination_id: str, row_index: int) -> str:
+    return f"case-{combination_id}-{row_index}.json"
 
 
 def _matrix(root: Path) -> dict[str, object]:
@@ -365,83 +509,127 @@ def _matrix(root: Path) -> dict[str, object]:
         {"schemaVersion": "moonmind.capture-manifest/v1", "artifacts": ["final"]},
     )
     _write(root / "captured-final.json", {"status": "completed"})
-    rows: dict[str, object] = {}
-    for index, (row_name, assertions) in enumerate(
-        REQUIRED_WORKFLOW_CHAT_ROWS.items()
-    ):
-        source_records = []
-        for record_type in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
-            record_ref = f"source-{index}-{record_type}.json"
-            _write(
-                root / record_ref,
-                {
-                    "schemaVersion": WORKFLOW_CHAT_SOURCE_RECORD_VERSION,
-                    "recordType": record_type,
-                    "row": row_name,
-                    "sourceCommit": "abc123",
-                    "observedAt": NOW.isoformat(),
-                    "images": IMAGES,
-                    "observed": True,
-                    "correlation": {
-                        "workflowId": "workflow-1",
-                        "chatBindingId": "binding-1",
-                        "bridgeSessionId": "bridge-1",
-                        "providerSessionId": "provider-session-1",
-                        "browserTraceId": f"browser-trace-{index}",
+    combinations: dict[str, object] = {}
+    for combination_id, combination in workflow_chat_combinations().items():
+        declared: dict[str, object] = {
+            "schemaVersion": WORKFLOW_CHAT_COMBINATION_VERSION,
+            "combinationId": combination_id,
+            "harnessId": combination.harness_id,
+            "hostClassRef": combination.host_class_ref,
+            "launchPolicyRef": combination.launch_policy_ref,
+            "executionRealizerRef": combination.execution_realizer_ref,
+            "hostMode": combination.host_mode,
+            "advertisedCapabilities": sorted(combination.advertised_capabilities),
+        }
+        if not combination.native_chat_claimed:
+            combinations[combination_id] = {
+                **declared,
+                "status": "unsupported",
+                "unsupportedReason": combination.unsupported_reason,
+            }
+            continue
+        rows: dict[str, object] = {}
+        cases: list[dict[str, object]] = []
+        for row_index, row_name in enumerate(ROW_NAMES):
+            assertions = {
+                name: True for name in REQUIRED_WORKFLOW_CHAT_ROWS[row_name]
+            }
+            source_records = []
+            for record_type in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
+                record_ref = _source_ref(combination_id, row_index, record_type)
+                _write(
+                    root / record_ref,
+                    {
+                        "schemaVersion": WORKFLOW_CHAT_SOURCE_RECORD_VERSION,
+                        "recordType": record_type,
+                        "row": row_name,
+                        "combination": combination_id,
+                        "sourceCommit": "abc123",
+                        "observedAt": NOW.isoformat(),
+                        "images": IMAGES,
+                        "observed": True,
+                        "correlation": _correlation(combination_id, row_index),
+                        "data": _record_data(
+                            record_type, row_name, row_index, combination, root
+                        ),
                     },
-                    "data": _record_data(record_type, row_name, index, root),
+                )
+                source_records.append(
+                    {
+                        "type": record_type,
+                        "ref": record_ref,
+                        "sha256": hashlib.sha256(
+                            (root / record_ref).read_bytes()
+                        ).hexdigest(),
+                    }
+                )
+            case_ref = _case_ref(combination_id, row_index)
+            _write(
+                root / case_ref,
+                {
+                    "schemaVersion": WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+                    "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
+                    "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
+                    "combination": combination_id,
+                    "row": row_name,
+                    "status": "passed",
+                    "sourceCommit": "abc123",
+                    "images": IMAGES,
+                    "stockHostUnmodified": True,
+                    "browserOriginated": True,
+                    "moonmindScopedOnly": True,
+                    "assertions": assertions,
+                    "sourceRecords": source_records,
+                    "observations": ["bounded protected observation"],
                 },
             )
-            source_records.append(
+            rows[row_name] = {
+                "status": "passed",
+                "assertions": assertions,
+                "evidenceRefs": [case_ref],
+            }
+            cases.append(
                 {
-                    "type": record_type,
-                    "ref": record_ref,
-                    "sha256": hashlib.sha256(
-                        (root / record_ref).read_bytes()
-                    ).hexdigest(),
+                    "caseId": f"workflow-chat-{combination_id}-{row_name}",
+                    "status": "passed",
+                    "durationMs": 1000 + row_index,
+                    "evidenceRefs": [case_ref],
                 }
             )
-        ref = f"case-{index}.json"
+        report_ref = f"report-{combination_id}.json"
         _write(
-            root / ref,
+            root / report_ref,
             {
-                "schemaVersion": WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
-                "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
-                "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
-                "row": row_name,
-                "status": "passed",
-                "sourceCommit": "abc123",
+                "schemaVersion": "moonmind.omnigent.conformance-report/v1",
+                "generatedAt": NOW.isoformat(),
                 "images": IMAGES,
-                "stockHostUnmodified": True,
-                "browserOriginated": True,
-                "moonmindScopedOnly": True,
-                "assertions": {name: True for name in assertions},
-                "sourceRecords": source_records,
-                "observations": ["bounded protected observation"],
+                "cases": cases,
+                "summary": {"passed": len(cases), "failed": 0, "skipped": 0},
             },
         )
-        rows[row_name] = {
+        timeline_ref = f"timeline-{combination_id}.json"
+        _write(
+            root / timeline_ref,
+            {
+                "sessionId": _correlation(combination_id, 0)["bridgeSessionId"],
+                "terminal": {"state": "completed"},
+                "cleanup": {"state": "cleaned"},
+            },
+        )
+        combinations[combination_id] = {
+            **declared,
             "status": "passed",
-            "assertions": {name: True for name in assertions},
-            "evidenceRefs": [ref],
+            "unsupportedReason": None,
+            "bindingIdentity": _binding_identity(combination),
+            "rows": rows,
+            "reports": [report_ref],
+            "timelineRef": timeline_ref,
+            "cleanupOutcome": {
+                "liveResourcesRemoved": True,
+                "providerProfileReleasedLast": True,
+                "cleanupState": "cleaned",
+            },
         }
-    _write(
-        root / "report.json",
-        {
-            "schemaVersion": "moonmind.omnigent.conformance-report/v1",
-            "generatedAt": NOW.isoformat(),
-            "images": IMAGES,
-            "cases": [
-                {
-                    "caseId": f"workflow-chat-{index}",
-                    "status": "passed",
-                    "evidenceRefs": [f"case-{index}.json"],
-                }
-                for index in range(len(REQUIRED_WORKFLOW_CHAT_ROWS))
-            ],
-            "summary": {"passed": 4, "failed": 0, "skipped": 0},
-        },
-    )
     scans: dict[str, object] = {}
     for channel in ("logs", "temporalHistory", "screenshots", "archives"):
         ref = f"scan-{channel}.json"
@@ -474,8 +662,9 @@ def _matrix(root: Path) -> dict[str, object]:
         "sourceCommit": "abc123",
         "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
         "images": IMAGES,
-        "rows": rows,
-        "reports": ["report.json"],
+        "bundleDigests": dict(BUNDLE_DIGESTS),
+        "supersededReportRef": "previous/workflow-chat-acceptance.json",
+        "combinations": combinations,
         "evidenceScans": scans,
     }
 
@@ -486,14 +675,14 @@ def _rewrite_source(
     row_name: str,
     record_type: str,
     update,
+    combination_id: str = PRIMARY_COMBINATION,
 ) -> None:
-    row_names = list(REQUIRED_WORKFLOW_CHAT_ROWS)
-    index = row_names.index(row_name)
-    source_path = root / f"source-{index}-{record_type}.json"
+    row_index = ROW_NAMES.index(row_name)
+    source_path = root / _source_ref(combination_id, row_index, record_type)
     payload = json.loads(source_path.read_text(encoding="utf-8"))
     update(payload)
     _write(source_path, payload)
-    case_path = root / f"case-{index}.json"
+    case_path = root / _case_ref(combination_id, row_index)
     case = json.loads(case_path.read_text(encoding="utf-8"))
     record = next(
         item for item in case["sourceRecords"] if item["type"] == record_type
@@ -514,9 +703,412 @@ def test_complete_native_chat_matrix_builds_and_validates(tmp_path: Path) -> Non
         now=NOW,
     )
 
-    assert set(manifest["rows"]) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
+    assert set(manifest["combinations"]) == set(workflow_chat_combinations())
     assert manifest["issue"] == WORKFLOW_CHAT_ACCEPTANCE_ISSUE
+    assert manifest["scenarioVersion"] == WORKFLOW_CHAT_SCENARIO_VERSION
+    assert manifest["routeInventoryVersion"] == compatibility_map()["version"]
+    assert set(manifest["bundleDigests"]) == set(REQUIRED_BUNDLE_DIGESTS)
     assert all(item["sha256"] for item in manifest["evidenceManifest"])
+    for entry in manifest["combinations"].values():
+        assert set(entry["rows"]) == set(REQUIRED_WORKFLOW_CHAT_ROWS)
+
+
+def test_every_claimed_combination_appears_in_the_protected_matrix() -> None:
+    inventory = workflow_chat_combinations()
+
+    assert {
+        "codex-on-demand-through-omnigent",
+        "codex-static-connected-through-omnigent",
+        "opencode-through-generic-omnigent-host",
+    } <= set(inventory)
+    assert inventory["opencode-through-generic-omnigent-host"].execution_realizer_ref == (
+        "generic-omnigent-host@1"
+    )
+    host_modes = {
+        combination.host_mode
+        for combination in inventory.values()
+        if combination.native_chat_claimed
+    }
+    assert {"on-demand", "static-connected"} <= host_modes
+    # A materially different cleanup mode must yield a different capability
+    # contract rather than reusing one constant row set.
+    on_demand = inventory["codex-on-demand-through-omnigent"].advertised_capabilities
+    static = inventory[
+        "codex-static-connected-through-omnigent"
+    ].advertised_capabilities
+    assert on_demand != static
+    assert "cleanupSession" in on_demand and "cleanupSession" not in static
+
+
+def test_missing_claimed_combination_fails_closed(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"].pop("opencode-through-generic-omnigent-host")
+
+    with pytest.raises(ConformanceContractError, match="combination coverage"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_unclaimed_combination_needs_its_stable_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inventory = workflow_chat_combinations()
+    declined = WorkflowChatCombination(
+        combination_id="declined-combination",
+        harness_id="opencode-native",
+        host_class_ref="omnigent-opencode@1",
+        launch_policy_ref="omnigent-on-demand@1",
+        execution_realizer_ref="generic-omnigent-host@1",
+        compose_profile="omnigent-host-codex",
+        compose_services=("omnigent",),
+        native_chat_claimed=False,
+        unsupported_reason="native_chat_not_advertised",
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.workflow_chat_acceptance.WORKFLOW_CHAT_COMBINATIONS",
+        (inventory[PRIMARY_COMBINATION], declined),
+    )
+    source = _matrix(tmp_path)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+    validate_workflow_chat_acceptance_manifest(
+        manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+    )
+    assert manifest["combinations"]["declined-combination"]["status"] == "unsupported"
+
+    manifest["combinations"]["declined-combination"]["unsupportedReason"] = None
+    with pytest.raises(ConformanceContractError, match="unsupported"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["harnessImplementationRef", "executionRealizerRef", "modelConfigDigest"],
+)
+def test_binding_identity_must_recompute_the_support_combination_key(
+    field: str, tmp_path: Path
+) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    identity = manifest["combinations"][PRIMARY_COMBINATION]["bindingIdentity"]
+    if field == "modelConfigDigest":
+        identity[field] = "sha256:" + "9" * 64
+    elif field == "executionRealizerRef":
+        identity[field] = "generic-omnigent-host@1"
+    else:
+        identity[field] = "omnigent-harness-implementation:sha256:" + "9" * 64
+
+    with pytest.raises(ConformanceContractError, match="binding identity|support combination key"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_binding_identity_must_be_complete(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][PRIMARY_COMBINATION]["bindingIdentity"].pop(
+        "providerProfileClass"
+    )
+
+    with pytest.raises(ConformanceContractError, match="binding identity is incomplete"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_bundle_digests_are_required(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["bundleDigests"].pop("omnigentUi")
+
+    with pytest.raises(ConformanceContractError, match="bundle digests"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_route_inventory_version_must_match_the_served_surface(
+    tmp_path: Path,
+) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["routeInventoryVersion"] = "omnigent.native-ui-compat/v0"
+
+    with pytest.raises(ConformanceContractError, match="route-inventory"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_report_cases_require_a_measured_duration(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+    report_path = tmp_path / f"report-{PRIMARY_COMBINATION}.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report["cases"][0].pop("durationMs")
+    _write(report_path, report)
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="report cases are malformed"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_operator_timeline_must_bind_the_terminal_cleaned_session(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+    timeline_path = tmp_path / f"timeline-{PRIMARY_COMBINATION}.json"
+    _write(
+        timeline_path,
+        {
+            "sessionId": "unrelated-session",
+            "terminal": {"state": "completed"},
+            "cleanup": {"state": "cleaned"},
+        },
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="operator timeline"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_execution_creation_must_use_the_public_executions_api(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="executionCreation",
+        update=lambda payload: payload["data"].update(
+            {"createdThroughPublicApi": False}
+        ),
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="/api/executions"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_execution_creation_must_resolve_the_live_session(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="executionCreation",
+        update=lambda payload: payload["data"].update(
+            {"resolvedBridgeSessionId": "other-session"}
+        ),
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="/api/executions"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+@pytest.mark.parametrize("kind", ["cross_user", "cross_workflow"])
+def test_cross_user_and_cross_workflow_denials_are_required(
+    kind: str, tmp_path: Path
+) -> None:
+    source = _matrix(tmp_path)
+
+    def drop_denial(payload: dict[str, object]) -> None:
+        removed = next(
+            item for item in payload["data"]["denials"] if item["kind"] == kind
+        )
+        payload["data"]["denials"].remove(removed)
+        payload["data"]["requestIds"].remove(removed["requestId"])
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="denialAudit",
+        update=drop_denial,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="denialAudit coverage"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_capability_coverage_is_derived_from_the_advertised_contract(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def drop_capability(payload: dict[str, object]) -> None:
+        payload["data"]["enforcement"].pop("readResources")
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="capabilitySnapshot",
+        update=drop_capability,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(
+        ConformanceContractError, match="every advertised capability"
+    ):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_capability_enforcement_must_match_the_effective_decision(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def allow_denied_capability(payload: dict[str, object]) -> None:
+        payload["data"]["enforcement"]["changeModel"]["outcome"] = "allowed"
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="capabilitySnapshot",
+        update=allow_denied_capability,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(
+        ConformanceContractError, match="does not match the effective decision"
+    ):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_advertised_capability_namespace_must_match_the_combination(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+
+    def widen_namespace(payload: dict[str, object]) -> None:
+        payload["data"]["advertised"] = payload["data"]["advertised"] + ["invented"]
+
+    _rewrite_source(
+        tmp_path,
+        row_name="authority-and-security-denials",
+        record_type="capabilitySnapshot",
+        update=widen_namespace,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(
+        ConformanceContractError, match="advertised capability contract"
+    ):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_cleanup_must_release_the_provider_profile_last(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def release_profile_first(payload: dict[str, object]) -> None:
+        steps = payload["data"]["steps"]
+        release = next(
+            item for item in steps if item["kind"] == "provider_profile_release"
+        )
+        release["order"] = 1
+        for step in steps:
+            if step is not release:
+                step["order"] += 1
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="cleanupReceipt",
+        update=release_profile_first,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="release-last cleanup"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_cleanup_receipt_must_cover_live_resource_removal(tmp_path: Path) -> None:
+    source = _matrix(tmp_path)
+
+    def drop_host_stop(payload: dict[str, object]) -> None:
+        steps = [
+            step
+            for step in payload["data"]["steps"]
+            if step["kind"] != "live_host_stopped"
+        ]
+        for order, step in enumerate(steps, start=1):
+            step["order"] = order
+        payload["data"]["steps"] = steps
+
+    _rewrite_source(
+        tmp_path,
+        row_name="terminal-evidence-and-continuation",
+        record_type="cleanupReceipt",
+        update=drop_host_stop,
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="release-last cleanup"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_combination_cleanup_outcome_is_required(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    manifest["combinations"][PRIMARY_COMBINATION]["cleanupOutcome"][
+        "providerProfileReleasedLast"
+    ] = False
+
+    with pytest.raises(ConformanceContractError, match="cleanup"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
 
 
 @pytest.mark.parametrize(
@@ -548,7 +1140,27 @@ def test_vacuous_source_record_cannot_satisfy_any_typed_schema(
         source, evidence_root=tmp_path
     )
 
-    with pytest.raises(ConformanceContractError, match="source record"):
+    with pytest.raises(ConformanceContractError, match="source record|Chat"):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+
+
+def test_source_records_must_declare_the_combination_under_test(
+    tmp_path: Path,
+) -> None:
+    source = _matrix(tmp_path)
+    _rewrite_source(
+        tmp_path,
+        row_name="native-live-conversation",
+        record_type="bindingSnapshot",
+        update=lambda payload: payload.update({"combination": "other-combination"}),
+    )
+    manifest = build_workflow_chat_acceptance_manifest(
+        source, evidence_root=tmp_path
+    )
+
+    with pytest.raises(ConformanceContractError, match="not bound to the combination"):
         validate_workflow_chat_acceptance_manifest(
             manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
         )
@@ -580,9 +1192,9 @@ def test_matrix_rows_must_bind_the_same_authoritative_workflow(tmp_path: Path) -
     source = _matrix(tmp_path)
 
     def substitute_workflow(payload: dict[str, object]) -> None:
-        payload["correlation"]["workflowId"] = "workflow-2"
+        payload["correlation"]["workflowId"] = "workflow-substituted"
         if payload["recordType"] == "browserTrace":
-            payload["data"]["route"] = "/workflows/workflow-2/chat"
+            payload["data"]["route"] = "/workflows/workflow-substituted/chat"
 
     for record_type in REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[
         "scoped-transports-and-resources"
@@ -711,7 +1323,7 @@ def test_every_observed_mutation_requires_one_receipt(tmp_path: Path) -> None:
     [
         ("native-live-conversation", 1, 500),
         ("authority-and-security-denials", 0, 200),
-        ("authority-and-security-denials", 5, 403),
+        ("authority-and-security-denials", 7, 403),
     ],
 )
 def test_browser_trace_requires_success_or_the_exact_denial_status(
@@ -741,7 +1353,7 @@ def test_browser_trace_scope_requires_a_path_segment_boundary(tmp_path: Path) ->
 
     def replace_path(payload: dict[str, object]) -> None:
         payload["data"]["networkEvents"][0]["path"] = (
-            "/omnigent-ui/workflow-chat/binding-1-attacker"
+            f"/omnigent-ui/workflow-chat/binding-{PRIMARY_COMBINATION}-attacker"
         )
 
     _rewrite_source(
@@ -886,6 +1498,7 @@ def test_source_records_must_bind_commit_and_immutable_images(
         "failed_report",
         "missing_scan",
         "missing_source_record",
+        "absolute_superseded_ref",
     ],
 )
 def test_native_chat_rollout_gate_fails_closed(
@@ -895,11 +1508,14 @@ def test_native_chat_rollout_gate_fails_closed(
     manifest = build_workflow_chat_acceptance_manifest(
         source, evidence_root=tmp_path
     )
+    entry = manifest["combinations"][PRIMARY_COMBINATION]
+    primary_case = _case_ref(PRIMARY_COMBINATION, 0)
     if mutation == "missing_row":
-        manifest["rows"].pop("native-live-conversation")
+        entry["rows"].pop("native-live-conversation")
     elif mutation == "failed_assertion":
-        row = manifest["rows"]["native-live-conversation"]
-        row["assertions"]["native_ui_primary"] = False
+        entry["rows"]["native-live-conversation"]["assertions"][
+            "native_ui_primary"
+        ] = False
     elif mutation == "stale":
         manifest["generatedAt"] = (NOW - timedelta(days=8)).isoformat()
     elif mutation == "wrong_commit":
@@ -907,50 +1523,40 @@ def test_native_chat_rollout_gate_fails_closed(
     elif mutation == "mutable_image":
         manifest["images"]["host"] = "ghcr.io/omnigent/host:latest"
     elif mutation == "unresolved_ref":
-        manifest["rows"]["native-live-conversation"]["evidenceRefs"] = [
-            "missing.json"
-        ]
+        entry["rows"]["native-live-conversation"]["evidenceRefs"] = ["missing.json"]
     elif mutation == "tampered_ref":
-        (tmp_path / "case-0.json").write_text("{}", encoding="utf-8")
+        (tmp_path / primary_case).write_text("{}", encoding="utf-8")
     elif mutation == "failed_report":
-        (tmp_path / "report.json").write_text(
-            json.dumps(
-                {
-                    "schemaVersion": "moonmind.omnigent.conformance-report/v1",
-                    "generatedAt": NOW.isoformat(),
-                    "images": IMAGES,
-                    "cases": [
-                        {
-                            "caseId": f"workflow-chat-{index}",
-                            "status": "failed" if index == 0 else "passed",
-                            "evidenceRefs": [f"case-{index}.json"],
-                        }
-                        for index in range(4)
-                    ],
-                    "summary": {"passed": 3, "failed": 1},
-                }
-            ),
-            encoding="utf-8",
-        )
+        report_ref = f"report-{PRIMARY_COMBINATION}.json"
+        report = json.loads((tmp_path / report_ref).read_text(encoding="utf-8"))
+        report["cases"][0]["status"] = "failed"
+        report["summary"] = {
+            "passed": len(report["cases"]) - 1,
+            "failed": 1,
+            "skipped": 0,
+        }
+        _write(tmp_path / report_ref, report)
         for item in manifest["evidenceManifest"]:
-            if item["ref"] == "report.json":
+            if item["ref"] == report_ref:
                 item["sha256"] = hashlib.sha256(
-                    (tmp_path / "report.json").read_bytes()
+                    (tmp_path / report_ref).read_bytes()
                 ).hexdigest()
     elif mutation == "missing_scan":
         manifest["evidenceScans"].pop("archives")
+    elif mutation == "absolute_superseded_ref":
+        manifest["supersededReportRef"] = "/etc/passwd"
     else:
-        case = json.loads((tmp_path / "case-0.json").read_text(encoding="utf-8"))
+        case = json.loads((tmp_path / primary_case).read_text(encoding="utf-8"))
         case["sourceRecords"] = [
             record
             for record in case["sourceRecords"]
             if record["type"] != "browserTrace"
         ]
-        _write(tmp_path / "case-0.json", case)
+        _write(tmp_path / primary_case, case)
         for item in manifest["evidenceManifest"]:
-            if item["ref"] == "case-0.json":
+            if item["ref"] == primary_case:
                 item["sha256"] = hashlib.sha256(
-                    (tmp_path / "case-0.json").read_bytes()
+                    (tmp_path / primary_case).read_bytes()
                 ).hexdigest()
 
     with pytest.raises(ConformanceContractError):
@@ -964,9 +1570,10 @@ def test_native_chat_rollout_gate_fails_closed(
 
 def test_native_chat_evidence_is_secret_scanned(tmp_path: Path) -> None:
     source = _matrix(tmp_path)
-    case = json.loads((tmp_path / "case-0.json").read_text(encoding="utf-8"))
+    case_ref = _case_ref(PRIMARY_COMBINATION, 0)
+    case = json.loads((tmp_path / case_ref).read_text(encoding="utf-8"))
     case["observations"] = ["Authorization: Bearer exposed-value"]
-    _write(tmp_path / "case-0.json", case)
+    _write(tmp_path / case_ref, case)
     manifest = build_workflow_chat_acceptance_manifest(
         source, evidence_root=tmp_path
     )
@@ -974,4 +1581,89 @@ def test_native_chat_evidence_is_secret_scanned(tmp_path: Path) -> None:
     with pytest.raises(ConformanceContractError, match="secret-like"):
         validate_workflow_chat_acceptance_manifest(
             manifest, evidence_root=tmp_path, now=NOW
+        )
+
+
+def test_retirement_guard_consumes_the_manifest_without_interpretation(
+    tmp_path: Path,
+) -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RETIREMENT_INVENTORY,
+        RetirementCriterion,
+        criteria_from_native_chat_acceptance,
+        evaluate_retirement,
+    )
+
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+
+    passed = criteria_from_native_chat_acceptance(
+        manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+    )
+
+    assert passed == frozenset({RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED})
+    native_chat_path = next(
+        path
+        for path in RETIREMENT_INVENTORY
+        if path.path_id == "omnigent.legacy.native_ui_compat"
+    )
+    decision = evaluate_retirement(native_chat_path, passed)
+    assert RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED not in (
+        decision.unmet_criteria
+    )
+
+
+@pytest.mark.parametrize("failure", ["missing", "expired", "incomplete"])
+def test_retirement_guard_gets_no_criterion_from_unusable_evidence(
+    failure: str, tmp_path: Path
+) -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        criteria_from_native_chat_acceptance,
+    )
+
+    if failure == "missing":
+        manifest = None
+    else:
+        manifest = build_workflow_chat_acceptance_manifest(
+            _matrix(tmp_path), evidence_root=tmp_path
+        )
+        if failure == "expired":
+            manifest["expiresAt"] = (NOW - timedelta(days=1)).isoformat()
+        else:
+            manifest["combinations"].pop(PRIMARY_COMBINATION)
+
+    assert (
+        criteria_from_native_chat_acceptance(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
+        )
+        == frozenset()
+    )
+
+
+def test_cleanup_outcome_must_match_the_typed_cleanup_receipt(tmp_path: Path) -> None:
+    manifest = build_workflow_chat_acceptance_manifest(
+        _matrix(tmp_path), evidence_root=tmp_path
+    )
+    entry = manifest["combinations"][PRIMARY_COMBINATION]
+    entry["cleanupOutcome"]["cleanupState"] = "claimed-clean"
+    _write(
+        tmp_path / f"timeline-{PRIMARY_COMBINATION}.json",
+        {
+            "sessionId": _correlation(PRIMARY_COMBINATION, 0)["bridgeSessionId"],
+            "terminal": {"state": "completed"},
+            "cleanup": {"state": "claimed-clean"},
+        },
+    )
+    for item in manifest["evidenceManifest"]:
+        if item["ref"] == f"timeline-{PRIMARY_COMBINATION}.json":
+            item["sha256"] = hashlib.sha256(
+                (tmp_path / item["ref"]).read_bytes()
+            ).hexdigest()
+
+    with pytest.raises(
+        ConformanceContractError, match="does not match the typed cleanup receipt"
+    ):
+        validate_workflow_chat_acceptance_manifest(
+            manifest, evidence_root=tmp_path, expected_commit="abc123", now=NOW
         )

--- a/tests/unit/test_omnigent_live_conformance_workflow.py
+++ b/tests/unit/test_omnigent_live_conformance_workflow.py
@@ -24,6 +24,7 @@ def test_live_conformance_is_scheduled_and_manually_gated() -> None:
     assert set(triggers["workflow_dispatch"]["inputs"]) == {
         "server_image",
         "host_image",
+        "opencode_host_image",
     }
     job = workflow["jobs"]["live-matrix"]
     assert job["environment"] == "omnigent-provider-verification"
@@ -52,6 +53,12 @@ def test_live_conformance_runs_the_complete_independent_matrix() -> None:
     assert "tools/run_omnigent_live_conformance.py" in run_step["run"]
     assert '--mode "${{ matrix.mode }}"' in run_step["run"]
     assert '--source-commit "${{ github.sha }}"' in run_step["run"]
+    # The OpenCode combination runs the dedicated OpenCode host image, so the
+    # protected run pins it separately from the Codex host digest.
+    assert (
+        '--opencode-host-image "${{ steps.images.outputs.opencode_host }}"'
+        in run_step["run"]
+    )
     assert run_step["env"]["MOONMIND_OMNIGENT_ACTION_COMMAND"] == (
         "${{ secrets.MOONMIND_OMNIGENT_ACTION_COMMAND }}"
     )

--- a/tests/unit/tools/test_run_omnigent_live_conformance.py
+++ b/tests/unit/tools/test_run_omnigent_live_conformance.py
@@ -612,7 +612,7 @@ def _workflow_chat_binding_identity(module, combination):
         ),
         "vendorRuntimeRefs": ["opencode@1.18.11#sha256:" + "d" * 64],
         "agentSourceRef": "agent-source:sha256:" + "c" * 64,
-        "materializerRefs": ["codex-oauth-home@1"],
+        "materializerRefs": [combination.credential_materializer_ref],
         "providerCompatibilityClass": "omnigent-provider-binding-set@1",
         "hostClassRef": combination.host_class_ref,
         "architecture": "linux/amd64",
@@ -624,14 +624,14 @@ def _workflow_chat_binding_identity(module, combination):
     return {
         **fields,
         "supportCombinationKey": "omnigent-support:sha256:" + "1" * 64,
-        "providerProfileClass": "omnigent-codex-oauth-profile-class@1",
+        "providerProfileClass": combination.provider_profile_class,
     }
 
 
 def _workflow_chat_cleanup_record(module, combination):
     return {
         "data": {
-            "liveResourcesRemoved": True,
+            "liveResourcesRemoved": combination.live_resources_removed_expected,
             "providerProfileReleasedLast": True,
             "cleanupState": "cleaned",
         }
@@ -666,10 +666,12 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     images = {
         "server": "ghcr.io/omnigent/server@sha256:" + "1" * 64,
         "host": "ghcr.io/omnigent/host@sha256:" + "2" * 64,
+        "opencodeHost": "ghcr.io/omnigent/host-opencode@sha256:" + "3" * 64,
     }
 
-    def action(scenario, row_name, **state):
+    def action(scenario, row_name, *, log_id="", **state):
         combination_id = state["combination"]
+        assert log_id == combination_id
         events.append(("action", row_name, dict(state)))
         records = []
         for record_type in module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
@@ -760,11 +762,32 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     )
     assert matrix["bundleDigests"] == WORKFLOW_CHAT_BUNDLE_DIGESTS
     for combination_id in claimed:
+        combination = module.workflow_chat_combinations()[combination_id]
         entry = matrix["combinations"][combination_id]
         assert entry["status"] == "passed"
         assert entry["cleanupOutcome"]["providerProfileReleasedLast"] is True
         assert entry["timelineRef"] == f"timeline-{combination_id}.json"
-        assert (tmp_path / entry["reports"][0]).is_file()
+        assert entry["hostImageRef"] == images[combination.host_image_key]
+        assert "_authMode" not in entry
+        report = json.loads(
+            (tmp_path / entry["reports"][0]).read_text(encoding="utf-8")
+        )
+        assert report["authMode"] == combination.auth_mode
+        assert {case["caseId"] for case in report["cases"]} == {
+            module.workflow_chat_case_id(combination_id, row_name)
+            for row_name in module.WORKFLOW_CHAT_ACTIONS
+        }
+    aggregate = json.loads(
+        (tmp_path / "workflow-chat-report.json").read_text(encoding="utf-8")
+    )
+    assert aggregate["authMode"] == "+".join(
+        sorted(
+            {
+                module.workflow_chat_combinations()[combination_id].auth_mode
+                for combination_id in claimed
+            }
+        )
+    )
     assert (tmp_path / "workflow-chat-matrix.json").is_file()
     assert (tmp_path / "workflow-chat-report.json").is_file()
     assert (tmp_path / "workflow-chat-acceptance.json").is_file()
@@ -785,6 +808,7 @@ def test_all_mode_reports_workflow_chat_and_scans_after_cleanup_and_report(
     images = {
         "server": "server@sha256:" + "1" * 64,
         "host": "host@sha256:" + "2" * 64,
+        "opencodeHost": "host-opencode@sha256:" + "3" * 64,
     }
 
     for mode in module.LIVE_CASES:
@@ -826,6 +850,8 @@ def test_all_mode_reports_workflow_chat_and_scans_after_cleanup_and_report(
             images["server"],
             "--host-image",
             images["host"],
+            "--opencode-host-image",
+            images["opencodeHost"],
             "--source-commit",
             "commit-1",
             "--output-dir",
@@ -860,7 +886,7 @@ def test_workflow_chat_controller_fails_before_provider_gate_when_scan_missing(
     monkeypatch.setattr(
         runner,
         "action",
-        lambda scenario, row_name, **state: _workflow_chat_action_result(
+        lambda scenario, row_name, log_id="", **state: _workflow_chat_action_result(
             module,
             tmp_path,
             row_name,
@@ -916,6 +942,7 @@ def test_workflow_chat_controller_fails_before_provider_gate_when_scan_missing(
             {
                 "server": "server@sha256:" + "1" * 64,
                 "host": "host@sha256:" + "2" * 64,
+                "opencodeHost": "host-opencode@sha256:" + "3" * 64,
             },
             "commit-1",
         )
@@ -1180,3 +1207,127 @@ def test_product_rejects_semantic_attestation_without_source_records(tmp_path, m
         assert "independently resolved source records" in str(exc)
     else:
         raise AssertionError("semantic product attestation was accepted")
+
+
+def test_workflow_chat_mode_requires_a_pinned_opencode_host_image(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            str(module.__file__),
+            "--mode",
+            "workflow_chat",
+            "--server-image",
+            "server@sha256:" + "1" * 64,
+            "--host-image",
+            "host@sha256:" + "2" * 64,
+            "--source-commit",
+            "commit-1",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 2
+
+
+def test_opencode_host_image_must_be_digest_pinned(tmp_path, monkeypatch):
+    module = _module()
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            str(module.__file__),
+            "--mode",
+            "workflow_chat",
+            "--server-image",
+            "server@sha256:" + "1" * 64,
+            "--host-image",
+            "host@sha256:" + "2" * 64,
+            "--opencode-host-image",
+            "host-opencode:latest",
+            "--source-commit",
+            "commit-1",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 2
+
+
+def test_pinned_opencode_host_image_reaches_the_server_environment(
+    tmp_path, monkeypatch
+):
+    module = _module()
+    captured = {}
+
+    def capture(self, images, source_commit):
+        captured["images"] = dict(images)
+        captured["opencodeRef"] = self.env.get("OMNIGENT_OPENCODE_HOST_IMAGE_REF")
+
+    monkeypatch.setattr(module.LiveRunner, "workflow_chat", capture)
+    monkeypatch.setattr(module.LiveRunner, "cleanup", lambda self, mode: None)
+    monkeypatch.setattr(
+        module.LiveRunner,
+        "scan",
+        lambda self: {
+            channel: {"status": "passed", "evidenceRef": f"scan-{channel}.json"}
+            for channel in module.EVIDENCE_ENV
+        },
+    )
+    monkeypatch.setattr(module.LiveRunner, "_scan_publication_tree", lambda self: None)
+    (tmp_path / "workflow-chat-report.json").write_text("{}", encoding="utf-8")
+    opencode_ref = "host-opencode@sha256:" + "3" * 64
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        [
+            str(module.__file__),
+            "--mode",
+            "workflow_chat",
+            "--server-image",
+            "server@sha256:" + "1" * 64,
+            "--host-image",
+            "host@sha256:" + "2" * 64,
+            "--opencode-host-image",
+            opencode_ref,
+            "--source-commit",
+            "commit-1",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert module.main() == 0
+    assert captured["images"]["opencodeHost"] == opencode_ref
+    assert captured["opencodeRef"] == opencode_ref
+
+
+def test_action_keeps_one_log_per_caller(tmp_path, monkeypatch):
+    module = _module()
+    runner = module.LiveRunner(
+        output_dir=tmp_path,
+        env={"MOONMIND_OMNIGENT_ACTION_COMMAND": "adapter"},
+    )
+    ref = _action_evidence(tmp_path, "static", "execute", {"workflowId": "w"})
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps({"ok": True, "workflowId": "w", "evidenceRefs": [ref]})
+        stderr = ""
+
+    monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: Result())
+    runner.action("static", "execute", log_id="combination-a")
+    runner.action("static", "execute", log_id="combination-b")
+
+    # Without a per-caller log identity the second run would overwrite the
+    # first caller's diagnostics.
+    assert {path.name for path in runner.logs} == {
+        "static-execute-combination-a.log",
+        "static-execute-combination-b.log",
+    }

--- a/tests/unit/tools/test_run_omnigent_live_conformance.py
+++ b/tests/unit/tools/test_run_omnigent_live_conformance.py
@@ -597,6 +597,66 @@ def test_every_mode_has_dedicated_scenario_evidence_channel():
     assert len(set(module.SCENARIO_EVIDENCE_ENV.values())) == len(module.LIVE_CASES)
 
 
+WORKFLOW_CHAT_BUNDLE_DIGESTS = {
+    "dashboard": "sha256:" + "7" * 64,
+    "omnigentUi": "sha256:" + "8" * 64,
+}
+
+
+def _workflow_chat_binding_identity(module, combination):
+    fields = {
+        "omnigentServerBuildRef": "sha256:" + "b" * 64,
+        "omnigentHostBuildRef": "sha256:" + "b" * 64,
+        "harnessImplementationRef": (
+            "omnigent-harness-implementation:sha256:" + "a" * 64
+        ),
+        "vendorRuntimeRefs": ["opencode@1.18.11#sha256:" + "d" * 64],
+        "agentSourceRef": "agent-source:sha256:" + "c" * 64,
+        "materializerRefs": ["codex-oauth-home@1"],
+        "providerCompatibilityClass": "omnigent-provider-binding-set@1",
+        "hostClassRef": combination.host_class_ref,
+        "architecture": "linux/amd64",
+        "launchPolicyRef": combination.launch_policy_ref,
+        "modelConfigDigest": "sha256:" + "e" * 64,
+        "executionRealizerRef": combination.execution_realizer_ref,
+        "requiredCapabilitiesDigest": "sha256:" + "f" * 64,
+    }
+    return {
+        **fields,
+        "supportCombinationKey": "omnigent-support:sha256:" + "1" * 64,
+        "providerProfileClass": "omnigent-codex-oauth-profile-class@1",
+    }
+
+
+def _workflow_chat_cleanup_record(module, combination):
+    return {
+        "data": {
+            "liveResourcesRemoved": True,
+            "providerProfileReleasedLast": True,
+            "cleanupState": "cleaned",
+        }
+    }
+
+
+def _workflow_chat_action_result(module, tmp_path, row_name, combination_id, records):
+    combination = module.workflow_chat_combinations()[combination_id]
+    result = {
+        "row": row_name,
+        "combination": combination_id,
+        "_sourceRecords": records,
+    }
+    if row_name == "native-live-conversation":
+        result["bindingIdentity"] = _workflow_chat_binding_identity(
+            module, combination
+        )
+        result["bundleDigests"] = dict(WORKFLOW_CHAT_BUNDLE_DIGESTS)
+    if row_name == "terminal-evidence-and-continuation":
+        timeline = tmp_path / f"timeline-{combination_id}.json"
+        timeline.write_text("{}", encoding="utf-8")
+        result["timelineRef"] = timeline.as_uri()
+    return result
+
+
 def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     tmp_path, monkeypatch
 ):
@@ -609,20 +669,30 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     }
 
     def action(scenario, row_name, **state):
+        combination_id = state["combination"]
         events.append(("action", row_name, dict(state)))
         records = []
         for record_type in module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]:
-            path = tmp_path / f"{row_name}-{record_type}.json"
+            path = tmp_path / f"{combination_id}-{row_name}-{record_type}.json"
             path.write_text("{}", encoding="utf-8")
+            resolved = (
+                _workflow_chat_cleanup_record(
+                    module, module.workflow_chat_combinations()[combination_id]
+                )
+                if record_type == "cleanupReceipt"
+                else {}
+            )
             records.append(
                 {
                     "type": record_type,
                     "ref": path.as_uri(),
                     "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-                    "_resolved": {},
+                    "_resolved": resolved,
                 }
             )
-        return {"row": row_name, "_sourceRecords": records}
+        return _workflow_chat_action_result(
+            module, tmp_path, row_name, combination_id, records
+        )
 
     def validate_sources(sources, *, row_name, expected_correlation, **kwargs):
         assert set(sources) == set(
@@ -652,12 +722,17 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
     monkeypatch.setattr(
         module,
         "build_workflow_chat_acceptance_manifest",
-        lambda matrix, evidence_root: {"schemaVersion": "acceptance", "rows": matrix["rows"]},
+        lambda matrix, evidence_root: {
+            "schemaVersion": "acceptance",
+            "combinations": matrix["combinations"],
+        },
     )
     monkeypatch.setattr(
         module,
         "validate_workflow_chat_acceptance_manifest",
-        lambda manifest, **kwargs: events.append(("validate", tuple(manifest["rows"]))),
+        lambda manifest, **kwargs: events.append(
+            ("validate", tuple(manifest["combinations"]))
+        ),
     )
     monkeypatch.setattr(
         runner,
@@ -667,11 +742,29 @@ def test_workflow_chat_controller_owns_action_order_manifest_and_provider_gate(
 
     runner.workflow_chat(images, "commit-1")
 
-    assert [event[1] for event in events if event[0] == "action"] == list(
-        module.WORKFLOW_CHAT_ACTIONS
-    )
-    assert events[-2][0] == "validate"
+    claimed = [
+        combination_id
+        for combination_id, combination in module.workflow_chat_combinations().items()
+        if combination.native_chat_claimed
+    ]
+    assert [event[1] for event in events if event[0] == "action"] == [
+        row_name for _ in claimed for row_name in module.WORKFLOW_CHAT_ACTIONS
+    ]
+    assert [
+        event[2]["combination"] for event in events if event[0] == "action"
+    ] == [combination_id for combination_id in claimed for _ in module.WORKFLOW_CHAT_ACTIONS]
+    assert events[-2] == ("validate", tuple(module.workflow_chat_combinations()))
     assert events[-1] == ("provider", "workflow_chat")
+    matrix = json.loads(
+        (tmp_path / "workflow-chat-matrix.json").read_text(encoding="utf-8")
+    )
+    assert matrix["bundleDigests"] == WORKFLOW_CHAT_BUNDLE_DIGESTS
+    for combination_id in claimed:
+        entry = matrix["combinations"][combination_id]
+        assert entry["status"] == "passed"
+        assert entry["cleanupOutcome"]["providerProfileReleasedLast"] is True
+        assert entry["timelineRef"] == f"timeline-{combination_id}.json"
+        assert (tmp_path / entry["reports"][0]).is_file()
     assert (tmp_path / "workflow-chat-matrix.json").is_file()
     assert (tmp_path / "workflow-chat-report.json").is_file()
     assert (tmp_path / "workflow-chat-acceptance.json").is_file()
@@ -767,13 +860,28 @@ def test_workflow_chat_controller_fails_before_provider_gate_when_scan_missing(
     monkeypatch.setattr(
         runner,
         "action",
-        lambda scenario, row_name, **state: {
-            "row": row_name,
-            "_sourceRecords": [
-                {"type": name, "ref": "https://evidence.invalid/record", "sha256": "0" * 64, "_resolved": {}}
+        lambda scenario, row_name, **state: _workflow_chat_action_result(
+            module,
+            tmp_path,
+            row_name,
+            state["combination"],
+            [
+                {
+                    "type": name,
+                    "ref": "https://evidence.invalid/record",
+                    "sha256": "0" * 64,
+                    "_resolved": (
+                        _workflow_chat_cleanup_record(
+                            module,
+                            module.workflow_chat_combinations()[state["combination"]],
+                        )
+                        if name == "cleanupReceipt"
+                        else {}
+                    ),
+                }
                 for name in module.REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS[row_name]
             ],
-        },
+        ),
     )
     monkeypatch.setattr(
         module,

--- a/tools/run_omnigent_live_conformance.py
+++ b/tools/run_omnigent_live_conformance.py
@@ -68,6 +68,7 @@ from moonmind.omnigent.workflow_chat_acceptance import (  # noqa: E402
     build_workflow_chat_acceptance_manifest,
     validate_workflow_chat_acceptance_manifest,
     validate_workflow_chat_source_records,
+    workflow_chat_case_id,
     workflow_chat_combinations,
 )
 
@@ -262,6 +263,7 @@ ONDEMAND_ACTIONS = (
     "host_removed", "workflow_detail_reloaded", "lease_released",
 )
 WORKFLOW_CHAT_ACTIONS = tuple(REQUIRED_WORKFLOW_CHAT_ROWS)
+_DIGEST_PINNED_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 SCENARIOS = {
     "browser": f"{PROVIDER_TEST}::test_live_browser_release_matrix",
     "product": f"{PROVIDER_TEST}::test_live_product_create_api_journey",
@@ -445,13 +447,19 @@ class LiveRunner:
             raise RuntimeError(f"{name} failed; see {log_path}")
         return log_path
 
-    def action(self, scenario: str, action: str, **inputs: object) -> dict[str, object]:
+    def action(
+        self, scenario: str, action: str, *, log_id: str = "", **inputs: object
+    ) -> dict[str, object]:
         """Execute an operator-supplied live adapter and parse its observed result.
 
         The adapter is a portable executable boundary, not an evidence file: each
         invocation must perform the named action and return one JSON object on
         stdout. This keeps credentials and deployment-specific API mechanics out
         of this repository while making the runner own ordering and conclusions.
+
+        ``log_id`` keeps each caller's diagnostics separate when the same
+        scenario/action pair is replayed for more than one combination; without
+        it a later run would overwrite the earlier run's log.
         """
         configured = self.env.get("MOONMIND_OMNIGENT_ACTION_COMMAND", "").strip()
         if not configured:
@@ -465,7 +473,10 @@ class LiveRunner:
             text=True, encoding="utf-8", check=False,
         )
         stdout, stderr = result.stdout, result.stderr
-        log_path = self.output_dir / f"{scenario}-{action.replace('.', '-')}.log"
+        log_name = f"{scenario}-{action.replace('.', '-')}"
+        if log_id:
+            log_name = f"{log_name}-{log_id}"
+        log_path = self.output_dir / f"{log_name}.log"
         log_path.write_text(
             f"--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}",
             encoding="utf-8",
@@ -742,6 +753,7 @@ class LiveRunner:
         *,
         name: str,
         images: dict[str, str],
+        auth_mode: str,
         cases: list[dict[str, object]],
         scans: dict[str, dict[str, str]],
     ) -> Path:
@@ -750,7 +762,7 @@ class LiveRunner:
             "generatedAt": datetime.now(timezone.utc).isoformat(),
             "images": images,
             "hostArchitecture": platform.machine(),
-            "authMode": "codex-oauth",
+            "authMode": auth_mode,
             "protocolVersion": "omnigent/v1",
             "capabilities": ["workflow_chat"],
             "evidenceScans": scans,
@@ -813,7 +825,12 @@ class LiveRunner:
         cleanup_outcome: dict[str, object] | None = None
         for row_index, row_name in enumerate(WORKFLOW_CHAT_ACTIONS):
             started = time.monotonic()
-            result = self.action("workflow_chat", row_name, **state)
+            result = self.action(
+                "workflow_chat",
+                row_name,
+                log_id=combination.combination_id,
+                **state,
+            )
             duration_ms = max(1, int((time.monotonic() - started) * 1000))
             if result.get("row") != row_name or result.get("combination") != (
                 combination.combination_id
@@ -907,7 +924,9 @@ class LiveRunner:
             case_refs.append(case_ref)
             cases.append(
                 {
-                    "caseId": f"workflow-chat-{combination.combination_id}-{row_name}",
+                    "caseId": workflow_chat_case_id(
+                        combination.combination_id, row_name
+                    ),
                     "status": "passed",
                     "durationMs": duration_ms,
                     "evidenceRefs": [case_ref],
@@ -988,6 +1007,23 @@ class LiveRunner:
             self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_REALIZER_REF"] = (
                 combination.execution_realizer_ref
             )
+            # The combination only qualifies the image that actually runs it, so
+            # the run publishes the host digest it pinned for this host class.
+            host_image_ref = images.get(combination.host_image_key, "")
+            if not _DIGEST_PINNED_IMAGE.fullmatch(host_image_ref):
+                raise ConformanceContractError(
+                    "workflow Chat combination requires a digest-pinned "
+                    f"{combination.host_image_key} image: {combination_id}"
+                )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_HOST_IMAGE_REF"] = (
+                host_image_ref
+            )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_PROVIDER_PROFILE_CLASS"] = (
+                combination.provider_profile_class
+            )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_AUTH_MODE"] = (
+                combination.auth_mode
+            )
             self.run(
                 f"workflow-chat-up-{combination_id}",
                 self.compose_profile(
@@ -1015,31 +1051,40 @@ class LiveRunner:
                 **declared,
                 "status": "passed",
                 "unsupportedReason": None,
+                "hostImageRef": host_image_ref,
                 "bindingIdentity": observed["bindingIdentity"],
                 "rows": observed["rows"],
                 "reports": [f"workflow-chat-report-{index}.json"],
                 "timelineRef": observed["timelineRef"],
                 "cleanupOutcome": observed["cleanupOutcome"],
                 "_cases": observed["cases"],
+                "_authMode": combination.auth_mode,
             }
         if bundle_digests is None:
             raise ConformanceContractError(
                 "workflow Chat matrix claims no supported combination"
             )
         scans = self.scan()
+        auth_modes: list[str] = []
         for entry in combinations.values():
             cases = entry.pop("_cases", None)
+            auth_mode = str(entry.pop("_authMode", ""))
             if cases is None:
                 continue
+            auth_modes.append(auth_mode)
             self._write_workflow_chat_report(
                 name=str(entry["reports"][0]),
                 images=images,
+                auth_mode=auth_mode,
                 cases=cases,
                 scans=scans,
             )
         self._write_workflow_chat_report(
             name="workflow-chat-report.json",
             images=images,
+            # The run-level report spans every claimed combination, so it names
+            # each authentication mode it actually exercised.
+            auth_mode="+".join(sorted(set(auth_modes))),
             cases=aggregate_cases,
             scans=scans,
         )
@@ -1893,6 +1938,15 @@ def main() -> int:
     parser.add_argument("--server-image", required=True)
     parser.add_argument("--host-image", required=True)
     parser.add_argument(
+        "--opencode-host-image",
+        default="",
+        help=(
+            "digest-pinned dedicated OpenCode host image; required for "
+            "workflow_chat mode because the OpenCode combination does not run "
+            "the Codex host image"
+        ),
+    )
+    parser.add_argument(
         "--source-commit",
         default=os.environ.get("GITHUB_SHA", ""),
         help="tested repository commit (required for workflow_chat mode)",
@@ -1900,6 +1954,16 @@ def main() -> int:
     parser.add_argument("--output-dir", type=Path, default=Path("artifacts/omnigent-conformance/live"))
     args = parser.parse_args()
     images = {"server": args.server_image, "host": args.host_image}
+    opencode_host_image = args.opencode_host_image.strip()
+    if opencode_host_image:
+        if not _DIGEST_PINNED_IMAGE.fullmatch(opencode_host_image):
+            print(
+                "live conformance failed: the dedicated OpenCode host image "
+                "must be pinned by immutable sha256 digest",
+                file=sys.stderr,
+            )
+            return 2
+        images["opencodeHost"] = opencode_host_image
     require_pinned_images(images)
     output_dir = args.output_dir if args.output_dir.is_absolute() else REPO_ROOT / args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1911,11 +1975,26 @@ def main() -> int:
         "OMNIGENT_HOST_IMAGE": args.host_image,
         "OMNIGENT_HOST_IMAGE_TAG": "",
     })
+    if "opencodeHost" in images:
+        # The dedicated OpenCode host image is pinned separately; without this
+        # the server would fall back to the deployment's configured tag and the
+        # run would qualify an image it never executed.
+        env["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] = images["opencodeHost"]
+        env["OMNIGENT_OPENCODE_HOST_IMAGE_TAG"] = ""
     runner = LiveRunner(output_dir=output_dir, env=env)
     selected = tuple(LIVE_CASES) if args.mode == "all" else (args.mode,)
     if "workflow_chat" in selected and not args.source_commit.strip():
         print(
             "live conformance failed: workflow Chat mode requires --source-commit",
+            file=sys.stderr,
+        )
+        return 2
+    if "workflow_chat" in selected and not _DIGEST_PINNED_IMAGE.fullmatch(
+        images.get("opencodeHost", "")
+    ):
+        print(
+            "live conformance failed: workflow Chat mode requires a "
+            "digest-pinned --opencode-host-image",
             file=sys.stderr,
         )
         return 2

--- a/tools/run_omnigent_live_conformance.py
+++ b/tools/run_omnigent_live_conformance.py
@@ -17,6 +17,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 import xml.etree.ElementTree as ET
 import urllib.parse
 import urllib.request
@@ -55,15 +56,19 @@ from moonmind.omnigent.remediation_matrix import (  # noqa: E402
     validate_remediation_evidence_artifact,
 )
 from moonmind.omnigent.workflow_chat_acceptance import (  # noqa: E402
+    REQUIRED_BUNDLE_DIGESTS,
     REQUIRED_WORKFLOW_CHAT_ROWS,
     REQUIRED_WORKFLOW_CHAT_SOURCE_RECORDS,
     WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
     WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
+    WORKFLOW_CHAT_COMBINATION_VERSION,
     WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
     WORKFLOW_CHAT_PARENT_ISSUE,
+    WorkflowChatCombination,
     build_workflow_chat_acceptance_manifest,
     validate_workflow_chat_acceptance_manifest,
     validate_workflow_chat_source_records,
+    workflow_chat_combinations,
 )
 
 PROFILE = REPO_ROOT / "tests/fixtures/omnigent/conformance-v4.json"
@@ -735,8 +740,9 @@ class LiveRunner:
     def _write_workflow_chat_report(
         self,
         *,
+        name: str,
         images: dict[str, str],
-        case_refs: list[str],
+        cases: list[dict[str, object]],
         scans: dict[str, dict[str, str]],
     ) -> Path:
         report = {
@@ -748,25 +754,15 @@ class LiveRunner:
             "protocolVersion": "omnigent/v1",
             "capabilities": ["workflow_chat"],
             "evidenceScans": scans,
-            "cases": [
-                {
-                    "caseId": f"workflow-chat-{row_name}",
-                    "status": "passed",
-                    "evidenceRefs": [case_ref],
-                    "diagnostics": [],
-                }
-                for row_name, case_ref in zip(
-                    WORKFLOW_CHAT_ACTIONS, case_refs, strict=True
-                )
-            ],
+            "cases": cases,
             "summary": {
-                "passed": len(case_refs),
-                "failed": 0,
-                "skipped": 0,
+                "passed": sum(case["status"] == "passed" for case in cases),
+                "failed": sum(case["status"] == "failed" for case in cases),
+                "skipped": sum(case["status"] == "skipped" for case in cases),
             },
         }
         assert_secret_free(report)
-        path = self.output_dir / "workflow-chat-report.json"
+        path = self.output_dir / name
         path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
         return path
 
@@ -796,35 +792,41 @@ class LiveRunner:
         path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         return path
 
-    def workflow_chat(self, images: dict[str, str], source_commit: str) -> None:
-        """Own the protected #3642 browser-to-stock-host acceptance matrix."""
+    def _workflow_chat_combination(
+        self,
+        combination: WorkflowChatCombination,
+        *,
+        index: int,
+        images: dict[str, str],
+        source_commit: str,
+    ) -> dict[str, object]:
+        """Run one claimed combination's full protected journey."""
 
-        if not source_commit.strip():
-            raise ConformanceContractError(
-                "workflow Chat mode requires the tested source commit"
-            )
-        self.env["MOONMIND_OMNIGENT_SOURCE_COMMIT"] = source_commit
-        self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE_DIR"] = str(
-            self.output_dir
-        )
-        self.run(
-            "workflow-chat-up",
-            self.compose("up", "-d", "--wait", "omnigent", "omnigent-host-codex"),
-        )
         rows: dict[str, dict[str, object]] = {}
+        cases: list[dict[str, object]] = []
         case_refs: list[str] = []
         correlation: dict[str, str] | None = None
-        state: dict[str, object] = {}
-        for index, row_name in enumerate(WORKFLOW_CHAT_ACTIONS):
+        state: dict[str, object] = {"combination": combination.combination_id}
+        binding_identity: object | None = None
+        bundle_digests: object | None = None
+        timeline_ref: str | None = None
+        cleanup_outcome: dict[str, object] | None = None
+        for row_index, row_name in enumerate(WORKFLOW_CHAT_ACTIONS):
+            started = time.monotonic()
             result = self.action("workflow_chat", row_name, **state)
-            if result.get("row") != row_name:
+            duration_ms = max(1, int((time.monotonic() - started) * 1000))
+            if result.get("row") != row_name or result.get("combination") != (
+                combination.combination_id
+            ):
                 raise ConformanceContractError(
-                    f"workflow Chat action returned the wrong row: {row_name}"
+                    "workflow Chat action returned the wrong row or combination: "
+                    f"{combination.combination_id}/{row_name}"
                 )
             records = result.get("_sourceRecords")
             if not isinstance(records, list):
                 raise ConformanceContractError(
-                    f"workflow Chat action lacks resolved source records: {row_name}"
+                    "workflow Chat action lacks resolved source records: "
+                    f"{combination.combination_id}/{row_name}"
                 )
             sources = {
                 str(record["type"]): record["_resolved"]
@@ -838,24 +840,42 @@ class LiveRunner:
                 source_commit=source_commit,
                 images=images,
                 generated_at=datetime.now(timezone.utc),
+                combination=combination,
                 expected_correlation=correlation,
             )
             if correlation is None:
                 correlation = observed_correlation
             state = {
-                field: observed_correlation[field]
-                for field in (
-                    "workflowId",
-                    "chatBindingId",
-                    "bridgeSessionId",
-                    "providerSessionId",
-                )
+                "combination": combination.combination_id,
+                **{
+                    field: observed_correlation[field]
+                    for field in (
+                        "workflowId",
+                        "chatBindingId",
+                        "bridgeSessionId",
+                        "providerSessionId",
+                    )
+                },
             }
-            case_ref = f"workflow-chat-case-{index}.json"
+            if row_name == "native-live-conversation":
+                binding_identity = result.get("bindingIdentity")
+                bundle_digests = result.get("bundleDigests")
+            if row_name == "terminal-evidence-and-continuation":
+                timeline_ref = self._portable_ref(str(result.get("timelineRef") or ""))
+                cleanup_data = sources["cleanupReceipt"]["data"]
+                cleanup_outcome = {
+                    "liveResourcesRemoved": cleanup_data["liveResourcesRemoved"],
+                    "providerProfileReleasedLast": cleanup_data[
+                        "providerProfileReleasedLast"
+                    ],
+                    "cleanupState": cleanup_data["cleanupState"],
+                }
+            case_ref = f"workflow-chat-case-{index}-{row_index}.json"
             case_payload = {
                 "schemaVersion": WORKFLOW_CHAT_CASE_EVIDENCE_VERSION,
                 "issue": WORKFLOW_CHAT_ACCEPTANCE_ISSUE,
                 "parentIssue": WORKFLOW_CHAT_PARENT_ISSUE,
+                "combination": combination.combination_id,
                 "row": row_name,
                 "status": "passed",
                 "sourceCommit": source_commit,
@@ -885,10 +905,143 @@ class LiveRunner:
                 "evidenceRefs": [case_ref],
             }
             case_refs.append(case_ref)
+            cases.append(
+                {
+                    "caseId": f"workflow-chat-{combination.combination_id}-{row_name}",
+                    "status": "passed",
+                    "durationMs": duration_ms,
+                    "evidenceRefs": [case_ref],
+                    "diagnostics": [],
+                }
+            )
+        if (
+            binding_identity is None
+            or timeline_ref is None
+            or cleanup_outcome is None
+            or not isinstance(bundle_digests, dict)
+            or set(bundle_digests) != set(REQUIRED_BUNDLE_DIGESTS)
+        ):
+            raise ConformanceContractError(
+                "workflow Chat combination did not report binding identity, "
+                "bundle digests, operator timeline, and cleanup outcome: "
+                f"{combination.combination_id}"
+            )
+        return {
+            "rows": rows,
+            "cases": cases,
+            "caseRefs": case_refs,
+            "bindingIdentity": binding_identity,
+            "bundleDigests": {
+                str(key): str(value) for key, value in bundle_digests.items()
+            },
+            "timelineRef": timeline_ref,
+            "cleanupOutcome": cleanup_outcome,
+        }
 
+    def workflow_chat(self, images: dict[str, str], source_commit: str) -> None:
+        """Own the protected #3642 native Workflow Chat combination matrix."""
+
+        if not source_commit.strip():
+            raise ConformanceContractError(
+                "workflow Chat mode requires the tested source commit"
+            )
+        self.env["MOONMIND_OMNIGENT_SOURCE_COMMIT"] = source_commit
+        self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_EVIDENCE_DIR"] = str(
+            self.output_dir
+        )
+        inventory = workflow_chat_combinations()
+        combinations: dict[str, dict[str, object]] = {}
+        aggregate_cases: list[dict[str, object]] = []
+        bundle_digests: dict[str, str] | None = None
+        for index, (combination_id, combination) in enumerate(inventory.items()):
+            declared: dict[str, object] = {
+                "schemaVersion": WORKFLOW_CHAT_COMBINATION_VERSION,
+                "combinationId": combination_id,
+                "harnessId": combination.harness_id,
+                "hostClassRef": combination.host_class_ref,
+                "launchPolicyRef": combination.launch_policy_ref,
+                "executionRealizerRef": combination.execution_realizer_ref,
+                "hostMode": combination.host_mode,
+                "advertisedCapabilities": sorted(
+                    combination.advertised_capabilities
+                ),
+            }
+            if not combination.native_chat_claimed:
+                # An unclaimed combination is reported with its stable reason
+                # instead of being silently dropped from the matrix.
+                combinations[combination_id] = {
+                    **declared,
+                    "status": "unsupported",
+                    "unsupportedReason": combination.unsupported_reason,
+                }
+                continue
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_COMBINATION"] = combination_id
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_HARNESS_ID"] = (
+                combination.harness_id
+            )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_HOST_CLASS_REF"] = (
+                combination.host_class_ref
+            )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_LAUNCH_POLICY_REF"] = (
+                combination.launch_policy_ref
+            )
+            self.env["MOONMIND_OMNIGENT_WORKFLOW_CHAT_REALIZER_REF"] = (
+                combination.execution_realizer_ref
+            )
+            self.run(
+                f"workflow-chat-up-{combination_id}",
+                self.compose_profile(
+                    combination.compose_profile,
+                    "up",
+                    "-d",
+                    "--wait",
+                    *combination.compose_services,
+                ),
+            )
+            observed = self._workflow_chat_combination(
+                combination,
+                index=index,
+                images=images,
+                source_commit=source_commit,
+            )
+            aggregate_cases.extend(observed["cases"])
+            if bundle_digests is None:
+                bundle_digests = observed["bundleDigests"]
+            elif bundle_digests != observed["bundleDigests"]:
+                raise ConformanceContractError(
+                    "workflow Chat combinations loaded different deployed bundles"
+                )
+            combinations[combination_id] = {
+                **declared,
+                "status": "passed",
+                "unsupportedReason": None,
+                "bindingIdentity": observed["bindingIdentity"],
+                "rows": observed["rows"],
+                "reports": [f"workflow-chat-report-{index}.json"],
+                "timelineRef": observed["timelineRef"],
+                "cleanupOutcome": observed["cleanupOutcome"],
+                "_cases": observed["cases"],
+            }
+        if bundle_digests is None:
+            raise ConformanceContractError(
+                "workflow Chat matrix claims no supported combination"
+            )
         scans = self.scan()
-        report_path = self._write_workflow_chat_report(
-            images=images, case_refs=case_refs, scans=scans
+        for entry in combinations.values():
+            cases = entry.pop("_cases", None)
+            if cases is None:
+                continue
+            self._write_workflow_chat_report(
+                name=str(entry["reports"][0]),
+                images=images,
+                cases=cases,
+                scans=scans,
+            )
+        self._write_workflow_chat_report(
+            name="workflow-chat-report.json",
+            images=images,
+            cases=aggregate_cases,
+            scans=scans,
         )
         generated_at = datetime.now(timezone.utc)
         matrix = {
@@ -897,8 +1050,14 @@ class LiveRunner:
             "sourceCommit": source_commit,
             "compatibilityProfile": WORKFLOW_CHAT_COMPATIBILITY_PROFILE,
             "images": images,
-            "rows": rows,
-            "reports": [report_path.name],
+            "bundleDigests": bundle_digests,
+            "supersededReportRef": (
+                self.env.get(
+                    "MOONMIND_OMNIGENT_WORKFLOW_CHAT_SUPERSEDED_REPORT", ""
+                ).strip()
+                or None
+            ),
+            "combinations": combinations,
             "evidenceScans": scans,
         }
         matrix_path = self.output_dir / "workflow-chat-matrix.json"
@@ -1547,9 +1706,13 @@ class LiveRunner:
 
     @staticmethod
     def compose(*args: str) -> list[str]:
+        return LiveRunner.compose_profile("omnigent-host-codex", *args)
+
+    @staticmethod
+    def compose_profile(profile: str, *args: str) -> list[str]:
         return [
             "docker", "compose", "--project-name", PROJECT,
-            "--profile", "omnigent-host-codex", *args,
+            "--profile", profile, *args,
         ]
 
     def scenario(self, mode: str, *, phase: str | None = None) -> None:


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3642 — [Omnigent release gate] Produce current protected Workflow Chat acceptance evidence

Closes MoonLadderStudios/MoonMind#3642

## Summary

The protected native Workflow Chat acceptance contract was a fixed four-row matrix bound to one hard-coded Codex host, so it could not express the combination matrix the issue requires and its report was not bound to the identity that actually ran. This change closes the remaining repo-verifiable gaps recorded by the assessment and makes the published report consumable as a release/retirement gate.

- **Combination inventory (AC1).** Declares the code-owned native-chat combination inventory — Codex on-demand, Codex static-connected, and OpenCode through `generic-omnigent-host@1`. The acceptance manifest is now keyed by combination: a claimed combination must carry its own full journey, and an unclaimed one must be reported `unsupported` with a stable reason. Exact-inventory validation rejects silent omission.
- **Exact-artifact binding (AC8).** Each combination's evidence is bound to its support-combination identity — harness implementation, vendor runtime, agent source, materializers, provider compatibility class, Host Class, architecture, launch policy, normalized model-configuration digest, execution realizer, required capabilities, and Provider Profile class (no secret values) — and `supportCombinationKey` is recomputed from that identity via `compute_support_combination_key`.
- **Missing report fields.** Adds deployed dashboard / Omnigent UI `bundleDigests`, `scenarioVersion`, `routeInventoryVersion`, `supersededReportRef`, per-combination `timelineRef` and `cleanupOutcome`, and per-case `durationMs`.
- **Normal product path (AC2).** Adds the `executionCreation` record so the matrix asserts the normal `POST /api/executions` create (`created_through_public_executions_api`) and its Temporal routing.
- **Capability contract (AC4).** `advertised_native_chat_capabilities` now derives the contract from Host Class features and Launch Policy control/capture/cleanup authority instead of a constant, and requires one observed enforcement outcome per advertised capability. Static-connected drops `cleanupSession` because its cleanup mode is drain; on-demand keeps it.
- **Isolation (AC5).** `_DENIAL_KINDS` adds `cross_user` and `cross_workflow` so those denials are required evidence.
- **Cleanup ordering (AC7).** Adds the `cleanupReceipt` record proving ordered live-host stop, provider-session removal, workspace publication, and Provider Profile release **last**, cross-checked against the combination cleanup outcome and timeline.
- **Retirement consumption (AC11).** `criteria_from_native_chat_acceptance` projects the manifest into `RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED` so #3712 guards consume it without manual interpretation; the CI publication job derives the criterion and fails closed on a missing, incomplete, or invalid manifest.

Per the pre-release compatibility policy the artifact is bumped to `moonmind.omnigent.workflow-chat-acceptance/v2` and the v1 shape is removed rather than aliased.

Changed paths: `moonmind/omnigent/workflow_chat_acceptance.py`, `moonmind/omnigent/legacy_retirement.py`, `tools/run_omnigent_live_conformance.py`, `.github/workflows/omnigent-live-conformance.yml`, their unit tests, one provider-verification assertion, and `docs/Omnigent/{ConformanceAndLiveSmoke,OmnigentBridge}.md`.

## Tests run

| Command | Result |
| --- | --- |
| `pytest tests/unit/omnigent/test_workflow_chat_acceptance.py tests/unit/omnigent/test_legacy_retirement.py tests/unit/tools/test_run_omnigent_live_conformance.py -q` | **116 passed** in 4.49s |
| `pytest tests/unit/test_omnigent_live_conformance_workflow.py tests/unit/omnigent/test_live_verification_health.py -q` | **32 passed** in 0.29s |
| `pytest tests/unit/omnigent tests/unit/tools tests/unit/test_omnigent_live_conformance_workflow.py -q` | 1873 passed, 3 skipped, 63 failed — all 63 failures are pre-existing and environment-caused (see below) |
| `./tools/test_integration.sh` (`integration_ci`) | **Not selected** — no Docker, compose, database, migration, or integration-boundary change in the diff |
| `tests/provider/omnigent` (provider verification) | **Not run** — requires real credentials; excluded from required CI. Reviewed statically: `test_live_native_workflow_chat_release_matrix` asserts the combination inventory instead of the removed top-level `rows` key, so no stale-schema assertion remains |

The 63 broad-suite failures come entirely from seven unchanged files (`test_oauth_profile_lifecycle`, `test_host_protocol_adapter`, `test_host_auth_remediation`, `test_host_auth_profile`, `test_native_ui_compat`, `test_bridge_embedded`, `test_embedded_host_channel`) and are environment-caused (`WORKSPACE_AUTHORITY_MISMATCH` needing `WORKFLOW_WORKSPACE_DAEMON_ROOT`, unavailable pinned Omnigent host frame codec / runner auth entrypoint, missing pinned upstream omnigent checkout). Proven pre-existing: the same seven files produce exactly 63 failed / 218 passed both at this HEAD and in a throwaway worktree at `origin/main` (fda73d66f). None is a changed path.

## Remaining risks

- **The protected run itself is not executed by this PR.** This change makes the contract able to express and bind the required evidence; it does not produce the fresh report. Every `Provider / Omnigent Live Conformance` run is currently pending, queued, or cancelled (latest pending 2026-08-17, queued 2026-08-10), so no current manifest exists. Dispatching it needs real provider credentials, the protected self-hosted `omnigent-provider-verification` runner, and a browser-reachable deployment — none available in this runtime. Next step for the protected-runner operator: `gh workflow run omnigent-live-conformance.yml --ref <this branch>` (mode `workflow_chat`) for commit 857326e96; the controller now runs all three claimed combinations and the publication job validates the v2 manifest and derives the #3712 criterion. Until that lands, readiness and rollout stay fail-closed, which is the intended behavior.
- **Live journey steps 1–15 remain behaviorally unverified here** (real provider streaming; tool/approval/task/subagent behavior; browser and transport disconnect/reconnect; periodic reauthorization and cursor-safe replay; live host and provider resource removal). They are covered by the same protected dispatch.
- **v2 is a breaking artifact shape change.** Any previously published v1 manifest is not readable by the new validator. This is intentional under the pre-release delete-don't-deprecate policy, but consumers must re-publish rather than migrate.
- **The capability contract is now derived, not constant.** A future Host Class or Launch Policy edit changes what evidence the matrix demands. That is the point, but it means host-metadata changes can newly fail the gate; the derivation is covered by boundary tests including the static-connected drain case.
- The combination inventory is code-owned and exact, so adding a host or runtime without adding its row (or an explicit unsupported reason) fails validation by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
