### PR TITLE
Fix direct managed workflow fanout readiness

### DIFF
--- a/moonmind/security/execution_fanout_capabilities.py
+++ b/moonmind/security/execution_fanout_capabilities.py
@@ -14,6 +14,14 @@ from typing import Any, Literal
 _AUDIENCE = "moonmind-execution-fanout"
 _VERSION = 1
 EXECUTION_FANOUT_REQUIRED_CAPABILITY = "execution.fanout"
+ExecutionFanoutSourceKind = Literal[
+    "managed_process",
+    "managed_session",
+    "omnigent",
+]
+_EXECUTION_FANOUT_SOURCE_KINDS: frozenset[str] = frozenset(
+    {"managed_process", "managed_session", "omnigent"}
+)
 
 
 class ExecutionFanoutCapabilityError(ValueError):
@@ -53,7 +61,7 @@ class ExecutionFanoutCapability:
     step_id: str | None
     session_id: str
     runtime_id: str
-    source_kind: Literal["managed_session", "omnigent"]
+    source_kind: ExecutionFanoutSourceKind
     expires_at: int
 
 
@@ -87,7 +95,7 @@ def mint_execution_fanout_capability(
     agent_run_id: str,
     session_id: str,
     runtime_id: str,
-    source_kind: Literal["managed_session", "omnigent"],
+    source_kind: ExecutionFanoutSourceKind,
     lifetime_seconds: int,
     step_id: str | None = None,
     now: int | None = None,
@@ -99,7 +107,7 @@ def mint_execution_fanout_capability(
         raise ExecutionFanoutCapabilityError(
             "execution fan-out capability lifetime must be positive"
         )
-    if source_kind not in {"managed_session", "omnigent"}:
+    if source_kind not in _EXECUTION_FANOUT_SOURCE_KINDS:
         raise ExecutionFanoutCapabilityError(
             "unsupported execution fan-out capability source kind"
         )
@@ -169,7 +177,7 @@ def verify_execution_fanout_capability(
     if expires_at <= current_time:
         raise ExecutionFanoutCapabilityError("expired execution fan-out capability")
     source_kind = payload.get("sourceKind")
-    if source_kind not in {"managed_session", "omnigent"}:
+    if source_kind not in _EXECUTION_FANOUT_SOURCE_KINDS:
         raise ExecutionFanoutCapabilityError("invalid execution fan-out capability")
     return ExecutionFanoutCapability(
         parent_workflow_id=_required_text(
@@ -188,6 +196,7 @@ __all__ = [
     "EXECUTION_FANOUT_REQUIRED_CAPABILITY",
     "ExecutionFanoutCapability",
     "ExecutionFanoutCapabilityError",
+    "ExecutionFanoutSourceKind",
     "mint_execution_fanout_capability",
     "require_execution_fanout_authorization",
     "verify_execution_fanout_capability",

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -25,6 +25,13 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
     ManagedRuntimeProfile,
     TERMINAL_AGENT_RUN_STATES,
+    resolve_execution_timeout_seconds,
+)
+from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
+    ExecutionFanoutCapabilityError,
+    mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
 )
 from moonmind.workflows.executions.repository_contract import (
     AuthoredLoreRepositoryTarget,
@@ -488,6 +495,7 @@ class ManagedRuntimeLauncher:
                 "jira",
                 "docker",
                 "container.run",
+                EXECUTION_FANOUT_REQUIRED_CAPABILITY,
             )
         )
 
@@ -881,6 +889,116 @@ class ManagedRuntimeLauncher:
             "MOONMIND_ARTIFACTS_DIR": str(artifacts_dir),
             "CI": "1",
         }
+
+    @staticmethod
+    def _execution_fanout_authorization(
+        request: AgentExecutionRequest,
+    ) -> Mapping[str, Any] | None:
+        step_execution = request.step_execution
+        if step_execution is None:
+            return None
+        policy = step_execution.skill_source_policy
+        if "executionFanout" not in policy:
+            return None
+        evidence = policy.get("executionFanout")
+        if not isinstance(evidence, Mapping):
+            raise ExecutionFanoutCapabilityError(
+                "execution fan-out authorization evidence is malformed"
+            )
+        return evidence
+
+    @classmethod
+    def _materialize_execution_fanout_environment(
+        cls,
+        *,
+        environment: dict[str, str],
+        request: AgentExecutionRequest,
+        workflow_id: str | None,
+        run_id: str,
+        runtime_id: str,
+    ) -> None:
+        """Mint direct-process fan-out authority from workflow-owned evidence."""
+
+        environment.pop("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", None)
+        environment.pop("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE", None)
+        raw_capabilities = request.parameters.get("requiredCapabilities")
+        if raw_capabilities is None:
+            required_capabilities: tuple[str, ...] = ()
+        elif isinstance(raw_capabilities, (list, tuple)):
+            required_capabilities = tuple(
+                str(value or "").strip().lower()
+                for value in raw_capabilities
+                if str(value or "").strip()
+            )
+        else:
+            raise ExecutionFanoutCapabilityError(
+                "requiredCapabilities must be a list when present on an agent request"
+            )
+        if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required_capabilities:
+            return
+
+        authorization = cls._execution_fanout_authorization(request)
+        require_execution_fanout_authorization(
+            required_capabilities,
+            authorization,
+        )
+        step_execution = request.step_execution
+        request_workflow_id = (
+            str(step_execution.workflow_id or "").strip()
+            if step_execution is not None
+            else ""
+        )
+        activity_workflow_id = str(workflow_id or "").strip()
+        if (
+            request_workflow_id
+            and activity_workflow_id
+            and request_workflow_id != activity_workflow_id
+        ):
+            raise ExecutionFanoutCapabilityError(
+                "execution fan-out parent workflow identity does not match the "
+                "Step Execution"
+            )
+        parent_workflow_id = activity_workflow_id or request_workflow_id
+        if not parent_workflow_id:
+            raise ExecutionFanoutCapabilityError(
+                "execution fan-out requires a parent workflow identity"
+            )
+        normalized_runtime_id = str(runtime_id or "").strip()
+        if not normalized_runtime_id:
+            raise ExecutionFanoutCapabilityError(
+                "execution fan-out requires a runtime identity"
+            )
+        if not str(environment.get("MOONMIND_URL") or "").strip():
+            raise ExecutionFanoutCapabilityError(
+                "execution fan-out requires the MoonMind execution API endpoint"
+            )
+
+        from moonmind.config.settings import settings as _mm_settings
+
+        environment["MOONMIND_TASK_WORKFLOW_ID"] = parent_workflow_id
+        environment["MOONMIND_AGENT_RUN_ID"] = run_id
+        environment["MOONMIND_RUNTIME_ID"] = normalized_runtime_id
+        if step_execution is not None:
+            environment["MOONMIND_STEP_ID"] = step_execution.logical_step_id
+        environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"] = (
+            mint_execution_fanout_capability(
+                secret=str(_mm_settings.security.JWT_SECRET_KEY or ""),
+                parent_workflow_id=parent_workflow_id,
+                agent_run_id=run_id,
+                step_id=(
+                    step_execution.logical_step_id
+                    if step_execution is not None
+                    else None
+                ),
+                session_id=run_id,
+                runtime_id=normalized_runtime_id,
+                source_kind="managed_process",
+                lifetime_seconds=resolve_execution_timeout_seconds(
+                    agent_kind=request.agent_kind,
+                    timeout_policy=request.timeout_policy,
+                ),
+            )
+        )
 
     @staticmethod
     def _build_github_socket_path(*, run_id: str, support_root: str | None) -> str:
@@ -2240,6 +2358,13 @@ class ManagedRuntimeLauncher:
                     resolved_workspace_path=resolved_workspace_path,
                     request=request,
                 )
+            )
+            self._materialize_execution_fanout_environment(
+                environment=env_overrides,
+                request=request,
+                workflow_id=workflow_id,
+                run_id=run_id,
+                runtime_id=normalize_runtime_id(profile.runtime_id),
             )
 
             github_token = await resolve_github_token_for_launch(env_overrides)

--- a/tests/integration/reliability/replays/direct-managed-fanout-readiness/expected-outcome.json
+++ b/tests/integration/reliability/replays/direct-managed-fanout-readiness/expected-outcome.json
@@ -1,0 +1,13 @@
+{
+  "invariant": "repository readiness defers execution.fanout to the direct managed runtime, which mints only a workflow-scoped bearer from trusted resolved-Skill authorization before launch",
+  "repositoryCapabilityOwner": "runtime",
+  "capabilitySourceKind": "managed_process",
+  "requiredClaimBindings": [
+    "parentWorkflowId",
+    "agentRunId",
+    "stepId",
+    "runtimeId"
+  ],
+  "staleCapabilityFileSelectorRemoved": true,
+  "unknownCapabilitiesRemainFailClosed": true
+}

--- a/tests/integration/reliability/replays/direct-managed-fanout-readiness/manifest.json
+++ b/tests/integration/reliability/replays/direct-managed-fanout-readiness/manifest.json
@@ -1,0 +1,55 @@
+{
+  "incidentWorkflowId": "mm:91c47b8e-212a-48c8-a1a1-f7c0f08e707a",
+  "agentRunId": "agent-run-52691cce",
+  "logicalStepId": "tpl:batch-github-workflows:01:52691cce",
+  "targetRuntime": "claude_code",
+  "repository": "MoonLadderStudios/MoonMind",
+  "preparedCommitSha": "abcdef0123456789",
+  "terminalFailureCode": "REPOSITORY_CAPABILITY_UNKNOWN",
+  "failureShape": "the built-in batch-workflows Skill required execution.fanout, but direct managed repository readiness had no owner for that runtime capability and blocked before Claude launched",
+  "request": {
+    "agentKind": "managed",
+    "agentId": "claude_code",
+    "executionProfileRef": "claude_anthropic_oauth",
+    "correlationId": "replay-mm-91c47b8e",
+    "idempotencyKey": "mm:91c47b8e:agent-run-52691cce",
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "repositoryTarget": {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "MoonLadderStudios/MoonMind"},
+        "branch": {"name": "main"}
+      }
+    },
+    "parameters": {
+      "publishMode": "none",
+      "requiredCapabilities": [
+        "claude_code",
+        "git",
+        "gh",
+        "execution.fanout"
+      ]
+    },
+    "skill": {
+      "name": "batch-workflows",
+      "requiredCapabilities": ["git", "gh", "execution.fanout"]
+    },
+    "stepExecution": {
+      "workflowId": "mm:91c47b8e-212a-48c8-a1a1-f7c0f08e707a",
+      "runId": "workflow-run-01a02308",
+      "logicalStepId": "tpl:batch-github-workflows:01:52691cce",
+      "executionOrdinal": 1,
+      "stepExecutionId": "mm:91c47b8e-212a-48c8-a1a1-f7c0f08e707a:workflow-run-01a02308:tpl:batch-github-workflows:01:52691cce:execution:1",
+      "runtimeContextPolicy": "fresh_agent_run",
+      "skillSourcePolicy": {
+        "executionFanout": {
+          "authorized": true,
+          "selectedSkill": "batch-workflows",
+          "sourceKind": "built_in",
+          "reasonCode": "trusted_resolved_skill_requirement"
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -78,6 +78,9 @@ from moonmind.security.egress import (
     OMNIGENT_EGRESS_PROFILE,
     omnigent_proxy_env,
 )
+from moonmind.security.execution_fanout_capabilities import (
+    verify_execution_fanout_capability,
+)
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
     SendCodexManagedSessionTurnRequest,
@@ -104,6 +107,10 @@ from moonmind.workflows.adapters.omnigent_agent_adapter import (
     build_omnigent_session_create_payload,
     build_omnigent_selection,
     resolve_omnigent_target,
+)
+from moonmind.workflows.executions.repository_contract import (
+    RepositoryClientEvidence,
+    RepositoryClientPolicy,
 )
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
@@ -209,6 +216,77 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+async def test_direct_managed_fanout_crosses_repository_and_launch_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:91c47b8e across both pre-launch authority handoffs."""
+
+    replay_id = "direct-managed-fanout-readiness"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(
+        return_value=manifest["preparedCommitSha"]
+    )
+
+    async def resolved_github_credential(*, repo: str) -> SimpleNamespace:
+        assert repo == manifest["repository"]
+        return SimpleNamespace(resolved=True, safe_summary="resolved")
+
+    monkeypatch.setattr(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        resolved_github_credential,
+    )
+    request = AgentExecutionRequest.model_validate(manifest["request"])
+
+    resolved_repository = await launcher._ensure_repository_ready_for_launch(
+        request,
+        None,
+    )
+    environment = {
+        "MOONMIND_URL": "http://api:8000",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "stale-token",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "/stale/token-file",
+    }
+    launcher._materialize_execution_fanout_environment(
+        environment=environment,
+        request=request,
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id=manifest["agentRunId"],
+        runtime_id=manifest["targetRuntime"],
+    )
+    capability = verify_execution_fanout_capability(
+        environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
+        secret=str(settings.security.JWT_SECRET_KEY),
+    )
+
+    assert resolved_repository is not None
+    assert (
+        resolved_repository.prepared_revision.commit_sha
+        == manifest["preparedCommitSha"]
+    )
+    assert capability.source_kind == expected["capabilitySourceKind"]
+    assert capability.parent_workflow_id == manifest["incidentWorkflowId"]
+    assert capability.agent_run_id == manifest["agentRunId"]
+    assert capability.step_id == manifest["logicalStepId"]
+    assert capability.runtime_id == manifest["targetRuntime"]
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE" not in environment
 
 
 async def test_managed_launcher_reuses_runtime_owned_workspace_with_exact_git_trust(

--- a/tests/unit/security/test_execution_fanout_capabilities.py
+++ b/tests/unit/security/test_execution_fanout_capabilities.py
@@ -8,13 +8,18 @@ from moonmind.security.container_job_capabilities import (
 )
 from moonmind.security.execution_fanout_capabilities import (
     ExecutionFanoutCapabilityError,
+    ExecutionFanoutSourceKind,
     mint_execution_fanout_capability,
     require_execution_fanout_authorization,
     verify_execution_fanout_capability,
 )
 
 
-def _mint(*, now: int = 100) -> str:
+def _mint(
+    *,
+    now: int = 100,
+    source_kind: ExecutionFanoutSourceKind = "omnigent",
+) -> str:
     return mint_execution_fanout_capability(
         secret="test-secret",
         parent_workflow_id="mm:parent",
@@ -22,7 +27,7 @@ def _mint(*, now: int = 100) -> str:
         step_id="step-1",
         session_id="session-1",
         runtime_id="codex_cli",
-        source_kind="omnigent",
+        source_kind=source_kind,
         lifetime_seconds=60,
         now=now,
     )
@@ -40,6 +45,14 @@ def test_execution_fanout_capability_round_trips_bounded_authority() -> None:
     assert capability.runtime_id == "codex_cli"
     assert capability.source_kind == "omnigent"
     assert capability.expires_at == 160
+
+
+def test_direct_managed_process_is_a_distinct_fanout_authority_source() -> None:
+    capability = verify_execution_fanout_capability(
+        _mint(source_kind="managed_process"), secret="test-secret", now=120
+    )
+
+    assert capability.source_kind == "managed_process"
 
 
 def test_execution_fanout_capability_rejects_tampering_and_expiry() -> None:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -9,9 +9,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from moonmind.auth.github_credentials import ResolvedGitHubCredential
+from moonmind.config.settings import settings
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.agent_runtime_models import ManagedRuntimeProfile
 from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
+from moonmind.security.execution_fanout_capabilities import (
+    ExecutionFanoutCapabilityError,
+    verify_execution_fanout_capability,
+)
 from moonmind.workflows.executions.repository_contract import (
     RepositoryClientEvidence,
     RepositoryClientPolicy,
@@ -378,6 +383,44 @@ async def test_default_repository_readiness_allows_gh_for_read_only_skill(tmp_pa
     assert resolved is not None
     assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
     assert resolved.remote_tip_expectation["kind"] == "must_equal"
+
+
+@pytest.mark.asyncio
+async def test_default_repository_readiness_defers_execution_fanout_to_runtime(
+    tmp_path,
+):
+    """Replay mm:91c47b8e at the repository-to-runtime readiness handoff."""
+
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="repository-client:git-system",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    launcher = ManagedRuntimeLauncher(
+        ManagedRunStore(tmp_path / "managed_runs"),
+        repository_client_policy=RepositoryClientPolicy(
+            pinnedVersion=evidence.client_version,
+            toolBundleRef=evidence.tool_bundle_ref,
+            executableSha256=evidence.executable_sha256,
+        ),
+    )
+    launcher._observe_git_client = AsyncMock(return_value=evidence)
+    launcher._observe_git_remote_tip = AsyncMock(return_value="abcdef0123456789")
+
+    with patch(
+        "moonmind.auth.github_credentials.resolve_github_credential",
+        AsyncMock(return_value=ResolvedGitHubCredential(token="test-token")),
+    ):
+        resolved = await launcher._ensure_repository_ready_for_launch(
+            _repository_readiness_request(
+                publish_mode="none",
+                skill_capabilities=["gh", "execution.fanout"],
+            ),
+            None,
+        )
+
+    assert resolved is not None
+    assert resolved.prepared_revision.commit_sha == "abcdef0123456789"
 
 
 @pytest.mark.asyncio
@@ -4480,6 +4523,123 @@ async def test_launch_generic_env_uses_logical_step_id_for_artifacts_dir(
         run_root / "artifacts" / "implement"
     )
     assert (run_root / "artifacts" / "implement").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_direct_managed_launch_materializes_scoped_execution_fanout(
+    tmp_path, monkeypatch
+):
+    """Replay mm:91c47b8e through the direct Claude launch environment."""
+
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    captured_env = _patch_generic_env_subprocess(monkeypatch)
+    workspace = tmp_path / "workspaces" / "agent-run-1" / "repo"
+    workspace.mkdir(parents=True)
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+    request = _make_request(
+        parameters={"requiredCapabilities": ["execution.fanout"]},
+        timeout_policy={"timeout_seconds": 300},
+        step_execution={
+            "workflowId": "mm:parent",
+            "runId": "workflow-run-1",
+            "logicalStepId": "batch-workflows",
+            "executionOrdinal": 1,
+            "stepExecutionId": (
+                "mm:parent:workflow-run-1:batch-workflows:execution:1"
+            ),
+            "runtimeContextPolicy": "fresh_agent_run",
+            "skillSourcePolicy": {
+                "executionFanout": {
+                    "authorized": True,
+                    "selectedSkill": "batch-workflows",
+                    "sourceKind": "built_in",
+                    "reasonCode": "trusted_resolved_skill_requirement",
+                }
+            },
+        },
+    )
+
+    _record, process, _cleanup, _deferred = await launcher.launch(
+        run_id="agent-run-1",
+        workflow_id="mm:parent",
+        request=request,
+        profile=_make_profile(
+            runtime_id="claude_code",
+            command_template=["echo", "hello"],
+        ),
+        workspace_path=str(workspace),
+    )
+    await process.wait()
+
+    capability = verify_execution_fanout_capability(
+        captured_env["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
+        secret=str(settings.security.JWT_SECRET_KEY),
+    )
+    assert capability.parent_workflow_id == "mm:parent"
+    assert capability.agent_run_id == "agent-run-1"
+    assert capability.step_id == "batch-workflows"
+    assert capability.session_id == "agent-run-1"
+    assert capability.runtime_id == "claude_code"
+    assert capability.source_kind == "managed_process"
+    assert captured_env["MOONMIND_TASK_WORKFLOW_ID"] == "mm:parent"
+    assert captured_env["MOONMIND_AGENT_RUN_ID"] == "agent-run-1"
+    assert captured_env["MOONMIND_RUNTIME_ID"] == "claude_code"
+    assert captured_env["MOONMIND_STEP_ID"] == "batch-workflows"
+
+
+def test_direct_managed_launch_removes_unrequested_ambient_fanout_authority() -> None:
+    environment = {
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "stale-inline-token",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "/stale/token-file",
+    }
+
+    ManagedRuntimeLauncher._materialize_execution_fanout_environment(
+        environment=environment,
+        request=_make_request(parameters={"requiredCapabilities": []}),
+        workflow_id="mm:parent",
+        run_id="agent-run-1",
+        runtime_id="claude_code",
+    )
+
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE" not in environment
+
+
+def test_direct_managed_launch_rejects_denied_fanout_authorization() -> None:
+    request = _make_request(
+        parameters={"requiredCapabilities": ["execution.fanout"]},
+        step_execution={
+            "workflowId": "mm:parent",
+            "runId": "workflow-run-1",
+            "logicalStepId": "batch-workflows",
+            "executionOrdinal": 1,
+            "stepExecutionId": (
+                "mm:parent:workflow-run-1:batch-workflows:execution:1"
+            ),
+            "runtimeContextPolicy": "fresh_agent_run",
+            "skillSourcePolicy": {
+                "executionFanout": {
+                    "authorized": False,
+                    "selectedSkill": "batch-workflows",
+                    "sourceKind": "repo",
+                    "reasonCode": "resolved_skill_policy_denied",
+                }
+            },
+        },
+    )
+    environment: dict[str, str] = {}
+
+    with pytest.raises(ExecutionFanoutCapabilityError, match="not authorized"):
+        ManagedRuntimeLauncher._materialize_execution_fanout_environment(
+            environment=environment,
+            request=request,
+            workflow_id="mm:parent",
+            run_id="agent-run-1",
+            runtime_id="claude_code",
+        )
+
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- treat `execution.fanout` as runtime-owned at direct managed repository readiness
- validate trusted resolved-Skill authorization and mint a parent/agent/step/runtime-scoped bearer for direct managed processes
- remove stale ambient fan-out authority when the capability is not requested
- add a minimized replay for failed workflow `mm:91c47b8e-212a-48c8-a1a1-f7c0f08e707a`

## Root cause

The built-in `batch-workflows` Skill correctly contributed `execution.fanout`, but the direct managed repository readiness registry had no owner for that runtime capability. The launch failed with `REPOSITORY_CAPABILITY_UNKNOWN` before Claude started. The direct managed subprocess path also lacked the scoped fan-out bearer and parent execution identity required by the portable queue helper.

## Verification

- launcher, fan-out security, and incident replay suite: 108 passed
- workflow required-capability propagation and trusted-provenance checks: 2 passed
- focused post-hardening replay checks: 5 passed
- AgentSession deployment-safety validation passed
- syntax, JSON, and diff checks passed