### PR TITLE
Integrate canonical Omnigent execution authority (MoonLadderStudios/MoonMind#3701)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -83,7 +83,12 @@ from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
     refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
+    resolve_default_agent_profile_snapshot,
 )
+from moonmind.omnigent.harness_platform.admission import (
+    compile_and_persist_execution_authority,
+)
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from api_service.services.control_stop_continuation import (
     SqlControlStopContinuationRepository,
     TemporalControlStopContinuationStarter,
@@ -11134,14 +11139,21 @@ async def _create_execution_from_workflow_request(
     agent_profile_selection = payload.get("agentProfile")
     if agent_profile_selection is None and isinstance(runtime_payload, Mapping):
         agent_profile_selection = runtime_payload.get("agentProfile")
-    if agent_profile_selection is not None:
-        if canonical_target_runtime != "omnigent":
-            raise _invalid_workflow_request(
-                "agentProfile is supported only for targetRuntime='omnigent'."
-            )
-        if not isinstance(agent_profile_selection, Mapping):
+    if (
+        agent_profile_selection is not None
+        and canonical_target_runtime != "omnigent"
+    ):
+        raise _invalid_workflow_request(
+            "agentProfile is supported only for targetRuntime='omnigent'."
+        )
+    if canonical_target_runtime == "omnigent":
+        if agent_profile_selection is not None and not isinstance(
+            agent_profile_selection, Mapping
+        ):
             raise _invalid_workflow_request("agentProfile must be an object.")
-        agent_profile_selection = dict(agent_profile_selection)
+        explicit_agent_profile = agent_profile_selection is not None
+        if explicit_agent_profile:
+            agent_profile_selection = dict(agent_profile_selection)
         authored_omnigent = payload.get("omnigent")
         authored_launch_policy_ref = (
             str(authored_omnigent.get("launchPolicyRef") or "").strip()
@@ -11149,7 +11161,7 @@ async def _create_execution_from_workflow_request(
             else ""
         )
         selected_launch_policy_ref = str(
-            agent_profile_selection.get("launchPolicyRef") or ""
+            (agent_profile_selection or {}).get("launchPolicyRef") or ""
         ).strip()
         if (
             authored_launch_policy_ref
@@ -11159,17 +11171,32 @@ async def _create_execution_from_workflow_request(
             raise _invalid_workflow_request(
                 "agentProfile.launchPolicyRef must match omnigent.launchPolicyRef."
             )
-        if authored_launch_policy_ref:
+        if authored_launch_policy_ref and explicit_agent_profile:
             agent_profile_selection["launchPolicyRef"] = (
                 authored_launch_policy_ref
             )
-        profile_snapshot = await resolve_agent_profile_snapshot(
-            session,
-            selection=agent_profile_selection,
-            consumer_type=("remediation" if task_payload.get("remediation") else "workflow"),
-            consumer_id=reserved_workflow_id,
-            user=user,
+        consumer_type = (
+            "remediation" if task_payload.get("remediation") else "workflow"
         )
+        if explicit_agent_profile:
+            profile_snapshot = await resolve_agent_profile_snapshot(
+                session,
+                selection=agent_profile_selection,
+                consumer_type=consumer_type,
+                consumer_id=reserved_workflow_id,
+                user=user,
+            )
+        else:
+            profile_snapshot = await resolve_default_agent_profile_snapshot(
+                session,
+                provider_profile_ref=(
+                    raw_profile_id if _provider_profile is not None else None
+                ),
+                launch_policy_ref=authored_launch_policy_ref or None,
+                consumer_type=consumer_type,
+                consumer_id=reserved_workflow_id,
+                user=user,
+            )
         authored_execution_target_ref = (
             str(authored_omnigent.get("executionTargetRef") or "").strip()
             if isinstance(authored_omnigent, Mapping)
@@ -11190,6 +11217,25 @@ async def _create_execution_from_workflow_request(
             initial_parameters,
             snapshot=profile_snapshot,
         )
+        try:
+            execution_plan = await compile_and_persist_execution_authority(
+                session,
+                agent_profile_snapshot=profile_snapshot,
+                workflow_parameters=initial_parameters,
+                workflow_id=reserved_workflow_id,
+            )
+        except HarnessPlatformError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": str(exc.code),
+                    "message": str(exc),
+                },
+            ) from exc
+        # Only the digest-addressed ref crosses into workflow history. The plan
+        # row and execution record are committed together by create_execution
+        # before Temporal is started.
+        initial_parameters["executionPlanRef"] = execution_plan.planRef
 
     try:
         start_contract = resolve_user_workflow_start_contract(settings.temporal)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -17740,6 +17740,21 @@ async def rerun_execution(
         consumer_id=reserved_workflow_id,
         user=user,
     )
+    rerun_snapshot = initial_params.get("agentProfileSnapshot")
+    if isinstance(rerun_snapshot, Mapping):
+        try:
+            rerun_plan = await compile_and_persist_execution_authority(
+                session,
+                agent_profile_snapshot=rerun_snapshot,
+                workflow_parameters=initial_params,
+                workflow_id=reserved_workflow_id,
+            )
+        except HarnessPlatformError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": str(exc.code), "message": str(exc)},
+            ) from exc
+        initial_params["executionPlanRef"] = rerun_plan.planRef
 
     # Generate a new idempotency key based on the original workflow ID
     new_idempotency_key = f"rerun:{workflow_id}:{_uuid4()}"

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -3735,6 +3735,7 @@ async def _claim_facade_message(
             )
             if receipt is not None:
                 await canonical_settle(
+                    workflow_id=str(row.moonmind_workflow_id),
                     idempotency_key=idempotency_key,
                     outcome=canonical_outcome,
                     result_ref=str(receipt.get("durableAuditRef") or "") or None,
@@ -3880,6 +3881,7 @@ async def _record_facade_mutation_audit(
 
         provider_receipt_id = str(metadata.get("upstreamCorrelation") or "") or None
         await canonical_settle(
+            workflow_id=str(row.moonmind_workflow_id),
             idempotency_key=request_id,
             outcome=(
                 ControlPlaneOutcome.DELIVERY_UNKNOWN

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -3597,6 +3597,43 @@ async def _claim_facade_message(
     """
 
     event_identity = f"workflow-chat-message:{idempotency_key}"
+    canonical_claim = getattr(store, "claim_canonical_turn_command", None)
+    if callable(canonical_claim):
+        try:
+            claim = await canonical_claim(
+                row=row,
+                command_type=event_type,
+                idempotency_key=idempotency_key,
+                payload_digest=payload_digest,
+            )
+        except Exception as exc:
+            from moonmind.omnigent.control_plane.turn_commands import (
+                CanonicalTurnAuthorityUnavailable,
+            )
+
+            if isinstance(exc, CanonicalTurnAuthorityUnavailable):
+                raise WorkflowChatFacadeError(
+                    str(exc),
+                    failure_class="system_error",
+                    status_code=status.HTTP_409_CONFLICT,
+                    code=CODE_SESSION_NOT_READY,
+                ) from exc
+            raise
+        from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+        if claim.outcome is ControlPlaneOutcome.ALREADY_APPLIED:
+            # Canonical settlement is authoritative even if the facade's
+            # compatibility ledger was lost or has not yet converged. Never
+            # redeliver a provider turn (or duplicate billing) from a second
+            # transport-local claim.
+            return False
+        if claim.outcome is not ControlPlaneOutcome.APPLIED:
+            raise WorkflowChatFacadeError(
+                "The canonical turn command is owned by another delivery.",
+                failure_class="system_error",
+                status_code=status.HTTP_409_CONFLICT,
+                code=CODE_SESSION_NOT_READY,
+            )
     now = request_time or datetime.now(tz=UTC).isoformat()
     launch = dict(getattr(row, "effective_launch_snapshot_json", None) or {})
     policy = dict(launch.get("policyAuthority") or {})
@@ -3678,6 +3715,31 @@ async def _claim_facade_message(
             status_code=status.HTTP_409_CONFLICT,
             code=CODE_IDEMPOTENCY_CONFLICT,
         )
+    # A process may have persisted the bridge receipt and then failed before
+    # settling the canonical command. Reconcile that narrow handoff on replay;
+    # never re-forward the provider mutation.
+    canonical_settle = getattr(store, "settle_canonical_turn_command", None)
+    if callable(canonical_settle):
+        from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+        for prior_outcome, canonical_outcome in (
+            ("posted", ControlPlaneOutcome.APPLIED),
+            ("delivery_unknown", ControlPlaneOutcome.DELIVERY_UNKNOWN),
+        ):
+            receipt = await store.get_lifecycle_event_metadata(
+                row.idempotency_key,
+                event_identity=(
+                    f"workflow-chat-control:{event_type}:{prior_outcome}:"
+                    f"{idempotency_key}"
+                ),
+            )
+            if receipt is not None:
+                await canonical_settle(
+                    idempotency_key=idempotency_key,
+                    outcome=canonical_outcome,
+                    result_ref=str(receipt.get("durableAuditRef") or "") or None,
+                )
+                break
     return False
 
 
@@ -3807,6 +3869,26 @@ async def _record_facade_mutation_audit(
         summary=f"workflow chat {control_type} {outcome}",
         metadata=metadata,
     )
+    canonical_settle = getattr(store, "settle_canonical_turn_command", None)
+    if callable(canonical_settle) and outcome in {
+        "posted",
+        "completed",
+        "accepted",
+        "delivery_unknown",
+    }:
+        from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+        provider_receipt_id = str(metadata.get("upstreamCorrelation") or "") or None
+        await canonical_settle(
+            idempotency_key=request_id,
+            outcome=(
+                ControlPlaneOutcome.DELIVERY_UNKNOWN
+                if outcome == "delivery_unknown"
+                else ControlPlaneOutcome.APPLIED
+            ),
+            provider_receipt_id=provider_receipt_id,
+            result_ref=str(metadata["durableAuditRef"]),
+        )
     return request_time or now
 
 

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -49,7 +49,7 @@ from moonmind.config.container_backend_settings import (
 )
 from moonmind.config.settings import settings
 from moonmind.omnigent.bridge_config import HOST_PROTOCOL_MODE_EMBEDDED
-from moonmind.omnigent.bridge_store import (
+from moonmind.omnigent.control_plane.identities import (
     EGRESS_CLEANUP_AUTHORITY_KEY,
     EGRESS_CLEANUP_AUTHORITY_VERSION,
 )

--- a/api_service/api/routers/omnigent_session_timeline.py
+++ b/api_service/api/routers/omnigent_session_timeline.py
@@ -17,9 +17,6 @@ internal token, raw host path, or unbounded payload is ever surfaced.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from urllib.parse import quote
-
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,30 +24,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from api_service.db.models import User
-from api_service.services.settings_catalog import has_settings_permission
-from moonmind.omnigent.control_plane.repositories import ControlPlaneRepositories
-from moonmind.omnigent.control_plane.stuck_state_reconciliation import (
-    inspect_stuck_state,
+from api_service.services.omnigent_session_timeline_service import (
+    OmnigentDiagnosticTargetUnavailable,
+    OmnigentSessionProjectionNotFound,
+    OmnigentSessionTimelineService,
 )
-from moonmind.omnigent.control_plane.timeline import build_timeline
-from moonmind.omnigent.control_plane.timeline import safe_timeline_ref
-from moonmind.observability import TelemetrySettings, build_backend_url
+from api_service.services.settings_catalog import has_settings_permission
 
 router = APIRouter(prefix="/api/omnigent/sessions", tags=["Omnigent Session Timeline"])
 
 _DIAGNOSTIC_PERMISSION = "operations.read"
-
-#: Observation types classified as substantive provider events / snapshots (kept
-#: in sync with the timeline projection so both endpoints read the same signal).
-_EVENT_OBSERVATION_TYPES = (
-    "event",
-    "event_frontier",
-    "event_batch",
-    "provider_event",
-    "provider_event_batch",
-)
-_SNAPSHOT_OBSERVATION_TYPES = ("snapshot", "provider_snapshot")
-
 
 def _require_diagnostic_read(user: User) -> None:
     if not has_settings_permission(user, _DIAGNOSTIC_PERMISSION):
@@ -69,91 +52,23 @@ async def get_session_timeline(
     """Return the machine-readable operator timeline for one canonical session."""
 
     _require_diagnostic_read(user)
-    repos = ControlPlaneRepositories.bind(db)
-
-    session = await repos.sessions.get(session_id)
-    if session is None:
+    try:
+        return await OmnigentSessionTimelineService(db).timeline(session_id)
+    except OmnigentSessionProjectionNotFound:
         raise HTTPException(404, "Session not found")
-
-    # Bounded latest/active queries plus a count, so an operator diagnostic never
-    # materializes the full append-only history of a long-running session.
-    active_turn = (
-        await repos.turn_attempts.get(session.active_turn_attempt_id)
-        if session.active_turn_attempt_id is not None
-        else None
-    )
-    turn_attempt_count = await repos.turn_attempts.count_for_session(session_id)
-    latest_snapshot = await repos.observations.latest_for_session(
-        session_id, observation_types=_SNAPSHOT_OBSERVATION_TYPES
-    )
-    latest_event = await repos.observations.latest_for_session(
-        session_id, observation_types=_EVENT_OBSERVATION_TYPES
-    )
-    active_command = await repos.commands.active_for_session(session_id)
-    # The session pointer is updated only during quarantine; stuck-state
-    # decisions are appended without advancing it, so prefer the journal's
-    # latest entry to avoid showing a stale decision.
-    latest_decision = await repos.decisions.latest_for_session(session_id)
-    if latest_decision is None and session.last_decision_ref is not None:
-        latest_decision = await repos.decisions.get(session.last_decision_ref)
-    cleanup = await repos.cleanup.get(session_id)
-    telemetry = TelemetrySettings.from_env()
-    encoded_session_id = quote(session_id, safe="")
-    trace_link = (
-        f"/api/omnigent/sessions/{encoded_session_id}/trace"
-        if latest_decision is not None
-        and safe_timeline_ref(latest_decision.trace_ref) is not None
-        and telemetry.trace_url_template
-        else None
-    )
-    log_link = (
-        f"/api/omnigent/sessions/{encoded_session_id}/logs"
-        if telemetry.logs_url_template
-        and session.moonmind_workflow_id
-        else None
-    )
-
-    timeline = build_timeline(
-        session=session,
-        turn_attempts=[active_turn] if active_turn is not None else (),
-        observations=[o for o in (latest_snapshot, latest_event) if o is not None],
-        commands=[active_command] if active_command is not None else (),
-        decisions=[latest_decision] if latest_decision is not None else (),
-        cleanup=cleanup,
-        turn_attempt_count=turn_attempt_count,
-        trace_link=trace_link,
-        log_link=log_link,
-    )
-    return timeline.to_dict()
 
 
 async def _diagnostic_redirect(
     *, session_id: str, kind: str, user: User, db: AsyncSession
 ) -> RedirectResponse:
     _require_diagnostic_read(user)
-    repos = ControlPlaneRepositories.bind(db)
-    session = await repos.sessions.get(session_id)
-    if session is None:
+    try:
+        target = await OmnigentSessionTimelineService(db).diagnostic_target(
+            session_id, kind
+        )
+    except OmnigentSessionProjectionNotFound:
         raise HTTPException(404, "Session not found")
-    telemetry = TelemetrySettings.from_env()
-    if kind == "trace":
-        # Prefer the newest journal entry; the session pointer lags.
-        decision = await repos.decisions.latest_for_session(session_id)
-        if decision is None and session.last_decision_ref is not None:
-            decision = await repos.decisions.get(session.last_decision_ref)
-        trace_id = (
-            safe_timeline_ref(decision.trace_ref)
-            if decision is not None
-            else None
-        )
-        target = build_backend_url(telemetry.trace_url_template, trace_id=trace_id)
-    else:
-        target = build_backend_url(
-            telemetry.logs_url_template,
-            workflow_id=session.moonmind_workflow_id,
-            run_id=session.moonmind_run_id,
-        )
-    if target is None:
+    except OmnigentDiagnosticTargetUnavailable:
         raise HTTPException(404, f"Authorized {kind} backend link unavailable")
     return RedirectResponse(target, status_code=307)
 
@@ -195,40 +110,10 @@ async def get_session_stuck_state(
     """
 
     _require_diagnostic_read(user)
-    repos = ControlPlaneRepositories.bind(db)
-
-    session = await repos.sessions.get(session_id)
-    if session is None:
+    try:
+        return await OmnigentSessionTimelineService(db).stuck_state(session_id)
+    except OmnigentSessionProjectionNotFound:
         raise HTTPException(404, "Session not found")
-
-    inspection = await inspect_stuck_state(
-        repos, session_id=session_id, now=datetime.now(UTC)
-    )
-    findings = inspection.findings if inspection is not None else ()
-    response = inspection.response if inspection is not None else None
-
-    return {
-        "sessionId": session_id,
-        "findings": [
-            {
-                "reason": f.reason.value,
-                "action": f.action.value,
-                "detail": f.detail,
-                "remediation": f.remediation,
-            }
-            for f in findings
-        ],
-        "response": None
-        if response is None
-        else {
-            "reconcile": response.reconcile,
-            "quarantine": response.quarantine,
-            "expectedRevision": response.expected_revision,
-            "expectedFencingGeneration": response.expected_fencing_generation,
-            "reasons": [r.value for r in response.reasons],
-            "remediation": response.remediation,
-        },
-    }
 
 
 __all__ = ["router"]

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -639,6 +639,8 @@ class OmnigentSession(Base):
         ),
         Index("ix_omnigent_sessions_workflow", "moonmind_workflow_id"),
         Index("ix_omnigent_sessions_deadline", "next_reconciliation_deadline"),
+        Index("ix_omnigent_sessions_execution_plan", "execution_plan_ref"),
+        Index("ix_omnigent_sessions_runtime_binding", "runtime_binding_ref"),
     )
 
     session_id: Mapped[str] = mapped_column(String(255), primary_key=True)
@@ -663,6 +665,22 @@ class OmnigentSession(Base):
     # Immutable intent ref and digest.
     intent_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
     intent_digest: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+
+    # Immutable admitted execution authority plus the latest immutable runtime
+    # binding stage. The plan ref never changes for this session; runtime
+    # binding refs advance only as generations/host/session evidence is added.
+    execution_plan_ref: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        ForeignKey("omnigent_execution_plans.plan_ref", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    runtime_binding_ref: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        ForeignKey(
+            "omnigent_runtime_bindings.runtime_binding_ref", ondelete="RESTRICT"
+        ),
+        nullable=True,
+    )
 
     # Desired / observed / reconciled lifecycle state.
     desired_state: Mapped[str] = mapped_column(

--- a/api_service/migrations/versions/359_omnigent_session_execution_authority.py
+++ b/api_service/migrations/versions/359_omnigent_session_execution_authority.py
@@ -1,0 +1,78 @@
+"""Bind canonical Omnigent sessions to plan/runtime authority.
+
+Source: MoonLadderStudios/MoonMind#3701.
+Revision ID: 359_omnigent_authority
+Revises: 358_generic_host
+Create Date: 2026-08-21
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "359_omnigent_authority"
+down_revision: Union[str, None] = "358_generic_host"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "omnigent_sessions",
+        sa.Column("execution_plan_ref", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "omnigent_sessions",
+        sa.Column("runtime_binding_ref", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ix_omnigent_sessions_execution_plan",
+        "omnigent_sessions",
+        ["execution_plan_ref"],
+    )
+    op.create_index(
+        "ix_omnigent_sessions_runtime_binding",
+        "omnigent_sessions",
+        ["runtime_binding_ref"],
+    )
+    op.create_foreign_key(
+        "fk_omnigent_sessions_execution_plan",
+        "omnigent_sessions",
+        "omnigent_execution_plans",
+        ["execution_plan_ref"],
+        ["plan_ref"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_omnigent_sessions_runtime_binding",
+        "omnigent_sessions",
+        "omnigent_runtime_bindings",
+        ["runtime_binding_ref"],
+        ["runtime_binding_ref"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_omnigent_sessions_runtime_binding",
+        "omnigent_sessions",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_omnigent_sessions_execution_plan",
+        "omnigent_sessions",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "ix_omnigent_sessions_runtime_binding", table_name="omnigent_sessions"
+    )
+    op.drop_index("ix_omnigent_sessions_execution_plan", table_name="omnigent_sessions")
+    op.drop_column("omnigent_sessions", "runtime_binding_ref")
+    op.drop_column("omnigent_sessions", "execution_plan_ref")
+
+
+_ = (revision, down_revision, branch_labels, depends_on)

--- a/api_service/services/checkpoint_branch_turn_execution.py
+++ b/api_service/services/checkpoint_branch_turn_execution.py
@@ -482,7 +482,15 @@ class CheckpointBranchTurnExecutionOwner:
             raise CheckpointBranchTurnLaunchError(
                 "branch_head_stale", "expected branch head version does not match"
             )
-        if branch.current_head_checkpoint_ref != turn.source_checkpoint_ref:
+        # A successfully launched turn advances ``current_head_checkpoint_ref``
+        # to its output checkpoint.  Exact idempotent delivery must reattach to
+        # that already-owned turn, not reinterpret its immutable source as a
+        # fresh claim against the now-advanced branch head.  Unlaunched turns
+        # still require the current head to match before any side effect.
+        if (
+            not turn.created_step_execution_id
+            and branch.current_head_checkpoint_ref != turn.source_checkpoint_ref
+        ):
             raise CheckpointBranchTurnLaunchError(
                 "branch_head_checkpoint_changed",
                 "turn source no longer matches the persisted branch head",
@@ -967,12 +975,13 @@ class CheckpointBranchTurnExecutionOwner:
             CanonicalSessionBootstrap,
             CanonicalTurnCommandService,
         )
-
-        source_command = self._turn_commands or CanonicalTurnCommandService(
-            self._bound_session_factory()
-        )
         from moonmind.omnigent.control_plane.repositories import (
             ControlPlaneRepositories,
+            OmnigentControlPlaneStore,
+        )
+
+        source_command = self._turn_commands or CanonicalTurnCommandService(
+            OmnigentControlPlaneStore(self._bound_session_factory())
         )
 
         canonical_claim = await source_command.claim_with_repositories(

--- a/api_service/services/checkpoint_branch_turn_execution.py
+++ b/api_service/services/checkpoint_branch_turn_execution.py
@@ -230,6 +230,7 @@ class CheckpointBranchTurnExecutionOwner:
         principal: str,
         client: TemporalClientAdapter | None = None,
         artifact_service: TemporalArtifactService | None = None,
+        turn_command_service: Any | None = None,
     ) -> None:
         self._session = session
         self._principal = principal
@@ -240,6 +241,14 @@ class CheckpointBranchTurnExecutionOwner:
         # may inject the real boundary fake directly.
         self._artifacts = artifact_service
         self._artifact_link: dict[str, Any] | None = None
+        self._turn_commands = turn_command_service
+
+    def _bound_session_factory(self) -> Any:
+        return (
+            async_sessionmaker(self._session.bind, expire_on_commit=False)
+            if self._session.bind is not None
+            else async_session_maker
+        )
 
     @asynccontextmanager
     async def _artifact_service(
@@ -248,11 +257,7 @@ class CheckpointBranchTurnExecutionOwner:
         if self._artifacts is not None:
             yield None, self._artifacts
             return
-        bound_factory = (
-            async_sessionmaker(self._session.bind, expire_on_commit=False)
-            if self._session.bind is not None
-            else async_session_maker
-        )
+        bound_factory = self._bound_session_factory()
         async with bound_factory() as artifact_session:
             yield artifact_session, get_checkpoint_branch_artifact_service(
                 artifact_session
@@ -767,6 +772,15 @@ class CheckpointBranchTurnExecutionOwner:
                 "execution_profile_mismatch",
                 "stored execution profile differs from checkpoint authority",
             )
+        selected_plan_ref = str(selection.get("executionPlanRef") or "").strip()
+        checkpoint_plan_ref = str(
+            omnigent.execution_plan_ref or ""
+        ).strip()
+        if selected_plan_ref and selected_plan_ref != checkpoint_plan_ref:
+            raise CheckpointBranchTurnLaunchError(
+                "execution_plan_mismatch",
+                "stored execution plan differs from checkpoint authority",
+            )
         agent_snapshot = selection.get("agentProfileSnapshot")
         agent_identity = selection.get("agentProfile")
         if agent_snapshot is not None:
@@ -942,10 +956,6 @@ class CheckpointBranchTurnExecutionOwner:
             branch_id=branch_id,
             branch_turn_id=branch_turn_id,
         )
-        if turn.created_step_execution_id:
-            await self._start_claimed_turn(branch=branch, turn=turn, binding=binding)
-            return turn
-
         checkpoint, profile, policy_snapshot = await self._validate_source_authority(
             branch=branch,
             turn=turn,
@@ -953,6 +963,69 @@ class CheckpointBranchTurnExecutionOwner:
             source=source,
             expected_head_version=request.expected_branch_head_version,
         )
+        from moonmind.omnigent.control_plane.turn_commands import (
+            CanonicalSessionBootstrap,
+            CanonicalTurnCommandService,
+        )
+
+        source_command = self._turn_commands or CanonicalTurnCommandService(
+            self._bound_session_factory()
+        )
+        from moonmind.omnigent.control_plane.repositories import (
+            ControlPlaneRepositories,
+        )
+
+        canonical_claim = await source_command.claim_with_repositories(
+            ControlPlaneRepositories.bind(self._session),
+            workflow_id=checkpoint.omnigent.workflow_id,
+            provider_session_ref=str(
+                checkpoint.omnigent.omnigent_session_id or ""
+            ),
+            chat_binding_id=None,
+            command_type="checkpoint_branch_resume",
+            idempotency_key=turn.idempotency_key,
+            payload_digest=turn.instruction_digest,
+            step_execution_id=checkpoint.omnigent.step_execution_id,
+            bootstrap=CanonicalSessionBootstrap(
+                provider="omnigent",
+                step_execution_id=checkpoint.omnigent.step_execution_id,
+                agent_run_id=checkpoint.omnigent.bridge_session_id,
+                source_idempotency_key=checkpoint.omnigent.idempotency_key,
+                execution_plan_ref=checkpoint.omnigent.execution_plan_ref,
+            ),
+        )
+        from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+        if canonical_claim.outcome not in {
+            ControlPlaneOutcome.APPLIED,
+            ControlPlaneOutcome.ALREADY_APPLIED,
+        }:
+            raise CheckpointBranchTurnLaunchError(
+                "canonical_turn_command_not_owned",
+                "checkpoint branch command is owned by another delivery",
+            )
+        if (
+            canonical_claim.outcome is ControlPlaneOutcome.ALREADY_APPLIED
+            and not turn.created_step_execution_id
+        ):
+            raise CheckpointBranchTurnLaunchError(
+                "canonical_turn_reconciliation_required",
+                "the canonical checkpoint command is settled without matching "
+                "branch execution authority",
+            )
+        # The canonical command is the authority for every later artifact,
+        # workflow start, and provider-facing turn. Make it durable before any
+        # such side effect, including replay reattachment.
+        await self._session.commit()
+        if turn.created_step_execution_id:
+            await self._start_claimed_turn(branch=branch, turn=turn, binding=binding)
+            if canonical_claim.outcome is ControlPlaneOutcome.APPLIED:
+                await source_command.settle(
+                    idempotency_key=turn.idempotency_key,
+                    outcome=ControlPlaneOutcome.APPLIED,
+                    result_ref=str(turn.step_execution_manifest_ref or "") or None,
+                )
+            return turn
         count = int(
             (
                 await self._session.execute(
@@ -1027,6 +1100,16 @@ class CheckpointBranchTurnExecutionOwner:
             "publishMode": publish_mode,
             "gitWorkBranch": binding.work_branch,
         }
+        # A checkpoint continuation consumes the source session's immutable
+        # plan. It must not re-resolve harness, model, Provider Profile, Host
+        # Class, launch policy, repository, workspace, or Skill authority.
+        # Checkpoints created before plan admission remain on the replay-visible
+        # legacy path and therefore carry no synthesized replacement plan.
+        source_plan_ref = str(
+            checkpoint.omnigent.execution_plan_ref or ""
+        ).strip()
+        if source_plan_ref:
+            runtime_selection["executionPlanRef"] = source_plan_ref
         remediation_context_ref = await self._validated_remediation_context_ref(turn)
         branch.diagnostics = {
             **(branch.diagnostics or {}),
@@ -1253,6 +1336,11 @@ class CheckpointBranchTurnExecutionOwner:
         )
         await self._session.commit()
         await self._start_claimed_turn(branch=branch, turn=claimed, binding=binding)
+        await source_command.settle(
+            idempotency_key=turn.idempotency_key,
+            outcome=ControlPlaneOutcome.APPLIED,
+            result_ref=manifest_ref,
+        )
         await self._session.refresh(claimed)
         return claimed
 

--- a/api_service/services/checkpoint_branch_turn_execution.py
+++ b/api_service/services/checkpoint_branch_turn_execution.py
@@ -1030,6 +1030,7 @@ class CheckpointBranchTurnExecutionOwner:
             await self._start_claimed_turn(branch=branch, turn=turn, binding=binding)
             if canonical_claim.outcome is ControlPlaneOutcome.APPLIED:
                 await source_command.settle(
+                    workflow_id=checkpoint.omnigent.workflow_id,
                     idempotency_key=turn.idempotency_key,
                     outcome=ControlPlaneOutcome.APPLIED,
                     result_ref=str(turn.step_execution_manifest_ref or "") or None,
@@ -1346,6 +1347,7 @@ class CheckpointBranchTurnExecutionOwner:
         await self._session.commit()
         await self._start_claimed_turn(branch=branch, turn=claimed, binding=binding)
         await source_command.settle(
+            workflow_id=checkpoint.omnigent.workflow_id,
             idempotency_key=turn.idempotency_key,
             outcome=ControlPlaneOutcome.APPLIED,
             result_ref=manifest_ref,

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -345,6 +345,105 @@ async def resolve_agent_profile_snapshot(
     return snapshot
 
 
+async def resolve_default_agent_profile_snapshot(
+    session: AsyncSession,
+    *,
+    provider_profile_ref: str | None,
+    launch_policy_ref: str | None,
+    consumer_type: str,
+    consumer_id: str,
+    user: User | None,
+) -> dict[str, Any]:
+    """Resolve the deployment-managed default into explicit launch authority.
+
+    The default is selected only at API admission.  The returned immutable
+    snapshot is then compiled into the same plan as an explicitly authored
+    Agent Profile, so workers never repeat default/profile resolution.
+    """
+
+    profile = await session.scalar(
+        select(OmnigentAgentProfile)
+        .where(OmnigentAgentProfile.default_for_runtime.is_(True))
+        .limit(1)
+    )
+    if profile is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "default Omnigent Agent Profile is unavailable",
+        )
+    if profile.state != "active" or profile.active_version is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "default Omnigent Agent Profile is not launch ready",
+        )
+    version = await session.scalar(
+        select(OmnigentAgentProfileVersion).where(
+            OmnigentAgentProfileVersion.profile_id == profile.profile_id,
+            OmnigentAgentProfileVersion.version == profile.active_version,
+        )
+    )
+    if version is None or not isinstance(version.document, Mapping):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "default Omnigent Agent Profile version is unavailable",
+        )
+    selected_provider_ref = str(provider_profile_ref or "").strip()
+    if not selected_provider_ref:
+        requirements = version.document.get("providerRequirements") or {}
+        query = (
+            select(ManagedAgentProviderProfile)
+            .where(
+                ManagedAgentProviderProfile.enabled.is_(True),
+                ManagedAgentProviderProfile.runtime_id
+                == requirements.get("runtimeId"),
+                ManagedAgentProviderProfile.credential_source
+                == requirements.get("credentialSource"),
+                ManagedAgentProviderProfile.runtime_materialization_mode
+                == requirements.get("materializationMode"),
+            )
+            .order_by(
+                ManagedAgentProviderProfile.is_default.desc(),
+                ManagedAgentProviderProfile.priority.desc(),
+                ManagedAgentProviderProfile.profile_id.asc(),
+            )
+        )
+        if requirements.get("providerIds"):
+            query = query.where(
+                ManagedAgentProviderProfile.provider_id.in_(
+                    requirements["providerIds"]
+                )
+            )
+        candidates = list((await session.scalars(query)).all())
+        selected = next(
+            (item for item in candidates if provider_profile_launch_ready(item)),
+            None,
+        )
+        if selected is None:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "no launch-ready Provider Profile matches the default Omnigent "
+                "Agent Profile",
+            )
+        selected_provider_ref = selected.profile_id
+    selection = {
+        "profileId": profile.profile_id,
+        "version": profile.active_version,
+        "providerProfileRef": selected_provider_ref,
+        **(
+            {"launchPolicyRef": str(launch_policy_ref).strip()}
+            if str(launch_policy_ref or "").strip()
+            else {}
+        ),
+    }
+    return await resolve_agent_profile_snapshot(
+        session,
+        selection=selection,
+        consumer_type=consumer_type,
+        consumer_id=consumer_id,
+        user=user,
+    )
+
+
 async def refresh_managed_bootstrap_snapshot(
     session: AsyncSession,
     *,
@@ -468,4 +567,5 @@ __all__ = [
     "compile_agent_profile_snapshot_parameters",
     "refresh_managed_bootstrap_snapshot",
     "resolve_agent_profile_snapshot",
+    "resolve_default_agent_profile_snapshot",
 ]

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -5,7 +5,7 @@ import copy
 from typing import Any, Mapping
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import (
@@ -23,6 +23,18 @@ from api_service.services.omnigent_agent_profile_service import (
 from api_service.services.provider_profile_readiness import provider_profile_launch_ready
 
 _OVERRIDABLE_SECTIONS = frozenset({"model", "capture", "rag", "publish"})
+
+
+def _provider_profile_visibility_filter(user: User | None) -> Any | None:
+    """Return the SQL visibility boundary shared by explicit/default selection."""
+
+    user_id = getattr(user, "id", None)
+    if user_id is None or bool(getattr(user, "is_superuser", False)):
+        return None
+    return or_(
+        ManagedAgentProviderProfile.owner_user_id.is_(None),
+        ManagedAgentProviderProfile.owner_user_id == user_id,
+    )
 
 
 def _enforce_override_ceilings(
@@ -256,6 +268,9 @@ async def resolve_agent_profile_snapshot(
             ManagedAgentProviderProfile.credential_source == requirements["credentialSource"],
             ManagedAgentProviderProfile.runtime_materialization_mode == requirements["materializationMode"],
         )
+    visibility_filter = _provider_profile_visibility_filter(user)
+    if visibility_filter is not None:
+        provider_query = provider_query.where(visibility_filter)
     if requirements.get("providerIds"):
         provider_query = provider_query.where(
             ManagedAgentProviderProfile.provider_id.in_(requirements["providerIds"])
@@ -316,13 +331,25 @@ async def resolve_agent_profile_snapshot(
         "upstreamSnapshot": upstream_snapshot,
         "validationResult": version.validation_result,
     }
-    if replace_existing_usage:
-        usage = await session.scalar(
-            select(OmnigentAgentProfileUsage).where(
-                OmnigentAgentProfileUsage.consumer_type == consumer_type,
-                OmnigentAgentProfileUsage.consumer_id == consumer_id,
-            )
+    usage = await session.scalar(
+        select(OmnigentAgentProfileUsage).where(
+            OmnigentAgentProfileUsage.consumer_type == consumer_type,
+            OmnigentAgentProfileUsage.consumer_id == consumer_id,
         )
+    )
+    if usage is not None and not replace_existing_usage:
+        if (
+            usage.profile_id != profile_id
+            or usage.version != version.version
+            or usage.digest != version.digest
+            or usage.effective_snapshot != snapshot
+        ):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "Agent Profile usage conflicts with the existing consumer authority",
+            )
+        return copy.deepcopy(dict(usage.effective_snapshot))
+    if replace_existing_usage:
         if usage is None:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
@@ -407,6 +434,9 @@ async def resolve_default_agent_profile_snapshot(
                 ManagedAgentProviderProfile.profile_id.asc(),
             )
         )
+        visibility_filter = _provider_profile_visibility_filter(user)
+        if visibility_filter is not None:
+            query = query.where(visibility_filter)
         if requirements.get("providerIds"):
             query = query.where(
                 ManagedAgentProviderProfile.provider_id.in_(

--- a/api_service/services/omnigent_agent_profile_service.py
+++ b/api_service/services/omnigent_agent_profile_service.py
@@ -12,10 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import OmnigentUpstreamAgentProjection
 
-# Generic harness support (Phase 5): synchronized catalog + trust records own launchability.
-# Only harnesses with a declared Host Class and approved materializer are launchable.
-# Keep explicit allowlist minimal; qwen/claude remain quarantined until Host Class exists.
-_SUPPORTED_HARNESSES = {"codex-native", "opencode-native", "pi-native"}
 _MAX_INVENTORY = 500
 _INVENTORY_FRESHNESS_TTL = timedelta(minutes=5)
 _METADATA_TEXT_LIMIT = 512
@@ -136,6 +132,10 @@ async def synchronize_upstream_inventory(
     now: datetime | None = None,
 ) -> int:
     """Upsert one bounded last-known projection and mark disappearances unavailable."""
+    from moonmind.omnigent.harness_platform.admission import (
+        HARNESS_ADMISSION_REGISTRATIONS,
+    )
+
     observed_at = now or datetime.now(timezone.utc)
     rows = list(inventory[:_MAX_INVENTORY])
     seen: set[str] = set()
@@ -153,7 +153,7 @@ async def synchronize_upstream_inventory(
             if isinstance(capabilities, list)
             else set()
         )
-        compatible = harness in _SUPPORTED_HARNESSES or (
+        compatible = harness in HARNESS_ADMISSION_REGISTRATIONS or (
             not harness and "codex-native" in capability_values
         )
         projection = await session.get(OmnigentUpstreamAgentProjection, projection_id)

--- a/api_service/services/omnigent_session_timeline_service.py
+++ b/api_service/services/omnigent_session_timeline_service.py
@@ -1,0 +1,163 @@
+"""Read-only persistence adapter for Omnigent operator projections."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from urllib.parse import quote
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from moonmind.observability import TelemetrySettings, build_backend_url
+from moonmind.omnigent.control_plane.repositories import ControlPlaneRepositories
+from moonmind.omnigent.control_plane.stuck_state_reconciliation import (
+    inspect_stuck_state,
+)
+from moonmind.omnigent.control_plane.timeline import build_timeline, safe_timeline_ref
+
+
+_EVENT_OBSERVATION_TYPES = (
+    "event",
+    "event_frontier",
+    "event_batch",
+    "provider_event",
+    "provider_event_batch",
+)
+_SNAPSHOT_OBSERVATION_TYPES = ("snapshot", "provider_snapshot")
+
+
+class OmnigentSessionProjectionNotFound(LookupError):
+    pass
+
+
+class OmnigentDiagnosticTargetUnavailable(LookupError):
+    pass
+
+
+class OmnigentSessionTimelineService:
+    """Build bounded read projections without exposing repositories to routers."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._repos = ControlPlaneRepositories.bind(session)
+
+    async def _session(self, session_id: str):
+        session = await self._repos.sessions.get(session_id)
+        if session is None:
+            raise OmnigentSessionProjectionNotFound(session_id)
+        return session
+
+    async def timeline(self, session_id: str) -> dict:
+        session = await self._session(session_id)
+        active_turn = (
+            await self._repos.turn_attempts.get(session.active_turn_attempt_id)
+            if session.active_turn_attempt_id is not None
+            else None
+        )
+        turn_attempt_count = await self._repos.turn_attempts.count_for_session(
+            session_id
+        )
+        latest_snapshot = await self._repos.observations.latest_for_session(
+            session_id, observation_types=_SNAPSHOT_OBSERVATION_TYPES
+        )
+        latest_event = await self._repos.observations.latest_for_session(
+            session_id, observation_types=_EVENT_OBSERVATION_TYPES
+        )
+        active_command = await self._repos.commands.active_for_session(session_id)
+        latest_decision = await self._repos.decisions.latest_for_session(session_id)
+        if latest_decision is None and session.last_decision_ref is not None:
+            latest_decision = await self._repos.decisions.get(
+                session.last_decision_ref
+            )
+        cleanup = await self._repos.cleanup.get(session_id)
+        telemetry = TelemetrySettings.from_env()
+        encoded_session_id = quote(session_id, safe="")
+        trace_link = (
+            f"/api/omnigent/sessions/{encoded_session_id}/trace"
+            if latest_decision is not None
+            and safe_timeline_ref(latest_decision.trace_ref) is not None
+            and telemetry.trace_url_template
+            else None
+        )
+        log_link = (
+            f"/api/omnigent/sessions/{encoded_session_id}/logs"
+            if telemetry.logs_url_template and session.moonmind_workflow_id
+            else None
+        )
+        return build_timeline(
+            session=session,
+            turn_attempts=[active_turn] if active_turn is not None else (),
+            observations=[
+                item
+                for item in (latest_snapshot, latest_event)
+                if item is not None
+            ],
+            commands=[active_command] if active_command is not None else (),
+            decisions=[latest_decision] if latest_decision is not None else (),
+            cleanup=cleanup,
+            turn_attempt_count=turn_attempt_count,
+            trace_link=trace_link,
+            log_link=log_link,
+        ).to_dict()
+
+    async def diagnostic_target(self, session_id: str, kind: str) -> str:
+        session = await self._session(session_id)
+        telemetry = TelemetrySettings.from_env()
+        if kind == "trace":
+            decision = await self._repos.decisions.latest_for_session(session_id)
+            if decision is None and session.last_decision_ref is not None:
+                decision = await self._repos.decisions.get(
+                    session.last_decision_ref
+                )
+            trace_id = (
+                safe_timeline_ref(decision.trace_ref)
+                if decision is not None
+                else None
+            )
+            target = build_backend_url(
+                telemetry.trace_url_template, trace_id=trace_id
+            )
+        else:
+            target = build_backend_url(
+                telemetry.logs_url_template,
+                workflow_id=session.moonmind_workflow_id,
+                run_id=session.moonmind_run_id,
+            )
+        if target is None:
+            raise OmnigentDiagnosticTargetUnavailable(kind)
+        return target
+
+    async def stuck_state(self, session_id: str) -> dict:
+        await self._session(session_id)
+        inspection = await inspect_stuck_state(
+            self._repos, session_id=session_id, now=datetime.now(UTC)
+        )
+        findings = inspection.findings if inspection is not None else ()
+        response = inspection.response if inspection is not None else None
+        return {
+            "sessionId": session_id,
+            "findings": [
+                {
+                    "reason": finding.reason.value,
+                    "action": finding.action.value,
+                    "detail": finding.detail,
+                    "remediation": finding.remediation,
+                }
+                for finding in findings
+            ],
+            "response": None
+            if response is None
+            else {
+                "reconcile": response.reconcile,
+                "quarantine": response.quarantine,
+                "expectedRevision": response.expected_revision,
+                "expectedFencingGeneration": response.expected_fencing_generation,
+                "reasons": [reason.value for reason in response.reasons],
+                "remediation": response.remediation,
+            },
+        }
+
+
+__all__ = [
+    "OmnigentDiagnosticTargetUnavailable",
+    "OmnigentSessionProjectionNotFound",
+    "OmnigentSessionTimelineService",
+]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,57 +1,24 @@
 [
-  {
-    "id": 3828381449,
-    "disposition": "addressed",
-    "rationale": "Added a distinct digest-pinned --opencode-host-image input, exported OMNIGENT_OPENCODE_HOST_IMAGE_REF for the run, gave each combination a code-owned host_image_key, and required every claimed combination to publish hostImageRef equal to that pinned images entry."
-  },
-  {
-    "id": 3828381452,
-    "disposition": "addressed",
-    "rationale": "Cleanup expectations are now derived from the launch policy cleanup mode: remove requires live_host_stopped with liveResourcesRemoved true, drain requires live_host_drained with liveResourcesRemoved false, at both the cleanupReceipt and manifest cleanupOutcome gates."
-  },
-  {
-    "id": 3828381455,
-    "disposition": "addressed",
-    "rationale": "The cleanup receipt now compares the ordered step list directly against the combination's required step tuple instead of comparing sets with a release-last check."
-  },
-  {
-    "id": 3828381462,
-    "disposition": "addressed",
-    "rationale": "Report cases must now equal the code-owned workflow_chat_case_id set for the combination's four rows and reference exactly that row's evidence refs; passed must equal the row count and skipped must be zero."
-  },
-  {
-    "id": 3828381466,
-    "disposition": "addressed",
-    "rationale": "action() takes a log_id and the workflow_chat controller passes the combination id, so each combination retains its own workflow_chat-<row>-<combination>.log."
-  },
-  {
-    "id": 3828381471,
-    "disposition": "addressed",
-    "rationale": "providerProfileClass is now pinned by the claimed combination inventory (with the credential materializer ref required in bindingIdentity.materializerRefs), so evidence collected under one credential/provider authority class cannot qualify another."
-  },
-  {
-    "id": 3828381477,
-    "disposition": "addressed",
-    "rationale": "executionCreation is cross-checked against the matching browser trace event's method and normalized path before created_through_public_executions_api is derived."
-  },
-  {
-    "id": 3828381485,
-    "disposition": "addressed",
-    "rationale": "Denied capability enforcement observations are propagated into expected_denial_statuses, and the unit fixture now uses an independent enforcement request id instead of reusing one from denialAudit."
-  },
-  {
-    "id": 4990980963,
-    "disposition": "not-applicable",
-    "rationale": "Informational Codex review summary body; no action requested."
-  },
-  {
-    "id": 3828381491,
-    "disposition": "addressed",
-    "rationale": "_write_workflow_chat_report takes an auth_mode; each per-combination report publishes the combination's code-owned auth mode (validated against the manifest) and the aggregate report names every mode it exercised."
-  },
-  {
-    "id": 3828381495,
-    "disposition": "addressed",
-    "rationale": "cross_user and cross_workflow denials must record authorized/attempted user and workflow identities, bind the authorized workflow to the session under test, and vary exactly the scope they claim to isolate."
-  }
+  {"id": 3832490788, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490807, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490813, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490827, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490844, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490857, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490870, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832490886, "disposition": "addressed", "rationale": "Replaced the no-op Protocol method body with an explicit NotImplementedError."},
+  {"id": 3832528263, "disposition": "addressed", "rationale": "The Activity now derives and persists a digest-addressed plan containing the actual resolved Skill snapshot before realizer dispatch."},
+  {"id": 3832528270, "disposition": "addressed", "rationale": "Retries reacquire and validate the deterministic Provider Profile lease, resume persisted host authority, reach the driver, then clean up and release."},
+  {"id": 3832528277, "disposition": "addressed", "rationale": "Explicit and default Provider Profile queries now enforce global-or-requesting-owner visibility."},
+  {"id": 3832528285, "disposition": "addressed", "rationale": "Exact existing Agent Profile usage is reused on idempotent retries instead of inserting a duplicate unique row."},
+  {"id": 3832528293, "disposition": "addressed", "rationale": "Removed Pi from normal-product admission until a production credential materializer exists."},
+  {"id": 3832528297, "disposition": "addressed", "rationale": "Step model and effort overrides are bound into a derived plan and support identity before runtime side effects."},
+  {"id": 3832528304, "disposition": "addressed", "rationale": "Canonical command and bootstrap-turn idempotency identities are now scoped by workflow."},
+  {"id": 4996059049, "disposition": "not-applicable", "rationale": "Informational automated review summary contains no actionable feedback."},
+  {"id": 3832528311, "disposition": "addressed", "rationale": "Docker launch now pins --platform to the architecture recorded in the admitted support identity."},
+  {"id": 3832528320, "disposition": "addressed", "rationale": "Full reruns compile and persist new execution authority against the reserved rerun workflow identity."},
+  {"id": 3832528326, "disposition": "addressed", "rationale": "Admission now rejects profiles without an effective model before lease or host acquisition."},
+  {"id": 3832528332, "disposition": "addressed", "rationale": "Run accepts normal-product registered harnesses and synchronizes their registered Provider runtime identities, including OpenCode."},
+  {"id": 3832528337, "disposition": "addressed", "rationale": "Generic realizer authorization now propagates provider lease, host, endpoint, plan, binding, policy, and realizer identity into the durable bridge row."},
+  {"id": 3832528341, "disposition": "addressed", "rationale": "Generic checkpoint capture omits effectiveLaunchRef because no valid omnigent-launch snapshot exists."}
 ]

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -1686,7 +1686,37 @@ The design is realized when:
 29. Omnigent can be the preselected execution provider while Codex remains the default proven Agent Profile.
 30. Direct runtimes remain available only according to their existing rollback and retirement contracts.
 
-## 33. Document authority and future promotion
+## 33. Enforced module dependency boundaries
+
+The settled control plane uses the following one-way ownership boundaries:
+
+| Boundary | Owned modules | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| Pure reconciliation and authority values | `omnigent/reconciler`, `control_plane/records.py`, `control_plane/identities.py`, immutable harness-platform value modules | Python and validation libraries, other pure value modules | API, SQL, Temporal, HTTP, process, container, filesystem, or environment adapters |
+| Application coordination | `control_plane/turn_commands.py`, `realizers/base.py`, `realizers/generic_host.py` | Pure contracts and injected repository/runtime capabilities | FastAPI, SQLAlchemy, Temporal clients, HTTP clients, Docker clients, or provider-specific harness selection |
+| Persistence | `control_plane/repositories.py`, `harness_platform/stores.py` | Pure records and database models | Router or provider-transport policy |
+| Provider transport and host lifecycle | bridge/execute adapters, `host_runtime.py`, `realizers/runtime_authority.py` | Application requests, Provider Profile and host interfaces | UI facade policy or plan recompilation |
+| Composition | `realizers/composition.py`, worker activity adapters | Every concrete capability needed to assemble a supported realizer | Harness-name selection or alternate authority semantics |
+| UI facade | API routers and WebSocket adapters | Application services and projections | Direct persistence mutation, provider identity selection, host lifecycle, or credential materialization |
+| Evidence and publication | conformance, acceptance, timeline, and publication adapters | Immutable plan/binding/session refs and observed artifacts | Replacement plan, session, or lifecycle authority |
+
+Dependency direction is from outer adapters toward application coordination and
+pure contracts. Pure modules never import infrastructure. Generic application
+coordination receives infrastructure through the composition boundary and does
+not branch on `codex-native`, `opencode-native`, `pi-native`, Provider Profile
+ids, or model vendors. Deterministic session and turn identities have one owner,
+`control_plane/identities.py`; callers import those functions rather than
+creating alternate authority vocabulary.
+
+The unit architecture contract parses imports and identity definitions. It
+fails when framework or infrastructure imports leak into declared pure or
+application modules, when generic coordination gains a harness-name branch, or
+when canonical identity functions acquire another definition. The existing
+Codex realizer is an explicit replay-visible legacy adapter and remains outside
+the generic-application rule until its evidence-qualified retirement gate
+allows removal.
+
+## 34. Document authority and future promotion
 
 This design owns the target generic harness-platform model.
 

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -31,6 +31,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.db.models import OmnigentBridgeSession, OmnigentBridgeSessionEvent
 from moonmind.omnigent.bridge_events import bounded_deduplication_key
 from moonmind.omnigent.bridge_security import BridgeSessionBinding, redact_raw_events
+from moonmind.omnigent.control_plane.identities import (
+    EGRESS_CLEANUP_AUTHORITY_KEY,
+    EGRESS_CLEANUP_AUTHORITY_VERSION,
+)
+from moonmind.omnigent.control_plane.repositories import OmnigentControlPlaneStore
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.utils.logging import redact_sensitive_payload
 
@@ -56,9 +61,6 @@ PROVIDER_SESSION_DELETED_KEY = "provider_session_deleted_at"
 EMBEDDED_LAUNCH_KEY = "embedded_runner_launch"
 EMBEDDED_LIFECYCLE_KEY = "embedded_runner_lifecycle"
 EMBEDDED_LIFECYCLE_VERSION = 1
-EGRESS_CLEANUP_AUTHORITY_KEY = "egress_cleanup_authority"
-EGRESS_CLEANUP_AUTHORITY_VERSION = 1
-
 EMBEDDED_RUNNER_STATES = frozenset(
     {
         "launch_reserved",
@@ -431,6 +433,7 @@ class OmnigentBridgeSessionStore:
 
     def __init__(self, session_factory: Callable[[], Any]) -> None:
         self._session_factory = session_factory
+        self._control_plane_store = OmnigentControlPlaneStore(session_factory)
 
     async def claim_canonical_turn_command(
         self,
@@ -453,7 +456,7 @@ class OmnigentBridgeSessionStore:
 
         launch = dict(row.effective_launch_snapshot_json or {})
 
-        return await CanonicalTurnCommandService(self._session_factory).claim(
+        return await CanonicalTurnCommandService(self._control_plane_store).claim(
             workflow_id=str(row.moonmind_workflow_id),
             provider_session_ref=str(row.omnigent_session_id or ""),
             chat_binding_id=str(row.chat_binding_id or "") or None,
@@ -483,7 +486,7 @@ class OmnigentBridgeSessionStore:
             CanonicalTurnCommandService,
         )
 
-        return await CanonicalTurnCommandService(self._session_factory).settle(
+        return await CanonicalTurnCommandService(self._control_plane_store).settle(
             idempotency_key=idempotency_key,
             outcome=outcome,
             provider_receipt_id=provider_receipt_id,

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -432,6 +432,64 @@ class OmnigentBridgeSessionStore:
     def __init__(self, session_factory: Callable[[], Any]) -> None:
         self._session_factory = session_factory
 
+    async def claim_canonical_turn_command(
+        self,
+        *,
+        row: Any,
+        command_type: str,
+        idempotency_key: str,
+        payload_digest: str,
+    ) -> Any:
+        """Claim the shared #3701 session/turn/command authority.
+
+        The bridge store supplies only persistence composition.  Turn semantics
+        remain in the transport-neutral control-plane application service.
+        """
+
+        from moonmind.omnigent.control_plane.turn_commands import (
+            CanonicalSessionBootstrap,
+            CanonicalTurnCommandService,
+        )
+
+        launch = dict(row.effective_launch_snapshot_json or {})
+
+        return await CanonicalTurnCommandService(self._session_factory).claim(
+            workflow_id=str(row.moonmind_workflow_id),
+            provider_session_ref=str(row.omnigent_session_id or ""),
+            chat_binding_id=str(row.chat_binding_id or "") or None,
+            command_type=command_type,
+            idempotency_key=idempotency_key,
+            payload_digest=payload_digest,
+            step_execution_id=str(row.step_execution_id or "") or None,
+            bootstrap=CanonicalSessionBootstrap(
+                provider=str(row.provider),
+                step_execution_id=str(row.step_execution_id or row.bridge_session_id),
+                agent_run_id=str(row.moonmind_agent_run_id),
+                source_idempotency_key=str(row.idempotency_key),
+                execution_plan_ref=str(launch.get("executionPlanRef") or "")
+                or None,
+            ),
+        )
+
+    async def settle_canonical_turn_command(
+        self,
+        *,
+        idempotency_key: str,
+        outcome: Any,
+        provider_receipt_id: str | None = None,
+        result_ref: str | None = None,
+    ) -> Any:
+        from moonmind.omnigent.control_plane.turn_commands import (
+            CanonicalTurnCommandService,
+        )
+
+        return await CanonicalTurnCommandService(self._session_factory).settle(
+            idempotency_key=idempotency_key,
+            outcome=outcome,
+            provider_receipt_id=provider_receipt_id,
+            result_ref=result_ref,
+        )
+
     async def list_embedded_host_readiness(self) -> list[dict[str, Any]]:
         """Return bounded, non-secret readiness for active embedded host leases."""
         from api_service.db.models import OmnigentOAuthHostLeaseRecord

--- a/moonmind/omnigent/bridge_store.py
+++ b/moonmind/omnigent/bridge_store.py
@@ -477,6 +477,7 @@ class OmnigentBridgeSessionStore:
     async def settle_canonical_turn_command(
         self,
         *,
+        workflow_id: str,
         idempotency_key: str,
         outcome: Any,
         provider_receipt_id: str | None = None,
@@ -487,6 +488,7 @@ class OmnigentBridgeSessionStore:
         )
 
         return await CanonicalTurnCommandService(self._control_plane_store).settle(
+            workflow_id=workflow_id,
             idempotency_key=idempotency_key,
             outcome=outcome,
             provider_receipt_id=provider_receipt_id,
@@ -1044,33 +1046,49 @@ class OmnigentBridgeSessionStore:
         """Persist lease-authorized routing before provider session creation."""
 
         if effective_launch_snapshot is not None:
-            authority = effective_launch_snapshot.get("policyAuthority")
-            if not isinstance(authority, dict):
-                raise OmnigentIdempotencyError(
-                    "bridge authorization requires policy authority evidence"
+            execution_plan_ref = str(
+                effective_launch_snapshot.get("executionPlanRef") or ""
+            ).strip()
+            if execution_plan_ref:
+                runtime_binding_ref = str(
+                    effective_launch_snapshot.get("runtimeBindingRef") or ""
+                ).strip()
+                if not execution_plan_ref.startswith(
+                    "omnigent-execution-plan:sha256:"
+                ) or not runtime_binding_ref.startswith(
+                    "omnigent-runtime-binding:sha256:"
+                ):
+                    raise OmnigentIdempotencyError(
+                        "bridge generic execution authority is incomplete"
+                    )
+            else:
+                authority = effective_launch_snapshot.get("policyAuthority")
+                if not isinstance(authority, dict):
+                    raise OmnigentIdempotencyError(
+                        "bridge authorization requires policy authority evidence"
+                    )
+                required_authority = {
+                    "policyId",
+                    "policyVersion",
+                    "policyRef",
+                    "policyDigest",
+                    "snapshotRef",
+                    "validation",
+                }
+                missing_authority = sorted(
+                    key for key in required_authority if not authority.get(key)
                 )
-            required_authority = {
-                "policyId",
-                "policyVersion",
-                "policyRef",
-                "policyDigest",
-                "snapshotRef",
-                "validation",
-            }
-            missing_authority = sorted(
-                key for key in required_authority if not authority.get(key)
-            )
-            if missing_authority:
-                raise OmnigentIdempotencyError(
-                    "bridge authorization policy authority is incomplete: "
-                    + ", ".join(missing_authority)
-                )
-            if effective_launch_snapshot.get("launchPolicyRef") != authority.get(
-                "policyRef"
-            ):
-                raise OmnigentIdempotencyError(
-                    "bridge launch policy does not match persisted policy authority"
-                )
+                if missing_authority:
+                    raise OmnigentIdempotencyError(
+                        "bridge authorization policy authority is incomplete: "
+                        + ", ".join(missing_authority)
+                    )
+                if effective_launch_snapshot.get("launchPolicyRef") != authority.get(
+                    "policyRef"
+                ):
+                    raise OmnigentIdempotencyError(
+                        "bridge launch policy does not match persisted policy authority"
+                    )
 
         await self.get_or_create(
             request=request,

--- a/moonmind/omnigent/checkpoints.py
+++ b/moonmind/omnigent/checkpoints.py
@@ -120,6 +120,8 @@ class OmnigentCheckpointIdentity(BaseModel):
     effective_launch_ref: str | None = Field(None, alias="effectiveLaunchRef", min_length=1)
     execution_profile_ref: str = Field(..., alias="executionProfileRef", min_length=1)
     launch_policy_ref: str = Field(..., alias="launchPolicyRef", min_length=1)
+    execution_plan_ref: str | None = Field(None, alias="executionPlanRef", min_length=1)
+    runtime_binding_ref: str | None = Field(None, alias="runtimeBindingRef", min_length=1)
     policy_id: str | None = Field(None, alias="policyId", min_length=1)
     policy_version: int | None = Field(None, alias="policyVersion", ge=1)
     policy_ref: str | None = Field(None, alias="policyRef", min_length=1)

--- a/moonmind/omnigent/control_plane/__init__.py
+++ b/moonmind/omnigent/control_plane/__init__.py
@@ -114,6 +114,12 @@ from .repositories import (
     SessionRepository,
     TurnAttemptRepository,
 )
+from .turn_commands import (
+    CanonicalSessionBootstrap,
+    CanonicalTurnAuthorityUnavailable,
+    CanonicalTurnCommandClaim,
+    CanonicalTurnCommandService,
+)
 
 __all__ = [
     "ALIAS_STATE_ACTIVE",
@@ -131,6 +137,10 @@ __all__ = [
     "COMMAND_STATE_PENDING",
     "COMMAND_STATES",
     "COMMAND_TERMINAL_STATES",
+    "CanonicalTurnAuthorityUnavailable",
+    "CanonicalSessionBootstrap",
+    "CanonicalTurnCommandClaim",
+    "CanonicalTurnCommandService",
     "CONFLICT_OUTCOMES",
     "CURRENT_SCHEMA_VERSION",
     "SUPPORTED_SCHEMA_VERSIONS",

--- a/moonmind/omnigent/control_plane/identities.py
+++ b/moonmind/omnigent/control_plane/identities.py
@@ -31,10 +31,12 @@ def omnigent_session_workflow_id(session_id: str) -> str:
     return f"omnigent-session:{session_id}"
 
 
-def canonical_turn_command_key(idempotency_key: str) -> str:
+def canonical_turn_command_key(workflow_id: str, idempotency_key: str) -> str:
     """Return the workflow-scoped durable key for one instruction delivery."""
 
-    return f"omnigent-turn-command:{idempotency_key}"
+    return "omnigent-turn-command:" + compute_digest(
+        ["workflow", workflow_id, idempotency_key]
+    )
 
 
 def canonical_turn_claim_token(command_key: str) -> str:

--- a/moonmind/omnigent/control_plane/identities.py
+++ b/moonmind/omnigent/control_plane/identities.py
@@ -1,0 +1,32 @@
+"""Provider-neutral deterministic identities for canonical Omnigent authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def canonical_omnigent_session_id(
+    *, workflow_id: str, step_execution_id: str, agent_run_id: str
+) -> str:
+    authority = json.dumps(
+        ["omnigent-session/v1", workflow_id, step_execution_id, agent_run_id],
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "oms_" + hashlib.sha256(authority).hexdigest()[:40]
+
+
+def canonical_omnigent_turn_attempt_id(session_id: str, ordinal: int = 1) -> str:
+    authority = f"omnigent-turn/v1:{session_id}:{ordinal}".encode("utf-8")
+    return "ota_" + hashlib.sha256(authority).hexdigest()[:40]
+
+
+def omnigent_session_workflow_id(session_id: str) -> str:
+    return f"omnigent-session:{session_id}"
+
+
+__all__ = [
+    "canonical_omnigent_session_id",
+    "canonical_omnigent_turn_attempt_id",
+    "omnigent_session_workflow_id",
+]

--- a/moonmind/omnigent/control_plane/identities.py
+++ b/moonmind/omnigent/control_plane/identities.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import hashlib
 import json
 
+from .records import compute_digest
+
+
+EGRESS_CLEANUP_AUTHORITY_KEY = "egress_cleanup_authority"
+EGRESS_CLEANUP_AUTHORITY_VERSION = 1
+
 
 def canonical_omnigent_session_id(
     *, workflow_id: str, step_execution_id: str, agent_run_id: str
@@ -25,8 +31,40 @@ def omnigent_session_workflow_id(session_id: str) -> str:
     return f"omnigent-session:{session_id}"
 
 
+def canonical_turn_command_key(idempotency_key: str) -> str:
+    """Return the workflow-scoped durable key for one instruction delivery."""
+
+    return f"omnigent-turn-command:{idempotency_key}"
+
+
+def canonical_turn_claim_token(command_key: str) -> str:
+    """Return the stable delivery claim token for a canonical command."""
+
+    return "otc_" + compute_digest([command_key, "delivery"])[:40]
+
+
+def canonical_followup_turn_attempt_id(session_id: str, command_key: str) -> str:
+    """Return the stable attempt identity for a non-bootstrap command."""
+
+    return "ota_" + compute_digest([session_id, command_key])[:40]
+
+
+def canonical_turn_command_id(
+    session_id: str, command_key: str, command_type: str
+) -> str:
+    """Return the stable side-effect-journal identity for one command."""
+
+    return "ocm_" + compute_digest([session_id, command_key, command_type])[:40]
+
+
 __all__ = [
+    "EGRESS_CLEANUP_AUTHORITY_KEY",
+    "EGRESS_CLEANUP_AUTHORITY_VERSION",
     "canonical_omnigent_session_id",
     "canonical_omnigent_turn_attempt_id",
+    "canonical_followup_turn_attempt_id",
+    "canonical_turn_claim_token",
+    "canonical_turn_command_id",
+    "canonical_turn_command_key",
     "omnigent_session_workflow_id",
 ]

--- a/moonmind/omnigent/control_plane/records.py
+++ b/moonmind/omnigent/control_plane/records.py
@@ -299,6 +299,8 @@ class SessionRecord:
     chat_binding_id: Optional[str] = None
     intent_ref: Optional[str] = None
     intent_digest: Optional[str] = None
+    execution_plan_ref: Optional[str] = None
+    runtime_binding_ref: Optional[str] = None
     desired_state: str = "pending"
     observed_state: Optional[str] = None
     reconciled_state: Optional[str] = None

--- a/moonmind/omnigent/control_plane/repositories.py
+++ b/moonmind/omnigent/control_plane/repositories.py
@@ -27,6 +27,7 @@ from api_service.db.models import (
     OmnigentCommand,
     OmnigentObservation,
     OmnigentReconciliationDecision,
+    OmnigentRuntimeBindingRecord,
     OmnigentSession,
     OmnigentTurnAttempt,
 )
@@ -132,6 +133,8 @@ def _session_record(row: OmnigentSession) -> SessionRecord:
         chat_binding_id=row.chat_binding_id,
         intent_ref=row.intent_ref,
         intent_digest=row.intent_digest,
+        execution_plan_ref=row.execution_plan_ref,
+        runtime_binding_ref=row.runtime_binding_ref,
         desired_state=row.desired_state,
         observed_state=row.observed_state,
         reconciled_state=row.reconciled_state,
@@ -321,6 +324,8 @@ class SessionRepository(_RepositoryBase):
         chat_binding_id: Optional[str] = None,
         intent_ref: Optional[str] = None,
         intent_digest: Optional[str] = None,
+        execution_plan_ref: Optional[str] = None,
+        runtime_binding_ref: Optional[str] = None,
         desired_state: str = "pending",
         provider_profile_id: Optional[str] = None,
         host_binding_ref: Optional[str] = None,
@@ -341,6 +346,8 @@ class SessionRepository(_RepositoryBase):
             chat_binding_id=chat_binding_id,
             intent_ref=intent_ref,
             intent_digest=intent_digest,
+            execution_plan_ref=execution_plan_ref,
+            runtime_binding_ref=runtime_binding_ref,
             desired_state=desired_state,
             provider_profile_id=provider_profile_id,
             host_binding_ref=host_binding_ref,
@@ -555,6 +562,8 @@ class SessionRepository(_RepositoryBase):
         credential_generation: Any = _UNSET,
         provider_profile_generation: Any = _UNSET,
         host_lease_generation: Any = _UNSET,
+        execution_plan_ref: Any = _UNSET,
+        runtime_binding_ref: Any = _UNSET,
         metadata_patch: Optional[dict[str, Any]] = None,
     ) -> SessionRecord:
         """Bind safe runtime refs under the supervisor revision/fence.
@@ -571,6 +580,47 @@ class SessionRepository(_RepositoryBase):
             raise ConflictingSessionAuthorityError(
                 f"Unknown canonical session {session_id!r}"
             )
+        if runtime_binding_ref is not _UNSET and runtime_binding_ref is not None:
+            binding = await self._session.get(
+                OmnigentRuntimeBindingRecord, runtime_binding_ref
+            )
+            if binding is None:
+                raise ConflictingSessionAuthorityError(
+                    f"Session {session_id!r} cannot bind unknown runtime authority"
+                )
+            intended_plan_ref = (
+                execution_plan_ref
+                if execution_plan_ref is not _UNSET
+                else row.execution_plan_ref
+            )
+            if (
+                intended_plan_ref is None
+                or binding.execution_plan_ref != intended_plan_ref
+            ):
+                raise ConflictingSessionAuthorityError(
+                    f"Session {session_id!r} runtime binding does not belong to "
+                    "its immutable execution plan"
+                )
+            if row.runtime_binding_ref not in {None, runtime_binding_ref}:
+                current_binding = await self._session.get(
+                    OmnigentRuntimeBindingRecord, row.runtime_binding_ref
+                )
+                if current_binding is None:
+                    raise ConflictingSessionAuthorityError(
+                        f"Session {session_id!r} lost its runtime binding authority"
+                    )
+                stage_rank = {
+                    "credentials_acquired": 1,
+                    "host_acquired": 2,
+                    "session_bound": 3,
+                }
+                if stage_rank.get(binding.state, 0) <= stage_rank.get(
+                    current_binding.state, 0
+                ):
+                    raise ConflictingSessionAuthorityError(
+                        f"Session {session_id!r} cannot replace or regress its "
+                        "runtime binding stage"
+                    )
         provided = {
             name: value
             for name, value in (
@@ -580,6 +630,7 @@ class SessionRepository(_RepositoryBase):
                 ("credential_generation", credential_generation),
                 ("provider_profile_generation", provider_profile_generation),
                 ("host_lease_generation", host_lease_generation),
+                ("execution_plan_ref", execution_plan_ref),
             )
             if value is not _UNSET
         }
@@ -590,7 +641,13 @@ class SessionRepository(_RepositoryBase):
                 (row.metadata_ or {}).get(key) == value
                 for key, value in metadata_patch.items()
             )
-        if already_applied and (provided or metadata_patch):
+        if runtime_binding_ref is not _UNSET:
+            already_applied = (
+                already_applied and row.runtime_binding_ref == runtime_binding_ref
+            )
+        if already_applied and (
+            provided or metadata_patch or runtime_binding_ref is not _UNSET
+        ):
             return _session_record(row)
         conflict = self._check_session_fence(
             row,
@@ -615,6 +672,10 @@ class SessionRepository(_RepositoryBase):
                     f"refusing {value!r}"
                 )
             setattr(row, name, value)
+        if runtime_binding_ref is not _UNSET:
+            # Runtime binding envelopes are immutable, digest-addressed stages;
+            # the session points at the latest stage for the same immutable plan.
+            row.runtime_binding_ref = runtime_binding_ref
         if metadata_patch:
             metadata = dict(row.metadata_ or {})
             for key, value in metadata_patch.items():
@@ -2619,6 +2680,7 @@ class OmnigentControlPlaneStore:
         compatibility_profile: Optional[str] = None,
         intent_ref: Optional[str] = None,
         intent_digest: Optional[str] = None,
+        execution_plan_ref: Optional[str] = None,
         instruction_digest: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> tuple[SessionRecord, TurnAttemptRecord]:
@@ -2635,6 +2697,7 @@ class OmnigentControlPlaneStore:
                 compatibility_profile=compatibility_profile,
                 intent_ref=intent_ref,
                 intent_digest=intent_digest,
+                execution_plan_ref=execution_plan_ref,
                 metadata=metadata,
             )
             await repos.chat_binding_aliases.register(

--- a/moonmind/omnigent/control_plane/turn_commands.py
+++ b/moonmind/omnigent/control_plane/turn_commands.py
@@ -1,0 +1,386 @@
+"""Canonical turn-command boundary for every follow-up instruction source.
+
+MoonLadderStudios/MoonMind#3701 requires Workflow Chat, steering, approval,
+continuation, remediation and checkpoint operations to share the same durable
+session/turn/command authority.  This application service is deliberately
+transport-neutral: HTTP and Temporal adapters supply an already-authorized
+session locator and receive a stable claim which must be settled after the
+side-effect boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .records import (
+    APPLIED_OUTCOMES,
+    ConflictingSessionAuthorityError,
+    ControlPlaneOutcome,
+    TURN_STATE_ACCEPTED,
+    TURN_STATE_DELIVERY_UNKNOWN,
+    compute_digest,
+)
+from .identities import (
+    canonical_omnigent_session_id,
+    canonical_omnigent_turn_attempt_id,
+)
+from .repositories import OmnigentControlPlaneStore
+
+
+class CanonicalTurnAuthorityUnavailable(RuntimeError):
+    """The supplied transport binding cannot resolve one canonical session."""
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalTurnCommandClaim:
+    session_id: str
+    turn_attempt_id: str
+    command_id: str
+    idempotency_key: str
+    claim_token: str
+    outcome: ControlPlaneOutcome
+    expected_session_revision: int
+    fencing_generation: int
+
+    @property
+    def owns_delivery(self) -> bool:
+        return self.outcome is ControlPlaneOutcome.APPLIED
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalSessionBootstrap:
+    """Verified legacy/source authority sufficient for on-demand convergence."""
+
+    provider: str
+    step_execution_id: str
+    agent_run_id: str
+    source_idempotency_key: str
+    execution_plan_ref: str | None = None
+
+
+def _stable_ref(prefix: str, *parts: object) -> str:
+    return f"{prefix}_{compute_digest(list(parts))[:40]}"
+
+
+def _lineage_kind(command_type: str) -> str:
+    normalized = command_type.strip().lower().replace(".", "_")
+    if "remediation" in normalized:
+        return "remediation"
+    if "checkpoint" in normalized or "branch" in normalized:
+        return "checkpoint_resume"
+    if "approval" in normalized or "elicitation" in normalized:
+        return "approval"
+    if "steer" in normalized or "interrupt" in normalized or "stop" in normalized:
+        return "steering"
+    return "continuation"
+
+
+class CanonicalTurnCommandService:
+    """Record, fence, claim and settle one instruction-bearing side effect."""
+
+    OWNER_CLASS = "canonical_turn_command"
+
+    def __init__(self, session_factory: Any) -> None:
+        self._store = OmnigentControlPlaneStore(session_factory)
+
+    async def claim(
+        self,
+        *,
+        workflow_id: str,
+        provider_session_ref: str,
+        chat_binding_id: str | None,
+        command_type: str,
+        idempotency_key: str,
+        payload_digest: str,
+        step_execution_id: str | None = None,
+        bootstrap: CanonicalSessionBootstrap | None = None,
+    ) -> CanonicalTurnCommandClaim:
+        """Claim current fenced authority before an external side effect."""
+
+        async with self._store.transaction() as repos:
+            return await self.claim_with_repositories(
+                repos,
+                workflow_id=workflow_id,
+                provider_session_ref=provider_session_ref,
+                chat_binding_id=chat_binding_id,
+                command_type=command_type,
+                idempotency_key=idempotency_key,
+                payload_digest=payload_digest,
+                step_execution_id=step_execution_id,
+                bootstrap=bootstrap,
+            )
+
+    async def claim_with_repositories(
+        self,
+        repos: Any,
+        *,
+        workflow_id: str,
+        provider_session_ref: str,
+        chat_binding_id: str | None,
+        command_type: str,
+        idempotency_key: str,
+        payload_digest: str,
+        step_execution_id: str | None = None,
+        bootstrap: CanonicalSessionBootstrap | None = None,
+    ) -> CanonicalTurnCommandClaim:
+        """Claim within an existing application transaction."""
+
+        canonical_key = f"omnigent-turn-command:{idempotency_key}"
+        claim_token = _stable_ref("otc", canonical_key, "delivery")
+        session = None
+        bootstrap_turn = None
+        if chat_binding_id:
+            alias = await repos.chat_binding_aliases.resolve(chat_binding_id)
+            if alias is not None and alias.resolves:
+                session = await repos.sessions.get(str(alias.session_id))
+            if session is None:
+                session = await repos.sessions.get_by_chat_binding(chat_binding_id)
+        if session is None and provider_session_ref:
+            session = await repos.sessions.get_by_scope(
+                workflow_id, provider_session_ref
+            )
+        if session is None and bootstrap is not None:
+            session_id = canonical_omnigent_session_id(
+                workflow_id=workflow_id,
+                step_execution_id=bootstrap.step_execution_id,
+                agent_run_id=bootstrap.agent_run_id,
+            )
+            existing_session = await repos.sessions.get(session_id)
+            if existing_session is not None:
+                if (
+                    existing_session.moonmind_workflow_id != workflow_id
+                    or existing_session.step_execution_id != bootstrap.step_execution_id
+                    or existing_session.moonmind_agent_run_id != bootstrap.agent_run_id
+                    or existing_session.execution_plan_ref
+                    != bootstrap.execution_plan_ref
+                ):
+                    raise CanonicalTurnAuthorityUnavailable(
+                        "deterministic session identity conflicts with its "
+                        "bootstrap authority"
+                    )
+                session = existing_session
+            else:
+                first_turn_id = canonical_omnigent_turn_attempt_id(session_id)
+                try:
+                    await repos.sessions.create(
+                        session_id=session_id,
+                        moonmind_workflow_id=workflow_id,
+                        provider=bootstrap.provider,
+                        provider_session_ref=provider_session_ref or None,
+                        chat_binding_id=chat_binding_id,
+                        step_execution_id=bootstrap.step_execution_id,
+                        moonmind_agent_run_id=bootstrap.agent_run_id,
+                        execution_plan_ref=bootstrap.execution_plan_ref,
+                        metadata={"canonicalizedOnDemand": True},
+                    )
+                except ConflictingSessionAuthorityError:
+                    # A concurrent identical bootstrap may win the deterministic
+                    # primary key while this transaction waits on PostgreSQL's
+                    # unique index. The savepoint leaves this transaction usable;
+                    # converge on the winner and verify it below.
+                    session = await repos.sessions.get(session_id)
+                    if session is None:
+                        raise
+                    if (
+                        session.moonmind_workflow_id != workflow_id
+                        or session.step_execution_id != bootstrap.step_execution_id
+                        or session.moonmind_agent_run_id != bootstrap.agent_run_id
+                        or session.execution_plan_ref != bootstrap.execution_plan_ref
+                    ):
+                        raise CanonicalTurnAuthorityUnavailable(
+                            "concurrent deterministic session bootstrap has "
+                            "different authority"
+                        )
+                else:
+                    if chat_binding_id:
+                        await repos.chat_binding_aliases.register(
+                            chat_binding_id=chat_binding_id,
+                            session_id=session_id,
+                        )
+                    bootstrap_turn = await repos.turn_attempts.create(
+                        turn_attempt_id=first_turn_id,
+                        session_id=session_id,
+                        idempotency_key=(
+                            "omnigent-bootstrap:" + bootstrap.source_idempotency_key
+                        ),
+                        lineage_kind="initial",
+                        step_execution_id=bootstrap.step_execution_id,
+                        instruction_digest=(
+                            payload_digest
+                            if bootstrap.source_idempotency_key == idempotency_key
+                            else None
+                        ),
+                    )
+                    session = await repos.sessions.update_lifecycle(
+                        session_id,
+                        expected_revision=1,
+                        expected_fencing_generation=0,
+                        active_turn_attempt_id=first_turn_id,
+                    )
+        if session is None:
+            raise CanonicalTurnAuthorityUnavailable(
+                "Instruction authority does not resolve a canonical OmnigentSession"
+            )
+        if session.moonmind_workflow_id != workflow_id:
+            raise CanonicalTurnAuthorityUnavailable(
+                "Instruction binding conflicts with canonical workflow authority"
+            )
+        if chat_binding_id:
+            await repos.chat_binding_aliases.register(
+                chat_binding_id=chat_binding_id,
+                session_id=session.session_id,
+            )
+
+        existing_command = await repos.commands.get_by_idempotency_key(canonical_key)
+        if existing_command is None:
+            if (
+                bootstrap_turn is not None
+                and bootstrap is not None
+                and bootstrap.source_idempotency_key == idempotency_key
+            ):
+                # The admitted initial instruction owns the bootstrap attempt;
+                # do not manufacture a second "continuation" for the same
+                # provider-facing command.
+                turn = bootstrap_turn
+            else:
+                turn_id = _stable_ref("ota", session.session_id, canonical_key)
+                turn = await repos.turn_attempts.create(
+                    turn_attempt_id=turn_id,
+                    session_id=session.session_id,
+                    idempotency_key=f"omnigent-turn:{idempotency_key}",
+                    lineage_kind=_lineage_kind(command_type),
+                    step_execution_id=step_execution_id,
+                    parent_turn_attempt_id=session.active_turn_attempt_id,
+                    instruction_digest=payload_digest,
+                )
+                session = await repos.sessions.update_lifecycle(
+                    session.session_id,
+                    expected_revision=session.revision,
+                    expected_fencing_generation=session.fencing_generation,
+                    active_turn_attempt_id=turn.turn_attempt_id,
+                )
+            command_id = _stable_ref(
+                "ocm", session.session_id, canonical_key, command_type
+            )
+            command = await repos.commands.record(
+                command_id=command_id,
+                session_id=session.session_id,
+                command_type=command_type,
+                idempotency_key=canonical_key,
+                payload_digest=payload_digest,
+                turn_attempt_id=turn.turn_attempt_id,
+                expected_session_revision=session.revision,
+                fencing_generation=session.fencing_generation,
+                owner_class=self.OWNER_CLASS,
+            )
+        else:
+            command = await repos.commands.record(
+                command_id=existing_command.command_id,
+                session_id=session.session_id,
+                command_type=command_type,
+                idempotency_key=canonical_key,
+                payload_digest=payload_digest,
+                turn_attempt_id=existing_command.turn_attempt_id,
+                expected_session_revision=existing_command.expected_session_revision,
+                fencing_generation=existing_command.fencing_generation,
+                owner_class=self.OWNER_CLASS,
+            )
+        claimed = await repos.commands.claim_command(
+            command.command_id,
+            owner_class=self.OWNER_CLASS,
+            claim_token=claim_token,
+        )
+        return CanonicalTurnCommandClaim(
+            session_id=session.session_id,
+            turn_attempt_id=str(command.turn_attempt_id),
+            command_id=command.command_id,
+            idempotency_key=canonical_key,
+            claim_token=claim_token,
+            outcome=claimed.outcome,
+            expected_session_revision=command.expected_session_revision,
+            fencing_generation=command.fencing_generation,
+        )
+
+    async def settle(
+        self,
+        *,
+        idempotency_key: str,
+        outcome: ControlPlaneOutcome,
+        provider_receipt_id: str | None = None,
+        result_ref: str | None = None,
+    ) -> ControlPlaneOutcome:
+        """Settle the command and advance its turn without session terminality."""
+
+        canonical_key = f"omnigent-turn-command:{idempotency_key}"
+        claim_token = _stable_ref("otc", canonical_key, "delivery")
+        async with self._store.transaction() as repos:
+            command = await repos.commands.get_by_idempotency_key(canonical_key)
+            if command is None or not command.turn_attempt_id:
+                raise CanonicalTurnAuthorityUnavailable(
+                    "canonical turn command was not claimed before settlement"
+                )
+            delivered = await repos.commands.record_command_delivery(
+                command.command_id,
+                owner_class=self.OWNER_CLASS,
+                claim_token=claim_token,
+                outcome=outcome,
+                provider_receipt_id=provider_receipt_id,
+                result_ref=result_ref,
+            )
+            turn = await repos.turn_attempts.get(command.turn_attempt_id)
+            session = await repos.sessions.get(command.session_id)
+            if turn is None or session is None:
+                raise CanonicalTurnAuthorityUnavailable(
+                    "canonical turn command lost its owning aggregate"
+                )
+            if not turn.is_terminal:
+                turn_state = (
+                    TURN_STATE_ACCEPTED
+                    if outcome in APPLIED_OUTCOMES
+                    else (
+                        TURN_STATE_DELIVERY_UNKNOWN
+                        if outcome is ControlPlaneOutcome.DELIVERY_UNKNOWN
+                        else None
+                    )
+                )
+                if turn_state is not None:
+                    if turn.state != turn_state:
+                        await repos.turn_attempts.advance_state(
+                            turn.turn_attempt_id,
+                            turn_state,
+                            expected_revision=turn.revision,
+                            expected_fencing_generation=session.fencing_generation,
+                        )
+            return delivered.outcome
+
+    async def bind_runtime_authority(
+        self,
+        *,
+        session_id: str,
+        execution_plan_ref: str,
+        runtime_binding_ref: str,
+    ) -> None:
+        """Advance the session's pointer to a binding stage under its fence."""
+
+        async with self._store.transaction() as repos:
+            session = await repos.sessions.get(session_id)
+            if session is None:
+                raise CanonicalTurnAuthorityUnavailable(
+                    "runtime binding lost its canonical session authority"
+                )
+            await repos.sessions.bind_runtime_authority(
+                session_id,
+                expected_revision=session.revision,
+                expected_fencing_generation=session.fencing_generation,
+                execution_plan_ref=execution_plan_ref,
+                runtime_binding_ref=runtime_binding_ref,
+            )
+
+
+__all__ = [
+    "CanonicalTurnAuthorityUnavailable",
+    "CanonicalTurnCommandClaim",
+    "CanonicalTurnCommandService",
+    "CanonicalSessionBootstrap",
+]

--- a/moonmind/omnigent/control_plane/turn_commands.py
+++ b/moonmind/omnigent/control_plane/turn_commands.py
@@ -13,19 +13,21 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .identities import (
+    canonical_followup_turn_attempt_id,
+    canonical_omnigent_session_id,
+    canonical_omnigent_turn_attempt_id,
+    canonical_turn_claim_token,
+    canonical_turn_command_id,
+    canonical_turn_command_key,
+)
 from .records import (
     APPLIED_OUTCOMES,
     ConflictingSessionAuthorityError,
     ControlPlaneOutcome,
     TURN_STATE_ACCEPTED,
     TURN_STATE_DELIVERY_UNKNOWN,
-    compute_digest,
 )
-from .identities import (
-    canonical_omnigent_session_id,
-    canonical_omnigent_turn_attempt_id,
-)
-from .repositories import OmnigentControlPlaneStore
 
 
 class CanonicalTurnAuthorityUnavailable(RuntimeError):
@@ -59,10 +61,6 @@ class CanonicalSessionBootstrap:
     execution_plan_ref: str | None = None
 
 
-def _stable_ref(prefix: str, *parts: object) -> str:
-    return f"{prefix}_{compute_digest(list(parts))[:40]}"
-
-
 def _lineage_kind(command_type: str) -> str:
     normalized = command_type.strip().lower().replace(".", "_")
     if "remediation" in normalized:
@@ -81,8 +79,10 @@ class CanonicalTurnCommandService:
 
     OWNER_CLASS = "canonical_turn_command"
 
-    def __init__(self, session_factory: Any) -> None:
-        self._store = OmnigentControlPlaneStore(session_factory)
+    def __init__(self, store: Any) -> None:
+        # Persistence is an injected capability; this application service does
+        # not import or construct a SQL-backed repository implementation.
+        self._store = store
 
     async def claim(
         self,
@@ -126,8 +126,8 @@ class CanonicalTurnCommandService:
     ) -> CanonicalTurnCommandClaim:
         """Claim within an existing application transaction."""
 
-        canonical_key = f"omnigent-turn-command:{idempotency_key}"
-        claim_token = _stable_ref("otc", canonical_key, "delivery")
+        canonical_key = canonical_turn_command_key(idempotency_key)
+        claim_token = canonical_turn_claim_token(canonical_key)
         session = None
         bootstrap_turn = None
         if chat_binding_id:
@@ -244,7 +244,9 @@ class CanonicalTurnCommandService:
                 # provider-facing command.
                 turn = bootstrap_turn
             else:
-                turn_id = _stable_ref("ota", session.session_id, canonical_key)
+                turn_id = canonical_followup_turn_attempt_id(
+                    session.session_id, canonical_key
+                )
                 turn = await repos.turn_attempts.create(
                     turn_attempt_id=turn_id,
                     session_id=session.session_id,
@@ -260,8 +262,8 @@ class CanonicalTurnCommandService:
                     expected_fencing_generation=session.fencing_generation,
                     active_turn_attempt_id=turn.turn_attempt_id,
                 )
-            command_id = _stable_ref(
-                "ocm", session.session_id, canonical_key, command_type
+            command_id = canonical_turn_command_id(
+                session.session_id, canonical_key, command_type
             )
             command = await repos.commands.record(
                 command_id=command_id,
@@ -312,8 +314,8 @@ class CanonicalTurnCommandService:
     ) -> ControlPlaneOutcome:
         """Settle the command and advance its turn without session terminality."""
 
-        canonical_key = f"omnigent-turn-command:{idempotency_key}"
-        claim_token = _stable_ref("otc", canonical_key, "delivery")
+        canonical_key = canonical_turn_command_key(idempotency_key)
+        claim_token = canonical_turn_claim_token(canonical_key)
         async with self._store.transaction() as repos:
             command = await repos.commands.get_by_idempotency_key(canonical_key)
             if command is None or not command.turn_attempt_id:

--- a/moonmind/omnigent/control_plane/turn_commands.py
+++ b/moonmind/omnigent/control_plane/turn_commands.py
@@ -126,7 +126,7 @@ class CanonicalTurnCommandService:
     ) -> CanonicalTurnCommandClaim:
         """Claim within an existing application transaction."""
 
-        canonical_key = canonical_turn_command_key(idempotency_key)
+        canonical_key = canonical_turn_command_key(workflow_id, idempotency_key)
         claim_token = canonical_turn_claim_token(canonical_key)
         session = None
         bootstrap_turn = None
@@ -202,7 +202,10 @@ class CanonicalTurnCommandService:
                         turn_attempt_id=first_turn_id,
                         session_id=session_id,
                         idempotency_key=(
-                            "omnigent-bootstrap:" + bootstrap.source_idempotency_key
+                            "omnigent-bootstrap:"
+                            + canonical_turn_command_key(
+                                workflow_id, bootstrap.source_idempotency_key
+                            )
                         ),
                         lineage_kind="initial",
                         step_execution_id=bootstrap.step_execution_id,
@@ -307,6 +310,7 @@ class CanonicalTurnCommandService:
     async def settle(
         self,
         *,
+        workflow_id: str,
         idempotency_key: str,
         outcome: ControlPlaneOutcome,
         provider_receipt_id: str | None = None,
@@ -314,7 +318,7 @@ class CanonicalTurnCommandService:
     ) -> ControlPlaneOutcome:
         """Settle the command and advance its turn without session terminality."""
 
-        canonical_key = canonical_turn_command_key(idempotency_key)
+        canonical_key = canonical_turn_command_key(workflow_id, idempotency_key)
         claim_token = canonical_turn_claim_token(canonical_key)
         async with self._store.transaction() as repos:
             command = await repos.commands.get_by_idempotency_key(canonical_key)

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -527,6 +527,11 @@ def _profile_authorization_evidence(
         "endpointRef",
         "omnigentHostId",
         "bridgeSessionId",
+        "executionPlanRef",
+        "runtimeBindingRef",
+        "hostClassRef",
+        "launchPolicyRef",
+        "executionRealizerRef",
     }
     return {key: payload[key] for key in allowed if payload.get(key) is not None}
 
@@ -1495,7 +1500,8 @@ async def run_omnigent_execution(
             endpoint_ref=selection.endpoint_ref or "default",
             idempotency_key=request.idempotency_key,
         )
-        external_state.update(_profile_authorization_evidence(request))
+        profile_authorization = _profile_authorization_evidence(request)
+        external_state.update(profile_authorization)
         delete_after_harvest = bool(
             selection.capture.get("deleteOmnigentSessionAfterHarvest", False)
         )
@@ -1548,6 +1554,49 @@ async def run_omnigent_execution(
                         "workspace": selection.session.workspace,
                     },
                 )
+                required_profile_authority = {
+                    "providerProfileId",
+                    "credentialGeneration",
+                    "providerLeaseRef",
+                    "hostBindingRef",
+                    "hostLeaseRef",
+                    "endpointRef",
+                    "executionPlanRef",
+                    "runtimeBindingRef",
+                }
+                if required_profile_authority <= set(profile_authorization):
+                    durable_row = await run_store.bind_profile_authorization(
+                        request=request,
+                        endpoint_ref=str(profile_authorization["endpointRef"]),
+                        provider_profile_id=str(
+                            profile_authorization["providerProfileId"]
+                        ),
+                        provider_lease_id=str(
+                            profile_authorization["providerLeaseRef"]
+                        ),
+                        credential_generation=int(
+                            profile_authorization["credentialGeneration"]
+                        ),
+                        host_binding_ref=str(
+                            profile_authorization["hostBindingRef"]
+                        ),
+                        host_lease_ref=str(profile_authorization["hostLeaseRef"]),
+                        omnigent_host_id=str(
+                            profile_authorization.get("omnigentHostId") or ""
+                        )
+                        or None,
+                        effective_launch_snapshot={
+                            key: profile_authorization[key]
+                            for key in (
+                                "executionPlanRef",
+                                "runtimeBindingRef",
+                                "hostClassRef",
+                                "launchPolicyRef",
+                                "executionRealizerRef",
+                            )
+                            if profile_authorization.get(key) is not None
+                        },
+                    )
                 bridge_session_id = str(
                     getattr(durable_row, "bridge_session_id", "") or ""
                 )

--- a/moonmind/omnigent/generic_opencode_runtime.py
+++ b/moonmind/omnigent/generic_opencode_runtime.py
@@ -108,6 +108,11 @@ def preflight_opencode_host(
     restricted egress before runner/session creation.
     """
     hc = get_opencode_host_class()
+    if credential_host_root is not None:
+        verify_opencode_auth_file(
+            host_root=credential_host_root,
+            expected_generation=expected_credential_generation,
+        )
     # Derive expected implementation from Host Class declaration for digest validation
     expected_impl = {
         "package": "omnigent",
@@ -124,8 +129,6 @@ def preflight_opencode_host(
         expectedOmnigentBuildDigest=hc.omnigentBuildDigest,
         expectedImplementation=expected_impl,
         expectedCredentialGeneration=expected_credential_generation,
-        verify_credential_file=credential_host_root is not None,
-        credential_host_root=credential_host_root,
         requiredSkillDeliveryRef=required_skill_delivery_ref,
         require_restricted_egress=True,
     )

--- a/moonmind/omnigent/harness_platform/admission.py
+++ b/moonmind/omnigent/harness_platform/admission.py
@@ -71,6 +71,7 @@ class HarnessAdmissionRegistration:
     implementation: HarnessImplementationIdentity
     host_class_ref: str
     integration_mode: str
+    provider_runtime_id: str
     materializer_ref: str
     accepted_auth_model: str
     model_route_ref: str
@@ -98,6 +99,7 @@ HARNESS_ADMISSION_REGISTRATIONS: dict[str, HarnessAdmissionRegistration] = {
         implementation=_implementation("e"),
         host_class_ref="omnigent-codex-current@1",
         integration_mode="native-server",
+        provider_runtime_id="codex_cli",
         materializer_ref="codex-oauth-home@1",
         accepted_auth_model="oauth_volume",
         model_route_ref="openai",
@@ -108,22 +110,19 @@ HARNESS_ADMISSION_REGISTRATIONS: dict[str, HarnessAdmissionRegistration] = {
         implementation=_implementation("a"),
         host_class_ref="omnigent-opencode@1",
         integration_mode="native-server",
+        provider_runtime_id="opencode_go",
         materializer_ref="opencode-auth-json@1",
         accepted_auth_model="own-auth",
         model_route_ref="opencode-go",
         catalog_capabilities=("interrupt", "streaming"),
     ),
-    "pi-native": HarnessAdmissionRegistration(
-        harness_id="pi-native",
-        implementation=_implementation("c"),
-        host_class_ref="omnigent-pi@1",
-        integration_mode="native-server",
-        materializer_ref="omnigent-provider-config@1",
-        accepted_auth_model="omnigent-provider-config",
-        model_route_ref="pi",
-        catalog_capabilities=("interrupt", "streaming"),
-    ),
 }
+
+NORMAL_PRODUCT_HARNESS_IDS = frozenset(HARNESS_ADMISSION_REGISTRATIONS)
+NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS = frozenset(
+    registration.provider_runtime_id
+    for registration in HARNESS_ADMISSION_REGISTRATIONS.values()
+)
 
 
 def _mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
@@ -365,6 +364,11 @@ def compile_normal_product_execution_plan(
         ).strip()
         or None
     )
+    if model_id is None:
+        raise HarnessPlatformError(
+            "an explicit model is required before Omnigent host acquisition",
+            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+        )
     effort = (
         str(
             workflow_parameters.get("effort") or model_document.get("effort") or ""
@@ -521,6 +525,8 @@ async def compile_and_persist_execution_authority(
 
 
 __all__ = [
+    "NORMAL_PRODUCT_HARNESS_IDS",
+    "NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS",
     "HARNESS_ADMISSION_REGISTRATIONS",
     "HarnessAdmissionRegistration",
     "compile_and_persist_execution_authority",

--- a/moonmind/omnigent/harness_platform/admission.py
+++ b/moonmind/omnigent/harness_platform/admission.py
@@ -1,0 +1,528 @@
+"""Normal-product Omnigent execution authority admission.
+
+This module is the single pre-side-effect compiler for
+MoonLadderStudios/MoonMind#3701.  It converts the immutable Agent Profile
+snapshot selected by the API into one secret-free, digest-addressed execution
+plan.  Harness differences are registrations consumed as data; execution
+activities must load the resulting plan ref and never repeat this selection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from moonmind.omnigent.harness_platform.catalog import (
+    HarnessImplementationIdentity,
+)
+from moonmind.omnigent.harness_platform.credential_bindings import (
+    create_binding_set,
+)
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+    compute_model_config_digest,
+    create_execution_plan_envelope,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import (
+    get_host_class,
+    get_launch_policy,
+    validate_policy_for_host_class,
+)
+from moonmind.omnigent.harness_platform.materializers import (
+    validate_binding_materializer,
+)
+from moonmind.omnigent.harness_platform.planner import select_execution_realizer
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_required_capabilities_digest,
+    compute_support_combination_key,
+)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _content_ref(prefix: str, value: Any) -> str:
+    return f"{prefix}:sha256:{_digest(value).removeprefix('sha256:')}"
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessAdmissionRegistration:
+    """Trusted catalog-to-realization registration used at admission."""
+
+    harness_id: str
+    implementation: HarnessImplementationIdentity
+    host_class_ref: str
+    integration_mode: str
+    materializer_ref: str
+    accepted_auth_model: str
+    model_route_ref: str
+    catalog_capabilities: tuple[str, ...]
+
+
+def _implementation(digest_character: str) -> HarnessImplementationIdentity:
+    return HarnessImplementationIdentity.model_validate(
+        {
+            "sourceKind": "core",
+            "package": "omnigent",
+            "version": "1.0.0",
+            "digest": "sha256:" + digest_character * 64,
+            "pluginEntryPoint": None,
+        }
+    )
+
+
+# Adding a harness changes this catalog registration plus the existing Host
+# Class, materializer, Provider Profile compatibility, policy and conformance
+# registrations.  Session lifecycle code contains no harness-name branches.
+HARNESS_ADMISSION_REGISTRATIONS: dict[str, HarnessAdmissionRegistration] = {
+    "codex-native": HarnessAdmissionRegistration(
+        harness_id="codex-native",
+        implementation=_implementation("e"),
+        host_class_ref="omnigent-codex-current@1",
+        integration_mode="native-server",
+        materializer_ref="codex-oauth-home@1",
+        accepted_auth_model="oauth_volume",
+        model_route_ref="openai",
+        catalog_capabilities=("interrupt", "streaming"),
+    ),
+    "opencode-native": HarnessAdmissionRegistration(
+        harness_id="opencode-native",
+        implementation=_implementation("a"),
+        host_class_ref="omnigent-opencode@1",
+        integration_mode="native-server",
+        materializer_ref="opencode-auth-json@1",
+        accepted_auth_model="own-auth",
+        model_route_ref="opencode-go",
+        catalog_capabilities=("interrupt", "streaming"),
+    ),
+    "pi-native": HarnessAdmissionRegistration(
+        harness_id="pi-native",
+        implementation=_implementation("c"),
+        host_class_ref="omnigent-pi@1",
+        integration_mode="native-server",
+        materializer_ref="omnigent-provider-config@1",
+        accepted_auth_model="omnigent-provider-config",
+        model_route_ref="pi",
+        catalog_capabilities=("interrupt", "streaming"),
+    ),
+}
+
+
+def _mapping(value: Any, *, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise HarnessPlatformError(
+            f"{field_name} must be an object",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        )
+    return value
+
+
+def _text(value: Any, *, field_name: str) -> str:
+    candidate = str(value or "").strip()
+    if not candidate:
+        raise HarnessPlatformError(
+            f"{field_name} is required",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        )
+    return candidate
+
+
+def _profile_snapshot_ref(snapshot: Mapping[str, Any]) -> str:
+    return _content_ref("omnigent-agent-profile", snapshot)
+
+
+def _registered_implementation(
+    *,
+    snapshot: Mapping[str, Any],
+    registration: HarnessAdmissionRegistration,
+) -> HarnessImplementationIdentity:
+    upstream = snapshot.get("upstreamSnapshot")
+    upstream = upstream if isinstance(upstream, Mapping) else {}
+    raw = upstream.get("harnessImplementation")
+    implementation = (
+        HarnessImplementationIdentity.model_validate(raw)
+        if isinstance(raw, Mapping)
+        else registration.implementation
+    )
+    if (
+        implementation.implementation_ref()
+        != registration.implementation.implementation_ref()
+    ):
+        raise HarnessPlatformError(
+            "Agent Profile harness implementation conflicts with the trusted registration",
+            code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+        )
+    return implementation
+
+
+def _agent_source(
+    snapshot: Mapping[str, Any], document: Mapping[str, Any]
+) -> dict[str, Any]:
+    source = _mapping(document.get("source"), field_name="agentProfile.document.source")
+    upstream_snapshot = snapshot.get("upstreamSnapshot")
+    upstream_snapshot = (
+        dict(upstream_snapshot) if isinstance(upstream_snapshot, Mapping) else {}
+    )
+    bundle_ref = str(source.get("bundleArtifactRef") or "").strip()
+    if bundle_ref:
+        return {
+            "kind": "bundle",
+            "bundleArtifactRef": bundle_ref,
+            "bundleDigest": _text(
+                source.get("bundleDigest"),
+                field_name="agentProfile.document.source.bundleDigest",
+            ),
+            "importReceiptRef": _text(
+                source.get("importReceiptRef"),
+                field_name="agentProfile.document.source.importReceiptRef",
+            ),
+            "importedAgentId": _text(
+                snapshot.get("agentId"), field_name="agentProfile.agentId"
+            ),
+            "importedAgentVersion": str(source.get("upstreamVersion") or "1"),
+            "importedContentDigest": _digest(upstream_snapshot or source),
+        }
+    return {
+        "kind": "upstream",
+        "upstreamId": _text(
+            snapshot.get("agentId") or source.get("upstreamId"),
+            field_name="agentProfile.agentId",
+        ),
+        "upstreamVersion": str(source.get("upstreamVersion") or "unversioned"),
+        "upstreamSnapshotDigest": _digest(upstream_snapshot or source),
+    }
+
+
+def _resolved_skill_authority(
+    snapshot: Mapping[str, Any], workflow_parameters: Mapping[str, Any]
+) -> dict[str, Any]:
+    workflow = workflow_parameters.get("workflow")
+    workflow = workflow if isinstance(workflow, Mapping) else {}
+    selection = {
+        "profileSkills": list(
+            _mapping(snapshot.get("document"), field_name="agentProfile.document").get(
+                "skills", []
+            )
+            or []
+        ),
+        "workflowSkills": workflow.get("skills"),
+        "steps": [
+            {
+                "id": step.get("id"),
+                "skills": step.get("skills"),
+                "skill": step.get("skill"),
+            }
+            for step in (workflow.get("steps") or [])
+            if isinstance(step, Mapping)
+        ],
+    }
+    resolved_ref = str(
+        workflow_parameters.get("resolvedSkillsetRef")
+        or workflow_parameters.get("resolved_skillset_ref")
+        or ""
+    ).strip()
+    selection_digest = _digest(selection)
+    return {
+        "resolvedSkillSetRef": resolved_ref or None,
+        "resolvedSkillSetDigest": selection_digest,
+        "skillDeliveryRef": _content_ref(
+            "skill-delivery", {"selectionDigest": selection_digest}
+        ),
+        "selectionDigest": selection_digest,
+    }
+
+
+def compile_normal_product_execution_plan(
+    *,
+    agent_profile_snapshot: Mapping[str, Any],
+    workflow_parameters: Mapping[str, Any],
+    workflow_id: str,
+) -> OmnigentExecutionPlanEnvelope:
+    """Compile the one immutable execution authority for a normal create.
+
+    The compiler is pure with respect to provider, lease, credential, host and
+    workspace side effects.  It may inspect only trusted, code-owned
+    registrations and the already-resolved immutable Agent Profile snapshot.
+    """
+
+    snapshot = dict(agent_profile_snapshot)
+    document = _mapping(snapshot.get("document"), field_name="agentProfile.document")
+    harness_id = _text(
+        document.get("harness"), field_name="agentProfile.document.harness"
+    )
+    registration = HARNESS_ADMISSION_REGISTRATIONS.get(harness_id)
+    if registration is None:
+        raise HarnessPlatformError(
+            f"harness {harness_id} has no normal-product admission registration",
+            code=HarnessPlatformFailure.OMNIGENT_HARNESS_UNKNOWN,
+        )
+
+    implementation = _registered_implementation(
+        snapshot=snapshot, registration=registration
+    )
+    host_class = get_host_class(registration.host_class_ref)
+    if not host_class.declares_harness(harness_id, implementation.implementation_ref()):
+        raise HarnessPlatformError(
+            f"Host Class {host_class.ref} does not declare {harness_id}",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_CLASS_UNAVAILABLE,
+        )
+
+    launch_policy_ref = _text(
+        snapshot.get("launchPolicyRef"), field_name="agentProfile.launchPolicyRef"
+    )
+    allowed = document.get("execution")
+    allowed = allowed if isinstance(allowed, Mapping) else {}
+    allowed_refs = tuple(allowed.get("allowedLaunchPolicyRefs") or ())
+    if launch_policy_ref not in allowed_refs:
+        raise HarnessPlatformError(
+            f"launch policy {launch_policy_ref} is outside the Agent Profile allowlist",
+            code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+        )
+    launch_policy = get_launch_policy(launch_policy_ref)
+    validate_policy_for_host_class(
+        policy=launch_policy,
+        host_class=host_class,
+        harness_integration_mode=registration.integration_mode,
+        materializer_refs=[registration.materializer_ref],
+    )
+    validate_binding_materializer(
+        materializer_ref=registration.materializer_ref,
+        harness_implementation_ref=implementation.implementation_ref(),
+        host_mode=(
+            "on-demand"
+            if launch_policy.hostMode == "on_demand_docker"
+            else (
+                "static-connected"
+                if launch_policy.hostMode == "static_compose"
+                else launch_policy.hostMode
+            )
+        ),
+    )
+
+    required_capabilities = sorted(
+        {
+            str(value).strip()
+            for value in (
+                list(document.get("requiredCapabilities") or [])
+                + list(workflow_parameters.get("requiredCapabilities") or [])
+            )
+            if str(value).strip()
+        }
+    )
+    available_capabilities = {
+        *registration.catalog_capabilities,
+        *(name for name, enabled in host_class.features.items() if enabled),
+        *launch_policy.controlCapabilities,
+    }
+    missing = sorted(set(required_capabilities) - available_capabilities)
+    if missing:
+        raise HarnessPlatformError(
+            f"required capabilities are unavailable: {missing}",
+            code=HarnessPlatformFailure.OMNIGENT_CAPABILITY_REQUIRED_UNSUPPORTED,
+        )
+
+    provider_profile_ref = _text(
+        snapshot.get("providerProfileRef"),
+        field_name="agentProfile.providerProfileRef",
+    )
+    binding_set = create_binding_set(
+        bindingSetId="admission-"
+        + hashlib.sha256(
+            f"{snapshot.get('profileId')}:{provider_profile_ref}".encode()
+        ).hexdigest()[:20],
+        version=int(snapshot.get("version") or 1),
+        bindings={
+            "primary-model": {
+                "providerProfileRef": provider_profile_ref,
+                "materializerRef": registration.materializer_ref,
+            }
+        },
+    )
+
+    model_document = document.get("model")
+    model_document = model_document if isinstance(model_document, Mapping) else {}
+    model_id = (
+        str(
+            workflow_parameters.get("model") or model_document.get("model") or ""
+        ).strip()
+        or None
+    )
+    effort = (
+        str(
+            workflow_parameters.get("effort") or model_document.get("effort") or ""
+        ).strip()
+        or None
+    )
+    normalized_options = dict(model_document.get("settings") or {})
+    model_digest = compute_model_config_digest(
+        qualifiedId=model_id,
+        effort=effort,
+        routeRef=registration.model_route_ref,
+        normalizedOptions=normalized_options,
+    )
+    realizer_ref = select_execution_realizer(
+        harness_id=harness_id,
+        is_codex=harness_id == "codex-native",
+    )
+
+    agent_source = _agent_source(snapshot, document)
+    upstream_snapshot = snapshot.get("upstreamSnapshot")
+    catalog_authority = {
+        "endpointRef": document.get("endpointRef"),
+        "observedAt": (
+            upstream_snapshot.get("catalogObservedAt")
+            if isinstance(upstream_snapshot, Mapping)
+            else None
+        ),
+        "harnessId": harness_id,
+        "implementation": implementation.model_dump(by_alias=True, mode="json"),
+        "hostBuildDigest": host_class.omnigentBuildDigest,
+    }
+    catalog_ref = _content_ref("omnigent-harness-catalog", catalog_authority)
+    agent_source_ref = _content_ref("agent-source", agent_source)
+    provider_requirements = document.get("providerRequirements")
+    provider_requirements = (
+        provider_requirements if isinstance(provider_requirements, Mapping) else {}
+    )
+    provider_compatibility_class = _canonical_json(
+        {
+            "runtimeId": provider_requirements.get("runtimeId"),
+            "credentialSource": provider_requirements.get("credentialSource"),
+            "materializationMode": provider_requirements.get("materializationMode"),
+        }
+    )
+    vendor_runtime_refs = tuple(
+        sorted(
+            f"{dependency.get('name')}@{dependency.get('version')}#{dependency.get('digest')}"
+            for entry in host_class.declaredHarnessImplementations
+            if entry.harnessId == harness_id
+            for dependency in entry.runtimeDependencies
+        )
+    )
+    support_identity = SupportKeyPayload.model_validate(
+        {
+            "omnigentServerBuildRef": host_class.omnigentBuildDigest,
+            "omnigentHostBuildRef": host_class.imageRef,
+            "harnessImplementationRef": implementation.implementation_ref(),
+            "vendorRuntimeRefs": vendor_runtime_refs,
+            "agentSourceRef": agent_source_ref,
+            "materializerRefs": [registration.materializer_ref],
+            "providerCompatibilityClass": provider_compatibility_class,
+            "hostClassRef": host_class.ref,
+            "architecture": host_class.architectures[0],
+            "launchPolicyRef": launch_policy.ref,
+            "modelConfigDigest": model_digest,
+            "executionRealizerRef": realizer_ref,
+            "requiredCapabilitiesDigest": compute_required_capabilities_digest(
+                required_capabilities
+            ),
+        }
+    )
+    support_key = compute_support_combination_key(support_identity)
+    workspace_intent = {
+        "workflowId": workflow_id,
+        "repository": workflow_parameters.get("repository"),
+        "workspace": document.get("workspace"),
+    }
+    policy_authority = {
+        "profilePolicyRef": snapshot.get("policyRef"),
+        "profileDigest": snapshot.get("digest"),
+        "launchPolicyRef": launch_policy.ref,
+    }
+    resolved_skills = _resolved_skill_authority(snapshot, workflow_parameters)
+
+    return create_execution_plan_envelope(
+        {
+            "schemaVersion": "moonmind.omnigent-execution-plan-payload.v1",
+            "endpointRef": _text(
+                document.get("endpointRef"),
+                field_name="agentProfile.document.endpointRef",
+            ),
+            "agentProfileSnapshotRef": _profile_snapshot_ref(snapshot),
+            "harnessCatalogRef": catalog_ref,
+            "harnessId": harness_id,
+            "harnessImplementationRef": implementation.implementation_ref(),
+            "agentSource": agent_source,
+            "credentialBindingSetRef": binding_set.ref,
+            "credentialBindings": {
+                slot: binding.model_dump(by_alias=True, mode="json")
+                for slot, binding in binding_set.bindings.items()
+            },
+            "hostClassRef": host_class.ref,
+            "launchPolicyRef": launch_policy.ref,
+            "executionRealizerRef": realizer_ref,
+            "model": {
+                "qualifiedId": model_id,
+                "effort": effort,
+                "routeRef": registration.model_route_ref,
+                "normalizedOptions": normalized_options,
+                "modelConfigDigest": model_digest,
+            },
+            "resolvedSkills": resolved_skills,
+            "classAdmissionDecision": {
+                "required": required_capabilities,
+                "requiredSatisfied": required_capabilities,
+                "preferredSatisfied": [],
+                "preferredMissing": [],
+            },
+            "runtimeValidationRequirements": [
+                "exact-harness-implementation",
+                "exact-vendor-runtime",
+                "exact-network-egress",
+                "exact-skill-delivery",
+                "live-model-option",
+            ],
+            "workspaceIntentRef": _content_ref("workspace-intent", workspace_intent),
+            "capturePolicyRef": _content_ref(
+                "omnigent-capture-policy", document.get("capture") or {}
+            ),
+            "policySnapshotRef": _content_ref("omnigent-policy", policy_authority),
+            "supportCombinationKey": support_key,
+            "supportIdentity": support_identity.model_dump(by_alias=True, mode="json"),
+        }
+    )
+
+
+async def compile_and_persist_execution_authority(
+    session: Any,
+    *,
+    agent_profile_snapshot: Mapping[str, Any],
+    workflow_parameters: Mapping[str, Any],
+    workflow_id: str,
+) -> OmnigentExecutionPlanEnvelope:
+    """Compile and flush the plan in the caller's create transaction."""
+
+    from moonmind.omnigent.harness_platform.stores import DbExecutionPlanStore
+
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=agent_profile_snapshot,
+        workflow_parameters=workflow_parameters,
+        workflow_id=workflow_id,
+    )
+    return await DbExecutionPlanStore.persist_in_session(session, plan)
+
+
+__all__ = [
+    "HARNESS_ADMISSION_REGISTRATIONS",
+    "HarnessAdmissionRegistration",
+    "compile_and_persist_execution_authority",
+    "compile_normal_product_execution_plan",
+]

--- a/moonmind/omnigent/harness_platform/attestation.py
+++ b/moonmind/omnigent/harness_platform/attestation.py
@@ -267,8 +267,6 @@ def validate_opencode_exact_host_preflight(
     # Additional OpenCode-specific checks
     expect_opencode_native: bool = True,
     expectedOpencodeVersion: str | None = OPENCODE_PINNED_VERSION,
-    verify_credential_file: bool = False,
-    credential_host_root: str | None = None,
     requiredSkillDeliveryRef: str | None = None,
     require_restricted_egress: bool = True,
 ) -> None:
@@ -348,15 +346,9 @@ def validate_opencode_exact_host_preflight(
             "opencode host not configured",
             code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
         )
-    # Credential file check (without printing contents)
-    if verify_credential_file:
-        from moonmind.omnigent.harness_platform.materializers import verify_opencode_auth_file
-
-        verify_opencode_auth_file(
-            host_root=credential_host_root or "/",
-            expected_generation=expectedCredentialGeneration,
-        )
-    # Generation fencing already checked via attestationGeneration; additionally ensure
+    # Credential-file I/O belongs to the outer trusted materializer adapter.
+    # This pure validator receives only its secret-free generation evidence.
+    # Generation fencing is already checked via attestationGeneration; additionally ensure
     # the credential generation matches materialized handle if provided
     # Enforce required Skill delivery ref if caller requested it
     if requiredSkillDeliveryRef is not None:

--- a/moonmind/omnigent/harness_platform/execution_plan.py
+++ b/moonmind/omnigent/harness_platform/execution_plan.py
@@ -16,6 +16,10 @@ from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformError,
     HarnessPlatformFailure,
 )
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_support_combination_key,
+)
 
 
 class ModelConfig(BaseModel):
@@ -51,9 +55,35 @@ class OmnigentExecutionPlanPayload(BaseModel):
     capturePolicyRef: str | None = Field(default=None, alias="capturePolicyRef")
     policySnapshotRef: str = Field(alias="policySnapshotRef")
     supportCombinationKey: str = Field(alias="supportCombinationKey")
+    # Added as optional for replay compatibility with execution plans admitted
+    # before MoonLadderStudios/MoonMind#3701 recorded the complete support
+    # identity. New admissions always populate it.
+    supportIdentity: SupportKeyPayload | None = Field(
+        default=None, alias="supportIdentity"
+    )
 
     @model_validator(mode="after")
     def validate_no_forbidden(self) -> "OmnigentExecutionPlanPayload":
+        if self.supportIdentity is not None:
+            if (
+                compute_support_combination_key(self.supportIdentity)
+                != self.supportCombinationKey
+            ):
+                raise ValueError(
+                    "supportCombinationKey does not match supportIdentity"
+                )
+            pinned = self.supportIdentity
+            if (
+                pinned.harnessImplementationRef != self.harnessImplementationRef
+                or pinned.hostClassRef != self.hostClassRef
+                or pinned.launchPolicyRef != self.launchPolicyRef
+                or pinned.executionRealizerRef != self.executionRealizerRef
+                or pinned.modelConfigDigest
+                != self.modelConfig.modelConfigDigest
+            ):
+                raise ValueError(
+                    "supportIdentity differs from admitted execution authority"
+                )
         forbidden_keys = {
             "credentialGeneration", "providerLeaseRef", "hostId", "hostLeaseRef",
             "volumeName", "hostBindingRef", "planRef", "credentials", "secretBody",
@@ -147,6 +177,27 @@ def verify_execution_plan_envelope(envelope: dict[str, Any] | OmnigentExecutionP
     # Verify without mutation: canonicalize only payload and compare
     parsed = OmnigentExecutionPlanEnvelope.model_validate(envelope)
     return parsed
+
+
+def execution_support_identity(
+    envelope: OmnigentExecutionPlanEnvelope,
+) -> dict[str, Any]:
+    """Project exact, secret-free support evidence from admitted authority."""
+
+    identity = envelope.payload.supportIdentity
+    if identity is None:
+        # Replay-visible plans admitted before the complete identity was
+        # embedded remain readable, but cannot be mistaken for current
+        # combination-qualified acceptance evidence.
+        return {
+            "supportCombinationKey": envelope.payload.supportCombinationKey,
+            "identityComplete": False,
+        }
+    return {
+        **identity.model_dump(by_alias=True, mode="json"),
+        "supportCombinationKey": envelope.payload.supportCombinationKey,
+        "identityComplete": True,
+    }
 
 
 def forbidden_plan_check(payload: dict[str, Any]) -> None:

--- a/moonmind/omnigent/harness_platform/execution_plan.py
+++ b/moonmind/omnigent/harness_platform/execution_plan.py
@@ -171,6 +171,103 @@ def create_execution_plan_envelope(payload: OmnigentExecutionPlanPayload | dict[
     )
 
 
+def bind_runtime_request_authority(
+    envelope: OmnigentExecutionPlanEnvelope,
+    *,
+    resolved_skillset_ref: str | None,
+    model: Any = None,
+    effort: Any = None,
+) -> OmnigentExecutionPlanEnvelope:
+    """Bind late-resolved step authority before any runtime side effect.
+
+    Skill snapshots are resolved by the deterministic Run workflow after API
+    admission, and a step may author a model override.  Both decisions must be
+    incorporated into a new immutable plan before the Activity acquires a
+    Provider Profile lease or launches a host.
+    """
+
+    payload = envelope.payload.model_dump(by_alias=True, mode="json")
+    changed = False
+
+    requested_skill_ref = str(resolved_skillset_ref or "").strip() or None
+    admitted_skills = dict(payload.get("resolvedSkills") or {})
+    admitted_skill_ref = str(
+        admitted_skills.get("resolvedSkillSetRef") or ""
+    ).strip() or None
+    if admitted_skill_ref and requested_skill_ref != admitted_skill_ref:
+        raise HarnessPlatformError(
+            "runtime request Skill snapshot differs from admitted authority",
+            code=HarnessPlatformFailure.OMNIGENT_SKILL_DELIVERY_MISMATCH,
+        )
+    if requested_skill_ref and admitted_skill_ref is None:
+        skill_digest = "sha256:" + hashlib.sha256(
+            requested_skill_ref.encode("utf-8")
+        ).hexdigest()
+        delivery_digest = hashlib.sha256(
+            json.dumps(
+                {
+                    "resolvedSkillSetRef": requested_skill_ref,
+                    "resolvedSkillSetDigest": skill_digest,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        payload["resolvedSkills"] = {
+            **admitted_skills,
+            "resolvedSkillSetRef": requested_skill_ref,
+            "resolvedSkillSetDigest": skill_digest,
+            "skillDeliveryRef": f"skill-delivery:sha256:{delivery_digest}",
+        }
+        changed = True
+
+    model_config = dict(payload["model"])
+    requested_model = str(model or "").strip() or None
+    requested_effort = str(effort or "").strip() or None
+    effective_model = requested_model or model_config.get("qualifiedId")
+    effective_effort = (
+        requested_effort if effort is not None else model_config.get("effort")
+    )
+    if not effective_model:
+        raise HarnessPlatformError(
+            "an explicit model is required before Omnigent host acquisition",
+            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+        )
+    if (
+        effective_model != model_config.get("qualifiedId")
+        or effective_effort != model_config.get("effort")
+    ):
+        model_digest = compute_model_config_digest(
+            qualifiedId=effective_model,
+            effort=effective_effort,
+            routeRef=model_config.get("routeRef"),
+            normalizedOptions=dict(model_config.get("normalizedOptions") or {}),
+        )
+        payload["model"] = {
+            **model_config,
+            "qualifiedId": effective_model,
+            "effort": effective_effort,
+            "modelConfigDigest": model_digest,
+        }
+        support_identity = payload.get("supportIdentity")
+        if not isinstance(support_identity, dict):
+            raise HarnessPlatformError(
+                "step model override requires complete support identity",
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+            )
+        updated_identity = {**support_identity, "modelConfigDigest": model_digest}
+        parsed_identity = SupportKeyPayload.model_validate(updated_identity)
+        payload["supportIdentity"] = parsed_identity.model_dump(
+            by_alias=True, mode="json"
+        )
+        payload["supportCombinationKey"] = compute_support_combination_key(
+            parsed_identity
+        )
+        changed = True
+
+    return create_execution_plan_envelope(payload) if changed else envelope
+
+
 def verify_execution_plan_envelope(envelope: dict[str, Any] | OmnigentExecutionPlanEnvelope) -> OmnigentExecutionPlanEnvelope:
     if isinstance(envelope, OmnigentExecutionPlanEnvelope):
         return envelope

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -362,7 +362,13 @@ def _opencode_host_class_data(image_ref: str) -> dict[str, object]:
             "mountedSkills": True,
             "mountedTools": True,
         },
-        "runtime": {"uid": 1000, "gid": 1000, "home": "/home/app"},
+        "runtime": {
+            "uid": 1000,
+            "gid": 1000,
+            "home": "/home/app",
+            "startupScript": "start-opencode-host.sh",
+            "credentialGenerationEnv": "OPENCODE_CREDENTIAL_GENERATION",
+        },
     }
 
 

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -70,7 +70,6 @@ from moonmind.omnigent.harness_platform.support import (
 def select_execution_realizer(
     *,
     harness_id: str,
-    agent_profile: OmnigentAgentProfileV2,
     is_codex: bool = False,
 ) -> str:
     """Select versioned execution realizer (section 6: executionRealizerRef is trusted planner only)."""
@@ -275,7 +274,6 @@ def compile_execution_plan(
     # Otherwise select via trusted policy
     trusted_realizer = select_execution_realizer(
         harness_id=profile.harness.id,
-        agent_profile=profile,
         is_codex=(profile.harness.id == "codex-native"),
     )
     if execution_realizer_ref is not None and execution_realizer_ref != trusted_realizer:
@@ -375,6 +373,9 @@ def compile_execution_plan(
             "capturePolicyRef": capture_policy_ref,
             "policySnapshotRef": policy_snapshot_ref,
             "supportCombinationKey": support_key,
+            "supportIdentity": support_payload.model_dump(
+                by_alias=True, mode="json"
+            ),
         }
     )
 

--- a/moonmind/omnigent/harness_platform/runtime_binding.py
+++ b/moonmind/omnigent/harness_platform/runtime_binding.py
@@ -37,10 +37,14 @@ class OmnigentRuntimeBinding(BaseModel):
     runtimeBindingRef: str = Field(alias="runtimeBindingRef")
     executionPlanRef: str = Field(alias="executionPlanRef")
     providerLeases: dict[str, RuntimeBindingProviderLease] = Field(alias="providerLeases")
-    hostBindingRef: str = Field(alias="hostBindingRef")
-    hostLeaseRef: str = Field(alias="hostLeaseRef")
-    hostLeaseGeneration: int = Field(alias="hostLeaseGeneration")
-    omnigentHostId: str = Field(alias="omnigentHostId")
+    # Host authority is intentionally absent in the first immutable stage. It
+    # is added only after the host lease has been acquired and attested.
+    hostBindingRef: str | None = Field(default=None, alias="hostBindingRef")
+    hostLeaseRef: str | None = Field(default=None, alias="hostLeaseRef")
+    hostLeaseGeneration: int | None = Field(
+        default=None, alias="hostLeaseGeneration"
+    )
+    omnigentHostId: str | None = Field(default=None, alias="omnigentHostId")
     hostHarnessAttestationRef: str | None = Field(default=None, alias="hostHarnessAttestationRef")
     exactHostCapabilityDecisionRef: str | None = Field(default=None, alias="exactHostCapabilityDecisionRef")
     workspaceResolutionRef: str | None = Field(default=None, alias="workspaceResolutionRef")
@@ -55,8 +59,18 @@ class OmnigentRuntimeBinding(BaseModel):
             raise ValueError("executionPlanRef invalid")
         if not self.runtimeBindingRef.startswith("omnigent-runtime-binding:sha256:"):
             raise ValueError("runtimeBindingRef invalid")
-        # hostLeaseGeneration must be positive
-        if self.hostLeaseGeneration < 1:
+        host_values = (
+            self.hostBindingRef,
+            self.hostLeaseRef,
+            self.hostLeaseGeneration,
+            self.omnigentHostId,
+        )
+        if any(value is not None for value in host_values) and not all(
+            value is not None for value in host_values
+        ):
+            raise ValueError("runtime binding host authority must be added atomically")
+        # hostLeaseGeneration must be positive after host acquisition.
+        if self.hostLeaseGeneration is not None and self.hostLeaseGeneration < 1:
             raise ValueError("hostLeaseGeneration must be >=1")
         for slot, lease in self.providerLeases.items():
             if lease.credentialGeneration < 1:
@@ -81,10 +95,10 @@ def create_runtime_binding(
     *,
     executionPlanRef: str,
     providerLeases: dict[str, dict[str, Any]],
-    hostBindingRef: str,
-    hostLeaseRef: str,
-    hostLeaseGeneration: int,
-    omnigentHostId: str,
+    hostBindingRef: str | None = None,
+    hostLeaseRef: str | None = None,
+    hostLeaseGeneration: int | None = None,
+    omnigentHostId: str | None = None,
     hostHarnessAttestationRef: str | None = None,
     exactHostCapabilityDecisionRef: str | None = None,
     workspaceResolutionRef: str | None = None,

--- a/moonmind/omnigent/harness_platform/stores.py
+++ b/moonmind/omnigent/harness_platform/stores.py
@@ -48,7 +48,12 @@ class OmnigentRuntimeBindingStore(Protocol):
         *,
         execution_plan_ref: str,
         provider_leases: dict[str, dict[str, Any]],
+        credential_handles: dict[str, dict[str, Any]] | None = None,
     ) -> OmnigentRuntimeBinding: pass  # noqa
+
+    async def latest_for_plan(
+        self, execution_plan_ref: str
+    ) -> OmnigentRuntimeBinding | None: pass  # noqa
 
     async def update_with_host(
         self,
@@ -58,6 +63,11 @@ class OmnigentRuntimeBindingStore(Protocol):
         host_lease_ref: str,
         host_lease_generation: int,
         omnigent_host_id: str,
+        host_harness_attestation_ref: str | None = None,
+        exact_host_capability_decision_ref: str | None = None,
+        workspace_resolution_ref: str | None = None,
+        model_option_attestation_ref: str | None = None,
+        skill_delivery_attestation_ref: str | None = None,
     ) -> OmnigentRuntimeBinding: pass  # noqa
 
     async def update_with_session(
@@ -122,24 +132,51 @@ class InMemoryRuntimeBindingStore:
         *,
         execution_plan_ref: str,
         provider_leases: dict[str, dict[str, Any]],
-        host_binding_ref: str = "host-binding:pending",
-        host_lease_ref: str = "host-lease:pending",
-        host_lease_generation: int = 1,
-        omnigent_host_id: str = "host_pending",
+        credential_handles: dict[str, dict[str, Any]] | None = None,
     ) -> OmnigentRuntimeBinding:
-        # Use placeholder host until host lease is realized; generation is fenced
+        existing = await self.latest_for_plan(execution_plan_ref)
+        if existing is not None:
+            expected = {
+                slot: value.model_dump(by_alias=True, mode="json")
+                for slot, value in existing.providerLeases.items()
+            }
+            if expected != provider_leases:
+                raise HarnessPlatformError(
+                    "runtime binding provider lease authority changed on retry",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            expected_cleanup_refs = tuple(
+                sorted(
+                    str(handle.get("cleanupRef"))
+                    for handle in (credential_handles or {}).values()
+                    if handle.get("cleanupRef")
+                )
+            )
+            if existing.cleanupAuthorityRefs != expected_cleanup_refs:
+                raise HarnessPlatformError(
+                    "runtime binding cleanup authority changed on retry",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            return existing
         binding = create_runtime_binding(
             executionPlanRef=execution_plan_ref,
             providerLeases=provider_leases,
-            hostBindingRef=host_binding_ref,
-            hostLeaseRef=host_lease_ref,
-            hostLeaseGeneration=host_lease_generation,
-            omnigentHostId=omnigent_host_id,
+            cleanupAuthorityRefs=sorted(
+                str(handle.get("cleanupRef"))
+                for handle in (credential_handles or {}).values()
+                if handle.get("cleanupRef")
+            ),
         )
         # Immutable core cannot be mutated after creation
         self._bindings[binding.runtimeBindingRef] = binding
         self._by_plan.setdefault(execution_plan_ref, []).append(binding.runtimeBindingRef)
         return binding
+
+    async def latest_for_plan(
+        self, execution_plan_ref: str
+    ) -> OmnigentRuntimeBinding | None:
+        refs = self._by_plan.get(execution_plan_ref) or []
+        return self._bindings.get(refs[-1]) if refs else None
 
     async def update_with_host(
         self,
@@ -149,6 +186,11 @@ class InMemoryRuntimeBindingStore:
         host_lease_ref: str,
         host_lease_generation: int,
         omnigent_host_id: str,
+        host_harness_attestation_ref: str | None = None,
+        exact_host_capability_decision_ref: str | None = None,
+        workspace_resolution_ref: str | None = None,
+        model_option_attestation_ref: str | None = None,
+        skill_delivery_attestation_ref: str | None = None,
     ) -> OmnigentRuntimeBinding:
         existing = self._bindings.get(runtime_binding_ref)
         if existing is None:
@@ -165,17 +207,20 @@ class InMemoryRuntimeBindingStore:
             hostLeaseRef=host_lease_ref,
             hostLeaseGeneration=host_lease_generation,
             omnigentHostId=omnigent_host_id,
-            hostHarnessAttestationRef=existing.hostHarnessAttestationRef,
-            exactHostCapabilityDecisionRef=existing.exactHostCapabilityDecisionRef,
-            workspaceResolutionRef=existing.workspaceResolutionRef,
-            modelOptionAttestationRef=existing.modelOptionAttestationRef,
-            skillDeliveryAttestationRef=existing.skillDeliveryAttestationRef,
+            hostHarnessAttestationRef=host_harness_attestation_ref,
+            exactHostCapabilityDecisionRef=exact_host_capability_decision_ref,
+            workspaceResolutionRef=workspace_resolution_ref,
+            modelOptionAttestationRef=model_option_attestation_ref,
+            skillDeliveryAttestationRef=skill_delivery_attestation_ref,
             omnigentSessionId=existing.omnigentSessionId,
             cleanupAuthorityRefs=list(existing.cleanupAuthorityRefs),
         )
         # New ref differs because host fields are part of digest; we store under new ref
         # but also keep old for history; return new
         self._bindings[updated.runtimeBindingRef] = updated
+        self._by_plan.setdefault(existing.executionPlanRef, []).append(
+            updated.runtimeBindingRef
+        )
         # Do not delete old; keep for audit
         return updated
 
@@ -207,6 +252,9 @@ class InMemoryRuntimeBindingStore:
             cleanupAuthorityRefs=list(existing.cleanupAuthorityRefs),
         )
         self._bindings[updated.runtimeBindingRef] = updated
+        self._by_plan.setdefault(existing.executionPlanRef, []).append(
+            updated.runtimeBindingRef
+        )
         return updated
 
 
@@ -272,6 +320,48 @@ class DbExecutionPlanStore:
                 ) from exc
             return envelope
 
+    @staticmethod
+    async def persist_in_session(
+        session: Any,
+        envelope: OmnigentExecutionPlanEnvelope,
+    ) -> OmnigentExecutionPlanEnvelope:
+        """Flush a plan inside an API caller's admission transaction.
+
+        The caller commits the execution record and plan together before
+        Temporal start.  This avoids a window in which a workflow can launch
+        without the immutable authority it names.
+        """
+
+        from api_service.db.models import OmnigentExecutionPlanRecord
+
+        verify_execution_plan_envelope(envelope)
+        existing = await session.get(OmnigentExecutionPlanRecord, envelope.planRef)
+        payload = envelope.payload.model_dump(by_alias=True, mode="json")
+        if existing is not None:
+            if existing.payload_json != payload:
+                raise HarnessPlatformError(
+                    f"execution plan conflict for {envelope.planRef}",
+                    code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+                )
+            return envelope
+        session.add(
+            OmnigentExecutionPlanRecord(
+                plan_ref=envelope.planRef,
+                schema_version=envelope.schemaVersion,
+                payload_json=payload,
+                agent_profile_snapshot_ref=envelope.payload.agentProfileSnapshotRef,
+                credential_binding_set_ref=envelope.payload.credentialBindingSetRef,
+                harness_id=envelope.payload.harnessId,
+                harness_implementation_ref=envelope.payload.harnessImplementationRef,
+                host_class_ref=envelope.payload.hostClassRef,
+                launch_policy_ref=envelope.payload.launchPolicyRef,
+                execution_realizer_ref=envelope.payload.executionRealizerRef,
+                support_combination_key=envelope.payload.supportCombinationKey,
+            )
+        )
+        await session.flush()
+        return envelope
+
     async def load_or_compile(
         self,
         *,
@@ -283,3 +373,283 @@ class DbExecutionPlanStore:
         if existing is not None:
             return existing
         return await self.persist(envelope)
+
+
+class DbRuntimeBindingStore:
+    """DB-backed immutable-stage runtime binding journal."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    @staticmethod
+    def _from_record(record: Any) -> OmnigentRuntimeBinding:
+        attestations = dict(record.attestation_refs_json or {})
+        return OmnigentRuntimeBinding.model_validate(
+            {
+                "schemaVersion": "moonmind.omnigent-runtime-binding.v1",
+                "runtimeBindingRef": record.runtime_binding_ref,
+                "executionPlanRef": record.execution_plan_ref,
+                "providerLeases": record.provider_leases_json or {},
+                "hostBindingRef": record.host_binding_ref,
+                "hostLeaseRef": record.host_lease_ref,
+                "hostLeaseGeneration": record.host_lease_generation,
+                "omnigentHostId": record.omnigent_host_id,
+                "hostHarnessAttestationRef": attestations.get(
+                    "hostHarnessAttestationRef"
+                ),
+                "exactHostCapabilityDecisionRef": attestations.get(
+                    "exactHostCapabilityDecisionRef"
+                ),
+                "workspaceResolutionRef": attestations.get(
+                    "workspaceResolutionRef"
+                ),
+                "modelOptionAttestationRef": attestations.get(
+                    "modelOptionAttestationRef"
+                ),
+                "skillDeliveryAttestationRef": attestations.get(
+                    "skillDeliveryAttestationRef"
+                ),
+                "omnigentSessionId": record.session_id,
+                "cleanupAuthorityRefs": record.cleanup_authority_refs_json or [],
+            }
+        )
+
+    async def get(self, runtime_binding_ref: str) -> OmnigentRuntimeBinding | None:
+        from api_service.db.models import OmnigentRuntimeBindingRecord
+
+        async with self._session_factory() as session:
+            record = await session.get(
+                OmnigentRuntimeBindingRecord, runtime_binding_ref
+            )
+            return self._from_record(record) if record is not None else None
+
+    async def latest_for_plan(
+        self, execution_plan_ref: str
+    ) -> OmnigentRuntimeBinding | None:
+        from api_service.db.models import OmnigentRuntimeBindingRecord
+        from sqlalchemy import case, select
+
+        async with self._session_factory() as session:
+            record = (
+                await session.execute(
+                    select(OmnigentRuntimeBindingRecord)
+                    .where(
+                        OmnigentRuntimeBindingRecord.execution_plan_ref
+                        == execution_plan_ref
+                    )
+                    .order_by(
+                        case(
+                            (
+                                OmnigentRuntimeBindingRecord.state
+                                == "session_bound",
+                                3,
+                            ),
+                            (
+                                OmnigentRuntimeBindingRecord.state
+                                == "host_acquired",
+                                2,
+                            ),
+                            else_=1,
+                        ).desc(),
+                        OmnigentRuntimeBindingRecord.created_at.desc(),
+                        OmnigentRuntimeBindingRecord.revision.desc(),
+                        OmnigentRuntimeBindingRecord.runtime_binding_ref.desc(),
+                    )
+                    .limit(1)
+                )
+            ).scalars().first()
+            return self._from_record(record) if record is not None else None
+
+    async def _persist(
+        self,
+        binding: OmnigentRuntimeBinding,
+        *,
+        state: str,
+        credential_handles: dict[str, Any] | None = None,
+    ) -> OmnigentRuntimeBinding:
+        from api_service.db.models import OmnigentRuntimeBindingRecord
+        from sqlalchemy.exc import IntegrityError
+
+        provider_leases = {
+            slot: lease.model_dump(by_alias=True, mode="json")
+            for slot, lease in binding.providerLeases.items()
+        }
+        attestation_refs = {
+            key: value
+            for key, value in {
+                "hostHarnessAttestationRef": binding.hostHarnessAttestationRef,
+                "exactHostCapabilityDecisionRef": binding.exactHostCapabilityDecisionRef,
+                "workspaceResolutionRef": binding.workspaceResolutionRef,
+                "modelOptionAttestationRef": binding.modelOptionAttestationRef,
+                "skillDeliveryAttestationRef": binding.skillDeliveryAttestationRef,
+            }.items()
+            if value is not None
+        }
+        async with self._session_factory() as session:
+            existing = await session.get(
+                OmnigentRuntimeBindingRecord, binding.runtimeBindingRef
+            )
+            if existing is not None:
+                loaded = self._from_record(existing)
+                if loaded != binding:
+                    raise HarnessPlatformError(
+                        f"runtime binding conflict for {binding.runtimeBindingRef}",
+                        code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                    )
+                return loaded
+            session.add(
+                OmnigentRuntimeBindingRecord(
+                    runtime_binding_ref=binding.runtimeBindingRef,
+                    execution_plan_ref=binding.executionPlanRef,
+                    state=state,
+                    provider_leases_json=provider_leases,
+                    host_binding_ref=binding.hostBindingRef,
+                    host_lease_ref=binding.hostLeaseRef,
+                    host_lease_generation=binding.hostLeaseGeneration,
+                    omnigent_host_id=binding.omnigentHostId,
+                    session_id=binding.omnigentSessionId,
+                    credential_runtime_handles_json=dict(credential_handles or {}),
+                    attestation_refs_json=attestation_refs,
+                    cleanup_authority_refs_json=list(binding.cleanupAuthorityRefs),
+                )
+            )
+            try:
+                await session.commit()
+            except IntegrityError as exc:
+                await session.rollback()
+                loaded = await self.get(binding.runtimeBindingRef)
+                if loaded is not None:
+                    return loaded
+                raise HarnessPlatformError(
+                    f"failed to persist runtime binding: {exc}",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                ) from exc
+        return binding
+
+    async def create_initial(
+        self,
+        *,
+        execution_plan_ref: str,
+        provider_leases: dict[str, dict[str, Any]],
+        credential_handles: dict[str, dict[str, Any]] | None = None,
+    ) -> OmnigentRuntimeBinding:
+        existing = await self.latest_for_plan(execution_plan_ref)
+        if existing is not None:
+            expected = {
+                slot: lease.model_dump(by_alias=True, mode="json")
+                for slot, lease in existing.providerLeases.items()
+            }
+            if expected != provider_leases:
+                raise HarnessPlatformError(
+                    "runtime binding provider lease authority changed on retry",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            expected_cleanup_refs = tuple(
+                sorted(
+                    str(handle.get("cleanupRef"))
+                    for handle in (credential_handles or {}).values()
+                    if handle.get("cleanupRef")
+                )
+            )
+            if existing.cleanupAuthorityRefs != expected_cleanup_refs:
+                raise HarnessPlatformError(
+                    "runtime binding cleanup authority changed on retry",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            return existing
+        binding = create_runtime_binding(
+            executionPlanRef=execution_plan_ref,
+            providerLeases=provider_leases,
+            cleanupAuthorityRefs=sorted(
+                str(handle.get("cleanupRef"))
+                for handle in (credential_handles or {}).values()
+                if handle.get("cleanupRef")
+            ),
+        )
+        return await self._persist(
+            binding,
+            state="credentials_acquired",
+            credential_handles=credential_handles,
+        )
+
+    async def update_with_host(
+        self,
+        runtime_binding_ref: str,
+        *,
+        host_binding_ref: str,
+        host_lease_ref: str,
+        host_lease_generation: int,
+        omnigent_host_id: str,
+        host_harness_attestation_ref: str | None = None,
+        exact_host_capability_decision_ref: str | None = None,
+        workspace_resolution_ref: str | None = None,
+        model_option_attestation_ref: str | None = None,
+        skill_delivery_attestation_ref: str | None = None,
+    ) -> OmnigentRuntimeBinding:
+        existing = await self.get(runtime_binding_ref)
+        if existing is None:
+            raise HarnessPlatformError(
+                f"runtime binding {runtime_binding_ref} not found",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        binding = create_runtime_binding(
+            executionPlanRef=existing.executionPlanRef,
+            providerLeases={
+                slot: lease.model_dump(by_alias=True, mode="json")
+                for slot, lease in existing.providerLeases.items()
+            },
+            hostBindingRef=host_binding_ref,
+            hostLeaseRef=host_lease_ref,
+            hostLeaseGeneration=host_lease_generation,
+            omnigentHostId=omnigent_host_id,
+            hostHarnessAttestationRef=host_harness_attestation_ref,
+            exactHostCapabilityDecisionRef=exact_host_capability_decision_ref,
+            workspaceResolutionRef=workspace_resolution_ref,
+            modelOptionAttestationRef=model_option_attestation_ref,
+            skillDeliveryAttestationRef=skill_delivery_attestation_ref,
+            omnigentSessionId=existing.omnigentSessionId,
+            cleanupAuthorityRefs=list(existing.cleanupAuthorityRefs),
+        )
+        return await self._persist(binding, state="host_acquired")
+
+    async def update_with_session(
+        self,
+        runtime_binding_ref: str,
+        *,
+        omnigent_session_id: str,
+    ) -> OmnigentRuntimeBinding:
+        existing = await self.get(runtime_binding_ref)
+        if existing is None:
+            raise HarnessPlatformError(
+                f"runtime binding {runtime_binding_ref} not found",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        binding = create_runtime_binding(
+            executionPlanRef=existing.executionPlanRef,
+            providerLeases={
+                slot: lease.model_dump(by_alias=True, mode="json")
+                for slot, lease in existing.providerLeases.items()
+            },
+            hostBindingRef=existing.hostBindingRef,
+            hostLeaseRef=existing.hostLeaseRef,
+            hostLeaseGeneration=existing.hostLeaseGeneration,
+            omnigentHostId=existing.omnigentHostId,
+            hostHarnessAttestationRef=existing.hostHarnessAttestationRef,
+            exactHostCapabilityDecisionRef=existing.exactHostCapabilityDecisionRef,
+            workspaceResolutionRef=existing.workspaceResolutionRef,
+            modelOptionAttestationRef=existing.modelOptionAttestationRef,
+            skillDeliveryAttestationRef=existing.skillDeliveryAttestationRef,
+            omnigentSessionId=omnigent_session_id,
+            cleanupAuthorityRefs=list(existing.cleanupAuthorityRefs),
+        )
+        return await self._persist(binding, state="session_bound")
+
+
+__all__ = [
+    "DbExecutionPlanStore",
+    "DbRuntimeBindingStore",
+    "InMemoryExecutionPlanStore",
+    "InMemoryRuntimeBindingStore",
+    "OmnigentExecutionPlanStore",
+    "OmnigentRuntimeBindingStore",
+]

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -115,6 +115,16 @@ class HostCleanupService(Protocol):
     ) -> None: ...
 
 
+class HostRealizationContextService(Protocol):
+    async def prepare_realization(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        authority: Mapping[str, Any],
+    ) -> None: ...
+
+
 class GenericOmnigentHostRuntime:
     """Harness-neutral host realization.
 
@@ -133,6 +143,7 @@ class GenericOmnigentHostRuntime:
         registration_waiter: HostRegistrationWaiter | None = None,
         image_attestor: HostImageAttestor | None = None,
         cleanup_service: HostCleanupService | None = None,
+        context_service: HostRealizationContextService | None = None,
     ) -> None:
         self._launcher = launcher
         self._workspace_service = workspace_service
@@ -141,6 +152,7 @@ class GenericOmnigentHostRuntime:
         self._registration_waiter = registration_waiter
         self._image_attestor = image_attestor
         self._cleanup_service = cleanup_service
+        self._context_service = context_service
 
     def assert_ready(self) -> None:
         """Fail before command, credential, lease, workspace, or host effects."""
@@ -227,6 +239,12 @@ class GenericOmnigentHostRuntime:
             runtime_binding_ref=runtime_binding_ref,
             command_authority=command_authority,
         )
+        if self._context_service is not None:
+            await self._context_service.prepare_realization(
+                request=request,
+                plan=plan,
+                authority=side_effect_authority,
+            )
 
         # Validate materializer compatibility with HostClass
         materializer_refs = [
@@ -314,7 +332,11 @@ class GenericOmnigentHostRuntime:
                 credential_handles=credential_handles,
                 authority=side_effect_authority,
             )
-            host_id = str(launch_result.get("hostId") or "").strip()
+            launched_host_id = str(launch_result.get("hostId") or "").strip()
+            expected_host_name = str(
+                launch_result.get("expectedHostName") or ""
+            ).strip()
+            host_id = launched_host_id
             host_binding_ref = str(
                 launch_result.get("hostBindingRef") or ""
             ).strip()
@@ -323,18 +345,18 @@ class GenericOmnigentHostRuntime:
             ).strip()
             host_lease_generation = launch_result.get("hostLeaseGeneration")
             if (
-                not host_id
+                (not launched_host_id and not expected_host_name)
                 or not host_binding_ref
                 or not host_lease_ref
                 or not isinstance(host_lease_generation, int)
                 or host_lease_generation < 1
             ):
-                if host_id:
+                if launched_host_id or expected_host_name:
                     try:
                         await self.cleanup(
                             plan.planRef,
                             runtime_binding_ref,
-                            host_id=host_id,
+                            host_id=launched_host_id or None,
                             command_authority=command_authority,
                         )
                     except Exception as cleanup_error:
@@ -346,7 +368,7 @@ class GenericOmnigentHostRuntime:
                     "host launcher omitted exact fenced host authority",
                     code=(
                         HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED
-                        if not host_id
+                        if not (launched_host_id or expected_host_name)
                         else HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY
                     ),
                 )
@@ -354,11 +376,11 @@ class GenericOmnigentHostRuntime:
         try:
             # ``assert_ready`` established both dependencies before launch.
             reg = await self._registration_waiter.wait_for_registration(  # type: ignore[union-attr]
-                expected_host_id=host_id,
+                expected_host_id=launched_host_id or None,
                 authority=side_effect_authority,
             )
             host_id = str(reg.get("hostId") or host_id)
-            if host_id != str(launch_result["hostId"]):
+            if launched_host_id and host_id != launched_host_id:
                 raise HarnessPlatformError(
                     "registered host differs from fenced launch authority",
                     code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
@@ -429,7 +451,7 @@ class GenericOmnigentHostRuntime:
                     if plan.payload.supportIdentity is not None
                     else hc.architectures[0]
                 ),
-                expectedHostId=str(launch_result["hostId"]),
+                expectedHostId=host_id,
                 currentHostLeaseGeneration=host_lease_generation,
                 expectedVendorRuntimes=list(host_entry.runtimeDependencies),
             )

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -22,36 +22,97 @@ dictionary.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from typing import Any, Protocol
 
-from moonmind.omnigent.harness_platform.host_classes import HostClass, LaunchPolicy, get_host_class, get_launch_policy
-from moonmind.omnigent.harness_platform.execution_plan import OmnigentExecutionPlanEnvelope
-from moonmind.omnigent.harness_platform.failures import HarnessPlatformError, HarnessPlatformFailure
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import (
+    HostClass,
+    LaunchPolicy,
+    get_host_class,
+    get_launch_policy,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 
+logger = logging.getLogger(__name__)
+
+
 class DockerHostLauncher(Protocol):
-    async def launch(self, *, host_class: HostClass, launch_policy: LaunchPolicy, workspace_handle: Any, skill_handle: Any, credential_handles: list[dict[str, Any]]) -> dict[str, Any]: pass  # noqa
+    async def launch(
+        self,
+        *,
+        host_class: HostClass,
+        launch_policy: LaunchPolicy,
+        workspace_handle: Any,
+        skill_handle: Any,
+        credential_handles: list[dict[str, Any]],
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
 
 
 class WorkspaceMaterializationService(Protocol):
-    async def materialize(self, request: AgentExecutionRequest) -> dict[str, Any]: pass  # noqa
+    async def materialize(
+        self,
+        request: AgentExecutionRequest,
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
 
 
 class SkillDeliveryService(Protocol):
-    async def materialize(self, resolved_skills: dict[str, Any]) -> dict[str, Any]: pass  # noqa
+    async def materialize(
+        self,
+        resolved_skills: dict[str, Any],
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
 
 
 class EgressAttachmentService(Protocol):
-    async def attest(self, launch_policy: LaunchPolicy) -> dict[str, Any]: pass  # noqa
+    async def attest(
+        self,
+        launch_policy: LaunchPolicy,
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
 
 
 class HostRegistrationWaiter(Protocol):
-    async def wait_for_registration(self, *, expected_host_id: str | None = None) -> dict[str, Any]: pass  # noqa
+    async def wait_for_registration(
+        self,
+        *,
+        expected_host_id: str | None = None,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
 
 
 class HostImageAttestor(Protocol):
-    async def attest(self, host_id: str, expected_image_ref: str) -> dict[str, Any]: pass  # noqa
+    async def attest(
+        self,
+        host_id: str,
+        expected_image_ref: str,
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]: ...
+
+
+class HostCleanupService(Protocol):
+    async def cleanup(
+        self,
+        *,
+        plan_ref: str,
+        runtime_binding_ref: str | None,
+        host_id: str | None,
+        authority: dict[str, Any],
+    ) -> None: ...
 
 
 class GenericOmnigentHostRuntime:
@@ -71,6 +132,7 @@ class GenericOmnigentHostRuntime:
         egress_service: EgressAttachmentService | None = None,
         registration_waiter: HostRegistrationWaiter | None = None,
         image_attestor: HostImageAttestor | None = None,
+        cleanup_service: HostCleanupService | None = None,
     ) -> None:
         self._launcher = launcher
         self._workspace_service = workspace_service
@@ -78,6 +140,59 @@ class GenericOmnigentHostRuntime:
         self._egress_service = egress_service
         self._registration_waiter = registration_waiter
         self._image_attestor = image_attestor
+        self._cleanup_service = cleanup_service
+
+    def assert_ready(self) -> None:
+        """Fail before command, credential, lease, workspace, or host effects."""
+
+        dependencies = {
+            "host launcher": self._launcher,
+            "workspace materializer": self._workspace_service,
+            "Skill delivery service": self._skill_service,
+            "egress attestor": self._egress_service,
+            "host registration waiter": self._registration_waiter,
+            "host image attestor": self._image_attestor,
+            "host cleanup service": self._cleanup_service,
+        }
+        missing = sorted(name for name, value in dependencies.items() if value is None)
+        if missing:
+            raise HarnessPlatformError(
+                "generic host runtime is not production-ready: " + ", ".join(missing),
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+
+    @staticmethod
+    def _side_effect_authority(
+        *,
+        plan_ref: str,
+        runtime_binding_ref: str | None,
+        command_authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        required = {
+            "commandId",
+            "claimToken",
+            "sessionId",
+            "turnAttemptId",
+            "expectedSessionRevision",
+            "fencingGeneration",
+        }
+        missing = sorted(required - set(command_authority))
+        if (
+            missing
+            or not plan_ref.startswith("omnigent-execution-plan:sha256:")
+            or not str(runtime_binding_ref or "").startswith(
+                "omnigent-runtime-binding:sha256:"
+            )
+        ):
+            raise HarnessPlatformError(
+                "generic host side effect lacks stable command or binding authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        return {
+            **command_authority,
+            "executionPlanRef": plan_ref,
+            "runtimeBindingRef": runtime_binding_ref,
+        }
 
     async def realize(
         self,
@@ -87,6 +202,8 @@ class GenericOmnigentHostRuntime:
         host_class: HostClass | None = None,
         launch_policy: LaunchPolicy | None = None,
         credential_handles: list[dict[str, Any]] | None = None,
+        runtime_binding_ref: str,
+        command_authority: dict[str, Any],
     ) -> dict[str, Any]:
         """Realize an attested Omnigent host for the plan.
 
@@ -104,9 +221,18 @@ class GenericOmnigentHostRuntime:
         """
         hc = host_class or get_host_class(plan.payload.hostClassRef)
         lp = launch_policy or get_launch_policy(plan.payload.launchPolicyRef)
+        self.assert_ready()
+        side_effect_authority = self._side_effect_authority(
+            plan_ref=plan.planRef,
+            runtime_binding_ref=runtime_binding_ref,
+            command_authority=command_authority,
+        )
 
         # Validate materializer compatibility with HostClass
-        materializer_refs = [b.materializerRef for b in plan.payload.credentialBindings.values()]
+        materializer_refs = [
+            str(binding["materializerRef"])
+            for binding in plan.payload.credentialBindings.values()
+        ]
         for mat_ref in materializer_refs:
             if not hc.supports_materializer(mat_ref):
                 raise HarnessPlatformError(
@@ -121,14 +247,24 @@ class GenericOmnigentHostRuntime:
                 code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
             )
 
-        # Shared services (stubbed for hermetic)
-        workspace_handle = {"path": "/workspaces/run", "locator": "sandbox"}
-        if self._workspace_service is not None:
-            workspace_handle = await self._workspace_service.materialize(request)
+        if self._workspace_service is None:
+            raise HarnessPlatformError(
+                "workspace materializer required for generic host realization",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+        workspace_handle = await self._workspace_service.materialize(  # type: ignore[union-attr]
+            request, authority=side_effect_authority
+        )
 
-        skill_handle = {"deliveryRef": plan.payload.resolvedSkills.get("skillDeliveryRef")}
-        if self._skill_service is not None:
-            skill_handle = await self._skill_service.materialize(plan.payload.resolvedSkills)
+        if self._skill_service is None:
+            raise HarnessPlatformError(
+                "Skill delivery service required for generic host realization",
+                code=HarnessPlatformFailure.OMNIGENT_SKILL_DELIVERY_MISMATCH,
+            )
+        skill_handle = await self._skill_service.materialize(  # type: ignore[union-attr]
+            plan.payload.resolvedSkills,
+            authority=side_effect_authority,
+        )
 
         # Build HostLaunchSpec (secret-free)
         host_launch_spec = {
@@ -138,6 +274,7 @@ class GenericOmnigentHostRuntime:
             "workspaceHandle": workspace_handle,
             "skillHandle": skill_handle,
             "materializerRefs": materializer_refs,
+            "authority": side_effect_authority,
         }
 
         # Use provided credential handles or validate (P1 3828196627)
@@ -152,45 +289,22 @@ class GenericOmnigentHostRuntime:
                 if mat.requiredSecretRoles and not any(
                     h.get("materializerRef") == mat_ref for h in credential_handles
                 ):
-                    import os
-
-                    if os.getenv("PYTEST_CURRENT_TEST"):
-                        # Hermetic: synthesize missing handle for test
-                        credential_handles.append(
-                            {
-                                "credentialRuntimeRef": f"credential-runtime:test:{mat_ref}",
-                                "providerProfileRef": "test-provider",
-                                "providerLeaseRef": f"provider-lease:test:{mat_ref}",
-                                "credentialGeneration": 1,
-                                "materializerRef": mat_ref,
-                                "targetPath": mat.target.get("path", ""),
-                                "accessMode": "read-only",
-                                "cleanupRef": f"credential-cleanup:test:{mat_ref}",
-                                "attestationRef": f"artifact:test:{mat_ref}",
-                            }
-                        )
-                    elif self._launcher is None:
-                        raise HarnessPlatformError(
-                            f"materializer {mat_ref} requires credential handles before host launch",
-                            code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
-                        )
+                    raise HarnessPlatformError(
+                        f"materializer {mat_ref} requires credential handles before host launch",
+                        code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+                    )
             except HarnessPlatformError:
                 raise
             except Exception:  # best-effort, ignore
                 pass
 
-        # Launch / attach – require real launcher in production (P1 3828196584)
+        # Launch / attach. Hermetic callers inject fakes through this same
+        # interface; production code never infers test mode or invents authority.
         if self._launcher is None:
-            import os
-
-            if os.getenv("PYTEST_CURRENT_TEST"):
-                # Hermetic: synthesize host context but mark as synthetic for caller to handle
-                host_id = f"host_{plan.payload.harnessId}_synthetic"
-            else:
-                raise HarnessPlatformError(
-                    "host launcher required for generic host realization",
-                    code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
-                )
+            raise HarnessPlatformError(
+                "host launcher required for generic host realization",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
         else:
             launch_result = await self._launcher.launch(
                 host_class=hc,
@@ -198,30 +312,209 @@ class GenericOmnigentHostRuntime:
                 workspace_handle=workspace_handle,
                 skill_handle=skill_handle,
                 credential_handles=credential_handles,
+                authority=side_effect_authority,
             )
-            host_id = str(launch_result.get("hostId") or f"host_{plan.payload.harnessId}_synthetic")
+            host_id = str(launch_result.get("hostId") or "").strip()
+            host_binding_ref = str(
+                launch_result.get("hostBindingRef") or ""
+            ).strip()
+            host_lease_ref = str(
+                launch_result.get("hostLeaseRef") or ""
+            ).strip()
+            host_lease_generation = launch_result.get("hostLeaseGeneration")
+            if (
+                not host_id
+                or not host_binding_ref
+                or not host_lease_ref
+                or not isinstance(host_lease_generation, int)
+                or host_lease_generation < 1
+            ):
+                if host_id:
+                    try:
+                        await self.cleanup(
+                            plan.planRef,
+                            runtime_binding_ref,
+                            host_id=host_id,
+                            command_authority=command_authority,
+                        )
+                    except Exception as cleanup_error:
+                        raise HarnessPlatformError(
+                            "generic host launch cleanup is deferred",
+                            code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                        ) from cleanup_error
+                raise HarnessPlatformError(
+                    "host launcher omitted exact fenced host authority",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED
+                        if not host_id
+                        else HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY
+                    ),
+                )
 
-        # Wait for registration
-        if self._registration_waiter is not None:
-            reg = await self._registration_waiter.wait_for_registration(expected_host_id=host_id)
+        try:
+            # ``assert_ready`` established both dependencies before launch.
+            reg = await self._registration_waiter.wait_for_registration(  # type: ignore[union-attr]
+                expected_host_id=host_id,
+                authority=side_effect_authority,
+            )
             host_id = str(reg.get("hostId") or host_id)
-        elif self._launcher is None:
-            # Without a launcher, we cannot attest registration; hermetic synthetic is allowed
-            pass
-
-        # Image attestation – require launcher attestation in production
-        if self._image_attestor is not None:
-            await self._image_attestor.attest(host_id, hc.imageRef)
-        elif self._launcher is not None:
-            raise HarnessPlatformError(
-                "host image attestor required when launcher is present",
-                code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+            if host_id != str(launch_result["hostId"]):
+                raise HarnessPlatformError(
+                    "registered host differs from fenced launch authority",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            raw_attestation = reg.get("attestation")
+            if not isinstance(raw_attestation, Mapping):
+                raise HarnessPlatformError(
+                    "exact host registration omitted harness attestation",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+                )
+            from moonmind.omnigent.harness_platform.attestation import (
+                HostHarnessAttestation,
+                compute_attestation_ref,
+                validate_exact_host_attestation,
             )
+            from moonmind.omnigent.harness_platform.catalog import (
+                HarnessImplementationIdentity,
+            )
+
+            attestation = HostHarnessAttestation.model_validate(raw_attestation)
+            if (
+                not attestation.attestationRef
+                or compute_attestation_ref(attestation)
+                != attestation.attestationRef
+            ):
+                raise HarnessPlatformError(
+                    "exact host attestation ref does not match its content",
+                    code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+                )
+            observed_implementation = HarnessImplementationIdentity.model_validate(
+                attestation.harnessImplementation
+            )
+            if (
+                observed_implementation.implementation_ref()
+                != plan.payload.harnessImplementationRef
+            ):
+                raise HarnessPlatformError(
+                    "exact host harness implementation differs from the plan",
+                    code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+                )
+            host_entry = next(
+                (
+                    entry
+                    for entry in hc.declaredHarnessImplementations
+                    if entry.harnessId == plan.payload.harnessId
+                    and entry.implementationRef
+                    == plan.payload.harnessImplementationRef
+                ),
+                None,
+            )
+            if host_entry is None:
+                raise HarnessPlatformError(
+                    "Host Class no longer declares the planned implementation",
+                    code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+                )
+            validate_exact_host_attestation(
+                attestation,
+                expectedHostClassRef=hc.ref,
+                expectedImageRef=hc.imageRef,
+                expectedOmnigentBuildDigest=hc.omnigentBuildDigest,
+                expectedHarnessId=plan.payload.harnessId,
+                expectedImplementation=attestation.harnessImplementation,
+                requiredCapabilities=list(
+                    plan.payload.classAdmissionDecision.get("required") or []
+                ),
+                expectedArchitecture=(
+                    plan.payload.supportIdentity.architecture
+                    if plan.payload.supportIdentity is not None
+                    else hc.architectures[0]
+                ),
+                expectedHostId=str(launch_result["hostId"]),
+                currentHostLeaseGeneration=host_lease_generation,
+                expectedVendorRuntimes=list(host_entry.runtimeDependencies),
+            )
+            image_evidence = await self._image_attestor.attest(  # type: ignore[union-attr]
+                host_id, hc.imageRef, authority=side_effect_authority
+            )
+            egress_evidence = await self._egress_service.attest(  # type: ignore[union-attr]
+                lp, authority=side_effect_authority
+            )
+            model_evidence = reg.get("modelOptionAttestation")
+            required_refs = {
+                "hostHarnessAttestationRef": attestation.attestationRef,
+                "exactHostCapabilityDecisionRef": reg.get(
+                    "exactHostCapabilityDecisionRef"
+                ),
+                "workspaceResolutionRef": workspace_handle.get("resolutionRef"),
+                "modelOptionAttestationRef": (
+                    model_evidence.get("attestationRef")
+                    if isinstance(model_evidence, Mapping)
+                    else None
+                ),
+                "skillDeliveryAttestationRef": skill_handle.get(
+                    "attestationRef"
+                ),
+                "imageAttestationRef": (
+                    image_evidence.get("attestationRef")
+                    if isinstance(image_evidence, Mapping)
+                    else None
+                ),
+                "egressAttestationRef": (
+                    egress_evidence.get("attestationRef")
+                    if isinstance(egress_evidence, Mapping)
+                    else None
+                ),
+            }
+            missing_refs = sorted(
+                key for key, value in required_refs.items() if not value
+            )
+            planned_model = plan.payload.modelConfig.qualifiedId
+            if (
+                missing_refs
+                or not isinstance(model_evidence, Mapping)
+                or model_evidence.get("available") is not True
+                or model_evidence.get("modelId") != planned_model
+                or skill_handle.get("deliveryRef")
+                != plan.payload.resolvedSkills.get("skillDeliveryRef")
+                or not isinstance(image_evidence, Mapping)
+                or image_evidence.get("observedImageRef") != hc.imageRef
+                or not isinstance(egress_evidence, Mapping)
+                or egress_evidence.get("enforced") is not True
+            ):
+                raise HarnessPlatformError(
+                    "exact host evidence is incomplete or differs from the plan: "
+                    + ", ".join(missing_refs),
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_EXACT_HOST_CAPABILITY_MISMATCH
+                    ),
+                )
+        except Exception:
+            # A launcher success transfers cleanup authority even if later
+            # registration or attestation fails. Do not strand an unowned host.
+            try:
+                await self.cleanup(
+                    plan.planRef,
+                    runtime_binding_ref,
+                    host_id=host_id,
+                    command_authority=command_authority,
+                )
+            except Exception as cleanup_error:
+                logger.exception(
+                    "Generic host cleanup remains pending after realization failure"
+                )
+                raise HarnessPlatformError(
+                    "generic host partial realization cleanup is deferred",
+                    code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                ) from cleanup_error
+            raise
 
         # Return generic host context (no harness-specific fields)
         return {
             "hostId": host_id,
             "omnigentHostId": host_id,
+            "hostBindingRef": host_binding_ref,
+            "hostLeaseRef": host_lease_ref,
+            "hostLeaseGeneration": host_lease_generation,
             "hostClassRef": hc.ref,
             "imageRef": hc.imageRef,
             "launchPolicyRef": lp.ref,
@@ -230,7 +523,42 @@ class GenericOmnigentHostRuntime:
             "materializerRefs": materializer_refs,
             "hostLaunchSpec": host_launch_spec,
             # Attestation refs for runtime binding
-            "hostHarnessAttestationRef": f"artifact:host-attestation:{host_id}",
-            "modelOptionAttestationRef": f"artifact:model-options:{host_id}",
-            "skillDeliveryAttestationRef": skill_handle.get("deliveryRef"),
+            "hostHarnessAttestationRef": required_refs[
+                "hostHarnessAttestationRef"
+            ],
+            "exactHostCapabilityDecisionRef": required_refs[
+                "exactHostCapabilityDecisionRef"
+            ],
+            "workspaceResolutionRef": required_refs["workspaceResolutionRef"],
+            "modelOptionAttestationRef": required_refs[
+                "modelOptionAttestationRef"
+            ],
+            "skillDeliveryAttestationRef": required_refs[
+                "skillDeliveryAttestationRef"
+            ],
         }
+
+    async def cleanup(
+        self,
+        plan_ref: str,
+        runtime_binding_ref: str | None,
+        *,
+        host_id: str | None = None,
+        command_authority: dict[str, Any],
+    ) -> None:
+        if self._cleanup_service is None:
+            raise HarnessPlatformError(
+                "host cleanup service required for generic host realization",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+        authority = self._side_effect_authority(
+            plan_ref=plan_ref,
+            runtime_binding_ref=runtime_binding_ref,
+            command_authority=command_authority,
+        )
+        await self._cleanup_service.cleanup(
+            plan_ref=plan_ref,
+            runtime_binding_ref=runtime_binding_ref,
+            host_id=host_id,
+            authority=authority,
+        )

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -55,7 +55,8 @@ class DockerHostLauncher(Protocol):
         skill_handle: Any,
         credential_handles: list[dict[str, Any]],
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class WorkspaceMaterializationService(Protocol):
@@ -64,7 +65,8 @@ class WorkspaceMaterializationService(Protocol):
         request: AgentExecutionRequest,
         *,
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class SkillDeliveryService(Protocol):
@@ -73,7 +75,8 @@ class SkillDeliveryService(Protocol):
         resolved_skills: dict[str, Any],
         *,
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class EgressAttachmentService(Protocol):
@@ -82,7 +85,8 @@ class EgressAttachmentService(Protocol):
         launch_policy: LaunchPolicy,
         *,
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class HostRegistrationWaiter(Protocol):
@@ -91,7 +95,8 @@ class HostRegistrationWaiter(Protocol):
         *,
         expected_host_id: str | None = None,
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class HostImageAttestor(Protocol):
@@ -101,7 +106,8 @@ class HostImageAttestor(Protocol):
         expected_image_ref: str,
         *,
         authority: dict[str, Any],
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
 
 class HostCleanupService(Protocol):
@@ -112,7 +118,8 @@ class HostCleanupService(Protocol):
         runtime_binding_ref: str | None,
         host_id: str | None,
         authority: dict[str, Any],
-    ) -> None: ...
+    ) -> None:
+        raise NotImplementedError
 
 
 class HostRealizationContextService(Protocol):
@@ -122,7 +129,8 @@ class HostRealizationContextService(Protocol):
         request: AgentExecutionRequest,
         plan: OmnigentExecutionPlanEnvelope,
         authority: Mapping[str, Any],
-    ) -> None: ...
+    ) -> None:
+        raise NotImplementedError
 
 
 class GenericOmnigentHostRuntime:

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -16,7 +16,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from urllib.parse import urlsplit
 from uuid import NAMESPACE_URL, uuid5
 
 from moonmind.config.settings import settings
@@ -32,6 +31,10 @@ from moonmind.omnigent.oauth_hosts import (
     validate_preflight_result,
 )
 from moonmind.omnigent.settings import OMNIGENT_RUNTIME_ACTIVE_SKILLS_DIR
+from moonmind.omnigent.repository_sources import (
+    RepositorySourceError,
+    normalize_repository_source,
+)
 from moonmind.publish.service import PublishService
 from moonmind.repositories.lore_adapter import (
     LORE_UNSUPPORTED_RUNTIME_LANE,
@@ -217,7 +220,6 @@ _PLACEHOLDER_DIGEST = "0" * 64
 _SAFE_NETWORK = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,254}$")
 _SAFE_STEP_EXECUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,510}[A-Za-z0-9]$")
-_GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 # Bound restore-input materialization so a hostile or oversized artifact ref
 # cannot exhaust the authorized workspace before the host launches. The limit is
 # enforced both per ref and cumulatively across every accepted ref so the
@@ -3588,36 +3590,12 @@ class OmnigentOAuthHostRuntime:
     def _normalize_repository_source(repository_source: str) -> tuple[str, str]:
         """Resolve an authored repository identity to a clone source and kind."""
 
-        value = str(repository_source or "").strip()
-        if not value:
+        try:
+            return normalize_repository_source(repository_source)
+        except RepositorySourceError as exc:
             raise OmnigentOAuthHostError(
-                "repository source is required to materialize the workspace",
-                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
-            )
-        # A ``file://`` URL is still a local on-disk read and must be authorized
-        # like any other local path, not treated as a trusted remote.
-        if value.startswith("file://"):
-            return value, "local"
-        if value.startswith(("http://", "https://", "git@", "ssh://")):
-            kind = "remote"
-            if value.startswith(("http://", "https://")):
-                # Only inject GitHub credentials when the URL host is exactly
-                # github.com. A substring check would misclassify hosts such as
-                # ``evil.com/github.com`` or ``github.com.evil.com`` as GitHub and
-                # leak the token to an attacker-controlled origin.
-                host = (urlsplit(value).hostname or "").lower()
-                if host == "github.com":
-                    kind = "github_https"
-            return value, kind
-        if value.startswith(("/", "./", "../")) or Path(value).is_absolute():
-            return value, "local"
-        if _GITHUB_SLUG.fullmatch(value):
-            suffix = "" if value.endswith(".git") else ".git"
-            return f"https://github.com/{value}{suffix}", "github_https"
-        raise OmnigentOAuthHostError(
-            "unsupported repository source; expected owner/repo, URL, or path",
-            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
-        )
+                str(exc), code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED"
+            ) from exc
 
     def _authorize_local_repository_source(self, source: str) -> None:
         """Reject a local repository source outside the authorized source root.

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -1853,6 +1853,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                 "effectiveLaunchRef": effective_launch["snapshotRef"],
                 "executionProfileRef": effective_launch["executionProfileRef"],
                 "launchPolicyRef": effective_launch["launchPolicyRef"],
+                "executionPlanRef": str(
+                    (request.parameters or {}).get("executionPlanRef") or ""
+                ).strip()
+                or None,
                 # The full attestation includes the compiled launch-policy
                 # boundary and is already durable behind this reference. Keep
                 # the workflow result plane reference-only so terminal evidence

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -44,6 +44,10 @@ from moonmind.omnigent.remediation_workspace import (
     RemediationWorkspaceOwner,
     SandboxRemediationWorkspaceOwner,
 )
+from moonmind.omnigent.repository_sources import (
+    RepositorySourceError,
+    normalize_repository_source,
+)
 from moonmind.omnigent.execution_profiles import (
     PROFILES,
     selection_from_request,
@@ -2723,13 +2727,9 @@ class OmnigentProfileBoundExecutionCoordinator:
         source = cls._repository_source(request)
         if not source:
             return None
-        from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
-
         try:
-            normalized, kind = OmnigentOAuthHostRuntime._normalize_repository_source(
-                source
-            )
-        except OmnigentOAuthHostError:
+            normalized, kind = normalize_repository_source(source)
+        except RepositorySourceError:
             return None
         return normalized if kind == "github_https" else None
 

--- a/moonmind/omnigent/realizers/base.py
+++ b/moonmind/omnigent/realizers/base.py
@@ -30,5 +30,7 @@ class OmnigentExecutionRealizer(Protocol):
         self,
         plan_ref: str,
         runtime_binding_ref: str | None,
+        *,
+        command_authority: dict[str, object],
     ) -> None:
         """Reconcile janitor/cleanup for a plan's runtime binding."""

--- a/moonmind/omnigent/realizers/codex_profile_bound.py
+++ b/moonmind/omnigent/realizers/codex_profile_bound.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from moonmind.omnigent.harness_platform.execution_plan import OmnigentExecutionPlanEnvelope
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+    execution_support_identity,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 
 
@@ -75,7 +78,13 @@ class CodexProfileBoundRealizer:
                 run_store=run_store,
                 artifact_gateway=artifact_gateway,
             )
-            return await coordinator.execute(request)
+            result = await coordinator.execute(request)
+            return await self._bind_result_authority(
+                request=request,
+                plan=plan,
+                result=result,
+                session_factory=session_factory,
+            )
 
         async with httpx.AsyncClient() as http_client:
             omnigent_client = OmnigentHttpClient(
@@ -99,12 +108,95 @@ class CodexProfileBoundRealizer:
                 execution_runner=run_omnigent_execution,
                 artifact_gateway=artifact_gateway,
             )
-            return await coordinator.execute(request)
+            result = await coordinator.execute(request)
+            return await self._bind_result_authority(
+                request=request,
+                plan=plan,
+                result=result,
+                session_factory=session_factory,
+            )
+
+    async def _bind_result_authority(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        result: AgentRunResult,
+        session_factory: Any,
+    ) -> AgentRunResult:
+        """Project the proven Codex lane into the common runtime binding."""
+
+        request_plan_ref = str(
+            (request.parameters or {}).get("executionPlanRef") or ""
+        ).strip()
+        if request_plan_ref != plan.planRef:
+            from moonmind.omnigent.harness_platform.failures import (
+                HarnessPlatformError,
+                HarnessPlatformFailure,
+            )
+
+            raise HarnessPlatformError(
+                "Codex request does not name the admitted execution plan",
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+            )
+        metadata = dict(result.metadata or {})
+        metadata["executionPlanRef"] = plan.planRef
+        metadata["supportCombinationIdentity"] = execution_support_identity(plan)
+        capture = dict(metadata.get("omnigentCheckpointCapture") or {})
+        if capture:
+            capture["executionPlanRef"] = plan.planRef
+        required = {
+            "providerProfileId",
+            "providerLeaseRef",
+            "credentialGeneration",
+            "credentialRef",
+            "hostBindingRef",
+            "hostLeaseRef",
+            "hostLeaseGeneration",
+            "omnigentHostId",
+        }
+        if required.issubset(capture) and all(capture.get(key) for key in required):
+            from moonmind.omnigent.harness_platform.stores import (
+                DbRuntimeBindingStore,
+            )
+
+            store = DbRuntimeBindingStore(session_factory)
+            binding = await store.create_initial(
+                execution_plan_ref=plan.planRef,
+                provider_leases={
+                    "primary-model": {
+                        "providerProfileRef": str(capture["providerProfileId"]),
+                        "providerLeaseRef": str(capture["providerLeaseRef"]),
+                        "credentialGeneration": int(capture["credentialGeneration"]),
+                        "credentialRuntimeRef": str(capture["credentialRef"]),
+                    }
+                },
+            )
+            binding = await store.update_with_host(
+                binding.runtimeBindingRef,
+                host_binding_ref=str(capture["hostBindingRef"]),
+                host_lease_ref=str(capture["hostLeaseRef"]),
+                host_lease_generation=int(capture["hostLeaseGeneration"]),
+                omnigent_host_id=str(capture["omnigentHostId"]),
+            )
+            provider_session_id = str(capture.get("omnigentSessionId") or "").strip()
+            if provider_session_id:
+                binding = await store.update_with_session(
+                    binding.runtimeBindingRef,
+                    omnigent_session_id=provider_session_id,
+                )
+            metadata["runtimeBindingRef"] = binding.runtimeBindingRef
+            capture["runtimeBindingRef"] = binding.runtimeBindingRef
+        if capture:
+            metadata["omnigentCheckpointCapture"] = capture
+        return result.model_copy(update={"metadata": metadata})
 
     async def reconcile(
         self,
         plan_ref: str,
         runtime_binding_ref: str | None,
+        *,
+        command_authority: dict[str, object],
     ) -> None:
         # Janitor delegates to existing cleanup; no-op for now
         return None

--- a/moonmind/omnigent/realizers/composition.py
+++ b/moonmind/omnigent/realizers/composition.py
@@ -16,9 +16,14 @@ from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.control_plane.turn_commands import (
     CanonicalTurnCommandService,
 )
+from moonmind.omnigent.control_plane.repositories import OmnigentControlPlaneStore
 from moonmind.omnigent.execute import run_omnigent_execution
 from moonmind.omnigent.harness_platform.stores import DbRuntimeBindingStore
 from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
+from moonmind.omnigent.realizers.deployment_adapters import (
+    DeploymentGenericHostServices,
+    TrustedCredentialMaterializer,
+)
 from moonmind.omnigent.realizers.generic_host import GenericRealizerDependencies
 from moonmind.omnigent.realizers.runtime_authority import (
     ProviderProfileRuntimeAuthority,
@@ -33,6 +38,14 @@ def build_generic_realizer_dependencies(
     factory = session_factory or async_session_maker
     artifact_gateway = LocalOmnigentArtifactGateway()
     run_store = OmnigentBridgeSessionStore(factory)
+    credential_materializer = TrustedCredentialMaterializer(
+        session_factory=factory
+    )
+    host_services = DeploymentGenericHostServices(
+        session_factory=factory,
+        artifact_gateway=artifact_gateway,
+        credential_materializer=credential_materializer,
+    )
 
     async def execute(request: Any) -> Any:
         return await run_omnigent_execution(
@@ -43,12 +56,23 @@ def build_generic_realizer_dependencies(
 
     return GenericRealizerDependencies(
         runtime_binding_store=DbRuntimeBindingStore(factory),
-        runtime_authority=ProviderProfileRuntimeAuthority(session_factory=factory),
-        # Concrete host services are registered by the deployment adapter.
-        # The empty runtime fails its readiness gate before acquiring authority
-        # when that registration is absent.
-        host_runtime=GenericOmnigentHostRuntime(),
-        turn_command_service=CanonicalTurnCommandService(factory),
+        runtime_authority=ProviderProfileRuntimeAuthority(
+            session_factory=factory,
+            credential_materializer=credential_materializer,
+        ),
+        host_runtime=GenericOmnigentHostRuntime(
+            launcher=host_services,
+            workspace_service=host_services,
+            skill_service=host_services,
+            egress_service=host_services,
+            registration_waiter=host_services,
+            image_attestor=host_services,
+            cleanup_service=host_services,
+            context_service=host_services,
+        ),
+        turn_command_service=CanonicalTurnCommandService(
+            OmnigentControlPlaneStore(factory)
+        ),
         execution_driver=execute,
     )
 

--- a/moonmind/omnigent/realizers/composition.py
+++ b/moonmind/omnigent/realizers/composition.py
@@ -1,0 +1,56 @@
+"""Infrastructure composition for versioned Omnigent execution realizers.
+
+This module is the only generic-realizer boundary allowed to depend on API
+persistence and concrete runtime services. Application coordination in
+``generic_host`` consumes injected capabilities and stays framework-neutral.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api_service.db.base import async_session_maker
+
+from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
+from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.omnigent.control_plane.turn_commands import (
+    CanonicalTurnCommandService,
+)
+from moonmind.omnigent.execute import run_omnigent_execution
+from moonmind.omnigent.harness_platform.stores import DbRuntimeBindingStore
+from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
+from moonmind.omnigent.realizers.generic_host import GenericRealizerDependencies
+from moonmind.omnigent.realizers.runtime_authority import (
+    ProviderProfileRuntimeAuthority,
+)
+
+
+def build_generic_realizer_dependencies(
+    session_factory: Any | None = None,
+) -> GenericRealizerDependencies:
+    """Build the production adapter graph without interpreting a harness id."""
+
+    factory = session_factory or async_session_maker
+    artifact_gateway = LocalOmnigentArtifactGateway()
+    run_store = OmnigentBridgeSessionStore(factory)
+
+    async def execute(request: Any) -> Any:
+        return await run_omnigent_execution(
+            request,
+            artifact_gateway=artifact_gateway,
+            run_store=run_store,
+        )
+
+    return GenericRealizerDependencies(
+        runtime_binding_store=DbRuntimeBindingStore(factory),
+        runtime_authority=ProviderProfileRuntimeAuthority(session_factory=factory),
+        # Concrete host services are registered by the deployment adapter.
+        # The empty runtime fails its readiness gate before acquiring authority
+        # when that registration is absent.
+        host_runtime=GenericOmnigentHostRuntime(),
+        turn_command_service=CanonicalTurnCommandService(factory),
+        execution_driver=execute,
+    )
+
+
+__all__ = ["build_generic_realizer_dependencies"]

--- a/moonmind/omnigent/realizers/deployment_adapters.py
+++ b/moonmind/omnigent/realizers/deployment_adapters.py
@@ -1,0 +1,1050 @@
+"""Concrete deployment adapters for the generic Omnigent realizer.
+
+The application coordinator consumes only the protocols in ``host_runtime``.
+This outer module owns the trusted filesystem, secret, database, Omnigent HTTP,
+restricted-egress, and container-command boundaries needed to realize those
+protocols in the normal product path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+from api_service.db.models import (
+    OmnigentCredentialRuntimeRecord,
+    OmnigentHostBindingRecordV2,
+    OmnigentHostLeaseRecordV2,
+)
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import HostClass, LaunchPolicy
+from moonmind.omnigent.harness_platform.materializers import (
+    cleanup_opencode_auth,
+    materialize_opencode_auth_json,
+)
+from moonmind.omnigent.settings import resolved_api_token, resolved_server_url
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+from moonmind.security.egress import (
+    OMNIGENT_EGRESS_PROFILE,
+    attest_docker_egress,
+    attest_docker_workload_egress,
+    omnigent_proxy_env,
+)
+from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+from moonmind.workflows.temporal.runtime.command_runner import run_runtime_command
+from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_managed_api_key_reference,
+)
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecordStore,
+    daemon_visible_workspace_path,
+    resolve_sandbox_workspace_locator,
+)
+from moonmind.workloads.docker_launcher import structured_container_security_args
+
+
+_COMMAND_TIMEOUT_SECONDS = 600.0
+_COMMAND_OUTPUT_LIMIT_BYTES = 16 * 1024
+_REGISTRATION_ATTEMPTS = 30
+_REGISTRATION_INTERVAL_SECONDS = 2.0
+_RUNTIME_DIR_NAME = "omnigent_generic_runtime"
+_SCRIPTS = (
+    "check-opencode-host.sh",
+    "check-runner-projections.sh",
+    "clear-stale-host-daemons.sh",
+    "start-host-with-projections.sh",
+    "start-opencode-host.sh",
+)
+
+
+def _digest(*values: object) -> str:
+    encoded = json.dumps(values, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact_ref(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        dict(payload), sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+    return "artifact:sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _runtime_root() -> Path:
+    workspace_root = Path(
+        os.getenv("WORKFLOW_WORKSPACE_ROOT", "/work/agent_jobs")
+    ).expanduser().resolve()
+    configured = os.getenv("OMNIGENT_GENERIC_RUNTIME_ROOT", "").strip()
+    root = (
+        Path(configured).expanduser().resolve()
+        if configured
+        else (workspace_root / _RUNTIME_DIR_NAME).resolve()
+    )
+    if not root.is_relative_to(workspace_root):
+        raise HarnessPlatformError(
+            "generic Omnigent runtime root escapes WORKFLOW_WORKSPACE_ROOT",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+        )
+    return root
+
+
+async def _run_docker(
+    argv: Sequence[str], *, env: Mapping[str, str] | None = None
+) -> tuple[int, bytes, bytes]:
+    """Execute Docker only at the trusted deployment/worker boundary."""
+
+    return await run_runtime_command(
+        ("docker", *argv),
+        env=env,
+        timeout_seconds=_COMMAND_TIMEOUT_SECONDS,
+        output_limit_bytes=_COMMAND_OUTPUT_LIMIT_BYTES,
+    )
+
+
+def _safe_segment(value: str) -> str:
+    normalized = "".join(
+        character if character.isalnum() or character in "_.-" else "-"
+        for character in value.strip()
+    ).strip(".-")
+    if not normalized:
+        raise HarnessPlatformError(
+            "generic host authority contains an empty unsafe identity",
+            code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+        )
+    return normalized[:120]
+
+
+def _docker_object_missing(stderr: bytes) -> bool:
+    diagnostic = stderr.decode(errors="replace").lower()
+    return "no such object" in diagnostic or "not found" in diagnostic
+
+
+@dataclass(slots=True)
+class _DeploymentState:
+    request: AgentExecutionRequest | None = None
+    plan: OmnigentExecutionPlanEnvelope | None = None
+    workspace_path: Path | None = None
+    skill_path: Path | None = None
+    skill_delivery_ref: str | None = None
+    skill_attestation_ref: str | None = None
+    host_binding_ref: str | None = None
+    host_lease_ref: str | None = None
+    host_lease_generation: int | None = None
+    container_name: str | None = None
+    omnigent_host_id: str | None = None
+    egress_attestation: Any | None = None
+    launched_at: datetime | None = None
+    evidence: dict[str, str] = field(default_factory=dict)
+
+
+class TrustedCredentialMaterializer:
+    """Resolve leased SecretRefs and materialize run-owned credential files."""
+
+    def __init__(self, *, session_factory: Any, runtime_root: Path | None = None) -> None:
+        self._session_factory = session_factory
+        self._root = (runtime_root or _runtime_root()).resolve() / "credentials"
+
+    def _credential_root(self, credential_runtime_ref: str) -> Path:
+        digest = credential_runtime_ref.rsplit(":", 1)[-1]
+        if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+            raise HarnessPlatformError(
+                "credential runtime ref is not content-addressed",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        root = (self._root / digest).resolve()
+        if not root.is_relative_to(self._root.resolve()):
+            raise HarnessPlatformError(
+                "credential runtime path escapes deployment authority",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        return root
+
+    @staticmethod
+    def _secret_ref(profile: Any, role: str) -> Any:
+        refs = profile.secret_refs if isinstance(profile.secret_refs, Mapping) else {}
+        value = refs.get(role)
+        if value is None:
+            raise HarnessPlatformError(
+                f"Provider Profile {profile.profile_id} has no {role} SecretRef",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZER_UNAVAILABLE,
+            )
+        return value
+
+    async def materialize(
+        self,
+        *,
+        profile: Any,
+        binding: dict[str, Any],
+        provider_lease_ref: str,
+        credential_generation: int,
+        execution_plan_ref: str,
+        command_authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        materializer_ref = str(binding.get("materializerRef") or "").strip()
+        identity_digest = _digest(
+            execution_plan_ref,
+            profile.profile_id,
+            provider_lease_ref,
+            credential_generation,
+            materializer_ref,
+        )
+        credential_runtime_ref = f"credential-runtime:sha256:{identity_digest}"
+        root = self._credential_root(credential_runtime_ref)
+
+        if materializer_ref != "opencode-auth-json@1":
+            raise HarnessPlatformError(
+                f"trusted materializer implementation {materializer_ref} is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZER_UNAVAILABLE,
+            )
+        api_key = await resolve_managed_api_key_reference(
+            self._secret_ref(profile, "api_key"),
+            field_name=f"Provider Profile {profile.profile_id} api_key SecretRef",
+        )
+        handle = await asyncio.to_thread(
+            materialize_opencode_auth_json,
+            api_key=api_key,
+            provider_profile_ref=profile.profile_id,
+            provider_lease_ref=provider_lease_ref,
+            credential_generation=credential_generation,
+            expected_generation=credential_generation,
+            host_root=root,
+        )
+        handle["credentialRuntimeRef"] = credential_runtime_ref
+        handle["cleanupRef"] = f"credential-cleanup:sha256:{identity_digest}"
+        handle["attestationRef"] = _artifact_ref(
+            {
+                "credentialRuntimeRef": credential_runtime_ref,
+                "providerProfileRef": profile.profile_id,
+                "providerLeaseRef": provider_lease_ref,
+                "credentialGeneration": credential_generation,
+                "materializerRef": materializer_ref,
+                "commandId": command_authority.get("commandId"),
+            }
+        )
+
+        async with self._session_factory() as session:
+            existing = await session.get(
+                OmnigentCredentialRuntimeRecord, credential_runtime_ref
+            )
+            values = {
+                "provider_profile_ref": profile.profile_id,
+                "provider_lease_ref": provider_lease_ref,
+                "credential_generation": credential_generation,
+                "materializer_ref": materializer_ref,
+                "target_path": str(handle["targetPath"]),
+                "access_mode": str(handle["accessMode"]),
+                "cleanup_ref": str(handle["cleanupRef"]),
+                "attestation_ref": str(handle["attestationRef"]),
+            }
+            if existing is None:
+                session.add(
+                    OmnigentCredentialRuntimeRecord(
+                        credential_runtime_ref=credential_runtime_ref, **values
+                    )
+                )
+            elif any(getattr(existing, key) != value for key, value in values.items()):
+                raise HarnessPlatformError(
+                    "credential runtime ref conflicts with persisted authority",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            await session.commit()
+        return handle
+
+    def mount_source(self, handle: Mapping[str, Any]) -> tuple[Path, PurePosixPath]:
+        root = self._credential_root(str(handle.get("credentialRuntimeRef") or ""))
+        target = PurePosixPath(str(handle.get("targetPath") or ""))
+        if not target.is_absolute() or ".." in target.parts:
+            raise HarnessPlatformError(
+                "credential target path is unsafe",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        source = root.joinpath(*target.parts[1:]).resolve()
+        if not source.is_relative_to(root) or not source.is_file():
+            raise HarnessPlatformError(
+                "credential runtime file is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        return source, target
+
+    async def cleanup(
+        self,
+        handles: Sequence[Mapping[str, Any]],
+        *,
+        command_authority: Mapping[str, Any],
+    ) -> None:
+        if not command_authority.get("commandId"):
+            raise HarnessPlatformError(
+                "credential cleanup lacks canonical command authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        for handle in reversed(tuple(handles)):
+            materializer_ref = str(handle.get("materializerRef") or "")
+            if materializer_ref != "opencode-auth-json@1":
+                raise HarnessPlatformError(
+                    f"credential cleanup implementation {materializer_ref} is unavailable",
+                    code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                )
+            root = self._credential_root(
+                str(handle.get("credentialRuntimeRef") or "")
+            )
+            await asyncio.to_thread(
+                cleanup_opencode_auth,
+                host_root=root,
+                provider_profile_ref=str(handle.get("providerProfileRef") or ""),
+                credential_generation=int(handle.get("credentialGeneration") or 0),
+            )
+            try:
+                root.rmdir()
+            except OSError:
+                # The materializer removes only owned credential state. A
+                # non-empty root is retained for janitor inspection.
+                pass
+
+
+class DeploymentGenericHostServices:
+    """Concrete implementation of every generic host runtime capability."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Any,
+        artifact_gateway: Any,
+        credential_materializer: TrustedCredentialMaterializer,
+        runtime_root: Path | None = None,
+        client: OmnigentHttpClient | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._artifact_gateway = artifact_gateway
+        self._credential_materializer = credential_materializer
+        self._workspace_root = Path(
+            os.getenv("WORKFLOW_WORKSPACE_ROOT", "/work/agent_jobs")
+        ).expanduser().resolve()
+        self._runtime_root = (runtime_root or _runtime_root()).resolve()
+        self._client = client or OmnigentHttpClient(
+            base_url=resolved_server_url(), api_token=resolved_api_token()
+        )
+        self._states: dict[str, _DeploymentState] = {}
+
+    @staticmethod
+    def _state_key(authority: Mapping[str, Any]) -> str:
+        key = str(authority.get("runtimeBindingRef") or "").strip()
+        if not key.startswith("omnigent-runtime-binding:sha256:"):
+            raise HarnessPlatformError(
+                "deployment service lacks fenced runtime binding authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        return key
+
+    def _state(self, authority: Mapping[str, Any]) -> _DeploymentState:
+        return self._states.setdefault(self._state_key(authority), _DeploymentState())
+
+    async def prepare_realization(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        authority: Mapping[str, Any],
+    ) -> None:
+        state = self._state(authority)
+        if state.plan is not None and state.plan.planRef != plan.planRef:
+            raise HarnessPlatformError(
+                "runtime binding attempted to replace its immutable execution plan",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        state.request = request
+        state.plan = plan
+
+    async def _write_evidence(
+        self, state: _DeploymentState, *, name: str, payload: Mapping[str, Any]
+    ) -> str:
+        if state.request is None:
+            raise HarnessPlatformError(
+                "deployment evidence lacks its execution request authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        return await self._artifact_gateway.write_json(
+            request=state.request,
+            name=name,
+            payload=dict(payload),
+            link_type="omnigent.generic_host.evidence",
+        )
+
+    async def materialize(
+        self,
+        value: AgentExecutionRequest | dict[str, Any],
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        # This object implements both workspace and Skill protocols. The value
+        # type selects the capability without provider or harness identity.
+        if isinstance(value, AgentExecutionRequest):
+            return await self._materialize_workspace(value, authority=authority)
+        return await self._materialize_skills(value, authority=authority)
+
+    async def _materialize_workspace(
+        self, request: AgentExecutionRequest, *, authority: dict[str, Any]
+    ) -> dict[str, Any]:
+        raw_locator = (request.workspace_spec or {}).get("workspaceLocator")
+        if not isinstance(raw_locator, Mapping):
+            raise HarnessPlatformError(
+                "generic host requires an authorized sandbox workspace locator",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+        locator = SandboxWorkspaceLocator.model_validate(raw_locator)
+        workflow_id = (
+            request.step_execution.workflow_id
+            if request.step_execution is not None
+            else request.correlation_id
+        )
+        step_execution_id = (
+            request.step_execution.step_execution_id
+            if request.step_execution is not None
+            else request.idempotency_key
+        )
+        expected_id = hashlib.sha256(
+            f"{workflow_id}:{step_execution_id}".encode("utf-8")
+        ).hexdigest()[:24]
+        owner_record = SandboxWorkspaceRecordStore(self._workspace_root).load(expected_id)
+        if owner_record is None:
+            raise HarnessPlatformError(
+                "generic host workspace owner record is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+        workspace = resolve_sandbox_workspace_locator(
+            locator,
+            workspace_root=self._workspace_root,
+            expected_workspace_id=expected_id,
+            owner_record=owner_record,
+            expected_workflow_id=workflow_id,
+            expected_step_execution_id=step_execution_id,
+        )
+        evidence = {
+            "workspaceLocator": locator.model_dump(by_alias=True, mode="json"),
+            "workflowId": workflow_id,
+            "stepExecutionId": step_execution_id,
+            "executionPlanRef": authority["executionPlanRef"],
+        }
+        state = self._state(authority)
+        state.workspace_path = workspace
+        evidence_ref = await self._write_evidence(
+            state, name="generic-host.workspace-resolution.json", payload=evidence
+        )
+        return {
+            "path": str(workspace),
+            "resolutionRef": evidence_ref,
+            "workspaceLocator": evidence["workspaceLocator"],
+        }
+
+    async def _materialize_skills(
+        self, resolved_skills: dict[str, Any], *, authority: dict[str, Any]
+    ) -> dict[str, Any]:
+        state = self._state(authority)
+        delivery_ref = str(resolved_skills.get("skillDeliveryRef") or "").strip()
+        digest = str(resolved_skills.get("resolvedSkillSetDigest") or "").strip()
+        resolved_ref = str(resolved_skills.get("resolvedSkillSetRef") or "").strip()
+        if not delivery_ref or not digest:
+            raise HarnessPlatformError(
+                "resolved Skill delivery authority is incomplete",
+                code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
+            )
+
+        projection = (self._runtime_root / "skills" / _digest(delivery_ref)).resolve()
+        if not projection.is_relative_to(self._runtime_root):
+            raise HarnessPlatformError(
+                "Skill projection escapes runtime authority",
+                code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
+            )
+        if resolved_ref:
+            if state.request is None or state.request.resolved_skillset_ref != resolved_ref:
+                raise HarnessPlatformError(
+                    "request Skill snapshot differs from the admitted plan",
+                    code=HarnessPlatformFailure.OMNIGENT_SKILL_DELIVERY_MISMATCH,
+                )
+            active = Path(os.getenv("MOONMIND_ACTIVE_SKILLS_DIR", "")).resolve()
+            if not active.is_dir() or not (active / "_manifest.json").is_file():
+                raise HarnessPlatformError(
+                    "resolved active Skill snapshot is unavailable to the host owner",
+                    code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
+                )
+            projection = active
+        else:
+            projection.mkdir(parents=True, exist_ok=True)
+            manifest = projection / "_manifest.json"
+            payload = {
+                "schemaVersion": "moonmind.active-skill-set.v1",
+                "skills": [],
+                "resolvedSkillSetDigest": digest,
+                "skillDeliveryRef": delivery_ref,
+            }
+            encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+            if manifest.exists() and manifest.read_text(encoding="utf-8") != encoded:
+                raise HarnessPlatformError(
+                    "existing empty Skill projection conflicts with the plan",
+                    code=HarnessPlatformFailure.OMNIGENT_SKILL_DELIVERY_MISMATCH,
+                )
+            manifest.write_text(encoded, encoding="utf-8")
+        evidence = {
+            "deliveryRef": delivery_ref,
+            "resolvedSkillSetDigest": digest,
+            "resolvedSkillSetRef": resolved_ref or None,
+            "manifestPresent": True,
+        }
+        attestation_ref = await self._write_evidence(
+            state, name="generic-host.skill-delivery.json", payload=evidence
+        )
+        state.skill_path = projection
+        state.skill_delivery_ref = delivery_ref
+        state.skill_attestation_ref = attestation_ref
+        return {
+            "path": str(projection),
+            "deliveryRef": delivery_ref,
+            "digest": digest,
+            "attestationRef": attestation_ref,
+        }
+
+    def _prepare_scripts(self) -> Path:
+        source = Path(__file__).resolve().parents[3] / "services" / "omnigent" / "scripts"
+        target = (self._runtime_root / "scripts").resolve()
+        target.mkdir(parents=True, exist_ok=True)
+        for name in _SCRIPTS:
+            source_file = source / name
+            target_file = target / name
+            if not source_file.is_file() or source_file.is_symlink():
+                raise HarnessPlatformError(
+                    f"generic host runtime script {name} is unavailable",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+                )
+            payload = source_file.read_bytes()
+            if target_file.exists() and target_file.read_bytes() != payload:
+                target_file.unlink()
+            if not target_file.exists():
+                target_file.write_bytes(payload)
+            target_file.chmod(0o555)
+        return target
+
+    async def launch(
+        self,
+        *,
+        host_class: HostClass,
+        launch_policy: LaunchPolicy,
+        workspace_handle: Any,
+        skill_handle: Any,
+        credential_handles: list[dict[str, Any]],
+        authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        state = self._state(authority)
+        if state.plan is None or state.request is None:
+            raise HarnessPlatformError(
+                "generic host launch was not prepared with immutable plan authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        binding_digest = _digest(
+            authority["runtimeBindingRef"], host_class.ref, launch_policy.ref
+        )
+        binding_ref = f"omnigent-host-binding:sha256:{binding_digest}"
+        lease_ref = f"omnigent-host-lease:sha256:{binding_digest}"
+        container_name = "moonmind-omnigent-" + binding_digest[:24]
+        generation = 1
+
+        provider_refs = sorted(
+            {
+                str(binding.get("providerProfileRef") or "")
+                for binding in state.plan.payload.credentialBindings.values()
+                if binding.get("providerProfileRef")
+            }
+        )
+        async with self._session_factory() as session:
+            existing_binding = await session.get(
+                OmnigentHostBindingRecordV2, binding_ref
+            )
+            binding_values = {
+                "host_class_ref": host_class.ref,
+                "launch_policy_ref": launch_policy.ref,
+                "harness_id": state.plan.payload.harnessId,
+                "harness_implementation_ref": (
+                    state.plan.payload.harnessImplementationRef
+                ),
+                "execution_plan_ref": state.plan.planRef,
+                "provider_profile_refs_json": provider_refs,
+            }
+            if existing_binding is None:
+                session.add(
+                    OmnigentHostBindingRecordV2(
+                        binding_id=binding_ref, **binding_values
+                    )
+                )
+            elif any(
+                getattr(existing_binding, key) != value
+                for key, value in binding_values.items()
+            ):
+                raise HarnessPlatformError(
+                    "host binding ref conflicts with persisted authority",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            lease = await session.get(OmnigentHostLeaseRecordV2, lease_ref)
+            if lease is None:
+                lease = OmnigentHostLeaseRecordV2(
+                    lease_id=lease_ref,
+                    binding_id=binding_ref,
+                    host_class_ref=host_class.ref,
+                    generation=generation,
+                    status="allocating",
+                    host_lease_generation=generation,
+                )
+                session.add(lease)
+            elif (
+                lease.binding_id != binding_ref
+                or lease.host_class_ref != host_class.ref
+                or lease.host_lease_generation != generation
+            ):
+                raise HarnessPlatformError(
+                    "host lease ref conflicts with persisted fencing authority",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            await session.commit()
+
+        async def docker_runner(argv: Sequence[str]) -> tuple[int, bytes, bytes]:
+            return await _run_docker(argv)
+
+        egress_attestation = await attest_docker_egress(
+            runner=docker_runner,
+            profile=OMNIGENT_EGRESS_PROFILE,
+            backend_ref="docker-cli/trusted-worker",
+        )
+        code, stdout, stderr = await _run_docker(
+            (
+                "inspect",
+                "--format",
+                '{{index .Config.Labels "moonmind.host_lease_id"}}',
+                container_name,
+            )
+        )
+        if code == 0:
+            if stdout.decode(errors="replace").strip() != lease_ref:
+                raise HarnessPlatformError(
+                    "deterministic host name is owned by another lease",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+        else:
+            if not _docker_object_missing(stderr):
+                raise HarnessPlatformError(
+                    "generic host ownership could not be inspected",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+                )
+            workspace_source = daemon_visible_workspace_path(
+                Path(str(workspace_handle["path"]))
+            )
+            skill_source = daemon_visible_workspace_path(
+                Path(str(skill_handle["path"]))
+            )
+            scripts = daemon_visible_workspace_path(self._prepare_scripts())
+            runtime = dict(host_class.runtime)
+            uid = int(runtime.get("uid", 1000))
+            gid = int(runtime.get("gid", 1000))
+            home = str(runtime.get("home") or "/home/app")
+            startup_script = _safe_segment(
+                str(runtime.get("startupScript") or "start-host-with-projections.sh")
+            )
+            generation_env = str(runtime.get("credentialGenerationEnv") or "").strip()
+            args: list[str] = [
+                "run",
+                "-d",
+                "--name",
+                container_name,
+                "--hostname",
+                container_name,
+                "--user",
+                f"{uid}:{gid}",
+                "--workdir",
+                home,
+                "--network",
+                OMNIGENT_EGRESS_PROFILE.network_ref,
+                *structured_container_security_args(),
+                "--cpus",
+                str(launch_policy.limits["cpuMillis"] / 1000),
+                "--memory",
+                f"{launch_policy.limits['memoryMiB']}m",
+                "--pids-limit",
+                str(launch_policy.limits["processes"]),
+                "--read-only",
+                "--tmpfs",
+                "/tmp:rw,noexec,nosuid,size="
+                f"{launch_policy.limits['temporaryStorageMiB']}m",
+                "--tmpfs",
+                f"{home}/.omnigent:rw,noexec,nosuid,size=32m,uid={uid},gid={gid}",
+                "--tmpfs",
+                f"{home}/.cache:rw,noexec,nosuid,size=128m,uid={uid},gid={gid}",
+                "--mount",
+                f"type=bind,src={workspace_source},dst=/workspaces/run",
+                "--mount",
+                f"type=bind,src={skill_source},dst=/opt/moonmind-skills,readonly",
+                "--mount",
+                f"type=bind,src={scripts},dst=/opt/moonmind,readonly",
+                "--label",
+                "moonmind.kind=omnigent-generic-host",
+                "--label",
+                f"moonmind.host_binding_id={binding_ref}",
+                "--label",
+                f"moonmind.host_lease_id={lease_ref}",
+                "--label",
+                f"moonmind.execution_plan_ref={state.plan.planRef}",
+                "--label",
+                f"moonmind.runtime_binding_ref={authority['runtimeBindingRef']}",
+                "--label",
+                f"moonmind.host_lease_generation={generation}",
+                "--env",
+                f"HOME={home}",
+                "--env",
+                f"OMNIGENT_SERVER_URL={resolved_server_url()}",
+                "--env",
+                "MOONMIND_ACTIVE_SKILLS_DIR=/opt/moonmind-skills",
+                "--env",
+                f"MOONMIND_STEP_EXECUTION_ID={state.request.idempotency_key}",
+            ]
+            for item in omnigent_proxy_env():
+                args.extend(("--env", item))
+            generations = {
+                int(handle.get("credentialGeneration") or 0)
+                for handle in credential_handles
+            }
+            if generation_env:
+                if len(generations) != 1 or min(generations) < 1:
+                    raise HarnessPlatformError(
+                        "host credential generation authority is ambiguous",
+                        code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_GENERATION_FENCED,
+                    )
+                args.extend(("--env", f"{generation_env}={next(iter(generations))}"))
+            for handle in credential_handles:
+                source, target = self._credential_materializer.mount_source(handle)
+                source = daemon_visible_workspace_path(source)
+                args.extend(
+                    (
+                        "--mount",
+                        f"type=bind,src={source},dst={target},readonly",
+                    )
+                )
+            child_env = dict(os.environ)
+            if resolved_api_token():
+                child_env["OMNIGENT_API_TOKEN"] = resolved_api_token()
+                args.extend(("--env", "OMNIGENT_API_TOKEN"))
+            args.extend(
+                (
+                    "--entrypoint",
+                    f"/opt/moonmind/{startup_script}",
+                    host_class.imageRef,
+                )
+            )
+            code, _, _ = await _run_docker(args, env=child_env)
+            if code:
+                raise HarnessPlatformError(
+                    "digest-pinned generic Omnigent host launch failed",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+                )
+
+        async with self._session_factory() as session:
+            lease = await session.get(OmnigentHostLeaseRecordV2, lease_ref)
+            if lease is None:
+                raise HarnessPlatformError(
+                    "persisted host lease disappeared after launch",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            lease.status = "registering"
+            await session.commit()
+
+        state.host_binding_ref = binding_ref
+        state.host_lease_ref = lease_ref
+        state.host_lease_generation = generation
+        state.container_name = container_name
+        state.egress_attestation = egress_attestation
+        state.launched_at = datetime.now(UTC)
+        return {
+            "hostId": None,
+            "expectedHostName": container_name,
+            "hostBindingRef": binding_ref,
+            "hostLeaseRef": lease_ref,
+            "hostLeaseGeneration": generation,
+        }
+
+    @staticmethod
+    def _host_id(host: Mapping[str, Any]) -> str:
+        return str(host.get("id") or host.get("hostId") or host.get("host_id") or "")
+
+    @staticmethod
+    def _host_name(host: Mapping[str, Any]) -> str:
+        return str(host.get("name") or host.get("hostname") or "")
+
+    async def wait_for_registration(
+        self,
+        *,
+        expected_host_id: str | None = None,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        state = self._state(authority)
+        if state.plan is None or not state.container_name or not state.host_lease_ref:
+            raise HarnessPlatformError(
+                "host registration lacks persisted launch authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        exact: dict[str, Any] | None = None
+        for attempt in range(_REGISTRATION_ATTEMPTS):
+            hosts = await self._client.list_hosts()
+            matches = [
+                host
+                for host in hosts
+                if (
+                    self._host_id(host) == expected_host_id
+                    if expected_host_id
+                    else self._host_name(host) == state.container_name
+                )
+                and str(host.get("status") or "online").lower() == "online"
+            ]
+            if len(matches) == 1:
+                exact = dict(matches[0])
+                break
+            if len(matches) > 1:
+                raise HarnessPlatformError(
+                    "host registration selector is ambiguous",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            if attempt + 1 < _REGISTRATION_ATTEMPTS:
+                await asyncio.sleep(_REGISTRATION_INTERVAL_SECONDS)
+        if exact is None:
+            raise HarnessPlatformError(
+                "exact generic host did not register within the bounded window",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+        host_id = self._host_id(exact)
+        metadata = exact.get("metadata") if isinstance(exact.get("metadata"), Mapping) else {}
+        attestation = (
+            exact.get("attestation")
+            or exact.get("harnessAttestation")
+            or metadata.get("attestation")
+            or metadata.get("harnessAttestation")
+        )
+        if not host_id or not isinstance(attestation, Mapping):
+            raise HarnessPlatformError(
+                "exact host registration omitted identity or harness attestation",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
+            )
+
+        model_response = await self._client.get_host_model_options(host_id)
+        raw_options = (
+            model_response.get("models")
+            or model_response.get("options")
+            or model_response.get("data")
+            or []
+        )
+        if not isinstance(raw_options, list):
+            raw_options = []
+        planned_model = state.plan.payload.modelConfig.qualifiedId
+        model_ids = {
+            str(item.get("qualifiedId") or item.get("modelId") or item.get("id") or "")
+            for item in raw_options
+            if isinstance(item, Mapping)
+        }
+        available = planned_model is not None and planned_model in model_ids
+        model_evidence = {
+            "hostId": host_id,
+            "modelId": planned_model,
+            "available": available,
+            "observedModelIds": sorted(item for item in model_ids if item),
+            "executionPlanRef": state.plan.planRef,
+        }
+        model_evidence["attestationRef"] = await self._write_evidence(
+            state,
+            name="generic-host.model-options.json",
+            payload=model_evidence,
+        )
+        capability_evidence = {
+            "hostId": host_id,
+            "required": list(state.plan.payload.classAdmissionDecision.get("required") or []),
+            "observedCapabilities": dict(attestation.get("capabilities") or {}),
+        }
+        capability_ref = await self._write_evidence(
+            state,
+            name="generic-host.capability-decision.json",
+            payload=capability_evidence,
+        )
+        async with self._session_factory() as session:
+            lease = await session.get(
+                OmnigentHostLeaseRecordV2, state.host_lease_ref
+            )
+            if lease is None or lease.host_lease_generation != state.host_lease_generation:
+                raise HarnessPlatformError(
+                    "host lease generation changed before registration",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            lease.omnigent_host_id = host_id
+            lease.status = "running"
+            await session.commit()
+        state.omnigent_host_id = host_id
+        state.evidence["capability"] = capability_ref
+        state.evidence["model"] = str(model_evidence["attestationRef"])
+        return {
+            "hostId": host_id,
+            "attestation": dict(attestation),
+            "exactHostCapabilityDecisionRef": capability_ref,
+            "modelOptionAttestation": model_evidence,
+        }
+
+    async def attest(
+        self,
+        value: str | LaunchPolicy,
+        expected_image_ref: str | None = None,
+        *,
+        authority: dict[str, Any],
+    ) -> dict[str, Any]:
+        # This object implements image and egress attestors. Their protocol
+        # argument shapes are disjoint and contain no provider identity.
+        if isinstance(value, LaunchPolicy):
+            return await self._attest_egress(value, authority=authority)
+        return await self._attest_image(
+            value, str(expected_image_ref or ""), authority=authority
+        )
+
+    async def _attest_image(
+        self, host_id: str, expected_image_ref: str, *, authority: dict[str, Any]
+    ) -> dict[str, Any]:
+        state = self._state(authority)
+        if state.omnigent_host_id != host_id or not state.container_name:
+            raise HarnessPlatformError(
+                "image attestation host differs from registered authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        code, stdout, _ = await _run_docker(
+            (
+                "inspect",
+                "--format",
+                '{{json .Config.Image}}',
+                state.container_name,
+            )
+        )
+        try:
+            observed_ref = json.loads(stdout.decode("utf-8")) if code == 0 else ""
+        except json.JSONDecodeError:
+            observed_ref = ""
+        if observed_ref != expected_image_ref:
+            raise HarnessPlatformError(
+                "running host image differs from the digest-pinned Host Class",
+                code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
+            )
+        evidence = {
+            "hostId": host_id,
+            "containerName": state.container_name,
+            "observedImageRef": observed_ref,
+            "hostLeaseRef": state.host_lease_ref,
+            "hostLeaseGeneration": state.host_lease_generation,
+        }
+        evidence["attestationRef"] = await self._write_evidence(
+            state, name="generic-host.image-attestation.json", payload=evidence
+        )
+        return evidence
+
+    async def _attest_egress(
+        self, launch_policy: LaunchPolicy, *, authority: dict[str, Any]
+    ) -> dict[str, Any]:
+        state = self._state(authority)
+        support_identity = (
+            state.plan.payload.supportIdentity if state.plan is not None else None
+        )
+        if (
+            state.egress_attestation is None
+            or not state.container_name
+            or support_identity is None
+            or launch_policy.network.get("egressPolicyRef")
+            != "omnigent-restricted-egress@1"
+        ):
+            raise HarnessPlatformError(
+                "generic host egress authority is unavailable or incompatible",
+                code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+            )
+
+        async def docker_runner(argv: Sequence[str]) -> tuple[int, bytes, bytes]:
+            return await _run_docker(argv)
+
+        observed = await attest_docker_workload_egress(
+            runner=docker_runner,
+            profile=OMNIGENT_EGRESS_PROFILE,
+            attestation=state.egress_attestation,
+            attachment_identity=state.container_name,
+            expected_image_ref=support_identity.omnigentHostBuildRef,
+            started_at=state.launched_at,
+            finished_at=datetime.now(UTC),
+        )
+        evidence = {**observed, "enforced": True}
+        evidence["attestationRef"] = await self._write_evidence(
+            state, name="generic-host.egress-attestation.json", payload=evidence
+        )
+        return evidence
+
+    async def cleanup(
+        self,
+        *,
+        plan_ref: str,
+        runtime_binding_ref: str | None,
+        host_id: str | None,
+        authority: dict[str, Any],
+    ) -> None:
+        state = self._state(authority)
+        if state.plan is not None and state.plan.planRef != plan_ref:
+            raise HarnessPlatformError(
+                "cleanup plan differs from persisted host authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        if not state.container_name or not state.host_lease_ref:
+            return
+        code, stdout, stderr = await _run_docker(
+            (
+                "inspect",
+                "--format",
+                '{{index .Config.Labels "moonmind.host_lease_id"}}',
+                state.container_name,
+            )
+        )
+        if code == 0:
+            if stdout.decode(errors="replace").strip() != state.host_lease_ref:
+                raise HarnessPlatformError(
+                    "cleanup refused a container owned by another host lease",
+                    code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                )
+            remove_code, _, _ = await _run_docker(("rm", "-f", state.container_name))
+            if remove_code:
+                raise HarnessPlatformError(
+                    "generic host cleanup remains pending",
+                    code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                )
+        elif not _docker_object_missing(stderr):
+            raise HarnessPlatformError(
+                "generic host cleanup could not inspect its owned container",
+                code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+            )
+        async with self._session_factory() as session:
+            lease = await session.get(
+                OmnigentHostLeaseRecordV2, state.host_lease_ref
+            )
+            if lease is not None:
+                if lease.host_lease_generation != state.host_lease_generation:
+                    raise HarnessPlatformError(
+                        "cleanup host lease generation is stale",
+                        code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+                    )
+                lease.status = "cleaned"
+                await session.commit()
+
+
+__all__ = [
+    "DeploymentGenericHostServices",
+    "TrustedCredentialMaterializer",
+]

--- a/moonmind/omnigent/realizers/deployment_adapters.py
+++ b/moonmind/omnigent/realizers/deployment_adapters.py
@@ -19,8 +19,10 @@ from typing import Any, Mapping, Sequence
 
 from api_service.db.models import (
     OmnigentCredentialRuntimeRecord,
+    OmnigentExecutionPlanRecord,
     OmnigentHostBindingRecordV2,
     OmnigentHostLeaseRecordV2,
+    OmnigentRuntimeBindingRecord,
 )
 from moonmind.omnigent.harness_platform.execution_plan import (
     OmnigentExecutionPlanEnvelope,
@@ -661,6 +663,8 @@ class DeploymentGenericHostServices:
             args: list[str] = [
                 "run",
                 "-d",
+                "--platform",
+                state.plan.payload.supportIdentity.architecture,
                 "--name",
                 container_name,
                 "--hostname",
@@ -998,6 +1002,33 @@ class DeploymentGenericHostServices:
         authority: dict[str, Any],
     ) -> None:
         state = self._state(authority)
+        if runtime_binding_ref and not state.container_name:
+            async with self._session_factory() as session:
+                binding = await session.get(
+                    OmnigentRuntimeBindingRecord, runtime_binding_ref
+                )
+                if binding is not None and binding.host_binding_ref:
+                    state.host_binding_ref = binding.host_binding_ref
+                    state.host_lease_ref = binding.host_lease_ref
+                    state.host_lease_generation = binding.host_lease_generation
+                    binding_digest = str(binding.host_binding_ref).rsplit(
+                        "sha256:", 1
+                    )[-1]
+                    state.container_name = (
+                        "moonmind-omnigent-" + binding_digest[:24]
+                    )
+                    if state.plan is None:
+                        plan_record = await session.get(
+                            OmnigentExecutionPlanRecord, binding.execution_plan_ref
+                        )
+                        if plan_record is not None:
+                            state.plan = OmnigentExecutionPlanEnvelope.model_validate(
+                                {
+                                    "schemaVersion": plan_record.schema_version,
+                                    "planRef": plan_record.plan_ref,
+                                    "payload": plan_record.payload_json,
+                                }
+                            )
         if state.plan is not None and state.plan.planRef != plan_ref:
             raise HarnessPlatformError(
                 "cleanup plan differs from persisted host authority",

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -1,34 +1,46 @@
-"""Generic Omnigent host realizer: `generic-omnigent-host@1`.
+"""Harness-neutral production realizer for ``generic-omnigent-host@1``.
 
-Owns only the work necessary to produce an attested Omnigent host:
-
-Resolve Host Class, launch policy, workspace, Skills, credential runtime
-state, build secret-free HostLaunchSpec, start/attach host, verify exact
-host and harness, verify model availability, persist runtime binding,
-delegate session execution to existing generic Omnigent driver.
-
-It does NOT understand how OpenCode sends messages or how Qwen streams.
-Omnigent owns those details.
-
-After realization, it uses the existing generic session driver:
-  run_omnigent_execution() + OmnigentHttpClient (sessions, events, streams,
-  files, diffs, interruption, termination)
-
-This realizer is harness-neutral: no `if harness == "opencode"` branches.
-Harness-specific behavior is data: catalog records, Host Classes,
-materializers, Agent Profiles, conformance evidence.
+The realizer consumes an already-persisted execution plan. It coordinates
+injected provider/credential, host, runtime-binding and session-driver
+boundaries without interpreting a harness id.
 """
 
 from __future__ import annotations
 
-import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
 from typing import Any
 
-from moonmind.omnigent.harness_platform.execution_plan import OmnigentExecutionPlanEnvelope
-from moonmind.omnigent.harness_platform.failures import HarnessPlatformError, HarnessPlatformFailure
-from moonmind.omnigent.harness_platform.host_classes import get_host_class, get_launch_policy
-from moonmind.omnigent.harness_platform.materializers import materialize_credential
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+    execution_support_identity,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import (
+    get_host_class,
+    get_launch_policy,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GenericRealizerDependencies:
+    """Infrastructure supplied at the outer composition boundary."""
+
+    runtime_binding_store: Any
+    runtime_authority: Any
+    host_runtime: Any
+    turn_command_service: Any
+    execution_driver: Callable[
+        [AgentExecutionRequest], Awaitable[AgentRunResult]
+    ]
 
 
 class GenericOmnigentHostRealizer:
@@ -40,12 +52,22 @@ class GenericOmnigentHostRealizer:
         session_factory: Any | None = None,
         plan_store: Any | None = None,
         runtime_binding_store: Any | None = None,
+        runtime_authority: Any | None = None,
         host_runtime: Any | None = None,
+        execution_driver: Callable[[AgentExecutionRequest], Awaitable[AgentRunResult]]
+        | None = None,
+        turn_command_service: Any | None = None,
+        dependency_factory: Callable[[Any | None], GenericRealizerDependencies]
+        | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._plan_store = plan_store
         self._runtime_binding_store = runtime_binding_store
+        self._runtime_authority = runtime_authority
         self._host_runtime = host_runtime
+        self._execution_driver = execution_driver
+        self._turn_command_service = turn_command_service
+        self._dependency_factory = dependency_factory
 
     async def execute(
         self,
@@ -57,174 +79,398 @@ class GenericOmnigentHostRealizer:
                 f"plan realizer {plan.payload.executionRealizerRef} != {self.ref}",
                 code=HarnessPlatformFailure.OMNIGENT_EXECUTION_REALIZER_UNAVAILABLE,
             )
-
-        # Validate plan is generically realizable (no harness branches)
+        request_plan_ref = str(
+            (request.parameters or {}).get("executionPlanRef") or ""
+        ).strip()
+        if request_plan_ref != plan.planRef:
+            raise HarnessPlatformError(
+                "runtime request does not name the admitted execution plan",
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+            )
+        if self._plan_store is not None:
+            persisted = await self._plan_store.load(plan.planRef)
+            if persisted != plan:
+                raise HarnessPlatformError(
+                    "execution plan is unavailable or differs from durable authority",
+                    code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+                )
         return await self._execute_generic(request, plan)
+
+    def _production_dependencies(self) -> GenericRealizerDependencies:
+        composed = (
+            self._dependency_factory(self._session_factory)
+            if self._dependency_factory is not None
+            else None
+        )
+        values = GenericRealizerDependencies(
+            runtime_binding_store=self._runtime_binding_store
+            or (composed.runtime_binding_store if composed is not None else None),
+            runtime_authority=self._runtime_authority
+            or (composed.runtime_authority if composed is not None else None),
+            host_runtime=self._host_runtime
+            or (composed.host_runtime if composed is not None else None),
+            turn_command_service=self._turn_command_service
+            or (composed.turn_command_service if composed is not None else None),
+            execution_driver=self._execution_driver
+            or (composed.execution_driver if composed is not None else None),
+        )
+        missing = sorted(
+            name
+            for name, value in {
+                "runtime binding store": values.runtime_binding_store,
+                "runtime authority": values.runtime_authority,
+                "host runtime": values.host_runtime,
+                "turn command service": values.turn_command_service,
+                "execution driver": values.execution_driver,
+            }.items()
+            if value is None
+        )
+        if missing:
+            raise HarnessPlatformError(
+                "generic realizer is not composed: " + ", ".join(missing),
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_REALIZER_UNAVAILABLE,
+            )
+        return values
 
     async def _execute_generic(
         self,
         request: AgentExecutionRequest,
         plan: OmnigentExecutionPlanEnvelope,
     ) -> AgentRunResult:
-        # 1. Resolve immutable decisions from plan (no secret, no lease yet)
         host_class = get_host_class(plan.payload.hostClassRef)
         launch_policy = get_launch_policy(plan.payload.launchPolicyRef)
-
-        # 2. Verify class-level admission already computed in plan; do not recompute
-        # 3. Acquire Provider Profile leases deterministically (stub for now)
-        # In production, this goes via ProviderProfileLeaseClient keyed by
-        # capacityScopeRef, not harness runtime_id.
-
-        # 4. For now, delegate to existing generic session driver with prepared
-        # authorization block. Full host realization (workspace, skills,
-        # credential materialization, host launch, attestation) is owned by
-        # GenericOmnigentHostRuntime which uses shared services.
-
-        # Import lazily to avoid cycles
-        from moonmind.omnigent.generic_opencode_runtime import (
-            compile_opencode_execution_plan,  # noqa: F401 - demonstrates wiring
-        )
-        from moonmind.omnigent.execute import run_omnigent_execution
-        from api_service.db.base import async_session_maker
-        from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
-        from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
-
-        # If host_runtime supplied (tests), use it for host realization;
-        # otherwise, fall back to direct session driver (host is externally
-        # managed or test harness).
-
-        # Acquire provider leases and materialize credential handles (secret-free)
-        credential_handles: list[dict[str, Any]] = []
-        for slot, binding in plan.payload.credentialBindings.items():
-            handle = materialize_credential(
-                materializer_ref=binding.materializerRef,
-                provider_profile_ref=binding.providerProfileRef,
-                provider_lease_ref=f"provider-lease:{binding.providerProfileRef}:{slot}",
-                credential_generation=1,
-            )
-            credential_handles.append(handle)
-
-        if self._host_runtime is not None:
-            # Let host runtime materialize host and verify attestation
-            host_ctx = await self._host_runtime.realize(
-                request=request,
-                plan=plan,
-                host_class=host_class,
-                launch_policy=launch_policy,
-                credential_handles=credential_handles,
-            )
-            # host_ctx contains attested hostId, workspace, handles
-            # Build generic session payload
-            # Delegate to generic driver
-            session_factory = self._session_factory or async_session_maker
-            artifact_gateway = LocalOmnigentArtifactGateway()
-            run_store = OmnigentBridgeSessionStore(session_factory)
-            # Enrich request with host binding (request is copied)
-            enriched = self._bind_host_to_request(request, host_ctx)
-            return await run_omnigent_execution(
-                enriched,
-                artifact_gateway=artifact_gateway,
-                run_store=run_store,
-            )
-
-        # Fallback: direct driver (no host materialization in this stub)
-        # This path still validates that the realizer contains no per-harness
-        # execution branches – the harnessId is data, not a branch.
-        from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
-
-        # Use shared services for workspace/skills/egress/cleanup extraction
-        # (Phase 2). For now, GenericOmnigentHostRuntime is a thin wrapper
-        # that validates attestation via harness_platform.
-
-        # If no host_runtime injected, create one with default services
-        host_runtime = GenericOmnigentHostRuntime()
-        # In hermetic tests, host_runtime.realize may be mocked to attest
-        # without docker; we attempt but fall back to direct execution if no
-        # docker backend.
-        try:
-            host_ctx = await host_runtime.realize(
-                request=request,
-                plan=plan,
-                host_class=host_class,
-                launch_policy=launch_policy,
-                credential_handles=credential_handles,
-            )
-            enriched = self._bind_host_to_request(request, host_ctx)
-            session_factory = self._session_factory or async_session_maker
-            artifact_gateway = LocalOmnigentArtifactGateway()
-            run_store = OmnigentBridgeSessionStore(session_factory)
-            return await run_omnigent_execution(enriched, artifact_gateway=artifact_gateway, run_store=run_store)
-        except HarnessPlatformError:
-            raise
-        except Exception as exc:
-            # In test environments without docker, fall back to direct driver
-            # with a synthetic host ctx that still validates attestation logic
-            # but does not require container launch.
-            if os.getenv("PYTEST_CURRENT_TEST"):
-                # Hermetic: synthesize attestation and proceed to driver
-                from api_service.db.base import async_session_maker
-                from moonmind.omnigent.bridge_artifacts import LocalOmnigentArtifactGateway
-                from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
-
-                session_factory = self._session_factory or async_session_maker
-                artifact_gateway = LocalOmnigentArtifactGateway()
-                run_store = OmnigentBridgeSessionStore(session_factory)
-                # Synthesize minimal host ctx for harness-neutral execution
-                synthetic_ctx = {
-                    "hostId": f"host_synthetic_{plan.payload.harnessId}",
-                    "workspacePath": "/workspaces/run",
-                    "hostClassRef": plan.payload.hostClassRef,
-                    "launchPolicyRef": plan.payload.launchPolicyRef,
-                }
-                enriched = self._bind_host_to_request(request, synthetic_ctx)
-                return await run_omnigent_execution(enriched, artifact_gateway=artifact_gateway, run_store=run_store)
+        dependencies = self._production_dependencies()
+        binding_store = dependencies.runtime_binding_store
+        runtime_authority = dependencies.runtime_authority
+        host_runtime = dependencies.host_runtime
+        turn_commands = dependencies.turn_command_service
+        readiness = getattr(host_runtime, "assert_ready", None)
+        if not callable(readiness):
             raise HarnessPlatformError(
-                f"generic host realization failed: {exc}",
+                "generic host runtime lacks a pre-side-effect readiness boundary",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_HARNESS_NOT_READY,
-            ) from exc
+            )
+        readiness()
+        authority_readiness = getattr(runtime_authority, "assert_ready", None)
+        if callable(authority_readiness):
+            authority_readiness(plan)
+
+        from moonmind.omnigent.control_plane.turn_commands import (
+            CanonicalSessionBootstrap,
+        )
+
+        step = request.step_execution
+        workflow_id = step.workflow_id if step is not None else request.correlation_id
+        step_execution_id = (
+            step.step_execution_id if step is not None else request.idempotency_key
+        )
+        command_claim = await turn_commands.claim(
+            workflow_id=workflow_id,
+            provider_session_ref="",
+            chat_binding_id=None,
+            command_type="execute_admitted_plan",
+            idempotency_key=request.idempotency_key,
+            payload_digest=plan.planRef,
+            step_execution_id=step_execution_id,
+            bootstrap=CanonicalSessionBootstrap(
+                provider="omnigent",
+                step_execution_id=step_execution_id,
+                agent_run_id=request.correlation_id,
+                source_idempotency_key=request.idempotency_key,
+                execution_plan_ref=plan.planRef,
+            ),
+        )
+        if not command_claim.owns_delivery:
+            raise HarnessPlatformError(
+                "canonical turn command is already settled or owned elsewhere; "
+                "reconciliation is required before delivery",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+
+        command_authority = {
+            "commandId": command_claim.command_id,
+            "claimToken": command_claim.claim_token,
+            "sessionId": command_claim.session_id,
+            "turnAttemptId": command_claim.turn_attempt_id,
+            "expectedSessionRevision": (
+                command_claim.expected_session_revision
+            ),
+            "fencingGeneration": command_claim.fencing_generation,
+        }
+        acquired = None
+        host_realized = False
+        existing_host_authority = False
+        cleanup_deferred = False
+        binding = None
+        try:
+            acquired = await runtime_authority.acquire(
+                request=request,
+                plan=plan,
+                command_authority=command_authority,
+            )
+            handles_by_slot: dict[str, dict[str, Any]] = {}
+            for handle in acquired.credential_handles:
+                slot = str(handle.get("credentialSlot") or "").strip()
+                if not slot and len(acquired.provider_leases) == 1:
+                    slot = next(iter(acquired.provider_leases))
+                if not slot or slot not in acquired.provider_leases:
+                    raise HarnessPlatformError(
+                        "credential runtime handle lacks its admitted slot identity",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                        ),
+                    )
+                if slot in handles_by_slot:
+                    raise HarnessPlatformError(
+                        f"credential slot {slot} produced duplicate runtime handles",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                        ),
+                    )
+                handles_by_slot[slot] = dict(handle)
+            binding = await binding_store.create_initial(
+                execution_plan_ref=plan.planRef,
+                provider_leases=dict(acquired.provider_leases),
+                credential_handles=handles_by_slot,
+            )
+            await turn_commands.bind_runtime_authority(
+                session_id=command_claim.session_id,
+                execution_plan_ref=plan.planRef,
+                runtime_binding_ref=binding.runtimeBindingRef,
+            )
+            existing_host_authority = binding.hostBindingRef is not None
+            if existing_host_authority:
+                raise HarnessPlatformError(
+                    "an existing host binding requires reconciliation; refusing "
+                    "to launch a duplicate host",
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            host_context = await host_runtime.realize(
+                request=request,
+                plan=plan,
+                host_class=host_class,
+                launch_policy=launch_policy,
+                credential_handles=list(acquired.credential_handles),
+                runtime_binding_ref=binding.runtimeBindingRef,
+                command_authority=command_authority,
+            )
+            host_realized = True
+            required_host_fields = {
+                "hostBindingRef": host_context.get("hostBindingRef"),
+                "hostLeaseRef": host_context.get("hostLeaseRef"),
+                "hostLeaseGeneration": host_context.get("hostLeaseGeneration"),
+                "omnigentHostId": host_context.get("omnigentHostId")
+                or host_context.get("hostId"),
+            }
+            missing = sorted(
+                key for key, value in required_host_fields.items() if value in {None, ""}
+            )
+            if missing:
+                raise HarnessPlatformError(
+                    "host realization omitted exact runtime-binding authority: "
+                    + ", ".join(missing),
+                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                )
+            binding = await binding_store.update_with_host(
+                binding.runtimeBindingRef,
+                host_binding_ref=str(required_host_fields["hostBindingRef"]),
+                host_lease_ref=str(required_host_fields["hostLeaseRef"]),
+                host_lease_generation=int(
+                    required_host_fields["hostLeaseGeneration"]
+                ),
+                omnigent_host_id=str(required_host_fields["omnigentHostId"]),
+                host_harness_attestation_ref=host_context.get(
+                    "hostHarnessAttestationRef"
+                ),
+                exact_host_capability_decision_ref=host_context.get(
+                    "exactHostCapabilityDecisionRef"
+                ),
+                workspace_resolution_ref=host_context.get(
+                    "workspaceResolutionRef"
+                ),
+                model_option_attestation_ref=host_context.get(
+                    "modelOptionAttestationRef"
+                ),
+                skill_delivery_attestation_ref=host_context.get(
+                    "skillDeliveryAttestationRef"
+                ),
+            )
+            await turn_commands.bind_runtime_authority(
+                session_id=command_claim.session_id,
+                execution_plan_ref=plan.planRef,
+                runtime_binding_ref=binding.runtimeBindingRef,
+            )
+            enriched = self._bind_host_to_request(
+                request,
+                host_context,
+                runtime_binding_ref=binding.runtimeBindingRef,
+            )
+            result = await dependencies.execution_driver(enriched)
+            metadata = result.metadata if isinstance(result.metadata, dict) else {}
+            provider_session_id = str(
+                metadata.get("omnigentSessionId")
+                or metadata.get("providerSessionId")
+                or ""
+            ).strip()
+            if provider_session_id:
+                binding = await binding_store.update_with_session(
+                    binding.runtimeBindingRef,
+                    omnigent_session_id=provider_session_id,
+                )
+                await turn_commands.bind_runtime_authority(
+                    session_id=command_claim.session_id,
+                    execution_plan_ref=plan.planRef,
+                    runtime_binding_ref=binding.runtimeBindingRef,
+                )
+            checkpoint_capture = dict(metadata.get("omnigentCheckpointCapture") or {})
+            primary_lease = binding.providerLeases.get("primary-model")
+            if primary_lease is not None:
+                checkpoint_capture.update(
+                    {
+                        "providerProfileId": primary_lease.providerProfileRef,
+                        "credentialRef": (
+                            "credential://provider-profile/"
+                            f"{primary_lease.providerProfileRef}/generation/"
+                            f"{primary_lease.credentialGeneration}"
+                        ),
+                        "credentialGeneration": primary_lease.credentialGeneration,
+                        "providerLeaseRef": primary_lease.providerLeaseRef,
+                        "hostBindingRef": binding.hostBindingRef,
+                        "hostLeaseRef": binding.hostLeaseRef,
+                        "hostLeaseGeneration": binding.hostLeaseGeneration,
+                        "endpointRef": plan.payload.endpointRef,
+                        "omnigentHostId": binding.omnigentHostId,
+                        "omnigentSessionId": provider_session_id or None,
+                        "bridgeSessionId": metadata.get("bridgeSessionId"),
+                        "externalStateRef": metadata.get("externalStateRef"),
+                        "captureManifestRef": metadata.get("captureManifestRef"),
+                        "effectiveLaunchRef": binding.hostHarnessAttestationRef,
+                        "executionProfileRef": plan.payload.agentProfileSnapshotRef,
+                        "launchPolicyRef": plan.payload.launchPolicyRef,
+                        "executionPlanRef": plan.planRef,
+                        "runtimeBindingRef": binding.runtimeBindingRef,
+                        "idempotencyKey": request.idempotency_key,
+                    }
+                )
+            final_result = result.model_copy(
+                update={
+                    "metadata": {
+                        **metadata,
+                        "executionPlanRef": plan.planRef,
+                        "runtimeBindingRef": binding.runtimeBindingRef,
+                        "supportCombinationIdentity": execution_support_identity(
+                            plan
+                        ),
+                        **(
+                            {"omnigentCheckpointCapture": checkpoint_capture}
+                            if checkpoint_capture
+                            else {}
+                        ),
+                    }
+                }
+            )
+            from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+            await turn_commands.settle(
+                idempotency_key=request.idempotency_key,
+                outcome=ControlPlaneOutcome.APPLIED,
+                provider_receipt_id=provider_session_id or None,
+                result_ref=str(metadata.get("externalStateRef") or "") or None,
+            )
+            return final_result
+        except Exception as exc:
+            cleanup_deferred = (
+                str(getattr(exc, "code", ""))
+                == str(HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED)
+            )
+            from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
+
+            try:
+                await turn_commands.settle(
+                    idempotency_key=request.idempotency_key,
+                    outcome=ControlPlaneOutcome.DELIVERY_UNKNOWN,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to park generic Omnigent command as delivery unknown"
+                )
+            raise
+        finally:
+            # Reverse authority order: stop the credential consumer before
+            # releasing Provider Profile capacity. Cleanup is distinct durable
+            # evidence and cannot replace the primary execution outcome.
+            cleanup_complete = (
+                not host_realized
+                and not existing_host_authority
+                and not cleanup_deferred
+            )
+            if host_realized and hasattr(host_runtime, "cleanup"):
+                try:
+                    await host_runtime.cleanup(
+                        plan.planRef,
+                        binding.runtimeBindingRef if binding is not None else None,
+                        command_authority=command_authority,
+                    )
+                    cleanup_complete = True
+                except Exception:
+                    logger.exception("Generic Omnigent host cleanup remains pending")
+            if acquired is not None and cleanup_complete:
+                try:
+                    await runtime_authority.release(
+                        acquired,
+                        command_authority=command_authority,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Generic Omnigent provider authority release remains pending"
+                    )
+            elif acquired is not None:
+                logger.error(
+                    "Retaining Generic Omnigent provider authority until host cleanup completes"
+                )
 
     def _bind_host_to_request(
         self,
         request: AgentExecutionRequest,
-        host_ctx: dict[str, Any],
+        host_context: dict[str, Any],
+        *,
+        runtime_binding_ref: str,
     ) -> AgentExecutionRequest:
-        """Build secret-free authorization block for generic session driver."""
+        """Build the secret-free authorization block consumed by the driver."""
+
         parameters = dict(request.parameters or {})
         omnigent = dict(parameters.get("omnigent") or {})
         session = dict(omnigent.get("session") or {})
         session["hostType"] = "external"
-        session["hostId"] = host_ctx.get("hostId") or host_ctx.get("omnigentHostId") or "host_synthetic"
-        session["workspace"] = host_ctx.get("workspacePath") or "/workspaces/run"
+        session["hostId"] = str(
+            host_context.get("omnigentHostId") or host_context.get("hostId")
+        )
+        session["workspace"] = str(host_context.get("workspacePath"))
         omnigent["session"] = session
         omnigent["_moonmindProfileAuthorization"] = {
-            "hostClassRef": host_ctx.get("hostClassRef"),
-            "launchPolicyRef": host_ctx.get("launchPolicyRef"),
+            "hostClassRef": host_context.get("hostClassRef"),
+            "launchPolicyRef": host_context.get("launchPolicyRef"),
             "executionRealizerRef": self.ref,
         }
         parameters["omnigent"] = omnigent
+        parameters["runtimeBindingRef"] = runtime_binding_ref
         return request.model_copy(update={"parameters": parameters})
 
     async def reconcile(
         self,
         plan_ref: str,
         runtime_binding_ref: str | None,
+        *,
+        command_authority: dict[str, Any],
     ) -> None:
-        # Reverse authority order: host, credential, leases (leases last)
-        # 1. Remove on-demand host or release connected host
-        if self._host_runtime is not None and hasattr(self._host_runtime, "cleanup"):
-            try:
-                await self._host_runtime.cleanup(plan_ref, runtime_binding_ref)  # type: ignore[attr-defined]
-            except Exception:  # best-effort cleanup, ignore
-                pass
-        # 2. Clean up materialized credential state
-        try:
-            from moonmind.omnigent.harness_platform.materializers import cleanup_opencode_auth
+        """Delegate cleanup generically; materializer behavior stays registered."""
 
-            # Best-effort cleanup for opencode; other materializers have their own cleanup
-            cleanup_opencode_auth(host_root="/")
-        except Exception:  # best-effort cleanup, ignore
-            pass
-        # 3. Release Provider Profile leases last (capacityScopeRef, not harness runtime)
-        # In production, this goes via ProviderProfileLeaseClient.release()
-        # Here we ensure the call is not silently omitted.
-        return None
+        if self._host_runtime is not None and hasattr(self._host_runtime, "cleanup"):
+            await self._host_runtime.cleanup(
+                plan_ref,
+                runtime_binding_ref,
+                command_authority=command_authority,
+            )
+
+
+__all__ = ["GenericOmnigentHostRealizer", "GenericRealizerDependencies"]

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -204,6 +204,7 @@ class GenericOmnigentHostRealizer:
         binding = None
         host_authority_binding_ref: str | None = None
         try:
+            previous_binding = await binding_store.latest_for_plan(plan.planRef)
             acquired = await runtime_authority.acquire(
                 request=request,
                 plan=plan,
@@ -229,82 +230,110 @@ class GenericOmnigentHostRealizer:
                         ),
                     )
                 handles_by_slot[slot] = dict(handle)
-            binding = await binding_store.create_initial(
-                execution_plan_ref=plan.planRef,
-                provider_leases=dict(acquired.provider_leases),
-                credential_handles=handles_by_slot,
-            )
+            if previous_binding is not None and previous_binding.hostBindingRef:
+                expected_leases = {
+                    slot: lease.model_dump(by_alias=True, mode="json")
+                    for slot, lease in previous_binding.providerLeases.items()
+                }
+                if expected_leases != acquired.provider_leases:
+                    raise HarnessPlatformError(
+                        "persisted host authority differs from reacquired Provider "
+                        "Profile generations",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT
+                        ),
+                    )
+                binding = previous_binding
+                existing_host_authority = True
+            else:
+                binding = await binding_store.create_initial(
+                    execution_plan_ref=plan.planRef,
+                    provider_leases=dict(acquired.provider_leases),
+                    credential_handles=handles_by_slot,
+                )
             host_authority_binding_ref = binding.runtimeBindingRef
             await turn_commands.bind_runtime_authority(
                 session_id=command_claim.session_id,
                 execution_plan_ref=plan.planRef,
                 runtime_binding_ref=binding.runtimeBindingRef,
             )
-            existing_host_authority = binding.hostBindingRef is not None
             if existing_host_authority:
-                raise HarnessPlatformError(
-                    "an existing host binding requires reconciliation; refusing "
-                    "to launch a duplicate host",
-                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                host_context = {
+                    "hostId": binding.omnigentHostId,
+                    "omnigentHostId": binding.omnigentHostId,
+                    "hostBindingRef": binding.hostBindingRef,
+                    "hostLeaseRef": binding.hostLeaseRef,
+                    "hostLeaseGeneration": binding.hostLeaseGeneration,
+                    "hostClassRef": host_class.ref,
+                    "launchPolicyRef": launch_policy.ref,
+                    "workspacePath": "/workspaces/run",
+                }
+                host_realized = True
+            else:
+                host_context = await host_runtime.realize(
+                    request=request,
+                    plan=plan,
+                    host_class=host_class,
+                    launch_policy=launch_policy,
+                    credential_handles=list(acquired.credential_handles),
+                    runtime_binding_ref=binding.runtimeBindingRef,
+                    command_authority=command_authority,
                 )
-            host_context = await host_runtime.realize(
-                request=request,
-                plan=plan,
-                host_class=host_class,
-                launch_policy=launch_policy,
-                credential_handles=list(acquired.credential_handles),
-                runtime_binding_ref=binding.runtimeBindingRef,
-                command_authority=command_authority,
-            )
-            host_realized = True
-            required_host_fields = {
-                "hostBindingRef": host_context.get("hostBindingRef"),
-                "hostLeaseRef": host_context.get("hostLeaseRef"),
-                "hostLeaseGeneration": host_context.get("hostLeaseGeneration"),
-                "omnigentHostId": host_context.get("omnigentHostId")
-                or host_context.get("hostId"),
-            }
-            missing = sorted(
-                key for key, value in required_host_fields.items() if value in {None, ""}
-            )
-            if missing:
-                raise HarnessPlatformError(
-                    "host realization omitted exact runtime-binding authority: "
-                    + ", ".join(missing),
-                    code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                host_realized = True
+                required_host_fields = {
+                    "hostBindingRef": host_context.get("hostBindingRef"),
+                    "hostLeaseRef": host_context.get("hostLeaseRef"),
+                    "hostLeaseGeneration": host_context.get("hostLeaseGeneration"),
+                    "omnigentHostId": host_context.get("omnigentHostId")
+                    or host_context.get("hostId"),
+                }
+                missing = sorted(
+                    key
+                    for key, value in required_host_fields.items()
+                    if value in {None, ""}
                 )
-            binding = await binding_store.update_with_host(
-                binding.runtimeBindingRef,
-                host_binding_ref=str(required_host_fields["hostBindingRef"]),
-                host_lease_ref=str(required_host_fields["hostLeaseRef"]),
-                host_lease_generation=int(
-                    required_host_fields["hostLeaseGeneration"]
-                ),
-                omnigent_host_id=str(required_host_fields["omnigentHostId"]),
-                host_harness_attestation_ref=host_context.get(
-                    "hostHarnessAttestationRef"
-                ),
-                exact_host_capability_decision_ref=host_context.get(
-                    "exactHostCapabilityDecisionRef"
-                ),
-                workspace_resolution_ref=host_context.get(
-                    "workspaceResolutionRef"
-                ),
-                model_option_attestation_ref=host_context.get(
-                    "modelOptionAttestationRef"
-                ),
-                skill_delivery_attestation_ref=host_context.get(
-                    "skillDeliveryAttestationRef"
-                ),
-            )
-            await turn_commands.bind_runtime_authority(
-                session_id=command_claim.session_id,
-                execution_plan_ref=plan.planRef,
-                runtime_binding_ref=binding.runtimeBindingRef,
-            )
+                if missing:
+                    raise HarnessPlatformError(
+                        "host realization omitted exact runtime-binding authority: "
+                        + ", ".join(missing),
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT
+                        ),
+                    )
+                binding = await binding_store.update_with_host(
+                    binding.runtimeBindingRef,
+                    host_binding_ref=str(required_host_fields["hostBindingRef"]),
+                    host_lease_ref=str(required_host_fields["hostLeaseRef"]),
+                    host_lease_generation=int(
+                        required_host_fields["hostLeaseGeneration"]
+                    ),
+                    omnigent_host_id=str(required_host_fields["omnigentHostId"]),
+                    host_harness_attestation_ref=host_context.get(
+                        "hostHarnessAttestationRef"
+                    ),
+                    exact_host_capability_decision_ref=host_context.get(
+                        "exactHostCapabilityDecisionRef"
+                    ),
+                    workspace_resolution_ref=host_context.get(
+                        "workspaceResolutionRef"
+                    ),
+                    model_option_attestation_ref=host_context.get(
+                        "modelOptionAttestationRef"
+                    ),
+                    skill_delivery_attestation_ref=host_context.get(
+                        "skillDeliveryAttestationRef"
+                    ),
+                )
+                await turn_commands.bind_runtime_authority(
+                    session_id=command_claim.session_id,
+                    execution_plan_ref=plan.planRef,
+                    runtime_binding_ref=binding.runtimeBindingRef,
+                )
             enriched = self._bind_host_to_request(
                 request,
                 host_context,
+                plan=plan,
+                binding=binding,
                 runtime_binding_ref=binding.runtimeBindingRef,
             )
             result = await dependencies.execution_driver(enriched)
@@ -346,7 +375,6 @@ class GenericOmnigentHostRealizer:
                         "bridgeSessionId": metadata.get("bridgeSessionId"),
                         "externalStateRef": metadata.get("externalStateRef"),
                         "captureManifestRef": metadata.get("captureManifestRef"),
-                        "effectiveLaunchRef": binding.hostHarnessAttestationRef,
                         "executionProfileRef": plan.payload.agentProfileSnapshotRef,
                         "launchPolicyRef": plan.payload.launchPolicyRef,
                         "executionPlanRef": plan.planRef,
@@ -374,6 +402,7 @@ class GenericOmnigentHostRealizer:
             from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
 
             await turn_commands.settle(
+                workflow_id=workflow_id,
                 idempotency_key=request.idempotency_key,
                 outcome=ControlPlaneOutcome.APPLIED,
                 provider_receipt_id=provider_session_id or None,
@@ -389,6 +418,7 @@ class GenericOmnigentHostRealizer:
 
             try:
                 await turn_commands.settle(
+                    workflow_id=workflow_id,
                     idempotency_key=request.idempotency_key,
                     outcome=ControlPlaneOutcome.DELIVERY_UNKNOWN,
                 )
@@ -436,6 +466,8 @@ class GenericOmnigentHostRealizer:
         request: AgentExecutionRequest,
         host_context: dict[str, Any],
         *,
+        plan: OmnigentExecutionPlanEnvelope,
+        binding: Any,
         runtime_binding_ref: str,
     ) -> AgentExecutionRequest:
         """Build the secret-free authorization block consumed by the driver."""
@@ -449,11 +481,27 @@ class GenericOmnigentHostRealizer:
         )
         session["workspace"] = str(host_context.get("workspacePath"))
         omnigent["session"] = session
-        omnigent["_moonmindProfileAuthorization"] = {
+        primary_lease = binding.providerLeases.get("primary-model")
+        profile_authorization = {
             "hostClassRef": host_context.get("hostClassRef"),
             "launchPolicyRef": host_context.get("launchPolicyRef"),
             "executionRealizerRef": self.ref,
+            "executionPlanRef": plan.planRef,
+            "runtimeBindingRef": runtime_binding_ref,
+            "endpointRef": plan.payload.endpointRef,
+            "hostBindingRef": binding.hostBindingRef,
+            "hostLeaseRef": binding.hostLeaseRef,
+            "omnigentHostId": binding.omnigentHostId,
         }
+        if primary_lease is not None:
+            profile_authorization.update(
+                {
+                    "providerProfileId": primary_lease.providerProfileRef,
+                    "providerLeaseRef": primary_lease.providerLeaseRef,
+                    "credentialGeneration": primary_lease.credentialGeneration,
+                }
+            )
+        omnigent["_moonmindProfileAuthorization"] = profile_authorization
         parameters["omnigent"] = omnigent
         parameters["runtimeBindingRef"] = runtime_binding_ref
         return request.model_copy(update={"parameters": parameters})

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -202,6 +202,7 @@ class GenericOmnigentHostRealizer:
         existing_host_authority = False
         cleanup_deferred = False
         binding = None
+        host_authority_binding_ref: str | None = None
         try:
             acquired = await runtime_authority.acquire(
                 request=request,
@@ -233,6 +234,7 @@ class GenericOmnigentHostRealizer:
                 provider_leases=dict(acquired.provider_leases),
                 credential_handles=handles_by_slot,
             )
+            host_authority_binding_ref = binding.runtimeBindingRef
             await turn_commands.bind_runtime_authority(
                 session_id=command_claim.session_id,
                 execution_plan_ref=plan.planRef,
@@ -408,7 +410,7 @@ class GenericOmnigentHostRealizer:
                 try:
                     await host_runtime.cleanup(
                         plan.planRef,
-                        binding.runtimeBindingRef if binding is not None else None,
+                        host_authority_binding_ref,
                         command_authority=command_authority,
                     )
                     cleanup_complete = True

--- a/moonmind/omnigent/realizers/registry.py
+++ b/moonmind/omnigent/realizers/registry.py
@@ -83,9 +83,16 @@ def get_default_registry() -> OmnigentExecutionRealizerRegistry:
         init_error = exc
 
     try:
+        from moonmind.omnigent.realizers.composition import (
+            build_generic_realizer_dependencies,
+        )
         from moonmind.omnigent.realizers.generic_host import GenericOmnigentHostRealizer
 
-        registry.register(GenericOmnigentHostRealizer())
+        registry.register(
+            GenericOmnigentHostRealizer(
+                dependency_factory=build_generic_realizer_dependencies
+            )
+        )
     except Exception as exc:  # pragma: no cover
         init_error = exc
 

--- a/moonmind/omnigent/realizers/runtime_authority.py
+++ b/moonmind/omnigent/realizers/runtime_authority.py
@@ -252,6 +252,16 @@ class ProviderProfileRuntimeAuthority:
         command_authority: dict[str, Any],
     ) -> None:
         self._validate_command_authority(command_authority)
+        cleanup = getattr(self._credential_materializer, "cleanup", None)
+        if callable(cleanup):
+            # Credential state is destroyed while Provider Profile capacity is
+            # still fenced. A cleanup failure deliberately retains the leases
+            # for durable reconciliation rather than exposing stale material to
+            # a subsequent owner.
+            await cleanup(
+                authority.credential_handles,
+                command_authority=command_authority,
+            )
         for lease in reversed(authority.leases):
             await self._lease_client.release_lease(lease)
 

--- a/moonmind/omnigent/realizers/runtime_authority.py
+++ b/moonmind/omnigent/realizers/runtime_authority.py
@@ -1,0 +1,259 @@
+"""Provider Profile and credential authority for the generic realizer.
+
+This infrastructure adapter performs the side effects selected by an admitted
+plan. It is separate from the harness-neutral realizer so provider transport,
+database access and credential materialization do not leak into lifecycle
+coordination.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from moonmind.omnigent.harness_platform.credential_bindings import (
+    deterministic_lease_order,
+)
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.materializers import materialize_credential
+from moonmind.provider_profiles.lease_client import (
+    CredentialLease,
+    CredentialLeasePurpose,
+    ProviderProfileLeaseClient,
+    deterministic_lease_owner_id,
+)
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+
+@dataclass(frozen=True, slots=True)
+class AcquiredRuntimeAuthority:
+    provider_leases: dict[str, dict[str, Any]]
+    credential_handles: tuple[dict[str, Any], ...]
+    leases: tuple[CredentialLease, ...]
+
+
+class ProviderProfileRuntimeAuthority:
+    """Acquire exact generations and return only secret-free runtime handles."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: Any,
+        lease_client: ProviderProfileLeaseClient | None = None,
+        credential_materializer: Any | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        if lease_client is None:
+            from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+            lease_client = ProviderProfileLeaseClient(TemporalClientAdapter())
+        self._lease_client = lease_client
+        self._credential_materializer = credential_materializer
+
+    def assert_ready(self, plan: OmnigentExecutionPlanEnvelope) -> None:
+        """Reject secret-bearing plans until a trusted materializer is wired."""
+
+        from moonmind.omnigent.harness_platform.materializers import (
+            get_materializer,
+        )
+
+        missing = sorted(
+            {
+                str(binding["materializerRef"])
+                for binding in plan.payload.credentialBindings.values()
+                if get_materializer(str(binding["materializerRef"])).requiredSecretRoles
+                and self._credential_materializer is None
+            }
+        )
+        if missing:
+            raise HarnessPlatformError(
+                "trusted credential materialization is not composed for: "
+                + ", ".join(missing),
+                code=(
+                    HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZER_UNAVAILABLE
+                ),
+            )
+
+    @staticmethod
+    def _validate_command_authority(command_authority: dict[str, Any]) -> None:
+        required = {
+            "commandId",
+            "claimToken",
+            "sessionId",
+            "turnAttemptId",
+            "expectedSessionRevision",
+            "fencingGeneration",
+        }
+        if required - set(command_authority):
+            raise HarnessPlatformError(
+                "Provider Profile side effect lacks canonical command authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+
+    async def acquire(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        command_authority: dict[str, Any],
+    ) -> AcquiredRuntimeAuthority:
+        self._validate_command_authority(command_authority)
+        from api_service.db.models import ManagedAgentProviderProfile
+
+        bindings_by_profile: dict[str, list[tuple[str, Any]]] = {}
+        for slot, binding in plan.payload.credentialBindings.items():
+            profile_ref = str(binding.get("providerProfileRef") or "").strip()
+            if not profile_ref:
+                raise HarnessPlatformError(
+                    f"credential slot {slot} has no Provider Profile authority",
+                    code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_SLOT_UNBOUND,
+                )
+            bindings_by_profile.setdefault(profile_ref, []).append((slot, binding))
+
+        provider_leases: dict[str, dict[str, Any]] = {}
+        handles: list[dict[str, Any]] = []
+        acquired: list[CredentialLease] = []
+        try:
+            for profile_ref in deterministic_lease_order(list(bindings_by_profile)):
+                async with self._session_factory() as session:
+                    profile = await session.get(
+                        ManagedAgentProviderProfile, profile_ref
+                    )
+                    if profile is None or not profile.enabled:
+                        raise HarnessPlatformError(
+                            f"Provider Profile {profile_ref} is unavailable",
+                            code=HarnessPlatformFailure.OMNIGENT_PROVIDER_PROFILE_INCOMPATIBLE,
+                        )
+                    runtime_id = str(
+                        getattr(profile.runtime_id, "value", profile.runtime_id)
+                    )
+
+                for slot, binding in sorted(bindings_by_profile[profile_ref]):
+                    owner_id = deterministic_lease_owner_id(
+                        profile_id=profile_ref,
+                        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+                        workflow_id=request.correlation_id,
+                        step_execution_id=request.idempotency_key,
+                        idempotency_key=f"{request.idempotency_key}:{slot}",
+                    )
+                    lease = await self._lease_client.acquire_execution_lease(
+                        runtime_id=runtime_id,
+                        profile_id=profile_ref,
+                        owner_id=owner_id,
+                        purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+                        metadata={
+                            "executionPlanRef": plan.planRef,
+                            "credentialSlot": slot,
+                            **command_authority,
+                        },
+                    )
+                    acquired.append(lease)
+                    # Read the acquired generation only after the lease is held.
+                    # The plan fixes the Provider Profile identity; the runtime
+                    # binding fixes the generation observed under that lease.
+                    async with self._session_factory() as session:
+                        acquired_profile = await session.get(
+                            ManagedAgentProviderProfile, profile_ref
+                        )
+                        if acquired_profile is None or not acquired_profile.enabled:
+                            raise HarnessPlatformError(
+                                f"Provider Profile {profile_ref} became unavailable",
+                                code=HarnessPlatformFailure.OMNIGENT_PROVIDER_PROFILE_INCOMPATIBLE,
+                            )
+                        acquired_runtime_id = str(
+                            getattr(
+                                acquired_profile.runtime_id,
+                                "value",
+                                acquired_profile.runtime_id,
+                            )
+                        )
+                        if acquired_runtime_id != runtime_id:
+                            raise HarnessPlatformError(
+                                f"Provider Profile {profile_ref} changed runtime while acquiring authority",
+                                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+                            )
+                        credential_generation = int(
+                            acquired_profile.credential_generation
+                        )
+                    materializer_ref = str(binding["materializerRef"])
+                    from moonmind.omnigent.harness_platform.materializers import (
+                        get_materializer,
+                    )
+
+                    materializer = get_materializer(materializer_ref)
+                    if materializer.requiredSecretRoles:
+                        if self._credential_materializer is None:
+                            raise HarnessPlatformError(
+                                "trusted credential materialization is unavailable",
+                                code=(
+                                    HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZER_UNAVAILABLE
+                                ),
+                            )
+                        handle = await self._credential_materializer.materialize(
+                            profile=acquired_profile,
+                            binding=dict(binding),
+                            provider_lease_ref=lease.lease_id,
+                            credential_generation=credential_generation,
+                            execution_plan_ref=plan.planRef,
+                            command_authority=dict(command_authority),
+                        )
+                    else:
+                        handle = materialize_credential(
+                            materializer_ref=materializer_ref,
+                            provider_profile_ref=profile_ref,
+                            provider_lease_ref=lease.lease_id,
+                            credential_generation=credential_generation,
+                        )
+                    if not isinstance(handle, dict) or any(
+                        key in handle
+                        for key in (
+                            "apiKey",
+                            "api_key",
+                            "secret",
+                            "secretBody",
+                            "token",
+                        )
+                    ):
+                        raise HarnessPlatformError(
+                            "credential materializer returned an unsafe runtime handle",
+                            code=(
+                                HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                            ),
+                        )
+                    handle = {**handle, "credentialSlot": slot}
+                    handles.append(handle)
+                    provider_leases[slot] = {
+                        "providerProfileRef": profile_ref,
+                        "providerLeaseRef": lease.lease_id,
+                        "credentialGeneration": credential_generation,
+                        "credentialRuntimeRef": handle["credentialRuntimeRef"],
+                    }
+        except Exception:
+            for lease in reversed(acquired):
+                await self._lease_client.release_lease(lease)
+            raise
+
+        return AcquiredRuntimeAuthority(
+            provider_leases=provider_leases,
+            credential_handles=tuple(handles),
+            leases=tuple(acquired),
+        )
+
+    async def release(
+        self,
+        authority: AcquiredRuntimeAuthority,
+        *,
+        command_authority: dict[str, Any],
+    ) -> None:
+        self._validate_command_authority(command_authority)
+        for lease in reversed(authority.leases):
+            await self._lease_client.release_lease(lease)
+
+
+__all__ = ["AcquiredRuntimeAuthority", "ProviderProfileRuntimeAuthority"]

--- a/moonmind/omnigent/repository_sources.py
+++ b/moonmind/omnigent/repository_sources.py
@@ -1,0 +1,46 @@
+"""Pure repository-source classification shared by intent and host adapters."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+_GITHUB_SLUG = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class RepositorySourceError(ValueError):
+    """The authored source cannot be classified without runtime authority."""
+
+
+def normalize_repository_source(repository_source: str) -> tuple[str, str]:
+    """Return the canonical clone source and its provider-neutral kind."""
+
+    value = str(repository_source or "").strip()
+    if not value:
+        raise RepositorySourceError(
+            "repository source is required to materialize the workspace"
+        )
+    if value.startswith("file://"):
+        return value, "local"
+    if value.startswith(("http://", "https://", "git@", "ssh://")):
+        kind = "remote"
+        if value.startswith(("http://", "https://")):
+            # Exact hostname matching prevents credentials from being offered
+            # to lookalike origins such as github.com.evil.example.
+            host = (urlsplit(value).hostname or "").lower()
+            if host == "github.com":
+                kind = "github_https"
+        return value, kind
+    if value.startswith(("/", "./", "../")) or Path(value).is_absolute():
+        return value, "local"
+    if _GITHUB_SLUG.fullmatch(value):
+        suffix = "" if value.endswith(".git") else ".git"
+        return f"https://github.com/{value}{suffix}", "github_https"
+    raise RepositorySourceError(
+        "unsupported repository source; expected owner/repo, URL, or path"
+    )
+
+
+__all__ = ["RepositorySourceError", "normalize_repository_source"]

--- a/moonmind/omnigent/workspace_intent.py
+++ b/moonmind/omnigent/workspace_intent.py
@@ -16,6 +16,10 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
 
+from moonmind.omnigent.repository_sources import (
+    RepositorySourceError,
+    normalize_repository_source,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.workspace_intent import (
     WORKSPACE_INTENT_LOCATOR_REQUIRED,
@@ -215,8 +219,7 @@ def _authored_publication_destination(
 def _classify_repository(source: str) -> str | None:
     """Classify an authored repository source through the canonical classifier.
 
-    Reuses ``OmnigentOAuthHostRuntime._normalize_repository_source`` — the single
-    materialization-layer authority for repository identity — so durable intent
+    Reuses the provider-neutral repository-source authority so durable intent
     and Workflow Detail can never diverge from how the workspace is actually
     cloned. That classifier resolves the ``owner/repo`` shorthand to
     ``github_https`` and matches GitHub on the exact URL host, avoiding the
@@ -227,14 +230,9 @@ def _classify_repository(source: str) -> str | None:
 
     if not source:
         return None
-    from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
-    from moonmind.omnigent.oauth_hosts import OmnigentOAuthHostError
-
     try:
-        _normalized, kind = OmnigentOAuthHostRuntime._normalize_repository_source(
-            source
-        )
-    except OmnigentOAuthHostError:
+        _normalized, kind = normalize_repository_source(source)
+    except RepositorySourceError:
         # An unsupported/unclassifiable authored source is treated as local so
         # bounded evidence redacts it rather than leaking a raw worker-local path.
         return "local"

--- a/moonmind/schemas/omnigent_session_models.py
+++ b/moonmind/schemas/omnigent_session_models.py
@@ -191,6 +191,13 @@ class OmnigentSessionAdmissionRequest(_OmnigentSessionModel):
     execution_profile_ref: str = Field(
         alias="executionProfileRef", min_length=1, max_length=255
     )
+    execution_plan_ref: str | None = Field(
+        None,
+        alias="executionPlanRef",
+        min_length=1,
+        max_length=255,
+        exclude_if=lambda value: value is None,
+    )
 
     @field_validator(
         "workflow_id", "step_execution_id", "agent_run_id", "execution_profile_ref"
@@ -211,6 +218,7 @@ class OmnigentSessionAdmissionDecision(_OmnigentSessionModel):
         "canary_owner_not_allowlisted",
         "execution_profile_not_allowlisted",
         "feature_generation_mismatch",
+        "realizer_managed_lifecycle",
     ] = Field(alias="reasonCode")
     admission_mode: Literal["disabled", "canary", "enabled"] = Field(
         alias="admissionMode"

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -366,6 +366,21 @@ async def _try_generic_realizer_dispatch(
                 providerErrorCode="OMNIGENT_EXECUTION_PLAN_UNAVAILABLE",
                 retryRecommendation="retry_transient_upstream",
             )
+        from moonmind.omnigent.harness_platform.execution_plan import (
+            bind_runtime_request_authority,
+        )
+
+        bound_plan = bind_runtime_request_authority(
+            persisted,
+            resolved_skillset_ref=request.resolved_skillset_ref,
+            model=params.get("model"),
+            effort=params.get("effort") if "effort" in params else None,
+        )
+        if bound_plan.planRef != persisted.planRef:
+            bound_plan = await plan_store.persist(bound_plan)
+            params = {**params, "executionPlanRef": bound_plan.planRef}
+            request = request.model_copy(update={"parameters": params})
+            persisted = bound_plan
         if realizer_registry is None:
             from moonmind.omnigent.realizers.registry import get_default_registry
 

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -12,23 +12,6 @@ from temporalio import activity
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 from moonmind.omnigent.control_plane import metrics as control_plane_metrics
 
-# Generic realizer dispatch helpers (Phase 1)
-_GENERIC_HARNESS_IDS = {"opencode-native", "pi-native", "qwen-native", "claude-native"}
-
-# Singleton plan store for retry-stable planRef (P1 3828196601) – fixed observedAt
-# ensures retries do not replan with a different digest.
-_GENERIC_PLAN_STORE: Any | None = None
-_GENERIC_CATALOG_OBSERVED_AT = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-
-
-def _get_generic_plan_store() -> Any:
-    global _GENERIC_PLAN_STORE
-    if _GENERIC_PLAN_STORE is None:
-        from moonmind.omnigent.harness_platform.stores import InMemoryExecutionPlanStore
-
-        _GENERIC_PLAN_STORE = InMemoryExecutionPlanStore()
-    return _GENERIC_PLAN_STORE
-
 
 _IMMUTABLE_RECOVERY_DIMENSIONS = (
     "instructionDigest",
@@ -340,214 +323,63 @@ async def _resolve_live_recovery_authority(
 async def _try_generic_realizer_dispatch(
     request: AgentExecutionRequest,
     *,
-    artifact_gateway: Any,
-    run_store: Any,
+    plan_store: Any | None = None,
+    realizer_registry: Any | None = None,
 ) -> AgentRunResult | None:
-    """Attempt harness-neutral dispatch via execution plan + realizer registry.
+    """Load and dispatch the plan admitted by the normal product path.
 
-    Returns None for legacy Codex-only requests (caller continues to legacy
-    coordinator). For generic requests, compiles or loads the plan and
-    dispatches to the persisted executionRealizerRef without harness branches.
-
-    Generic detection is deliberately narrow: a request is generic if it
-    carries an Agent Profile v2 payload (`omnigent.agentProfileV2` or
-    `omnigentAgentProfileV2`) or an explicit `harnessId` in
-    `omnigent.agent` / `omnigent.session` that is not codex-native.
-    Workflow input cannot author `executionRealizerRef` – the planner's
-    trusted selection is used, and any request-supplied value is ignored.
+    Requests without a plan ref are either replay-visible legacy Codex inputs
+    (return ``None``) or attempted generic inputs (fail closed).  This Activity
+    never compiles, selects, mutates, or substitutes execution authority.
     """
     params = request.parameters if isinstance(request.parameters, dict) else {}
     omnigent = params.get("omnigent") if isinstance(params.get("omnigent"), dict) else {}
-    agent = omnigent.get("agent") if isinstance(omnigent.get("agent"), dict) else {}
-    session_cfg = omnigent.get("session") if isinstance(omnigent.get("session"), dict) else {}
-
-    # Detect generic v2 payload
-    has_v2_profile = (
+    attempted_unadmitted_generic = (
         isinstance(omnigent.get("agentProfileV2"), dict)
         or isinstance(params.get("omnigentAgentProfileV2"), dict)
         or isinstance(params.get("agentProfileV2"), dict)
+        or bool(params.get("_genericHarnessTest"))
+        or bool(omnigent.get("_genericHarnessTest"))
     )
-    # Canonical harness override is `harnessOverride` (profile_bound_execution._bind_exact_host)
-    harness_id = str(
-        agent.get("harnessOverride")
-        or agent.get("harnessId")
-        or agent.get("harness")
-        or session_cfg.get("harnessOverride")
-        or session_cfg.get("harness")
-        or session_cfg.get("harnessId")
-        or ""
-    ).strip()
-    # If v2 profile present, its harness takes precedence over session/agent override
-    if has_v2_profile:
-        v2_payload = omnigent.get("agentProfileV2") if isinstance(omnigent.get("agentProfileV2"), dict) else (params.get("omnigentAgentProfileV2") if isinstance(params.get("omnigentAgentProfileV2"), dict) else params.get("agentProfileV2"))
-        if isinstance(v2_payload, dict):
-            v2_harness = v2_payload.get("harness", {}) if isinstance(v2_payload.get("harness"), dict) else {}
-            v2_id = str(v2_harness.get("id") or "").strip()
-            if v2_id:
-                harness_id = v2_id
-    is_generic_harness = harness_id in _GENERIC_HARNESS_IDS and harness_id != "codex-native"
+    plan_ref = str(params.get("executionPlanRef") or "").strip()
+    if not plan_ref:
+        if not attempted_unadmitted_generic:
+            return None
+        return AgentRunResult(
+            summary="generic Omnigent execution requires an admitted execution plan",
+            failureClass="integration_error",
+            providerErrorCode="OMNIGENT_EXECUTION_PLAN_REQUIRED",
+            retryRecommendation="do_not_retry",
+        )
 
-    # Also detect via explicit generic marker for hermetic tests
-    generic_marker = bool(params.get("_genericHarnessTest") or omnigent.get("_genericHarnessTest"))
-
-    if not (has_v2_profile or is_generic_harness or generic_marker):
-        return None
-
-    # For now, generic dispatch is validated via planner + registry
-    # The actual plan compilation requires catalog, skills, binding set, etc.
-    # which are not yet available in this activity's request shape for
-    # hermetic tests. We validate that the dispatch path is reachable and
-    # that harness-specific branches are absent.
-
-    # If the request explicitly tries to author a realizer, ignore it (trusted)
-    # and use planner's selection. We surface this as a metric, not a failure.
-    # The planner will reject workflow-authored realizers that are incompatible.
-
-    # Check if caller attempted to author realizer via params
-    attempted_realizer = params.get("executionRealizerRef") or omnigent.get("executionRealizerRef")
-    if attempted_realizer:
-        # Do not honor workflow-authored realizer; planner will select trusted
-        pass
-
-    # Unified generic dispatch – both harness-only and v2 payloads compile and
-    # delegate via the same harness-neutral planner path (P1 3828196581).
-    # This ensures the canonical v2 input also goes through plan persistence
-    # and realizer dispatch, not the legacy driver.
     try:
-        from datetime import UTC, datetime
+        if plan_store is None:
+            from api_service.db.base import async_session_maker
+            from moonmind.omnigent.harness_platform.stores import DbExecutionPlanStore
 
-        from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfileV2
-        from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot, classify_harness_trust, HarnessImplementationIdentity, TrustState
-        from moonmind.omnigent.harness_platform.credential_bindings import create_binding_set
-        from moonmind.omnigent.harness_platform.planner import compile_execution_plan
-        from moonmind.omnigent.harness_platform.skills import ResolvedSkillSet
-        from moonmind.omnigent.harness_platform.stores import InMemoryExecutionPlanStore
-        from moonmind.omnigent.realizers.registry import get_default_registry
+            plan_store = DbExecutionPlanStore(async_session_maker)
+        persisted = await plan_store.load(plan_ref)
+        if persisted is None:
+            return AgentRunResult(
+                summary="admitted Omnigent execution plan is unavailable",
+                failureClass="integration_error",
+                providerErrorCode="OMNIGENT_EXECUTION_PLAN_UNAVAILABLE",
+                retryRecommendation="retry_transient_upstream",
+            )
+        if realizer_registry is None:
+            from moonmind.omnigent.realizers.registry import get_default_registry
 
-        # Minimal synthetic catalog for the requested harness
-        impl_digest = "sha256:" + "a" * 64
-        if harness_id == "pi-native":
-            impl_digest = "sha256:" + "c" * 64
-        impl = HarnessImplementationIdentity.model_validate(
-            {"sourceKind": "core", "package": "omnigent", "version": "1.0.0", "digest": impl_digest, "pluginEntryPoint": None}
+            realizer_registry = get_default_registry()
+        realizer = realizer_registry.require(
+            persisted.payload.executionRealizerRef
         )
-        catalog = create_catalog_snapshot(
-            endpointRef="default",
-            omnigentVersion="1.0.0",
-            omnigentBuildDigest="sha256:" + "b" * 64,
-            sourceDigest="sha256:" + "c" * 64,
-            harnesses=[
-                {
-                    "id": harness_id,
-                    "aliases": [],
-                    "label": harness_id,
-                    "implementation": {"sourceKind": "core", "package": "omnigent", "version": "1.0.0", "digest": impl_digest, "pluginEntryPoint": None},
-                    "runtimeRequirements": {},
-                    "capabilities": {"integrationMode": "native-server", "authModel": "own-auth", "interrupt": True, "streaming": True},
-                    "setupSteps": [],
-                }
-            ],
-            observedAt=_GENERIC_CATALOG_OBSERVED_AT,
-        )
-        trust = classify_harness_trust(harnessId=harness_id, implementation=impl, trustState=TrustState.core_trusted)
-        # Use a minimal v2 profile for the harness
-        profile = OmnigentAgentProfileV2.model_validate(
-            {
-                "schemaVersion": "moonmind.omnigent-agent-profile.v2",
-                "endpointRef": "default",
-                "source": {"kind": "upstream", "upstreamId": f"{harness_id}-ui", "upstreamVersion": "1.0.0", "upstreamSnapshotDigest": "sha256:" + "d" * 64},
-                "harness": {"id": harness_id, "catalogRef": catalog.catalogRef, "implementationRef": impl.implementation_ref()},
-                "requirements": {"harness": {"required": [], "preferred": []}, "moonmind": {"required": []}, "host": {"required": []}},
-                "credentialSlots": [{"id": "primary-model", "optional": False, "acceptedAuthModels": ["own-auth"], "acceptedProviderIds": ["opencode"]}],
-                "model": {},
-                "workspace": {},
-                "skills": [],
-                "tools": [],
-                "capture": {},
-                "continuations": {},
-                "publish": {},
-                "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
-            }
-        )
-        skills = ResolvedSkillSet.model_validate({"resolvedSkillSetRef": "artifact:test", "resolvedSkillSetDigest": "sha256:" + "a" * 64, "skillDeliveryRef": "skill-delivery:sha256:" + "b" * 64})
-        bs = create_binding_set(bindingSetId="test-generic", version=1, bindings={"primary-model": {"providerProfileRef": "test-provider", "materializerRef": "opencode-auth-json@1" if harness_id != "pi-native" else "omnigent-provider-config@1"}})
-        # Host class selection: dedicated images per harness (fail closed without real digest)
-        if harness_id == "opencode-native":
-            host_class_ref = "omnigent-opencode@1"
-        elif harness_id == "pi-native":
-            host_class_ref = "omnigent-pi@1"
-        else:
-            host_class_ref = "omnigent-native-standard@3"
-        # Fail closed when dedicated image not configured – do not inject fabricated digest
-        if harness_id == "opencode-native":
-            import os
-
-            from moonmind.omnigent.harness_platform.failures import HarnessPlatformError as _HPE, HarnessPlatformFailure as _HPF
-
-            if not os.getenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", "").strip():
-                raise _HPE(
-                    "OMNIGENT_OPENCODE_HOST_IMAGE_REF must be set to a digest-pinned image for opencode",
-                    code=_HPF.OMNIGENT_HARNESS_BUILD_MISMATCH,
-                )
-        if harness_id == "pi-native":
-            import os
-
-            from moonmind.omnigent.harness_platform.failures import HarnessPlatformError as _HPE2, HarnessPlatformFailure as _HPF2
-
-            if not os.getenv("OMNIGENT_PI_HOST_IMAGE_REF", "").strip():
-                raise _HPE2(
-                    "OMNIGENT_PI_HOST_IMAGE_REF must be set to a digest-pinned image for pi",
-                    code=_HPF2.OMNIGENT_HARNESS_BUILD_MISMATCH,
-                )
-        # Bind plan to request's actual model selection (P1 3828196631)
-        model_qualified_id = (
-            str(params.get("model") or "").strip()
-            or str(omnigent.get("model") or "").strip()
-            or str(agent.get("model") or "").strip()
-            or str(params.get("modelId") or "").strip()
-            or "test/model"
-        )
-        model_route_ref = str(
-            params.get("modelRoute") or params.get("model_route") or omnigent.get("modelRoute") or omnigent.get("routeRef") or ("pi" if harness_id == "pi-native" else "opencode-go")
-        ).strip() or ("pi" if harness_id == "pi-native" else "opencode-go")
-        _effort_raw = params.get("effort") or params.get("modelEffort") or omnigent.get("effort") or agent.get("effort")
-        model_effort = str(_effort_raw).strip() if isinstance(_effort_raw, str) and str(_effort_raw).strip() else None
-        model_options = params.get("modelOptions") if isinstance(params.get("modelOptions"), dict) else (omnigent.get("modelOptions") if isinstance(omnigent.get("modelOptions"), dict) else {})
-
-        # Use singleton store so retries load same planRef (P1 3828196601)
-        store = _get_generic_plan_store()
-        # Compile via store's load_or_compile to ensure retry stability (fixed observedAt)
-        persisted = await store.load_or_compile(
-            compile_fn=compile_execution_plan,
-            compile_kwargs=dict(
-                agent_profile=profile,
-                harness_catalog=catalog,
-                trust_record=trust,
-                resolved_skills=skills,
-                credential_binding_set=bs,
-                host_class_ref=host_class_ref,
-                launch_policy_ref="omnigent-on-demand@1",
-                model_qualified_id=model_qualified_id,
-                model_effort=model_effort,
-                model_route_ref=model_route_ref,
-                model_normalized_options=model_options,
-            ),
-        )
-        # Dispatch via registry – must be generic-omnigent-host@1, no fallback
-        registry = get_default_registry()
-        realizer = registry.require(persisted.payload.executionRealizerRef)
-        # Verify harness-neutral: realizer ref must be generic for non-codex
-        if harness_id != "codex-native" and persisted.payload.executionRealizerRef != "generic-omnigent-host@1":
-            raise ValueError(f"non-codex harness must use generic realizer, got {persisted.payload.executionRealizerRef}")
         return await realizer.execute(request, persisted)
     except Exception as exc:
-        # Surface as integration_error but do not fallback to codex
-        from moonmind.schemas.agent_runtime_models import AgentRunResult
-
+        code = str(getattr(exc, "code", "OMNIGENT_EXECUTION_PLAN_DISPATCH_FAILED"))
         return AgentRunResult(
-            summary=f"generic dispatch failed: {exc}",
+            summary=f"admitted Omnigent dispatch failed: {exc}",
             failureClass="integration_error",
-            providerErrorCode="OMNIGENT_GENERIC_DISPATCH_FAILED",
+            providerErrorCode=code,
             retryRecommendation="retry_transient_upstream",
         )
 
@@ -597,11 +429,7 @@ async def _omnigent_execute_activity(
     # If the request carries a v2 Agent Profile or explicit harness catalog,
     # compile a secret-free execution plan and dispatch via trusted realizer
     # registry. This path is harness-neutral: no `if harness == "opencode"` branches.
-    generic_dispatch = await _try_generic_realizer_dispatch(
-        request,
-        artifact_gateway=artifact_gateway,
-        run_store=run_store,
-    )
+    generic_dispatch = await _try_generic_realizer_dispatch(request)
     if generic_dispatch is not None:
         return generic_dispatch
 

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -157,6 +157,16 @@ async def omnigent_evaluate_session_admission_activity(
     from moonmind.config.settings import settings
 
     request = OmnigentSessionAdmissionRequest.model_validate(payload)
+    plan = None
+    if request.execution_plan_ref:
+        from api_service.db.base import async_session_maker
+        from moonmind.omnigent.harness_platform.stores import DbExecutionPlanStore
+
+        plan = await DbExecutionPlanStore(async_session_maker).load(
+            request.execution_plan_ref
+        )
+        if plan is None:
+            raise ValueError("admitted Omnigent execution plan is unavailable")
     flags = settings.feature_flags
     mode = flags.omnigent_session_supervisor_admission_mode
     generation = str(flags.omnigent_session_supervisor_generation or "").strip()
@@ -175,7 +185,16 @@ async def omnigent_evaluate_session_admission_activity(
 
     admitted = True
     reason = "enabled"
-    if generation != OMNIGENT_SESSION_FEATURE_GENERATION:
+    effective_mode = mode
+    if plan is not None:
+        # Normal-product admission already persisted exact immutable authority.
+        # It must not depend on a legacy rollout flag whose omission could route
+        # the same request into a parallel lifecycle.
+        effective_mode = "enabled"
+        if plan.payload.executionRealizerRef != "codex-profile-bound@1":
+            admitted = False
+            reason = "realizer_managed_lifecycle"
+    elif generation != OMNIGENT_SESSION_FEATURE_GENERATION:
         admitted = False
         reason = "feature_generation_mismatch"
     elif mode == "disabled":
@@ -195,7 +214,7 @@ async def omnigent_evaluate_session_admission_activity(
     return OmnigentSessionAdmissionDecision(
         admitted=admitted,
         reasonCode=reason,
-        admissionMode=mode,
+        admissionMode=effective_mode,
         admittedFeatureGeneration=OMNIGENT_SESSION_FEATURE_GENERATION,
     ).model_dump(mode="json", by_alias=True)
 
@@ -215,7 +234,73 @@ async def _load_intent_request(
     raw_request = payload.get("request")
     if not isinstance(raw_request, Mapping):
         raise ValueError("compiled execution intent is missing request authority")
-    return AgentExecutionRequest.model_validate(raw_request)
+    agent_request = AgentExecutionRequest.model_validate(raw_request)
+    plan_ref = str(
+        (agent_request.parameters or {}).get("executionPlanRef") or ""
+    ).strip()
+    if not plan_ref:
+        return agent_request
+
+    from api_service.db.base import async_session_maker
+    from moonmind.omnigent.harness_platform.stores import DbExecutionPlanStore
+
+    plan = await DbExecutionPlanStore(async_session_maker).load(plan_ref)
+    if plan is None:
+        raise ValueError("admitted Omnigent execution plan is unavailable")
+    if plan.payload.executionRealizerRef != "codex-profile-bound@1":
+        raise ValueError(
+            "Codex session Activities cannot consume a different execution realizer"
+        )
+    provider_profile_ref = str(
+        plan.payload.credentialBindings["primary-model"].get(
+            "providerProfileRef"
+        )
+        or ""
+    )
+    if agent_request.execution_profile_ref != provider_profile_ref:
+        raise ValueError("Provider Profile differs from admitted execution plan")
+    parameters = agent_request.parameters or {}
+    for field_name, planned in (
+        ("model", plan.payload.modelConfig.qualifiedId),
+        ("effort", plan.payload.modelConfig.effort),
+    ):
+        requested = parameters.get(field_name)
+        if requested is not None and requested != planned:
+            raise ValueError(f"{field_name} differs from admitted execution plan")
+    return agent_request
+
+
+async def _session_execution_authority_metadata(session: Any) -> dict[str, Any]:
+    """Project exact admitted/runtime authority into every terminal result."""
+
+    plan_ref = str(getattr(session, "execution_plan_ref", None) or "").strip()
+    if not plan_ref:
+        return {}
+    from api_service.db.base import async_session_maker
+    from moonmind.omnigent.harness_platform.execution_plan import (
+        execution_support_identity,
+    )
+    from moonmind.omnigent.harness_platform.stores import (
+        DbExecutionPlanStore,
+        DbRuntimeBindingStore,
+    )
+
+    plan = await DbExecutionPlanStore(async_session_maker).load(plan_ref)
+    if plan is None:
+        raise ValueError("canonical session execution plan is unavailable")
+    metadata = {
+        "executionPlanRef": plan.planRef,
+        "supportCombinationIdentity": execution_support_identity(plan),
+    }
+    binding_ref = str(getattr(session, "runtime_binding_ref", None) or "").strip()
+    if binding_ref:
+        binding = await DbRuntimeBindingStore(async_session_maker).get(binding_ref)
+        if binding is None or binding.executionPlanRef != plan.planRef:
+            raise ValueError(
+                "canonical session runtime binding conflicts with its execution plan"
+            )
+        metadata["runtimeBindingRef"] = binding.runtimeBindingRef
+    return metadata
 
 
 async def omnigent_resolve_intent_activity(
@@ -295,6 +380,10 @@ async def omnigent_resolve_intent_activity(
                 compatibility_profile=resolved.compatibility_version,
                 intent_ref=intent_ref,
                 intent_digest=intent_digest,
+                execution_plan_ref=str(
+                    (request.parameters or {}).get("executionPlanRef") or ""
+                ).strip()
+                or None,
                 instruction_digest=compute_digest(request.instruction_ref or ""),
                 metadata={
                     "featureGeneration": resolved.admitted_feature_generation,
@@ -1006,9 +1095,8 @@ async def omnigent_ensure_provider_profile_lease_activity(
         workflow_id=request.session_id,
         step_execution_id=request.session_id,
     )
-    lease = await ProviderProfileLeaseClient(
-        TemporalClientAdapter()
-    ).acquire_execution_lease(
+    lease_client = ProviderProfileLeaseClient(TemporalClientAdapter())
+    lease = await lease_client.acquire_execution_lease(
         runtime_id=runtime_id,
         profile_id=profile_id,
         owner_id=owner_id,
@@ -1027,6 +1115,52 @@ async def omnigent_ensure_provider_profile_lease_activity(
             "ownerIsWorkflow": False,
         },
     )
+    # The plan selects the Provider Profile but the binding records the
+    # generation acquired under its lease. Re-read after acquisition so a
+    # pre-lease observation cannot become runtime authority.
+    try:
+        async with async_session_maker() as session:
+            acquired_profile = await session.get(
+                ManagedAgentProviderProfile, profile_id
+            )
+        if acquired_profile is None or not acquired_profile.enabled:
+            raise ValueError("Provider Profile became unavailable after acquisition")
+        acquired_runtime_id = str(
+            getattr(
+                acquired_profile.runtime_id,
+                "value",
+                acquired_profile.runtime_id,
+            )
+        )
+        if acquired_runtime_id != runtime_id:
+            raise ValueError("Provider Profile runtime changed during acquisition")
+        acquired_generation = int(acquired_profile.credential_generation)
+    except Exception:
+        await lease_client.release_lease(lease)
+        raise
+    runtime_binding = None
+    execution_plan_ref = getattr(session_authority, "execution_plan_ref", None)
+    if execution_plan_ref:
+        from moonmind.omnigent.harness_platform.stores import (
+            DbRuntimeBindingStore,
+        )
+
+        runtime_binding = await DbRuntimeBindingStore(
+            async_session_maker
+        ).create_initial(
+            execution_plan_ref=execution_plan_ref,
+            provider_leases={
+                "primary-model": {
+                    "providerProfileRef": profile_id,
+                    "providerLeaseRef": lease.lease_id,
+                    "credentialGeneration": acquired_generation,
+                    "credentialRuntimeRef": (
+                        "credential-runtime:provider-profile:"
+                        f"{profile_id}:generation:{acquired_generation}"
+                    ),
+                }
+            },
+        )
     async with store.transaction() as repos:
         updated = await repos.sessions.bind_runtime_authority(
             request.session_id,
@@ -1036,7 +1170,13 @@ async def omnigent_ensure_provider_profile_lease_activity(
             provider_profile_generation=(
                 session_authority.provider_profile_generation
             ),
-            credential_generation=int(profile.credential_generation),
+            credential_generation=acquired_generation,
+            execution_plan_ref=execution_plan_ref,
+            runtime_binding_ref=(
+                runtime_binding.runtimeBindingRef
+                if runtime_binding is not None
+                else None
+            ),
             metadata_patch={
                 "providerLeaseRef": lease.lease_id,
                 "providerLeaseOwnerId": lease.owner_id,
@@ -1338,6 +1478,25 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
             new_status="assigned",
             fields={"bridge_session_id": bridge.bridge_session_id},
         )
+    runtime_binding = None
+    if session.execution_plan_ref:
+        from moonmind.omnigent.harness_platform.stores import (
+            DbRuntimeBindingStore,
+        )
+
+        if not session.runtime_binding_ref:
+            raise ValueError(
+                "admitted execution plan is missing acquired runtime binding"
+            )
+        runtime_binding = await DbRuntimeBindingStore(
+            async_session_maker
+        ).update_with_host(
+            session.runtime_binding_ref,
+            host_binding_ref=binding.binding_ref,
+            host_lease_ref=lease.lease_id,
+            host_lease_generation=int(session.host_lease_generation or 0),
+            omnigent_host_id=host_id,
+        )
     async with store.transaction() as repos:
         updated = await repos.sessions.bind_runtime_authority(
             request.session_id,
@@ -1347,6 +1506,12 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
             host_lease_ref=lease.lease_id,
             host_lease_generation=session.host_lease_generation,
             credential_generation=lease.credential_generation,
+            execution_plan_ref=session.execution_plan_ref,
+            runtime_binding_ref=(
+                runtime_binding.runtimeBindingRef
+                if runtime_binding is not None
+                else None
+            ),
             metadata_patch={
                 "omnigentHostRef": host_id,
                 "hostHarness": str(effective_launch["harness"]),
@@ -1399,12 +1564,41 @@ async def omnigent_ensure_provider_session_activity(
             raise ValueError(
                 "provider session exists without matching bridge authority"
             )
-        if session.metadata.get("bridgeSessionRef") != bridge.bridge_session_id:
+        runtime_binding = None
+        if session.execution_plan_ref:
+            from moonmind.omnigent.harness_platform.stores import (
+                DbRuntimeBindingStore,
+            )
+
+            if not session.runtime_binding_ref:
+                raise ValueError(
+                    "admitted execution plan is missing host runtime binding"
+                )
+            runtime_binding = await DbRuntimeBindingStore(
+                async_session_maker
+            ).update_with_session(
+                session.runtime_binding_ref,
+                omnigent_session_id=session.provider_session_ref,
+            )
+        if (
+            session.metadata.get("bridgeSessionRef") != bridge.bridge_session_id
+            or (
+                runtime_binding is not None
+                and session.runtime_binding_ref
+                != runtime_binding.runtimeBindingRef
+            )
+        ):
             async with store.transaction() as repos:
                 session = await repos.sessions.bind_runtime_authority(
                     request.session_id,
                     expected_revision=session.revision,
                     expected_fencing_generation=request.fencing_generation,
+                    execution_plan_ref=session.execution_plan_ref,
+                    runtime_binding_ref=(
+                        runtime_binding.runtimeBindingRef
+                        if runtime_binding is not None
+                        else None
+                    ),
                     metadata_patch={"bridgeSessionRef": bridge.bridge_session_id},
                 )
         settled = await _settle_command(request)
@@ -1474,6 +1668,22 @@ async def omnigent_ensure_provider_session_activity(
         await http_client.aclose()
 
     await bridge_store.attach_session(agent_request.idempotency_key, provider_session_id)
+    runtime_binding = None
+    if session.execution_plan_ref:
+        from moonmind.omnigent.harness_platform.stores import (
+            DbRuntimeBindingStore,
+        )
+
+        if not session.runtime_binding_ref:
+            raise ValueError(
+                "admitted execution plan is missing host runtime binding"
+            )
+        runtime_binding = await DbRuntimeBindingStore(
+            async_session_maker
+        ).update_with_session(
+            session.runtime_binding_ref,
+            omnigent_session_id=provider_session_id,
+        )
     async with store.transaction() as repos:
         attached = await repos.sessions.attach_provider_session(
             request.session_id,
@@ -1485,6 +1695,12 @@ async def omnigent_ensure_provider_session_activity(
             request.session_id,
             expected_revision=attached.revision,
             expected_fencing_generation=attached.fencing_generation,
+            execution_plan_ref=attached.execution_plan_ref,
+            runtime_binding_ref=(
+                runtime_binding.runtimeBindingRef
+                if runtime_binding is not None
+                else None
+            ),
             metadata_patch={"bridgeSessionRef": bridge.bridge_session_id},
         )
     settled = await _settle_command(request)
@@ -2192,6 +2408,9 @@ async def omnigent_persist_failure_activity(
     status = request.status
     if command is not None and command.delivery_ambiguous:
         status = "delivery_unknown"
+    execution_authority_metadata = await _session_execution_authority_metadata(
+        session
+    )
 
     existing_ref = str(session.metadata.get(evidence_metadata_key) or "").strip()
     if existing_ref:
@@ -2261,6 +2480,7 @@ async def omnigent_persist_failure_activity(
             {
                 "cleanupOwner": _JANITOR_OWNER,
                 "janitorRequired": True,
+                **execution_authority_metadata,
             }
         )
         result = primary_result.model_copy(update={"metadata": metadata})
@@ -2272,6 +2492,7 @@ async def omnigent_persist_failure_activity(
                 "omnigentSessionStatus": status,
                 "primaryOmnigentSessionStatus": primary_terminal.status,
                 "reasonCode": request.reason_code,
+                **execution_authority_metadata,
             }
         )
         result = primary_result.model_copy(
@@ -2295,6 +2516,7 @@ async def omnigent_persist_failure_activity(
                 "canonicalSessionId": request.session_id,
                 "omnigentSessionStatus": status,
                 "reasonCode": request.reason_code,
+                **execution_authority_metadata,
                 **(
                     {
                         "cleanupOwner": _JANITOR_OWNER,
@@ -2613,6 +2835,7 @@ async def omnigent_publish_workspace_activity(
             "chatBindingId": session.chat_binding_id,
             "terminalState": session.terminal_state,
             "publicationEvidenceRef": publication_ref,
+            **(await _session_execution_authority_metadata(session)),
         },
     )
     terminal = OmnigentSessionTerminalResult(status=status, result=result)

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -15939,6 +15939,8 @@ class TemporalCheckpointActivities:
             effectiveLaunchRef=capture.get("effectiveLaunchRef"),
             executionProfileRef=capture["executionProfileRef"],
             launchPolicyRef=capture["launchPolicyRef"],
+            executionPlanRef=capture.get("executionPlanRef"),
+            runtimeBindingRef=capture.get("runtimeBindingRef"),
             policyId=capture.get("policyId"),
             policyVersion=capture.get("policyVersion"),
             policyRef=capture.get("policyRef"),

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -231,6 +231,9 @@ OMNIGENT_SESSION_SUPERVISOR_PATCH_ID = (
 OMNIGENT_SESSION_ADMISSION_PATCH_ID = (
     "agent-run-omnigent-session-admission-v1"
 )
+OMNIGENT_EXECUTION_PLAN_ADMISSION_PATCH_ID = (
+    "agent-run-omnigent-execution-plan-admission-v1"
+)
 MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
 MANAGED_STATUS_ROLLOUT_TOLERANCE_PATCH_ID = (
     "agent-run-managed-status-rollout-tolerance-v1"
@@ -4302,6 +4305,9 @@ class MoonMindAgentRun:
         use_omnigent_session_admission = workflow.patched(
             OMNIGENT_SESSION_ADMISSION_PATCH_ID
         )
+        use_omnigent_execution_plan_admission = workflow.patched(
+            OMNIGENT_EXECUTION_PLAN_ADMISSION_PATCH_ID
+        )
         requested_execution_profile_ref = request.execution_profile_ref
         resiliency_policy: Mapping[str, Any] = {}
         if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
@@ -5086,6 +5092,17 @@ class MoonMindAgentRun:
                                     agentRunId=workflow.info().workflow_id,
                                     executionProfileRef=(
                                         request.execution_profile_ref
+                                    ),
+                                    executionPlanRef=(
+                                        str(
+                                            (request.parameters or {}).get(
+                                                "executionPlanRef"
+                                            )
+                                            or ""
+                                        ).strip()
+                                        or None
+                                        if use_omnigent_execution_plan_admission
+                                        else None
                                     ),
                                 ).model_dump(mode="json", by_alias=True),
                                 cancellation_type=(

--- a/moonmind/workflows/temporal/workflows/omnigent_session.py
+++ b/moonmind/workflows/temporal/workflows/omnigent_session.py
@@ -11,8 +11,6 @@ correctness backstop for lost terminal edges.
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import json
 from datetime import datetime, timedelta
 from typing import Any, Mapping
 
@@ -21,6 +19,11 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import CancelledError
 
 with workflow.unsafe.imports_passed_through():
+    from moonmind.omnigent.control_plane.identities import (
+        canonical_omnigent_session_id,
+        canonical_omnigent_turn_attempt_id,
+        omnigent_session_workflow_id,
+    )
     from moonmind.omnigent.reconciler import (
         DecisionKind,
         DurableSessionState,
@@ -144,27 +147,6 @@ def _is_cancellation_failure(error: BaseException) -> bool:
         )
         current = cause if isinstance(cause, BaseException) else None
     return False
-
-
-def canonical_omnigent_session_id(
-    *, workflow_id: str, step_execution_id: str, agent_run_id: str
-) -> str:
-    """Return the canonical identity derived only from durable owner scope."""
-
-    authority = json.dumps(
-        ["omnigent-session/v1", workflow_id, step_execution_id, agent_run_id],
-        separators=(",", ":"),
-    ).encode("utf-8")
-    return "oms_" + hashlib.sha256(authority).hexdigest()[:40]
-
-
-def canonical_omnigent_turn_attempt_id(session_id: str, ordinal: int = 1) -> str:
-    authority = f"omnigent-turn/v1:{session_id}:{ordinal}".encode("utf-8")
-    return "ota_" + hashlib.sha256(authority).hexdigest()[:40]
-
-
-def omnigent_session_workflow_id(session_id: str) -> str:
-    return f"omnigent-session:{session_id}"
 
 
 @workflow.defn(name=WORKFLOW_TYPE)

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -726,6 +726,9 @@ RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH = (
 RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH = (
     "run-omnigent-stock-agent-identity-v1"
 )
+RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH = (
+    "run-omnigent-execution-plan-ref-v1"
+)
 RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH = (
     "run-agent-required-capabilities-propagation-v1"
 )
@@ -19305,6 +19308,32 @@ class MoonMindRunWorkflow:
                 param_val = workflow_parameters.get(param_key)
             if param_val is not None:
                 parameters[param_key] = param_val
+        if (
+            agent_id == "omnigent"
+            and self._workflow_patch_enabled(
+                RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH
+            )
+            and isinstance(workflow_parameters, Mapping)
+        ):
+            admitted_plan_ref = str(
+                workflow_parameters.get("executionPlanRef") or ""
+            ).strip()
+            if admitted_plan_ref:
+                if not admitted_plan_ref.startswith(
+                    "omnigent-execution-plan:sha256:"
+                ):
+                    raise ValueError("workflow.executionPlanRef is invalid")
+                for source_name, source in (
+                    ("node.runtime", runtime_block),
+                    ("node", node_inputs),
+                ):
+                    supplied = str(source.get("executionPlanRef") or "").strip()
+                    if supplied and supplied != admitted_plan_ref:
+                        raise ValueError(
+                            f"{source_name}.executionPlanRef conflicts with "
+                            "the admitted workflow executionPlanRef"
+                        )
+                parameters["executionPlanRef"] = admitted_plan_ref
         if repository_operation:
             if repository_operation not in {"read", "write"}:
                 raise ValueError(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -30,6 +30,10 @@ with workflow.unsafe.imports_passed_through():
         authored_repository_source,
         authored_starting_branch,
     )
+    from moonmind.omnigent.harness_platform.admission import (
+        NORMAL_PRODUCT_HARNESS_IDS,
+        NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS,
+    )
     from api_service.services.provider_profile_readiness import (
         provider_profile_launch_ready_from_payload,
     )
@@ -999,7 +1003,10 @@ def _worker_capability_unavailable_error(
 
 
 MM_STARTED_AT_SEARCH_ATTRIBUTE = "mm_started_at"
-_PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code")
+_PROFILE_SYNC_RUNTIME_IDS = (
+    *sorted(NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS),
+    "claude_code",
+)
 _MANAGED_AGENT_IDS = frozenset(
     {
         "claude",
@@ -20696,7 +20703,9 @@ class MoonMindRunWorkflow:
                 child_runtime_id = self._managed_runtime_id(agent_id or "")
                 compatible_runtime_ids = {child_runtime_id}
                 if child_runtime_id == "omnigent":
-                    compatible_runtime_ids.add("codex_cli")
+                    compatible_runtime_ids.update(
+                        NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS
+                    )
                 if compatible_runtime_ids.isdisjoint(
                     str(item).strip() for item in authoritative_runtime_ids
                 ):
@@ -20721,7 +20730,7 @@ class MoonMindRunWorkflow:
         child_runtime_id = self._managed_runtime_id(agent_id)
         compatible_runtime_ids = {child_runtime_id}
         if child_runtime_id == "omnigent":
-            compatible_runtime_ids.add("codex_cli")
+            compatible_runtime_ids.update(NORMAL_PRODUCT_PROVIDER_RUNTIME_IDS)
         if runtime_id not in compatible_runtime_ids:
             if self._workflow_is_replaying():
                 return profile_id
@@ -22719,7 +22728,7 @@ class MoonMindRunWorkflow:
         agent = normalized.get("agent")
         if isinstance(agent, Mapping):
             harness = agent.get("harnessOverride")
-            if harness not in {"codex-native", "claude-native"}:
+            if harness not in {*NORMAL_PRODUCT_HARNESS_IDS, "claude-native"}:
                 raise ValueError(
                     f"{path}.agent.harnessOverride must be a supported native harness"
                 )
@@ -22805,7 +22814,7 @@ class MoonMindRunWorkflow:
             "harness",
             error_message="agentProfileSnapshot.document.harness is required",
         )
-        if harness not in {"codex-native", "claude-native"}:
+        if harness not in {*NORMAL_PRODUCT_HARNESS_IDS, "claude-native"}:
             raise ValueError("agentProfileSnapshot.document.harness is unsupported")
 
         authored = self._json_mapping(value, path=path)

--- a/tests/integration/api/test_checkpoint_branch_migration.py
+++ b/tests/integration/api/test_checkpoint_branch_migration.py
@@ -436,8 +436,13 @@ async def test_public_checkpoint_branch_launch_is_idempotent_under_postgres_race
         "publicationState": "none",
     }
     omnigent_checkpoint = SimpleNamespace(
+        workflow_id=workflow_id,
+        step_execution_id=f"{workflow_id}:source-step",
+        bridge_session_id=f"bridge-{suffix}",
+        omnigent_session_id=None,
         execution_profile_ref="profile-race",
         launch_policy_ref="codex-on-demand@1",
+        execution_plan_ref=None,
         idempotency_key=f"source-message-{suffix}",
         source_branch="main",
         publication_state="none",

--- a/tests/integration/omnigent/conftest.py
+++ b/tests/integration/omnigent/conftest.py
@@ -24,10 +24,14 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from api_service.db.models import (
+    ManagedAgentProviderProfile,
     OmnigentChatBindingAlias,
     OmnigentCleanupAuthority,
     OmnigentCommand,
+    OmnigentCredentialRuntimeRecord,
     OmnigentExecutionPlanRecord,
+    OmnigentHostBindingRecordV2,
+    OmnigentHostLeaseRecordV2,
     OmnigentObservation,
     OmnigentReconciliationDecision,
     OmnigentRuntimeBindingRecord,
@@ -40,8 +44,12 @@ _CONTROL_PLANE_TABLES = [
     # MoonLadderStudios/MoonMind#3701: the canonical session now has foreign
     # keys to the immutable admission authority, so PostgreSQL integration
     # fixtures must exercise those real handoff tables too.
+    ManagedAgentProviderProfile.__table__,
     OmnigentExecutionPlanRecord.__table__,
     OmnigentRuntimeBindingRecord.__table__,
+    OmnigentHostBindingRecordV2.__table__,
+    OmnigentHostLeaseRecordV2.__table__,
+    OmnigentCredentialRuntimeRecord.__table__,
     OmnigentSession.__table__,
     OmnigentTurnAttempt.__table__,
     OmnigentObservation.__table__,

--- a/tests/integration/omnigent/conftest.py
+++ b/tests/integration/omnigent/conftest.py
@@ -27,14 +27,21 @@ from api_service.db.models import (
     OmnigentChatBindingAlias,
     OmnigentCleanupAuthority,
     OmnigentCommand,
+    OmnigentExecutionPlanRecord,
     OmnigentObservation,
     OmnigentReconciliationDecision,
+    OmnigentRuntimeBindingRecord,
     OmnigentSession,
     OmnigentTurnAttempt,
 )
 from moonmind.omnigent.control_plane import OmnigentControlPlaneStore
 
 _CONTROL_PLANE_TABLES = [
+    # MoonLadderStudios/MoonMind#3701: the canonical session now has foreign
+    # keys to the immutable admission authority, so PostgreSQL integration
+    # fixtures must exercise those real handoff tables too.
+    OmnigentExecutionPlanRecord.__table__,
+    OmnigentRuntimeBindingRecord.__table__,
     OmnigentSession.__table__,
     OmnigentTurnAttempt.__table__,
     OmnigentObservation.__table__,

--- a/tests/integration/omnigent/test_control_plane_postgres.py
+++ b/tests/integration/omnigent/test_control_plane_postgres.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from api_service.db.models import (
+    OmnigentExecutionPlanRecord,
+    OmnigentRuntimeBindingRecord,
+)
 from moonmind.omnigent.control_plane import (
     ConflictingSessionAuthorityError,
     ControlPlaneOutcome,
@@ -46,6 +50,78 @@ async def test_postgres_scope_uniqueness_fails_closed(pg_store) -> None:
                 moonmind_workflow_id="wf-1",
                 provider="codex",
                 provider_session_ref="psess-1",
+            )
+
+
+@pytest.mark.asyncio
+async def test_postgres_session_advances_immutable_runtime_binding_stages(
+    pg_store,
+) -> None:
+    """MoonLadderStudios/MoonMind#3701 authority handoff is DB-enforced."""
+
+    plan_ref = "omnigent-execution-plan:sha256:" + "3" * 64
+    credential_ref = "omnigent-runtime-binding:sha256:" + "4" * 64
+    host_ref = "omnigent-runtime-binding:sha256:" + "5" * 64
+    alternate_host_ref = "omnigent-runtime-binding:sha256:" + "6" * 64
+    async with pg_store._session_factory() as session:
+        session.add(
+            OmnigentExecutionPlanRecord(
+                plan_ref=plan_ref,
+                schema_version="moonmind.omnigent-execution-plan.v1",
+                payload_json={},
+                harness_id="opencode-native",
+                harness_implementation_ref="core:omnigent@1",
+                host_class_ref="omnigent-opencode@1",
+                launch_policy_ref="omnigent-on-demand@1",
+                execution_realizer_ref="generic-omnigent-host@1",
+            )
+        )
+        for ref, state in (
+            (credential_ref, "credentials_acquired"),
+            (host_ref, "host_acquired"),
+            (alternate_host_ref, "host_acquired"),
+        ):
+            session.add(
+                OmnigentRuntimeBindingRecord(
+                    runtime_binding_ref=ref,
+                    execution_plan_ref=plan_ref,
+                    state=state,
+                    provider_leases_json={},
+                )
+            )
+        await session.commit()
+
+    async with pg_store.transaction() as repos:
+        created = await repos.sessions.create(
+            session_id="s-authority",
+            moonmind_workflow_id="wf-authority",
+            provider="omnigent",
+            execution_plan_ref=plan_ref,
+        )
+        credentials = await repos.sessions.bind_runtime_authority(
+            "s-authority",
+            expected_revision=created.revision,
+            expected_fencing_generation=created.fencing_generation,
+            execution_plan_ref=plan_ref,
+            runtime_binding_ref=credential_ref,
+        )
+        host = await repos.sessions.bind_runtime_authority(
+            "s-authority",
+            expected_revision=credentials.revision,
+            expected_fencing_generation=credentials.fencing_generation,
+            execution_plan_ref=plan_ref,
+            runtime_binding_ref=host_ref,
+        )
+
+    assert host.runtime_binding_ref == host_ref
+    with pytest.raises(ConflictingSessionAuthorityError):
+        async with pg_store.transaction() as repos:
+            await repos.sessions.bind_runtime_authority(
+                "s-authority",
+                expected_revision=host.revision,
+                expected_fencing_generation=host.fencing_generation,
+                execution_plan_ref=plan_ref,
+                runtime_binding_ref=alternate_host_ref,
             )
 
 

--- a/tests/integration/omnigent/test_default_generic_realizer_product_path.py
+++ b/tests/integration/omnigent/test_default_generic_realizer_product_path.py
@@ -1,0 +1,436 @@
+"""Normal-product boundary coverage for the default generic realizer.
+
+The test keeps the production registry, SQL stores, canonical command service,
+credential materializer, workspace owner, host services, and cleanup path. Only
+the deployment-owned external endpoints (Temporal lease RPC, Docker command
+runner, Omnigent HTTP API, and secret resolver) are bounded test fixtures.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    OmnigentCredentialRuntimeRecord,
+    OmnigentHostLeaseRecordV2,
+    ProviderCredentialSource,
+    ProviderProfileAuthMethod,
+    ProviderProfileAuthState,
+    RuntimeMaterializationMode,
+)
+from moonmind.omnigent.harness_platform.admission import (
+    compile_normal_product_execution_plan,
+)
+from moonmind.omnigent.harness_platform.attestation import (
+    HostHarnessAttestation,
+    compute_attestation_ref,
+)
+from moonmind.omnigent.harness_platform.catalog import (
+    HarnessImplementationIdentity,
+)
+from moonmind.omnigent.harness_platform.host_classes import get_host_class
+from moonmind.omnigent.harness_platform.materializers import (
+    FORBIDDEN_AMBIENT_ENV_KEYS,
+)
+from moonmind.omnigent.harness_platform.stores import (
+    DbExecutionPlanStore,
+    DbRuntimeBindingStore,
+)
+from moonmind.omnigent.realizers.registry import (
+    get_default_registry,
+    reset_default_registry,
+)
+from moonmind.provider_profiles.lease_client import (
+    CredentialLease,
+    CredentialLeasePurpose,
+)
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.security.egress import (
+    EGRESS_CONFIG_DIGEST,
+    ENFORCER_IMPLEMENTATION,
+    EgressAttestation,
+    OMNIGENT_EGRESS_PROFILE,
+)
+from moonmind.workflows.temporal.activities.omnigent_activities import (
+    _try_generic_realizer_dispatch,
+)
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def _agent_profile_snapshot() -> tuple[dict[str, object], dict[str, object]]:
+    implementation = HarnessImplementationIdentity.model_validate(
+        {
+            "sourceKind": "core",
+            "package": "omnigent",
+            "version": "1.0.0",
+            "digest": "sha256:" + "a" * 64,
+            "pluginEntryPoint": None,
+        }
+    )
+    implementation_payload = implementation.model_dump(by_alias=True, mode="json")
+    snapshot: dict[str, object] = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "opencode-native-profile",
+        "version": 7,
+        "digest": "sha256:" + "1" * 64,
+        "providerProfileRef": "opencode-native-provider",
+        "executionProfileRef": "opencode-native@1",
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "agentId": "opencode-native-agent",
+        "policyRef": "omnigent-policy:integration",
+        "document": {
+            "schemaVersion": "moonmind.omnigent-agent-profile.v1",
+            "endpointRef": "default",
+            "bridgeMode": "proxy",
+            "source": {
+                "upstreamId": "opencode-native-agent",
+                "upstreamVersion": "1.0.0",
+            },
+            "harness": "opencode-native",
+            "requiredCapabilities": ["streaming"],
+            "execution": {
+                "defaultExecutionProfileRef": "opencode-native@1",
+                "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
+            },
+            "providerRequirements": {
+                "runtimeId": "opencode_go",
+                "credentialSource": "api_key",
+                "materializationMode": "generated_file",
+                "providerIds": ["opencode"],
+            },
+            "model": {"model": "provider/model", "settings": {}},
+            "workspace": {"mutation": "allowed", "requiredCapabilities": []},
+            "skills": [],
+            "tools": [],
+            "capture": {"stream": True, "evidence": True},
+            "rag": {"initial": {}, "followUp": {}},
+            "continuations": {
+                "checkpoint": True,
+                "branch": True,
+                "remediation": True,
+            },
+            "publish": {"mode": "none"},
+            "policyRef": "omnigent-policy:integration",
+        },
+        "upstreamSnapshot": {
+            "id": "opencode-native-agent",
+            "version": "1.0.0",
+            "harness": "opencode-native",
+            "catalogObservedAt": datetime.now(UTC).isoformat(),
+            "harnessImplementation": implementation_payload,
+        },
+        "validationResult": {"ready": True},
+    }
+    return snapshot, implementation_payload
+
+
+@pytest.mark.asyncio
+async def test_default_registry_executes_and_cleans_up_opencode_product_path(
+    pg_store,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Exercise the default registry across persisted production boundaries."""
+
+    image_ref = (
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64
+    )
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "local")
+    monkeypatch.delenv("WORKFLOW_WORKSPACE_DAEMON_ROOT", raising=False)
+    monkeypatch.setenv("OMNIGENT_GENERIC_RUNTIME_ROOT", str(tmp_path / "runtime"))
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "http://omnigent.invalid")
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", image_ref)
+    monkeypatch.chdir(tmp_path)
+    for name in FORBIDDEN_AMBIENT_ENV_KEYS:
+        monkeypatch.delenv(name, raising=False)
+
+    snapshot, implementation_payload = _agent_profile_snapshot()
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=snapshot,
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:default-generic-product-path",
+    )
+    plan_store = DbExecutionPlanStore(pg_store._session_factory)
+    await plan_store.persist(plan)
+
+    async with pg_store._session_factory() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="opencode-native-provider",
+                runtime_id="opencode_go",
+                provider_id="opencode",
+                credential_source=ProviderCredentialSource.SECRET_REF,
+                runtime_materialization_mode=(
+                    RuntimeMaterializationMode.CONFIG_BUNDLE
+                ),
+                secret_refs={"api_key": {"kind": "managed", "ref": "test-key"}},
+                credential_generation=6,
+                max_parallel_runs=2,
+                enabled=True,
+                auth_state=ProviderProfileAuthState.CONNECTED,
+                last_auth_method=ProviderProfileAuthMethod.SECRET_REF,
+            )
+        )
+        await session.commit()
+
+    correlation_id = "mm:default-generic-product-path"
+    idempotency_key = "step-default-generic-product-path"
+    workspace_id = hashlib.sha256(
+        f"{correlation_id}:{idempotency_key}".encode("utf-8")
+    ).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    workspace.mkdir(parents=True)
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id=correlation_id,
+            step_execution_id=idempotency_key,
+            relative_path="repo",
+        )
+    )
+
+    released_leases: list[str] = []
+
+    async def acquire_execution_lease(_client, **kwargs):
+        return CredentialLease(
+            profile_id=kwargs["profile_id"],
+            runtime_id=kwargs["runtime_id"],
+            lease_id="provider-lease:default-product-path",
+            owner_id=kwargs["owner_id"],
+            purpose=CredentialLeasePurpose.EXECUTION_OMNIGENT,
+        )
+
+    async def release_lease(_client, lease):
+        released_leases.append(lease.lease_id)
+
+    async def resolve_secret(_secret_ref, *, field_name):
+        assert "api_key SecretRef" in field_name
+        return "integration-only-opencode-key"
+
+    monkeypatch.setattr(
+        "moonmind.provider_profiles.lease_client."
+        "ProviderProfileLeaseClient.acquire_execution_lease",
+        acquire_execution_lease,
+    )
+    monkeypatch.setattr(
+        "moonmind.provider_profiles.lease_client.ProviderProfileLeaseClient.release_lease",
+        release_lease,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.deployment_adapters.resolve_managed_api_key_reference",
+        resolve_secret,
+    )
+
+    docker_state: dict[str, object] = {"launched": False, "removed": False}
+
+    async def run_docker(argv, *, env=None):
+        args = list(argv)
+        if args[0] == "run":
+            docker_state["launched"] = True
+            docker_state["container"] = args[args.index("--name") + 1]
+            docker_state["image"] = args[-1]
+            docker_state["lease"] = next(
+                value.split("=", 1)[1]
+                for index, value in enumerate(args)
+                if args[index - 1] == "--label"
+                and value.startswith("moonmind.host_lease_id=")
+            )
+            assert env is not None
+            return 0, b"container-id", b""
+        if args[:2] == ["rm", "-f"]:
+            docker_state["removed"] = True
+            return 0, b"", b""
+        if args[0] == "inspect" and "{{json .Config.Image}}" in args:
+            return 0, json.dumps(docker_state["image"]).encode("utf-8"), b""
+        if args[0] == "inspect":
+            if docker_state["launched"]:
+                return 0, str(docker_state["lease"]).encode("utf-8"), b""
+            return 1, b"", b"not found"
+        raise AssertionError(f"unexpected deployment command: {args[0]}")
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.deployment_adapters._run_docker", run_docker
+    )
+
+    egress_attestation = EgressAttestation(
+        profileRef=OMNIGENT_EGRESS_PROFILE.ref,
+        profileDigest=OMNIGENT_EGRESS_PROFILE.digest,
+        enforcerImplementation=ENFORCER_IMPLEMENTATION,
+        backendRef="docker-cli/trusted-worker",
+        networkRef=OMNIGENT_EGRESS_PROFILE.network_ref,
+        gatewayRef=OMNIGENT_EGRESS_PROFILE.gateway_ref,
+        appliedRuleDigest="sha256:" + "2" * 64,
+        configDigest=EGRESS_CONFIG_DIGEST,
+        gatewayImageDigest="sha256:" + "3" * 64,
+        validatedAt=datetime.now(UTC),
+    )
+
+    async def attest_egress(**_kwargs):
+        return egress_attestation
+
+    async def attest_workload_egress(**kwargs):
+        assert kwargs["attachment_identity"] == docker_state["container"]
+        assert kwargs["expected_image_ref"] == image_ref
+        return {
+            "profileRef": OMNIGENT_EGRESS_PROFILE.ref,
+            "attachmentIdentity": kwargs["attachment_identity"],
+            "enforced": True,
+        }
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.deployment_adapters.attest_docker_egress",
+        attest_egress,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.deployment_adapters.attest_docker_workload_egress",
+        attest_workload_egress,
+    )
+
+    host_class = get_host_class(plan.payload.hostClassRef)
+    host_entry = next(
+        entry
+        for entry in host_class.declaredHarnessImplementations
+        if entry.harnessId == plan.payload.harnessId
+    )
+
+    async def list_hosts(_client):
+        capabilities = {
+            capability: True
+            for capability in plan.payload.classAdmissionDecision.get("required", [])
+        }
+        capabilities.update({"mountedSkills": True, "restricted-egress": True})
+        raw = {
+            "hostId": "omnigent-host:default-product-path",
+            "hostClassRef": host_class.ref,
+            "hostImageRef": host_class.imageRef,
+            "omnigentVersion": host_class.omnigentVersion,
+            "omnigentBuildDigest": host_class.omnigentBuildDigest,
+            "harnessId": plan.payload.harnessId,
+            "harnessImplementation": implementation_payload,
+            "runtimeDependencies": [
+                dict(dependency)
+                for dependency in host_entry.runtimeDependencies
+            ],
+            "configured": True,
+            "capabilities": capabilities,
+            "architecture": plan.payload.supportIdentity.architecture,
+            "attestationGeneration": 1,
+            "observedAt": datetime.now(UTC).isoformat(),
+        }
+        attestation = HostHarnessAttestation.model_validate(raw)
+        raw["attestationRef"] = compute_attestation_ref(attestation)
+        return [
+            {
+                "id": "omnigent-host:default-product-path",
+                "name": docker_state["container"],
+                "status": "online",
+                "attestation": raw,
+            }
+        ]
+
+    async def get_model_options(_client, host_id):
+        assert host_id == "omnigent-host:default-product-path"
+        return {"models": [{"qualifiedId": "provider/model"}]}
+
+    monkeypatch.setattr(
+        "moonmind.workflows.adapters.omnigent_client.OmnigentHttpClient.list_hosts",
+        list_hosts,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.adapters.omnigent_client.OmnigentHttpClient.get_host_model_options",
+        get_model_options,
+    )
+
+    observed_driver_requests: list[AgentExecutionRequest] = []
+
+    async def execute_session(request, **_kwargs):
+        observed_driver_requests.append(request)
+        return AgentRunResult(
+            summary="default registry completed",
+            metadata={"omnigentSessionId": "provider-session:default-product-path"},
+        )
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.composition.run_omnigent_execution",
+        execute_session,
+    )
+
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=correlation_id,
+        idempotencyKey=idempotency_key,
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": "repo",
+            }
+        },
+        parameters={"executionPlanRef": plan.planRef},
+    )
+    reset_default_registry()
+    try:
+        registry = get_default_registry()
+        default_realizer = registry.require("generic-omnigent-host@1")
+        default_realizer._session_factory = pg_store._session_factory
+        result = await _try_generic_realizer_dispatch(
+            request,
+            plan_store=plan_store,
+            realizer_registry=registry,
+        )
+    finally:
+        reset_default_registry()
+
+    assert result is not None and result.summary == "default registry completed"
+    assert result.metadata["executionPlanRef"] == plan.planRef
+    assert result.metadata["supportCombinationIdentity"]["identityComplete"] is True
+    assert observed_driver_requests[0].parameters["omnigent"]["session"]["hostId"] == (
+        "omnigent-host:default-product-path"
+    )
+    assert docker_state["launched"] is True
+    assert docker_state["removed"] is True
+    assert released_leases == ["provider-lease:default-product-path"]
+
+    binding = await DbRuntimeBindingStore(pg_store._session_factory).latest_for_plan(
+        plan.planRef
+    )
+    assert binding is not None
+    assert binding.providerLeases["primary-model"].credentialGeneration == 6
+    assert binding.omnigentHostId == "omnigent-host:default-product-path"
+    assert binding.hostLeaseGeneration == 1
+    assert binding.omnigentSessionId == "provider-session:default-product-path"
+    assert binding.hostHarnessAttestationRef
+    assert binding.exactHostCapabilityDecisionRef
+    assert binding.modelOptionAttestationRef
+
+    async with pg_store._session_factory() as session:
+        host_lease = await session.get(
+            OmnigentHostLeaseRecordV2, binding.hostLeaseRef
+        )
+        credential_record = (
+            await session.execute(
+                select(OmnigentCredentialRuntimeRecord)
+            )
+        ).scalars().one()
+    assert host_lease is not None and host_lease.status == "cleaned"
+    assert host_lease.omnigent_host_id == "omnigent-host:default-product-path"
+    assert credential_record.credential_generation == 6
+    credential_root = tmp_path / "runtime" / "credentials"
+    assert not any(credential_root.rglob("auth.json"))
+    assert "integration-only-opencode-key" not in json.dumps(
+        result.model_dump(by_alias=True, mode="json")
+    )

--- a/tests/integration/omnigent/test_default_generic_realizer_product_path.py
+++ b/tests/integration/omnigent/test_default_generic_realizer_product_path.py
@@ -241,6 +241,7 @@ async def test_default_registry_executes_and_cleans_up_opencode_product_path(
         if args[0] == "run":
             docker_state["launched"] = True
             docker_state["container"] = args[args.index("--name") + 1]
+            docker_state["platform"] = args[args.index("--platform") + 1]
             docker_state["image"] = args[-1]
             docker_state["lease"] = next(
                 value.split("=", 1)[1]
@@ -402,6 +403,7 @@ async def test_default_registry_executes_and_cleans_up_opencode_product_path(
         "omnigent-host:default-product-path"
     )
     assert docker_state["launched"] is True
+    assert docker_state["platform"] == plan.payload.supportIdentity.architecture
     assert docker_state["removed"] is True
     assert released_leases == ["provider-lease:default-product-path"]
 

--- a/tests/integration/reliability_journey/test_omnigent_cumulative_remediation_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_cumulative_remediation_journey.py
@@ -32,7 +32,12 @@ from moonmind.workflows.temporal.remediation_workspace_head import (
     advance_head,
     freeze_attempt_input,
 )
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
+    RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
+    RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH,
+    MoonMindRunWorkflow,
+)
 from tests.unit.api.routers.test_executions import (
     _build_execution_record,
     _override_user_dependencies,
@@ -136,7 +141,36 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
     app.dependency_overrides[_get_service] = lambda: service
     app.dependency_overrides[get_temporal_client] = AsyncMock
     _override_user_dependencies(app, is_superuser=False)
-    with TestClient(app) as client:
+    profile_snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "omnigent-bootstrap-default",
+        "version": 1,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "omnigent-codex",
+        "executionProfileRef": "omnigent-host-codex",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "codex-native-ui",
+        "document": {
+            "endpointRef": "default",
+            "harness": "codex-native",
+            "model": {"model": "gpt-5"},
+            "capture": {},
+            "rag": {},
+            "publish": {},
+            "workspace": {},
+        },
+    }
+    with patch(
+        "api_service.api.routers.executions.resolve_default_agent_profile_snapshot",
+        AsyncMock(return_value=profile_snapshot),
+    ), patch(
+        "api_service.api.routers.executions.compile_and_persist_execution_authority",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                planRef="omnigent-execution-plan:sha256:" + "b" * 64
+            )
+        ),
+    ), TestClient(app) as client:
         response = client.post("/api/executions", json={
             "type": "workflow",
             "payload": {
@@ -170,6 +204,14 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
         return_value=SimpleNamespace(
             workflow_id="mm:wf-3480", run_id="run-1", namespace="default"
         ),
+    ), patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.patched",
+        side_effect=lambda patch_id: patch_id
+        in {
+            RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
+            RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
+            RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH,
+        },
     ):
         compiled = compiler._build_agent_execution_request(
             node_inputs={
@@ -179,7 +221,6 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
                         "executionProfileRef"
                     ],
                 },
-                "omnigent": {"harness": "codex-native"},
             },
             node_id="initial-implementation",
             tool_name="omnigent",
@@ -188,7 +229,15 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
     assert compiled.agent_kind == "external"
     assert compiled.agent_id == "omnigent"
     assert compiled.execution_profile_ref == "omnigent-codex"
-    assert compiled.parameters["omnigent"] == {"harness": "codex-native"}
+    assert compiled.parameters["executionPlanRef"].startswith(
+        "omnigent-execution-plan:sha256:"
+    )
+    assert compiled.parameters["omnigent"]["executionTargetRef"] == (
+        "omnigent-host-codex"
+    )
+    assert compiled.parameters["omnigent"]["agent"]["harnessOverride"] == (
+        "codex-native"
+    )
     assert compiled.step_execution.workflow_id == "mm:wf-3480"
 
     artifacts = _CheckpointStore(tmp_path / "artifacts")

--- a/tests/integration/workflows/temporal/test_checkpoint_branch_turn_execution.py
+++ b/tests/integration/workflows/temporal/test_checkpoint_branch_turn_execution.py
@@ -1369,7 +1369,7 @@ async def test_public_root_continue_and_fork_cross_the_real_execution_owner(
                     "/api/executions/mm:wf-public-owner/checkpoint-branches",
                     json=root_payload,
                 )
-                assert replayed_root.status_code == 201
+                assert replayed_root.status_code == 201, replayed_root.text
                 assert replayed_root.json()["branchId"] == root_branch_id
 
                 continue_payload = {

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -13370,6 +13370,90 @@ def test_request_rerun_update_redirects_response_to_created_rerun_execution() ->
 
 
 @pytest.mark.asyncio
+async def test_rerun_recompiles_execution_authority_for_reserved_workflow() -> None:
+    old_plan_ref = "omnigent-execution-plan:sha256:" + "1" * 64
+    new_plan_ref = "omnigent-execution-plan:sha256:" + "2" * 64
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "profile-1",
+        "version": 2,
+        "digest": "sha256:" + "3" * 64,
+        "providerProfileRef": "provider-1",
+        "executionProfileRef": "omnigent-opencode@1",
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "agentId": "agent-1",
+        "document": {"model": {"model": "provider/model"}},
+    }
+    refreshed = {
+        "agentProfileSnapshot": snapshot,
+        "executionPlanRef": old_plan_ref,
+        "model": "provider/model",
+    }
+    canonical = SimpleNamespace(
+        workflow_id="mm:source",
+        run_id="run-source",
+        workflow_type=SimpleNamespace(value="MoonMind.UserWorkflow"),
+        owner_id=uuid4(),
+        owner_type=SimpleNamespace(value="user"),
+        memo={"title": "Rerun source"},
+        parameters=dict(refreshed),
+        input_ref=None,
+        plan_ref=None,
+        manifest_ref=None,
+    )
+    created = SimpleNamespace(workflow_id="mm:rerun-created")
+    service = SimpleNamespace(
+        _full_rerun_parameters=Mock(return_value=dict(refreshed)),
+        create_execution=AsyncMock(return_value=created),
+    )
+    session = SimpleNamespace(
+        get=AsyncMock(return_value=canonical),
+        commit=AsyncMock(),
+    )
+    compiler = AsyncMock(return_value=SimpleNamespace(planRef=new_plan_ref))
+    user = SimpleNamespace(id=canonical.owner_id, is_superuser=False)
+
+    with patch.object(
+        executions_module,
+        "_get_owned_execution",
+        AsyncMock(return_value=SimpleNamespace()),
+    ), patch.object(
+        executions_module,
+        "refresh_managed_bootstrap_snapshot",
+        AsyncMock(return_value=dict(refreshed)),
+    ), patch.object(
+        executions_module,
+        "compile_and_persist_execution_authority",
+        compiler,
+    ), patch.object(
+        executions_module,
+        "_persist_original_workflow_input_snapshot_from_parameters",
+        AsyncMock(return_value=None),
+    ), patch.object(
+        executions_module,
+        "_serialize_execution",
+        Mock(return_value={"workflowId": "mm:rerun-created"}),
+    ):
+        result = await executions_module.rerun_execution(
+            workflow_id="mm:source",
+            response=Response(),
+            service=service,
+            session=session,
+            user=user,
+            _submit_enabled=None,
+        )
+
+    assert result == {"workflowId": "mm:rerun-created"}
+    compile_kwargs = compiler.await_args.kwargs
+    reserved_workflow_id = compile_kwargs["workflow_id"]
+    assert reserved_workflow_id.startswith("mm:")
+    assert compile_kwargs["agent_profile_snapshot"] == snapshot
+    create_kwargs = service.create_execution.await_args.kwargs
+    assert create_kwargs["_workflow_id"] == reserved_workflow_id
+    assert create_kwargs["initial_parameters"]["executionPlanRef"] == new_plan_ref
+
+
+@pytest.mark.asyncio
 async def test_request_rerun_update_flushes_snapshot_reuse_before_serializing_response(
     tmp_path,
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4626,27 +4626,49 @@ def test_create_task_shaped_execution_preserves_omnigent_selection(
 ) -> None:
     test_client, service, _user = client
     service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    snapshot = {
+        "profileId": "default",
+        "version": 1,
+        "digest": "sha256:" + "1" * 64,
+        "providerProfileRef": "codex-oauth-profile",
+        "executionProfileRef": "on-demand-docker",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "codex-native-ui",
+        "document": {"model": {}, "rag": {}, "capture": {}, "workspace": {}},
+    }
+    plan_ref = "omnigent-execution-plan:sha256:" + "a" * 64
 
-    response = test_client.post(
-        "/api/executions",
-        json={
-            "type": "workflow",
-            "payload": {
-                "targetRuntime": "omnigent",
-                "omnigent": {
-                    "executionTargetRef": "on-demand-docker",
-                    "launchPolicyRef": "codex-on-demand@1",
-                },
-                "workflow": {
-                    "instructions": "Run through Omnigent.",
-                    "runtime": {
-                        "mode": "omnigent",
-                        "executionProfileRef": "codex-oauth-profile",
+    with (
+        patch(
+            "api_service.api.routers.executions.resolve_default_agent_profile_snapshot",
+            new=AsyncMock(return_value=snapshot),
+        ),
+        patch(
+            "api_service.api.routers.executions.compile_and_persist_execution_authority",
+            new=AsyncMock(return_value=SimpleNamespace(planRef=plan_ref)),
+        ),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "omnigent",
+                    "omnigent": {
+                        "executionTargetRef": "on-demand-docker",
+                        "launchPolicyRef": "codex-on-demand@1",
+                    },
+                    "workflow": {
+                        "instructions": "Run through Omnigent.",
+                        "runtime": {
+                            "mode": "omnigent",
+                            "executionProfileRef": "codex-oauth-profile",
+                        },
                     },
                 },
             },
-        },
-    )
+        )
 
     assert response.status_code == 201, response.text
     initial_parameters = service.create_execution.await_args.kwargs[
@@ -4661,6 +4683,7 @@ def test_create_task_shaped_execution_preserves_omnigent_selection(
         "mode": "omnigent",
         "executionProfileRef": "codex-oauth-profile",
     }
+    assert initial_parameters["executionPlanRef"] == plan_ref
 
 
 def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
@@ -4687,9 +4710,20 @@ def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
     }
 
     profile_resolver = AsyncMock(return_value=snapshot)
-    with patch(
-        "api_service.api.routers.executions.resolve_agent_profile_snapshot",
-        new=profile_resolver,
+    authority_compiler = AsyncMock(
+        return_value=SimpleNamespace(
+            planRef="omnigent-execution-plan:sha256:" + "b" * 64
+        )
+    )
+    with (
+        patch(
+            "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+            new=profile_resolver,
+        ),
+        patch(
+            "api_service.api.routers.executions.compile_and_persist_execution_authority",
+            new=authority_compiler,
+        ),
     ):
         response = test_client.post(
             "/api/executions",
@@ -4723,6 +4757,15 @@ def test_create_execution_keeps_resolved_agent_profile_out_of_authored_omnigent(
         "initial_parameters"
     ]
     assert initial_parameters["agentProfileSnapshot"] == snapshot
+    assert initial_parameters["executionPlanRef"] == (
+        "omnigent-execution-plan:sha256:" + "b" * 64
+    )
+    assert authority_compiler.await_args.kwargs["workflow_id"].startswith("mm:")
+    assert (
+        authority_compiler.await_args.kwargs["workflow_parameters"]
+        ["agentProfileSnapshot"]
+        == snapshot
+    )
     assert initial_parameters["profileId"] == "codex-openai-oauth"
     assert initial_parameters["omnigent"] == {
         "executionTargetRef": "omnigent-codex@1",
@@ -6322,26 +6365,48 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
 
     test_client, service, _user = client
     service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = _empty_session_override
+    snapshot = {
+        "profileId": "default",
+        "version": 1,
+        "digest": "sha256:" + "2" * 64,
+        "providerProfileRef": "codex-oauth-profile",
+        "executionProfileRef": "omnigent-codex@1",
+        "launchPolicyRef": "codex-on-demand@1",
+        "agentId": "codex-native-ui",
+        "document": {"model": {}, "rag": {}, "capture": {}, "workspace": {}},
+    }
+    plan_ref = "omnigent-execution-plan:sha256:" + "b" * 64
 
-    response = test_client.post(
-        "/api/executions",
-        json={
-            "type": "task",
-            "payload": {
-                "repository": "MoonLadderStudios/MoonMind",
-                "targetRuntime": "omnigent",
-                "omnigent": {
-                    "executionTargetRef": "omnigent-codex@1",
-                    "launchPolicyRef": "codex-on-demand@1",
-                },
-                "task": {
-                    "instructions": "Make the bounded deterministic change.",
-                    "git": {"branch": "main"},
-                    "runtime": {"mode": "omnigent"},
+    with (
+        patch(
+            "api_service.api.routers.executions.resolve_default_agent_profile_snapshot",
+            new=AsyncMock(return_value=snapshot),
+        ),
+        patch(
+            "api_service.api.routers.executions.compile_and_persist_execution_authority",
+            new=AsyncMock(return_value=SimpleNamespace(planRef=plan_ref)),
+        ),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "omnigent",
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-codex@1",
+                        "launchPolicyRef": "codex-on-demand@1",
+                    },
+                    "task": {
+                        "instructions": "Make the bounded deterministic change.",
+                        "git": {"branch": "main"},
+                        "runtime": {"mode": "omnigent"},
+                    },
                 },
             },
-        },
-    )
+        )
 
     assert response.status_code == 201
     initial_parameters = service.create_execution.await_args.kwargs[
@@ -6358,6 +6423,7 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
     assert initial_parameters["instructions"] == (
         "Make the bounded deterministic change."
     )
+    assert initial_parameters["executionPlanRef"] == plan_ref
     serialized = json.dumps(initial_parameters)
     assert all(
         forbidden not in serialized

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -27,6 +27,7 @@ from api_service.api.routers.omnigent_bridge import (
     _get_bridge_store,
     _get_create_embedded_facade,
     _get_execution_service,
+    _claim_facade_message,
     _require_bridge_enabled,
     _validate_native_resource_path,
     workflow_chat_router,
@@ -39,6 +40,7 @@ from moonmind.omnigent.bridge_config import (
     HOST_PROTOCOL_MODE_PROXY,
 )
 from moonmind.omnigent.effective_capabilities import CAPABILITY_NAMES
+from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
 from moonmind.omnigent.settings import resolved_proxy_forward_headers
 from moonmind.omnigent.workflow_chat_facade import (
     CAP_CONTROL_UNSUPPORTED,
@@ -2099,6 +2101,28 @@ def test_message_claim_records_scanned_payload_digest(monkeypatch) -> None:
         and entry["metadata"].get("controlOutcome") == "pending"
         for entry in store.lifecycle
     )
+
+
+@pytest.mark.asyncio
+async def test_canonical_settlement_suppresses_facade_ledger_redelivery() -> None:
+    store = _FakeStore()
+
+    async def claim_canonical_turn_command(**_kwargs: Any) -> Any:
+        return SimpleNamespace(outcome=ControlPlaneOutcome.ALREADY_APPLIED)
+
+    store.claim_canonical_turn_command = claim_canonical_turn_command  # type: ignore[attr-defined]
+
+    claimed = await _claim_facade_message(
+        store=store,  # type: ignore[arg-type]
+        row=_row(),
+        event_type="message",
+        actor="operator",
+        idempotency_key="canonical-replay-1",
+        payload_digest="sha256:" + "a" * 64,
+    )
+
+    assert claimed is False
+    assert store.lifecycle == []
 
 
 # --- Approval authority ------------------------------------------------------

--- a/tests/unit/api_service/test_omnigent_session_execution_authority_migration.py
+++ b/tests/unit/api_service/test_omnigent_session_execution_authority_migration.py
@@ -1,0 +1,62 @@
+"""Migration coverage for MoonLadderStudios/MoonMind#3701."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, call
+
+
+def test_session_execution_authority_migration_upgrade_and_downgrade(
+    monkeypatch,
+) -> None:
+    migration = importlib.import_module(
+        "api_service.migrations.versions.359_omnigent_session_execution_authority"
+    )
+    assert migration.down_revision == "358_generic_host"
+    operations = MagicMock()
+    monkeypatch.setattr(migration, "op", operations)
+
+    migration.upgrade()
+
+    assert [item.args[1].name for item in operations.add_column.call_args_list] == [
+        "execution_plan_ref",
+        "runtime_binding_ref",
+    ]
+    operations.create_index.assert_has_calls(
+        [
+            call(
+                "ix_omnigent_sessions_execution_plan",
+                "omnigent_sessions",
+                ["execution_plan_ref"],
+            ),
+            call(
+                "ix_omnigent_sessions_runtime_binding",
+                "omnigent_sessions",
+                ["runtime_binding_ref"],
+            ),
+        ]
+    )
+    assert operations.create_foreign_key.call_count == 2
+
+    operations.reset_mock()
+    migration.downgrade()
+
+    assert operations.drop_constraint.call_count == 2
+    operations.drop_index.assert_has_calls(
+        [
+            call(
+                "ix_omnigent_sessions_runtime_binding",
+                table_name="omnigent_sessions",
+            ),
+            call(
+                "ix_omnigent_sessions_execution_plan",
+                table_name="omnigent_sessions",
+            ),
+        ]
+    )
+    operations.drop_column.assert_has_calls(
+        [
+            call("omnigent_sessions", "runtime_binding_ref"),
+            call("omnigent_sessions", "execution_plan_ref"),
+        ]
+    )

--- a/tests/unit/omnigent/test_bridge_store.py
+++ b/tests/unit/omnigent/test_bridge_store.py
@@ -125,6 +125,39 @@ def _effective_launch() -> dict:
 
 
 @pytest.mark.asyncio
+async def test_generic_profile_authorization_persists_plan_and_binding(store) -> None:
+    request = _request("generic-authority", with_step=True)
+    launch = {
+        "executionPlanRef": "omnigent-execution-plan:sha256:" + "4" * 64,
+        "runtimeBindingRef": "omnigent-runtime-binding:sha256:" + "5" * 64,
+        "hostClassRef": "omnigent-opencode@1",
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "executionRealizerRef": "generic-omnigent-host@1",
+    }
+
+    row = await store.bind_profile_authorization(
+        request=request,
+        endpoint_ref="default",
+        provider_profile_id="opencode-profile",
+        provider_lease_id="provider-lease-generic",
+        credential_generation=3,
+        host_binding_ref="host-binding-generic",
+        host_lease_ref="host-lease-generic",
+        omnigent_host_id="host-generic",
+        effective_launch_snapshot=launch,
+    )
+
+    assert row.effective_launch_snapshot_json == launch
+    claim = await store.claim_canonical_turn_command(
+        row=row,
+        command_type="message",
+        idempotency_key="generic-follow-up",
+        payload_digest="sha256:" + "6" * 64,
+    )
+    assert claim.owns_delivery is True
+
+
+@pytest.mark.asyncio
 async def test_stopped_lease_retry_retires_and_rebinds_cleanup_authority(
     store,
 ) -> None:

--- a/tests/unit/omnigent/test_checkpoint_branch_turn_execution.py
+++ b/tests/unit/omnigent/test_checkpoint_branch_turn_execution.py
@@ -18,6 +18,7 @@ from api_service.services.checkpoint_branch_turn_execution import (
     build_branch_turn_execution_identity,
 )
 from moonmind.omnigent.checkpoints import CandidateWorkspaceAuthority
+from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
 from moonmind.omnigent.profile_bound_execution import (
     OmnigentProfileBoundExecutionCoordinator,
 )
@@ -59,6 +60,7 @@ class _Session:
 def _authority_graph():
     turn = SimpleNamespace(
         branch_turn_id="turn-1",
+        idempotency_key="checkpoint-branch-turn:turn-1",
         branch_id="branch-1",
         parent_turn_id=None,
         source_checkpoint_ref="artifact://source-checkpoint",
@@ -126,6 +128,13 @@ def _authority_graph():
     )
     omnigent = SimpleNamespace(
         idempotency_key="source-message",
+        workflow_id="source-workflow",
+        step_execution_id="source-step-execution-1",
+        bridge_session_id="source-bridge-1",
+        omnigent_session_id="source-provider-session-1",
+        execution_plan_ref=(
+            "omnigent-execution-plan:sha256:" + "9" * 64
+        ),
         launch_policy_ref="policy-1@1",
         source_branch="main",
         publication_state="none",
@@ -320,11 +329,21 @@ async def test_owner_allocates_and_claims_canonical_omnigent_request_before_star
 ) -> None:
     session = _Session()
     client = SimpleNamespace()
+    turn_commands = SimpleNamespace(
+        claim_with_repositories=AsyncMock(
+            side_effect=[
+                SimpleNamespace(outcome=ControlPlaneOutcome.APPLIED),
+                SimpleNamespace(outcome=ControlPlaneOutcome.ALREADY_APPLIED),
+            ]
+        ),
+        settle=AsyncMock(),
+    )
     owner = CheckpointBranchTurnExecutionOwner(
         session,  # type: ignore[arg-type]
         principal="service:test",
         client=client,  # type: ignore[arg-type]
         artifact_service=SimpleNamespace(),  # type: ignore[arg-type]
+        turn_command_service=turn_commands,
     )
     branch, turn, binding, source, checkpoint, profile, policy = _authority_graph()
     branch.diagnostics["runtimeSelection"]["agentProfileSnapshot"] = {
@@ -389,7 +408,7 @@ async def test_owner_allocates_and_claims_canonical_omnigent_request_before_star
     )
 
     assert events == ["claim", "start"]
-    assert session.commit.await_count == 1
+    assert session.commit.await_count == 2
     assert launched.created_step_execution_id == (
         "checkpoint-branch-turn:turn-1:branch-turn-turn-1:implement:execution:1"
     )
@@ -412,6 +431,9 @@ async def test_owner_allocates_and_claims_canonical_omnigent_request_before_star
     assert request["parameters"]["effort"] == "medium"
     assert request["parameters"]["maxBudgetUsd"] == 2.5
     assert request["parameters"]["agentProfile"]["profileId"] == "agent-profile-1"
+    assert request["parameters"]["executionPlanRef"] == (
+        "omnigent-execution-plan:sha256:" + "9" * 64
+    )
     assert request["parameters"]["omnigent"]["executionTargetRef"] == "profile-1"
     assert "artifact://remediation/context" in request["inputRefs"]
     assert "artifact://remediation/context" in request["stepExecution"][
@@ -428,7 +450,9 @@ async def test_owner_allocates_and_claims_canonical_omnigent_request_before_star
         intent={"idempotencyKey": "authorized-recovery-operation"},
     )
     assert events == ["claim", "start", "start"]
-    assert owner._validate_source_authority.await_count == 1
+    assert owner._validate_source_authority.await_count == 2
+    assert session.commit.await_count == 3
+    turn_commands.settle.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -709,6 +733,7 @@ async def test_owner_rejects_stored_authority_mismatches_before_artifact_or_runt
         ("launch_policy", "launch_policy_mismatch"),
         ("provider_profile", "provider_profile_mismatch"),
         ("execution_profile", "execution_profile_mismatch"),
+        ("execution_plan", "execution_plan_mismatch"),
         ("credential_generation", "credential_generation_changed"),
         ("profile_readiness", "provider_profile_not_ready"),
         ("repository_baseline", "repository_baseline_mismatch"),
@@ -773,6 +798,10 @@ async def test_owner_rejects_complete_authority_mismatch_matrix_before_mutation(
         selection["providerProfileRef"] = "profile-other"
     elif case == "execution_profile":
         selection["executionProfileRef"] = "profile-other"
+    elif case == "execution_plan":
+        selection["executionPlanRef"] = (
+            "omnigent-execution-plan:sha256:" + "8" * 64
+        )
     elif case == "credential_generation":
         session.profile.credential_generation = 2
     elif case == "profile_readiness":

--- a/tests/unit/omnigent/test_control_plane_aggregates.py
+++ b/tests/unit/omnigent/test_control_plane_aggregates.py
@@ -784,6 +784,7 @@ async def test_workflow_chat_uses_canonical_turn_and_command_authority(
     assert alias is not None and alias.session_id == session.session_id
 
     outcome = await service.settle(
+        workflow_id="wf-chat-command",
         idempotency_key="browser-message-1",
         outcome=ControlPlaneOutcome.APPLIED,
         provider_receipt_id="provider-receipt-1",
@@ -842,6 +843,7 @@ async def test_initial_command_uses_the_single_bootstrap_turn(
     assert turns[0].instruction_digest == "sha256:" + "7" * 64
 
     await service.settle(
+        workflow_id="wf-initial-command",
         idempotency_key="initial-command-idempotency",
         outcome=ControlPlaneOutcome.APPLIED,
     )
@@ -862,6 +864,36 @@ async def test_initial_command_uses_the_single_bootstrap_turn(
         ),
     )
     assert replay.outcome is ControlPlaneOutcome.ALREADY_APPLIED
+
+
+@pytest.mark.asyncio
+async def test_canonical_command_idempotency_is_scoped_to_workflow(store) -> None:
+    service = CanonicalTurnCommandService(store)
+    claims = []
+    for workflow_id in ("wf-scope-one", "wf-scope-two"):
+        claims.append(
+            await service.claim(
+                workflow_id=workflow_id,
+                provider_session_ref="",
+                chat_binding_id=None,
+                command_type="execute_admitted_plan",
+                idempotency_key="shared-client-key",
+                payload_digest="sha256:" + "8" * 64,
+                step_execution_id=f"step-{workflow_id}",
+                bootstrap=CanonicalSessionBootstrap(
+                    provider="omnigent",
+                    step_execution_id=f"step-{workflow_id}",
+                    agent_run_id=f"agent-{workflow_id}",
+                    source_idempotency_key="shared-client-key",
+                    execution_plan_ref=None,
+                ),
+            )
+        )
+
+    assert claims[0].session_id != claims[1].session_id
+    assert claims[0].command_id != claims[1].command_id
+    assert claims[0].idempotency_key != claims[1].idempotency_key
+    assert all(claim.owns_delivery for claim in claims)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_control_plane_aggregates.py
+++ b/tests/unit/omnigent/test_control_plane_aggregates.py
@@ -758,7 +758,7 @@ async def test_workflow_chat_uses_canonical_turn_and_command_authority(
         first_turn_attempt_id="initial-chat-command",
         first_turn_idempotency_key="initial-chat-command-idempotency",
     )
-    service = CanonicalTurnCommandService(session_factory)
+    service = CanonicalTurnCommandService(store)
 
     claim = await service.claim(
         workflow_id="wf-chat-command",
@@ -815,7 +815,7 @@ async def test_workflow_chat_uses_canonical_turn_and_command_authority(
 async def test_initial_command_uses_the_single_bootstrap_turn(
     store, session_factory
 ) -> None:
-    service = CanonicalTurnCommandService(session_factory)
+    service = CanonicalTurnCommandService(store)
 
     claim = await service.claim(
         workflow_id="wf-initial-command",

--- a/tests/unit/omnigent/test_control_plane_aggregates.py
+++ b/tests/unit/omnigent/test_control_plane_aggregates.py
@@ -21,6 +21,8 @@ from api_service.db.models import (
     Base,
     OmnigentBridgeSession,
     OmnigentBridgeSessionEvent,
+    OmnigentExecutionPlanRecord,
+    OmnigentRuntimeBindingRecord,
     OmnigentSession,
     OmnigentTurnAttempt,
 )
@@ -29,6 +31,7 @@ from moonmind.omnigent.control_plane import (
     TURN_STATE_TERMINAL,
     CommandIdempotencyConflictError,
     ConflictingSessionAuthorityError,
+    ControlPlaneOutcome,
     FencingConflictError,
     FencingScope,
     OmnigentControlPlaneStore,
@@ -39,6 +42,10 @@ from moonmind.omnigent.control_plane import (
     compute_digest,
     plan_backfill,
     run_backfill,
+)
+from moonmind.omnigent.control_plane.turn_commands import (
+    CanonicalSessionBootstrap,
+    CanonicalTurnCommandService,
 )
 
 
@@ -736,6 +743,266 @@ async def test_continuation_turn_reuses_session_without_new_binding(store) -> No
     async with store.transaction() as repos:
         by_binding = await repos.sessions.get_by_chat_binding("cb-1")
     assert by_binding.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_workflow_chat_uses_canonical_turn_and_command_authority(
+    store, session_factory
+) -> None:
+    session, initial = await store.establish_session(
+        session_id="s-chat-command",
+        moonmind_workflow_id="wf-chat-command",
+        provider="omnigent",
+        chat_binding_id="canonical-chat-binding",
+        provider_session_ref="provider-session-chat-command",
+        first_turn_attempt_id="initial-chat-command",
+        first_turn_idempotency_key="initial-chat-command-idempotency",
+    )
+    service = CanonicalTurnCommandService(session_factory)
+
+    claim = await service.claim(
+        workflow_id="wf-chat-command",
+        provider_session_ref="provider-session-chat-command",
+        chat_binding_id="browser-chat-binding",
+        command_type="message",
+        idempotency_key="browser-message-1",
+        payload_digest="sha256:" + "5" * 64,
+        step_execution_id="step-chat-command",
+    )
+
+    assert claim.owns_delivery is True
+    async with store.transaction() as repos:
+        current = await repos.sessions.get(session.session_id)
+        turn = await repos.turn_attempts.get(claim.turn_attempt_id)
+        command = await repos.commands.get(claim.command_id)
+        alias = await repos.chat_binding_aliases.resolve("browser-chat-binding")
+    assert current is not None and current.terminal_state is None
+    assert current.active_turn_attempt_id == claim.turn_attempt_id
+    assert turn is not None and turn.lineage_kind == "continuation"
+    assert turn.parent_turn_attempt_id == initial.turn_attempt_id
+    assert command is not None and command.status == "claimed"
+    assert alias is not None and alias.session_id == session.session_id
+
+    outcome = await service.settle(
+        idempotency_key="browser-message-1",
+        outcome=ControlPlaneOutcome.APPLIED,
+        provider_receipt_id="provider-receipt-1",
+        result_ref="omnigent-bridge-event://receipt-1",
+    )
+
+    assert outcome is ControlPlaneOutcome.APPLIED
+    async with store.transaction() as repos:
+        current = await repos.sessions.get(session.session_id)
+        turn = await repos.turn_attempts.get(claim.turn_attempt_id)
+        command = await repos.commands.get(claim.command_id)
+    assert current is not None and current.terminal_state is None
+    assert turn is not None and turn.state == "accepted" and not turn.is_terminal
+    assert command is not None and command.status == "applied"
+
+    replay = await service.claim(
+        workflow_id="wf-chat-command",
+        provider_session_ref="provider-session-chat-command",
+        chat_binding_id="browser-chat-binding",
+        command_type="message",
+        idempotency_key="browser-message-1",
+        payload_digest="sha256:" + "5" * 64,
+        step_execution_id="step-chat-command",
+    )
+    assert replay.outcome is ControlPlaneOutcome.ALREADY_APPLIED
+
+
+@pytest.mark.asyncio
+async def test_initial_command_uses_the_single_bootstrap_turn(
+    store, session_factory
+) -> None:
+    service = CanonicalTurnCommandService(session_factory)
+
+    claim = await service.claim(
+        workflow_id="wf-initial-command",
+        provider_session_ref="",
+        chat_binding_id=None,
+        command_type="execute_admitted_plan",
+        idempotency_key="initial-command-idempotency",
+        payload_digest="sha256:" + "7" * 64,
+        step_execution_id="step-initial-command",
+        bootstrap=CanonicalSessionBootstrap(
+            provider="omnigent",
+            step_execution_id="step-initial-command",
+            agent_run_id="agent-run-initial-command",
+            source_idempotency_key="initial-command-idempotency",
+            execution_plan_ref=None,
+        ),
+    )
+
+    async with store.transaction() as repos:
+        turns = await repos.turn_attempts.list_for_session(claim.session_id)
+    assert len(turns) == 1
+    assert turns[0].turn_attempt_id == claim.turn_attempt_id
+    assert turns[0].lineage_kind == "initial"
+    assert turns[0].instruction_digest == "sha256:" + "7" * 64
+
+    await service.settle(
+        idempotency_key="initial-command-idempotency",
+        outcome=ControlPlaneOutcome.APPLIED,
+    )
+    replay = await service.claim(
+        workflow_id="wf-initial-command",
+        provider_session_ref="",
+        chat_binding_id=None,
+        command_type="execute_admitted_plan",
+        idempotency_key="initial-command-idempotency",
+        payload_digest="sha256:" + "7" * 64,
+        step_execution_id="step-initial-command",
+        bootstrap=CanonicalSessionBootstrap(
+            provider="omnigent",
+            step_execution_id="step-initial-command",
+            agent_run_id="agent-run-initial-command",
+            source_idempotency_key="initial-command-idempotency",
+            execution_plan_ref=None,
+        ),
+    )
+    assert replay.outcome is ControlPlaneOutcome.ALREADY_APPLIED
+
+
+@pytest.mark.asyncio
+async def test_session_binds_plan_and_runtime_authority_without_mutating_plan(
+    store, session_factory
+) -> None:
+    plan_ref = "omnigent-execution-plan:sha256:" + "3" * 64
+    runtime_binding_ref = "omnigent-runtime-binding:sha256:" + "4" * 64
+    alternate_binding_ref = "omnigent-runtime-binding:sha256:" + "6" * 64
+    async with session_factory() as db_session:
+        db_session.add(
+            OmnigentExecutionPlanRecord(
+                plan_ref=plan_ref,
+                schema_version="moonmind.omnigent-execution-plan.v1",
+                payload_json={},
+                harness_id="codex-native",
+                harness_implementation_ref="core:omnigent@1",
+                host_class_ref="omnigent-codex-current@1",
+                launch_policy_ref="codex-on-demand@1",
+                execution_realizer_ref="codex-profile-bound@1",
+            )
+        )
+        db_session.add(
+            OmnigentRuntimeBindingRecord(
+                runtime_binding_ref=runtime_binding_ref,
+                execution_plan_ref=plan_ref,
+                state="credentials_acquired",
+                provider_leases_json={},
+            )
+        )
+        db_session.add(
+            OmnigentRuntimeBindingRecord(
+                runtime_binding_ref=alternate_binding_ref,
+                execution_plan_ref=plan_ref,
+                state="credentials_acquired",
+                provider_leases_json={},
+            )
+        )
+        await db_session.commit()
+    session, _turn = await store.establish_session(
+        session_id="s-authority",
+        moonmind_workflow_id="wf-authority",
+        provider="omnigent",
+        chat_binding_id="cb-authority",
+        first_turn_attempt_id="turn-authority",
+        first_turn_idempotency_key="idem-authority",
+        execution_plan_ref=plan_ref,
+    )
+    assert session.execution_plan_ref == plan_ref
+    assert session.runtime_binding_ref is None
+
+    async with store.transaction() as repos:
+        bound = await repos.sessions.bind_runtime_authority(
+            "s-authority",
+            expected_revision=session.revision,
+            expected_fencing_generation=session.fencing_generation,
+            execution_plan_ref=plan_ref,
+            runtime_binding_ref=runtime_binding_ref,
+        )
+    assert bound.execution_plan_ref == plan_ref
+    assert bound.runtime_binding_ref == runtime_binding_ref
+
+    async with store.transaction() as repos:
+        replayed = await repos.sessions.bind_runtime_authority(
+            "s-authority",
+            expected_revision=session.revision,
+            expected_fencing_generation=session.fencing_generation,
+            execution_plan_ref=plan_ref,
+            runtime_binding_ref=runtime_binding_ref,
+        )
+    assert replayed == bound
+
+    async with store.transaction() as repos:
+        with pytest.raises(ConflictingSessionAuthorityError):
+            await repos.sessions.bind_runtime_authority(
+                "s-authority",
+                expected_revision=bound.revision,
+                expected_fencing_generation=bound.fencing_generation,
+                execution_plan_ref=plan_ref,
+                runtime_binding_ref=alternate_binding_ref,
+            )
+
+    async with store.transaction() as repos:
+        with pytest.raises(ConflictingSessionAuthorityError):
+            await repos.sessions.bind_runtime_authority(
+                "s-authority",
+                expected_revision=bound.revision,
+                expected_fencing_generation=bound.fencing_generation,
+                execution_plan_ref="omnigent-execution-plan:sha256:" + "5" * 64,
+                runtime_binding_ref=runtime_binding_ref,
+            )
+
+
+@pytest.mark.asyncio
+async def test_db_runtime_binding_store_returns_highest_immutable_stage(
+    session_factory,
+) -> None:
+    from moonmind.omnigent.harness_platform.stores import DbRuntimeBindingStore
+
+    plan_ref = "omnigent-execution-plan:sha256:" + "8" * 64
+    async with session_factory() as session:
+        session.add(
+            OmnigentExecutionPlanRecord(
+                plan_ref=plan_ref,
+                schema_version="moonmind.omnigent-execution-plan.v1",
+                payload_json={},
+                harness_id="opencode-native",
+                harness_implementation_ref="core:omnigent@1",
+                host_class_ref="omnigent-opencode@1",
+                launch_policy_ref="omnigent-on-demand@1",
+                execution_realizer_ref="generic-omnigent-host@1",
+            )
+        )
+        await session.commit()
+    store = DbRuntimeBindingStore(session_factory)
+    credentials = await store.create_initial(
+        execution_plan_ref=plan_ref,
+        provider_leases={
+            "primary-model": {
+                "providerProfileRef": "profile-1",
+                "providerLeaseRef": "provider-lease-1",
+                "credentialGeneration": 2,
+                "credentialRuntimeRef": "credential-runtime-1",
+            }
+        },
+    )
+    host = await store.update_with_host(
+        credentials.runtimeBindingRef,
+        host_binding_ref="host-binding-1",
+        host_lease_ref="host-lease-1",
+        host_lease_generation=3,
+        omnigent_host_id="host-1",
+    )
+    bound = await store.update_with_session(
+        host.runtimeBindingRef,
+        omnigent_session_id="provider-session-1",
+    )
+
+    latest = await store.latest_for_plan(plan_ref)
+
+    assert latest == bound
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_module_architecture.py
+++ b/tests/unit/omnigent/test_module_architecture.py
@@ -1,6 +1,11 @@
 """Machine-enforced Omnigent package architecture.
 
 Source issue: MoonLadderStudios/MoonMind#3701.
+
+The contract mirrors the responsibility table in
+``docs/Omnigent/OmnigentHarnessPlatformDesign.md``. Keep the rules here
+data-driven: adding a concrete module to a responsibility makes the one-way
+dependency checks apply to it.
 """
 
 from __future__ import annotations
@@ -13,28 +18,90 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-PURE_MODULES = (
-    "moonmind/omnigent/control_plane/records.py",
-    "moonmind/omnigent/control_plane/identities.py",
-    "moonmind/omnigent/harness_platform/agent_profile.py",
-    "moonmind/omnigent/harness_platform/attestation.py",
-    "moonmind/omnigent/harness_platform/capabilities.py",
-    "moonmind/omnigent/harness_platform/catalog.py",
-    "moonmind/omnigent/harness_platform/credential_bindings.py",
-    "moonmind/omnigent/harness_platform/execution_plan.py",
-    "moonmind/omnigent/harness_platform/failures.py",
-    "moonmind/omnigent/harness_platform/runtime_binding.py",
-    "moonmind/omnigent/harness_platform/skills.py",
-    "moonmind/omnigent/harness_platform/support.py",
-)
+RESPONSIBILITY_MODULES: dict[str, tuple[str, ...]] = {
+    "pure": (
+        "moonmind/omnigent/reconciler/contracts.py",
+        "moonmind/omnigent/reconciler/reducer.py",
+        "moonmind/omnigent/control_plane/records.py",
+        "moonmind/omnigent/control_plane/identities.py",
+        "moonmind/omnigent/harness_platform/agent_profile.py",
+        "moonmind/omnigent/harness_platform/attestation.py",
+        "moonmind/omnigent/harness_platform/capabilities.py",
+        "moonmind/omnigent/harness_platform/catalog.py",
+        "moonmind/omnigent/harness_platform/credential_bindings.py",
+        "moonmind/omnigent/harness_platform/execution_plan.py",
+        "moonmind/omnigent/harness_platform/failures.py",
+        "moonmind/omnigent/harness_platform/runtime_binding.py",
+        "moonmind/omnigent/harness_platform/skills.py",
+        "moonmind/omnigent/harness_platform/support.py",
+    ),
+    "application": (
+        "moonmind/omnigent/control_plane/turn_commands.py",
+        "moonmind/omnigent/realizers/base.py",
+        "moonmind/omnigent/realizers/generic_host.py",
+    ),
+    "persistence": (
+        "moonmind/omnigent/control_plane/repositories.py",
+        "moonmind/omnigent/harness_platform/stores.py",
+    ),
+    "provider_host": (
+        "moonmind/omnigent/bridge_artifacts.py",
+        "moonmind/omnigent/bridge_store.py",
+        "moonmind/omnigent/execute.py",
+        "moonmind/omnigent/host_runtime.py",
+        "moonmind/omnigent/oauth_host_runtime.py",
+        "moonmind/omnigent/realizers/runtime_authority.py",
+        "moonmind/omnigent/generic_opencode_runtime.py",
+    ),
+    "workspace_credential": (
+        "moonmind/omnigent/repository_sources.py",
+        "moonmind/omnigent/workspace_intent.py",
+        "moonmind/omnigent/harness_platform/materializers.py",
+    ),
+    "composition": (
+        "moonmind/omnigent/realizers/composition.py",
+        "moonmind/omnigent/realizers/deployment_adapters.py",
+        "moonmind/workflows/temporal/activities/omnigent_activities.py",
+        "moonmind/workflows/temporal/activities/omnigent_session_activities.py",
+    ),
+    "ui": (
+        "moonmind/omnigent/workflow_chat_facade.py",
+        "api_service/api/routers/omnigent_catalog.py",
+        "api_service/api/routers/omnigent_session_timeline.py",
+    ),
+    "evidence_publication": (
+        "moonmind/omnigent/conformance.py",
+        "moonmind/omnigent/exact_artifact_conformance.py",
+        "moonmind/omnigent/workflow_chat_acceptance.py",
+        "moonmind/omnigent/control_plane/timeline.py",
+    ),
+}
 
-APPLICATION_MODULES = (
-    "moonmind/omnigent/control_plane/turn_commands.py",
-    "moonmind/omnigent/realizers/base.py",
-    "moonmind/omnigent/realizers/generic_host.py",
-)
+# Same-layer dependencies are always permitted. Cross-layer entries are the
+# complete inward-facing dependency graph. In particular, UI and evidence do
+# not own persistence, host, credential, plan, or session authority.
+ALLOWED_DEPENDENCIES: dict[str, frozenset[str]] = {
+    "pure": frozenset({"pure"}),
+    "application": frozenset({"pure", "application"}),
+    "persistence": frozenset({"pure", "persistence"}),
+    "provider_host": frozenset(
+        {
+            "pure",
+            "application",
+            "persistence",
+            "workspace_credential",
+            "provider_host",
+        }
+    ),
+    "workspace_credential": frozenset({"pure", "workspace_credential"}),
+    "composition": frozenset(RESPONSIBILITY_MODULES),
+    "ui": frozenset({"pure", "application", "ui", "evidence_publication"}),
+    "evidence_publication": frozenset(
+        {"pure", "application", "evidence_publication"}
+    ),
+}
 
-FORBIDDEN_INFRASTRUCTURE_IMPORTS = (
+FORBIDDEN_DOMAIN_INFRASTRUCTURE_IMPORTS = (
     "api_service",
     "sqlalchemy",
     "fastapi",
@@ -53,15 +120,33 @@ FORBIDDEN_INFRASTRUCTURE_IMPORTS = (
     "moonmind.repositories",
 )
 
+FORBIDDEN_UI_AUTHORITY_IMPORTS = (
+    "moonmind.omnigent.control_plane.repositories",
+    "moonmind.omnigent.harness_platform.materializers",
+    "moonmind.omnigent.harness_platform.stores",
+    "moonmind.omnigent.host_runtime",
+    "moonmind.omnigent.oauth_host_runtime",
+    "moonmind.omnigent.realizers.composition",
+    "moonmind.omnigent.realizers.runtime_authority",
+)
+
+FORBIDDEN_EVIDENCE_AUTHORITY_IMPORTS = (
+    "moonmind.omnigent.harness_platform.admission",
+    "moonmind.omnigent.harness_platform.planner",
+    "moonmind.omnigent.realizers.composition",
+    "moonmind.omnigent.realizers.runtime_authority",
+)
+
 
 def _tree(relative_path: str) -> ast.AST:
     return ast.parse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
 
 
-def _imports(relative_path: str) -> tuple[str, ...]:
+def _imports_from_tree(
+    tree: ast.AST, *, current_module: str = "fixture"
+) -> tuple[str, ...]:
     imported: list[str] = []
-    current_module = relative_path.removesuffix(".py").replace("/", ".")
-    for node in ast.walk(_tree(relative_path)):
+    for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             imported.extend(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.module:
@@ -73,14 +158,97 @@ def _imports(relative_path: str) -> tuple[str, ...]:
     return tuple(imported)
 
 
-@pytest.mark.parametrize("relative_path", PURE_MODULES + APPLICATION_MODULES)
+def _imports(relative_path: str) -> tuple[str, ...]:
+    current_module = relative_path.removesuffix(".py").replace("/", ".")
+    return _imports_from_tree(_tree(relative_path), current_module=current_module)
+
+
+def _assert_dependency_allowed(owner: str, dependency: str) -> None:
+    if dependency not in ALLOWED_DEPENDENCIES[owner]:
+        raise AssertionError(
+            f"Omnigent {owner} responsibility may not depend on {dependency}"
+        )
+
+
+def _assert_no_import_prefixes(source: str, prefixes: tuple[str, ...]) -> None:
+    for imported in _imports_from_tree(ast.parse(source)):
+        if imported.startswith(prefixes):
+            raise AssertionError(f"forbidden infrastructure import: {imported}")
+
+
+def test_every_documented_responsibility_has_machine_enforced_modules() -> None:
+    assert set(RESPONSIBILITY_MODULES) == {
+        "pure",
+        "application",
+        "persistence",
+        "provider_host",
+        "workspace_credential",
+        "composition",
+        "ui",
+        "evidence_publication",
+    }
+    assert all(RESPONSIBILITY_MODULES.values())
+    for paths in RESPONSIBILITY_MODULES.values():
+        assert all((REPO_ROOT / path).is_file() for path in paths)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    RESPONSIBILITY_MODULES["pure"] + RESPONSIBILITY_MODULES["application"],
+)
 def test_domain_and_application_modules_do_not_import_infrastructure(
     relative_path: str,
 ) -> None:
     for imported in _imports(relative_path):
-        assert not imported.startswith(FORBIDDEN_INFRASTRUCTURE_IMPORTS), (
+        assert not imported.startswith(FORBIDDEN_DOMAIN_INFRASTRUCTURE_IMPORTS), (
             f"{relative_path} imports outer infrastructure {imported}; "
             "inject it at the composition boundary"
+        )
+
+
+def test_declared_responsibility_dependency_graph_is_one_way_and_acyclic() -> None:
+    module_to_layer = {
+        path.removesuffix(".py").replace("/", "."): layer
+        for layer, paths in RESPONSIBILITY_MODULES.items()
+        for path in paths
+    }
+    for owner_layer, paths in RESPONSIBILITY_MODULES.items():
+        for path in paths:
+            for imported in _imports(path):
+                dependency_layer = module_to_layer.get(imported)
+                if dependency_layer is not None:
+                    _assert_dependency_allowed(owner_layer, dependency_layer)
+
+    # A cycle between responsibilities would require mutual permission. Same
+    # layer edges are intentionally ignored because they share one owner.
+    edges = {
+        owner: set(allowed) - {owner}
+        for owner, allowed in ALLOWED_DEPENDENCIES.items()
+    }
+    for owner, dependencies in edges.items():
+        for dependency in dependencies:
+            assert owner not in edges[dependency], (
+                f"responsibility cycle permitted between {owner} and {dependency}"
+            )
+
+
+@pytest.mark.parametrize("relative_path", RESPONSIBILITY_MODULES["ui"])
+def test_ui_facades_cannot_import_authority_owning_adapters(relative_path: str) -> None:
+    for imported in _imports(relative_path):
+        assert not imported.startswith(FORBIDDEN_UI_AUTHORITY_IMPORTS), (
+            f"{relative_path} bypasses application projections via {imported}"
+        )
+
+
+@pytest.mark.parametrize(
+    "relative_path", RESPONSIBILITY_MODULES["evidence_publication"]
+)
+def test_evidence_and_publication_cannot_replace_execution_authority(
+    relative_path: str,
+) -> None:
+    for imported in _imports(relative_path):
+        assert not imported.startswith(FORBIDDEN_EVIDENCE_AUTHORITY_IMPORTS), (
+            f"{relative_path} imports authority-producing module {imported}"
         )
 
 
@@ -92,45 +260,17 @@ def test_generic_realizer_has_no_harness_specific_selection_branch() -> None:
         assert harness_id not in source
 
 
-def test_domain_and_application_dependency_graph_is_acyclic() -> None:
-    paths = PURE_MODULES + APPLICATION_MODULES
-    module_by_path = {
-        path: path.removesuffix(".py").replace("/", ".") for path in paths
-    }
-    path_by_module = {module: path for path, module in module_by_path.items()}
-    edges = {
-        path: {
-            path_by_module[imported]
-            for imported in _imports(path)
-            if imported in path_by_module
-        }
-        for path in paths
-    }
-    visiting: list[str] = []
-    visited: set[str] = set()
-
-    def visit(path: str) -> None:
-        if path in visiting:
-            cycle = visiting[visiting.index(path) :] + [path]
-            pytest.fail("Omnigent package dependency cycle: " + " -> ".join(cycle))
-        if path in visited:
-            return
-        visiting.append(path)
-        for dependency in edges[path]:
-            visit(dependency)
-        visiting.pop()
-        visited.add(path)
-
-    for path in paths:
-        visit(path)
-
-
 def test_canonical_authority_identity_functions_have_one_owner() -> None:
-    definitions: dict[str, list[str]] = {
-        "canonical_omnigent_session_id": [],
-        "canonical_omnigent_turn_attempt_id": [],
-        "omnigent_session_workflow_id": [],
+    names = {
+        "canonical_omnigent_session_id",
+        "canonical_omnigent_turn_attempt_id",
+        "omnigent_session_workflow_id",
+        "canonical_turn_command_key",
+        "canonical_turn_claim_token",
+        "canonical_followup_turn_attempt_id",
+        "canonical_turn_command_id",
     }
+    definitions: dict[str, list[str]] = {name: [] for name in names}
     roots = (REPO_ROOT / "moonmind/omnigent", REPO_ROOT / "api_service")
     for root in roots:
         for path in root.rglob("*.py"):
@@ -141,6 +281,25 @@ def test_canonical_authority_identity_functions_have_one_owner() -> None:
                         definitions[node.name].append(relative)
     expected = "moonmind/omnigent/control_plane/identities.py"
     assert definitions == {name: [expected] for name in definitions}
+
+
+def test_canonical_identity_vocabulary_is_not_reimplemented() -> None:
+    forbidden_literals = (
+        "omnigent-session/v1",
+        "omnigent-turn/v1",
+        "omnigent-turn-command:",
+    )
+    owner = REPO_ROOT / "moonmind/omnigent/control_plane/identities.py"
+    for root in (REPO_ROOT / "moonmind/omnigent", REPO_ROOT / "api_service"):
+        for path in root.rglob("*.py"):
+            if path == owner:
+                continue
+            source = path.read_text(encoding="utf-8")
+            for literal in forbidden_literals:
+                assert literal not in source, (
+                    f"{path.relative_to(REPO_ROOT)} reimplements canonical "
+                    f"authority vocabulary {literal!r}"
+                )
 
 
 def test_composition_is_the_only_generic_realizer_api_persistence_import() -> None:
@@ -154,10 +313,78 @@ def test_composition_is_the_only_generic_realizer_api_persistence_import() -> No
         )
     }
     # Codex remains an explicit legacy realizer. Its eventual retirement is
-    # governed by the existing cutover gate; new generic infrastructure belongs
-    # only in composition.py.
+    # governed by the existing cutover gate; generic infrastructure belongs
+    # only in outer adapter modules and composition.py.
     assert importing_api == {
         "codex_profile_bound.py",
         "composition.py",
+        "deployment_adapters.py",
         "runtime_authority.py",
     }
+
+
+@pytest.mark.parametrize(
+    ("owner", "dependency"),
+    (
+        ("pure", "application"),
+        ("application", "persistence"),
+        ("persistence", "provider_host"),
+        ("provider_host", "ui"),
+        ("workspace_credential", "ui"),
+        ("ui", "persistence"),
+        ("ui", "provider_host"),
+        ("evidence_publication", "composition"),
+    ),
+)
+def test_forbidden_dependency_directions_have_negative_fixtures(
+    owner: str, dependency: str
+) -> None:
+    with pytest.raises(AssertionError, match="may not depend"):
+        _assert_dependency_allowed(owner, dependency)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import sqlalchemy",
+        "from fastapi import APIRouter",
+        "import temporalio",
+        "from moonmind.workflows.temporal.client import TemporalClientAdapter",
+        "import subprocess",
+    ),
+)
+def test_framework_leakage_negative_fixtures(source: str) -> None:
+    with pytest.raises(AssertionError, match="forbidden infrastructure import"):
+        _assert_no_import_prefixes(source, FORBIDDEN_DOMAIN_INFRASTRUCTURE_IMPORTS)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime",
+        "from moonmind.omnigent.harness_platform.materializers import get_materializer",
+        "from moonmind.omnigent.control_plane.repositories import ControlPlaneRepositories",
+    ),
+)
+def test_ui_authority_bypass_negative_fixtures(source: str) -> None:
+    with pytest.raises(AssertionError, match="forbidden infrastructure import"):
+        _assert_no_import_prefixes(source, FORBIDDEN_UI_AUTHORITY_IMPORTS)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        'SESSION_KIND = "omnigent-session/v1"',
+        'TURN_KIND = "omnigent-turn/v1"',
+        'COMMAND_KEY = "omnigent-turn-command:" + key',
+    ),
+)
+def test_duplicate_authority_vocabulary_negative_fixtures(source: str) -> None:
+    assert any(
+        literal in source
+        for literal in (
+            "omnigent-session/v1",
+            "omnigent-turn/v1",
+            "omnigent-turn-command:",
+        )
+    )

--- a/tests/unit/omnigent/test_module_architecture.py
+++ b/tests/unit/omnigent/test_module_architecture.py
@@ -1,0 +1,163 @@
+"""Machine-enforced Omnigent package architecture.
+
+Source issue: MoonLadderStudios/MoonMind#3701.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PURE_MODULES = (
+    "moonmind/omnigent/control_plane/records.py",
+    "moonmind/omnigent/control_plane/identities.py",
+    "moonmind/omnigent/harness_platform/agent_profile.py",
+    "moonmind/omnigent/harness_platform/attestation.py",
+    "moonmind/omnigent/harness_platform/capabilities.py",
+    "moonmind/omnigent/harness_platform/catalog.py",
+    "moonmind/omnigent/harness_platform/credential_bindings.py",
+    "moonmind/omnigent/harness_platform/execution_plan.py",
+    "moonmind/omnigent/harness_platform/failures.py",
+    "moonmind/omnigent/harness_platform/runtime_binding.py",
+    "moonmind/omnigent/harness_platform/skills.py",
+    "moonmind/omnigent/harness_platform/support.py",
+)
+
+APPLICATION_MODULES = (
+    "moonmind/omnigent/control_plane/turn_commands.py",
+    "moonmind/omnigent/realizers/base.py",
+    "moonmind/omnigent/realizers/generic_host.py",
+)
+
+FORBIDDEN_INFRASTRUCTURE_IMPORTS = (
+    "api_service",
+    "sqlalchemy",
+    "fastapi",
+    "temporalio",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "docker",
+    "os",
+    "pathlib",
+    "shutil",
+    "socket",
+    "subprocess",
+    "moonmind.config",
+    "moonmind.workflows",
+    "moonmind.repositories",
+)
+
+
+def _tree(relative_path: str) -> ast.AST:
+    return ast.parse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def _imports(relative_path: str) -> tuple[str, ...]:
+    imported: list[str] = []
+    current_module = relative_path.removesuffix(".py").replace("/", ".")
+    for node in ast.walk(_tree(relative_path)):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.level:
+                package = current_module.split(".")[: -node.level]
+                imported.append(".".join([*package, node.module]))
+            else:
+                imported.append(node.module)
+    return tuple(imported)
+
+
+@pytest.mark.parametrize("relative_path", PURE_MODULES + APPLICATION_MODULES)
+def test_domain_and_application_modules_do_not_import_infrastructure(
+    relative_path: str,
+) -> None:
+    for imported in _imports(relative_path):
+        assert not imported.startswith(FORBIDDEN_INFRASTRUCTURE_IMPORTS), (
+            f"{relative_path} imports outer infrastructure {imported}; "
+            "inject it at the composition boundary"
+        )
+
+
+def test_generic_realizer_has_no_harness_specific_selection_branch() -> None:
+    source = (REPO_ROOT / "moonmind/omnigent/realizers/generic_host.py").read_text(
+        encoding="utf-8"
+    )
+    for harness_id in ("codex-native", "opencode-native", "pi-native"):
+        assert harness_id not in source
+
+
+def test_domain_and_application_dependency_graph_is_acyclic() -> None:
+    paths = PURE_MODULES + APPLICATION_MODULES
+    module_by_path = {
+        path: path.removesuffix(".py").replace("/", ".") for path in paths
+    }
+    path_by_module = {module: path for path, module in module_by_path.items()}
+    edges = {
+        path: {
+            path_by_module[imported]
+            for imported in _imports(path)
+            if imported in path_by_module
+        }
+        for path in paths
+    }
+    visiting: list[str] = []
+    visited: set[str] = set()
+
+    def visit(path: str) -> None:
+        if path in visiting:
+            cycle = visiting[visiting.index(path) :] + [path]
+            pytest.fail("Omnigent package dependency cycle: " + " -> ".join(cycle))
+        if path in visited:
+            return
+        visiting.append(path)
+        for dependency in edges[path]:
+            visit(dependency)
+        visiting.pop()
+        visited.add(path)
+
+    for path in paths:
+        visit(path)
+
+
+def test_canonical_authority_identity_functions_have_one_owner() -> None:
+    definitions: dict[str, list[str]] = {
+        "canonical_omnigent_session_id": [],
+        "canonical_omnigent_turn_attempt_id": [],
+        "omnigent_session_workflow_id": [],
+    }
+    roots = (REPO_ROOT / "moonmind/omnigent", REPO_ROOT / "api_service")
+    for root in roots:
+        for path in root.rglob("*.py"):
+            relative = str(path.relative_to(REPO_ROOT))
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.name in definitions:
+                        definitions[node.name].append(relative)
+    expected = "moonmind/omnigent/control_plane/identities.py"
+    assert definitions == {name: [expected] for name in definitions}
+
+
+def test_composition_is_the_only_generic_realizer_api_persistence_import() -> None:
+    realizer_files = (REPO_ROOT / "moonmind/omnigent/realizers").glob("*.py")
+    importing_api = {
+        path.name
+        for path in realizer_files
+        if any(
+            name.startswith("api_service")
+            for name in _imports(str(path.relative_to(REPO_ROOT)))
+        )
+    }
+    # Codex remains an explicit legacy realizer. Its eventual retirement is
+    # governed by the existing cutover gate; new generic infrastructure belongs
+    # only in composition.py.
+    assert importing_api == {
+        "codex_profile_bound.py",
+        "composition.py",
+        "runtime_authority.py",
+    }

--- a/tests/unit/omnigent/test_normal_product_execution_authority.py
+++ b/tests/unit/omnigent/test_normal_product_execution_authority.py
@@ -16,6 +16,7 @@ from moonmind.omnigent.harness_platform.catalog import (
 )
 from moonmind.omnigent.harness_platform.execution_plan import (
     OmnigentExecutionPlanEnvelope,
+    bind_runtime_request_authority,
 )
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from moonmind.omnigent.harness_platform.stores import (
@@ -162,6 +163,32 @@ def test_normal_product_plan_freezes_registered_authority(
     assert "providerLeaseRef" not in serialized
     assert "credentialGeneration" not in serialized
     assert "hostLeaseRef" not in serialized
+
+
+def test_normal_product_rejects_unmaterializable_pi_and_missing_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    with pytest.raises(HarnessPlatformError) as pi_error:
+        compile_normal_product_execution_plan(
+            agent_profile_snapshot=_snapshot(harness="pi-native"),
+            workflow_parameters={"model": "provider/model", "workflow": {}},
+            workflow_id="mm:unsupported-pi",
+        )
+    assert pi_error.value.code == "OMNIGENT_HARNESS_UNKNOWN"
+
+    snapshot = _snapshot()
+    snapshot["document"]["model"] = {}
+    with pytest.raises(HarnessPlatformError) as model_error:
+        compile_normal_product_execution_plan(
+            agent_profile_snapshot=snapshot,
+            workflow_parameters={"workflow": {}},
+            workflow_id="mm:missing-model",
+        )
+    assert model_error.value.code == "OMNIGENT_MODEL_UNAVAILABLE"
 
 
 def test_default_registry_composes_every_generic_host_production_boundary(
@@ -364,6 +391,72 @@ async def test_generic_dispatch_loads_persisted_plan_without_replanning() -> Non
 
 
 @pytest.mark.asyncio
+async def test_generic_dispatch_derives_late_skill_and_step_model_authority() -> None:
+    store = InMemoryExecutionPlanStore()
+    admitted = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(harness="codex-native"),
+        workflow_parameters={"model": "gpt-5", "workflow": {}},
+        workflow_id="mm:dispatch-late-authority",
+    )
+    await store.persist(admitted)
+    realizer = SimpleNamespace(
+        execute=AsyncMock(return_value=AgentRunResult(summary="derived"))
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr-derived",
+        idempotencyKey="idem-derived",
+        resolvedSkillsetRef="artifact://skills/resolved-step",
+        parameters={
+            "executionPlanRef": admitted.planRef,
+            "model": "provider/step-model",
+            "effort": "high",
+        },
+    )
+
+    result = await _try_generic_realizer_dispatch(
+        request,
+        plan_store=store,
+        realizer_registry=SimpleNamespace(require=lambda _ref: realizer),
+    )
+
+    assert result is not None and result.summary == "derived"
+    dispatched_request, dispatched_plan = realizer.execute.await_args.args
+    assert dispatched_plan.planRef != admitted.planRef
+    assert dispatched_request.parameters["executionPlanRef"] == dispatched_plan.planRef
+    assert dispatched_plan.payload.resolvedSkills["resolvedSkillSetRef"] == (
+        "artifact://skills/resolved-step"
+    )
+    assert dispatched_plan.payload.modelConfig.qualifiedId == "provider/step-model"
+    assert dispatched_plan.payload.modelConfig.effort == "high"
+    assert dispatched_plan.payload.supportIdentity.modelConfigDigest == (
+        dispatched_plan.payload.modelConfig.modelConfigDigest
+    )
+    assert await store.load(dispatched_plan.planRef) == dispatched_plan
+
+
+def test_runtime_request_rejects_a_different_resolved_skill_snapshot() -> None:
+    admitted = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(harness="codex-native"),
+        workflow_parameters={
+            "model": "gpt-5",
+            "resolvedSkillsetRef": "artifact://skills/admitted",
+            "workflow": {},
+        },
+        workflow_id="mm:dispatch-skill-conflict",
+    )
+
+    with pytest.raises(HarnessPlatformError) as exc_info:
+        bind_runtime_request_authority(
+            admitted,
+            resolved_skillset_ref="artifact://skills/different",
+        )
+
+    assert exc_info.value.code == "OMNIGENT_SKILL_DELIVERY_MISMATCH"
+
+
+@pytest.mark.asyncio
 async def test_generic_request_without_admitted_plan_fails_closed() -> None:
     request = AgentExecutionRequest(
         agentKind="external",
@@ -485,8 +578,113 @@ async def test_generic_realizer_persists_generations_and_exact_host(
         "supportCombinationKey": plan.payload.supportCombinationKey,
         "identityComplete": True,
     }
+    assert "effectiveLaunchRef" not in result.metadata["omnigentCheckpointCapture"]
     authority.release.assert_awaited_once()
     host_runtime.cleanup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_resumes_persisted_host_authority_on_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:resume-host",
+    )
+    provider_leases = {
+        "primary-model": {
+            "providerProfileRef": "opencode-native-provider",
+            "providerLeaseRef": "provider-lease:resume",
+            "credentialGeneration": 4,
+            "credentialRuntimeRef": "credential-runtime:resume",
+        }
+    }
+    binding_store = InMemoryRuntimeBindingStore()
+    initial = await binding_store.create_initial(
+        execution_plan_ref=plan.planRef,
+        provider_leases=provider_leases,
+    )
+    persisted = await binding_store.update_with_host(
+        initial.runtimeBindingRef,
+        host_binding_ref="host-binding:resume",
+        host_lease_ref="host-lease:resume",
+        host_lease_generation=8,
+        omnigent_host_id="host-resume",
+    )
+    acquired = SimpleNamespace(
+        provider_leases=provider_leases,
+        credential_handles=(),
+    )
+    runtime_authority = SimpleNamespace(
+        acquire=AsyncMock(return_value=acquired),
+        release=AsyncMock(),
+    )
+    host_runtime = SimpleNamespace(
+        assert_ready=lambda: None,
+        realize=AsyncMock(),
+        cleanup=AsyncMock(),
+    )
+    driver = AsyncMock(return_value=AgentRunResult(summary="resumed"))
+    turn_commands = SimpleNamespace(
+        claim=AsyncMock(
+            return_value=SimpleNamespace(
+                session_id="canonical-session",
+                turn_attempt_id="turn-resume",
+                command_id="command-resume",
+                claim_token="claim-resume",
+                expected_session_revision=2,
+                fencing_generation=1,
+                owns_delivery=True,
+            )
+        ),
+        bind_runtime_authority=AsyncMock(),
+        settle=AsyncMock(),
+    )
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=binding_store,
+        runtime_authority=runtime_authority,
+        host_runtime=host_runtime,
+        execution_driver=driver,
+        turn_command_service=turn_commands,
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr-resume",
+        idempotencyKey="idem-resume",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    result = await realizer.execute(request, plan)
+
+    assert result.summary == "resumed"
+    host_runtime.realize.assert_not_awaited()
+    enriched = driver.await_args.args[0]
+    assert enriched.parameters["runtimeBindingRef"] == persisted.runtimeBindingRef
+    authorization = enriched.parameters["omnigent"][
+        "_moonmindProfileAuthorization"
+    ]
+    assert authorization["executionPlanRef"] == plan.planRef
+    assert authorization["runtimeBindingRef"] == persisted.runtimeBindingRef
+    assert authorization["providerLeaseRef"] == "provider-lease:resume"
+    host_runtime.cleanup.assert_awaited_once_with(
+        plan.planRef,
+        persisted.runtimeBindingRef,
+        command_authority=host_runtime.cleanup.await_args.kwargs[
+            "command_authority"
+        ],
+    )
+    runtime_authority.release.assert_awaited_once_with(
+        acquired,
+        command_authority=runtime_authority.release.await_args.kwargs[
+            "command_authority"
+        ],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_normal_product_execution_authority.py
+++ b/tests/unit/omnigent/test_normal_product_execution_authority.py
@@ -1,0 +1,817 @@
+"""Normal-product authority handoffs for MoonLadderStudios/MoonMind#3701."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from moonmind.omnigent.harness_platform.admission import (
+    compile_normal_product_execution_plan,
+)
+from moonmind.omnigent.harness_platform.catalog import (
+    HarnessImplementationIdentity,
+)
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+)
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.harness_platform.stores import (
+    InMemoryExecutionPlanStore,
+    InMemoryRuntimeBindingStore,
+)
+from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
+from moonmind.omnigent.realizers.generic_host import GenericOmnigentHostRealizer
+from moonmind.omnigent.realizers.codex_profile_bound import CodexProfileBoundRealizer
+from moonmind.omnigent.realizers.runtime_authority import (
+    ProviderProfileRuntimeAuthority,
+)
+from moonmind.omnigent.harness_platform.support import (
+    compute_support_combination_key,
+)
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.workflows.temporal.activities.omnigent_activities import (
+    _try_generic_realizer_dispatch,
+)
+from moonmind.workflows.temporal.activities.omnigent_session_activities import (
+    _session_execution_authority_metadata,
+)
+
+
+def _snapshot(*, harness: str = "opencode-native") -> dict[str, object]:
+    implementation = HarnessImplementationIdentity.model_validate(
+        {
+            "sourceKind": "core",
+            "package": "omnigent",
+            "version": "1.0.0",
+            "digest": "sha256:" + ("a" if harness == "opencode-native" else "e") * 64,
+            "pluginEntryPoint": None,
+        }
+    )
+    observed_at = datetime.now(UTC).isoformat()
+    return {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": f"{harness}-profile",
+        "version": 7,
+        "digest": "sha256:" + "1" * 64,
+        "providerProfileRef": f"{harness}-provider",
+        "executionProfileRef": f"{harness}@1",
+        "launchPolicyRef": (
+            "omnigent-on-demand@1"
+            if harness == "opencode-native"
+            else "codex-on-demand@1"
+        ),
+        "agentId": f"{harness}-agent",
+        "policyRef": "omnigent-policy:test",
+        "document": {
+            "schemaVersion": "moonmind.omnigent-agent-profile.v1",
+            "endpointRef": "default",
+            "bridgeMode": "proxy",
+            "source": {"upstreamId": f"{harness}-agent", "upstreamVersion": "1.0.0"},
+            "harness": harness,
+            "requiredCapabilities": ["streaming"],
+            "execution": {
+                "defaultExecutionProfileRef": f"{harness}@1",
+                "allowedLaunchPolicyRefs": [
+                    (
+                        "omnigent-on-demand@1"
+                        if harness == "opencode-native"
+                        else "codex-on-demand@1"
+                    )
+                ],
+            },
+            "providerRequirements": {
+                "runtimeId": (
+                    "opencode_go" if harness == "opencode-native" else "codex_cli"
+                ),
+                "credentialSource": (
+                    "api_key" if harness == "opencode-native" else "oauth"
+                ),
+                "materializationMode": (
+                    "generated_file" if harness == "opencode-native" else "oauth_home"
+                ),
+                "providerIds": [
+                    "opencode" if harness == "opencode-native" else "openai"
+                ],
+            },
+            "model": {"model": "provider/model", "settings": {}},
+            "workspace": {"mutation": "allowed", "requiredCapabilities": []},
+            "skills": [],
+            "tools": [],
+            "capture": {"stream": True, "evidence": True},
+            "rag": {"initial": {}, "followUp": {}},
+            "continuations": {"checkpoint": True, "branch": True, "remediation": True},
+            "publish": {"mode": "none"},
+            "policyRef": "omnigent-policy:test",
+        },
+        "upstreamSnapshot": {
+            "id": f"{harness}-agent",
+            "version": "1.0.0",
+            "harness": harness,
+            "catalogObservedAt": observed_at,
+            "harnessImplementation": implementation.model_dump(
+                by_alias=True, mode="json"
+            ),
+        },
+        "validationResult": {"ready": True},
+    }
+
+
+def test_normal_product_plan_freezes_registered_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={
+            "model": "provider/model",
+            "effort": "high",
+            "requiredCapabilities": ["streaming"],
+            "workflow": {"skills": {"include": []}},
+        },
+        workflow_id="mm:normal-product",
+    )
+
+    assert plan.payload.harnessId == "opencode-native"
+    assert plan.payload.executionRealizerRef == "generic-omnigent-host@1"
+    assert plan.payload.hostClassRef == "omnigent-opencode@1"
+    assert plan.payload.credentialBindings["primary-model"]["providerProfileRef"] == (
+        "opencode-native-provider"
+    )
+    assert plan.payload.agentProfileSnapshotRef.startswith(
+        "omnigent-agent-profile:sha256:"
+    )
+    assert plan.payload.supportIdentity is not None
+    assert (
+        plan.payload.supportIdentity.executionRealizerRef == "generic-omnigent-host@1"
+    )
+    serialized = plan.model_dump_json(by_alias=True)
+    assert "providerLeaseRef" not in serialized
+    assert "credentialGeneration" not in serialized
+    assert "hostLeaseRef" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected_realizer", "expected_host_class"),
+    [
+        ("codex-native", "codex-profile-bound@1", "omnigent-codex-current@1"),
+        (
+            "opencode-native",
+            "generic-omnigent-host@1",
+            "omnigent-opencode@1",
+        ),
+    ],
+)
+def test_normal_product_records_admitted_support_identity_for_each_realizer(
+    monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+    expected_realizer: str,
+    expected_host_class: str,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(harness=harness),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id=f"mm:support:{harness}",
+    )
+
+    identity = plan.payload.supportIdentity
+    assert identity is not None
+    assert identity.executionRealizerRef == expected_realizer
+    assert identity.hostClassRef == expected_host_class
+    assert identity.harnessImplementationRef == plan.payload.harnessImplementationRef
+    assert identity.modelConfigDigest == plan.payload.modelConfig.modelConfigDigest
+    # The dedicated OpenCode Host Class pins its vendor CLI.  The replay-
+    # visible Codex Host Class still records an empty tuple until protected
+    # exact-host evidence supplies the legacy vendor-runtime identity; do not
+    # invent a version at admission.
+    if harness == "opencode-native":
+        assert identity.vendorRuntimeRefs
+    else:
+        assert identity.vendorRuntimeRefs == ()
+    assert identity.materializerRefs
+    assert identity.providerCompatibilityClass
+    assert compute_support_combination_key(identity) == (
+        plan.payload.supportCombinationKey
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_realizer_returns_the_admitted_support_identity() -> None:
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(harness="codex-native"),
+        workflow_parameters={"model": "gpt-5", "workflow": {}},
+        workflow_id="mm:codex-support",
+    )
+    coordinator = SimpleNamespace(
+        execute=AsyncMock(return_value=AgentRunResult(summary="codex completed"))
+    )
+    realizer = CodexProfileBoundRealizer(
+        session_factory=SimpleNamespace(),
+        coordinator_factory=lambda **_kwargs: coordinator,
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr-codex",
+        idempotencyKey="idem-codex",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    result = await realizer.execute(request, plan)
+
+    assert result.summary == "codex completed"
+    assert result.metadata["executionPlanRef"] == plan.planRef
+    assert (
+        result.metadata["supportCombinationIdentity"]["executionRealizerRef"]
+        == "codex-profile-bound@1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_canonical_terminal_projection_names_plan_binding_and_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.omnigent.harness_platform.stores import (
+        DbExecutionPlanStore,
+        DbRuntimeBindingStore,
+    )
+
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(harness="codex-native"),
+        workflow_parameters={"model": "gpt-5", "workflow": {}},
+        workflow_id="mm:terminal-support",
+    )
+    bindings = InMemoryRuntimeBindingStore()
+    binding = await bindings.create_initial(
+        execution_plan_ref=plan.planRef,
+        provider_leases={
+            "primary-model": {
+                "providerProfileRef": "codex-native-provider",
+                "providerLeaseRef": "provider-lease:terminal",
+                "credentialGeneration": 2,
+                "credentialRuntimeRef": "credential-runtime:terminal",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        DbExecutionPlanStore,
+        "load",
+        AsyncMock(return_value=plan),
+    )
+    monkeypatch.setattr(
+        DbRuntimeBindingStore,
+        "get",
+        AsyncMock(return_value=binding),
+    )
+
+    metadata = await _session_execution_authority_metadata(
+        SimpleNamespace(
+            execution_plan_ref=plan.planRef,
+            runtime_binding_ref=binding.runtimeBindingRef,
+        )
+    )
+
+    assert metadata["executionPlanRef"] == plan.planRef
+    assert metadata["runtimeBindingRef"] == binding.runtimeBindingRef
+    assert metadata["supportCombinationIdentity"]["identityComplete"] is True
+
+
+@pytest.mark.asyncio
+async def test_generic_dispatch_loads_persisted_plan_without_replanning() -> None:
+    store = InMemoryExecutionPlanStore()
+    plan = OmnigentExecutionPlanEnvelope.model_validate(
+        compile_normal_product_execution_plan(
+            agent_profile_snapshot=_snapshot(harness="codex-native"),
+            workflow_parameters={"model": "gpt-5", "workflow": {}},
+            workflow_id="mm:dispatch",
+        )
+    )
+    await store.persist(plan)
+    realizer = SimpleNamespace(
+        execute=AsyncMock(return_value=AgentRunResult(summary="ok"))
+    )
+    registry = SimpleNamespace(require=lambda ref: realizer)
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    result = await _try_generic_realizer_dispatch(
+        request,
+        plan_store=store,
+        realizer_registry=registry,
+    )
+
+    assert result is not None and result.summary == "ok"
+    realizer.execute.assert_awaited_once_with(request, plan)
+
+
+@pytest.mark.asyncio
+async def test_generic_request_without_admitted_plan_fails_closed() -> None:
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem",
+        parameters={"omnigent": {"agentProfileV2": {"schemaVersion": "v2"}}},
+    )
+
+    result = await _try_generic_realizer_dispatch(
+        request,
+        plan_store=InMemoryExecutionPlanStore(),
+        realizer_registry=SimpleNamespace(require=lambda _ref: None),
+    )
+
+    assert result is not None
+    assert result.provider_error_code == "OMNIGENT_EXECUTION_PLAN_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_persists_generations_and_exact_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:binding",
+    )
+    binding_store = InMemoryRuntimeBindingStore()
+    authority = SimpleNamespace(
+        acquire=AsyncMock(
+            return_value=SimpleNamespace(
+                provider_leases={
+                    "primary-model": {
+                        "providerProfileRef": "opencode-native-provider",
+                        "providerLeaseRef": "provider-lease:exact",
+                        "credentialGeneration": 4,
+                        "credentialRuntimeRef": "credential-runtime:exact",
+                    }
+                },
+                credential_handles=[
+                    {
+                        "providerProfileRef": "opencode-native-provider",
+                        "providerLeaseRef": "provider-lease:exact",
+                        "credentialGeneration": 4,
+                        "credentialRuntimeRef": "credential-runtime:exact",
+                        "materializerRef": "opencode-auth-json@1",
+                        "cleanupRef": "credential-cleanup:exact",
+                    }
+                ],
+            )
+        ),
+        release=AsyncMock(),
+    )
+    host_runtime = SimpleNamespace(
+        assert_ready=lambda: None,
+        realize=AsyncMock(
+            return_value={
+                "hostId": "host-exact",
+                "hostBindingRef": "host-binding:exact",
+                "hostLeaseRef": "host-lease:exact",
+                "hostLeaseGeneration": 8,
+                "hostClassRef": "omnigent-opencode@1",
+                "launchPolicyRef": "omnigent-on-demand@1",
+                "workspacePath": "/workspaces/run",
+            }
+        ),
+        cleanup=AsyncMock(),
+    )
+    driver = AsyncMock(return_value=AgentRunResult(summary="completed"))
+    turn_commands = SimpleNamespace(
+        claim=AsyncMock(
+            return_value=SimpleNamespace(
+                session_id="canonical-session",
+                turn_attempt_id="turn-1",
+                command_id="command-1",
+                claim_token="claim-1",
+                expected_session_revision=2,
+                fencing_generation=1,
+                owns_delivery=True,
+            )
+        ),
+        bind_runtime_authority=AsyncMock(),
+        settle=AsyncMock(),
+    )
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=binding_store,
+        runtime_authority=authority,
+        host_runtime=host_runtime,
+        execution_driver=driver,
+        turn_command_service=turn_commands,
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    result = await realizer.execute(request, plan)
+
+    assert result.summary == "completed"
+    enriched = driver.await_args.args[0]
+    binding_ref = enriched.parameters["runtimeBindingRef"]
+    binding = await binding_store.get(binding_ref)
+    assert binding is not None
+    assert binding.executionPlanRef == plan.planRef
+    assert binding.providerLeases["primary-model"].credentialGeneration == 4
+    assert binding.omnigentHostId == "host-exact"
+    assert binding.hostLeaseGeneration == 8
+    assert binding.cleanupAuthorityRefs == ("credential-cleanup:exact",)
+    assert result.metadata["supportCombinationIdentity"] == {
+        **plan.payload.supportIdentity.model_dump(by_alias=True, mode="json"),
+        "supportCombinationKey": plan.payload.supportCombinationKey,
+        "identityComplete": True,
+    }
+    authority.release.assert_awaited_once()
+    host_runtime.cleanup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_does_not_repeat_settled_turn_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:no-repeat",
+    )
+    authority = SimpleNamespace(acquire=AsyncMock(), release=AsyncMock())
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=InMemoryRuntimeBindingStore(),
+        runtime_authority=authority,
+        host_runtime=SimpleNamespace(
+            assert_ready=lambda: None,
+            realize=AsyncMock(),
+            cleanup=AsyncMock(),
+        ),
+        execution_driver=AsyncMock(),
+        turn_command_service=SimpleNamespace(
+            claim=AsyncMock(
+                return_value=SimpleNamespace(
+                    session_id="canonical-session", owns_delivery=False
+                )
+            )
+        ),
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    with pytest.raises(HarnessPlatformError):
+        await realizer.execute(request, plan)
+
+    authority.acquire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_requires_trusted_secret_materializer_before_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:materializer-readiness",
+    )
+    turn_commands = SimpleNamespace(claim=AsyncMock())
+    authority = ProviderProfileRuntimeAuthority(
+        session_factory=SimpleNamespace(),
+        lease_client=SimpleNamespace(),
+    )
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=InMemoryRuntimeBindingStore(),
+        runtime_authority=authority,
+        host_runtime=SimpleNamespace(assert_ready=lambda: None),
+        execution_driver=AsyncMock(),
+        turn_command_service=turn_commands,
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem-materializer",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    with pytest.raises(HarnessPlatformError) as exc_info:
+        await realizer.execute(request, plan)
+
+    assert exc_info.value.code == "OMNIGENT_CREDENTIAL_MATERIALIZER_UNAVAILABLE"
+    turn_commands.claim.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_parks_claim_when_authority_acquisition_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:acquire-failure",
+    )
+    turn_commands = SimpleNamespace(
+        claim=AsyncMock(
+            return_value=SimpleNamespace(
+                session_id="canonical-session",
+                turn_attempt_id="turn-acquire",
+                command_id="command-acquire",
+                claim_token="claim-acquire",
+                expected_session_revision=2,
+                fencing_generation=1,
+                owns_delivery=True,
+            )
+        ),
+        settle=AsyncMock(),
+    )
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=InMemoryRuntimeBindingStore(),
+        runtime_authority=SimpleNamespace(
+            acquire=AsyncMock(side_effect=RuntimeError("lease unavailable")),
+            release=AsyncMock(),
+        ),
+        host_runtime=SimpleNamespace(assert_ready=lambda: None),
+        execution_driver=AsyncMock(),
+        turn_command_service=turn_commands,
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem-acquire-failure",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    with pytest.raises(RuntimeError, match="lease unavailable"):
+        await realizer.execute(request, plan)
+
+    settle = turn_commands.settle.await_args.kwargs
+    assert settle["idempotency_key"] == "idem-acquire-failure"
+    assert settle["outcome"].value == "delivery_unknown"
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_retains_provider_authority_until_cleanup_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:cleanup-order",
+    )
+    authority = SimpleNamespace(
+        acquire=AsyncMock(
+            return_value=SimpleNamespace(
+                provider_leases={
+                    "primary-model": {
+                        "providerProfileRef": "opencode-native-provider",
+                        "providerLeaseRef": "provider-lease:exact",
+                        "credentialGeneration": 4,
+                        "credentialRuntimeRef": "credential-runtime:exact",
+                    }
+                },
+                credential_handles=[],
+            )
+        ),
+        release=AsyncMock(),
+    )
+    host_runtime = SimpleNamespace(
+        assert_ready=lambda: None,
+        realize=AsyncMock(
+            return_value={
+                "hostId": "host-exact",
+                "hostBindingRef": "host-binding:exact",
+                "hostLeaseRef": "host-lease:exact",
+                "hostLeaseGeneration": 8,
+                "hostClassRef": "omnigent-opencode@1",
+                "launchPolicyRef": "omnigent-on-demand@1",
+                "workspacePath": "/workspaces/run",
+            }
+        ),
+        cleanup=AsyncMock(side_effect=RuntimeError("cleanup pending")),
+    )
+    realizer = GenericOmnigentHostRealizer(
+        runtime_binding_store=InMemoryRuntimeBindingStore(),
+        runtime_authority=authority,
+        host_runtime=host_runtime,
+        execution_driver=AsyncMock(return_value=AgentRunResult(summary="completed")),
+        turn_command_service=SimpleNamespace(
+            claim=AsyncMock(
+                return_value=SimpleNamespace(
+                    session_id="canonical-session",
+                    turn_attempt_id="turn-cleanup",
+                    command_id="command-cleanup",
+                    claim_token="claim-cleanup",
+                    expected_session_revision=2,
+                    fencing_generation=1,
+                    owns_delivery=True,
+                )
+            ),
+            bind_runtime_authority=AsyncMock(),
+            settle=AsyncMock(),
+        ),
+    )
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem-cleanup",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    result = await realizer.execute(request, plan)
+
+    assert result.summary == "completed"
+    host_runtime.cleanup.assert_awaited_once()
+    authority.release.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_host_side_effects_receive_one_command_and_fence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "9" * 64,
+    )
+    plan = compile_normal_product_execution_plan(
+        agent_profile_snapshot=_snapshot(),
+        workflow_parameters={"model": "provider/model", "workflow": {}},
+        workflow_id="mm:side-effect-fence",
+    )
+    from moonmind.omnigent.harness_platform.attestation import (
+        HostHarnessAttestation,
+        compute_attestation_ref,
+    )
+    from moonmind.omnigent.harness_platform.host_classes import get_host_class
+
+    host_class = get_host_class(plan.payload.hostClassRef)
+    host_entry = next(
+        entry
+        for entry in host_class.declaredHarnessImplementations
+        if entry.harnessId == plan.payload.harnessId
+    )
+    raw_attestation = {
+        "hostId": "host-exact",
+        "hostClassRef": host_class.ref,
+        "hostImageRef": host_class.imageRef,
+        "omnigentVersion": host_class.omnigentVersion,
+        "omnigentBuildDigest": host_class.omnigentBuildDigest,
+        "harnessId": plan.payload.harnessId,
+        "harnessImplementation": _snapshot()["upstreamSnapshot"][
+            "harnessImplementation"
+        ],
+        "runtimeDependencies": list(host_entry.runtimeDependencies),
+        "configured": True,
+        "capabilities": {"streaming": True},
+        "architecture": plan.payload.supportIdentity.architecture,
+        "attestationGeneration": 8,
+        "observedAt": datetime.now(UTC).isoformat(),
+    }
+    parsed_attestation = HostHarnessAttestation.model_validate(raw_attestation)
+    raw_attestation["attestationRef"] = compute_attestation_ref(parsed_attestation)
+    workspace = SimpleNamespace(
+        materialize=AsyncMock(
+            return_value={
+                "path": "/workspaces/run",
+                "resolutionRef": "artifact:workspace-exact",
+            }
+        )
+    )
+    skills = SimpleNamespace(
+        materialize=AsyncMock(
+            return_value={
+                "deliveryRef": plan.payload.resolvedSkills["skillDeliveryRef"],
+                "attestationRef": "artifact:skills-exact",
+            }
+        )
+    )
+    launcher = SimpleNamespace(
+        launch=AsyncMock(
+            return_value={
+                "hostId": "host-exact",
+                "hostBindingRef": "host-binding:exact",
+                "hostLeaseRef": "host-lease:exact",
+                "hostLeaseGeneration": 8,
+            }
+        )
+    )
+    registration = SimpleNamespace(
+        wait_for_registration=AsyncMock(
+            return_value={
+                "hostId": "host-exact",
+                "attestation": raw_attestation,
+                "exactHostCapabilityDecisionRef": "artifact:capability-exact",
+                "modelOptionAttestation": {
+                    "modelId": plan.payload.modelConfig.qualifiedId,
+                    "available": True,
+                    "attestationRef": "artifact:model-exact",
+                },
+            }
+        )
+    )
+    image = SimpleNamespace(
+        attest=AsyncMock(
+            return_value={
+                "observedImageRef": host_class.imageRef,
+                "attestationRef": "artifact:image-exact",
+            }
+        )
+    )
+    egress = SimpleNamespace(
+        attest=AsyncMock(
+            return_value={
+                "enforced": True,
+                "attestationRef": "artifact:egress-exact",
+            }
+        )
+    )
+    cleanup = SimpleNamespace(cleanup=AsyncMock())
+    runtime = GenericOmnigentHostRuntime(
+        launcher=launcher,
+        workspace_service=workspace,
+        skill_service=skills,
+        egress_service=egress,
+        registration_waiter=registration,
+        image_attestor=image,
+        cleanup_service=cleanup,
+    )
+    command = {
+        "commandId": "command-1",
+        "claimToken": "claim-1",
+        "sessionId": "session-1",
+        "turnAttemptId": "turn-1",
+        "expectedSessionRevision": 2,
+        "fencingGeneration": 1,
+    }
+    binding_ref = "omnigent-runtime-binding:sha256:" + "7" * 64
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="corr",
+        idempotencyKey="idem-host",
+        parameters={"executionPlanRef": plan.planRef},
+    )
+
+    await runtime.realize(
+        request=request,
+        plan=plan,
+        credential_handles=[{"materializerRef": "opencode-auth-json@1"}],
+        runtime_binding_ref=binding_ref,
+        command_authority=command,
+    )
+    await runtime.cleanup(
+        plan.planRef,
+        binding_ref,
+        host_id="host-exact",
+        command_authority=command,
+    )
+
+    expected = {
+        **command,
+        "executionPlanRef": plan.planRef,
+        "runtimeBindingRef": binding_ref,
+    }
+    assert workspace.materialize.await_args.kwargs["authority"] == expected
+    assert skills.materialize.await_args.kwargs["authority"] == expected
+    assert launcher.launch.await_args.kwargs["authority"] == expected
+    assert registration.wait_for_registration.await_args.kwargs["authority"] == expected
+    assert image.attest.await_args.kwargs["authority"] == expected
+    assert egress.attest.await_args.kwargs["authority"] == expected
+    assert cleanup.cleanup.await_args.kwargs["authority"] == expected

--- a/tests/unit/omnigent/test_normal_product_execution_authority.py
+++ b/tests/unit/omnigent/test_normal_product_execution_authority.py
@@ -28,6 +28,14 @@ from moonmind.omnigent.realizers.codex_profile_bound import CodexProfileBoundRea
 from moonmind.omnigent.realizers.runtime_authority import (
     ProviderProfileRuntimeAuthority,
 )
+from moonmind.omnigent.realizers.deployment_adapters import (
+    DeploymentGenericHostServices,
+    TrustedCredentialMaterializer,
+)
+from moonmind.omnigent.realizers.registry import (
+    get_default_registry,
+    reset_default_registry,
+)
 from moonmind.omnigent.harness_platform.support import (
     compute_support_combination_key,
 )
@@ -154,6 +162,43 @@ def test_normal_product_plan_freezes_registered_authority(
     assert "providerLeaseRef" not in serialized
     assert "credentialGeneration" not in serialized
     assert "hostLeaseRef" not in serialized
+
+
+def test_default_registry_composes_every_generic_host_production_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The shipped registry must be executable without test dependency injection."""
+
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(tmp_path))
+    monkeypatch.setenv(
+        "OMNIGENT_GENERIC_RUNTIME_ROOT", str(tmp_path / "generic-runtime")
+    )
+    reset_default_registry()
+    try:
+        realizer = get_default_registry().require("generic-omnigent-host@1")
+        dependencies = realizer._production_dependencies()
+
+        assert isinstance(
+            dependencies.runtime_authority, ProviderProfileRuntimeAuthority
+        )
+        materializer = dependencies.runtime_authority._credential_materializer
+        assert isinstance(materializer, TrustedCredentialMaterializer)
+        assert isinstance(dependencies.host_runtime, GenericOmnigentHostRuntime)
+
+        services = dependencies.host_runtime._launcher
+        assert isinstance(services, DeploymentGenericHostServices)
+        assert dependencies.host_runtime._workspace_service is services
+        assert dependencies.host_runtime._skill_service is services
+        assert dependencies.host_runtime._egress_service is services
+        assert dependencies.host_runtime._registration_waiter is services
+        assert dependencies.host_runtime._image_attestor is services
+        assert dependencies.host_runtime._cleanup_service is services
+        assert dependencies.host_runtime._context_service is services
+        assert services._credential_materializer is materializer
+        dependencies.host_runtime.assert_ready()
+    finally:
+        reset_default_registry()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/omnigent/test_omnigent_session_timeline_api.py
+++ b/tests/unit/omnigent/test_omnigent_session_timeline_api.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 import api_service.api.routers.omnigent_session_timeline as timeline_api
+import api_service.services.omnigent_session_timeline_service as timeline_service
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from moonmind.omnigent.control_plane.records import (
@@ -160,7 +161,7 @@ def session_record():
 @pytest.mark.asyncio
 async def test_timeline_endpoint_returns_projection(monkeypatch, session_record):
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
     )
     app = _build_app(session_record, _FakeUser())
     transport = ASGITransport(app=app)
@@ -176,7 +177,7 @@ async def test_timeline_endpoint_returns_projection(monkeypatch, session_record)
 @pytest.mark.asyncio
 async def test_timeline_endpoint_404_for_unknown_session(monkeypatch, session_record):
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
     )
     app = _build_app(session_record, _FakeUser())
     transport = ASGITransport(app=app)
@@ -188,7 +189,7 @@ async def test_timeline_endpoint_404_for_unknown_session(monkeypatch, session_re
 @pytest.mark.asyncio
 async def test_timeline_endpoint_requires_operator_permission(monkeypatch, session_record):
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: _FakeRepos(session_record))
     )
     unauthorized = _FakeUser(is_superuser=False, settings_permissions=set())
     app = _build_app(session_record, unauthorized)
@@ -221,7 +222,7 @@ async def test_timeline_links_redirect_through_authorized_server_routes(
     )
     repos = _FakeRepos(session_record, latest_decision=decision)
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories,
+        timeline_service.ControlPlaneRepositories,
         "bind",
         classmethod(lambda cls, db: repos),
     )
@@ -281,7 +282,7 @@ async def test_stuck_state_endpoint_returns_findings_and_response(monkeypatch):
     )
     repos = _FakeRepos(active, active_turn=_active_turn(), turn_count=1)
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
     )
     app = _build_app(active, _FakeUser())
     transport = ASGITransport(app=app)
@@ -317,7 +318,7 @@ async def test_stuck_state_endpoint_escalates_with_durable_detection_count(monke
         reason_counts={"moonmind_active_no_recent_evidence": 3},
     )
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
     )
     app = _build_app(active, _FakeUser())
     transport = ASGITransport(app=app)
@@ -356,7 +357,7 @@ async def test_stuck_state_endpoint_projects_provider_and_lease_divergence(monke
     )
     repos = _FakeRepos(active, latest_snapshot=snapshot)
     monkeypatch.setattr(
-        timeline_api.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
+        timeline_service.ControlPlaneRepositories, "bind", classmethod(lambda cls, db: repos)
     )
     app = _build_app(active, _FakeUser())
     transport = ASGITransport(app=app)

--- a/tests/unit/omnigent/test_opencode_host.py
+++ b/tests/unit/omnigent/test_opencode_host.py
@@ -393,29 +393,21 @@ def test_exact_host_preflight_with_credential_file():
     materialize_opencode_auth_json(api_key=key, provider_profile_ref="p", provider_lease_ref="l", credential_generation=5, host_root=tmp)
     hc = get_opencode_host_class()
     att = _make_attestation()
-    # With credential file verification
+    # Pure host attestation and outer credential-file verification remain
+    # separate architecture boundaries.
     validate_opencode_exact_host_preflight(
         attestation=att,
         expectedHostClassRef=hc.ref,
         expectedImageRef=hc.imageRef,
         expectedOmnigentBuildDigest="sha256:" + "b" * 64,
         expectedImplementation={"package": "omnigent", "version": "1.0.0", "digest": "sha256:" + "a" * 64, "pluginEntryPoint": None},
-        verify_credential_file=True,
-        credential_host_root=tmp,
         expectedCredentialGeneration=5,
     )
+    verify_opencode_auth_file(host_root=tmp, expected_generation=5)
     cleanup_opencode_auth(host_root=tmp)
-    # Without file should fail when verification requested but file missing
+    # The outer verifier fails once cleanup removes the file.
     with pytest.raises(HarnessPlatformError):
-        validate_opencode_exact_host_preflight(
-            attestation=att,
-            expectedHostClassRef=hc.ref,
-            expectedImageRef=hc.imageRef,
-            expectedOmnigentBuildDigest="sha256:" + "b" * 64,
-            expectedImplementation={"package": "omnigent", "version": "1.0.0", "digest": "sha256:" + "a" * 64, "pluginEntryPoint": None},
-            verify_credential_file=True,
-            credential_host_root=tmp,
-        )
+        verify_opencode_auth_file(host_root=tmp)
 
 
 def test_image_does_not_install_unrelated_harnesses():

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -18,6 +18,7 @@ from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
     refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
+    resolve_default_agent_profile_snapshot,
 )
 
 
@@ -63,6 +64,8 @@ class _Session:
 
     async def scalar(self, statement):
         entity = statement.column_descriptions[0].get("entity")
+        if entity is OmnigentAgentProfile:
+            return self.profile
         if entity is OmnigentAgentProfileVersion:
             return self.version
         if entity is ManagedAgentProviderProfile:
@@ -156,6 +159,24 @@ async def test_resolver_persists_exact_version_digest_and_effective_overrides():
     assert isinstance(usage, OmnigentAgentProfileUsage)
     assert usage.consumer_type == "checkpoint"
     assert usage.effective_snapshot == snapshot
+
+
+@pytest.mark.asyncio
+async def test_default_resolver_freezes_default_and_explicit_provider_at_admission():
+    session = _Session()
+
+    snapshot = await resolve_default_agent_profile_snapshot(
+        session,
+        provider_profile_ref="oauth-team",
+        launch_policy_ref="on-demand@1",
+        consumer_type="workflow",
+        consumer_id="workflow-default-1",
+        user=SimpleNamespace(id=uuid4()),
+    )
+
+    assert snapshot["profileId"] == "team-codex"
+    assert snapshot["providerProfileRef"] == "oauth-team"
+    assert snapshot["launchPolicyRef"] == "on-demand@1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -58,11 +58,13 @@ class _Session:
         )
         self.usage = None
         self.added = []
+        self.statements = []
 
     async def get(self, model, key):
         return self.profile if model is OmnigentAgentProfile else None
 
     async def scalar(self, statement):
+        self.statements.append(statement)
         entity = statement.column_descriptions[0].get("entity")
         if entity is OmnigentAgentProfile:
             return self.profile
@@ -177,6 +179,71 @@ async def test_default_resolver_freezes_default_and_explicit_provider_at_admissi
     assert snapshot["profileId"] == "team-codex"
     assert snapshot["providerProfileRef"] == "oauth-team"
     assert snapshot["launchPolicyRef"] == "on-demand@1"
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_selection_is_scoped_to_requesting_user():
+    session = _Session()
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    await resolve_agent_profile_snapshot(
+        session,
+        selection={
+            "profileId": "team-codex",
+            "version": 2,
+            "providerProfileRef": "oauth-team",
+        },
+        consumer_type="workflow",
+        consumer_id="workflow-owner-scope",
+        user=user,
+    )
+
+    provider_queries = [
+        statement
+        for statement in session.statements
+        if statement.column_descriptions[0].get("entity")
+        is ManagedAgentProviderProfile
+    ]
+    assert len(provider_queries) == 1
+    sql = str(provider_queries[0])
+    assert "owner_user_id IS NULL" in sql
+    assert "owner_user_id =" in sql
+
+
+@pytest.mark.asyncio
+async def test_idempotent_default_resolution_reuses_exact_profile_usage():
+    session = _Session()
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+    first = await resolve_default_agent_profile_snapshot(
+        session,
+        provider_profile_ref="oauth-team",
+        launch_policy_ref="on-demand@1",
+        consumer_type="workflow",
+        consumer_id="workflow-idempotent-default",
+        user=user,
+    )
+    session.usage = session.added.pop()
+
+    second = await resolve_default_agent_profile_snapshot(
+        session,
+        provider_profile_ref="oauth-team",
+        launch_policy_ref="on-demand@1",
+        consumer_type="workflow",
+        consumer_id="workflow-idempotent-default",
+        user=user,
+    )
+
+    assert second == first
+    assert second is not session.usage.effective_snapshot
+    assert session.added == []
+    provider_queries = [
+        str(statement)
+        for statement in session.statements
+        if statement.column_descriptions[0].get("entity")
+        is ManagedAgentProviderProfile
+    ]
+    assert provider_queries
+    assert all("owner_user_id IS NULL" in statement for statement in provider_queries)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -1022,6 +1022,7 @@ async def test_profile_lease_request_carries_owning_workflow_authority(
             return session
 
         async def bind_runtime_authority(self, _session_id: str, **_kwargs: object):
+            captured["boundRuntimeAuthority"] = dict(_kwargs)
             return session
 
     class FakeStore:
@@ -1040,12 +1041,17 @@ async def test_profile_lease_request_carries_owning_workflow_authority(
             )
 
     class FakeDbSession:
+        reads = 0
+
         async def get(self, _model: object, _profile_id: str) -> object:
+            type(self).reads += 1
             return SimpleNamespace(
                 enabled=True,
                 auth_state="connected",
                 runtime_id="codex_cli",
-                credential_generation=4,
+                credential_generation=(
+                    3 if type(self).reads == 1 else 4
+                ),
             )
 
         async def __aenter__(self):
@@ -1110,3 +1116,4 @@ async def test_profile_lease_request_carries_owning_workflow_authority(
     )
     assert safe["workflowId"] == omnigent_session_workflow_id("oms_123")
     assert "canonicalSessionId" not in safe
+    assert captured["boundRuntimeAuthority"]["credential_generation"] == 4  # type: ignore[index]

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -42,6 +42,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
     RUN_OMNIGENT_CHECKPOINT_BRANCH_TURN_REQUEST_PATCH,
+    RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH,
     RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
     RUN_PR_RESOLVER_SKILL_OWNED_EXECUTION_PATCH,
     RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
@@ -56,6 +57,70 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_TRUSTED_PR_RESOLVER_NATIVE_BINDING_PATCH,
     MoonMindRunWorkflow,
 )
+
+
+def test_omnigent_request_propagates_only_admitted_execution_plan_ref() -> None:
+    workflow = MoonMindRunWorkflow()
+    plan_ref = "omnigent-execution-plan:sha256:" + "4" * 64
+    info = SimpleNamespace(
+        namespace="default",
+        workflow_id="mm:execution-plan-authority",
+        run_id="run-1",
+        parent=None,
+    )
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=info,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: (
+                patch_id == RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH
+            ),
+        ),
+    ):
+        request = workflow._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "omnigent"}},
+            node_id="omnigent",
+            tool_name="auto",
+            workflow_parameters={"executionPlanRef": plan_ref},
+        )
+
+    assert request.parameters["executionPlanRef"] == plan_ref
+
+
+def test_omnigent_request_rejects_step_plan_substitution() -> None:
+    workflow = MoonMindRunWorkflow()
+    plan_ref = "omnigent-execution-plan:sha256:" + "4" * 64
+    info = SimpleNamespace(
+        namespace="default",
+        workflow_id="mm:execution-plan-authority",
+        run_id="run-1",
+        parent=None,
+    )
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=info,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            side_effect=lambda patch_id: (
+                patch_id == RUN_OMNIGENT_EXECUTION_PLAN_REF_PATCH
+            ),
+        ),
+        pytest.raises(ValueError, match="executionPlanRef conflicts"),
+    ):
+        workflow._build_agent_execution_request(
+            node_inputs={
+                "runtime": {"mode": "omnigent"},
+                "executionPlanRef": "omnigent-execution-plan:sha256:" + "5" * 64,
+            },
+            node_id="omnigent",
+            tool_name="auto",
+            workflow_parameters={"executionPlanRef": plan_ref},
+        )
 
 
 def test_auto_publish_compiles_execution_bound_terminal_contract() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -2496,6 +2496,66 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         )
         self.assertEqual(request.execution_profile_ref, "codex-openai-oauth")
 
+    def test_agent_profile_snapshot_compiles_admitted_opencode_harness(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._profile_snapshots = {
+            "opencode-provider": {
+                "profile_id": "opencode-provider",
+                "runtime_id": "opencode_go",
+            }
+        }
+
+        class MockInfo:
+            namespace = "default"
+            workflow_id = "mm:opencode-profile"
+            run_id = "run-1"
+
+        snapshot = {
+            "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+            "profileId": "omnigent-opencode-default",
+            "version": 1,
+            "digest": "sha256:" + "b" * 64,
+            "providerProfileRef": "opencode-provider",
+            "executionProfileRef": "omnigent-opencode@1",
+            "launchPolicyRef": "omnigent-on-demand@1",
+            "agentId": "opencode-agent",
+            "document": {
+                "endpointRef": "default",
+                "harness": "opencode-native",
+            },
+        }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ), patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=True,
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "omnigent",
+                        "executionProfileRef": "opencode-provider",
+                    },
+                },
+                workflow_parameters={
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-opencode@1",
+                        "launchPolicyRef": "omnigent-on-demand@1",
+                    },
+                    "agentProfileSnapshot": snapshot,
+                },
+                node_id="node-opencode",
+                tool_name="omnigent",
+            )
+
+        self.assertEqual(request.execution_profile_ref, "opencode-provider")
+        self.assertEqual(
+            request.parameters["omnigent"]["agent"]["harnessOverride"],
+            "opencode-native",
+        )
+
     def test_agent_profile_snapshot_rejects_conflicting_legacy_authority(self) -> None:
         wf = MoonMindRunWorkflow()
 
@@ -3597,7 +3657,7 @@ class TestFetchProfileSnapshots(unittest.TestCase):
                                 },
                             ]
                         }
-                    elif runtime_id == "claude_code":
+                    elif runtime_id == "opencode_go":
                         return {"profiles": []}
                 return {}
 
@@ -3669,7 +3729,10 @@ class TestFetchProfileSnapshots(unittest.TestCase):
             # codex_cli profiles are missing, but claude_code profiles should be there
             self.assertIn("claude_anthropic_sonnet", wf._profile_snapshots)
             self.assertNotIn("codex_openrouter_qwen36_plus", wf._profile_snapshots)
-            self.assertEqual(wf._profile_snapshot_runtime_ids, {"claude_code"})
+            self.assertEqual(
+                wf._profile_snapshot_runtime_ids,
+                {"claude_code", "opencode_go"},
+            )
             self.assertEqual(
                 wf._validated_execution_profile_ref(
                     "codex-profile-from-failed-fetch",


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3701

Closes MoonLadderStudios/MoonMind#3701

## Summary

- persist one immutable Omnigent execution-plan reference during normal execution admission, then bind exact provider, credential, lease, host, and workspace authority after acquisition
- route initial, continuation, remediation, Workflow Chat, approval, steering, checkpoint, and linked-branch instructions through canonical session and turn-command ownership
- compose provider-neutral generic realizer capabilities, preserve the explicit Codex path, and enforce documented package boundaries
- add migration coverage, production-boundary execution tests, replay checks, authority tests, and architecture violation fixtures

## Tests run

- Focused remediation unit and contract suite: 326 passed
- Adjacent Omnigent realizer, profile, replay, and Workflow Chat suite: 400 passed, 9 subtests passed
- Production-boundary integration suite for the default non-Codex path and checkpoint replay: 2 passed
- Total controlling evidence: 726 focused unit tests and 2 integration tests passed

## Remaining risks

Protected-live provider journeys and exact deployable-image conformance were not rerun because the managed verifier had no Docker endpoint or protected provider credentials. The verifier classified this as advisory: repository-local exact-artifact contracts, recorded realizer identities, and hermetic production-boundary tests passed.