### PR TITLE
fix(omnigent): make OpenCode via Omnigent work from OPENCODE_API_KEY alone

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -63,10 +63,21 @@ OMNIGENT_CONFIG=""
 OMNIGENT_HOST_IMAGE_REF=""
 OMNIGENT_HOST_IMAGE="ghcr.io/omnigent-ai/omnigent-host"
 OMNIGENT_HOST_IMAGE_TAG="latest"
-# Dedicated OpenCode host (issue 3752). Set to a digest-pinned GHCR ref, e.g.:
+# OpenCode Go credential. Setting this is the only value the default Compose
+# deployment needs to make "OpenCode via Omnigent" launchable: startup
+# reconciliation enrolls the Provider Profile, runs pinned-runtime validation,
+# and keeps its model evidence current as the host image is re-resolved.
+OPENCODE_API_KEY=""
+# The stock OpenCode Go model is a contributor tier, so enrollment records an
+# explicit data-use acknowledgement. Set to false to decline; enrollment then
+# stops instead of accepting on your behalf.
+OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE=true
+# Dedicated OpenCode host (issue 3752). Leave empty to let the deployment
+# resolve the digest from the image and tag below. Set to a digest-pinned GHCR
+# ref to pin it explicitly, e.g.:
 # ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:<digest>
-# Mutable tags fail closed for launch authority. The image is pulled lazily
-# only when an OpenCode workflow requires it and reuses cached base layers.
+# Mutable tags never become launch authority: startup resolves the tag to its
+# immutable digest once and every selector reads that digest.
 OMNIGENT_OPENCODE_HOST_IMAGE_REF=""
 OMNIGENT_OPENCODE_HOST_IMAGE="ghcr.io/moonladderstudios/omnigent-host-opencode"
 OMNIGENT_OPENCODE_HOST_IMAGE_TAG="1.18.11"

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -409,6 +409,36 @@ def _reason(code: str) -> GateReason:
     return GateReason(code=code, message=message, remediationHref=href)
 
 
+def _revalidation_is_exhausted(provider: Any, selected_classes: Any) -> bool:
+    """Report whether re-validation gave up on this credential and image.
+
+    Re-validation preserves the enrolled credential and its prior evidence when
+    the pinned runtime rejects it, so a revoked or incompatible credential looks
+    exactly like an attempt in flight. The reconciler records its bounded
+    outcome, and reading it here is what keeps readiness from promising forever
+    that the wait "finishes automatically".
+    """
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    behavior = getattr(provider, "command_behavior", None) or {}
+    record = behavior.get(REVALIDATION_FAILURE_KEY)
+    if not isinstance(record, dict) or record.get("exhausted") is not True:
+        return False
+    try:
+        generation = int(record.get("credentialGeneration") or 0)
+    except (TypeError, ValueError):
+        return False
+    if generation != int(provider.credential_generation):
+        # A rotated credential has not been attempted yet.
+        return False
+    return str(record.get("imageRef") or "") in {
+        item.imageRef for item in selected_classes
+    }
+
+
 def _valid_server_url(value: str) -> bool:
     try:
         url = httpx.URL(value)
@@ -1680,7 +1710,9 @@ async def get_omnigent_execution_readiness(
             if evidence_generation != int(provider.credential_generation) or str(
                 evidence.get("imageRef") or ""
             ) not in {item.imageRef for item in selected_classes}:
-                if evidence:
+                if evidence and not _revalidation_is_exhausted(
+                    provider, selected_classes
+                ):
                     # The credential is enrolled and connected; only its
                     # runtime-backed evidence trails the currently pinned host
                     # image or credential generation. The bootstrap reconciler

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -388,6 +388,11 @@ _REASONS: dict[str, tuple[str, str]] = {
         "Connect and validate a compatible Provider Profile.",
         "/settings#provider-profiles",
     ),
+    "provider_runtime_revalidation_pending": (
+        "MoonMind is re-validating this Provider Profile against the updated "
+        "pinned host image. This finishes automatically; retry shortly.",
+        "/settings#provider-profiles",
+    ),
     "model_catalog_unavailable": (
         "Run runtime-backed Provider Profile validation to discover models.",
         "/settings#provider-profiles",
@@ -1636,6 +1641,7 @@ async def get_omnigent_execution_readiness(
         compatible: list[dict[str, Any]] = []
         host_classes: set[str] = set()
         models: set[str] = set()
+        revalidating: list[str] = []
         for provider in visible_providers:
             state = getattr(provider.auth_state, "value", provider.auth_state)
             if (
@@ -1674,6 +1680,13 @@ async def get_omnigent_execution_readiness(
             if evidence_generation != int(provider.credential_generation) or str(
                 evidence.get("imageRef") or ""
             ) not in {item.imageRef for item in selected_classes}:
+                if evidence:
+                    # The credential is enrolled and connected; only its
+                    # runtime-backed evidence trails the currently pinned host
+                    # image or credential generation. The bootstrap reconciler
+                    # re-validates it against the exact selected image, so this
+                    # is a bounded wait rather than a reconnect.
+                    revalidating.append(provider.profile_id)
                 continue
             observed_models = {
                 model
@@ -1691,7 +1704,13 @@ async def get_omnigent_execution_readiness(
             host_classes.update(item.ref for item in selected_classes)
             models.update(observed_models)
         if not compatible:
-            reasons.append(_reason("compatible_provider_profile_unavailable"))
+            reasons.append(
+                _reason(
+                    "provider_runtime_revalidation_pending"
+                    if revalidating
+                    else "compatible_provider_profile_unavailable"
+                )
+            )
         if not host_classes:
             reasons.append(_reason("host_class_unavailable"))
         if not models:

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -373,6 +373,115 @@ async def _sync_omnigent_harness_catalog() -> bool:
         return False
 
 
+async def _sync_omnigent_deployment_images() -> bool:
+    """Resolve and export the deployment's digest-pinned Omnigent images.
+
+    Host Class selection, launch policy compilation, and Provider Profile
+    runtime validation all read digest-pinned refs from the process environment,
+    and the canonical Compose path deliberately leaves
+    ``OMNIGENT_OPENCODE_HOST_IMAGE_REF`` unset so the deployment resolves its own
+    digests from the configured image and tag. Without this leg those digests
+    only ever existed inside a console bootstrap request, so a restart left Host
+    Class selection with nothing to select.
+    """
+
+    try:
+        from moonmind.omnigent.bootstrap.image_resolution import (
+            publish_resolved_omnigent_images,
+        )
+        from moonmind.omnigent.settings import (
+            build_omnigent_gate,
+            generic_host_enabled,
+        )
+
+        if not build_omnigent_gate().enabled or not generic_host_enabled():
+            return True
+
+        state = await publish_resolved_omnigent_images()
+        if not state.opencode_host_image_ref:
+            logger.warning(
+                "Omnigent image resolution incomplete: no digest-pinned OpenCode "
+                "host image is available for the configured image and tag",
+            )
+            return False
+        logger.info(
+            "Resolved Omnigent deployment images: serverImageRef=%s "
+            "opencodeHostImageRef=%s",
+            state.server_image_ref,
+            state.opencode_host_image_ref,
+        )
+        return True
+    except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
+        logger.warning("Omnigent image resolution deferred: %s", exc)
+        return False
+    except Exception as exc:  # pragma: no cover - bounded startup reconciliation
+        logger.warning("Omnigent image resolution deferred: %s", exc)
+        return False
+
+
+async def _sync_omnigent_provider_readiness(*, allow_enrollment: bool) -> bool:
+    """Keep the deployment-configured OpenCode credential launchable.
+
+    Two failures used to require a console action. A configured
+    ``OPENCODE_API_KEY`` was never enrolled, and evidence recorded against an
+    earlier host image was never refreshed after the deployment re-resolved that
+    image. Either one strands the operator behind a "connect and validate a
+    compatible Provider Profile" gate for a deployment that already has
+    everything it needs.
+    """
+
+    try:
+        from api_service.db.base import async_session_maker
+        from moonmind.omnigent.bootstrap.provider_revalidation import (
+            reconcile_opencode_provider_readiness,
+        )
+        from moonmind.omnigent.settings import (
+            build_omnigent_gate,
+            generic_host_enabled,
+            opencode_support_enabled,
+        )
+
+        if (
+            not build_omnigent_gate().enabled
+            or not generic_host_enabled()
+            or not opencode_support_enabled()
+        ):
+            # No OpenCode execution plane means no credential to keep current.
+            return True
+
+        outcome = await reconcile_opencode_provider_readiness(
+            session_factory=async_session_maker,
+            allow_enrollment=allow_enrollment,
+        )
+        if outcome.enrolled:
+            logger.info(
+                "Enrolled the deployment-configured OpenCode Provider Profile",
+            )
+        if outcome.refreshed:
+            logger.info(
+                "Refreshed OpenCode Provider Profile model evidence: profiles=%s",
+                ",".join(outcome.refreshed),
+            )
+        if not outcome.ready and outcome.reason:
+            logger.warning(
+                "OpenCode Provider Profile readiness deferred: %s",
+                outcome.reason,
+            )
+        return outcome.ready
+    except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
+        logger.warning(
+            "OpenCode Provider Profile readiness deferred: %s",
+            exc,
+        )
+        return False
+    except Exception as exc:  # pragma: no cover - bounded startup reconciliation
+        logger.warning(
+            "OpenCode Provider Profile readiness deferred: %s",
+            exc,
+        )
+        return False
+
+
 @dataclass(frozen=True)
 class OmnigentBootstrapReadiness:
     """Per-leg outcome of one bootstrap reconciliation pass.
@@ -382,18 +491,22 @@ class OmnigentBootstrapReadiness:
     aggregate readiness that drives the backoff schedule.
     """
 
+    images_ready: bool
     policies_ready: bool
     agent_ready: bool
     catalog_ready: bool
     schedules_ready: bool
+    provider_ready: bool
 
     @property
     def ready(self) -> bool:
         return (
-            self.policies_ready
+            self.images_ready
+            and self.policies_ready
             and self.agent_ready
             and self.catalog_ready
             and self.schedules_ready
+            and self.provider_ready
         )
 
 
@@ -401,6 +514,9 @@ async def _reconcile_omnigent_bootstrap_once(
     *,
     refresh_images: bool,
 ) -> OmnigentBootstrapReadiness:
+    # Image identities come first: every downstream leg selects Host Classes and
+    # validates credentials against the digests this leg exports.
+    images_ready = await _sync_omnigent_deployment_images()
     policies_ready = await _sync_omnigent_bootstrap_policies(
         refresh_images=refresh_images
     )
@@ -411,11 +527,24 @@ async def _reconcile_omnigent_bootstrap_once(
         if policies_ready and agent_ready
         else False
     )
+    # First-time enrollment runs the full bootstrap and gets one attempt per
+    # configuration, so it waits for the image and catalog authorities it depends
+    # on. Re-validating an already-enrolled credential only needs the pinned
+    # image.
+    provider_ready = (
+        await _sync_omnigent_provider_readiness(
+            allow_enrollment=images_ready and catalog_ready
+        )
+        if images_ready
+        else False
+    )
     return OmnigentBootstrapReadiness(
+        images_ready=images_ready,
         policies_ready=policies_ready,
         agent_ready=agent_ready,
         catalog_ready=catalog_ready,
         schedules_ready=schedules_ready,
+        provider_ready=provider_ready,
     )
 
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -281,13 +281,22 @@ async def _sync_omnigent_bootstrap_policies(
             resolve_local_bootstrap_image_ref,
             seed_bootstrap_policies,
         )
+        from moonmind.omnigent.bootstrap.image_resolution import (
+            operator_image_configuration,
+        )
 
+        # This is the only leg allowed to acquire images from the registry, and
+        # it keys on the configured refs. Reading the live environment would
+        # hand it a digest the image leg published, which is indistinguishable
+        # from an operator pin and would silently disable tag refresh.
+        configuration = operator_image_configuration()
         async with get_async_session_context() as session:
             if refresh_images:
-                await seed_bootstrap_policies(session)
+                await seed_bootstrap_policies(session, env=configuration)
             else:
                 await seed_bootstrap_policies(
                     session,
+                    env=configuration,
                     image_resolver=resolve_local_bootstrap_image_ref,
                 )
             return await bootstrap_policies_ready(session)
@@ -392,13 +401,18 @@ async def _sync_omnigent_deployment_images() -> bool:
         from moonmind.omnigent.settings import (
             build_omnigent_gate,
             generic_host_enabled,
+            opencode_support_enabled,
         )
 
         if not build_omnigent_gate().enabled or not generic_host_enabled():
             return True
 
         state = await publish_resolved_omnigent_images()
-        if not state.opencode_host_image_ref:
+        if not state.opencode_host_image_ref and opencode_support_enabled():
+            # Only a deployment that actually runs OpenCode depends on this
+            # digest. An operator who turned the harness off must not inherit
+            # its registry dependency, or the kill switch would leave bootstrap
+            # readiness retrying forever on an image nothing will launch.
             logger.warning(
                 "Omnigent image resolution incomplete: no digest-pinned OpenCode "
                 "host image is available for the configured image and tag",

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -82,6 +82,38 @@ OPENAI_API_KEY, ANTHROPIC_API_KEY
 
 Never use `OPENCODE_AUTH_CONTENT`, CLI arguments, labels, generated environment files, or ordinary Docker environment variables for the production secret path. The execution plan, runtime binding, Temporal payloads, Docker inspection data, and cleanup handles contain only references and generations.
 
+## Deployment setup
+
+The canonical local path needs one value. Set `OPENCODE_API_KEY` in `.env` and
+start Docker Compose; the Omnigent bootstrap reconciliation does the rest on
+startup and on its ongoing cadence:
+
+1. resolve the configured OpenCode host image and tag to an immutable digest and
+   export it, so Host Class selection and launch policy compilation have an
+   authority to select (`OMNIGENT_OPENCODE_HOST_IMAGE_REF` stays optional and
+   overrides the resolution when set);
+2. synchronize the authenticated harness catalog and seed the built-in
+   `omnigent-opencode-default` Agent Profile;
+3. enroll the `opencode-go-default` Provider Profile from `OPENCODE_API_KEY`,
+   running the same pinned-runtime validation as the console action; and
+4. keep that profile's model catalog evidence current as the host image is
+   re-resolved.
+
+`OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE` defaults to `true` because the stock
+OpenCode Go model is a contributor tier whose enrollment records a data-use
+acknowledgement. Set it to `false` to decline; enrollment then stops with an
+actionable failure instead of acknowledging on the operator's behalf.
+
+Enrollment runs the full bootstrap, so it waits for the immutable image and
+harness catalog authorities it depends on, and it is attempted once per distinct
+configuration. Correcting the credential or the acknowledgement produces a new
+configuration and retries; so does restarting the service. Re-validating an
+already-enrolled credential is separate and repeats on every pass.
+
+Console enrollment through **Settings → Provider Profiles** remains available and
+is the path for a deployment that does not carry the credential in its
+environment.
+
 ## Provider Profile: OpenCode Go
 
 Create in **Settings → Provider Profiles**:
@@ -107,6 +139,24 @@ Validation (Settings → Validate):
 6. Persist only normalized model metadata, image/runtime identity, and validation evidence
 
 Raw key is never returned after submission.
+
+### Automatic re-validation after a host image change
+
+Model catalog evidence is bound to the exact digest-pinned host image that
+produced it and to the credential generation that was active at the time.
+Readiness, planning, and smoke admission all reject evidence that belongs to any
+other image or generation, so re-pulling or rebuilding the OpenCode host image
+invalidates every previously validated Provider Profile.
+
+MoonMind therefore re-validates automatically. The Omnigent bootstrap
+reconciliation pass re-runs the pinned-runtime validation above for every
+enabled, connected OpenCode Provider Profile whose evidence no longer matches
+the currently pinned image, using the already-enrolled `opencode_api_key`
+SecretRef. No new credential is requested, no image is substituted, and a
+credential the runtime rejects keeps its previous evidence and stays connected.
+While a profile is waiting for that pass, Workflow Create reports
+`provider_runtime_revalidation_pending` rather than asking the operator to
+reconnect a profile that is already connected.
 
 ## Agent Profile
 

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -6,7 +6,9 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
-from moonmind.omnigent.bootstrap.image_resolution import resolve_omnigent_images
+from moonmind.omnigent.bootstrap.image_resolution import (
+    publish_resolved_omnigent_images,
+)
 from moonmind.omnigent.bootstrap.models import (
     BootstrapDesired,
     BootstrapRecord,
@@ -21,7 +23,6 @@ from moonmind.omnigent.bootstrap.opencode import (
 from moonmind.omnigent.bootstrap.store import (
     load_bootstrap_record,
     save_bootstrap_record,
-    save_resolved_state,
 )
 from moonmind.omnigent.harness_platform.support import (
     compute_support_combination_key,
@@ -88,17 +89,11 @@ class BootstrapController:
             # 1. Resolve images
             record = record.model_copy(update={"state": BootstrapState.resolving_images})
             save_bootstrap_record(record)
-            resolved = await resolve_omnigent_images()
-            save_resolved_state(resolved)
-            # Propagate resolved digests into process environment so downstream selectors
-            # and `get_opencode_host_image_ref()` see the authoritative pinned refs even
-            # when the operator did not export them (default Compose path).
-            if resolved.opencode_host_image_ref:
-                os.environ["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] = resolved.opencode_host_image_ref
-            if resolved.server_image_ref:
-                os.environ["OMNIGENT_IMAGE_REF"] = resolved.server_image_ref
-            if resolved.omnigent_build_digest:
-                os.environ["OMNIGENT_BUILD_DIGEST"] = resolved.omnigent_build_digest
+            # One boundary resolves, persists, and exports the pinned digests so
+            # downstream selectors and `get_opencode_host_image_ref()` observe the
+            # authoritative refs even when the operator did not export them
+            # (default Compose path).
+            resolved = await publish_resolved_omnigent_images()
             # Ensure image refs are available; if not, try fallback to existing env host image or build
             if not resolved.opencode_host_image_ref:
                 # Try to build locally if missing
@@ -205,50 +200,28 @@ class BootstrapController:
             raise
 
     async def _sync_catalog(self, resolved: Any) -> None:
+        """Synchronize the harness catalog through the one canonical boundary.
+
+        The canonical service applies the synthetic OpenCode overlay before
+        persisting, so the snapshot it publishes is the one that carries the
+        ``opencode-native`` harness and its trust record. Synchronizing
+        separately would publish an overlay-free snapshot as ``latest()`` and
+        make the profile this bootstrap just enrolled fail the harness-catalog
+        attestation, which is exactly the readiness gate bootstrap exists to
+        satisfy.
+        """
+
+        del resolved
+
         from api_service.db.base import async_session_maker
-        from moonmind.omnigent.production import (
-            build_generic_omnigent_execution_services,
+        from api_service.services.omnigent_agent_profile_service import (
+            synchronize_omnigent_harness_catalog,
         )
 
-        # Use production services to sync
         try:
-            services = build_generic_omnigent_execution_services(
-                session_factory=async_session_maker
-            )
-            result = await services.catalog_service.synchronize()
-            # Ensure built-in profile
-            from api_service.api.routers.omnigent_agent_profiles import (
-                ensure_builtin_opencode_agent_profile,
-            )
-            from api_service.db.base import async_session_maker as asm
-
-            async with asm() as session:
-                await ensure_builtin_opencode_agent_profile(session=session, catalog=result)
+            async with async_session_maker() as session:
+                await synchronize_omnigent_harness_catalog(session)
         except Exception as exc:
-            # If duplicate source digest, treat as already synchronized
-            err_text = str(exc).lower()
-            if "duplicate" in err_text and "uq_omnigent_catalog" in err_text:
-                # Load existing catalog
-                from api_service.api.routers.omnigent_agent_profiles import (
-                    ensure_builtin_opencode_agent_profile,
-                )
-                from api_service.db.base import async_session_maker as asm2
-                from moonmind.omnigent.harness_platform.catalog_service import (
-                    DbHarnessCatalogRepository,
-                )
-
-                try:
-                    async with asm2() as session:
-                        repo = DbHarnessCatalogRepository(asm2)
-                        latest = await repo.latest("default")
-                        if latest is not None:
-                            await ensure_builtin_opencode_agent_profile(
-                                session=session, catalog=latest
-                            )
-                            return
-                except Exception:
-                    # Best-effort fallback already attempted; propagate original catalog sync error
-                    pass
             raise RuntimeError(f"catalog synchronization failed: {exc}") from exc
 
     async def _ensure_provider_profile(
@@ -785,7 +758,7 @@ class BootstrapController:
             # Override catalog for support identity build digest to use synthetic
             catalog = type("obj", (), {"snapshot": synth_catalog})()
         # Feed resolved host image into selection via explicit environment dict.
-        # Ensure resolve_omnigent_images() was called upstream; if the passed
+        # Ensure publish_resolved_omnigent_images() ran upstream; if the passed
         # resolved state is empty, try the persisted resolved state before failing.
         if not resolved or not getattr(resolved, "opencode_host_image_ref", None):
             try:
@@ -807,7 +780,7 @@ class BootstrapController:
         if not resolved_image or "@sha256:" not in resolved_image:
             raise RuntimeError(
                 "resolved opencode host image is missing or not digest-pinned; "
-                "ensure resolve_omnigent_images() succeeded before host class selection and that OMNIGENT_OPENCODE_HOST_IMAGE_REF is digest-pinned"
+                "ensure publish_resolved_omnigent_images() succeeded before host class selection and that OMNIGENT_OPENCODE_HOST_IMAGE_REF is digest-pinned"
             )
         selector_env = {
             "OMNIGENT_OPENCODE_HOST_IMAGE_REF": resolved_image,

--- a/moonmind/omnigent/bootstrap/image_resolution.py
+++ b/moonmind/omnigent/bootstrap/image_resolution.py
@@ -182,6 +182,35 @@ async def resolve_omnigent_images() -> ResolvedOmnigentDeploymentState:
     return state
 
 
+async def publish_resolved_omnigent_images() -> ResolvedOmnigentDeploymentState:
+    """Resolve, persist, and export the deployment's immutable image identities.
+
+    Host Class selection, launch policy compilation, and Provider Profile
+    runtime validation all read the digest-pinned refs straight from the process
+    environment, and the canonical Compose path leaves
+    ``OMNIGENT_OPENCODE_HOST_IMAGE_REF`` unset so the deployment can resolve its
+    own digests. This is the single boundary that turns the configured
+    image/tag into those exported digests, so every caller observes one
+    authority instead of resolving separately.
+    """
+
+    from moonmind.omnigent.bootstrap.store import save_resolved_state
+
+    state = await resolve_omnigent_images()
+    save_resolved_state(state)
+    exported = {
+        "OMNIGENT_IMAGE_REF": state.server_image_ref,
+        "OMNIGENT_BUILD_DIGEST": state.omnigent_build_digest,
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF": state.opencode_host_image_ref,
+        "OMNIGENT_PI_HOST_IMAGE_REF": state.pi_host_image_ref,
+    }
+    for key, value in exported.items():
+        cleaned = str(value or "").strip()
+        if cleaned:
+            os.environ[key] = cleaned
+    return state
+
+
 def resolved_server_image_ref(state: ResolvedOmnigentDeploymentState | None) -> str:
     if state and state.server_image_ref:
         return state.server_image_ref

--- a/moonmind/omnigent/bootstrap/image_resolution.py
+++ b/moonmind/omnigent/bootstrap/image_resolution.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 from datetime import UTC, datetime
+from typing import Mapping
 
 from moonmind.omnigent.bootstrap.models import ResolvedOmnigentDeploymentState
 
@@ -72,16 +73,22 @@ async def _resolve_via_docker_pull(image: str, tag: str) -> str | None:
     return await _resolve_via_docker_inspect(ref)
 
 
-async def _resolve_image(image_env: str, tag_env: str, ref_env: str) -> tuple[str | None, str | None]:
+async def _resolve_image(
+    image_env: str,
+    tag_env: str,
+    ref_env: str,
+    env: Mapping[str, str] | None = None,
+) -> tuple[str | None, str | None]:
     """Resolve one image to digest-pinned ref. Returns (pinned_ref, build_digest)."""
-    pinned = os.getenv(ref_env, "").strip()
+    source = os.environ if env is None else env
+    pinned = str(source.get(ref_env) or "").strip()
     if pinned and _is_digest_pinned(pinned) and not pinned.endswith("0" * 64) and not pinned.endswith("c" * 64):
         # Valid pinned ref
         build_digest = _extract_digest(pinned)
         return pinned, build_digest
     # Need to resolve from image+tag
-    image = os.getenv(image_env, "").strip()
-    tag = os.getenv(tag_env, "").strip() or "latest"
+    image = str(source.get(image_env) or "").strip()
+    tag = str(source.get(tag_env) or "").strip() or "latest"
     if not image:
         return None, None
     # Try inspect existing local image without pull
@@ -104,22 +111,30 @@ async def _resolve_image(image_env: str, tag_env: str, ref_env: str) -> tuple[st
     return None, None
 
 
-async def resolve_omnigent_images() -> ResolvedOmnigentDeploymentState:
+async def resolve_omnigent_images(
+    env: Mapping[str, str] | None = None,
+) -> ResolvedOmnigentDeploymentState:
     """Resolve server and OpenCode host images to immutable digests.
 
     This is best-effort: if docker is unavailable or images cannot be pulled,
     returns whatever is configured via env or previously persisted state.
+
+    ``env`` exists so callers can resolve against the deployment's own image
+    configuration rather than a digest a previous pass published. Resolving
+    against a self-published digest would make every configured mutable tag look
+    explicitly pinned and silently disable tag refresh.
     """
     from moonmind.omnigent.bootstrap.store import load_resolved_state
 
+    source = os.environ if env is None else env
     previous = load_resolved_state()
 
     # Server image
     server_ref, server_digest = await _resolve_image(
-        "OMNIGENT_IMAGE", "OMNIGENT_IMAGE_TAG", "OMNIGENT_IMAGE_REF"
+        "OMNIGENT_IMAGE", "OMNIGENT_IMAGE_TAG", "OMNIGENT_IMAGE_REF", source
     )
     # Also check OMNIGENT_BUILD_DIGEST directly
-    build_digest = os.getenv("OMNIGENT_BUILD_DIGEST", "").strip()
+    build_digest = str(source.get("OMNIGENT_BUILD_DIGEST") or "").strip()
     if build_digest and _SHA256_RE.fullmatch(build_digest):
         server_digest = build_digest
     elif server_ref:
@@ -130,11 +145,15 @@ async def resolve_omnigent_images() -> ResolvedOmnigentDeploymentState:
         "OMNIGENT_OPENCODE_HOST_IMAGE",
         "OMNIGENT_OPENCODE_HOST_IMAGE_TAG",
         "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        source,
     )
 
     # Pi host (optional)
     pi_ref, _ = await _resolve_image(
-        "OMNIGENT_PI_HOST_IMAGE", "OMNIGENT_PI_HOST_IMAGE_TAG", "OMNIGENT_PI_HOST_IMAGE_REF"
+        "OMNIGENT_PI_HOST_IMAGE",
+        "OMNIGENT_PI_HOST_IMAGE_TAG",
+        "OMNIGENT_PI_HOST_IMAGE_REF",
+        source,
     )
     # Fall back to previous if still None
     if not server_ref and previous and previous.server_image_ref:
@@ -182,6 +201,54 @@ async def resolve_omnigent_images() -> ResolvedOmnigentDeploymentState:
     return state
 
 
+# The digests published below are written back into the process environment so
+# every selector observes one authority. That export must never become an input
+# to resolution or to registry acquisition: a self-published digest is
+# indistinguishable from an operator pin, and treating it as one would disable
+# refresh for every configured mutable tag. These are the keys publication
+# writes, captured once at their operator-supplied values.
+_PUBLISHED_IMAGE_KEYS = (
+    "OMNIGENT_IMAGE_REF",
+    "OMNIGENT_BUILD_DIGEST",
+    "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+    "OMNIGENT_PI_HOST_IMAGE_REF",
+)
+_operator_image_baseline: dict[str, str] | None = None
+
+
+def operator_image_configuration(
+    *, env: Mapping[str, str] | None = None
+) -> Mapping[str, str]:
+    """Return the deployment's own image configuration, free of published digests.
+
+    Callers that resolve or acquire images must read this instead of the live
+    environment so tag refresh keeps working across passes. Callers that only
+    consume an already-resolved identity should keep reading the environment.
+    """
+
+    global _operator_image_baseline
+
+    source = os.environ if env is None else env
+    if _operator_image_baseline is None:
+        _operator_image_baseline = {
+            key: str(source.get(key) or "").strip() for key in _PUBLISHED_IMAGE_KEYS
+        }
+    merged = dict(source)
+    for key, value in _operator_image_baseline.items():
+        if value:
+            merged[key] = value
+        else:
+            merged.pop(key, None)
+    return merged
+
+
+def reset_operator_image_configuration() -> None:
+    """Forget the captured baseline (tests only)."""
+
+    global _operator_image_baseline
+    _operator_image_baseline = None
+
+
 async def publish_resolved_omnigent_images() -> ResolvedOmnigentDeploymentState:
     """Resolve, persist, and export the deployment's immutable image identities.
 
@@ -192,11 +259,15 @@ async def publish_resolved_omnigent_images() -> ResolvedOmnigentDeploymentState:
     own digests. This is the single boundary that turns the configured
     image/tag into those exported digests, so every caller observes one
     authority instead of resolving separately.
+
+    Resolution always reads :func:`operator_image_configuration`, never the
+    digests this function exports, so a configured mutable tag stays refreshable
+    on every pass.
     """
 
     from moonmind.omnigent.bootstrap.store import save_resolved_state
 
-    state = await resolve_omnigent_images()
+    state = await resolve_omnigent_images(operator_image_configuration())
     save_resolved_state(state)
     exported = {
         "OMNIGENT_IMAGE_REF": state.server_image_ref,

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -42,13 +42,25 @@ OPENCODE_RUNTIME_ID = "opencode"
 OPENCODE_PROVIDER_ID = "opencode-go"
 OPENCODE_SECRET_ROLE = "opencode_api_key"
 
+# Readiness reads this ``command_behavior`` entry to distinguish a bounded
+# re-validation attempt in flight from a credential the pinned runtime keeps
+# rejecting, which only an operator can fix.
+REVALIDATION_FAILURE_KEY = "runtime_revalidation_failure"
+MAX_REVALIDATION_ATTEMPTS = 3
+
 # Enrollment runs the full bootstrap (image acquisition, catalog sync, pinned
-# runtime validation, qualification). Repeating that every reconciliation pass
-# for configuration the runtime already rejected would burn the deployment's
-# Docker and provider budget with no new information, so an attempt is made once
-# per distinct configuration. Changing the key, the acknowledgement, or the
-# resolved host image produces a new fingerprint and retries; so does a restart.
-_ATTEMPTED_ENROLLMENTS: set[str] = set()
+# runtime validation, qualification). Repeating that forever for configuration
+# the provider has definitively rejected would burn the deployment's Docker and
+# provider budget with no new information, so attempts per distinct
+# configuration are bounded rather than unlimited. They are not limited to one:
+# Temporal, Docker, and the database are all startup dependencies whose
+# transient unavailability must stay retryable through the caller's existing
+# backoff. A configuration the deployment states incorrectly -- a malformed key,
+# or a declined acknowledgement -- is terminal on the first attempt because no
+# amount of retrying changes it. Changing the key, the acknowledgement, or the
+# resolved host image produces a new fingerprint; so does a restart.
+_MAX_ENROLLMENT_ATTEMPTS = 5
+_ENROLLMENT_ATTEMPTS: dict[str, int] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,9 +76,9 @@ class ProviderReconcileOutcome:
 
 
 def reset_enrollment_attempts() -> None:
-    """Clear the per-configuration enrollment latch (tests and operator retry)."""
+    """Clear the per-configuration attempt budget (tests and operator retry)."""
 
-    _ATTEMPTED_ENROLLMENTS.clear()
+    _ENROLLMENT_ATTEMPTS.clear()
 
 
 def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
@@ -89,15 +101,21 @@ def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
     return str(evidence.get("imageRef") or "") == image_ref
 
 
-def _is_enrolled(profile: Any) -> bool:
-    """Report whether this profile already carries a usable enrolled credential."""
+def _has_enrolled_credential(profile: Any) -> bool:
+    """Report whether this profile already carries an enrolled credential.
+
+    Deliberately independent of ``enabled``. Enrollment applies API-key setup
+    with ``enabled=True``, so treating a disabled-but-connected profile as
+    absent would let deployment configuration silently undo an operator's
+    decision to disable it. The credential identity is what enrollment owns;
+    ``enabled`` belongs to the operator.
+    """
 
     from api_service.db.models import ProviderProfileAuthState
 
     state = getattr(profile.auth_state, "value", profile.auth_state)
     return (
-        bool(profile.enabled)
-        and state == ProviderProfileAuthState.CONNECTED.value
+        state == ProviderProfileAuthState.CONNECTED.value
         and OPENCODE_SECRET_ROLE in (profile.secret_refs or {})
     )
 
@@ -164,7 +182,11 @@ async def reconcile_opencode_provider_readiness(
 
     image_ref = _pinned_image_ref()
     profiles = await _opencode_profiles(session_factory)
-    enrolled = [profile for profile in profiles if _is_enrolled(profile)]
+    enrolled = [profile for profile in profiles if _has_enrolled_credential(profile)]
+    # A disabled profile cannot launch, and re-validating it would neither help
+    # nor honor the operator. Its credential still counts as enrolled above, so
+    # deployment configuration never re-enables it.
+    launchable = [profile for profile in enrolled if profile.enabled]
 
     if not enrolled:
         api_key = resolved_opencode_api_key(env=env)
@@ -191,6 +213,12 @@ async def reconcile_opencode_provider_readiness(
             controller=controller,
         )
 
+    if not launchable:
+        return ProviderReconcileOutcome(
+            ready=True,
+            checked=len(profiles),
+            reason="every enrolled OpenCode Provider Profile is disabled",
+        )
     if image_ref is None:
         # The image-policy leg owns acquiring the pinned image. Defer rather
         # than record evidence for an image the deployment does not select.
@@ -201,7 +229,7 @@ async def reconcile_opencode_provider_readiness(
         )
     return await _revalidate_stale_evidence(
         session_factory=session_factory,
-        profiles=enrolled,
+        profiles=launchable,
         checked=len(profiles),
         image_ref=image_ref,
     )
@@ -224,16 +252,17 @@ async def _enroll_from_deployment_config(
     fingerprint = _enrollment_fingerprint(
         api_key=api_key, accepted=accepted, image_ref=image_ref
     )
-    if fingerprint in _ATTEMPTED_ENROLLMENTS:
+    attempts = _ENROLLMENT_ATTEMPTS.get(fingerprint, 0)
+    if attempts >= _MAX_ENROLLMENT_ATTEMPTS:
         return ProviderReconcileOutcome(
             ready=False,
             checked=checked,
             reason=(
-                "OpenCode enrollment already failed for this configuration; "
-                "correct the credential or acknowledgement and restart"
+                "OpenCode enrollment exhausted its attempts for this "
+                "configuration; correct the credential or acknowledgement"
             ),
         )
-    _ATTEMPTED_ENROLLMENTS.add(fingerprint)
+    _ENROLLMENT_ATTEMPTS[fingerprint] = attempts + 1
 
     active = controller or BootstrapController(session_factory=session_factory)
     try:
@@ -241,9 +270,27 @@ async def _enroll_from_deployment_config(
             api_key=api_key,
             accept_contributor_data_use=accepted,
         )
+    except ValueError as exc:
+        # The deployment stated its configuration incorrectly: a malformed key,
+        # or a declined contributor acknowledgement. Retrying cannot change the
+        # outcome, so this consumes the whole budget instead of one attempt.
+        _ENROLLMENT_ATTEMPTS[fingerprint] = _MAX_ENROLLMENT_ATTEMPTS
+        logger.warning("OpenCode enrollment configuration is invalid: %s", exc)
+        return ProviderReconcileOutcome(
+            ready=False,
+            checked=checked,
+            reason=f"OpenCode enrollment configuration is invalid: {exc}",
+        )
     except Exception as exc:
+        # Temporal, Docker, the registry, and the database are all startup
+        # dependencies. Their transient unavailability keeps the remaining
+        # attempts and defers to the caller's bounded backoff.
         logger.warning(
-            "OpenCode enrollment from deployment configuration failed: %s", exc
+            "OpenCode enrollment from deployment configuration failed "
+            "(attempt %s of %s): %s",
+            attempts + 1,
+            _MAX_ENROLLMENT_ATTEMPTS,
+            exc,
         )
         return ProviderReconcileOutcome(
             ready=False, checked=checked, reason=f"OpenCode enrollment failed: {exc}"
@@ -253,7 +300,10 @@ async def _enroll_from_deployment_config(
     if state != BootstrapState.ready.value:
         failure = (record.failure or {}).get("message") or state
         logger.warning(
-            "OpenCode enrollment from deployment configuration did not complete: %s",
+            "OpenCode enrollment from deployment configuration did not complete "
+            "(attempt %s of %s): %s",
+            attempts + 1,
+            _MAX_ENROLLMENT_ATTEMPTS,
             failure,
         )
         return ProviderReconcileOutcome(
@@ -262,7 +312,7 @@ async def _enroll_from_deployment_config(
             reason=f"OpenCode enrollment did not complete: {failure}",
         )
 
-    _ATTEMPTED_ENROLLMENTS.discard(fingerprint)
+    _ENROLLMENT_ATTEMPTS.pop(fingerprint, None)
     logger.info(
         "Enrolled the deployment-configured OpenCode Provider Profile: profile_id=%s",
         record.provider_profile_ref,
@@ -345,13 +395,30 @@ async def _revalidate_stale_evidence(
                         exc_info=True,
                     )
         if evidence is None:
+            await _record_revalidation_failure(
+                session_factory=session_factory,
+                profile_id=profile_id,
+                image_ref=image_ref,
+            )
             continue
 
-        await _persist_evidence(
+        committed = await _persist_evidence(
             session_factory=session_factory,
             profile_id=profile_id,
             evidence=evidence,
         )
+        if not committed:
+            # The authority handoff did not land, so readiness and planning still
+            # reject this profile. Reporting it refreshed would let the startup
+            # coordinator record a successful pass over an unlaunchable profile.
+            deferred.append(profile_id)
+            logger.warning(
+                "OpenCode Provider Profile evidence was not committed: "
+                "profile_id=%s image_ref=%s",
+                profile_id,
+                image_ref,
+            )
+            continue
         refreshed.append(profile_id)
         logger.info(
             "Refreshed OpenCode Provider Profile model evidence: "
@@ -374,21 +441,25 @@ async def _persist_evidence(
     session_factory: Any,
     profile_id: str,
     evidence: dict[str, Any],
-) -> None:
-    """Record refreshed evidence without touching enrolled credential identity."""
+) -> bool:
+    """Record refreshed evidence without touching enrolled credential identity.
+
+    Returns whether this pass actually committed launchable evidence, so the
+    caller never reports a profile refreshed that readiness still rejects.
+    """
 
     from api_service.db.models import ManagedAgentProviderProfile
 
     async with session_factory() as session:
         profile = await session.get(ManagedAgentProviderProfile, profile_id)
         if profile is None:
-            return
+            return False
         if int(evidence.get("credentialGeneration") or 0) != int(
             profile.credential_generation
         ):
             # The credential rotated while validation ran; that rotation owns
             # the authoritative evidence for its own generation.
-            return
+            return False
         models = [
             str(item.get("qualifiedId") or "")
             for item in evidence.get("models", [])
@@ -405,14 +476,62 @@ async def _persist_evidence(
             "runtime_versions": evidence.get("runtimeVersions"),
             "model_count": len(models),
         }
+        behavior.pop(REVALIDATION_FAILURE_KEY, None)
+        profile.command_behavior = behavior
+        await session.commit()
+        return True
+
+
+async def _record_revalidation_failure(
+    *,
+    session_factory: Any,
+    profile_id: str,
+    image_ref: str,
+) -> None:
+    """Count a failed re-validation so readiness can stop promising a retry.
+
+    Re-validation deliberately preserves the enrolled credential and its prior
+    evidence when the pinned runtime rejects it, which is indistinguishable from
+    an in-flight attempt unless the outcome is recorded. Readiness reads this to
+    tell "MoonMind is re-validating" apart from "this credential needs an
+    operator".
+    """
+
+    from api_service.db.models import ManagedAgentProviderProfile
+
+    async with session_factory() as session:
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        if profile is None:
+            return
+        behavior = dict(profile.command_behavior or {})
+        previous = behavior.get(REVALIDATION_FAILURE_KEY)
+        attempts = 0
+        if isinstance(previous, dict) and str(
+            previous.get("imageRef") or ""
+        ) == image_ref and int(previous.get("credentialGeneration") or 0) == int(
+            profile.credential_generation
+        ):
+            try:
+                attempts = int(previous.get("attempts") or 0)
+            except (TypeError, ValueError):
+                attempts = 0
+        behavior[REVALIDATION_FAILURE_KEY] = {
+            "imageRef": image_ref,
+            "credentialGeneration": int(profile.credential_generation),
+            "attempts": attempts + 1,
+            "exhausted": attempts + 1 >= MAX_REVALIDATION_ATTEMPTS,
+            "lastAttemptAt": datetime.now(UTC).isoformat(),
+        }
         profile.command_behavior = behavior
         await session.commit()
 
 
 __all__ = [
+    "MAX_REVALIDATION_ATTEMPTS",
     "OPENCODE_PROVIDER_ID",
     "OPENCODE_RUNTIME_ID",
     "OPENCODE_SECRET_ROLE",
+    "REVALIDATION_FAILURE_KEY",
     "ProviderReconcileOutcome",
     "evidence_is_current",
     "reconcile_opencode_provider_readiness",

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -1,0 +1,420 @@
+"""Keep the deployment's configured OpenCode credential launchable.
+
+Two things must be true before ``moonmind.omnigent-execution-readiness.v3``
+advertises an OpenCode target: a Provider Profile must be enrolled and
+connected, and its persisted ``model_catalog_evidence_json`` must have been
+observed on the exact digest-pinned host image the deployment currently selects.
+
+Both used to require a console action. Enrollment only happened through the
+one-action bootstrap endpoint, and evidence was only written at that moment, so
+a rebuilt or re-pulled OpenCode host image silently invalidated a perfectly good
+credential. Either way the operator was told to "connect and validate a
+compatible Provider Profile" for a deployment that already had everything it
+needed.
+
+This boundary closes both gaps from deployment configuration alone:
+
+* enrollment runs the canonical bootstrap for the configured
+  ``OPENCODE_API_KEY`` when no connected profile exists; and
+* re-validation re-runs the pinned-runtime check against the already-enrolled
+  SecretRef when only the evidence is stale.
+
+Neither path substitutes a credential, an image, or a weaker evidence contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Mapping
+from uuid import uuid4
+
+from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
+
+# The runtime-backed model catalog evidence contract exists for exactly one
+# provider route today. Keep that identity explicit rather than inferring it
+# from a name list that would drift from the materializer contract.
+OPENCODE_RUNTIME_ID = "opencode"
+OPENCODE_PROVIDER_ID = "opencode-go"
+OPENCODE_SECRET_ROLE = "opencode_api_key"
+
+# Enrollment runs the full bootstrap (image acquisition, catalog sync, pinned
+# runtime validation, qualification). Repeating that every reconciliation pass
+# for configuration the runtime already rejected would burn the deployment's
+# Docker and provider budget with no new information, so an attempt is made once
+# per distinct configuration. Changing the key, the acknowledgement, or the
+# resolved host image produces a new fingerprint and retries; so does a restart.
+_ATTEMPTED_ENROLLMENTS: set[str] = set()
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderReconcileOutcome:
+    """Result of one bounded pass over the configured OpenCode credential."""
+
+    ready: bool
+    checked: int = 0
+    enrolled: bool = False
+    refreshed: tuple[str, ...] = field(default_factory=tuple)
+    deferred: tuple[str, ...] = field(default_factory=tuple)
+    reason: str | None = None
+
+
+def reset_enrollment_attempts() -> None:
+    """Clear the per-configuration enrollment latch (tests and operator retry)."""
+
+    _ATTEMPTED_ENROLLMENTS.clear()
+
+
+def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
+    """Report whether persisted evidence still matches the launchable identity.
+
+    This mirrors the readiness and planner admission checks exactly: evidence
+    must belong to the profile's current credential generation and to the host
+    image the deployment currently pins.
+    """
+
+    evidence = profile.model_catalog_evidence_json
+    if not isinstance(evidence, dict):
+        return False
+    try:
+        generation = int(evidence.get("credentialGeneration") or 0)
+    except (TypeError, ValueError):
+        return False
+    if generation != int(profile.credential_generation):
+        return False
+    return str(evidence.get("imageRef") or "") == image_ref
+
+
+def _is_enrolled(profile: Any) -> bool:
+    """Report whether this profile already carries a usable enrolled credential."""
+
+    from api_service.db.models import ProviderProfileAuthState
+
+    state = getattr(profile.auth_state, "value", profile.auth_state)
+    return (
+        bool(profile.enabled)
+        and state == ProviderProfileAuthState.CONNECTED.value
+        and OPENCODE_SECRET_ROLE in (profile.secret_refs or {})
+    )
+
+
+def _pinned_image_ref() -> str | None:
+    from moonmind.omnigent.harness_platform.host_classes import (
+        get_opencode_host_image_ref,
+    )
+
+    try:
+        return get_opencode_host_image_ref()
+    except Exception:
+        return None
+
+
+def _enrollment_fingerprint(
+    *,
+    api_key: str,
+    accepted: bool,
+    image_ref: str,
+) -> str:
+    """Return a non-secret identity for one enrollment configuration."""
+
+    material = "\x1f".join((api_key, "1" if accepted else "0", image_ref))
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:32]
+
+
+async def _opencode_profiles(session_factory: Any) -> list[Any]:
+    from api_service.db.models import ManagedAgentProviderProfile
+
+    async with session_factory() as session:
+        return list(
+            (
+                await session.execute(
+                    select(ManagedAgentProviderProfile).where(
+                        ManagedAgentProviderProfile.runtime_id == OPENCODE_RUNTIME_ID,
+                        ManagedAgentProviderProfile.provider_id
+                        == OPENCODE_PROVIDER_ID,
+                    )
+                )
+            ).scalars()
+        )
+
+
+async def reconcile_opencode_provider_readiness(
+    *,
+    session_factory: Any,
+    allow_enrollment: bool = True,
+    env: Mapping[str, Any] | None = None,
+    controller: Any | None = None,
+) -> ProviderReconcileOutcome:
+    """Enroll or re-validate the configured OpenCode credential.
+
+    ``allow_enrollment`` is the caller's statement that the immutable image and
+    harness-catalog authorities enrollment depends on are already established.
+    Enrollment is skipped (not failed) until then so a first-boot race cannot
+    burn the one attempt this configuration gets.
+    """
+
+    from moonmind.omnigent.settings import (
+        opencode_contributor_data_use_accepted,
+        resolved_opencode_api_key,
+    )
+
+    image_ref = _pinned_image_ref()
+    profiles = await _opencode_profiles(session_factory)
+    enrolled = [profile for profile in profiles if _is_enrolled(profile)]
+
+    if not enrolled:
+        api_key = resolved_opencode_api_key(env=env)
+        if not api_key:
+            # Nothing configured: the console enrollment path stays available and
+            # readiness correctly reports that no compatible profile exists.
+            return ProviderReconcileOutcome(
+                ready=True,
+                checked=len(profiles),
+                reason="no deployment-configured OpenCode credential",
+            )
+        if not allow_enrollment:
+            return ProviderReconcileOutcome(
+                ready=False,
+                checked=len(profiles),
+                reason="waiting for immutable image and harness catalog authority",
+            )
+        return await _enroll_from_deployment_config(
+            session_factory=session_factory,
+            api_key=api_key,
+            accepted=opencode_contributor_data_use_accepted(env=env),
+            image_ref=image_ref or "",
+            checked=len(profiles),
+            controller=controller,
+        )
+
+    if image_ref is None:
+        # The image-policy leg owns acquiring the pinned image. Defer rather
+        # than record evidence for an image the deployment does not select.
+        return ProviderReconcileOutcome(
+            ready=False,
+            checked=len(profiles),
+            reason="pinned OpenCode host image unavailable",
+        )
+    return await _revalidate_stale_evidence(
+        session_factory=session_factory,
+        profiles=enrolled,
+        checked=len(profiles),
+        image_ref=image_ref,
+    )
+
+
+async def _enroll_from_deployment_config(
+    *,
+    session_factory: Any,
+    api_key: str,
+    accepted: bool,
+    image_ref: str,
+    checked: int,
+    controller: Any | None,
+) -> ProviderReconcileOutcome:
+    """Run the canonical bootstrap for the deployment-configured credential."""
+
+    from moonmind.omnigent.bootstrap.controller import BootstrapController
+    from moonmind.omnigent.bootstrap.models import BootstrapState
+
+    fingerprint = _enrollment_fingerprint(
+        api_key=api_key, accepted=accepted, image_ref=image_ref
+    )
+    if fingerprint in _ATTEMPTED_ENROLLMENTS:
+        return ProviderReconcileOutcome(
+            ready=False,
+            checked=checked,
+            reason=(
+                "OpenCode enrollment already failed for this configuration; "
+                "correct the credential or acknowledgement and restart"
+            ),
+        )
+    _ATTEMPTED_ENROLLMENTS.add(fingerprint)
+
+    active = controller or BootstrapController(session_factory=session_factory)
+    try:
+        record = await active.configure_opencode(
+            api_key=api_key,
+            accept_contributor_data_use=accepted,
+        )
+    except Exception as exc:
+        logger.warning(
+            "OpenCode enrollment from deployment configuration failed: %s", exc
+        )
+        return ProviderReconcileOutcome(
+            ready=False, checked=checked, reason=f"OpenCode enrollment failed: {exc}"
+        )
+
+    state = getattr(record.state, "value", record.state)
+    if state != BootstrapState.ready.value:
+        failure = (record.failure or {}).get("message") or state
+        logger.warning(
+            "OpenCode enrollment from deployment configuration did not complete: %s",
+            failure,
+        )
+        return ProviderReconcileOutcome(
+            ready=False,
+            checked=checked,
+            reason=f"OpenCode enrollment did not complete: {failure}",
+        )
+
+    _ATTEMPTED_ENROLLMENTS.discard(fingerprint)
+    logger.info(
+        "Enrolled the deployment-configured OpenCode Provider Profile: profile_id=%s",
+        record.provider_profile_ref,
+    )
+    return ProviderReconcileOutcome(ready=True, checked=checked, enrolled=True)
+
+
+async def _revalidate_stale_evidence(
+    *,
+    session_factory: Any,
+    profiles: list[Any],
+    checked: int,
+    image_ref: str,
+) -> ProviderReconcileOutcome:
+    """Refresh stale OpenCode model evidence against the pinned host image.
+
+    A profile the runtime rejects is left untouched and reported as deferred:
+    this boundary never downgrades an enrolled credential, and it never records
+    evidence for an image other than the one the deployment selects.
+    """
+
+    from moonmind.omnigent.opencode_runtime_validation import (
+        OpenCodeProviderRuntimeValidationService,
+    )
+    from moonmind.omnigent.production import build_omnigent_secret_resolver
+    from moonmind.provider_profiles.lease_client import CredentialLeasePurpose
+    from moonmind.provider_profiles.maintenance import (
+        acquire_credential_maintenance_guard,
+    )
+
+    stale = [
+        profile
+        for profile in profiles
+        if not evidence_is_current(profile, image_ref=image_ref)
+    ]
+    if not stale:
+        return ProviderReconcileOutcome(ready=True, checked=checked)
+
+    resolver = build_omnigent_secret_resolver()
+    refreshed: list[str] = []
+    deferred: list[str] = []
+    for row in stale:
+        profile_id = row.profile_id
+        operation_id = uuid4().hex
+        guard = None
+        evidence: dict[str, Any] | None = None
+        try:
+            guard = await acquire_credential_maintenance_guard(
+                runtime_id=OPENCODE_RUNTIME_ID,
+                profile_id=profile_id,
+                purpose=CredentialLeasePurpose.CREDENTIAL_VALIDATION,
+                operation_id=operation_id,
+                metadata={
+                    "workflowId": f"provider-revalidation:{operation_id}",
+                    "ownerIsWorkflow": False,
+                },
+            )
+            evidence = await OpenCodeProviderRuntimeValidationService(
+                session_factory=session_factory,
+                resolver=resolver,
+                image_ref=image_ref,
+            ).validate(profile=row, lease=guard.lease)
+        except Exception as exc:
+            deferred.append(profile_id)
+            logger.warning(
+                "OpenCode Provider Profile re-validation deferred: "
+                "profile_id=%s image_ref=%s error=%s",
+                profile_id,
+                image_ref,
+                exc,
+            )
+        finally:
+            if guard is not None:
+                try:
+                    await guard.release()
+                except Exception:
+                    logger.warning(
+                        "OpenCode re-validation lease release failed: profile_id=%s",
+                        profile_id,
+                        exc_info=True,
+                    )
+        if evidence is None:
+            continue
+
+        await _persist_evidence(
+            session_factory=session_factory,
+            profile_id=profile_id,
+            evidence=evidence,
+        )
+        refreshed.append(profile_id)
+        logger.info(
+            "Refreshed OpenCode Provider Profile model evidence: "
+            "profile_id=%s image_ref=%s",
+            profile_id,
+            image_ref,
+        )
+
+    return ProviderReconcileOutcome(
+        ready=not deferred,
+        checked=checked,
+        refreshed=tuple(refreshed),
+        deferred=tuple(deferred),
+        reason=None if not deferred else "pinned runtime re-validation deferred",
+    )
+
+
+async def _persist_evidence(
+    *,
+    session_factory: Any,
+    profile_id: str,
+    evidence: dict[str, Any],
+) -> None:
+    """Record refreshed evidence without touching enrolled credential identity."""
+
+    from api_service.db.models import ManagedAgentProviderProfile
+
+    async with session_factory() as session:
+        profile = await session.get(ManagedAgentProviderProfile, profile_id)
+        if profile is None:
+            return
+        if int(evidence.get("credentialGeneration") or 0) != int(
+            profile.credential_generation
+        ):
+            # The credential rotated while validation ran; that rotation owns
+            # the authoritative evidence for its own generation.
+            return
+        models = [
+            str(item.get("qualifiedId") or "")
+            for item in evidence.get("models", [])
+            if isinstance(item, dict)
+        ]
+        profile.model_catalog_evidence_json = evidence
+        if not profile.default_model and models:
+            profile.default_model = models[0]
+        behavior = dict(profile.command_behavior or {})
+        behavior["runtime_validation"] = {
+            "last_validated_at": evidence.get("validatedAt")
+            or datetime.now(UTC).isoformat(),
+            "image_ref": evidence["imageRef"],
+            "runtime_versions": evidence.get("runtimeVersions"),
+            "model_count": len(models),
+        }
+        profile.command_behavior = behavior
+        await session.commit()
+
+
+__all__ = [
+    "OPENCODE_PROVIDER_ID",
+    "OPENCODE_RUNTIME_ID",
+    "OPENCODE_SECRET_ROLE",
+    "ProviderReconcileOutcome",
+    "evidence_is_current",
+    "reconcile_opencode_provider_readiness",
+    "reset_enrollment_attempts",
+]

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -29,8 +29,39 @@ OPENCODE_PINNED_VERSION = "1.18.11"
 OPENCODE_SUPPORTED_RANGE = ">=1.17.7,<1.19.0"
 
 
+def _persisted_image_ref(key: str) -> str:
+    """Return the digest this deployment already resolved for ``key``.
+
+    Only the API process resolves images, but every process that launches a host
+    selects a Host Class. Execution workers start with the runtime-pack refs
+    unset on the canonical Compose path and read the same persisted resolved
+    state, so consulting it here is what keeps an advertised target launchable
+    on the worker that actually runs it. The value is still validated as a
+    digest-pinned ref below, and an operator-supplied environment value always
+    wins.
+    """
+
+    try:
+        from moonmind.omnigent.bootstrap.store import load_resolved_state
+
+        state = load_resolved_state()
+    except Exception:
+        return ""
+    if state is None:
+        return ""
+    attribute = {
+        OMNIGENT_OPENCODE_HOST_IMAGE_ENV: "opencode_host_image_ref",
+        OMNIGENT_PI_HOST_IMAGE_ENV: "pi_host_image_ref",
+    }.get(key)
+    if attribute is None:
+        return ""
+    return str(getattr(state, attribute, "") or "").strip()
+
+
 def _require_image_ref(environment: Mapping[str, str], key: str) -> str:
     raw = str(environment.get(key) or "").strip()
+    if not raw:
+        raw = _persisted_image_ref(key)
     if not raw or not _IMAGE_RE.fullmatch(raw):
         raise HarnessPlatformError(
             f"{key} must be set to a digest-pinned image ref",

--- a/moonmind/omnigent/settings.py
+++ b/moonmind/omnigent/settings.py
@@ -86,6 +86,10 @@ def is_omnigent_enabled(*, env: Mapping[str, Any] | None = None) -> bool:
     return build_omnigent_gate(env=env).enabled
 
 
+OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY"
+OPENCODE_CONTRIBUTOR_DATA_USE_ENV = "OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE"
+
+
 def _parse_bool_with_default(
     value: object | None, *, default: bool
 ) -> bool:
@@ -129,6 +133,35 @@ def opencode_support_enabled(*, env: Mapping[str, Any] | None = None) -> bool:
     source = env if env is not None else os.environ
     return _parse_bool_with_default(
         source.get(OMNIGENT_OPENCODE_ENABLED_ENV), default=True
+    )
+
+
+def resolved_opencode_api_key(*, env: Mapping[str, Any] | None = None) -> str:
+    """Return the deployment-configured OpenCode Go API key, if any.
+
+    Presence of this value is what makes the default Compose path launchable
+    without a separate console action: the bootstrap reconciler enrolls and
+    runtime-validates the OpenCode Provider Profile from it.
+    """
+
+    source = env if env is not None else os.environ
+    return _clean(source.get(OPENCODE_API_KEY_ENV))
+
+
+def opencode_contributor_data_use_accepted(
+    *, env: Mapping[str, Any] | None = None
+) -> bool:
+    """Return whether the operator accepts OpenCode contributor data use.
+
+    The stock OpenCode Go model is a contributor tier whose enrollment requires
+    an explicit data-use acknowledgement. It defaults to accepted so the
+    documented one-value setup completes, and stays an explicit, documented
+    switch an operator can set to ``false``.
+    """
+
+    source = env if env is not None else os.environ
+    return _parse_bool_with_default(
+        source.get(OPENCODE_CONTRIBUTOR_DATA_USE_ENV), default=True
     )
 
 
@@ -258,6 +291,10 @@ __all__ = [
     "is_omnigent_enabled",
     "generic_host_enabled",
     "opencode_support_enabled",
+    "opencode_contributor_data_use_accepted",
+    "resolved_opencode_api_key",
+    "OPENCODE_API_KEY_ENV",
+    "OPENCODE_CONTRIBUTOR_DATA_USE_ENV",
     "omnigent_evidence_policy",
     "OMNIGENT_GENERIC_HOST_ENABLED_ENV",
     "OMNIGENT_OPENCODE_ENABLED_ENV",

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -556,6 +556,43 @@ async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconne
     assert "compatible_provider_profile_unavailable" in fresh_codes
     assert "provider_runtime_revalidation_pending" not in fresh_codes
 
+    # A credential the pinned runtime keeps rejecting needs an operator, so the
+    # bounded-wait message must stop once re-validation has given up on it.
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    exhausted_provider = SimpleNamespace(
+        profile_id="opencode-go-revoked",
+        account_label="OpenCode Go",
+        provider_id="opencode-go",
+        runtime_id="opencode",
+        enabled=True,
+        auth_state=SimpleNamespace(value="connected"),
+        credential_generation=4,
+        command_behavior={
+            REVALIDATION_FAILURE_KEY: {
+                "imageRef": "registry.test/opencode@sha256:" + "6" * 64,
+                "credentialGeneration": 4,
+                "attempts": 3,
+                "exhausted": True,
+            }
+        },
+        model_catalog_evidence_json={
+            "credentialGeneration": 4,
+            "imageRef": "registry.test/opencode@sha256:" + "9" * 64,
+            "models": ["opencode-go/test-model"],
+        },
+    )
+    exhausted = await catalog.get_omnigent_execution_readiness(
+        session=Session(exhausted_provider), current_user=current_user
+    )
+    exhausted_codes = {
+        reason.code for reason in exhausted.execution_targets[0].gate_reasons
+    }
+    assert "compatible_provider_profile_unavailable" in exhausted_codes
+    assert "provider_runtime_revalidation_pending" not in exhausted_codes
+
 
 def test_ready_catalog_lists_only_launch_ready_codex_oauth_profiles(monkeypatch):
     profiles = [

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -400,6 +400,163 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
     assert enabled_target.models == ["opencode-go/test-model"]
 
 
+@pytest.mark.asyncio
+async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconnect(
+    monkeypatch,
+):
+    """A connected profile awaiting re-validation must not read as unconnected."""
+
+    from moonmind.omnigent.harness_platform import catalog_service
+    from moonmind.omnigent.harness_platform.catalog import (
+        TrustState,
+        classify_harness_trust,
+        create_catalog_snapshot,
+    )
+    from moonmind.omnigent.harness_platform.catalog_service import (
+        HarnessCatalogSyncResult,
+    )
+
+    implementation = {
+        "sourceKind": "core",
+        "package": "omnigent",
+        "version": "0.11.0",
+        "digest": "sha256:" + "3" * 64,
+    }
+    snapshot = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="0.11.0",
+        omnigentBuildDigest="sha256:" + "4" * 64,
+        sourceDigest="sha256:" + "5" * 64,
+        harnesses=[
+            {
+                "id": "opencode-native",
+                "label": "OpenCode",
+                "implementation": implementation,
+                "capabilities": {"integrationMode": "native-server"},
+            }
+        ],
+    )
+    harness = snapshot.harnesses[0]
+    catalog_result = HarnessCatalogSyncResult(
+        snapshot,
+        (
+            classify_harness_trust(
+                harnessId=harness.id,
+                implementation=harness.implementation,
+                trustState=TrustState.core_trusted,
+            ),
+        ),
+        {},
+    )
+
+    class Repository:
+        def __init__(self, _session_factory):
+            pass
+
+        async def load(self, _catalog_ref):
+            return catalog_result
+
+        async def latest(self, _endpoint_ref):
+            return catalog_result
+
+    monkeypatch.setattr(catalog_service, "DbHarnessCatalogRepository", Repository)
+    monkeypatch.setattr(
+        catalog, "_require_provider_profile_permission", lambda *_: None
+    )
+    monkeypatch.setattr(catalog, "_can_view_profile", lambda *_: True)
+    monkeypatch.setenv("MOONMIND_OMNIGENT_GENERIC_HOST_ENABLED", "true")
+    monkeypatch.setenv("MOONMIND_OMNIGENT_OPENCODE_ENABLED", "true")
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "registry.test/opencode@sha256:" + "6" * 64,
+    )
+
+    profile_row = SimpleNamespace(
+        profile_id="omnigent-opencode-default",
+        active_version=1,
+        visibility="public",
+        owner_id=None,
+    )
+    version = SimpleNamespace(
+        version=1,
+        digest="sha256:" + "8" * 64,
+        document={
+            "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+            "endpointRef": "default",
+            "source": {
+                "kind": "upstream",
+                "upstreamId": "opencode-native-ui",
+                "upstreamVersion": "1",
+                "upstreamSnapshotDigest": "sha256:" + "7" * 64,
+            },
+            "harness": {
+                "id": harness.id,
+                "catalogRef": snapshot.catalogRef,
+                "implementationRef": harness.implementation.implementation_ref(),
+            },
+            "credentialSlots": [
+                {"id": "primary-model", "acceptedProviderIds": ["opencode-go"]}
+            ],
+            "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
+        },
+        validation_result={"ready": True},
+    )
+    # Connected and enrolled, but the pinned host image moved on since the last
+    # runtime-backed validation.
+    stale_provider = SimpleNamespace(
+        profile_id="opencode-go-primary",
+        account_label="OpenCode Go",
+        provider_id="opencode-go",
+        runtime_id="opencode",
+        enabled=True,
+        auth_state=SimpleNamespace(value="connected"),
+        credential_generation=4,
+        model_catalog_evidence_json={
+            "credentialGeneration": 4,
+            "imageRef": "registry.test/opencode@sha256:" + "9" * 64,
+            "models": ["opencode-go/test-model"],
+        },
+    )
+
+    class Session:
+        def __init__(self, provider):
+            self._results = iter((_Result([profile_row]), _Result([provider])))
+
+        async def execute(self, _statement):
+            return next(self._results)
+
+        async def scalar(self, _statement):
+            return version
+
+    current_user = SimpleNamespace(id=None, is_superuser=True)
+    stale = await catalog.get_omnigent_execution_readiness(
+        session=Session(stale_provider), current_user=current_user
+    )
+    stale_target = stale.execution_targets[0]
+    assert stale_target.available is False
+    codes = {reason.code for reason in stale_target.gate_reasons}
+    assert "provider_runtime_revalidation_pending" in codes
+    assert "compatible_provider_profile_unavailable" not in codes
+
+    # A profile that was never runtime-validated still needs an operator action.
+    never_validated = SimpleNamespace(
+        profile_id="opencode-go-new",
+        account_label="OpenCode Go",
+        provider_id="opencode-go",
+        runtime_id="opencode",
+        enabled=True,
+        auth_state=SimpleNamespace(value="connected"),
+        credential_generation=1,
+        model_catalog_evidence_json=None,
+    )
+    fresh = await catalog.get_omnigent_execution_readiness(
+        session=Session(never_validated), current_user=current_user
+    )
+    fresh_codes = {reason.code for reason in fresh.execution_targets[0].gate_reasons}
+    assert "compatible_provider_profile_unavailable" in fresh_codes
+    assert "provider_runtime_revalidation_pending" not in fresh_codes
+
+
 def test_ready_catalog_lists_only_launch_ready_codex_oauth_profiles(monkeypatch):
     profiles = [
         _profile(),

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -63,14 +63,16 @@ async def test_api_startup_bootstrap_uses_only_local_image_evidence(
     from api_service.services import omnigent_policies
 
     observed_resolver = None
+    observed_env = None
 
     @asynccontextmanager
     async def session_context():
         yield object()
 
-    async def seed(_session, *, image_resolver):
-        nonlocal observed_resolver
+    async def seed(_session, *, image_resolver, env=None):
+        nonlocal observed_resolver, observed_env
         observed_resolver = image_resolver
+        observed_env = env
 
     async def ready(_session) -> bool:
         return True
@@ -83,6 +85,9 @@ async def test_api_startup_bootstrap_uses_only_local_image_evidence(
         refresh_images=False
     )
     assert observed_resolver is omnigent_policies.resolve_local_bootstrap_image_ref
+    # The registry-acquiring leg keys on the configured refs, so it must read the
+    # operator's own configuration rather than a digest publication exported.
+    assert observed_env is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -26,10 +26,12 @@ async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inve
         reconciliations.append(refresh_images)
         ready = len(reconciliations) > 1
         return api_main.OmnigentBootstrapReadiness(
+            images_ready=ready,
             policies_ready=ready,
             agent_ready=ready,
             catalog_ready=ready,
             schedules_ready=ready,
+            provider_ready=ready,
         )
 
     async def refresh_inventory() -> bool:
@@ -105,6 +107,15 @@ async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
         calls.append("schedules")
         return True
 
+    async def images() -> bool:
+        calls.append("images")
+        return True
+
+    async def provider(*, allow_enrollment: bool) -> bool:
+        calls.append(f"provider:{allow_enrollment}")
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", images)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
     monkeypatch.setattr(api_main, "_sync_omnigent_harness_catalog", catalog)
@@ -113,11 +124,25 @@ async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
         "_sync_managed_bootstrap_recurring_schedules",
         schedules,
     )
+    monkeypatch.setattr(
+        api_main,
+        "_sync_omnigent_provider_readiness",
+        provider,
+    )
 
     assert (
         await api_main._reconcile_omnigent_bootstrap_once(refresh_images=True)
     ).ready
-    assert calls == ["policies:True", "agent", "catalog", "schedules"]
+    # Image identities are exported before any leg that selects a Host Class or
+    # validates a credential against one.
+    assert calls == [
+        "images",
+        "policies:True",
+        "agent",
+        "catalog",
+        "schedules",
+        "provider:True",
+    ]
 
 
 @pytest.mark.asyncio
@@ -142,6 +167,14 @@ async def test_harness_catalog_sync_runs_on_bootstrap_reconciliation(
     async def schedules() -> bool:
         return True
 
+    async def images() -> bool:
+        return True
+
+    async def provider(*, allow_enrollment: bool) -> bool:
+        del allow_enrollment
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", images)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
     monkeypatch.setattr(api_main, "_sync_omnigent_harness_catalog", catalog)
@@ -149,6 +182,11 @@ async def test_harness_catalog_sync_runs_on_bootstrap_reconciliation(
         api_main,
         "_sync_managed_bootstrap_recurring_schedules",
         schedules,
+    )
+    monkeypatch.setattr(
+        api_main,
+        "_sync_omnigent_provider_readiness",
+        provider,
     )
 
     assert (
@@ -457,3 +495,92 @@ async def test_image_policy_outage_keeps_retrying_registry_refresh(
         )
 
     assert image_refreshes == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_enrollment_waits_for_image_and_catalog_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-time enrollment gets one attempt, so it must not race the catalog."""
+
+    observed: list[bool] = []
+
+    async def policies(*, refresh_images: bool) -> bool:
+        del refresh_images
+        return True
+
+    async def agent() -> bool:
+        return True
+
+    async def schedules() -> bool:
+        return True
+
+    async def images() -> bool:
+        return True
+
+    async def catalog() -> bool:
+        return False
+
+    async def provider(*, allow_enrollment: bool) -> bool:
+        observed.append(allow_enrollment)
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", images)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
+    monkeypatch.setattr(api_main, "_sync_omnigent_harness_catalog", catalog)
+    monkeypatch.setattr(
+        api_main, "_sync_managed_bootstrap_recurring_schedules", schedules
+    )
+    monkeypatch.setattr(api_main, "_sync_omnigent_provider_readiness", provider)
+
+    outcome = await api_main._reconcile_omnigent_bootstrap_once(refresh_images=False)
+
+    assert observed == [False]
+    assert outcome.ready is False
+
+
+@pytest.mark.asyncio
+async def test_provider_readiness_is_skipped_without_resolved_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing validates a credential against an image the deployment lacks."""
+
+    called = False
+
+    async def policies(*, refresh_images: bool) -> bool:
+        del refresh_images
+        return True
+
+    async def agent() -> bool:
+        return True
+
+    async def catalog() -> bool:
+        return True
+
+    async def schedules() -> bool:
+        return True
+
+    async def images() -> bool:
+        return False
+
+    async def provider(*, allow_enrollment: bool) -> bool:
+        nonlocal called
+        del allow_enrollment
+        called = True
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", images)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
+    monkeypatch.setattr(api_main, "_sync_omnigent_harness_catalog", catalog)
+    monkeypatch.setattr(
+        api_main, "_sync_managed_bootstrap_recurring_schedules", schedules
+    )
+    monkeypatch.setattr(api_main, "_sync_omnigent_provider_readiness", provider)
+
+    outcome = await api_main._reconcile_omnigent_bootstrap_once(refresh_images=False)
+
+    assert called is False
+    assert outcome.provider_ready is False
+    assert outcome.ready is False

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -147,7 +147,7 @@ def test_selectors_fall_back_to_persisted_state_for_worker_processes(
         host_classes.get_opencode_host_image_ref()
 
     # Workers mount the same resolved-state file the API writes.
-    monkeypatch.setattr(store, "load_resolved_state", lambda: _state())
+    monkeypatch.setattr(store, "load_resolved_state", _state)
     assert host_classes.get_opencode_host_image_ref() == HOST_REF
 
     # A placeholder digest in persisted state still fails closed.

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -46,11 +46,13 @@ async def test_publication_exports_resolved_digests_and_persists_state(
 
     saved: list[ResolvedOmnigentDeploymentState] = []
 
-    async def resolve() -> ResolvedOmnigentDeploymentState:
+    async def resolve(env=None) -> ResolvedOmnigentDeploymentState:
+        del env
         return _state()
 
     monkeypatch.setattr(image_resolution, "resolve_omnigent_images", resolve)
     monkeypatch.setattr(store, "save_resolved_state", saved.append)
+    image_resolution.reset_operator_image_configuration()
     # The default Compose path ships these unset.
     for key in (
         "OMNIGENT_IMAGE_REF",
@@ -69,6 +71,96 @@ async def test_publication_exports_resolved_digests_and_persists_state(
 
 
 @pytest.mark.asyncio
+async def test_resolution_never_reads_a_digest_publication_exported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A published digest must not masquerade as an operator pin.
+
+    ``_resolve_image`` short-circuits on an explicitly pinned ref, and the
+    registry-acquiring policy leg keys on the same variables, so resolving
+    against a self-published digest would permanently disable tag refresh for
+    every configured mutable tag.
+    """
+
+    from moonmind.omnigent.bootstrap import store
+
+    observed: list[str] = []
+
+    async def resolve(env=None):
+        source = env if env is not None else {}
+        observed.append(str(source.get("OMNIGENT_OPENCODE_HOST_IMAGE_REF") or ""))
+        return _state()
+
+    monkeypatch.setattr(image_resolution, "resolve_omnigent_images", resolve)
+    monkeypatch.setattr(store, "save_resolved_state", lambda _state: None)
+    image_resolution.reset_operator_image_configuration()
+    monkeypatch.delenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", raising=False)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE", "ghcr.io/example/host")
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_TAG", "1.18.11")
+
+    await image_resolution.publish_resolved_omnigent_images()
+    # Publication exported the digest into the live environment...
+    import os
+
+    assert os.environ["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] == HOST_REF
+    await image_resolution.publish_resolved_omnigent_images()
+
+    # ...but the second pass still resolved from the unset operator baseline.
+    assert observed == ["", ""]
+    image_resolution.reset_operator_image_configuration()
+
+
+def test_operator_pin_is_preserved_as_resolution_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit operator pin stays authoritative over the tag."""
+
+    pinned = "ghcr.io/example/host@sha256:" + "7" * 64
+    image_resolution.reset_operator_image_configuration()
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", pinned)
+
+    configuration = image_resolution.operator_image_configuration()
+    assert configuration["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] == pinned
+
+    # Even after publication overwrites the live value, the baseline is the pin.
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", HOST_REF)
+    assert (
+        image_resolution.operator_image_configuration()[
+            "OMNIGENT_OPENCODE_HOST_IMAGE_REF"
+        ]
+        == pinned
+    )
+    image_resolution.reset_operator_image_configuration()
+
+
+def test_selectors_fall_back_to_persisted_state_for_worker_processes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the API resolves images; every host-launching process selects one."""
+
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform import host_classes
+
+    monkeypatch.delenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", raising=False)
+    monkeypatch.setattr(store, "load_resolved_state", lambda: None)
+    with pytest.raises(Exception):
+        host_classes.get_opencode_host_image_ref()
+
+    # Workers mount the same resolved-state file the API writes.
+    monkeypatch.setattr(store, "load_resolved_state", lambda: _state())
+    assert host_classes.get_opencode_host_image_ref() == HOST_REF
+
+    # A placeholder digest in persisted state still fails closed.
+    monkeypatch.setattr(
+        store,
+        "load_resolved_state",
+        lambda: _state(opencodeHostImageRef="ghcr.io/x/y@sha256:" + "0" * 64),
+    )
+    with pytest.raises(Exception):
+        host_classes.get_opencode_host_image_ref()
+
+
+@pytest.mark.asyncio
 async def test_publication_never_clears_an_operator_pinned_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -76,12 +168,14 @@ async def test_publication_never_clears_an_operator_pinned_ref(
 
     from moonmind.omnigent.bootstrap import store
 
-    async def resolve() -> ResolvedOmnigentDeploymentState:
+    async def resolve(env=None) -> ResolvedOmnigentDeploymentState:
+        del env
         return _state(piHostImageRef=None)
 
     pinned_pi = "ghcr.io/moonladderstudios/omnigent-host-pi@sha256:" + "4" * 64
     monkeypatch.setattr(image_resolution, "resolve_omnigent_images", resolve)
     monkeypatch.setattr(store, "save_resolved_state", lambda _state: None)
+    image_resolution.reset_operator_image_configuration()
     monkeypatch.setenv("OMNIGENT_PI_HOST_IMAGE_REF", pinned_pi)
 
     await image_resolution.publish_resolved_omnigent_images()

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -1,0 +1,91 @@
+"""Deployment image identities must reach every selector, not one request.
+
+Host Class selection, launch policy compilation, and Provider Profile runtime
+validation all read digest-pinned refs from the process environment. The
+canonical Compose path leaves ``OMNIGENT_OPENCODE_HOST_IMAGE_REF`` unset so the
+deployment resolves its own digests, so the resolution boundary has to export
+them where those selectors look.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from moonmind.omnigent.bootstrap import image_resolution
+from moonmind.omnigent.bootstrap.models import ResolvedOmnigentDeploymentState
+
+SERVER_REF = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+HOST_REF = "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "2" * 64
+BUILD_DIGEST = "sha256:" + "3" * 64
+
+
+def _state(**overrides) -> ResolvedOmnigentDeploymentState:
+    payload = {
+        "serverImageRef": SERVER_REF,
+        "opencodeHostImageRef": HOST_REF,
+        "piHostImageRef": None,
+        "omnigentBuildDigest": BUILD_DIGEST,
+        "architecture": "linux/amd64",
+        "resolvedAt": datetime(2026, 8, 25, tzinfo=UTC),
+        "source": "auto",
+    }
+    payload.update(overrides)
+    return ResolvedOmnigentDeploymentState.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_publication_exports_resolved_digests_and_persists_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform.host_classes import (
+        get_opencode_host_image_ref,
+    )
+
+    saved: list[ResolvedOmnigentDeploymentState] = []
+
+    async def resolve() -> ResolvedOmnigentDeploymentState:
+        return _state()
+
+    monkeypatch.setattr(image_resolution, "resolve_omnigent_images", resolve)
+    monkeypatch.setattr(store, "save_resolved_state", saved.append)
+    # The default Compose path ships these unset.
+    for key in (
+        "OMNIGENT_IMAGE_REF",
+        "OMNIGENT_BUILD_DIGEST",
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    published = await image_resolution.publish_resolved_omnigent_images()
+
+    assert published.opencode_host_image_ref == HOST_REF
+    assert [item.opencode_host_image_ref for item in saved] == [HOST_REF]
+    # Host Class selection reads the digest straight from the environment, so
+    # publication is what makes it selectable at all.
+    assert get_opencode_host_image_ref() == HOST_REF
+
+
+@pytest.mark.asyncio
+async def test_publication_never_clears_an_operator_pinned_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable optional image must not erase what the operator pinned."""
+
+    from moonmind.omnigent.bootstrap import store
+
+    async def resolve() -> ResolvedOmnigentDeploymentState:
+        return _state(piHostImageRef=None)
+
+    pinned_pi = "ghcr.io/moonladderstudios/omnigent-host-pi@sha256:" + "4" * 64
+    monkeypatch.setattr(image_resolution, "resolve_omnigent_images", resolve)
+    monkeypatch.setattr(store, "save_resolved_state", lambda _state: None)
+    monkeypatch.setenv("OMNIGENT_PI_HOST_IMAGE_REF", pinned_pi)
+
+    await image_resolution.publish_resolved_omnigent_images()
+
+    import os
+
+    assert os.environ["OMNIGENT_PI_HOST_IMAGE_REF"] == pinned_pi

--- a/tests/unit/omnigent/test_opencode_host.py
+++ b/tests/unit/omnigent/test_opencode_host.py
@@ -147,7 +147,16 @@ def test_opencode_version_supported_range():
     assert exc.value.code == HarnessPlatformFailure.OMNIGENT_VENDOR_RUNTIME_MISMATCH
 
 
-def test_opencode_image_ref_fail_closed():
+def test_opencode_image_ref_fail_closed(monkeypatch):
+    # Selection now falls back to the deployment's persisted resolved state so
+    # execution workers can select a Host Class the API resolved. That is a
+    # second *source*, not a second contract: no source may synthesize a digest
+    # from a mutable tag or accept a placeholder. Isolate the persisted source
+    # here so the environment-only rules below are what is under test.
+    from moonmind.omnigent.bootstrap import store
+
+    monkeypatch.setattr(store, "load_resolved_state", lambda: None)
+
     # Missing REF must fail closed (no synthetic digest from image:tag)
     os.environ.pop("OMNIGENT_OPENCODE_HOST_IMAGE_REF", None)
     os.environ.pop("OMNIGENT_OPENCODE_HOST_IMAGE", None)
@@ -169,6 +178,24 @@ def test_opencode_image_ref_fail_closed():
     with pytest.raises(HarnessPlatformError):
         get_opencode_host_image_ref()
     os.environ.pop("OMNIGENT_OPENCODE_HOST_IMAGE_REF", None)
+    # A mutable tag or placeholder reaching selection through the persisted
+    # resolved state fails closed exactly like the environment value does.
+    os.environ.pop("OMNIGENT_OPENCODE_HOST_IMAGE_REF", None)
+    for unusable in (
+        "ghcr.io/moonladderstudios/omnigent-host-opencode:1.18.11",
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "0" * 64,
+    ):
+        monkeypatch.setattr(
+            store,
+            "load_resolved_state",
+            lambda ref=unusable: SimpleNamespace(
+                opencode_host_image_ref=ref, pi_host_image_ref=None
+            ),
+        )
+        with pytest.raises(HarnessPlatformError):
+            get_opencode_host_image_ref()
+    monkeypatch.setattr(store, "load_resolved_state", lambda: None)
+
     # Mutable tag fails closed
     os.environ["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] = (
         "ghcr.io/moonladderstudios/omnigent-host-opencode:latest"

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -1,0 +1,476 @@
+"""Deployment-configured OpenCode credential readiness.
+
+Two things must hold before an OpenCode target is launchable: a connected
+Provider Profile must exist, and its model catalog evidence must have been
+observed on the exact digest-pinned host image the deployment selects. These
+tests pin the self-healing contract for both — enrollment straight from
+``OPENCODE_API_KEY``, and re-validation after the pinned image moves — plus the
+boundaries that must not be crossed to get there.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.omnigent.bootstrap.provider_revalidation import (
+    ProviderReconcileOutcome,
+    evidence_is_current,
+    reconcile_opencode_provider_readiness,
+    reset_enrollment_attempts,
+)
+
+CURRENT_IMAGE = "ghcr.io/moonmind/omnigent-host-opencode@sha256:" + "a" * 64
+PREVIOUS_IMAGE = "ghcr.io/moonmind/omnigent-host-opencode@sha256:" + "b" * 64
+API_KEY = "sk-" + "z" * 40
+
+
+@pytest.fixture(autouse=True)
+def _clear_enrollment_latch():
+    reset_enrollment_attempts()
+    yield
+    reset_enrollment_attempts()
+
+
+def _profile(
+    *,
+    profile_id: str = "opencode-go-default",
+    generation: int = 3,
+    evidence_image: str | None = PREVIOUS_IMAGE,
+    evidence_generation: int | None = None,
+    enabled: bool = True,
+    auth_state: str = "connected",
+    secret_refs: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    evidence = None
+    if evidence_image is not None:
+        evidence = {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": evidence_image,
+            "credentialGeneration": (
+                generation if evidence_generation is None else evidence_generation
+            ),
+        }
+    return SimpleNamespace(
+        profile_id=profile_id,
+        runtime_id="opencode",
+        provider_id="opencode-go",
+        enabled=enabled,
+        auth_state=auth_state,
+        credential_generation=generation,
+        capacity_scope_ref=None,
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        command_behavior={},
+        secret_refs=(
+            {"opencode_api_key": "db://opencode-key"}
+            if secret_refs is None
+            else secret_refs
+        ),
+        model_catalog_evidence_json=evidence,
+    )
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return iter(self._rows)
+
+
+class _Session:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def execute(self, _statement):
+        return _Result(self._rows)
+
+    async def get(self, _model, key):
+        return next((row for row in self._rows if row.profile_id == key), None)
+
+    async def commit(self):
+        return None
+
+
+def _session_factory(rows):
+    return lambda: _Session(rows)
+
+
+def _install_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    validate=None,
+    image_ref: str | None = CURRENT_IMAGE,
+    releases: list[str] | None = None,
+    acquire_error: Exception | None = None,
+):
+    """Stub the pinned image, credential lease, and runtime validation substrate."""
+
+    def _image() -> str:
+        if image_ref is None:
+            raise RuntimeError("OMNIGENT_OPENCODE_HOST_IMAGE_REF must be set")
+        return image_ref
+
+    class _Guard:
+        def __init__(self, profile_id: str) -> None:
+            self.lease = SimpleNamespace(lease_id=f"lease-{profile_id}")
+            self._profile_id = profile_id
+
+        async def release(self) -> None:
+            if releases is not None:
+                releases.append(self._profile_id)
+
+    async def acquire(*, runtime_id, profile_id, purpose, operation_id, metadata=None):
+        del runtime_id, purpose, operation_id, metadata
+        if acquire_error is not None:
+            raise acquire_error
+        return _Guard(profile_id)
+
+    class _ValidationService:
+        def __init__(self, *, session_factory, resolver, image_ref):
+            del session_factory, resolver
+            self.image_ref = image_ref
+
+        async def validate(self, *, profile, lease, **kwargs):
+            assert validate is not None, "validation must not run in this scenario"
+            return await validate(profile, self.image_ref, lease, kwargs)
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.harness_platform.host_classes.get_opencode_host_image_ref",
+        _image,
+    )
+    monkeypatch.setattr(
+        "moonmind.provider_profiles.maintenance.acquire_credential_maintenance_guard",
+        acquire,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.opencode_runtime_validation."
+        "OpenCodeProviderRuntimeValidationService",
+        _ValidationService,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.production.build_omnigent_secret_resolver",
+        lambda *args, **kwargs: object(),
+    )
+
+
+class _Controller:
+    """Records what the canonical bootstrap was asked to enroll."""
+
+    def __init__(self, *, state: str = "ready", error: Exception | None = None) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._state = state
+        self._error = error
+
+    async def configure_opencode(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._error is not None:
+            raise self._error
+        return SimpleNamespace(
+            state=SimpleNamespace(value=self._state),
+            provider_profile_ref="opencode-go-default",
+            failure=None if self._state == "ready" else {"message": "rejected"},
+        )
+
+
+def test_evidence_is_current_requires_generation_and_pinned_image() -> None:
+    assert evidence_is_current(
+        _profile(evidence_image=CURRENT_IMAGE), image_ref=CURRENT_IMAGE
+    )
+    assert not evidence_is_current(_profile(), image_ref=CURRENT_IMAGE)
+    assert not evidence_is_current(
+        _profile(evidence_image=CURRENT_IMAGE, evidence_generation=2),
+        image_ref=CURRENT_IMAGE,
+    )
+    assert not evidence_is_current(
+        _profile(evidence_image=None), image_ref=CURRENT_IMAGE
+    )
+
+
+@pytest.mark.asyncio
+async def test_configured_api_key_enrolls_the_profile_on_a_cold_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPENCODE_API_KEY alone must produce a launchable Provider Profile."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    monkeypatch.delenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", raising=False)
+    controller = _Controller()
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]),
+        controller=controller,
+    )
+
+    assert outcome.ready is True
+    assert outcome.enrolled is True
+    # The contributor acknowledgement defaults to accepted so the documented
+    # one-value setup completes without a console action.
+    assert controller.calls == [
+        {"api_key": API_KEY, "accept_contributor_data_use": True}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_declined_contributor_acknowledgement_is_not_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    monkeypatch.setenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", "false")
+    controller = _Controller()
+
+    await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]),
+        controller=controller,
+    )
+
+    assert controller.calls[0]["accept_contributor_data_use"] is False
+
+
+@pytest.mark.asyncio
+async def test_enrollment_waits_for_image_and_catalog_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first-boot race must not consume this configuration's one attempt."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller()
+
+    deferred = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]),
+        allow_enrollment=False,
+        controller=controller,
+    )
+    assert deferred.ready is False
+    assert controller.calls == []
+
+    # Once the authorities land, the attempt is still available.
+    allowed = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]),
+        controller=controller,
+    )
+    assert allowed.enrolled is True
+    assert len(controller.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_enrollment_is_not_retried_for_the_same_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected configuration must not re-run the full bootstrap every pass."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller(state="failed")
+
+    first = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+    second = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+
+    assert first.ready is False
+    assert second.ready is False
+    assert len(controller.calls) == 1
+
+    # Correcting the credential produces a new configuration and retries.
+    monkeypatch.setenv("OPENCODE_API_KEY", "sk-" + "y" * 40)
+    third = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+    assert len(controller.calls) == 2
+    assert third.ready is False
+
+
+@pytest.mark.asyncio
+async def test_no_configured_credential_leaves_console_enrollment_to_the_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stubs(monkeypatch)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+    controller = _Controller()
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+
+    assert outcome.ready is True
+    assert outcome.enrolled is False
+    assert controller.calls == []
+
+
+@pytest.mark.asyncio
+async def test_current_evidence_is_left_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stubs(monkeypatch)
+    controller = _Controller()
+    rows = [_profile(evidence_image=CURRENT_IMAGE)]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=controller
+    )
+
+    assert outcome == ProviderReconcileOutcome(ready=True, checked=1)
+    assert controller.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stale_host_image_evidence_is_revalidated_and_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The connected credential re-qualifies itself against the pinned image."""
+
+    observed: list[tuple[str, str, dict]] = []
+    releases: list[str] = []
+
+    async def validate(profile, image_ref, lease, kwargs):
+        observed.append((profile.profile_id, image_ref, kwargs))
+        assert lease.lease_id == "lease-opencode-go-default"
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": image_ref,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "validatedAt": "2026-08-25T01:00:00+00:00",
+            "credentialGeneration": profile.credential_generation,
+        }
+
+    _install_stubs(monkeypatch, validate=validate, releases=releases)
+    controller = _Controller()
+    rows = [_profile()]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=controller
+    )
+
+    assert outcome.ready is True
+    assert outcome.refreshed == ("opencode-go-default",)
+    assert outcome.deferred == ()
+    # An enrolled profile is refreshed in place, never re-bootstrapped.
+    assert controller.calls == []
+    # No candidate secret is supplied: the enrolled SecretRef stays authoritative.
+    assert observed == [("opencode-go-default", CURRENT_IMAGE, {})]
+    assert releases == ["opencode-go-default"]
+    assert rows[0].model_catalog_evidence_json["imageRef"] == CURRENT_IMAGE
+    assert rows[0].command_behavior["runtime_validation"]["image_ref"] == CURRENT_IMAGE
+    assert evidence_is_current(rows[0], image_ref=CURRENT_IMAGE)
+
+
+@pytest.mark.asyncio
+async def test_rejected_credential_defers_without_downgrading_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def validate(*_args, **_kwargs):
+        raise RuntimeError("pinned OpenCode runtime rejected the Provider Profile")
+
+    releases: list[str] = []
+    _install_stubs(monkeypatch, validate=validate, releases=releases)
+    rows = [_profile()]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.ready is False
+    assert outcome.deferred == ("opencode-go-default",)
+    assert outcome.refreshed == ()
+    assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE
+    assert rows[0].enabled is True
+    assert rows[0].auth_state == "connected"
+    assert releases == ["opencode-go-default"]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_maintenance_lease_defers_the_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stubs(monkeypatch, acquire_error=RuntimeError("profile is busy"))
+    rows = [_profile()]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.ready is False
+    assert outcome.deferred == ("opencode-go-default",)
+    assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE
+
+
+@pytest.mark.asyncio
+async def test_missing_pinned_image_defers_instead_of_recording_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_stubs(monkeypatch, image_ref=None)
+    rows = [_profile()]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.ready is False
+    assert outcome.reason == "pinned OpenCode host image unavailable"
+    assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE
+
+
+@pytest.mark.asyncio
+async def test_unenrolled_profile_rows_are_re_enrolled_from_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row that exists but never connected is not mistaken for an enrollment."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller()
+    rows = [
+        _profile(profile_id="never-connected", auth_state="api_key_pending"),
+        _profile(profile_id="disabled", enabled=False),
+        _profile(profile_id="no-secret", secret_refs={}),
+    ]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=controller
+    )
+
+    assert outcome.enrolled is True
+    assert outcome.checked == 3
+    assert len(controller.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_credential_rotation_during_validation_keeps_rotation_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generation that moved mid-flight owns its own evidence."""
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        # The rotation lands while the pinned runtime check is in flight.
+        profile.credential_generation = 4
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": image_ref,
+            "validatedAt": "2026-08-25T01:00:00+00:00",
+            "credentialGeneration": 3,
+        }
+
+    _install_stubs(monkeypatch, validate=validate)
+    rows = [_profile()]
+
+    await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -42,6 +42,7 @@ def _profile(
     enabled: bool = True,
     auth_state: str = "connected",
     secret_refs: dict[str, str] | None = None,
+    command_behavior: dict | None = None,
 ) -> SimpleNamespace:
     evidence = None
     if evidence_image is not None:
@@ -62,7 +63,7 @@ def _profile(
         credential_generation=generation,
         capacity_scope_ref=None,
         default_model="opencode-go/muse-spark-1.2-contributor",
-        command_behavior={},
+        command_behavior=dict(command_behavior or {}),
         secret_refs=(
             {"opencode_api_key": "db://opencode-key"}
             if secret_refs is None
@@ -265,14 +266,50 @@ async def test_enrollment_waits_for_image_and_catalog_authority(
 
 
 @pytest.mark.asyncio
-async def test_failed_enrollment_is_not_retried_for_the_same_configuration(
+async def test_transient_enrollment_failures_stay_retryable_within_a_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A rejected configuration must not re-run the full bootstrap every pass."""
+    """Temporal, Docker, and the database are startup dependencies."""
+
+    from moonmind.omnigent.bootstrap import provider_revalidation
 
     _install_stubs(monkeypatch)
     monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
-    controller = _Controller(state="failed")
+    controller = _Controller(error=RuntimeError("temporal is unavailable"))
+
+    budget = provider_revalidation._MAX_ENROLLMENT_ATTEMPTS
+    for _ in range(budget):
+        outcome = await reconcile_opencode_provider_readiness(
+            session_factory=_session_factory([]), controller=controller
+        )
+        assert outcome.ready is False
+    # A transient failure keeps retrying rather than latching on the first pass.
+    assert len(controller.calls) == budget
+
+    exhausted = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+    assert exhausted.ready is False
+    assert "exhausted its attempts" in (exhausted.reason or "")
+    assert len(controller.calls) == budget
+
+    # Correcting the credential produces a new configuration with a new budget.
+    monkeypatch.setenv("OPENCODE_API_KEY", "sk-" + "y" * 40)
+    await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([]), controller=controller
+    )
+    assert len(controller.calls) == budget + 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_configuration_consumes_the_whole_budget_at_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrying cannot fix a malformed key or a declined acknowledgement."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller(error=ValueError("API key appears invalid"))
 
     first = await reconcile_opencode_provider_readiness(
         session_factory=_session_factory([]), controller=controller
@@ -281,17 +318,9 @@ async def test_failed_enrollment_is_not_retried_for_the_same_configuration(
         session_factory=_session_factory([]), controller=controller
     )
 
-    assert first.ready is False
+    assert "configuration is invalid" in (first.reason or "")
     assert second.ready is False
     assert len(controller.calls) == 1
-
-    # Correcting the credential produces a new configuration and retries.
-    monkeypatch.setenv("OPENCODE_API_KEY", "sk-" + "y" * 40)
-    third = await reconcile_opencode_provider_readiness(
-        session_factory=_session_factory([]), controller=controller
-    )
-    assert len(controller.calls) == 2
-    assert third.ready is False
 
 
 @pytest.mark.asyncio
@@ -436,7 +465,6 @@ async def test_unenrolled_profile_rows_are_re_enrolled_from_configuration(
     controller = _Controller()
     rows = [
         _profile(profile_id="never-connected", auth_state="api_key_pending"),
-        _profile(profile_id="disabled", enabled=False),
         _profile(profile_id="no-secret", secret_refs={}),
     ]
 
@@ -445,8 +473,32 @@ async def test_unenrolled_profile_rows_are_re_enrolled_from_configuration(
     )
 
     assert outcome.enrolled is True
-    assert outcome.checked == 3
+    assert outcome.checked == 2
     assert len(controller.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_operator_disabled_profile_is_never_re_enabled_by_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enrollment applies enabled=True, so a disabled profile must be left alone."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller()
+    # Connected and enrolled, but the operator turned it off. Its evidence is
+    # also stale, which must not become a reason to touch it either.
+    rows = [_profile(enabled=False)]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=controller
+    )
+
+    assert controller.calls == []
+    assert outcome.enrolled is False
+    assert outcome.refreshed == ()
+    assert outcome.ready is True
+    assert rows[0].enabled is False
 
 
 @pytest.mark.asyncio
@@ -469,8 +521,83 @@ async def test_credential_rotation_during_validation_keeps_rotation_authoritativ
     _install_stubs(monkeypatch, validate=validate)
     rows = [_profile()]
 
-    await reconcile_opencode_provider_readiness(
+    outcome = await reconcile_opencode_provider_readiness(
         session_factory=_session_factory(rows), controller=_Controller()
     )
 
     assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE
+    # The write did not land, so the pass must not claim the profile refreshed.
+    assert outcome.refreshed == ()
+    assert outcome.deferred == ("opencode-go-default",)
+    assert outcome.ready is False
+
+
+@pytest.mark.asyncio
+async def test_repeated_rejection_is_recorded_and_marked_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revoked credential must become distinguishable from a wait in flight."""
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        MAX_REVALIDATION_ATTEMPTS,
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    async def validate(*_args, **_kwargs):
+        raise RuntimeError("pinned OpenCode runtime rejected the Provider Profile")
+
+    _install_stubs(monkeypatch, validate=validate)
+    rows = [_profile()]
+
+    for _ in range(MAX_REVALIDATION_ATTEMPTS):
+        await reconcile_opencode_provider_readiness(
+            session_factory=_session_factory(rows), controller=_Controller()
+        )
+
+    record = rows[0].command_behavior[REVALIDATION_FAILURE_KEY]
+    assert record["attempts"] == MAX_REVALIDATION_ATTEMPTS
+    assert record["exhausted"] is True
+    assert record["imageRef"] == CURRENT_IMAGE
+    assert record["credentialGeneration"] == 3
+    # The credential itself is untouched; only an operator can reconnect it.
+    assert rows[0].auth_state == "connected"
+    assert rows[0].model_catalog_evidence_json["imageRef"] == PREVIOUS_IMAGE
+
+
+@pytest.mark.asyncio
+async def test_a_successful_refresh_clears_a_recorded_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": image_ref,
+            "validatedAt": "2026-08-25T01:00:00+00:00",
+            "credentialGeneration": profile.credential_generation,
+        }
+
+    _install_stubs(monkeypatch, validate=validate)
+    rows = [
+        _profile(
+            command_behavior={
+                REVALIDATION_FAILURE_KEY: {
+                    "imageRef": CURRENT_IMAGE,
+                    "credentialGeneration": 3,
+                    "attempts": 3,
+                    "exhausted": True,
+                }
+            }
+        )
+    ]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.refreshed == ("opencode-go-default",)
+    assert REVALIDATION_FAILURE_KEY not in rows[0].command_behavior


### PR DESCRIPTION
## Problem

Selecting **OpenCode via Omnigent** on Workflow Create reported:

> Omnigent cannot be submitted: Connect and validate a compatible Provider Profile.

for a deployment whose `opencode-go-default` profile was enabled, `connected`, and holding a valid credential. Three independent gaps kept the documented default path from completing, and the gate message pointed at none of them.

### 1. Model catalog evidence never refreshed after the host image moved

`GET /api/omnigent/execution-readiness` (and the planner and smoke admission) require a profile's `model_catalog_evidence_json.imageRef` to equal the currently selected Host Class image exactly. Evidence was only ever written during interactive credential setup, so re-pulling or rebuilding the OpenCode host image silently dropped the profile out of `compatibleProviderProfiles`.

On the affected deployment, evidence held `…omnigent-host-opencode@sha256:9b9a4a30…` while the deployment had re-resolved to `…@sha256:f228955f…` — the same physical image, recorded once as an image ID and once as a RepoDigest. There was no path back short of re-entering the key.

### 2. Host image digest never resolved outside a console request

Host Class selection, launch policy compilation, and Provider Profile validation all read digest-pinned refs from the process environment. The canonical Compose path ships `OMNIGENT_OPENCODE_HOST_IMAGE_REF` empty on purpose, and `resolve_omnigent_images()` had exactly two callers: `POST /api/omnigent/bootstrap/opencode` and a manual `python -m` entrypoint. The console path published digests by mutating `os.environ` in one process, so a restart left Host Class selection with nothing to select → `host_class_unavailable`.

### 3. `OPENCODE_API_KEY` never read at startup

The env→managed-secret import covered only GitHub tokens and `ATLASSIAN_API_KEY`. The `opencode-go-default` profile was created and validated *only* by the console bootstrap action, and `OPENCODE_API_KEY` was not even present in `.env-template` → `compatible_provider_profile_unavailable` on any fresh deployment.

## Changes

**`moonmind/omnigent/bootstrap/provider_revalidation.py`** (new) — one boundary that keeps the deployment's configured OpenCode credential launchable:

- **enrollment** runs the canonical bootstrap for `OPENCODE_API_KEY` when no connected profile exists; and
- **re-validation** re-runs the pinned-runtime check against the already-enrolled SecretRef when only the evidence is stale.

Neither path substitutes a credential, an image, or a weaker evidence contract. A credential the runtime rejects keeps its previous evidence and stays connected. Enrollment runs the full bootstrap, so it waits for the immutable-image and harness-catalog authorities it depends on and is attempted once per distinct configuration; correcting the credential or the acknowledgement produces a new configuration and retries, as does a restart.

**`moonmind/omnigent/bootstrap/image_resolution.py`** — `publish_resolved_omnigent_images()` resolves, persists, and exports the digests at one boundary. `BootstrapController` now calls it instead of carrying its own copy.

**`api_service/main.py`** — two legs added to the existing Omnigent bootstrap reconciliation (startup plus the 120 s cadence). Image identities resolve first, since every downstream leg selects Host Classes against them; provider readiness runs last and only once images are available.

**`moonmind/omnigent/bootstrap/controller.py`** — `_sync_catalog` synchronized the harness catalog through its own overlay-free copy of the canonical service. That published a snapshot *without* the synthetic `opencode-native` harness as `latest()`, so a freshly enrolled profile failed the harness-catalog attestation bootstrap exists to satisfy (observed live: a 9-harness snapshot superseding the canonical 10-harness one). The duplicate is removed in favour of `synchronize_omnigent_harness_catalog`.

**`api_service/api/routers/omnigent_catalog.py`** — a connected-but-stale profile now reports `provider_runtime_revalidation_pending` with an accurate message, rather than telling the operator to reconnect a profile that is already connected. A profile that was never runtime-validated still reports `compatible_provider_profile_unavailable`.

**`moonmind/omnigent/settings.py`, `.env-template`** — `OPENCODE_API_KEY` and `OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE`. The stock OpenCode Go model is a contributor tier whose enrollment records a data-use acknowledgement; it defaults to `true` so the documented one-value setup completes, and remains an explicit, documented switch an operator can set to `false` — enrollment then stops with an actionable failure instead of acknowledging on the operator's behalf.

**`docs/Omnigent/OpenCodeHost.md`** — a "Deployment setup" section describing the one-value path, what reconciliation does on startup, the acknowledgement default, and the retry semantics. Console enrollment remains documented for deployments that do not carry the credential in their environment.

## Verification

Against the live Compose deployment, exercising the real startup journey rather than nearby functions:

| Starting state | Result after one restart |
|---|---|
| No `opencode-go-default` row at all (row deleted) | Created, validated, `connected`, `credential_generation=1`, evidence on the current pinned digest; readiness `available=true`, `gateReasons: []` |
| Row present but `not_configured`, disabled, no SecretRef, no evidence | Enrolled and validated from `OPENCODE_API_KEY`; readiness `available=true`, `gateReasons: []` |
| Evidence reset to the superseded `9b9a4a30` digest | Self-healed to `f228955f` on the next pass, with the `Refreshed OpenCode Provider Profile model evidence` log line |
| Nothing pinned in the environment | `get_opencode_host_image_ref()` raises before the image leg and returns the resolved digest after it |

Unit tests: `tests/unit/omnigent/test_provider_revalidation.py` (enrollment from configuration, declined acknowledgement not overridden, enrollment waiting for authority, one-attempt-per-configuration, refresh in place, rejected credential not downgraded, lease unavailable, missing pinned image, mid-flight rotation), `tests/unit/omnigent/test_bootstrap_image_publication.py`, plus updated `test_omnigent_catalog.py` and `test_managed_session_reconcile_schedule_startup.py` coverage for the new gate reason and leg ordering.

## Notes for review

Two pre-existing issues found while verifying, both outside this change and not addressed here:

1. `OpenCodeProviderRuntimeValidationService` runs `opencode models` in a `--read-only` container and it fails with `EROFS: … mkdir '/.local'`, so validation falls back to asserting the profile's default model rather than a live catalog. This fallback predates the change and also runs on the console setup path — the discovered model list is not currently coming from the runtime.
2. `resolve_omnigent_images()` produced an image-ID-shaped ref on one run and a RepoDigest-shaped ref on another for the same image, which is what created the original mismatch. The reconciler now absorbs that churn, but the inconsistency is worth pinning down separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
