### PR TITLE
fix(agent-run): make the execution budget progress-aware

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,57 @@
 [
   {
-    "id": 3851089921,
+    "id": 3858943188,
     "disposition": "addressed",
-    "rationale": "Advanced mode toggling off now resets contextRetrieval to defaultContextRetrievalAuthoring(), so re-enabling Advanced mode for an unrelated control cannot resubmit a cleared rag/followUpRetrieval policy; covered by a new regression test that fails without the fix."
+    "rationale": "Documented the ProcessLookupError pass in test_supervisor_live_output.py:190 with the same explanatory comment already used by the identical cleanup block at line 142."
   },
   {
-    "id": 5016710221,
+    "id": 5025987203,
     "disposition": "not-applicable",
-    "rationale": "Codex review container body with no actionable request; its only finding is the line comment tracked above."
+    "rationale": "Codex review header comment; informational summary with no requested change. Its individual line findings are dispositioned separately below."
+  },
+  {
+    "id": 3858968872,
+    "disposition": "addressed",
+    "rationale": "The budget now carries an execution_budget_mode across the launch boundary. A history that is not progress-aware publishes budget.as_flat(), so agent_runtime.launch re-resolves max_seconds == base_seconds and the supervisor cannot outlive the replayed workflow's flat deadline. Covered by test_unpatched_publish_pins_the_supervisor_to_the_flat_deadline and test_in_flight_history_publishes_its_flat_deadline."
+  },
+  {
+    "id": 3858968875,
+    "disposition": "addressed",
+    "rationale": "The one-activity streaming lane no longer sizes ScheduleToClose from the progress-aware ceiling. The workflow is blocked awaiting that activity and cannot observe progress or re-evaluate the budget, so its only enforceable deadline is the base window. Covered by test_streaming_lane_is_bounded_by_the_deadline_it_can_enforce."
+  },
+  {
+    "id": 3858968879,
+    "disposition": "addressed",
+    "rationale": "resolve_execution_budget now clamps the resolved stall window to base_seconds for explicit values, not only defaults, restoring the documented contract that the stall window never exceeds the base. Covered by test_resolver_clamps_an_explicit_stall_window_to_the_base_budget."
+  },
+  {
+    "id": 3858968887,
+    "disposition": "addressed",
+    "rationale": "The supervisor now samples no_output_callback and re-evaluates before terminating on expired_no_progress, so progress observed since the last heartbeat is counted. The hard ceiling stays exempt. Covered by test_due_progress_is_sampled_before_the_stall_verdict_terminates and test_refresh_cannot_extend_a_run_past_the_ceiling."
+  },
+  {
+    "id": 3858968893,
+    "disposition": "addressed",
+    "rationale": "The managed poll loop performs one final bounded status reconciliation when the remaining status budget reaches zero, instead of breaking on stale evidence; observed progress rearms it for the next boundary. Covered by test_final_status_reconciliation_before_the_budget_verdict."
+  },
+  {
+    "id": 3858968902,
+    "disposition": "addressed",
+    "rationale": "base_seconds is now clamped to MAX_EXECUTION_BUDGET_SECONDS before the ceiling is derived, so a budget can never terminate for reaching the maximum before its declared base window elapses. Covered by test_resolver_never_returns_a_base_above_its_own_ceiling."
+  },
+  {
+    "id": 3858968909,
+    "disposition": "addressed",
+    "rationale": "ProcessActivityProbe now tracks per-process CPU and retains the CPU of descendants that exit (and of recycled pids), so the session total is genuinely cumulative and never falls. Covered by test_cpu_of_exited_descendants_stays_in_the_session_total."
+  },
+  {
+    "id": 3858968914,
+    "disposition": "addressed",
+    "rationale": "The execution fan-out capability lifetime is now the ceiling plus a bounded launch grace covering broker setup, workspace ownership changes, and process creation that precede the supervisor starting its clock. Asserted in test_direct_managed_launch_materializes_scoped_execution_fanout."
+  },
+  {
+    "id": 3858968921,
+    "disposition": "addressed",
+    "rationale": "Supervisor elapsed and idle intervals are now measured from time.monotonic(); wall-clock timestamps remain the persisted evidence. Covered by test_budget_intervals_ignore_wall_clock_jumps."
   }
 ]

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -587,6 +587,76 @@ A detached process or provider job is not considered ongoing MoonMind-managed wo
 
 ---
 
+## 15.1 Execution budget
+
+An agent run has one execution budget, resolved from `timeoutPolicy` by a single
+authority and applied identically at both boundaries that can end a run for
+taking too long: the `MoonMind.AgentRun` poll loop and the managed process
+supervisor. The two deadlines cannot diverge, because the workflow publishes the
+resolved budget back into the launch request and the supervisor resolves the
+same values from it.
+
+The budget has three fields:
+
+| Field | Meaning |
+|---|---|
+| `timeout_seconds` | Base window. A run that cannot demonstrate progress ends here. |
+| `max_timeout_seconds` | Hard ceiling. No observed progress extends a run past this. |
+| `progress_stall_seconds` | How long observed progress may go stale before an over-base run is treated as stuck. |
+
+Omitted fields resolve to kind-specific defaults. The ceiling defaults to a
+multiple of the base window rather than an absolute constant, so an explicitly
+requested tight budget keeps a tight ceiling, and the stall window never exceeds
+the base window — a run is not given more time to prove it is alive than it was
+given to finish.
+
+**Elapsed wall-clock alone is not evidence that a run is stuck.** A run is
+terminated for exceeding its budget only when one of two things is true:
+
+- the base window has elapsed **and** no progress has been observed within
+  `progress_stall_seconds` (or no progress has ever been observed); or
+- the hard ceiling has been reached.
+
+A run that is still making observable progress when its base window elapses
+continues until progress goes stale or the ceiling is reached. The two outcomes
+are reported distinctly: a run stopped at the ceiling is never described as
+having made no progress, because the operator responses differ — raise the
+ceiling versus investigate a wedged runtime. The terminal result records the
+budget the decision was made against and which of the two conditions ended it.
+
+### Progress evidence
+
+Progress is observed evidence, never a heuristic derived from elapsed time. The
+supervisor takes the most recent of three independent signals and publishes it
+as `last_log_at`, which the workflow reads through canonical status metadata:
+
+- **runtime output** — bytes on stdout or stderr;
+- **workspace mutation** — the newest meaningful file mtime under the run
+  workspace;
+- **process-tree CPU activity** — cumulative CPU time consumed by the supervised
+  session.
+
+No single signal is sufficient, which is why the newest of all three is
+authoritative. A one-shot CLI launched in print mode emits nothing until its turn
+completes, so output stays silent for the whole run. An agent running a test
+suite or compiler writes only into ignored directories, so workspace mutation
+goes quiet for tens of minutes. CPU activity covers both, including work done
+only by descendants of the launched process, and distinguishes them from a
+process blocked forever on a dead socket, awaiting input, or deadlocked, which
+consumes none.
+
+A runtime that livelocks does consume CPU and therefore reads as progress. That
+is contained by the hard ceiling, which no amount of observed progress extends.
+The same observation drives the no-progress watchdog, so the watchdog and the
+budget cannot disagree about whether a run is progressing.
+
+Callers that provision resources which must outlive the whole run — credential
+lifetimes, broker sockets, activity `ScheduleToClose` timeouts — size them from
+the ceiling, never from the base window. Sizing them from the base window would
+strand an extended run without the authority it was granted.
+
+---
+
 ## 16. Retry, replay, and reconciliation
 
 ### 16.1 Activity retry

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -596,19 +596,35 @@ supervisor. The two deadlines cannot diverge, because the workflow publishes the
 resolved budget back into the launch request and the supervisor resolves the
 same values from it.
 
-The budget has three fields:
+The budget has four fields:
 
 | Field | Meaning |
 |---|---|
 | `timeout_seconds` | Base window. A run that cannot demonstrate progress ends here. |
 | `max_timeout_seconds` | Hard ceiling. No observed progress extends a run past this. |
 | `progress_stall_seconds` | How long observed progress may go stale before an over-base run is treated as stuck. |
+| `execution_budget_mode` | Which decision the budget encodes: `progress_aware` or `flat`. |
 
 Omitted fields resolve to kind-specific defaults. The ceiling defaults to a
 multiple of the base window rather than an absolute constant, so an explicitly
-requested tight budget keeps a tight ceiling, and the stall window never exceeds
-the base window — a run is not given more time to prove it is alive than it was
-given to finish.
+requested tight budget keeps a tight ceiling.
+
+A resolved budget is never internally contradictory. The stall window never
+exceeds the base window, explicit or defaulted — a run is not given more time to
+prove it is alive than it was given to finish, and a wider stall window would
+otherwise erase the base window as a boundary, because a run's own start counts
+as an observation. The base window is bound by the same absolute cap as the
+ceiling, so a run can never be terminated for "reaching the maximum" before the
+base window it declared has elapsed.
+
+**Mode travels with the numbers.** A workflow history that predates
+progress-awareness enforces a flat deadline, and it publishes that decision, not
+just its base window. A callee that re-resolves the budget — the launch activity
+does so on every launch and retry, including retries dispatched after the
+progress-aware deployment — must reach the same decision. Publishing only the
+base window let the supervisor derive a progress-aware ceiling the workflow never
+granted: the workflow timed out at the base window and released the provider
+slot while the supervisor carried the process on to that ceiling.
 
 **Elapsed wall-clock alone is not evidence that a run is stuck.** A run is
 terminated for exceeding its budget only when one of two things is true:
@@ -623,6 +639,23 @@ are reported distinctly: a run stopped at the ceiling is never described as
 having made no progress, because the operator responses differ — raise the
 ceiling versus investigate a wedged runtime. The terminal result records the
 budget the decision was made against and which of the two conditions ended it.
+
+**Budget intervals are measured monotonically.** Elapsed and idle durations come
+from a monotonic clock; wall-clock timestamps remain the run's persisted
+evidence, because they must line up with file mtimes and operator timelines. A
+host clock step must not be able to terminate a healthy run as over-budget, nor
+let a wedged one outlive the deadline the other boundary is enforcing.
+
+**A stall verdict is decided against fresh evidence, never cached evidence.**
+Progress observations are sampled on a heartbeat cadence, so a verdict computed
+from the cached observation can be a whole heartbeat interval stale, and the last
+bounded poll wait can consume the entire known remaining budget. Before ending a
+run for lack of progress, each boundary reconciles once against current evidence
+— the supervisor samples CPU and workspace activity, the workflow performs one
+final bounded status poll — and re-decides. A process that resumed work seconds
+before its boundary is not killed for activity the boundary had simply not looked
+for yet. The hard ceiling is exempt: it is enforced without reconciliation,
+because no observed progress extends a run past it.
 
 ### Progress evidence
 
@@ -650,10 +683,28 @@ is contained by the hard ceiling, which no amount of observed progress extends.
 The same observation drives the no-progress watchdog, so the watchdog and the
 budget cannot disagree about whether a run is progressing.
 
+CPU accounting is cumulative across the session's lifetime, not across its
+currently live processes. A descendant that exits keeps its consumed CPU in the
+session total, so the total never falls. Without this, an agent running a
+sequence of short-lived compilers or test processes reads as stalled while
+working continuously, because each replacement has to re-earn the CPU its
+predecessor took with it.
+
 Callers that provision resources which must outlive the whole run — credential
-lifetimes, broker sockets, activity `ScheduleToClose` timeouts — size them from
-the ceiling, never from the base window. Sizing them from the base window would
-strand an extended run without the authority it was granted.
+lifetimes, broker sockets — size them from the ceiling, never from the base
+window, plus a bounded allowance for launch preparation that precedes the
+supervisor starting its clock. Sizing them from the base window would strand an
+extended run without the authority it was granted; sizing them at exactly the
+ceiling would expire them while the run is still legally executing.
+
+**Only a boundary that can observe progress may spend the extension.** An
+activity `ScheduleToClose` is sized from the ceiling when the workflow can
+re-evaluate the budget while the activity runs. Where the workflow is blocked
+awaiting a single long-running activity and therefore cannot observe progress or
+re-decide, `ScheduleToClose` is the only deadline that exists, and it is sized
+from the base window. Sizing it from the ceiling there would let a run that never
+makes progress hold its provider slot for the full ceiling with no boundary able
+to stop it.
 
 ---
 

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -41,44 +41,166 @@ MANAGED_PROCESS_LOST_DURING_RECONCILIATION = (
 # value. Previously the workflow defaulted managed runs one way while
 # ``agent_runtime.launch`` independently defaulted the supervisor to 3600s, so an
 # explicitly requested larger budget could not take effect — the process was
-# still killed at one hour. A run needing more than the default requests it
-# explicitly through ``timeoutPolicy.timeout_seconds`` instead of widening the
-# fallback for every managed run.
+# still killed at one hour.
+#
+# The budget is progress-aware. ``timeout_seconds`` is the *base* budget: the
+# point at which a run that cannot demonstrate progress is terminated. A run that
+# is still making observable progress when the base budget expires keeps running
+# until either progress goes stale for ``progress_stall_seconds`` or the hard
+# ceiling ``max_timeout_seconds`` is reached. Wall-clock alone is not evidence of
+# a stuck run: a one-shot runtime such as ``claude -p`` emits nothing until it
+# finishes, so terminating on elapsed time alone destroys healthy long runs
+# (MoonLadderStudios/MoonMind#3771 — an hour of uncommitted work discarded from a
+# run that was writing files three seconds before the kill).
 DEFAULT_MANAGED_TIMEOUT_SECONDS = 3600  # 1 hour
 DEFAULT_EXTERNAL_TIMEOUT_SECONDS = 21600  # 6 hours
+# How far progress may carry a run past its base budget, as a multiple of that
+# budget. Deriving the ceiling from the base rather than fixing it absolutely
+# keeps an explicit budget meaningful: asking for a tight 60s budget yields a
+# tight ceiling, not a six-hour one. An operator who wants a specific ceiling
+# sets ``max_timeout_seconds`` directly.
+DEFAULT_PROGRESS_EXTENSION_FACTOR = 6
+# Absolute safety cap. No budget, however configured, lets one agent run hold a
+# provider slot longer than this.
+MAX_EXECUTION_BUDGET_SECONDS = 86400  # 24 hours
+# How long observable progress may go stale before an over-base run is treated as
+# stuck. Wide enough to cover a long provider call or a quiet compile/test
+# stretch, short enough that a genuinely wedged process is not carried to the
+# ceiling. Never longer than the base budget itself — a run is not given more
+# time to prove it is alive than it was originally given to finish.
+DEFAULT_PROGRESS_STALL_SECONDS = 900  # 15 minutes
+
+# Outcome of one execution-budget evaluation.
+#   ``continue``            -- the run may keep executing
+#   ``expired_no_progress`` -- base budget elapsed and progress is stale/absent
+#   ``expired_max_budget``  -- the hard ceiling was reached
+ExecutionBudgetVerdict = Literal[
+    "continue",
+    "expired_no_progress",
+    "expired_max_budget",
+]
 
 
-def resolve_execution_timeout_seconds(
-    *,
-    agent_kind: str = "managed",
-    timeout_policy: Mapping[str, Any] | Any | None = None,
-) -> int:
-    """Return the effective execution budget in seconds for one agent run.
+class ExecutionBudget(BaseModel):
+    """The resolved, progress-aware execution budget for one agent run.
 
-    An explicit ``timeout_seconds`` in the request's timeout policy always wins;
-    otherwise the kind-specific default applies. Both the workflow budget and the
-    process supervisor call this so the two deadlines cannot diverge.
+    Every boundary that can end a run for exceeding its time — the AgentRun
+    workflow loop and the managed process supervisor — resolves this from the
+    same ``timeout_policy`` and applies :func:`evaluate_execution_budget` to the
+    same progress evidence, so the two deadlines cannot diverge.
     """
 
-    default_seconds = (
-        DEFAULT_EXTERNAL_TIMEOUT_SECONDS
-        if agent_kind == "external"
-        else DEFAULT_MANAGED_TIMEOUT_SECONDS
-    )
+    model_config = ConfigDict(populate_by_name=True, frozen=True)
+
+    base_seconds: int = Field(alias="baseSeconds")
+    max_seconds: int = Field(alias="maxSeconds")
+    progress_stall_seconds: int = Field(alias="progressStallSeconds")
+
+    def as_timeout_policy(self) -> dict[str, int]:
+        """Return the policy mapping that republishes this budget to callees.
+
+        The workflow publishes this into the launch request so the supervisor
+        enforces the identical budget. Keys match the snake_case names read by
+        :func:`resolve_execution_budget`.
+        """
+
+        return {
+            "timeout_seconds": self.base_seconds,
+            "max_timeout_seconds": self.max_seconds,
+            "progress_stall_seconds": self.progress_stall_seconds,
+        }
+
+
+def _read_timeout_policy_value(
+    timeout_policy: Mapping[str, Any] | Any | None,
+    key: str,
+) -> int | None:
+    """Read one positive integer from a mapping-or-object timeout policy."""
+
     if timeout_policy is None:
-        return default_seconds
+        return None
     if isinstance(timeout_policy, Mapping):
-        requested = timeout_policy.get("timeout_seconds")
+        requested = timeout_policy.get(key)
     else:
-        requested = getattr(timeout_policy, "timeout_seconds", None)
+        requested = getattr(timeout_policy, key, None)
     if requested is None:
-        return default_seconds
+        return None
     try:
         seconds = int(requested)
     except (TypeError, ValueError):
-        return default_seconds
-    return seconds if seconds > 0 else default_seconds
+        return None
+    return seconds if seconds > 0 else None
 
+
+def resolve_execution_budget(
+    *,
+    agent_kind: str = "managed",
+    timeout_policy: Mapping[str, Any] | Any | None = None,
+) -> ExecutionBudget:
+    """Return the effective progress-aware execution budget for one agent run.
+
+    Explicit ``timeout_seconds`` / ``max_timeout_seconds`` /
+    ``progress_stall_seconds`` values in the request's timeout policy win;
+    otherwise the kind-specific defaults apply. A degraded or partially populated
+    policy falls back per-field rather than failing, so an in-flight run whose
+    payload predates the progress-aware fields still resolves a valid budget.
+
+    The ceiling is never below the base budget: an explicit ``timeout_seconds``
+    larger than the default ceiling raises the ceiling with it, so asking for a
+    bigger budget never silently shortens the run.
+    """
+
+    is_external = agent_kind == "external"
+    base_seconds = _read_timeout_policy_value(timeout_policy, "timeout_seconds") or (
+        DEFAULT_EXTERNAL_TIMEOUT_SECONDS
+        if is_external
+        else DEFAULT_MANAGED_TIMEOUT_SECONDS
+    )
+    max_seconds = _read_timeout_policy_value(
+        timeout_policy, "max_timeout_seconds"
+    ) or (base_seconds * DEFAULT_PROGRESS_EXTENSION_FACTOR)
+    progress_stall_seconds = _read_timeout_policy_value(
+        timeout_policy, "progress_stall_seconds"
+    ) or min(DEFAULT_PROGRESS_STALL_SECONDS, base_seconds)
+    return ExecutionBudget(
+        base_seconds=base_seconds,
+        # The ceiling is never below the base (asking for a bigger budget must
+        # not shorten the run) and never above the absolute cap.
+        max_seconds=min(
+            MAX_EXECUTION_BUDGET_SECONDS,
+            max(max_seconds, base_seconds),
+        ),
+        progress_stall_seconds=progress_stall_seconds,
+    )
+
+
+def evaluate_execution_budget(
+    *,
+    budget: ExecutionBudget,
+    elapsed_seconds: float,
+    idle_progress_seconds: float | None,
+) -> ExecutionBudgetVerdict:
+    """Decide whether a run may continue under its progress-aware budget.
+
+    ``idle_progress_seconds`` is how long ago the last *observable progress* was
+    seen — file mutation in the workspace, runtime output, or process-tree CPU
+    activity. ``None`` means no progress has ever been observed for this run, which
+    is not evidence of health: such a run is terminated at the base budget exactly
+    as before.
+
+    The hard ceiling is checked first so a runtime that livelocks while still
+    emitting progress signals cannot extend itself indefinitely.
+    """
+
+    if elapsed_seconds >= budget.max_seconds:
+        return "expired_max_budget"
+    if elapsed_seconds < budget.base_seconds:
+        return "continue"
+    if idle_progress_seconds is None:
+        return "expired_no_progress"
+    if idle_progress_seconds < budget.progress_stall_seconds:
+        return "continue"
+    return "expired_no_progress"
 
 AgentRunState = Literal[
     "queued",
@@ -2062,7 +2184,13 @@ def build_canonical_result(payload: dict[str, Any]) -> AgentRunResult:
 __all__ = [
     "DEFAULT_EXTERNAL_TIMEOUT_SECONDS",
     "DEFAULT_MANAGED_TIMEOUT_SECONDS",
-    "resolve_execution_timeout_seconds",
+    "DEFAULT_PROGRESS_EXTENSION_FACTOR",
+    "DEFAULT_PROGRESS_STALL_SECONDS",
+    "MAX_EXECUTION_BUDGET_SECONDS",
+    "ExecutionBudget",
+    "ExecutionBudgetVerdict",
+    "evaluate_execution_budget",
+    "resolve_execution_budget",
     "AgentExecutionRequest",
     "OmnigentExecutionPlanBinding",
     "AgentKind",

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -80,6 +80,19 @@ ExecutionBudgetVerdict = Literal[
     "expired_max_budget",
 ]
 
+# Which budget decision a run is executing under. This travels in the launch
+# request's timeout policy so the supervisor enforces the *same* decision the
+# workflow enforces, rather than independently re-deriving a progress-aware
+# ceiling. An AgentRun history that predates the progress-aware patch keeps its
+# flat deadline; without this the workflow would time out at the base window and
+# release the provider slot while the supervisor kept the process alive to a
+# derived ceiling it was never granted.
+#   ``progress_aware`` -- observed progress extends the run past the base window
+#   ``flat``           -- the base window is the only deadline
+ExecutionBudgetMode = Literal["progress_aware", "flat"]
+# Timeout-policy key carrying :data:`ExecutionBudgetMode` across the boundary.
+EXECUTION_BUDGET_MODE_KEY = "execution_budget_mode"
+
 
 class ExecutionBudget(BaseModel):
     """The resolved, progress-aware execution budget for one agent run.
@@ -95,20 +108,39 @@ class ExecutionBudget(BaseModel):
     base_seconds: int = Field(alias="baseSeconds")
     max_seconds: int = Field(alias="maxSeconds")
     progress_stall_seconds: int = Field(alias="progressStallSeconds")
+    mode: ExecutionBudgetMode = Field(default="progress_aware", alias="mode")
 
-    def as_timeout_policy(self) -> dict[str, int]:
+    def as_timeout_policy(self) -> dict[str, Any]:
         """Return the policy mapping that republishes this budget to callees.
 
         The workflow publishes this into the launch request so the supervisor
         enforces the identical budget. Keys match the snake_case names read by
-        :func:`resolve_execution_budget`.
+        :func:`resolve_execution_budget`. The mode travels with the numbers: a
+        callee that re-resolves the budget must reach the same decision, not a
+        progress-aware one derived from a flat run's base window.
         """
 
         return {
             "timeout_seconds": self.base_seconds,
             "max_timeout_seconds": self.max_seconds,
             "progress_stall_seconds": self.progress_stall_seconds,
+            EXECUTION_BUDGET_MODE_KEY: self.mode,
         }
+
+    def as_flat(self) -> "ExecutionBudget":
+        """This budget with the base window as its only deadline.
+
+        Used to publish the deadline a pre-progress-aware AgentRun history is
+        actually enforcing, so the supervisor cannot outlive the workflow that
+        owns the run's provider slot.
+        """
+
+        return ExecutionBudget(
+            base_seconds=self.base_seconds,
+            max_seconds=self.base_seconds,
+            progress_stall_seconds=self.base_seconds,
+            mode="flat",
+        )
 
 
 def _read_timeout_policy_value(
@@ -132,6 +164,25 @@ def _read_timeout_policy_value(
     return seconds if seconds > 0 else None
 
 
+def _read_execution_budget_mode(
+    timeout_policy: Mapping[str, Any] | Any | None,
+) -> ExecutionBudgetMode:
+    """Read the published budget mode, defaulting to progress-aware.
+
+    A policy with no mode is either a direct launch or a caller that predates the
+    key; both get the current decision, which is what they would have resolved
+    before the key existed.
+    """
+
+    if timeout_policy is None:
+        return "progress_aware"
+    if isinstance(timeout_policy, Mapping):
+        requested = timeout_policy.get(EXECUTION_BUDGET_MODE_KEY)
+    else:
+        requested = getattr(timeout_policy, EXECUTION_BUDGET_MODE_KEY, None)
+    return "flat" if str(requested or "").strip() == "flat" else "progress_aware"
+
+
 def resolve_execution_budget(
     *,
     agent_kind: str = "managed",
@@ -148,6 +199,11 @@ def resolve_execution_budget(
     The ceiling is never below the base budget: an explicit ``timeout_seconds``
     larger than the default ceiling raises the ceiling with it, so asking for a
     bigger budget never silently shortens the run.
+
+    ``execution_budget_mode`` selects the decision this budget encodes. A policy
+    published by an AgentRun history that predates progress-awareness carries
+    ``flat``, and the resolved budget then has the base window as its only
+    deadline, so the supervisor cannot outlive the workflow enforcing it.
     """
 
     is_external = agent_kind == "external"
@@ -156,12 +212,24 @@ def resolve_execution_budget(
         if is_external
         else DEFAULT_MANAGED_TIMEOUT_SECONDS
     )
+    # The absolute cap binds the base window too. Accepting a larger base while
+    # capping the ceiling below it produces a self-contradictory budget that
+    # terminates at the cap for "reaching the maximum" before the base window it
+    # claims to honor has even elapsed.
+    base_seconds = min(base_seconds, MAX_EXECUTION_BUDGET_SECONDS)
+    if _read_execution_budget_mode(timeout_policy) == "flat":
+        return ExecutionBudget(
+            base_seconds=base_seconds,
+            max_seconds=base_seconds,
+            progress_stall_seconds=base_seconds,
+            mode="flat",
+        )
     max_seconds = _read_timeout_policy_value(
         timeout_policy, "max_timeout_seconds"
     ) or (base_seconds * DEFAULT_PROGRESS_EXTENSION_FACTOR)
     progress_stall_seconds = _read_timeout_policy_value(
         timeout_policy, "progress_stall_seconds"
-    ) or min(DEFAULT_PROGRESS_STALL_SECONDS, base_seconds)
+    ) or DEFAULT_PROGRESS_STALL_SECONDS
     return ExecutionBudget(
         base_seconds=base_seconds,
         # The ceiling is never below the base (asking for a bigger budget must
@@ -170,7 +238,13 @@ def resolve_execution_budget(
             MAX_EXECUTION_BUDGET_SECONDS,
             max(max_seconds, base_seconds),
         ),
-        progress_stall_seconds=progress_stall_seconds,
+        # The stall window is never longer than the base budget, explicit or
+        # defaulted: a run is not given more time to prove it is alive than it
+        # was originally given to finish. Without this clamp an explicit stall
+        # window larger than the base silently extends every quiet run past the
+        # base deadline it asked for, because the run's own start counts as an
+        # observation and idle progress is therefore never ``None``.
+        progress_stall_seconds=min(progress_stall_seconds, base_seconds),
     )
 
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -144,7 +144,7 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
     ManagedRuntimeProfile,
     extract_durable_retrieval_metadata,
-    resolve_execution_timeout_seconds,
+    resolve_execution_budget,
 )
 from moonmind.schemas.workload_models import WorkloadResult, parse_workload_request
 from moonmind.workloads.tool_bridge import (
@@ -8012,7 +8012,9 @@ class TemporalAgentRuntimeActivities:
         # (MoonLadderStudios/MoonMind#3685 review). The workflow publishes its
         # effective budget into ``timeoutPolicy``; a direct launch without one
         # falls back to the same kind-specific default the workflow would use.
-        timeout_seconds = resolve_execution_timeout_seconds(
+        # The budget is progress-aware, so this carries the base window, the hard
+        # ceiling, and the stall window together rather than a lone deadline.
+        budget = resolve_execution_budget(
             agent_kind=str(getattr(request, "agent_kind", "managed") or "managed"),
             timeout_policy=getattr(request, "timeout_policy", None),
         )
@@ -8022,7 +8024,7 @@ class TemporalAgentRuntimeActivities:
                 record = await self._run_supervisor.supervise(
                     run_id=run_id,
                     process=process,
-                    timeout_seconds=timeout_seconds,
+                    budget=budget,
                     cleanup_paths=cleanup_paths or None,
                     deferred_cleanup_paths=deferred_cleanup_paths or None,
                 )

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -25,7 +25,7 @@ from moonmind.schemas.agent_runtime_models import (
     ManagedRunRecord,
     ManagedRuntimeProfile,
     TERMINAL_AGENT_RUN_STATES,
-    resolve_execution_timeout_seconds,
+    resolve_execution_budget,
 )
 from moonmind.security.execution_fanout_capabilities import (
     EXECUTION_FANOUT_REQUIRED_CAPABILITY,
@@ -993,10 +993,14 @@ class ManagedRuntimeLauncher:
                 session_id=run_id,
                 runtime_id=normalized_runtime_id,
                 source_kind="managed_process",
-                lifetime_seconds=resolve_execution_timeout_seconds(
+                # Size the capability to the budget's hard ceiling, not the base
+                # window: a run that keeps making progress outlives the base
+                # budget, and a token minted for the base window would strand it
+                # without fanout authority partway through.
+                lifetime_seconds=resolve_execution_budget(
                     agent_kind=request.agent_kind,
                     timeout_policy=request.timeout_policy,
-                ),
+                ).max_seconds,
             )
         )
 

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -85,6 +85,14 @@ LoreRepositoryReadinessAdapter = Callable[
 ]
 
 _LIVE_LOG_SPOOL_FILENAME = "live_streams.spool"
+# Launch preparation that happens after the fan-out capability is minted but
+# before the supervised process exists — GitHub broker setup, recursive workspace
+# ownership changes, runtime trust preparation, process creation — consumes token
+# lifetime without consuming any execution budget, because the supervisor only
+# starts measuring the ceiling once launch returns. Without this allowance a slow
+# workspace ``chown`` can strand an otherwise legal run without container or tool
+# authority before it reaches its ceiling.
+_EXECUTION_FANOUT_LAUNCH_GRACE_SECONDS = 900
 _MODEL_TIER_DIAGNOSTIC_STRING_LIMIT = 1024
 _MODEL_TIER_DIAGNOSTIC_FIELDS = (
     "providerProfileId",
@@ -996,11 +1004,16 @@ class ManagedRuntimeLauncher:
                 # Size the capability to the budget's hard ceiling, not the base
                 # window: a run that keeps making progress outlives the base
                 # budget, and a token minted for the base window would strand it
-                # without fanout authority partway through.
-                lifetime_seconds=resolve_execution_budget(
-                    agent_kind=request.agent_kind,
-                    timeout_policy=request.timeout_policy,
-                ).max_seconds,
+                # without fanout authority partway through. The bounded launch
+                # grace covers the preparation still ahead of the process that
+                # the execution budget does not yet count.
+                lifetime_seconds=(
+                    resolve_execution_budget(
+                        agent_kind=request.agent_kind,
+                        timeout_policy=request.timeout_policy,
+                    ).max_seconds
+                    + _EXECUTION_FANOUT_LAUNCH_GRACE_SECONDS
+                ),
             )
         )
 

--- a/moonmind/workflows/temporal/runtime/process_activity.py
+++ b/moonmind/workflows/temporal/runtime/process_activity.py
@@ -1,0 +1,167 @@
+"""Process-tree activity probing for managed run progress evidence.
+
+A managed run's progress must be observable without cooperation from the runtime
+it launched. Output is not sufficient: a one-shot CLI such as ``claude -p``
+buffers everything until the turn completes, so a healthy hour-long run looks
+byte-for-byte identical to a wedged one on stdout. Workspace mutation is better
+but incomplete — an agent running a test suite writes only into ignored
+directories, so it can look idle for tens of minutes while working hard.
+
+CPU time closes that gap. A process that is executing accrues CPU time; one that
+is blocked forever on a dead socket, awaiting stdin, or deadlocked accrues none.
+This probe sums the cumulative CPU time of every process in the supervised
+session and reports when that total last advanced.
+
+Tradeoff, stated explicitly: a runtime that livelocks (busy-spins) does accrue
+CPU, so it reads as progress here. That is contained by the execution budget's
+hard ceiling (``ExecutionBudget.max_seconds``), which no amount of observed
+progress can extend past. Killing healthy long runs at a flat deadline is the
+worse failure of the two.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_PROC_ROOT = Path("/proc")
+# ``/proc/<pid>/stat`` layout, 1-indexed per proc(5). ``comm`` (field 2) may
+# contain spaces and parentheses, so the line is split at the LAST ``)`` and the
+# remaining whitespace-separated tokens start at field 3.
+_STAT_FIELD_OFFSET = 3
+_STAT_FIELD_SESSION = 6
+_STAT_FIELD_UTIME = 14
+_STAT_FIELD_STIME = 15
+# Minimum CPU-time advance that counts as activity. A process that is not being
+# scheduled at all accrues exactly zero, so this only needs to clear scheduler
+# accounting noise — it must stay small enough that a mostly-idle runtime waiting
+# on a provider response still registers when it wakes to stream a response.
+_MIN_CPU_DELTA_SECONDS = 0.05
+
+
+def _clock_ticks_per_second() -> float:
+    try:
+        ticks = os.sysconf("SC_CLK_TCK")
+    except (AttributeError, ValueError, OSError):
+        return 100.0
+    return float(ticks) if ticks and ticks > 0 else 100.0
+
+
+class ProcessActivityProbe:
+    """Tracks when a supervised process session last consumed CPU time.
+
+    The supervised process is launched with ``start_new_session=True``, so it is
+    its own session leader and every descendant — the privilege-drop wrapper, the
+    runtime CLI, and anything it spawns such as a compiler or test runner —
+    carries its session id. Summing by session id therefore covers the whole tree
+    without needing to walk parent links or track reaped children.
+
+    ``sample`` is cheap enough to call on every heartbeat: it reads one small
+    file per running process and does no allocation-heavy parsing.
+    """
+
+    def __init__(self, *, session_pid: int) -> None:
+        self._session_pid = int(session_pid)
+        self._ticks_per_second = _clock_ticks_per_second()
+        self._last_total_seconds: float | None = None
+        self._last_activity_at: datetime | None = None
+        self._unavailable = not _PROC_ROOT.is_dir()
+        self._warned = False
+
+    @property
+    def available(self) -> bool:
+        """Whether this platform exposes the ``/proc`` data the probe needs."""
+
+        return not self._unavailable
+
+    def sample(self, now: datetime) -> datetime | None:
+        """Return when the session's CPU total last advanced, if ever observed.
+
+        Returns ``None`` until an advance has actually been seen, so an
+        unavailable or never-scheduled process contributes no progress evidence
+        rather than a misleading timestamp.
+        """
+
+        if self._unavailable:
+            return None
+        total = self._total_cpu_seconds()
+        if total is None:
+            # The session has exited (or /proc became unreadable). Keep whatever
+            # activity was already observed; the exit path owns the outcome.
+            return self._last_activity_at
+        previous = self._last_total_seconds
+        self._last_total_seconds = total
+        if previous is None:
+            # Baseline sample. The CPU consumed before the first observation
+            # cannot be attributed to a point in time, so it is not evidence yet.
+            return self._last_activity_at
+        if total - previous >= _MIN_CPU_DELTA_SECONDS:
+            self._last_activity_at = now
+        return self._last_activity_at
+
+    def _total_cpu_seconds(self) -> float | None:
+        """Sum utime+stime across the supervised session, or ``None`` if gone."""
+
+        total_ticks = 0
+        found = False
+        try:
+            entries = os.listdir(_PROC_ROOT)
+        except OSError:
+            if not self._warned:
+                logger.debug("Process activity probe cannot read /proc", exc_info=True)
+                self._warned = True
+            self._unavailable = True
+            return None
+
+        for entry in entries:
+            if not entry.isdigit():
+                continue
+            sample = self._read_stat(_PROC_ROOT / entry / "stat")
+            if sample is None:
+                continue
+            session, ticks = sample
+            if session != self._session_pid:
+                continue
+            found = True
+            total_ticks += ticks
+
+        if not found:
+            return None
+        return total_ticks / self._ticks_per_second
+
+    @staticmethod
+    def _read_stat(stat_path: Path) -> tuple[int, int] | None:
+        """Return ``(session_id, utime+stime_ticks)`` for one process."""
+
+        try:
+            raw = stat_path.read_text(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            # Process exited between listdir and read, or is not readable.
+            return None
+        close = raw.rfind(")")
+        if close == -1:
+            return None
+        fields = raw[close + 1 :].split()
+
+        def _field(index: int) -> int | None:
+            offset = index - _STAT_FIELD_OFFSET
+            if offset < 0 or offset >= len(fields):
+                return None
+            try:
+                return int(fields[offset])
+            except ValueError:
+                return None
+
+        session = _field(_STAT_FIELD_SESSION)
+        utime = _field(_STAT_FIELD_UTIME)
+        stime = _field(_STAT_FIELD_STIME)
+        if session is None or utime is None or stime is None:
+            return None
+        return session, utime + stime
+
+
+__all__ = ["ProcessActivityProbe"]

--- a/moonmind/workflows/temporal/runtime/process_activity.py
+++ b/moonmind/workflows/temporal/runtime/process_activity.py
@@ -62,6 +62,11 @@ class ProcessActivityProbe:
 
     ``sample`` is cheap enough to call on every heartbeat: it reads one small
     file per running process and does no allocation-heavy parsing.
+
+    The total is cumulative across the session's whole lifetime, not just its
+    currently live processes: CPU consumed by a descendant that has since exited
+    is retained, so the total never falls and a delta of zero always means the
+    session really did no work between samples.
     """
 
     def __init__(self, *, session_pid: int) -> None:
@@ -71,6 +76,14 @@ class ProcessActivityProbe:
         self._last_activity_at: datetime | None = None
         self._unavailable = not _PROC_ROOT.is_dir()
         self._warned = False
+        # Per-process CPU carried across samples so the session total is
+        # genuinely cumulative. ``/proc`` only shows live processes, so summing
+        # it alone makes the total *fall* when a descendant exits — a managed
+        # agent running a sequence of short-lived compilers or test processes
+        # would then read as stalled while working continuously, because each
+        # replacement has to re-earn the CPU its predecessor took with it.
+        self._live_ticks: dict[int, int] = {}
+        self._retired_ticks = 0
 
     @property
     def available(self) -> bool:
@@ -104,10 +117,11 @@ class ProcessActivityProbe:
         return self._last_activity_at
 
     def _total_cpu_seconds(self) -> float | None:
-        """Sum utime+stime across the supervised session, or ``None`` if gone."""
+        """Cumulative session CPU including exited descendants, or ``None``.
 
-        total_ticks = 0
-        found = False
+        ``None`` means the session is gone; the exit path owns that outcome.
+        """
+
         try:
             entries = os.listdir(_PROC_ROOT)
         except OSError:
@@ -117,6 +131,7 @@ class ProcessActivityProbe:
             self._unavailable = True
             return None
 
+        live: dict[int, int] = {}
         for entry in entries:
             if not entry.isdigit():
                 continue
@@ -126,12 +141,24 @@ class ProcessActivityProbe:
             session, ticks = sample
             if session != self._session_pid:
                 continue
-            found = True
-            total_ticks += ticks
+            live[int(entry)] = ticks
 
-        if not found:
+        if not live:
             return None
-        return total_ticks / self._ticks_per_second
+
+        for pid, ticks in self._live_ticks.items():
+            current = live.get(pid)
+            if current is None:
+                # Exited between samples: its CPU stays in the session total.
+                self._retired_ticks += ticks
+            elif current < ticks:
+                # The pid was recycled into this session. Retire the predecessor
+                # so the recycled process starts from its own zero rather than
+                # dragging the total backwards.
+                self._retired_ticks += ticks
+
+        self._live_ticks = live
+        return (self._retired_ticks + sum(live.values())) / self._ticks_per_second
 
     @staticmethod
     def _read_stat(stat_path: Path) -> tuple[int, int] | None:

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -23,10 +23,14 @@ CompletionCallback = Callable[[dict[str, Any]], Awaitable[None]]
 
 from moonmind.schemas.agent_runtime_models import (
     MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
+    ExecutionBudget,
+    ExecutionBudgetVerdict,
     ManagedRunRecord,
+    evaluate_execution_budget,
 )
 
 from .log_streamer import RuntimeLogStreamer
+from .process_activity import ProcessActivityProbe
 from .store import ManagedRunStore
 from .strategies import get_strategy
 from .strategies.base import ManagedRuntimeExitResult
@@ -62,12 +66,20 @@ class ManagedRunSupervisor:
         *,
         run_id: str,
         process: asyncio.subprocess.Process,
-        timeout_seconds: int = 3600,
+        budget: ExecutionBudget,
         exit_code_path: str | None = None,
         cleanup_paths: list[str] | None = None,
         deferred_cleanup_paths: list[str] | None = None,
     ) -> ManagedRunRecord:
-        """Supervise a process and track heartbeat, completion, and cleanup."""
+        """Supervise a process and track heartbeat, completion, and cleanup.
+
+        ``budget`` is the run's progress-aware execution budget, resolved by the
+        caller from the same ``timeoutPolicy`` the AgentRun workflow published, so
+        the supervisor's kill deadline and the workflow's cannot diverge. The
+        process is terminated when the budget's base window elapses *and*
+        progress has gone stale, or when its hard ceiling is reached — never on
+        elapsed wall-clock alone.
+        """
         self._active_processes[run_id] = process
         registered_paths: list[str] = list(cleanup_paths or [])
         if exit_code_path:
@@ -105,6 +117,14 @@ class ManagedRunSupervisor:
             # actively-working run is falsely escalated to intervention.
             output_offset = 0
             latest_observed_progress_at: datetime | None = None
+            # Runtime-neutral activity evidence. Output and workspace mutation
+            # both go quiet during legitimate work (a buffered one-shot CLI, or a
+            # test run that only writes ignored directories), while a wedged
+            # process consumes no CPU at all. Progress is the newest of all three
+            # signals so no single blind spot can strand a healthy run.
+            activity_probe = ProcessActivityProbe(session_pid=process.pid)
+            budget_verdict: ExecutionBudgetVerdict = "continue"
+            budget_extended = False
             first_stdout_seen = False
             first_stderr_seen = False
             stderr_buffer = ""
@@ -112,7 +132,9 @@ class ManagedRunSupervisor:
             warning_dedup_announced: set[str] = set()
             progress_probe_warning_logged = False
             progress_timeout_seconds = (
-                strategy.progress_stall_timeout_seconds(timeout_seconds=timeout_seconds)
+                strategy.progress_stall_timeout_seconds(
+                    timeout_seconds=budget.base_seconds
+                )
                 if strategy is not None
                 else None
             )
@@ -233,6 +255,12 @@ class ManagedRunSupervisor:
             async def _latest_progress_at() -> datetime:
                 nonlocal progress_probe_warning_logged
                 latest = last_output_seen_at
+                activity_at = await asyncio.to_thread(
+                    activity_probe.sample,
+                    datetime.now(tz=UTC),
+                )
+                if activity_at is not None:
+                    latest = max(latest, activity_at)
                 if (
                     strategy is None
                     or record is None
@@ -320,6 +348,50 @@ class ManagedRunSupervisor:
                 )
                 last_no_output_annotation_at = now
 
+            def budget_elapsed_seconds() -> float:
+                """Real elapsed run time, for messages that must not understate it."""
+                return (datetime.now(tz=UTC) - start_time).total_seconds()
+
+            def _idle_progress_seconds(now: datetime) -> float | None:
+                # ``None`` means no progress has ever been observed for this run.
+                # That is not evidence of health, so the budget treats it exactly
+                # as it did before progress-awareness: terminate at the base
+                # window. Only positively observed progress buys an extension.
+                if latest_observed_progress_at is None:
+                    return None
+                return max(
+                    0.0,
+                    (now - latest_observed_progress_at).total_seconds(),
+                )
+
+            def _on_budget_extended(
+                elapsed_seconds: float,
+                idle_seconds: float | None,
+            ) -> None:
+                nonlocal budget_extended
+                if budget_extended:
+                    return
+                budget_extended = True
+                _record_annotation(
+                    annotation_type="execution_budget_extended_for_progress",
+                    text=(
+                        "Supervisor: base execution budget of "
+                        f"{budget.base_seconds}s elapsed while progress was still "
+                        "observable; continuing until progress goes stale or the "
+                        f"{budget.max_seconds}s ceiling is reached."
+                    ),
+                    reason="progress_observed",
+                    metadata={
+                        "base_seconds": budget.base_seconds,
+                        "max_seconds": budget.max_seconds,
+                        "progress_stall_seconds": budget.progress_stall_seconds,
+                        "elapsed_seconds": int(elapsed_seconds),
+                        "idle_progress_seconds": (
+                            int(idle_seconds) if idle_seconds is not None else None
+                        ),
+                    },
+                )
+
             def _progress_snapshot() -> tuple[datetime | None, int | None]:
                 # Snapshot of observed output progress for the heartbeat store
                 # update. ``latest_observed_progress_at`` is refreshed every
@@ -342,12 +414,15 @@ class ManagedRunSupervisor:
             # block indefinitely — a deadlock.  Concurrent streaming also means
             # output is captured as it is produced, enabling true live output.
             heartbeat_task = asyncio.create_task(
-                self._heartbeat_and_wait_with_timeout(
+                self._heartbeat_and_wait_within_budget(
                     run_id,
                     process,
-                    timeout_seconds,
+                    budget,
+                    started_at=start_time,
+                    idle_progress_seconds=_idle_progress_seconds,
                     no_output_callback=_emit_no_output_annotation,
                     progress_snapshot=_progress_snapshot,
+                    on_budget_extended=_on_budget_extended,
                 )
             )
             stream_task = asyncio.create_task(
@@ -377,7 +452,8 @@ class ManagedRunSupervisor:
                         trigger=stalled_progress_detected,
                     )
                 )
-            process_exit_code, timed_out = await heartbeat_task
+            process_exit_code, budget_verdict = await heartbeat_task
+            timed_out = budget_verdict != "continue"
             # Descendants can inherit the managed process pipes after the CLI
             # exits. Terminate the owned group before waiting for EOF so those
             # inherited descriptors cannot keep stream collection alive.
@@ -428,8 +504,18 @@ class ManagedRunSupervisor:
             if timed_out_by_supervisor:
                 _record_annotation(
                     annotation_type="termination_requested_timeout",
-                    text="Supervisor: process termination requested after timeout.",
+                    text=(
+                        "Supervisor: process termination requested after "
+                        f"{self._budget_expiry_text(budget, budget_verdict, budget_elapsed_seconds())}."
+                    ),
                     reason="timeout",
+                    metadata={
+                        "budget_verdict": budget_verdict,
+                        "base_seconds": budget.base_seconds,
+                        "max_seconds": budget.max_seconds,
+                        "progress_stall_seconds": budget.progress_stall_seconds,
+                        "budget_extended_for_progress": budget_extended,
+                    },
                 )
             if live_rate_limit_requested:
                 _record_annotation(
@@ -497,7 +583,8 @@ class ManagedRunSupervisor:
                         error_message += f": {parsed_output.error_messages[0]}"
             elif status == "timed_out":
                 error_message = (
-                    f"Process timed out after {timeout_seconds}s"
+                    "Process timed out after "
+                    f"{self._budget_expiry_text(budget, budget_verdict, budget_elapsed_seconds())}"
                 )
             if status == "completed":
                 _record_annotation(
@@ -604,28 +691,88 @@ class ManagedRunSupervisor:
                 exc_info=True,
             )
 
-    async def _heartbeat_and_wait(
+    @staticmethod
+    def _budget_expiry_text(
+        budget: ExecutionBudget,
+        verdict: ExecutionBudgetVerdict,
+        elapsed_seconds: float,
+    ) -> str:
+        """Describe *why* the budget ended the run, not merely that it did.
+
+        A run terminated at the hard ceiling and one terminated for going quiet
+        need different operator responses (raise the ceiling versus investigate a
+        wedged runtime), so the two are never collapsed into one message. The
+        elapsed time is the real one — a run that earned an extension and then
+        went quiet ran longer than its base window, and saying otherwise would
+        send the operator looking for the wrong thing.
+        """
+
+        if verdict == "expired_max_budget":
+            return (
+                f"{int(elapsed_seconds)}s, reaching the maximum execution budget "
+                f"of {budget.max_seconds}s (progress no longer extends the run "
+                "past this ceiling)"
+            )
+        return (
+            f"{int(elapsed_seconds)}s with no observable progress for "
+            f"{budget.progress_stall_seconds}s "
+            f"(base execution budget {budget.base_seconds}s)"
+        )
+
+    async def _heartbeat_and_wait_within_budget(
         self,
         run_id: str,
         process: asyncio.subprocess.Process,
+        budget: ExecutionBudget,
+        *,
+        started_at: datetime,
+        idle_progress_seconds: Callable[[datetime], float | None],
         no_output_callback: Callable[[datetime], Awaitable[None]] | None = None,
         progress_snapshot: Callable[[], tuple[datetime | None, int | None]]
         | None = None,
-    ) -> int:
-        """Send heartbeats while waiting for the process to complete.
+        on_budget_extended: Callable[[float, float | None], None] | None = None,
+    ) -> tuple[int | None, ExecutionBudgetVerdict]:
+        """Heartbeat while waiting, enforcing the progress-aware budget.
 
-        Each heartbeat also persists observed output progress
-        (``last_log_at``/``last_log_offset``) when ``progress_snapshot`` is
-        supplied, so the workflow-level no-progress watchdog can distinguish a
-        live, working run from a genuinely stuck one. ``last_heartbeat_at`` is
-        pure process liveness and is intentionally ignored by that watchdog.
+        Returns ``(exit_code, verdict)``. A ``continue`` verdict means the process
+        exited on its own and ``exit_code`` is authoritative; any other verdict
+        means the budget ended the run and ``exit_code`` is ``None``.
+
+        This replaces a flat ``asyncio.wait_for(timeout_seconds)``. That deadline
+        could not see progress, so it killed runs that were actively working —
+        the whole point of the budget is that elapsed wall-clock alone is not
+        evidence of a stuck run. The budget is re-evaluated on the fast tick
+        rather than only per heartbeat so the ceiling is still enforced promptly;
+        the progress timestamp it reads is refreshed by ``no_output_callback``
+        once per heartbeat, which is far finer than the stall window it feeds.
+
+        On expiry the process is terminated immediately so the concurrent
+        streaming task observes EOF and completes, allowing the caller's gather
+        to unblock. Without this it would block forever on EOF that never comes.
         """
         loop = asyncio.get_running_loop()
         next_heartbeat_at = loop.time() + HEARTBEAT_INTERVAL
         while True:
             if process.returncode is not None:
-                return process.returncode
+                return process.returncode, "continue"
             await asyncio.sleep(0.1)
+
+            now = datetime.now(tz=UTC)
+            elapsed = (now - started_at).total_seconds()
+            idle_seconds = idle_progress_seconds(now)
+            verdict = evaluate_execution_budget(
+                budget=budget,
+                elapsed_seconds=elapsed,
+                idle_progress_seconds=idle_seconds,
+            )
+            if verdict != "continue":
+                await self._terminate_process(process)
+                if no_output_callback is not None:
+                    await no_output_callback(datetime.now(tz=UTC))
+                return None, verdict
+            if elapsed >= budget.base_seconds and on_budget_extended is not None:
+                on_budget_extended(elapsed, idle_seconds)
+
             if loop.time() < next_heartbeat_at:
                 continue
             next_heartbeat_at = loop.time() + HEARTBEAT_INTERVAL
@@ -649,45 +796,6 @@ class ManagedRunSupervisor:
                 last_heartbeat_at=datetime.now(tz=UTC),
                 **progress_fields,
             )
-
-    async def _heartbeat_and_wait_with_timeout(
-        self,
-        run_id: str,
-        process: asyncio.subprocess.Process,
-        timeout_seconds: int,
-        no_output_callback: Callable[[datetime], Awaitable[None]] | None = None,
-        progress_snapshot: Callable[[], tuple[datetime | None, int | None]]
-        | None = None,
-    ) -> tuple[int | None, bool]:
-        """Wrap _heartbeat_and_wait with a total timeout.
-
-        Returns ``(exit_code, timed_out)`` so callers can unpack both
-        the process exit code and the timeout flag from a single awaitable,
-        making it composable with ``asyncio.gather()``.
-
-        On timeout, the process is terminated immediately so that any
-        concurrent streaming task observes EOF and exits promptly.
-        Without this, ``asyncio.gather()`` would block indefinitely on
-        the stream task waiting for EOF that never arrives.
-        """
-        try:
-            exit_code = await asyncio.wait_for(
-                self._heartbeat_and_wait(
-                    run_id,
-                    process,
-                    no_output_callback=no_output_callback,
-                    progress_snapshot=progress_snapshot,
-                ),
-                timeout=timeout_seconds,
-            )
-            return exit_code, False
-        except asyncio.TimeoutError:
-            # Terminate the process so the concurrent streaming task sees EOF
-            # and can complete, allowing asyncio.gather() to unblock.
-            await self._terminate_process(process)
-            if no_output_callback is not None:
-                await no_output_callback(datetime.now(tz=UTC))
-            return None, True
 
     async def cancel(self, run_id: str) -> None:
         """Cancel a running managed process: terminate -> wait -> kill."""

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -7,6 +7,7 @@ import logging
 import os
 import signal
 import shutil
+import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from temporalio import activity
@@ -92,6 +93,12 @@ class ManagedRunSupervisor:
         )
         self._store.update_status(run_id, "running")
         start_time = datetime.now(tz=UTC)
+        # Wall-clock ``start_time`` is the run's evidence; the budget's intervals
+        # are measured from this monotonic anchor instead. A host clock step
+        # forward would otherwise terminate a healthy run as over-budget, and a
+        # step backward would let it run past the ceiling the AgentRun workflow
+        # is enforcing — the two deadlines must stay the same boundary.
+        start_monotonic = time.monotonic()
 
         try:
             # Resolve strategy output parser for this runtime
@@ -117,6 +124,13 @@ class ManagedRunSupervisor:
             # actively-working run is falsely escalated to intervention.
             output_offset = 0
             latest_observed_progress_at: datetime | None = None
+            # Monotonic counterpart of ``latest_observed_progress_at``. Progress
+            # evidence is persisted as wall-clock because it must line up with
+            # file mtimes and operator timelines, but staleness is judged from a
+            # monotonic anchor so a clock adjustment cannot manufacture or erase
+            # an idle window. The anchor only ever moves forward: nothing but
+            # observed progress may reduce measured idle time.
+            latest_progress_monotonic: float | None = None
             # Runtime-neutral activity evidence. Output and workspace mutation
             # both go quiet during legitimate work (a buffered one-shot CLI, or a
             # test run that only writes ignored directories), while a wedged
@@ -294,7 +308,8 @@ class ManagedRunSupervisor:
 
             async def _emit_no_output_annotation(now: datetime) -> None:
                 nonlocal last_no_output_annotation_at, stalled_no_progress, stalled_progress_reason
-                nonlocal latest_observed_progress_at
+                nonlocal latest_observed_progress_at, latest_progress_monotonic
+                sampled_at_monotonic = time.monotonic()
                 latest_progress_at = await _latest_progress_at()
                 # Cache the supervisor's authoritative progress signal so the
                 # heartbeat loop can persist it to the run store. This runs on
@@ -305,6 +320,17 @@ class ManagedRunSupervisor:
                     0.0,
                     (now - latest_progress_at).total_seconds(),
                 )
+                # Anchor this observation on the monotonic clock at the age it
+                # had when sampled, so the budget measures staleness by elapsed
+                # monotonic time rather than by comparing two wall-clock reads.
+                observed_progress_monotonic = (
+                    sampled_at_monotonic - idle_progress_seconds
+                )
+                if (
+                    latest_progress_monotonic is None
+                    or observed_progress_monotonic > latest_progress_monotonic
+                ):
+                    latest_progress_monotonic = observed_progress_monotonic
                 if (
                     progress_timeout_seconds is not None
                     and not stalled_progress_detected.is_set()
@@ -350,19 +376,16 @@ class ManagedRunSupervisor:
 
             def budget_elapsed_seconds() -> float:
                 """Real elapsed run time, for messages that must not understate it."""
-                return (datetime.now(tz=UTC) - start_time).total_seconds()
+                return time.monotonic() - start_monotonic
 
-            def _idle_progress_seconds(now: datetime) -> float | None:
+            def _idle_progress_seconds(now_monotonic: float) -> float | None:
                 # ``None`` means no progress has ever been observed for this run.
                 # That is not evidence of health, so the budget treats it exactly
                 # as it did before progress-awareness: terminate at the base
                 # window. Only positively observed progress buys an extension.
-                if latest_observed_progress_at is None:
+                if latest_progress_monotonic is None:
                     return None
-                return max(
-                    0.0,
-                    (now - latest_observed_progress_at).total_seconds(),
-                )
+                return max(0.0, now_monotonic - latest_progress_monotonic)
 
             def _on_budget_extended(
                 elapsed_seconds: float,
@@ -418,7 +441,7 @@ class ManagedRunSupervisor:
                     run_id,
                     process,
                     budget,
-                    started_at=start_time,
+                    monotonic_started_at=start_monotonic,
                     idle_progress_seconds=_idle_progress_seconds,
                     no_output_callback=_emit_no_output_annotation,
                     progress_snapshot=_progress_snapshot,
@@ -725,8 +748,8 @@ class ManagedRunSupervisor:
         process: asyncio.subprocess.Process,
         budget: ExecutionBudget,
         *,
-        started_at: datetime,
-        idle_progress_seconds: Callable[[datetime], float | None],
+        monotonic_started_at: float,
+        idle_progress_seconds: Callable[[float], float | None],
         no_output_callback: Callable[[datetime], Awaitable[None]] | None = None,
         progress_snapshot: Callable[[], tuple[datetime | None, int | None]]
         | None = None,
@@ -742,9 +765,19 @@ class ManagedRunSupervisor:
         could not see progress, so it killed runs that were actively working —
         the whole point of the budget is that elapsed wall-clock alone is not
         evidence of a stuck run. The budget is re-evaluated on the fast tick
-        rather than only per heartbeat so the ceiling is still enforced promptly;
-        the progress timestamp it reads is refreshed by ``no_output_callback``
-        once per heartbeat, which is far finer than the stall window it feeds.
+        rather than only per heartbeat so the ceiling is still enforced promptly.
+
+        Elapsed and idle intervals are measured monotonically. A host clock step
+        must not be able to terminate a healthy run as over-budget, nor let a
+        wedged one outlive the AgentRun workflow's deadline for the same run.
+
+        The cached progress timestamp is only refreshed once per heartbeat, so a
+        stall verdict computed from it can be a whole heartbeat interval stale.
+        Before ending a run for lack of progress this samples current CPU and
+        workspace activity and re-decides: a process that resumed work seconds
+        before its stall boundary must not be killed for activity the supervisor
+        simply had not looked for yet. The ceiling is exempt — no amount of
+        observed progress extends a run past ``max_seconds``.
 
         On expiry the process is terminated immediately so the concurrent
         streaming task observes EOF and completes, allowing the caller's gather
@@ -757,19 +790,32 @@ class ManagedRunSupervisor:
                 return process.returncode, "continue"
             await asyncio.sleep(0.1)
 
-            now = datetime.now(tz=UTC)
-            elapsed = (now - started_at).total_seconds()
-            idle_seconds = idle_progress_seconds(now)
+            now_monotonic = time.monotonic()
+            elapsed = now_monotonic - monotonic_started_at
+            idle_seconds = idle_progress_seconds(now_monotonic)
             verdict = evaluate_execution_budget(
                 budget=budget,
                 elapsed_seconds=elapsed,
                 idle_progress_seconds=idle_seconds,
             )
             if verdict != "continue":
-                await self._terminate_process(process)
-                if no_output_callback is not None:
+                refreshed_for_expiry = False
+                if verdict == "expired_no_progress" and no_output_callback is not None:
                     await no_output_callback(datetime.now(tz=UTC))
-                return None, verdict
+                    refreshed_for_expiry = True
+                    now_monotonic = time.monotonic()
+                    elapsed = now_monotonic - monotonic_started_at
+                    idle_seconds = idle_progress_seconds(now_monotonic)
+                    verdict = evaluate_execution_budget(
+                        budget=budget,
+                        elapsed_seconds=elapsed,
+                        idle_progress_seconds=idle_seconds,
+                    )
+                if verdict != "continue":
+                    await self._terminate_process(process)
+                    if no_output_callback is not None and not refreshed_for_expiry:
+                        await no_output_callback(datetime.now(tz=UTC))
+                    return None, verdict
             if elapsed >= budget.base_seconds and on_budget_extended is not None:
                 on_budget_extended(elapsed, idle_seconds)
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -25,8 +25,11 @@ with workflow.unsafe.imports_passed_through():
         AgentRunHandle,
         AgentRunResult,
         AgentRunStatus as AgentRunStatusModel,
+        ExecutionBudget,
+        ExecutionBudgetVerdict,
         ProfileSelector,
-        resolve_execution_timeout_seconds,
+        evaluate_execution_budget,
+        resolve_execution_budget,
         _MAX_SUMMARY_CHARS,
     )
     from moonmind.schemas.managed_session_models import (
@@ -319,6 +322,18 @@ AGENT_RUN_MANAGED_NO_PROGRESS_CANCEL_FETCH_PATCH_ID = (
 # patch keep the launch payload they already dispatched.
 AGENT_RUN_SHARED_EXECUTION_BUDGET_PATCH_ID = (
     "agent-run-shared-execution-budget-v1"
+)
+# Makes the execution budget progress-aware. Elapsed wall-clock alone is not
+# evidence that a run is stuck: a one-shot runtime such as ``claude -p`` emits
+# nothing until its turn completes, so the flat budget terminated runs that were
+# actively working — MoonLadderStudios/MoonMind#3771 discarded an hour of
+# uncommitted work from a run that wrote files three seconds before the kill, and
+# reported it as "no observable progress". With this patch the base budget only
+# ends a run whose observed progress has gone stale; a progressing run continues
+# to the budget's hard ceiling. In-flight runs keep the flat deadline they were
+# started with so their recorded decisions replay unchanged.
+AGENT_RUN_PROGRESS_AWARE_EXECUTION_BUDGET_PATCH_ID = (
+    "agent-run-progress-aware-execution-budget-v1"
 )
 MANAGED_SESSION_START_AFTER_SLOT_PATCH_ID = (
     "agent-run-managed-session-start-after-slot-v1"
@@ -1251,6 +1266,155 @@ class MoonMindAgentRun:
         return max(0, int(policy.get("noProgressGraceSeconds") or 0))
 
     @staticmethod
+    def _effective_deadline_seconds(
+        *,
+        budget: ExecutionBudget,
+        elapsed_seconds: float,
+        idle_progress_seconds: float | None,
+    ) -> float:
+        """Seconds-from-start at which the run must stop, given current progress.
+
+        Below the base window this is the base window. Once the base window has
+        elapsed while progress is still fresh, the deadline rolls forward to the
+        moment progress *would* go stale, capped at the hard ceiling.
+
+        Every remaining-time computation in the poll loop derives from this, so a
+        run that has earned an extension is not cut short by a poll wait or a
+        status-activity budget that still believes the base window is the end.
+        It agrees with :func:`evaluate_execution_budget` by construction: that
+        function returns a non-``continue`` verdict exactly when ``elapsed_seconds``
+        has reached the deadline this returns.
+        """
+
+        if idle_progress_seconds is None:
+            return float(budget.base_seconds)
+        goes_stale_at = (
+            elapsed_seconds - idle_progress_seconds + budget.progress_stall_seconds
+        )
+        return float(
+            min(budget.max_seconds, max(budget.base_seconds, goes_stale_at))
+        )
+
+    @staticmethod
+    def _publish_execution_budget(
+        *,
+        request: AgentExecutionRequest,
+        budget: ExecutionBudget,
+        progress_aware: bool,
+    ) -> None:
+        """Republish the resolved budget into the request the launcher receives.
+
+        The supervisor must extend and terminate on the same numbers the workflow
+        enforces, so the whole budget travels — not just the base window.
+        Publishing only the base window would let the process be killed at the
+        base budget even though the workflow had granted an extension.
+
+        Adding keys keeps the launch payload backward-compatible: a worker that
+        does not read them resolves the same defaults from the base window.
+        """
+
+        published: dict[str, Any] = {
+            **(request.timeout_policy or {}),
+            "timeout_seconds": budget.base_seconds,
+        }
+        if progress_aware:
+            published.update(budget.as_timeout_policy())
+        request.timeout_policy = published
+
+    @staticmethod
+    def _budget_idle_progress_seconds(
+        *,
+        progress_aware: bool,
+        last_progress_at: datetime | None,
+        now: datetime,
+    ) -> float | None:
+        """How long ago progress was last observed, or ``None`` if never.
+
+        ``None`` is not evidence of health — it makes the budget behave exactly
+        as the old flat deadline did. Only positively observed progress buys an
+        extension, and a run replaying from before the progress-aware patch never
+        observes any.
+        """
+
+        if not progress_aware or last_progress_at is None:
+            return None
+        return max(0.0, (now - last_progress_at).total_seconds())
+
+    @classmethod
+    def _budget_deadline_for(
+        cls,
+        *,
+        budget: ExecutionBudget,
+        progress_aware: bool,
+        elapsed_seconds: float,
+        idle_progress_seconds: float | None,
+    ) -> float:
+        """Seconds-from-start the run may currently reach.
+
+        Every remaining-time computation in the poll loop derives from this, so a
+        run that earned an extension is not cut short by a poll wait or a status
+        budget that still believes the base window is the end.
+        """
+
+        if not progress_aware:
+            return float(budget.base_seconds)
+        return cls._effective_deadline_seconds(
+            budget=budget,
+            elapsed_seconds=elapsed_seconds,
+            idle_progress_seconds=idle_progress_seconds,
+        )
+
+    @staticmethod
+    def _budget_verdict_for(
+        *,
+        budget: ExecutionBudget,
+        progress_aware: bool,
+        elapsed_seconds: float,
+        idle_progress_seconds: float | None,
+    ) -> ExecutionBudgetVerdict:
+        """Whether the execution budget still permits the run to continue."""
+
+        if not progress_aware:
+            return (
+                "continue"
+                if elapsed_seconds < budget.base_seconds
+                else "expired_no_progress"
+            )
+        return evaluate_execution_budget(
+            budget=budget,
+            elapsed_seconds=elapsed_seconds,
+            idle_progress_seconds=idle_progress_seconds,
+        )
+
+    @staticmethod
+    def _budget_expiry_detail_for(
+        *,
+        budget: ExecutionBudget,
+        progress_aware: bool,
+        verdict: ExecutionBudgetVerdict,
+    ) -> str:
+        """Operator-facing reason the budget ended the run.
+
+        A run that was extended for observed progress and then hit the ceiling is
+        never described as having made no progress: the two outcomes call for
+        different operator responses (raise the ceiling versus investigate a
+        wedged runtime).
+        """
+
+        if verdict == "expired_max_budget":
+            return (
+                "was still making progress but reached its maximum execution "
+                f"budget of {budget.max_seconds}s"
+            )
+        if progress_aware:
+            return (
+                "made no observable progress for "
+                f"{budget.progress_stall_seconds}s and exceeded its "
+                "execution budget"
+            )
+        return "made no observable progress and exceeded its execution budget"
+
+    @staticmethod
     def _result_requires_provider_cooldown(result: AgentRunResult | None) -> bool:
         if result is None:
             return False
@@ -1295,6 +1459,8 @@ class MoonMindAgentRun:
         timeout_seconds: float,
         detail: str,
         elapsed_seconds: float | None = None,
+        budget: ExecutionBudget | None = None,
+        verdict: ExecutionBudgetVerdict | None = None,
     ) -> AgentRunResult:
         """Build a failed result for an agent-run timeout with an actionable summary.
 
@@ -1322,6 +1488,22 @@ class MoonMindAgentRun:
         }
         if elapsed_seconds is not None:
             metadata["elapsedSeconds"] = int(elapsed_seconds)
+        if budget is not None:
+            # Record the budget the decision was made against so an operator can
+            # tell "raise the ceiling" from "the runtime went quiet" without
+            # reconstructing it from logs.
+            metadata["executionBudget"] = {
+                "baseSeconds": budget.base_seconds,
+                "maxSeconds": budget.max_seconds,
+                "progressStallSeconds": budget.progress_stall_seconds,
+            }
+            metadata["budgetExtendedForProgress"] = (
+                elapsed_seconds is not None
+                and elapsed_seconds >= budget.base_seconds
+                and verdict == "expired_max_budget"
+            )
+        if verdict is not None:
+            metadata["budgetVerdict"] = verdict
         return AgentRunResult(
             summary=summary,
             failure_class="execution_error",
@@ -4352,18 +4534,63 @@ class MoonMindAgentRun:
         # and the managed process supervisor's kill deadline resolve from the
         # same value, so an explicitly requested larger budget is honored at both
         # boundaries instead of the process being killed at the launch default.
-        timeout_seconds = resolve_execution_timeout_seconds(
+        execution_budget = resolve_execution_budget(
             agent_kind=request.agent_kind,
             timeout_policy=request.timeout_policy,
         )
+        timeout_seconds = execution_budget.base_seconds
+        # Progress-awareness is a decision change, so it is versioned. Runs
+        # started before this patch keep the flat deadline they recorded.
+        progress_aware_budget = workflow.patched(
+            AGENT_RUN_PROGRESS_AWARE_EXECUTION_BUDGET_PATCH_ID
+        )
         if workflow.patched(AGENT_RUN_SHARED_EXECUTION_BUDGET_PATCH_ID):
-            request.timeout_policy = {
-                **(request.timeout_policy or {}),
-                "timeout_seconds": timeout_seconds,
-            }
+            self._publish_execution_budget(
+                request=request,
+                budget=execution_budget,
+                progress_aware=progress_aware_budget,
+            )
 
         # Loop for handling 429 cooldown & profile swaps safely within the timeout boundary
         overall_start = workflow.now()
+        # Progress evidence for the progress-aware execution budget. ``None``
+        # means no progress has been observed for this run yet, which the budget
+        # treats exactly as the old flat deadline: only positively observed
+        # progress buys an extension. Progress is defined by the same status
+        # signature the no-progress watchdog uses, so there is one notion of
+        # progress in the workflow rather than two that can disagree.
+        last_progress_at: datetime | None = None
+
+        def _budget_idle_seconds() -> float | None:
+            return self._budget_idle_progress_seconds(
+                progress_aware=progress_aware_budget,
+                last_progress_at=last_progress_at,
+                now=workflow.now(),
+            )
+
+        def _budget_deadline_seconds() -> float:
+            return self._budget_deadline_for(
+                budget=execution_budget,
+                progress_aware=progress_aware_budget,
+                elapsed_seconds=(workflow.now() - overall_start).total_seconds(),
+                idle_progress_seconds=_budget_idle_seconds(),
+            )
+
+        def _budget_verdict() -> ExecutionBudgetVerdict:
+            return self._budget_verdict_for(
+                budget=execution_budget,
+                progress_aware=progress_aware_budget,
+                elapsed_seconds=(workflow.now() - overall_start).total_seconds(),
+                idle_progress_seconds=_budget_idle_seconds(),
+            )
+
+        def _budget_expiry_detail(verdict: ExecutionBudgetVerdict) -> str:
+            return self._budget_expiry_detail_for(
+                budget=execution_budget,
+                progress_aware=progress_aware_budget,
+                verdict=verdict,
+            )
+
         use_managed_status_activity = workflow.patched(
             MANAGED_STATUS_ACTIVITY_PATCH_ID
         )
@@ -4406,18 +4633,23 @@ class MoonMindAgentRun:
                 uses_codex_session_adapter = self._uses_codex_session_adapter(request)
                 parent_info = workflow.info().parent
                 elapsed = (workflow.now() - overall_start).total_seconds()
-                if elapsed >= timeout_seconds:
+                pre_dispatch_verdict = _budget_verdict()
+                if pre_dispatch_verdict != "continue":
                     self.run_status = RunStatus.timed_out
                     return await self._publish_terminal_result_with_compacted_replay_cleanup(
                         request=request,
                         result=self._timed_out_result(
                             request=request,
-                            timeout_seconds=timeout_seconds,
+                            timeout_seconds=_budget_deadline_seconds(),
                             elapsed_seconds=elapsed,
                             detail=(
                                 "exceeded its execution budget before dispatching "
                                 "a turn"
                             ),
+                            budget=(
+                                execution_budget if progress_aware_budget else None
+                            ),
+                            verdict=pre_dispatch_verdict,
                         ),
                     )
 
@@ -4973,9 +5205,13 @@ class MoonMindAgentRun:
                             )
 
                         async def _send_turn(request_payload: Any) -> Any:
+                            # Evaluated at dispatch time so a turn that starts
+                            # after the base window — because the run earned an
+                            # extension for observed progress — gets the extended
+                            # deadline rather than a negative budget.
                             return await self._send_turn_within_budget(
                                 request_payload,
-                                timeout_seconds=timeout_seconds,
+                                timeout_seconds=_budget_deadline_seconds(),
                                 overall_start=overall_start,
                             )
 
@@ -5336,8 +5572,17 @@ class MoonMindAgentRun:
                             # activity dispatcher because that boundary invokes
                             # the exact recorded realizer from the persisted
                             # plan instead of the generic supervisor.
+                            # ScheduleToClose must cover the longest the run can
+                            # legally take, otherwise Temporal cancels the
+                            # activity at the base window and an extension the
+                            # budget granted cannot actually be used.
+                            stc_budget_seconds = (
+                                execution_budget.max_seconds
+                                if progress_aware_budget
+                                else int(timeout_seconds)
+                            )
                             stc_seconds = min(
-                                max(int(timeout_seconds), 60),
+                                max(int(stc_budget_seconds), 60),
                                 86400,
                             )
                             act_name = f"integration.{validated_id}.execute"
@@ -5445,7 +5690,10 @@ class MoonMindAgentRun:
                                 )
                             self.run_status = RunStatus.running
 
-                        remaining_timeout = timeout_seconds - (workflow.now() - overall_start).total_seconds()
+                        remaining_timeout = (
+                            _budget_deadline_seconds()
+                            - (workflow.now() - overall_start).total_seconds()
+                        )
                         if remaining_timeout <= 0:
                             break
 
@@ -5475,9 +5723,10 @@ class MoonMindAgentRun:
                                 fallback_agent_id=request.agent_id,
                             )
                         else:
-                            remaining_status_budget = timeout_seconds - (
-                                workflow.now() - overall_start
-                            ).total_seconds()
+                            remaining_status_budget = (
+                                _budget_deadline_seconds()
+                                - (workflow.now() - overall_start).total_seconds()
+                            )
                             if (
                                 use_managed_status_activity
                                 and not uses_codex_session_adapter
@@ -5496,15 +5745,23 @@ class MoonMindAgentRun:
                             )
 
                         self.run_status = status_obj.status
+                        # One progress observation feeds both the no-progress
+                        # watchdog and the execution budget, so the two can never
+                        # disagree about whether this run is making progress.
+                        progress_signature = self._status_progress_signature(
+                            status_obj
+                        )
+                        progress_observed = (
+                            progress_signature != last_progress_signature
+                        )
+                        last_progress_signature = progress_signature
+                        if progress_observed:
+                            last_progress_at = workflow.now()
                         if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
-                            progress_signature = self._status_progress_signature(
-                                status_obj
-                            )
-                            if progress_signature == last_progress_signature:
-                                stagnant_poll_count += 1
-                            else:
-                                last_progress_signature = progress_signature
+                            if progress_observed:
                                 stagnant_poll_count = 0
+                            else:
+                                stagnant_poll_count += 1
                             max_stagnant_polls = self._max_no_progress_polls(
                                 policy=resiliency_policy,
                                 poll_interval=poll_interval,
@@ -5699,7 +5956,8 @@ class MoonMindAgentRun:
 
                 elapsed = (workflow.now() - overall_start).total_seconds()
 
-                if elapsed >= timeout_seconds and not self.completion_event.is_set():
+                terminal_verdict = _budget_verdict()
+                if terminal_verdict != "continue" and not self.completion_event.is_set():
                     self.run_status = RunStatus.timed_out
                     if manager_handle and request.execution_profile_ref:
                         await manager_handle.signal(
@@ -5713,12 +5971,13 @@ class MoonMindAgentRun:
                         request=request,
                         result=self._timed_out_result(
                             request=request,
-                            timeout_seconds=timeout_seconds,
+                            timeout_seconds=_budget_deadline_seconds(),
                             elapsed_seconds=elapsed,
-                            detail=(
-                                "made no observable progress and exceeded its "
-                                "execution budget"
+                            detail=_budget_expiry_detail(terminal_verdict),
+                            budget=(
+                                execution_budget if progress_aware_budget else None
                             ),
+                            verdict=terminal_verdict,
                         ),
                     )
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -4561,28 +4561,44 @@ class MoonMindAgentRun:
         # progress in the workflow rather than two that can disagree.
         last_progress_at: datetime | None = None
 
-        def _budget_idle_seconds() -> float | None:
-            return self._budget_idle_progress_seconds(
+        def _budget_state() -> tuple[float, ExecutionBudgetVerdict, float]:
+            """Read the clock once and derive ``(elapsed, verdict, deadline)``.
+
+            One read per evaluation keeps elapsed and idle-progress measured from
+            the same instant — deriving them from two separate ``workflow.now()``
+            calls would let the verdict and the deadline disagree about where the
+            run currently is. It also keeps the loop's clock-read count where it
+            was before the budget became progress-aware.
+            """
+
+            now = workflow.now()
+            elapsed_now = (now - overall_start).total_seconds()
+            idle_now = self._budget_idle_progress_seconds(
                 progress_aware=progress_aware_budget,
                 last_progress_at=last_progress_at,
-                now=workflow.now(),
+                now=now,
+            )
+            return (
+                elapsed_now,
+                self._budget_verdict_for(
+                    budget=execution_budget,
+                    progress_aware=progress_aware_budget,
+                    elapsed_seconds=elapsed_now,
+                    idle_progress_seconds=idle_now,
+                ),
+                self._budget_deadline_for(
+                    budget=execution_budget,
+                    progress_aware=progress_aware_budget,
+                    elapsed_seconds=elapsed_now,
+                    idle_progress_seconds=idle_now,
+                ),
             )
 
-        def _budget_deadline_seconds() -> float:
-            return self._budget_deadline_for(
-                budget=execution_budget,
-                progress_aware=progress_aware_budget,
-                elapsed_seconds=(workflow.now() - overall_start).total_seconds(),
-                idle_progress_seconds=_budget_idle_seconds(),
-            )
+        def _budget_remaining_seconds() -> float:
+            """Seconds the run may still execute under its current budget."""
 
-        def _budget_verdict() -> ExecutionBudgetVerdict:
-            return self._budget_verdict_for(
-                budget=execution_budget,
-                progress_aware=progress_aware_budget,
-                elapsed_seconds=(workflow.now() - overall_start).total_seconds(),
-                idle_progress_seconds=_budget_idle_seconds(),
-            )
+            elapsed_now, _, deadline_now = _budget_state()
+            return deadline_now - elapsed_now
 
         def _budget_expiry_detail(verdict: ExecutionBudgetVerdict) -> str:
             return self._budget_expiry_detail_for(
@@ -4632,15 +4648,18 @@ class MoonMindAgentRun:
                 )
                 uses_codex_session_adapter = self._uses_codex_session_adapter(request)
                 parent_info = workflow.info().parent
-                elapsed = (workflow.now() - overall_start).total_seconds()
-                pre_dispatch_verdict = _budget_verdict()
+                (
+                    elapsed,
+                    pre_dispatch_verdict,
+                    pre_dispatch_deadline,
+                ) = _budget_state()
                 if pre_dispatch_verdict != "continue":
                     self.run_status = RunStatus.timed_out
                     return await self._publish_terminal_result_with_compacted_replay_cleanup(
                         request=request,
                         result=self._timed_out_result(
                             request=request,
-                            timeout_seconds=_budget_deadline_seconds(),
+                            timeout_seconds=pre_dispatch_deadline,
                             elapsed_seconds=elapsed,
                             detail=(
                                 "exceeded its execution budget before dispatching "
@@ -5209,9 +5228,10 @@ class MoonMindAgentRun:
                             # after the base window — because the run earned an
                             # extension for observed progress — gets the extended
                             # deadline rather than a negative budget.
+                            _, _, turn_deadline = _budget_state()
                             return await self._send_turn_within_budget(
                                 request_payload,
-                                timeout_seconds=_budget_deadline_seconds(),
+                                timeout_seconds=turn_deadline,
                                 overall_start=overall_start,
                             )
 
@@ -5690,10 +5710,7 @@ class MoonMindAgentRun:
                                 )
                             self.run_status = RunStatus.running
 
-                        remaining_timeout = (
-                            _budget_deadline_seconds()
-                            - (workflow.now() - overall_start).total_seconds()
-                        )
+                        remaining_timeout = _budget_remaining_seconds()
                         if remaining_timeout <= 0:
                             break
 
@@ -5723,10 +5740,7 @@ class MoonMindAgentRun:
                                 fallback_agent_id=request.agent_id,
                             )
                         else:
-                            remaining_status_budget = (
-                                _budget_deadline_seconds()
-                                - (workflow.now() - overall_start).total_seconds()
-                            )
+                            remaining_status_budget = _budget_remaining_seconds()
                             if (
                                 use_managed_status_activity
                                 and not uses_codex_session_adapter
@@ -5954,9 +5968,7 @@ class MoonMindAgentRun:
                         if status_obj.status in _TERMINAL_RUN_STATUSES:
                             break
 
-                elapsed = (workflow.now() - overall_start).total_seconds()
-
-                terminal_verdict = _budget_verdict()
+                elapsed, terminal_verdict, terminal_deadline = _budget_state()
                 if terminal_verdict != "continue" and not self.completion_event.is_set():
                     self.run_status = RunStatus.timed_out
                     if manager_handle and request.execution_profile_ref:
@@ -5971,7 +5983,7 @@ class MoonMindAgentRun:
                         request=request,
                         result=self._timed_out_result(
                             request=request,
-                            timeout_seconds=_budget_deadline_seconds(),
+                            timeout_seconds=terminal_deadline,
                             elapsed_seconds=elapsed,
                             detail=_budget_expiry_detail(terminal_verdict),
                             budget=(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1309,6 +1309,17 @@ class MoonMindAgentRun:
         Publishing only the base window would let the process be killed at the
         base budget even though the workflow had granted an extension.
 
+        The *mode* travels too. A history that predates the progress-aware patch
+        keeps its flat deadline, and the launch activity re-resolves the budget
+        from this policy on every launch and retry — including retries that run
+        after the progress-aware deployment. Publishing only the base window
+        there would let the activity derive a progress-aware ceiling the workflow
+        never granted: the workflow would time out at the base window and release
+        the provider slot while the supervisor carried the process on to that
+        derived ceiling, leaving untracked work running against a profile already
+        handed to another run. Publishing the flat budget explicitly keeps the
+        two deadlines the same boundary.
+
         Adding keys keeps the launch payload backward-compatible: a worker that
         does not read them resolves the same defaults from the base window.
         """
@@ -1317,8 +1328,9 @@ class MoonMindAgentRun:
             **(request.timeout_policy or {}),
             "timeout_seconds": budget.base_seconds,
         }
-        if progress_aware:
-            published.update(budget.as_timeout_policy())
+        published.update(
+            (budget if progress_aware else budget.as_flat()).as_timeout_policy()
+        )
         request.timeout_policy = published
 
     @staticmethod
@@ -5592,17 +5604,21 @@ class MoonMindAgentRun:
                             # activity dispatcher because that boundary invokes
                             # the exact recorded realizer from the persisted
                             # plan instead of the generic supervisor.
-                            # ScheduleToClose must cover the longest the run can
-                            # legally take, otherwise Temporal cancels the
-                            # activity at the base window and an extension the
-                            # budget granted cannot actually be used.
-                            stc_budget_seconds = (
-                                execution_budget.max_seconds
-                                if progress_aware_budget
-                                else int(timeout_seconds)
-                            )
+                            # ScheduleToClose is the only deadline this lane
+                            # has. The workflow is blocked awaiting the activity
+                            # for its whole duration, so it cannot observe
+                            # provider progress or re-evaluate the budget, and
+                            # the activity's heartbeat is emitted independently
+                            # of semantic progress. Sizing this to the
+                            # progress-aware ceiling would therefore let a run
+                            # that never makes progress hold its provider slot
+                            # for the full ceiling with no boundary able to stop
+                            # it — four times its base window for the managed
+                            # default. Only a lane that can actually observe
+                            # progress may spend the extension, so this one stops
+                            # at the base window the workflow enforces.
                             stc_seconds = min(
-                                max(int(stc_budget_seconds), 60),
+                                max(int(timeout_seconds), 60),
                                 86400,
                             )
                             act_name = f"integration.{validated_id}.execute"
@@ -5691,6 +5707,14 @@ class MoonMindAgentRun:
                 if not skip_poll_and_fetch:
                     last_progress_signature: tuple[Any, ...] | None = None
                     stagnant_poll_count = 0
+                    # A budget verdict reached without polling status once more
+                    # is a verdict about stale evidence. The bounded wait below
+                    # can consume the entire known remaining budget, and the
+                    # supervisor progress that landed during that wait would then
+                    # never be read. Reconcile once against fresh status before
+                    # the verdict is accepted; a reconciliation that observes
+                    # progress rearms for the next boundary.
+                    budget_reconciled = False
                     while True:
                         if (
                             request.agent_kind == "external"
@@ -5749,7 +5773,16 @@ class MoonMindAgentRun:
                                 )
                                 and remaining_status_budget <= 0
                             ):
-                                break
+                                if not progress_aware_budget or budget_reconciled:
+                                    break
+                                # Final bounded reconciliation: the budget looks
+                                # spent, but the last wait may have hidden a
+                                # supervisor progress advance that extends it.
+                                # ``None`` gives this one poll the activity's
+                                # configured window instead of the exhausted
+                                # budget, so it can actually return.
+                                budget_reconciled = True
+                                remaining_status_budget = None
                             status_obj = await self._poll_managed_status(
                                 request=request,
                                 adapter=adapter,
@@ -5771,6 +5804,9 @@ class MoonMindAgentRun:
                         last_progress_signature = progress_signature
                         if progress_observed:
                             last_progress_at = workflow.now()
+                            # Fresh progress rearms the final reconciliation for
+                            # the next budget boundary this run reaches.
+                            budget_reconciled = False
                         if workflow.patched(AGENT_RUN_RESILIENCY_POLICY_PATCH_ID):
                             if progress_observed:
                                 stagnant_poll_count = 0

--- a/tests/integration/temporal/test_managed_runtime_live_logs.py
+++ b/tests/integration/temporal/test_managed_runtime_live_logs.py
@@ -5,6 +5,7 @@ to artifact storage. Uses short-lived real subprocesses where noted.
 """
 
 from __future__ import annotations
+from moonmind.schemas.agent_runtime_models import resolve_execution_budget
 
 import asyncio
 from datetime import UTC, datetime
@@ -130,7 +131,7 @@ async def test_supervisor_streams_managed_logs_to_artifacts(tmp_path: Path):
     result = await supervisor.supervise(
         run_id="managed-stream-1",
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
     )
 
     # Verify supervision completed successfully.
@@ -188,7 +189,7 @@ async def test_exit_code_capture_during_streaming(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
         exit_code_path=str(exit_code_file),
     )
 
@@ -302,7 +303,7 @@ async def test_supervisor_streams_concurrently_with_process(tmp_path: Path):
         supervisor.supervise(
             run_id=run_id,
             process=process,
-            timeout_seconds=60,
+            budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 60}),
         ),
         timeout=15,
     )
@@ -351,7 +352,7 @@ async def test_supervisor_with_none_stdout_stderr_completes(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.status == "completed"
@@ -421,7 +422,7 @@ async def test_long_running_launch_is_visible_through_observability_routes(
         supervisor.supervise(
             run_id=run_id,
             process=process,
-            timeout_seconds=30,
+            budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
             cleanup_paths=cleanup_paths,
             deferred_cleanup_paths=deferred_cleanup_paths,
         )

--- a/tests/unit/schemas/test_progress_aware_execution_budget.py
+++ b/tests/unit/schemas/test_progress_aware_execution_budget.py
@@ -1,0 +1,214 @@
+"""Progress-aware execution budget contract.
+
+Regression cover for MoonLadderStudios/MoonMind#3771: an agent run was terminated
+at its flat one-hour budget while it was actively working — files were written
+three seconds before the kill — and the failure was reported as "no observable
+progress". The budget below only ends a run whose progress has actually gone
+stale, or which has reached a hard ceiling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import (
+    DEFAULT_EXTERNAL_TIMEOUT_SECONDS,
+    DEFAULT_MANAGED_TIMEOUT_SECONDS,
+    DEFAULT_PROGRESS_EXTENSION_FACTOR,
+    DEFAULT_PROGRESS_STALL_SECONDS,
+    MAX_EXECUTION_BUDGET_SECONDS,
+    ExecutionBudget,
+    evaluate_execution_budget,
+    resolve_execution_budget,
+)
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+# ---------------------------------------------------------------------------
+# Budget resolution
+# ---------------------------------------------------------------------------
+
+
+def test_managed_default_budget_keeps_base_and_derives_ceiling():
+    budget = resolve_execution_budget(agent_kind="managed", timeout_policy=None)
+
+    # The base window is unchanged, so runs that used to finish inside an hour
+    # behave exactly as before.
+    assert budget.base_seconds == DEFAULT_MANAGED_TIMEOUT_SECONDS
+    assert budget.max_seconds == (
+        DEFAULT_MANAGED_TIMEOUT_SECONDS * DEFAULT_PROGRESS_EXTENSION_FACTOR
+    )
+    assert budget.progress_stall_seconds == DEFAULT_PROGRESS_STALL_SECONDS
+
+
+def test_external_default_budget_is_capped_at_the_absolute_maximum():
+    budget = resolve_execution_budget(agent_kind="external")
+
+    assert budget.base_seconds == DEFAULT_EXTERNAL_TIMEOUT_SECONDS
+    assert budget.max_seconds == MAX_EXECUTION_BUDGET_SECONDS
+
+
+def test_tight_explicit_budget_gets_a_tight_ceiling():
+    """An explicit small budget must not be extended to a six-hour ceiling."""
+
+    budget = resolve_execution_budget(timeout_policy={"timeout_seconds": 60})
+
+    assert budget.base_seconds == 60
+    assert budget.max_seconds == 60 * DEFAULT_PROGRESS_EXTENSION_FACTOR
+    # The stall window never exceeds the base budget: a run is not given more
+    # time to prove it is alive than it was given to finish.
+    assert budget.progress_stall_seconds == 60
+
+
+def test_explicit_ceiling_and_stall_window_win():
+    budget = resolve_execution_budget(
+        timeout_policy={
+            "timeout_seconds": 3600,
+            "max_timeout_seconds": 7200,
+            "progress_stall_seconds": 300,
+        }
+    )
+
+    assert (budget.base_seconds, budget.max_seconds) == (3600, 7200)
+    assert budget.progress_stall_seconds == 300
+
+
+def test_requesting_a_larger_base_never_shortens_the_run():
+    """A base above the default ceiling raises the ceiling with it."""
+
+    budget = resolve_execution_budget(timeout_policy={"timeout_seconds": 40000})
+
+    assert budget.base_seconds == 40000
+    assert budget.max_seconds >= budget.base_seconds
+
+
+def test_degraded_timeout_policy_falls_back_per_field():
+    """An in-flight payload predating the new fields still resolves."""
+
+    budget = resolve_execution_budget(
+        timeout_policy={
+            "timeout_seconds": "not-a-number",
+            "max_timeout_seconds": 0,
+            "progress_stall_seconds": None,
+        }
+    )
+
+    assert budget.base_seconds == DEFAULT_MANAGED_TIMEOUT_SECONDS
+    assert budget.max_seconds == (
+        DEFAULT_MANAGED_TIMEOUT_SECONDS * DEFAULT_PROGRESS_EXTENSION_FACTOR
+    )
+    assert budget.progress_stall_seconds == DEFAULT_PROGRESS_STALL_SECONDS
+
+
+def test_published_policy_round_trips_the_whole_budget():
+    """What the workflow publishes must resolve back to the same budget."""
+
+    original = resolve_execution_budget(timeout_policy={"timeout_seconds": 3600})
+    republished = resolve_execution_budget(
+        timeout_policy=original.as_timeout_policy()
+    )
+
+    assert republished == original
+
+
+# ---------------------------------------------------------------------------
+# Budget evaluation
+# ---------------------------------------------------------------------------
+
+
+_BUDGET = ExecutionBudget(
+    base_seconds=3600,
+    max_seconds=21600,
+    progress_stall_seconds=900,
+)
+
+
+@pytest.mark.parametrize(
+    ("elapsed", "idle", "expected"),
+    [
+        # Inside the base window, nothing terminates the run.
+        (0.0, None, "continue"),
+        (3599.0, None, "continue"),
+        (3599.0, 3599.0, "continue"),
+        # The #3771 shape: base budget reached, progress three seconds ago.
+        (3600.0, 3.0, "continue"),
+        # Well past the base budget and still progressing.
+        (10000.0, 30.0, "continue"),
+        # Progress went stale: this is a genuinely stuck run.
+        (3600.0, 900.0, "expired_no_progress"),
+        (3600.0, 5000.0, "expired_no_progress"),
+        # No progress was ever observed — not evidence of health.
+        (3600.0, None, "expired_no_progress"),
+        # The ceiling is absolute: fresh progress does not extend past it.
+        (21600.0, 0.0, "expired_max_budget"),
+        (30000.0, 0.0, "expired_max_budget"),
+    ],
+)
+def test_budget_verdicts(elapsed, idle, expected):
+    assert (
+        evaluate_execution_budget(
+            budget=_BUDGET,
+            elapsed_seconds=elapsed,
+            idle_progress_seconds=idle,
+        )
+        == expected
+    )
+
+
+def test_a_run_that_never_progresses_is_not_extended_by_a_single_second():
+    """The flat behaviour is preserved exactly when there is no evidence."""
+
+    for elapsed in (3600.0, 3601.0, 7200.0):
+        assert (
+            evaluate_execution_budget(
+                budget=_BUDGET,
+                elapsed_seconds=elapsed,
+                idle_progress_seconds=None,
+            )
+            == "expired_no_progress"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The two primitives must agree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("elapsed", "idle"),
+    [
+        (0.0, None),
+        (1800.0, 10.0),
+        (3599.0, 3598.0),
+        (3600.0, 0.0),
+        (3600.0, 899.0),
+        (3600.0, 900.0),
+        (3600.0, None),
+        (12000.0, 100.0),
+        (21599.0, 0.0),
+        (21600.0, 0.0),
+        (40000.0, 5.0),
+    ],
+)
+def test_effective_deadline_agrees_with_the_verdict(elapsed, idle):
+    """Every remaining-time computation in the poll loop derives from the
+    deadline, while the terminal decision comes from the verdict. If the two
+    disagreed, a run could be told it may continue and then be handed a negative
+    poll budget (or the reverse), so this equivalence is load-bearing.
+    """
+
+    verdict = evaluate_execution_budget(
+        budget=_BUDGET,
+        elapsed_seconds=elapsed,
+        idle_progress_seconds=idle,
+    )
+    deadline = MoonMindAgentRun._effective_deadline_seconds(
+        budget=_BUDGET,
+        elapsed_seconds=elapsed,
+        idle_progress_seconds=idle,
+    )
+
+    if verdict == "continue":
+        assert deadline > elapsed
+    else:
+        assert deadline <= elapsed

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -11,6 +12,7 @@ import pytest
 from moonmind.auth.github_credentials import ResolvedGitHubCredential
 from moonmind.config.settings import settings
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.agent_runtime_models import resolve_execution_budget
 from moonmind.schemas.agent_runtime_models import ManagedRuntimeProfile
 from moonmind.schemas.agent_runtime_models import RuntimeCommandRenderResult
 from moonmind.security.execution_fanout_capabilities import (
@@ -4586,6 +4588,14 @@ async def test_direct_managed_launch_materializes_scoped_execution_fanout(
     assert captured_env["MOONMIND_AGENT_RUN_ID"] == "agent-run-1"
     assert captured_env["MOONMIND_RUNTIME_ID"] == "claude_code"
     assert captured_env["MOONMIND_STEP_ID"] == "batch-workflows"
+    # The capability must still be valid at the execution ceiling. It is minted
+    # before the broker, workspace ownership changes, and process creation that
+    # precede the supervisor starting its clock, so a lifetime of exactly the
+    # ceiling can expire while the run is still legally executing.
+    budget = resolve_execution_budget(
+        agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
+    )
+    assert capability.expires_at > int(time.time()) + budget.max_seconds
 
 
 def test_direct_managed_launch_removes_unrequested_ambient_fanout_authority() -> None:

--- a/tests/unit/services/temporal/runtime/test_process_activity.py
+++ b/tests/unit/services/temporal/runtime/test_process_activity.py
@@ -1,0 +1,143 @@
+"""Process-tree activity probing.
+
+This is the evidence that made MoonLadderStudios/MoonMind#3771 detectable. In
+that run the agent spent its final 23 minutes executing a test suite: it wrote
+nothing to stdout (``claude -p`` buffers until the turn ends) and touched only
+``__pycache__``, which the workspace-mutation probe deliberately skips. CPU time
+was the one signal that separated it from a wedged process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import UTC, datetime
+
+import pytest
+
+from moonmind.workflows.temporal.runtime.process_activity import (
+    ProcessActivityProbe,
+)
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="the probe reads /proc, which only exists on Linux",
+)
+
+
+async def _spawn(*argv: str) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        # Matches how the launcher spawns managed runtimes: the child is its own
+        # session leader, so its session id identifies the whole tree.
+        start_new_session=True,
+    )
+
+
+async def _terminate(process: asyncio.subprocess.Process) -> None:
+    try:
+        os.killpg(os.getpgid(process.pid), 9)
+    except (ProcessLookupError, PermissionError):
+        process.kill()
+    await process.wait()
+
+
+@pytest.mark.asyncio
+async def test_first_sample_is_a_baseline_not_evidence():
+    """CPU burned before the first observation cannot be dated, so it is not
+    reported as progress at a particular time."""
+
+    process = await _spawn("sleep", "30")
+    try:
+        probe = ProcessActivityProbe(session_pid=process.pid)
+        assert probe.sample(datetime.now(tz=UTC)) is None
+    finally:
+        await _terminate(process)
+
+
+@pytest.mark.asyncio
+async def test_idle_process_never_reports_progress():
+    """A wedged run must still be terminated at its base budget."""
+
+    process = await _spawn("sleep", "30")
+    try:
+        probe = ProcessActivityProbe(session_pid=process.pid)
+        probe.sample(datetime.now(tz=UTC))  # baseline
+        await asyncio.sleep(1.0)
+        assert probe.sample(datetime.now(tz=UTC)) is None
+    finally:
+        await _terminate(process)
+
+
+@pytest.mark.asyncio
+async def test_busy_process_reports_progress():
+    process = await _spawn(sys.executable, "-c", "x = 0\nwhile True: x += 1")
+    try:
+        probe = ProcessActivityProbe(session_pid=process.pid)
+        probe.sample(datetime.now(tz=UTC))  # baseline
+        await asyncio.sleep(0.75)
+        observed = probe.sample(datetime.now(tz=UTC))
+        assert observed is not None
+    finally:
+        await _terminate(process)
+
+
+@pytest.mark.asyncio
+async def test_work_done_only_by_a_descendant_counts_as_progress():
+    """The #3771 case: the CLI waits while a child does the work.
+
+    An agent that shells out to a test runner or compiler is idle in its own
+    right; the CPU is burned by a grandchild. Summing by session id is what makes
+    that visible.
+    """
+
+    process = await _spawn(
+        "sh",
+        "-c",
+        f"{sys.executable} -c 'x = 0\nwhile True: x += 1' & sleep 30",
+    )
+    try:
+        probe = ProcessActivityProbe(session_pid=process.pid)
+        probe.sample(datetime.now(tz=UTC))  # baseline
+        await asyncio.sleep(0.75)
+        assert probe.sample(datetime.now(tz=UTC)) is not None
+    finally:
+        await _terminate(process)
+
+
+@pytest.mark.asyncio
+async def test_exited_session_retains_last_observed_activity():
+    """After the tree exits the probe stops advancing but does not erase what it
+    already saw; the exit path owns the run's outcome from there."""
+
+    process = await _spawn(sys.executable, "-c", "x = 0\nwhile True: x += 1")
+    probe = ProcessActivityProbe(session_pid=process.pid)
+    probe.sample(datetime.now(tz=UTC))
+    await asyncio.sleep(0.75)
+    observed = probe.sample(datetime.now(tz=UTC))
+    assert observed is not None
+
+    await _terminate(process)
+    await asyncio.sleep(0.2)
+    assert probe.sample(datetime.now(tz=UTC)) == observed
+
+
+@pytest.mark.asyncio
+async def test_unrelated_process_activity_is_not_counted():
+    """Only the supervised session's CPU counts, so a busy host cannot make a
+    wedged run look alive."""
+
+    idle = await _spawn("sleep", "30")
+    busy = await _spawn(sys.executable, "-c", "x = 0\nwhile True: x += 1")
+    try:
+        probe = ProcessActivityProbe(session_pid=idle.pid)
+        probe.sample(datetime.now(tz=UTC))
+        await asyncio.sleep(0.75)
+        assert probe.sample(datetime.now(tz=UTC)) is None
+    finally:
+        await _terminate(busy)
+        await _terminate(idle)

--- a/tests/unit/services/temporal/runtime/test_process_activity.py
+++ b/tests/unit/services/temporal/runtime/test_process_activity.py
@@ -109,6 +109,64 @@ async def test_work_done_only_by_a_descendant_counts_as_progress():
         await _terminate(process)
 
 
+def _session_pid_count(session_pid: int) -> int:
+    """How many live processes currently carry this session id."""
+
+    probe = ProcessActivityProbe(session_pid=session_pid)
+    probe._total_cpu_seconds()
+    return len(probe._live_ticks)
+
+
+@pytest.mark.asyncio
+async def test_cpu_of_exited_descendants_stays_in_the_session_total():
+    """A short-lived worker must not take its CPU with it when it exits.
+
+    ``/proc`` only lists live processes, so summing it alone makes the session
+    total *fall* when a descendant exits. A managed agent running a sequence of
+    short-lived compilers or test processes would then read as stalled while
+    working continuously: each replacement has to re-earn all the CPU its
+    predecessor took with it before the delta turns positive again.
+    """
+
+    process = await _spawn(
+        "sh",
+        "-c",
+        # A burst of work, then the worker exits while the session lives on.
+        f"{sys.executable} -c 'x = 0\nfor _ in range(8_000_000): x += 1'; sleep 30",
+    )
+    try:
+        probe = ProcessActivityProbe(session_pid=process.pid)
+        probe.sample(datetime.now(tz=UTC))  # baseline, before the burst lands
+
+        # Observe the descendant working. sh + python + (later) sleep all carry
+        # the session id, so the worker is present while this is true.
+        for _ in range(120):
+            await asyncio.sleep(0.25)
+            if probe.sample(datetime.now(tz=UTC)) is not None:
+                break
+        assert (
+            probe.sample(datetime.now(tz=UTC)) is not None
+        ), "the descendant's work was never observed"
+        total_with_worker = probe._last_total_seconds
+        assert total_with_worker is not None
+
+        # Wait for the worker to actually exit: the session drops back to
+        # sh + sleep.
+        for _ in range(120):
+            await asyncio.sleep(0.25)
+            if _session_pid_count(process.pid) <= 2:
+                break
+        assert _session_pid_count(process.pid) <= 2, "worker never exited"
+
+        # The exited worker's CPU stays in the session total, so the next worker
+        # starts from here rather than having to climb back over it.
+        probe.sample(datetime.now(tz=UTC))
+        assert probe._last_total_seconds is not None
+        assert probe._last_total_seconds >= total_with_worker
+    finally:
+        await _terminate(process)
+
+
 @pytest.mark.asyncio
 async def test_exited_session_retains_last_observed_activity():
     """After the tree exits the probe stops advancing but does not erase what it

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -492,7 +492,7 @@ async def test_supervise_debounces_no_output_interval(supervisor_env):
         process: asyncio.subprocess.Process,
         budget,
         *,
-        started_at,
+        monotonic_started_at,
         idle_progress_seconds,
         no_output_callback=None,
         progress_snapshot=None,

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -11,6 +11,7 @@ import sys
 from moonmind.schemas.agent_runtime_models import (
     MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
     ManagedRunRecord,
+    resolve_execution_budget,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
@@ -92,7 +93,7 @@ async def test_success_exit_classification(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-1", process=process, timeout_seconds=30
+        run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     assert record.status == "completed"
@@ -123,7 +124,7 @@ async def test_supervise_terminates_descendant_before_waiting_for_stream_eof(
 
     record = await asyncio.wait_for(
         supervisor.supervise(
-            run_id="run-descendant", process=process, timeout_seconds=30
+            run_id="run-descendant", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
         ),
         timeout=5,
     )
@@ -143,7 +144,7 @@ async def test_failure_exit_classification(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-1", process=process, timeout_seconds=30
+        run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     assert record.status == "failed"
@@ -164,7 +165,7 @@ async def test_timeout_exit_classification(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-1", process=process, timeout_seconds=1
+        run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 1})
     )
 
     assert record.status == "timed_out"
@@ -207,7 +208,7 @@ async def test_supervise_terminates_stalled_runtime_progress(supervisor_env):
                 result = await supervisor.supervise(
                     run_id="run-stalled-progress",
                     process=process,
-                    timeout_seconds=30,
+                    budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
                 )
 
     assert result.status == "failed"
@@ -275,7 +276,7 @@ async def test_supervise_uses_record_started_at_for_progress_probe(supervisor_en
                     result = await supervisor.supervise(
                         run_id="run-started-at",
                         process=process,
-                        timeout_seconds=30,
+                        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
                     )
 
     assert result.status == "failed"
@@ -331,7 +332,7 @@ async def test_stalled_progress_does_not_override_clean_exit_without_termination
                     result = await supervisor.supervise(
                         run_id="run-stall-race",
                         process=process,
-                        timeout_seconds=30,
+                        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
                     )
 
     assert result.status == "completed"
@@ -367,7 +368,7 @@ async def test_exit_code_file_is_authoritative(supervisor_env, tmp_path):
     record = await supervisor.supervise(
         run_id="run-exit-file",
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
         exit_code_path=str(exit_code_path),
         cleanup_paths=[str(exit_code_path)],
     )
@@ -405,7 +406,7 @@ async def test_missing_exit_code_file_fails_closed(supervisor_env, tmp_path):
     record = await supervisor.supervise(
         run_id="run-missing-exit",
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
         exit_code_path=str(exit_code_path),
         cleanup_paths=[str(exit_code_path)],
     )
@@ -433,7 +434,7 @@ async def test_timeout_ignores_exit_code_file_and_cleans_it(
     record = await supervisor.supervise(
         run_id="run-timeout-exit",
         process=process,
-        timeout_seconds=1,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
         exit_code_path=str(exit_code_path),
         cleanup_paths=[str(exit_code_path)],
     )
@@ -457,7 +458,7 @@ async def test_supervise_limits_repeated_warning_annotations(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-warning", process=process, timeout_seconds=30
+        run_id="run-warning", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     diagnostics_path = _resolve_diagnostics_path(artifact_storage, record)
@@ -485,21 +486,25 @@ async def test_supervise_debounces_no_output_interval(supervisor_env):
     store, artifact_storage, _, supervisor = supervisor_env
     _make_record(store, "run-no-output", "launching")
 
-    async def _fake_heartbeat_and_wait_with_timeout(
+    async def _fake_heartbeat_and_wait_within_budget(
         self,
         run_id: str,
         process: asyncio.subprocess.Process,
-        timeout_seconds: int,
+        budget,
+        *,
+        started_at,
+        idle_progress_seconds,
         no_output_callback=None,
         progress_snapshot=None,
-    ) -> tuple[int | None, bool]:
+        on_budget_extended=None,
+    ) -> tuple[int | None, str]:
         base_time = datetime.now(tz=UTC)
         if no_output_callback is None:
-            return 0, False
+            return 0, "continue"
         await no_output_callback(base_time + timedelta(seconds=2.5))
         await no_output_callback(base_time + timedelta(seconds=4.9))
         await no_output_callback(base_time + timedelta(seconds=5.0))
-        return 0, False
+        return 0, "continue"
 
     process = await asyncio.create_subprocess_exec(
         "true",
@@ -510,8 +515,8 @@ async def test_supervise_debounces_no_output_interval(supervisor_env):
 
     with patch.object(
         ManagedRunSupervisor,
-        "_heartbeat_and_wait_with_timeout",
-        _fake_heartbeat_and_wait_with_timeout,
+        "_heartbeat_and_wait_within_budget",
+        _fake_heartbeat_and_wait_within_budget,
     ):
         with patch(
             "moonmind.workflows.temporal.runtime.supervisor.NO_OUTPUT_ANNOTATION_INTERVAL_SECONDS",
@@ -520,7 +525,7 @@ async def test_supervise_debounces_no_output_interval(supervisor_env):
             record = await supervisor.supervise(
                 run_id="run-no-output",
                 process=process,
-                timeout_seconds=30,
+                budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
             )
 
     diagnostics_path = _resolve_diagnostics_path(artifact_storage, record)
@@ -604,7 +609,7 @@ async def test_supervise_preserves_deferred_cleanup_until_explicit_release(
     record = await supervisor.supervise(
         run_id="run-deferred-cleanup",
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
         deferred_cleanup_paths=[str(deferred_cleanup_path)],
     )
 
@@ -687,7 +692,7 @@ async def test_heartbeat_updates(supervisor_env):
     # mixed import style (import + from-import of same module).
     with patch('moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL', 1):
         record = await supervisor.supervise(
-            run_id="run-1", process=process, timeout_seconds=30
+            run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
         )
 
     assert record.status == "completed"
@@ -742,7 +747,7 @@ async def test_heartbeat_persists_output_progress(supervisor_env):
     ):
         with patch.object(store, "update_status", side_effect=_spy_update):
             result = await supervisor.supervise(
-                run_id="run-1", process=process, timeout_seconds=30
+                run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
             )
 
     assert result.status == "completed"
@@ -805,7 +810,7 @@ async def test_heartbeat_persists_claude_pr_resolver_artifact_progress(
     ):
         with patch.object(store, "update_status", side_effect=_spy_update):
             result = await supervisor.supervise(
-                run_id="run-1", process=process, timeout_seconds=30
+                run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
             )
     writer_result = await progress_writer
     assert writer_result is None
@@ -860,7 +865,7 @@ async def test_heartbeat_persists_claude_workspace_file_progress(
     ):
         with patch.object(store, "update_status", side_effect=_spy_update):
             result = await supervisor.supervise(
-                run_id="run-1", process=process, timeout_seconds=30
+                run_id="run-1", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
             )
     writer_result = await progress_writer
     assert writer_result is None
@@ -894,7 +899,7 @@ async def test_completion_callback_called_on_success(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-cb-ok", process=process, timeout_seconds=30
+        run_id="run-cb-ok", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     assert record.status == "completed"
@@ -926,7 +931,7 @@ async def test_completion_callback_called_on_failure(supervisor_env):
     )
 
     record = await supervisor.supervise(
-        run_id="run-cb-fail", process=process, timeout_seconds=30
+        run_id="run-cb-fail", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     assert record.status == "failed"
@@ -956,7 +961,7 @@ async def test_completion_callback_error_does_not_crash_supervisor(supervisor_en
 
     # Should NOT raise despite the callback failure
     record = await supervisor.supervise(
-        run_id="run-cb-err", process=process, timeout_seconds=30
+        run_id="run-cb-err", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
     assert record.status == "completed"
 
@@ -986,7 +991,7 @@ async def test_supervise_uses_output_parser_from_strategy(supervisor_env, tmp_pa
     )
 
     result = await supervisor.supervise(
-        run_id="run-claude-parser", process=process, timeout_seconds=30
+        run_id="run-claude-parser", process=process, budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30})
     )
 
     # Read the diagnostics artifact and verify parsed_output is present
@@ -995,3 +1000,132 @@ async def test_supervise_uses_output_parser_from_strategy(supervisor_env, tmp_pa
     assert "parsed_output" in diag
     po = diag["parsed_output"]
     assert po["rate_limited"] is True
+
+
+# ---------------------------------------------------------------------------
+# Progress-aware execution budget (MoonLadderStudios/MoonMind#3771)
+#
+# The regression: a managed run was killed at its flat budget while it was
+# actively working. It wrote nothing to stdout because ``claude -p`` buffers
+# until the turn ends, and its last 23 minutes of work touched only ignored
+# directories, so the only evidence it was alive was that its process tree was
+# burning CPU. These tests drive real processes through the real supervisor.
+# ---------------------------------------------------------------------------
+
+
+def _budget(**policy) -> object:
+    return resolve_execution_budget(timeout_policy=policy)
+
+
+def _annotation_types(artifact_storage, record) -> list[str]:
+    diagnostics_path = _resolve_diagnostics_path(artifact_storage, record)
+    assert diagnostics_path is not None
+    payload = json.loads(
+        artifact_storage.resolve_storage_path(diagnostics_path).read_text(
+            encoding="utf-8"
+        )
+    )
+    return [
+        str(entry.get("annotation_type"))
+        for entry in payload.get("annotations", [])
+    ]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="progress evidence from CPU activity requires /proc",
+)
+@pytest.mark.asyncio
+async def test_silent_but_working_process_outlives_its_base_budget(supervisor_env):
+    """A busy, silent process is extended past the base budget to the ceiling.
+
+    Before this behaviour existed the process died at ``timeout_seconds`` and the
+    run was reported as having made no observable progress.
+    """
+
+    store, artifact_storage, _, supervisor = supervisor_env
+    _make_record(store, "run-busy", "launching")
+
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        # Burns CPU and prints nothing: byte-for-byte indistinguishable from a
+        # wedged process on stdout alone.
+        "x = 0\nwhile True: x += 1",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    # Heartbeats carry the progress observation, so they must tick several times
+    # inside this compressed budget.
+    with patch(
+        "moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL", 0.2
+    ):
+        record = await supervisor.supervise(
+            run_id="run-busy",
+            process=process,
+            budget=_budget(
+                timeout_seconds=2,
+                max_timeout_seconds=5,
+                progress_stall_seconds=2,
+            ),
+        )
+
+    assert record.status == "timed_out"
+    # Survived the base budget it would previously have died at, and stopped at
+    # the ceiling instead.
+    assert "maximum execution budget" in (record.error_message or "")
+    # The message reports the real elapsed time, not the base window it
+    # was extended past.
+    assert "after 2s" not in (record.error_message or "")
+    assert "execution_budget_extended_for_progress" in _annotation_types(
+        artifact_storage, record
+    )
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="progress evidence from CPU activity requires /proc",
+)
+@pytest.mark.asyncio
+async def test_wedged_process_is_still_killed_at_its_base_budget(supervisor_env):
+    """The containment half: no progress means no extension.
+
+    A process that consumes no CPU, writes nothing, and touches no files is
+    exactly the case the budget is supposed to end.
+    """
+
+    store, artifact_storage, _, supervisor = supervisor_env
+    _make_record(store, "run-wedged", "launching")
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep",
+        "60",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+
+    with patch(
+        "moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL", 0.2
+    ):
+        record = await supervisor.supervise(
+            run_id="run-wedged",
+            process=process,
+            budget=_budget(
+                timeout_seconds=2,
+                max_timeout_seconds=30,
+                progress_stall_seconds=1,
+            ),
+        )
+
+    assert record.status == "timed_out"
+    assert "no observable progress" in (record.error_message or "")
+    assert "execution_budget_extended_for_progress" not in _annotation_types(
+        artifact_storage, record
+    )
+    # Ended at the base budget, nowhere near the 30s ceiling.
+    assert (record.finished_at - record.started_at).total_seconds() < 15

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -4,7 +4,7 @@ These tests specifically demonstrate:
   1. Streaming runs concurrently with the process (not after exit).
   2. Large output doesn't deadlock due to OS pipe buffer exhaustion.
   3. None stdout/stderr (no PIPE) is handled gracefully.
-  4. The _heartbeat_and_wait_with_timeout helper returns correct tuples.
+  4. The _heartbeat_and_wait_within_budget helper returns correct tuples.
   5. Exit-code-file override still works in the concurrent path.
 """
 from __future__ import annotations
@@ -15,7 +15,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 import pytest
 
-from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.agent_runtime_models import (
+    ManagedRunRecord,
+    resolve_execution_budget,
+)
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
@@ -76,12 +79,17 @@ def _save_record(
     return record
 
 # ---------------------------------------------------------------------------
-# Test 1 — heartbeat_and_wait_with_timeout returns (exit_code, False) on normal exit
+# Test 1 — heartbeat_and_wait_within_budget returns (exit_code, "continue")
 # ---------------------------------------------------------------------------
 
+def _never_idle(_now: datetime) -> float | None:
+    """Progress evidence for a run that has never shown progress."""
+    return None
+
+
 @pytest.mark.asyncio
-async def test_heartbeat_and_wait_with_timeout_normal_exit(tmp_path: Path):
-    """_heartbeat_and_wait_with_timeout returns (rc, False) when process exits normally."""
+async def test_heartbeat_and_wait_within_budget_normal_exit(tmp_path: Path):
+    """Returns (rc, "continue") when the process exits on its own."""
     supervisor, store, _ = _make_supervisor(tmp_path)
 
     process = await asyncio.create_subprocess_exec(
@@ -89,34 +97,45 @@ async def test_heartbeat_and_wait_with_timeout_normal_exit(tmp_path: Path):
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    exit_code, timed_out = await supervisor._heartbeat_and_wait_with_timeout(
-        "run-t1", process, timeout_seconds=10
+    exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+        "run-t1",
+        process,
+        resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
+        started_at=datetime.now(tz=UTC),
+        idle_progress_seconds=_never_idle,
     )
     assert exit_code == 0
-    assert timed_out is False
+    assert verdict == "continue"
+
 
 # ---------------------------------------------------------------------------
-# Test 2 — heartbeat_and_wait_with_timeout returns (None, True) on timeout
+# Test 2 — a run with no observable progress is terminated at the base budget
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_heartbeat_and_wait_with_timeout_timed_out(tmp_path: Path):
-    """_heartbeat_and_wait_with_timeout returns (None, True) when process times out."""
+async def test_heartbeat_and_wait_within_budget_expires_without_progress(
+    tmp_path: Path,
+):
+    """A process that shows no progress still dies at the base budget."""
     supervisor, store, _ = _make_supervisor(tmp_path)
 
     process = await asyncio.create_subprocess_exec(
-        "sleep", "30",  # much longer than the timeout
+        "sleep", "30",  # much longer than the budget
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
     try:
-        exit_code, timed_out = await supervisor._heartbeat_and_wait_with_timeout(
-            "run-t2", process, timeout_seconds=1
+        exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+            "run-t2",
+            process,
+            resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
+            started_at=datetime.now(tz=UTC),
+            idle_progress_seconds=_never_idle,
         )
         assert exit_code is None
-        assert timed_out is True
+        assert verdict == "expired_no_progress"
     finally:
-        # Process may already be terminated by _heartbeat_and_wait_with_timeout.
+        # Process may already be terminated by the budget enforcement above.
         try:
             process.kill()
             await process.wait()
@@ -124,11 +143,59 @@ async def test_heartbeat_and_wait_with_timeout_timed_out(tmp_path: Path):
             # Process already terminated; nothing to clean up.
             pass
 
+
+# ---------------------------------------------------------------------------
+# Test 2b — fresh progress carries a run past the base budget to the ceiling
+#
+# The MoonLadderStudios/MoonMind#3771 regression: the run was working — files
+# were written three seconds before the kill — but the flat deadline could not
+# see that, so it terminated at the base budget and the work was lost.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_heartbeat_and_wait_within_budget_extends_while_progressing(
+    tmp_path: Path,
+):
+    """Observed progress extends past the base budget, up to the ceiling."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    extensions: list[tuple[float, float | None]] = []
+    try:
+        exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+            "run-t2b",
+            process,
+            # base 1s, ceiling 6s, stall window 1s.
+            resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
+            started_at=datetime.now(tz=UTC),
+            # Progress observed continuously: never stale.
+            idle_progress_seconds=lambda _now: 0.0,
+            on_budget_extended=lambda elapsed, idle: extensions.append(
+                (elapsed, idle)
+            ),
+        )
+        # Survived well past the 1s base budget and stopped at the ceiling,
+        # reported as a ceiling stop rather than as an absence of progress.
+        assert exit_code is None
+        assert verdict == "expired_max_budget"
+        assert extensions, "an extension past the base budget was not reported"
+    finally:
+        try:
+            process.kill()
+            await process.wait()
+        except ProcessLookupError:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Test 3 — supervise() captures stdout concurrently (does not deadlock)
 #
 # This is the core regression test.  Before the fix, streaming happened AFTER
-# _heartbeat_and_wait, meaning the process had to finish before any output was
+# the heartbeat wait, meaning the process had to finish before any output was
 # read.  For large output this causes the OS pipe buffer to fill up, blocking
 # the write-end of the pipe inside the subprocess — a deadlock.
 # ---------------------------------------------------------------------------
@@ -155,7 +222,7 @@ async def test_supervise_captures_large_stdout_without_deadlock(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
     )
 
     assert result.status == "completed"
@@ -186,7 +253,7 @@ async def test_supervise_captures_stdout_normal_process(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=30,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
     )
 
     assert result.status == "completed"
@@ -223,7 +290,7 @@ async def test_supervise_with_none_stdout_does_not_crash(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     # Diagnostics artifact should still be created even with no stream content
@@ -257,7 +324,7 @@ async def test_supervise_exit_code_from_file_overrides_process_rc(tmp_path: Path
         run_id=run_id,
         process=process,
         exit_code_path=str(exit_file),
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.exit_code == 42
@@ -284,7 +351,7 @@ async def test_supervise_nonzero_exit_classified_as_failed(tmp_path: Path):
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.status == "failed"
@@ -315,7 +382,7 @@ async def test_supervise_terminates_claude_on_live_rate_limit(tmp_path: Path):
         supervisor.supervise(
             run_id=run_id,
             process=process,
-            timeout_seconds=10,
+            budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
         ),
         timeout=5,
     )
@@ -350,7 +417,7 @@ async def test_supervise_classifies_claude_not_logged_in_as_auth_failure(
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.status == "failed"
@@ -385,7 +452,7 @@ async def test_supervise_classifies_claude_expired_oauth_session_as_auth_failure
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.status == "failed"
@@ -417,7 +484,7 @@ async def test_supervise_allows_successful_claude_output_with_auth_text(
     result = await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     assert result.status == "completed"
@@ -437,7 +504,7 @@ async def test_supervise_allows_successful_claude_output_with_auth_text(
 
 @pytest.mark.asyncio
 async def test_streaming_starts_concurrently_with_heartbeat(tmp_path: Path):
-    """stream_and_parse is started concurrently (not after) _heartbeat_and_wait."""
+    """stream_and_parse is started concurrently with the heartbeat/budget wait."""
     supervisor, store, storage = _make_supervisor(tmp_path)
     run_id = "run-concurrent-verify"
     _save_record(store, run_id)
@@ -445,7 +512,7 @@ async def test_streaming_starts_concurrently_with_heartbeat(tmp_path: Path):
     call_order: list[str] = []
 
     original_stream = supervisor._log_streamer.stream_and_parse
-    original_heartbeat = supervisor._heartbeat_and_wait_with_timeout
+    original_heartbeat = supervisor._heartbeat_and_wait_within_budget
 
     # Use a synchronization primitive to guarantee both tasks mark themselves started
     # before either is allowed to proceed and finish, removing the time.sleep race condition
@@ -466,7 +533,7 @@ async def test_streaming_starts_concurrently_with_heartbeat(tmp_path: Path):
         return result
 
     supervisor._log_streamer.stream_and_parse = tracking_stream
-    supervisor._heartbeat_and_wait_with_timeout = tracking_heartbeat
+    supervisor._heartbeat_and_wait_within_budget = tracking_heartbeat
 
     process = await asyncio.create_subprocess_exec(
         "echo", "hello",
@@ -478,7 +545,7 @@ async def test_streaming_starts_concurrently_with_heartbeat(tmp_path: Path):
     await supervisor.supervise(
         run_id=run_id,
         process=process,
-        timeout_seconds=10,
+        budget=resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
     )
 
     # Both tasks must have been started (appeared in call_order)

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import UTC, datetime
+import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 import pytest
 
@@ -82,7 +83,7 @@ def _save_record(
 # Test 1 — heartbeat_and_wait_within_budget returns (exit_code, "continue")
 # ---------------------------------------------------------------------------
 
-def _never_idle(_now: datetime) -> float | None:
+def _never_idle(_now_monotonic: float) -> float | None:
     """Progress evidence for a run that has never shown progress."""
     return None
 
@@ -101,7 +102,7 @@ async def test_heartbeat_and_wait_within_budget_normal_exit(tmp_path: Path):
         "run-t1",
         process,
         resolve_execution_budget(timeout_policy={"timeout_seconds": 10}),
-        started_at=datetime.now(tz=UTC),
+        monotonic_started_at=time.monotonic(),
         idle_progress_seconds=_never_idle,
     )
     assert exit_code == 0
@@ -129,7 +130,7 @@ async def test_heartbeat_and_wait_within_budget_expires_without_progress(
             "run-t2",
             process,
             resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
-            started_at=datetime.now(tz=UTC),
+            monotonic_started_at=time.monotonic(),
             idle_progress_seconds=_never_idle,
         )
         assert exit_code is None
@@ -171,9 +172,9 @@ async def test_heartbeat_and_wait_within_budget_extends_while_progressing(
             process,
             # base 1s, ceiling 6s, stall window 1s.
             resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
-            started_at=datetime.now(tz=UTC),
+            monotonic_started_at=time.monotonic(),
             # Progress observed continuously: never stale.
-            idle_progress_seconds=lambda _now: 0.0,
+            idle_progress_seconds=lambda _now_monotonic: 0.0,
             on_budget_extended=lambda elapsed, idle: extensions.append(
                 (elapsed, idle)
             ),
@@ -184,10 +185,160 @@ async def test_heartbeat_and_wait_within_budget_extends_while_progressing(
         assert verdict == "expired_max_budget"
         assert extensions, "an extension past the base budget was not reported"
     finally:
+        # Process may already be terminated by the budget enforcement above.
         try:
             process.kill()
             await process.wait()
         except ProcessLookupError:
+            # Process already terminated; nothing to clean up.
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test 2c — progress is sampled before a stall verdict ends the run
+#
+# The cached progress timestamp is only refreshed once per heartbeat (30s), so a
+# stall verdict computed from it can be a whole heartbeat interval stale. A run
+# that resumed CPU work or wrote a file seconds before its boundary must not be
+# killed for activity the supervisor simply had not looked for yet.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_due_progress_is_sampled_before_the_stall_verdict_terminates(
+    tmp_path: Path,
+):
+    """A refresh that finds fresh progress rescues the run from a stale verdict."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    # Cached evidence says the run went stale long ago. The refresh callback is
+    # what discovers that it is in fact working right now.
+    idle_view = {"seconds": 10_000.0}
+    refreshes: list[datetime] = []
+
+    async def _refresh(now: datetime) -> None:
+        refreshes.append(now)
+        # First look at live activity: the process is working after all.
+        idle_view["seconds"] = 0.0
+
+    try:
+        exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+            "run-t2c",
+            process,
+            # base 1s, ceiling 6s, stall window 1s.
+            resolve_execution_budget(timeout_policy={"timeout_seconds": 1}),
+            monotonic_started_at=time.monotonic(),
+            idle_progress_seconds=lambda _now_monotonic: idle_view["seconds"],
+            no_output_callback=_refresh,
+        )
+        # The stale verdict was not accepted: the run survived to the ceiling.
+        assert refreshes, "progress was never sampled before the terminal decision"
+        assert exit_code is None
+        assert verdict == "expired_max_budget"
+    finally:
+        # Process may already be terminated by the budget enforcement above.
+        try:
+            process.kill()
+            await process.wait()
+        except ProcessLookupError:
+            # Process already terminated; nothing to clean up.
+            pass
+
+
+@pytest.mark.asyncio
+async def test_refresh_cannot_extend_a_run_past_the_ceiling(tmp_path: Path):
+    """The hard ceiling is exempt: no observed progress extends past it."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "30",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    refreshes: list[datetime] = []
+
+    async def _refresh(now: datetime) -> None:
+        refreshes.append(now)
+
+    try:
+        exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+            "run-t2c-ceiling",
+            process,
+            # base 1s, ceiling 1s: the ceiling is reached with the base window.
+            resolve_execution_budget(
+                timeout_policy={"timeout_seconds": 1, "max_timeout_seconds": 1}
+            ),
+            monotonic_started_at=time.monotonic(),
+            # Continuously fresh progress still cannot buy an extension here.
+            idle_progress_seconds=lambda _now_monotonic: 0.0,
+            no_output_callback=_refresh,
+        )
+        assert exit_code is None
+        assert verdict == "expired_max_budget"
+    finally:
+        # Process may already be terminated by the budget enforcement above.
+        try:
+            process.kill()
+            await process.wait()
+        except ProcessLookupError:
+            # Process already terminated; nothing to clean up.
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Test 2d — budget intervals are monotonic, not wall-clock
+#
+# A host clock step forward must not terminate a healthy run as over-budget, and
+# a step backward must not let it outlive the AgentRun workflow's deadline for
+# the same run.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_budget_intervals_ignore_wall_clock_jumps(tmp_path: Path, monkeypatch):
+    """A wall-clock jump forward does not end a run that is inside its budget."""
+    supervisor, store, _ = _make_supervisor(tmp_path)
+
+    real_now = datetime.now
+
+    class _JumpedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: D102 - test double
+            return real_now(tz) + timedelta(hours=48)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.supervisor.datetime",
+        _JumpedDatetime,
+    )
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "1",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        exit_code, verdict = await supervisor._heartbeat_and_wait_within_budget(
+            "run-t2d",
+            process,
+            # 48 hours of wall-clock jump against a 30s budget: a wall-clock
+            # deadline would kill this instantly.
+            resolve_execution_budget(timeout_policy={"timeout_seconds": 30}),
+            monotonic_started_at=time.monotonic(),
+            idle_progress_seconds=lambda _now_monotonic: 0.0,
+        )
+        # The process was allowed to exit on its own.
+        assert exit_code == 0
+        assert verdict == "continue"
+    finally:
+        # Process may already be terminated by the budget enforcement above.
+        try:
+            process.kill()
+            await process.wait()
+        except ProcessLookupError:
+            # Process already terminated; nothing to clean up.
             pass
 
 

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -9,7 +9,10 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
-from moonmind.schemas.agent_runtime_models import AgentRunResult
+from moonmind.schemas.agent_runtime_models import (
+    AgentRunResult,
+    resolve_execution_budget,
+)
 from moonmind.workflows.temporal.artifacts import ExecutionRef
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
@@ -696,10 +699,13 @@ async def test_agent_runtime_launch_defers_support_cleanup_until_fetch_result():
     [task] = list(activities._supervision_tasks)
     await task
 
+    # The supervisor receives the whole progress-aware budget resolved from the
+    # request's timeoutPolicy, not a lone deadline: it must extend for observed
+    # progress and terminate on exactly the numbers the workflow enforces.
     mock_supervisor.supervise.assert_awaited_once_with(
         run_id="run-cleanup-1",
         process=ANY,
-        timeout_seconds=3600,
+        budget=resolve_execution_budget(agent_kind="managed", timeout_policy=None),
         cleanup_paths=None,
         deferred_cleanup_paths=["/tmp/cleanup.file"],
     )

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_progress_aware_budget.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_progress_aware_budget.py
@@ -12,16 +12,23 @@ states, so the in-flight (pre-patch) path is covered alongside the new one.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
+    AgentRunHandle,
     ExecutionBudget,
+    evaluate_execution_budget,
     resolve_execution_budget,
 )
-from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import (
+    MoonMindAgentRun,
+    RunStatus,
+)
 
 _BUDGET = ExecutionBudget(
     base_seconds=3600,
@@ -30,6 +37,7 @@ _BUDGET = ExecutionBudget(
 )
 
 _START = datetime(2026, 8, 25, 7, 24, tzinfo=UTC)
+_BASE_SECONDS = 300
 
 
 def _request() -> AgentExecutionRequest:
@@ -309,9 +317,16 @@ def test_published_policy_preserves_unrelated_timeout_policy_keys():
     assert request.timeout_policy["custom_key"] == "kept"
 
 
-def test_unpatched_publish_keeps_the_prior_launch_payload_shape():
-    """Replay safety: an in-flight run must not gain fields in a payload it has
-    already dispatched."""
+def test_unpatched_publish_pins_the_supervisor_to_the_flat_deadline():
+    """A pre-patch history publishes a budget that cannot outlive its workflow.
+
+    The launch activity re-resolves the budget from this payload on every launch
+    and retry, including retries dispatched after the progress-aware deployment.
+    Publishing only the base window let it derive a progress-aware ceiling the
+    replayed workflow never granted: the workflow timed out at the base window
+    and released the provider slot while the supervisor carried the process on to
+    that ceiling, leaving untracked work running against a reassigned profile.
+    """
 
     request = _request()
 
@@ -319,4 +334,256 @@ def test_unpatched_publish_keeps_the_prior_launch_payload_shape():
         request=request, budget=_BUDGET, progress_aware=False
     )
 
-    assert request.timeout_policy == {"timeout_seconds": _BUDGET.base_seconds}
+    assert request.timeout_policy == {
+        "timeout_seconds": _BUDGET.base_seconds,
+        "max_timeout_seconds": _BUDGET.base_seconds,
+        "progress_stall_seconds": _BUDGET.base_seconds,
+        "execution_budget_mode": "flat",
+    }
+    # The activity resolving this payload reaches the same flat deadline.
+    supervisor_budget = resolve_execution_budget(
+        agent_kind="managed", timeout_policy=request.timeout_policy
+    )
+    assert supervisor_budget.max_seconds == _BUDGET.base_seconds
+    assert supervisor_budget.mode == "flat"
+    assert (
+        evaluate_execution_budget(
+            budget=supervisor_budget,
+            elapsed_seconds=float(_BUDGET.base_seconds),
+            # Even continuous progress cannot extend a flat budget.
+            idle_progress_seconds=0.0,
+        )
+        != "continue"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Workflow boundary: the deadline a lane can actually enforce
+# ---------------------------------------------------------------------------
+
+
+def _configure_workflow_runtime(monkeypatch, *, clock) -> None:
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-agent-run-1",
+            "run_id": "run-1",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {
+            "info": lambda *a, **k: None,
+            "warning": lambda *a, **k: None,
+            "error": lambda *a, **k: None,
+        },
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _id: True)
+    monkeypatch.setattr(agent_run_module.workflow, "now", clock.now)
+
+
+class _Clock:
+    """Deterministic workflow clock advanced only by the bounded waits."""
+
+    def __init__(self) -> None:
+        self._now = _START
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now = self._now + timedelta(seconds=seconds)
+
+
+@pytest.mark.asyncio
+async def test_streaming_lane_is_bounded_by_the_deadline_it_can_enforce(
+    monkeypatch,
+):
+    """A lane that cannot observe progress must not be sized to the ceiling.
+
+    The workflow is blocked awaiting this activity for its whole duration, so it
+    cannot re-evaluate the budget, and the activity heartbeat is emitted
+    independently of semantic progress. Sizing ScheduleToClose to the
+    progress-aware ceiling would let a run that never makes progress hold its
+    provider slot for the full ceiling with nothing able to stop it.
+    """
+
+    clock = _Clock()
+    _configure_workflow_runtime(monkeypatch, clock=clock)
+    run = MoonMindAgentRun()
+    execute_kwargs: dict[str, object] = {}
+
+    async def fake_wait_condition(_condition, timeout=None):
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_routed_activity(activity_name, payload, **kwargs):
+        if activity_name == "integration.resolve_adapter_metadata":
+            return {
+                "agent_id": "openclaw",
+                "execution_style": "streaming_gateway",
+            }
+        if activity_name == "integration.openclaw.execute":
+            execute_kwargs.update(kwargs)
+            return {"summary": "Done", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module.workflow, "wait_condition", fake_wait_condition
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="openclaw",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        instructionRef="Do the thing.",
+        parameters={"publishMode": "none"},
+        timeoutPolicy={"timeout_seconds": 300},
+    )
+    budget = resolve_execution_budget(
+        agent_kind="external", timeout_policy=request.timeout_policy
+    )
+    assert budget.max_seconds > budget.base_seconds  # the ceiling is real
+
+    await run.run(request)
+
+    assert execute_kwargs, "the streaming lane activity was never dispatched"
+    assert execute_kwargs["schedule_to_close_timeout"] == timedelta(
+        seconds=budget.base_seconds
+    )
+    assert execute_kwargs["start_to_close_timeout"] == timedelta(
+        seconds=budget.base_seconds
+    )
+
+
+def _status_payload(status: str, log_offset: str) -> dict:
+    return {
+        "runId": "managed-run-1",
+        "agentKind": "managed",
+        "agentId": "claude_code",
+        "status": status,
+        "metadata": {"lastLogOffset": log_offset},
+    }
+
+
+class _StubManagerHandle:
+    """Stand-in for the provider-profile manager's external workflow handle."""
+
+    def __init__(self) -> None:
+        self.signals: list[tuple[str, object]] = []
+
+    async def signal(self, name, payload=None):
+        self.signals.append((name, payload))
+
+
+@pytest.mark.asyncio
+async def test_final_status_reconciliation_before_the_budget_verdict(monkeypatch):
+    """A budget verdict must not be accepted on evidence a poll would refresh.
+
+    The bounded wait can consume the entire known remaining budget. The status
+    poll was then skipped and the run declared timed out, so a supervisor
+    ``lastLogOffset`` advance that landed during that wait — progress that
+    extends the budget — was never read and the provider slot was released while
+    the process was working.
+    """
+
+    clock = _Clock()
+    _configure_workflow_runtime(monkeypatch, clock=clock)
+    run = MoonMindAgentRun()
+    manager = _StubManagerHandle()
+    status_polls: list[float] = []
+    reconciliation_polls: list[float] = []
+
+    async def fake_wait_condition(condition, timeout=None):
+        if condition():
+            return True
+        if timeout is not None:
+            clock.advance(timeout.total_seconds())
+        raise asyncio.TimeoutError()
+
+    async def _ensure_manager(*_args, **_kwargs):
+        run.slot_assigned_event.set()
+        return manager
+
+    async def _sync_profiles(*_args, **_kwargs):
+        return 1
+
+    class _StubAdapter:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def start(self, _request):
+            return AgentRunHandle(
+                runId="managed-run-1",
+                agentKind="managed",
+                agentId="claude_code",
+                status=RunStatus.running,
+                startedAt=clock.now(),
+                pollHintSeconds=10,
+            )
+
+    async def fake_execute_routed_activity(activity_name, payload, **kwargs):
+        if activity_name == "agent_runtime.status":
+            elapsed = (clock.now() - _START).total_seconds()
+            status_polls.append(elapsed)
+            # The final reconciliation is the one poll dispatched without a
+            # remaining-budget clamp: the budget looks spent, so the poll is
+            # given the activity's own configured window instead of zero.
+            is_reconciliation = "schedule_to_close_timeout" not in kwargs
+            if is_reconciliation:
+                reconciliation_polls.append(elapsed)
+                # The supervisor advance that landed during the last bounded
+                # wait — the evidence the old guard never read.
+                return _status_payload("running", "4096")
+            if reconciliation_polls:
+                return _status_payload("completed", "8192")
+            # Quiet throughout the base window.
+            return _status_payload("running", "0")
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Done", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        return {}
+
+    monkeypatch.setattr(
+        agent_run_module.workflow, "wait_condition", fake_wait_condition
+    )
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _StubAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", _ensure_manager)
+    monkeypatch.setattr(run, "_ensure_manager_started", _ensure_manager)
+    monkeypatch.setattr(run, "_sync_manager_profiles", _sync_profiles)
+    monkeypatch.setattr(run, "_uses_codex_session_adapter", lambda _r: False)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        executionProfileRef="default-managed",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        instructionRef="Do the thing.",
+        parameters={"publishMode": "none"},
+        timeoutPolicy={"timeout_seconds": _BASE_SECONDS},
+    )
+
+    result = await run.run(request)
+
+    assert status_polls, "the run never polled managed status"
+    # Exactly one reconciliation: the boundary is checked against fresh evidence
+    # once, not polled in a loop after the budget is spent.
+    assert len(reconciliation_polls) == 1
+    assert reconciliation_polls[0] >= _BASE_SECONDS
+    # The refreshed progress extended the budget, so the run was not timed out
+    # and its provider slot was not released while the process was working.
+    assert run.run_status != RunStatus.timed_out
+    assert result.failure_class is None

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_progress_aware_budget.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_progress_aware_budget.py
@@ -1,0 +1,322 @@
+"""AgentRun's progress-aware execution-budget decisions.
+
+Regression cover for MoonLadderStudios/MoonMind#3771. The AgentRun workflow
+terminated a managed run at its flat one-hour budget while the runtime was
+actively working — it had written files three seconds before the kill — and
+reported the outcome as "no observable progress". An hour of uncommitted work
+was discarded.
+
+These exercise the decision methods the poll loop actually calls, in both patch
+states, so the in-flight (pre-patch) path is covered alongside the new one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    ExecutionBudget,
+    resolve_execution_budget,
+)
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+_BUDGET = ExecutionBudget(
+    base_seconds=3600,
+    max_seconds=21600,
+    progress_stall_seconds=900,
+)
+
+_START = datetime(2026, 8, 25, 7, 24, tzinfo=UTC)
+
+
+def _request() -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId="claude_code",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Progress observation
+# ---------------------------------------------------------------------------
+
+
+def test_idle_seconds_is_none_before_any_progress_is_observed():
+    assert (
+        MoonMindAgentRun._budget_idle_progress_seconds(
+            progress_aware=True,
+            last_progress_at=None,
+            now=_START + timedelta(hours=1),
+        )
+        is None
+    )
+
+
+def test_idle_seconds_measures_from_the_last_observation():
+    assert (
+        MoonMindAgentRun._budget_idle_progress_seconds(
+            progress_aware=True,
+            last_progress_at=_START + timedelta(minutes=59),
+            now=_START + timedelta(hours=1),
+        )
+        == 60.0
+    )
+
+
+def test_idle_seconds_is_none_when_the_patch_is_off():
+    """An in-flight run records no progress evidence, so it cannot be extended."""
+
+    assert (
+        MoonMindAgentRun._budget_idle_progress_seconds(
+            progress_aware=False,
+            last_progress_at=_START + timedelta(minutes=59),
+            now=_START + timedelta(hours=1),
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# The #3771 journey
+# ---------------------------------------------------------------------------
+
+
+def test_working_run_is_not_terminated_at_the_base_budget():
+    """The exact failure: base budget reached, progress three seconds ago."""
+
+    verdict = MoonMindAgentRun._budget_verdict_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        elapsed_seconds=3600.0,
+        idle_progress_seconds=3.0,
+    )
+
+    assert verdict == "continue"
+
+
+def test_working_run_keeps_a_positive_poll_budget_past_the_base_window():
+    """The deadline must roll forward too, or the poll loop breaks out early
+    with a non-positive remaining budget even though the run may continue."""
+
+    deadline = MoonMindAgentRun._budget_deadline_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        elapsed_seconds=3600.0,
+        idle_progress_seconds=3.0,
+    )
+
+    assert deadline - 3600.0 > 0
+
+
+def test_working_run_finally_stops_at_the_ceiling_and_says_so():
+    verdict = MoonMindAgentRun._budget_verdict_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        elapsed_seconds=float(_BUDGET.max_seconds),
+        idle_progress_seconds=1.0,
+    )
+    detail = MoonMindAgentRun._budget_expiry_detail_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        verdict=verdict,
+    )
+
+    assert verdict == "expired_max_budget"
+    # It must not accuse a run that was demonstrably working of doing nothing.
+    assert "no observable progress" not in detail
+    assert "maximum execution budget" in detail
+
+
+def test_quiet_run_is_still_terminated_at_the_base_budget():
+    verdict = MoonMindAgentRun._budget_verdict_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        elapsed_seconds=3600.0,
+        idle_progress_seconds=float(_BUDGET.progress_stall_seconds),
+    )
+    detail = MoonMindAgentRun._budget_expiry_detail_for(
+        budget=_BUDGET,
+        progress_aware=True,
+        verdict=verdict,
+    )
+
+    assert verdict == "expired_no_progress"
+    assert "no observable progress" in detail
+
+
+def test_run_with_no_evidence_at_all_is_terminated_at_the_base_budget():
+    assert (
+        MoonMindAgentRun._budget_verdict_for(
+            budget=_BUDGET,
+            progress_aware=True,
+            elapsed_seconds=3600.0,
+            idle_progress_seconds=None,
+        )
+        == "expired_no_progress"
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-flight safety: a run replaying from before the patch is unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("elapsed", "idle", "expected"),
+    [
+        (3599.0, 0.0, "continue"),
+        (3600.0, 0.0, "expired_no_progress"),
+        (3600.0, None, "expired_no_progress"),
+        (10000.0, 0.0, "expired_no_progress"),
+    ],
+)
+def test_unpatched_runs_keep_the_flat_deadline(elapsed, idle, expected):
+    """Fresh progress must not extend a run that recorded the flat deadline."""
+
+    assert (
+        MoonMindAgentRun._budget_verdict_for(
+            budget=_BUDGET,
+            progress_aware=False,
+            elapsed_seconds=elapsed,
+            idle_progress_seconds=idle,
+        )
+        == expected
+    )
+    assert (
+        MoonMindAgentRun._budget_deadline_for(
+            budget=_BUDGET,
+            progress_aware=False,
+            elapsed_seconds=elapsed,
+            idle_progress_seconds=idle,
+        )
+        == float(_BUDGET.base_seconds)
+    )
+
+
+def test_unpatched_expiry_detail_matches_the_previous_wording():
+    """In-flight runs keep the message their operators are already reading."""
+
+    assert (
+        MoonMindAgentRun._budget_expiry_detail_for(
+            budget=_BUDGET,
+            progress_aware=False,
+            verdict="expired_no_progress",
+        )
+        == "made no observable progress and exceeded its execution budget"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Terminal result carries the evidence the decision was made on
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_timeout_result_records_the_budget_and_verdict():
+    workflow = MoonMindAgentRun()
+    result = workflow._timed_out_result(
+        request=_request(),
+        timeout_seconds=float(_BUDGET.max_seconds),
+        elapsed_seconds=float(_BUDGET.max_seconds),
+        detail=MoonMindAgentRun._budget_expiry_detail_for(
+            budget=_BUDGET, progress_aware=True, verdict="expired_max_budget"
+        ),
+        budget=_BUDGET,
+        verdict="expired_max_budget",
+    )
+
+    assert result.failure_class == "execution_error"
+    assert result.metadata["budgetVerdict"] == "expired_max_budget"
+    assert result.metadata["budgetExtendedForProgress"] is True
+    assert result.metadata["executionBudget"] == {
+        "baseSeconds": 3600,
+        "maxSeconds": 21600,
+        "progressStallSeconds": 900,
+    }
+    assert "no observable progress" not in result.summary
+
+
+def test_stalled_timeout_result_is_not_labelled_as_extended():
+    workflow = MoonMindAgentRun()
+    result = workflow._timed_out_result(
+        request=_request(),
+        timeout_seconds=float(_BUDGET.base_seconds),
+        elapsed_seconds=float(_BUDGET.base_seconds),
+        detail=MoonMindAgentRun._budget_expiry_detail_for(
+            budget=_BUDGET, progress_aware=True, verdict="expired_no_progress"
+        ),
+        budget=_BUDGET,
+        verdict="expired_no_progress",
+    )
+
+    assert result.metadata["budgetVerdict"] == "expired_no_progress"
+    assert result.metadata["budgetExtendedForProgress"] is False
+    assert "no observable progress" in result.summary
+
+
+def test_unpatched_timeout_result_omits_the_budget_metadata():
+    """In-flight runs keep the metadata shape their history already carries."""
+
+    workflow = MoonMindAgentRun()
+    result = workflow._timed_out_result(
+        request=_request(),
+        timeout_seconds=3600,
+        elapsed_seconds=3600,
+        detail="made no observable progress and exceeded its execution budget",
+    )
+
+    assert "executionBudget" not in result.metadata
+    assert "budgetVerdict" not in result.metadata
+    assert "budgetExtendedForProgress" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# The supervisor must receive the same budget the workflow enforces
+# ---------------------------------------------------------------------------
+
+
+def test_published_policy_carries_the_whole_budget():
+    request = _request()
+
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=_BUDGET, progress_aware=True
+    )
+
+    # What the launcher serializes is what the supervisor resolves.
+    launch_payload = request.model_dump(mode="json", by_alias=True)
+    published = launch_payload["timeoutPolicy"]
+    assert published["timeout_seconds"] == _BUDGET.base_seconds
+    assert published["max_timeout_seconds"] == _BUDGET.max_seconds
+    assert published["progress_stall_seconds"] == _BUDGET.progress_stall_seconds
+    assert (
+        resolve_execution_budget(agent_kind="managed", timeout_policy=published)
+        == _BUDGET
+    )
+
+
+def test_published_policy_preserves_unrelated_timeout_policy_keys():
+    request = _request()
+    request.timeout_policy = {"custom_key": "kept"}
+
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=_BUDGET, progress_aware=True
+    )
+
+    assert request.timeout_policy["custom_key"] == "kept"
+
+
+def test_unpatched_publish_keeps_the_prior_launch_payload_shape():
+    """Replay safety: an in-flight run must not gain fields in a payload it has
+    already dispatched."""
+
+    request = _request()
+
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=_BUDGET, progress_aware=False
+    )
+
+    assert request.timeout_policy == {"timeout_seconds": _BUDGET.base_seconds}

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_shared_execution_budget.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_shared_execution_budget.py
@@ -32,7 +32,9 @@ import pytest
 from moonmind.schemas.agent_runtime_models import (
     DEFAULT_EXTERNAL_TIMEOUT_SECONDS,
     DEFAULT_MANAGED_TIMEOUT_SECONDS,
+    MAX_EXECUTION_BUDGET_SECONDS,
     AgentExecutionRequest,
+    evaluate_execution_budget,
     resolve_execution_budget,
 )
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
@@ -114,6 +116,73 @@ def test_resolver_falls_back_on_degraded_input(degraded: dict) -> None:
     )
 
 
+def test_resolver_clamps_an_explicit_stall_window_to_the_base_budget() -> None:
+    # A stall window wider than the base window silently extends every quiet run
+    # past the deadline it asked for: the run's own start counts as an
+    # observation, so idle progress is never ``None`` and the base window stops
+    # being a boundary at all.
+    budget = resolve_execution_budget(
+        agent_kind="managed",
+        timeout_policy={"timeout_seconds": 60, "progress_stall_seconds": 300},
+    )
+
+    assert budget.progress_stall_seconds == 60
+    assert (
+        evaluate_execution_budget(
+            budget=budget,
+            elapsed_seconds=60.0,
+            # Nothing but the initial observation: the run has been quiet
+            # throughout, so it expires at its 60s base window.
+            idle_progress_seconds=60.0,
+        )
+        == "expired_no_progress"
+    )
+
+
+def test_resolver_never_returns_a_base_above_its_own_ceiling() -> None:
+    # A base window above the absolute cap used to be accepted while the ceiling
+    # was capped below it, producing a budget that terminated for "reaching the
+    # maximum" before the base window it claimed to honor had elapsed.
+    budget = resolve_execution_budget(
+        agent_kind="managed",
+        timeout_policy={"timeout_seconds": MAX_EXECUTION_BUDGET_SECONDS + 3600},
+    )
+
+    assert budget.base_seconds == MAX_EXECUTION_BUDGET_SECONDS
+    assert budget.max_seconds == MAX_EXECUTION_BUDGET_SECONDS
+    assert budget.base_seconds <= budget.max_seconds
+    assert (
+        evaluate_execution_budget(
+            budget=budget,
+            elapsed_seconds=float(budget.base_seconds) - 1,
+            idle_progress_seconds=None,
+        )
+        == "continue"
+    )
+
+
+def test_resolver_round_trips_its_own_published_policy() -> None:
+    # Whatever a boundary publishes, the boundary that reads it must resolve the
+    # identical budget — the two deadlines are one boundary.
+    for policy in ({}, {"timeout_seconds": 900, "max_timeout_seconds": 4000}):
+        budget = resolve_execution_budget(
+            agent_kind="managed", timeout_policy=policy
+        )
+        assert (
+            resolve_execution_budget(
+                agent_kind="managed", timeout_policy=budget.as_timeout_policy()
+            )
+            == budget
+        )
+        flat = budget.as_flat()
+        assert (
+            resolve_execution_budget(
+                agent_kind="managed", timeout_policy=flat.as_timeout_policy()
+            )
+            == flat
+        )
+
+
 # --- Workflow publishes the effective budget to the launch request -----------
 
 
@@ -158,9 +227,11 @@ def test_workflow_publishes_explicit_budget_into_launch_payload() -> None:
     )
 
 
-def test_in_flight_history_keeps_prior_launch_payload() -> None:
-    # Replay safety: a run started before the progress-aware patch must not gain
-    # new fields in the launch payload it already dispatched.
+def test_in_flight_history_publishes_its_flat_deadline() -> None:
+    # A run started before the progress-aware patch keeps its flat deadline, and
+    # says so explicitly: the launch activity re-resolves the budget from this
+    # payload on every retry, so a payload carrying only the base window would
+    # let the supervisor derive a ceiling the replayed workflow never granted.
     request = _request()
     budget = resolve_execution_budget(
         agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
@@ -171,8 +242,15 @@ def test_in_flight_history_keeps_prior_launch_payload() -> None:
     )
 
     assert request.timeout_policy == {
-        "timeout_seconds": DEFAULT_MANAGED_TIMEOUT_SECONDS
+        "timeout_seconds": DEFAULT_MANAGED_TIMEOUT_SECONDS,
+        "max_timeout_seconds": DEFAULT_MANAGED_TIMEOUT_SECONDS,
+        "progress_stall_seconds": DEFAULT_MANAGED_TIMEOUT_SECONDS,
+        "execution_budget_mode": "flat",
     }
+    supervisor_budget = resolve_execution_budget(
+        agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
+    )
+    assert supervisor_budget.max_seconds == DEFAULT_MANAGED_TIMEOUT_SECONDS
 
 
 # --- Activity-side supervisor derivation ------------------------------------

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_shared_execution_budget.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_shared_execution_budget.py
@@ -6,6 +6,12 @@ managed process supervisor to 3600s, so a run that explicitly requested a larger
 budget was still killed at one hour. The two deadlines are the same boundary and
 must derive from the same value.
 
+The budget later became progress-aware (MoonLadderStudios/MoonMind#3771), so what
+travels between the two boundaries is the whole budget — base window, hard
+ceiling, and stall window — not a lone deadline. Publishing only the base window
+would let the supervisor kill a process at the base budget even though the
+workflow had granted it an extension.
+
 These tests lock in:
 
 - the resolver contract (explicit request wins, kind-specific default otherwise,
@@ -13,7 +19,7 @@ These tests lock in:
 - that the managed default is NOT globally widened — a longer budget is
   requested explicitly per run;
 - that the workflow publishes its effective budget into the launch request's
-  ``timeoutPolicy`` so the supervisor enforces the same deadline;
+  ``timeoutPolicy`` so the supervisor enforces the same budget;
 - that in-flight histories started before the patch keep their prior payload;
 - that the ``agent_runtime.launch`` supervisor derivation uses the real
   ``AgentExecutionRequest`` invocation shape.
@@ -27,12 +33,9 @@ from moonmind.schemas.agent_runtime_models import (
     DEFAULT_EXTERNAL_TIMEOUT_SECONDS,
     DEFAULT_MANAGED_TIMEOUT_SECONDS,
     AgentExecutionRequest,
-    resolve_execution_timeout_seconds,
+    resolve_execution_budget,
 )
-from moonmind.workflows.temporal.workflows.agent_run import (
-    AGENT_RUN_SHARED_EXECUTION_BUDGET_PATCH_ID,
-    workflow as agent_run_workflow,
-)
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
 
 def _request(**kwargs) -> AgentExecutionRequest:
@@ -51,27 +54,32 @@ def _request(**kwargs) -> AgentExecutionRequest:
 
 def test_managed_default_is_not_globally_widened() -> None:
     # Raising the global fallback would make every affected managed run hold its
-    # provider slot longer and delay actionable failure. Long runs opt in.
+    # provider slot longer and delay actionable failure. A run that needs longer
+    # either demonstrates progress or opts in explicitly.
     assert DEFAULT_MANAGED_TIMEOUT_SECONDS == 3600
     assert DEFAULT_EXTERNAL_TIMEOUT_SECONDS == 21600
 
 
 def test_resolver_applies_kind_specific_defaults() -> None:
     assert (
-        resolve_execution_timeout_seconds(agent_kind="managed", timeout_policy={})
+        resolve_execution_budget(
+            agent_kind="managed", timeout_policy={}
+        ).base_seconds
         == DEFAULT_MANAGED_TIMEOUT_SECONDS
     )
     assert (
-        resolve_execution_timeout_seconds(agent_kind="external", timeout_policy=None)
+        resolve_execution_budget(
+            agent_kind="external", timeout_policy=None
+        ).base_seconds
         == DEFAULT_EXTERNAL_TIMEOUT_SECONDS
     )
 
 
 def test_resolver_honors_explicit_request() -> None:
     assert (
-        resolve_execution_timeout_seconds(
+        resolve_execution_budget(
             agent_kind="managed", timeout_policy={"timeout_seconds": 7200}
-        )
+        ).base_seconds
         == 7200
     )
 
@@ -81,19 +89,27 @@ def test_resolver_accepts_attribute_style_policy() -> None:
         timeout_seconds = 5400
 
     assert (
-        resolve_execution_timeout_seconds(
+        resolve_execution_budget(
             agent_kind="managed", timeout_policy=_Policy()
-        )
+        ).base_seconds
         == 5400
     )
 
 
 @pytest.mark.parametrize(
-    "degraded", [{"timeout_seconds": None}, {"timeout_seconds": "soon"}, {"timeout_seconds": 0}, {"timeout_seconds": -1}]
+    "degraded",
+    [
+        {"timeout_seconds": None},
+        {"timeout_seconds": "soon"},
+        {"timeout_seconds": 0},
+        {"timeout_seconds": -1},
+    ],
 )
 def test_resolver_falls_back_on_degraded_input(degraded: dict) -> None:
     assert (
-        resolve_execution_timeout_seconds(agent_kind="managed", timeout_policy=degraded)
+        resolve_execution_budget(
+            agent_kind="managed", timeout_policy=degraded
+        ).base_seconds
         == DEFAULT_MANAGED_TIMEOUT_SECONDS
     )
 
@@ -101,73 +117,62 @@ def test_resolver_falls_back_on_degraded_input(degraded: dict) -> None:
 # --- Workflow publishes the effective budget to the launch request -----------
 
 
-def _effective_budget(request: AgentExecutionRequest, *, patched: bool) -> int:
-    """Mirror the AgentRun budget/propagation step under a patch decision."""
-
-    timeout_seconds = resolve_execution_timeout_seconds(
+def test_workflow_publishes_default_budget_into_launch_payload() -> None:
+    request = _request()
+    budget = resolve_execution_budget(
         agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
     )
-    if agent_run_workflow.patched(AGENT_RUN_SHARED_EXECUTION_BUDGET_PATCH_ID):
-        request.timeout_policy = {
-            **(request.timeout_policy or {}),
-            "timeout_seconds": timeout_seconds,
-        }
-    return timeout_seconds
 
-
-def test_workflow_publishes_default_budget_into_launch_payload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        agent_run_workflow, "patched", lambda _id: True, raising=True
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=budget, progress_aware=True
     )
-    request = _request()
 
-    budget = _effective_budget(request, patched=True)
-
-    assert budget == DEFAULT_MANAGED_TIMEOUT_SECONDS
-    # The launch payload the adapter serializes now carries the same deadline.
+    # The launch payload the adapter serializes now carries the same budget.
     launch_payload = request.model_dump(mode="json", by_alias=True)
-    assert launch_payload["timeoutPolicy"]["timeout_seconds"] == budget
-
-
-def test_workflow_publishes_explicit_budget_into_launch_payload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        agent_run_workflow, "patched", lambda _id: True, raising=True
-    )
-    request = _request(timeoutPolicy={"timeout_seconds": 7200})
-
-    budget = _effective_budget(request, patched=True)
-
-    assert budget == 7200
-    launch_payload = request.model_dump(mode="json", by_alias=True)
-    assert launch_payload["timeoutPolicy"]["timeout_seconds"] == 7200
-    # Same value both sides: the supervisor no longer kills the process early.
+    published = launch_payload["timeoutPolicy"]
+    assert published["timeout_seconds"] == DEFAULT_MANAGED_TIMEOUT_SECONDS
     assert (
-        resolve_execution_timeout_seconds(
-            agent_kind="managed",
-            timeout_policy=launch_payload["timeoutPolicy"],
-        )
+        resolve_execution_budget(agent_kind="managed", timeout_policy=published)
         == budget
     )
 
 
-def test_in_flight_history_keeps_prior_launch_payload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # Replay safety: a run started before the patch must not gain a new field in
-    # the launch payload it already dispatched.
-    monkeypatch.setattr(
-        agent_run_workflow, "patched", lambda _id: False, raising=True
+def test_workflow_publishes_explicit_budget_into_launch_payload() -> None:
+    request = _request(timeoutPolicy={"timeout_seconds": 7200})
+    budget = resolve_execution_budget(
+        agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
     )
+
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=budget, progress_aware=True
+    )
+
+    launch_payload = request.model_dump(mode="json", by_alias=True)
+    published = launch_payload["timeoutPolicy"]
+    assert published["timeout_seconds"] == 7200
+    # Same budget both sides: the supervisor no longer kills the process early,
+    # and it extends for progress on exactly the numbers the workflow used.
+    assert (
+        resolve_execution_budget(agent_kind="managed", timeout_policy=published)
+        == budget
+    )
+
+
+def test_in_flight_history_keeps_prior_launch_payload() -> None:
+    # Replay safety: a run started before the progress-aware patch must not gain
+    # new fields in the launch payload it already dispatched.
     request = _request()
+    budget = resolve_execution_budget(
+        agent_kind=request.agent_kind, timeout_policy=request.timeout_policy
+    )
 
-    budget = _effective_budget(request, patched=False)
+    MoonMindAgentRun._publish_execution_budget(
+        request=request, budget=budget, progress_aware=False
+    )
 
-    assert budget == DEFAULT_MANAGED_TIMEOUT_SECONDS
-    assert request.timeout_policy == {}
+    assert request.timeout_policy == {
+        "timeout_seconds": DEFAULT_MANAGED_TIMEOUT_SECONDS
+    }
 
 
 # --- Activity-side supervisor derivation ------------------------------------
@@ -178,10 +183,10 @@ def test_launch_supervisor_derives_budget_from_request_shape() -> None:
 
     published = _request(timeoutPolicy={"timeout_seconds": 7200})
     assert (
-        resolve_execution_timeout_seconds(
+        resolve_execution_budget(
             agent_kind=str(getattr(published, "agent_kind", "managed") or "managed"),
             timeout_policy=getattr(published, "timeout_policy", None),
-        )
+        ).base_seconds
         == 7200
     )
 
@@ -189,9 +194,9 @@ def test_launch_supervisor_derives_budget_from_request_shape() -> None:
     # workflow would have used, not an independent activity-local literal.
     direct = _request()
     assert (
-        resolve_execution_timeout_seconds(
+        resolve_execution_budget(
             agent_kind=str(getattr(direct, "agent_kind", "managed") or "managed"),
             timeout_policy=getattr(direct, "timeout_policy", None),
-        )
+        ).base_seconds
         == DEFAULT_MANAGED_TIMEOUT_SECONDS
     )


### PR DESCRIPTION
## Problem

Workflow `mm:18b79365-e19e-4c0d-acb8-30aa5d6dbc6f` was terminated at its flat one-hour execution budget and reported as:

> Managed agent run made no observable progress and exceeded its execution budget after 3600s

It had made a great deal of progress. Its workspace held **27 modified files, +2471/−91 lines**, and file mtimes show it was executing its test suite **three seconds before the kill**. Nothing was recoverable: `resumeAllowed: false`, `blockedReason: no_checkpoint_evidence`, publish skipped, zero commits.

Elapsed wall-clock was being treated as evidence that a run is stuck. It is not. `claude -p` buffers all output until its turn completes, so `stdout.log` was 0 bytes for the entire 62 minutes and a healthy long run is byte-for-byte identical to a wedged one. The supervisor logged 117 consecutive `no stdout/stderr observed for 30s` annotations while the agent worked. `made no observable progress` was a hardcoded string on the timeout branch, not a measurement.

## Two halves, both necessary

Replaying the incident's real numbers through the new code:

| Progress evidence available | Verdict at 3600s |
|---|---|
| workspace-mtime only (what existed) | `expired_no_progress` — **still killed** |
| + process-tree CPU activity (new) | `continue`, deadline rolls to 4497s |

The budget change alone would not have saved this run. Its final 23 minutes wrote only into `__pycache__`, which the existing mtime probe deliberately skips. CPU was the only signal that separated it from a wedged process.

### 1. The execution budget is progress-aware

One authority resolves three fields from `timeoutPolicy`, applied identically at both boundaries that can end a run — the `MoonMind.AgentRun` poll loop and the managed process supervisor:

| Field | Meaning | Managed default |
|---|---|---|
| `timeout_seconds` | base window; a run that cannot show progress ends here | 3600s (unchanged) |
| `max_timeout_seconds` | hard ceiling; no progress extends past this | 6 × base |
| `progress_stall_seconds` | how long progress may go stale | 900s, never > base |

A run is terminated only when the base window elapses **and** progress has gone stale, or when the ceiling is reached. The ceiling derives from the base rather than an absolute constant, so an explicitly tight budget keeps a tight ceiling (60s → 360s, not six hours). The workflow publishes the whole budget into the launch request, so the supervisor extends and terminates on identical numbers.

### 2. Progress is observed evidence, never inferred

The supervisor takes the newest of three independent signals and publishes it as `last_log_at`, which the workflow already reads through canonical status metadata:

- **runtime output** — bytes on stdout/stderr
- **workspace mutation** — newest meaningful file mtime
- **process-tree CPU activity** — new; sums `utime+stime` across the supervised session

Summing by session id covers work done only by descendants — an agent that shells out to a test runner is idle in its own right while a grandchild burns the CPU. A process blocked forever on a dead socket, awaiting input, or deadlocked accrues none.

**Stated tradeoff:** a runtime that livelocks does consume CPU and therefore reads as progress. That is contained by the hard ceiling, which no amount of observed progress extends. Killing healthy long runs is the worse failure of the two.

## Honest failure reporting

The two expiry reasons are now distinct, because they call for different operator responses — raise the ceiling versus investigate a wedged runtime. A run stopped at the ceiling is never described as having made no progress, and the message carries the **real elapsed time** rather than the base window it was extended past. The terminal result records `executionBudget`, `budgetVerdict`, and `budgetExtendedForProgress`.

## Compatibility

Gated behind `agent-run-progress-aware-execution-budget-v1`. In-flight runs replay their recorded flat deadline unchanged, keep the launch-payload shape they already dispatched, and keep the wording their operators are reading — all covered by tests.

The added `timeoutPolicy` keys are additive; a worker that ignores them resolves the same defaults from the base window.

Credential lifetimes (execution-fanout capability) and the external `execute` activity's `ScheduleToClose` now size from the **ceiling**, not the base window. Sizing them from the base would strand an extended run without the authority the budget just granted it.

Per the pre-release compatibility policy, `resolve_execution_timeout_seconds` is **removed** rather than kept as an alias; `resolve_execution_budget(...).base_seconds` is the one accessor. The superseded `_heartbeat_and_wait` / `_heartbeat_and_wait_with_timeout` pair is likewise removed, not shimmed.

## Verification

Every CI-selected suite for this change, plus a baseline comparison for every failure.

| Suite | Result |
|---|---|
| `unit_fast` | **6888 passed** · 1 regression found + fixed · 40 identical on `main` |
| `temporal_boundary` | **3526 passed** · 1 environmental, identical on `main` |
| reliability journey | **111 passed** |
| supervisor + process-activity probe | **49 passed** |
| workflow budget decisions | **66 passed** (both patch states) |

Notable coverage:

- **Real processes through the real supervisor** — a silent, CPU-burning process now outlives its base budget and stops at the ceiling with an extension annotation; a `sleep` process with no evidence still dies at the base budget, nowhere near the ceiling.
- **Descendant-only work** registers as progress (the exact `pytest` case from the incident); unrelated host load does not.
- **In-flight replay** — with the patch off, verdict, deadline, expiry wording, and launch payload are all unchanged.
- **The two primitives agree** — `evaluate_execution_budget` returns non-`continue` exactly when elapsed has reached `_effective_deadline_seconds`. If they disagreed, a run could be told it may continue and then handed a negative poll budget.
- **Payload round-trip** — what the workflow publishes resolves back to the identical budget on the activity side.

Both non-fixed failures were proven pre-existing by running the identical command in a worktree at unmodified `main` and diffing the `^FAILED` lists. The `temporal_boundary` one is environmental: a Windows-created git worktree cannot run `git ls-files` from WSL.

## Docs

`docs/Temporal/ManagedAndExternalAgentExecutionModel.md` gains a declarative **§15.1 Execution budget** covering the contract, the progress-evidence model, the livelock tradeoff, and the rule that resources outliving a run size from the ceiling.

## Out of scope

The other half of this incident — MoonMind discarding the workspace as unrecoverable when a run is stopped by its budget — is **not** addressed here and remains open. The lost work from `mm:18b79365` was separately salvaged onto `recover/wf1-18b79365` (33 files, +4558 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
