### PR TITLE
feat(merge-automation): Fix and Review Loop preset with an opt-in pr-resolver finish

### DIFF
--- a/.agents/skills/_shared/publish_evidence.py
+++ b/.agents/skills/_shared/publish_evidence.py
@@ -540,6 +540,18 @@ def _resolver_head(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> st
     return head or _local_head_optional()
 
 
+def _pr_resolver_remediated(result: Mapping[str, Any]) -> bool:
+    """Return True when this resolver run ran a remediation (and so pushed)."""
+
+    history = result.get("attempt_history")
+    if not isinstance(history, list):
+        return False
+    return any(
+        isinstance(entry, Mapping) and _text(entry.get("stage")) == "full"
+        for entry in history
+    )
+
+
 def _is_no_work_result(result: Mapping[str, Any]) -> bool:
     disposition = _resolver_disposition(result)
     status = _resolver_status(result)
@@ -600,6 +612,39 @@ def from_pr_resolver_result(
                 reason="remote_merge_verification_unavailable",
                 artifacts_dir=artifacts_dir,
             )
+
+    if disposition == "review_clean" or status == "review_clean":
+        # fix_only finish mode: the merge gate opened with nothing left to
+        # address. The branch head is the authoritative evidence; no merge was
+        # attempted and none is claimed.
+        try:
+            local_head, remote_head, commands = _verify_exact_remote_head(branch)
+        except PublishEvidenceError:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="remote_verification_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+        pushed = _pr_resolver_remediated(result)
+        return _write_payload(
+            _evidence_payload(
+                skill_id="pr-resolver",
+                status="verified" if pushed else "no_op_verified",
+                action="push" if pushed else "none",
+                repository=repo,
+                branch=branch,
+                local_head=local_head,
+                remote_branch_head=remote_head,
+                remote_verified=True,
+                pushed=pushed,
+                merged=False,
+                pr_url=pr_url or None,
+                verification_commands=commands,
+            ),
+            artifacts_dir=artifacts_dir,
+        )
 
     if disposition == "reenter_gate" and status in {
         "blocked",

--- a/.agents/skills/_shared/publish_evidence.py
+++ b/.agents/skills/_shared/publish_evidence.py
@@ -213,6 +213,29 @@ def _verify_pr_merged(pr_url: str) -> tuple[dict[str, Any], list[str]]:
     ]
 
 
+def _verify_pr_unmerged(pr_selector: str) -> list[str]:
+    """Prove the PR is still open before claiming a no-merge terminal success.
+
+    `review_clean` asserts that the resolver finished *without* the merge side
+    effect. Local artifacts cannot prove that, so the remote PR state is the
+    authoritative evidence.
+    """
+
+    selector = _text(pr_selector)
+    if not selector:
+        raise PublishEvidenceError(
+            "a PR selector is required for review_clean publish evidence"
+        )
+    command = ["gh", "pr", "view", selector, "--json", "state,mergedAt,mergeCommit,url"]
+    payload = _run_json(command)
+    state = _text(payload.get("state")).upper()
+    if not state:
+        raise PublishEvidenceError("PR state is unavailable")
+    if state == "MERGED" or _text(payload.get("mergedAt")) or payload.get("mergeCommit"):
+        raise PublishEvidenceError("PR is merged; review_clean cannot be claimed")
+    return ["gh pr view <pr-url> --json state,mergedAt,mergeCommit,url"]
+
+
 def _evidence_payload(
     *,
     skill_id: str,
@@ -540,6 +563,12 @@ def _resolver_head(result: Mapping[str, Any], snapshot: Mapping[str, Any]) -> st
     return head or _local_head_optional()
 
 
+# Stage token both orchestration paths record for a remediation attempt
+# (`pr_resolve_orchestrate.py` and `pr_resolve_full.py`). The publish artifact
+# claims a push only when this exact stage appears in the result history.
+PR_RESOLVER_REMEDIATION_STAGE = "full_remediation"
+
+
 def _pr_resolver_remediated(result: Mapping[str, Any]) -> bool:
     """Return True when this resolver run ran a remediation (and so pushed)."""
 
@@ -547,7 +576,8 @@ def _pr_resolver_remediated(result: Mapping[str, Any]) -> bool:
     if not isinstance(history, list):
         return False
     return any(
-        isinstance(entry, Mapping) and _text(entry.get("stage")) == "full"
+        isinstance(entry, Mapping)
+        and _text(entry.get("stage")) == PR_RESOLVER_REMEDIATION_STAGE
         for entry in history
     )
 
@@ -625,6 +655,18 @@ def from_pr_resolver_result(
                 repo=repo,
                 branch=branch,
                 reason="remote_verification_unavailable",
+                artifacts_dir=artifacts_dir,
+            )
+        try:
+            commands = commands + _verify_pr_unmerged(
+                pr_url or _resolver_pr_selector(result, snapshot)
+            )
+        except PublishEvidenceError:
+            return write_blocked(
+                skill_id="pr-resolver",
+                repo=repo,
+                branch=branch,
+                reason="unmerged_pr_verification_unavailable",
                 artifacts_dir=artifacts_dir,
             )
         pushed = _pr_resolver_remediated(result)

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -50,6 +50,17 @@ inputSchema:
       description: >-
         When true, the resolver refuses to merge a head SHA that has no fresh
         review from reviewProvider and asks its owning gate to request one.
+    finishMode:
+      type: string
+      title: Finish mode
+      enum:
+        - merge
+        - fix_only
+      default: merge
+      description: >-
+        "merge" finishes by merging the pull request once the merge gate opens.
+        "fix_only" keeps remediating comments, CI, and conflicts but stops at an
+        open merge gate and reports review_clean instead of merging.
   anyOf:
     - required:
         - pr
@@ -66,6 +77,13 @@ You are the master orchestrator for finishing Pull Requests. Use bounded retries
 
 The task is not complete until the target PR is merged or is proven already merged. A local fix, local commit, passing local test run, unresolved review reply, or unpushed branch is not a successful PR resolution.
 
+`inputs.finishMode = fix_only` is the one exception, and it narrows only the
+final side effect: every remediation, push, verification, and gate check still
+applies, but when the merge gate opens with nothing left to address the resolver
+reports `review_clean` and stops instead of merging. `fix_only` never relaxes a
+blocker, never merges, and never reports success while comments, CI, or
+conflicts remain actionable.
+
 ## Inputs (skill args)
 - inputs.repo (optional)
 - inputs.pr (optional)
@@ -73,6 +91,8 @@ The task is not complete until the target PR is merged or is proven already merg
 - inputs.mergeMethod (merge|squash|rebase)
 - inputs.reviewProvider (default empty; `codex` enables the Codex review loop)
 - inputs.requireFreshReview (default false; true requires a fresh review per head)
+- inputs.finishMode (`merge` default, or `fix_only` to stop at an open merge
+  gate without merging)
 - inputs.maxIterations (default 5, full remediation cap per cycle)
 - inputs.finalizeMaxRetries (default 60)
 - inputs.finalizeBackoffSeconds (default 30)
@@ -136,14 +156,21 @@ metadata flag.
      --merge-method <merge|squash|rebase> \
      --review-provider <inputs.reviewProvider or ""> \
      --require-fresh-review \
+     --finish-mode <merge|fix_only> \
      --strict-exit-codes
    ```
 
    Use `--no-require-fresh-review` when `inputs.requireFreshReview` is false or
-   absent. `PR_RESOLVER_REVIEW_PROVIDER` and `PR_RESOLVER_REQUIRE_FRESH_REVIEW`
-   are equivalent environment defaults for non-agent automation.
+   absent. Pass `--finish-mode` exactly as supplied by `inputs.finishMode`;
+   omitting it defaults to `merge`, which grants merge authority this run may
+   not have. `PR_RESOLVER_REVIEW_PROVIDER`, `PR_RESOLVER_REQUIRE_FRESH_REVIEW`,
+   and `PR_RESOLVER_FINISH_MODE` are equivalent environment defaults for
+   non-agent automation.
 
 3. Read `var/pr_resolver/result.json` and perform exactly the indicated action:
+   - `review_clean`: `finishMode` is `fix_only`, the merge gate opened, and
+     nothing is left to address. Publish terminal evidence for the verified
+     branch head and stop without merging.
    - `merged` or independently verified `already_merged`: publish terminal
      evidence and stop. A successful `gh pr merge` request is not terminal
      evidence until a fresh `gh pr view` reports `state=MERGED`; merge-queue or
@@ -183,11 +210,18 @@ metadata flag.
 Allowed successful terminal states:
 - `var/pr_resolver/result.json` has `status=merged`, `merge_outcome=merged`, and `mergeAutomationDisposition=merged`.
 - The PR is independently confirmed as already merged after a snapshot/finalize race, with `mergeAutomationDisposition=already_merged`.
+- `finishMode=fix_only` reached an open merge gate: `status=review_clean`,
+  `merge_outcome=skipped`, and `mergeAutomationDisposition=review_clean`. This
+  state is allowed only when the same gate that authorizes a merge is fully
+  open; it is never a way to report an unresolved blocker as success.
 
 ## Merge Automation Result Contract
 Every terminal `var/pr_resolver/result.json` MUST include `mergeAutomationDisposition`:
 - `merged`: the resolver merged the PR.
 - `already_merged`: the PR was independently confirmed as already merged.
+- `review_clean`: `finishMode` is `fix_only` and the merge gate opened with no
+  actionable comments, CI failures, or conflicts left. The resolver did not
+  merge and must not claim a merge.
 - `request_review`: the current head SHA needs one fresh automated review from
   the configured provider before merge is allowed. Include a
   `gated-continuation/v2` `gatedContinuation` naming only the provider, the

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -43,7 +43,11 @@ EXIT_CODE_MERGED = 0
 EXIT_CODE_BLOCKED = 2
 EXIT_CODE_ATTEMPTS_EXHAUSTED = 3
 EXIT_CODE_FAILED = 4
-EXIT_CODE_REVIEW_CLEAN = 5
+# `review_clean` is a documented terminal success, so it exits zero like
+# `merged`. Shells, CI runners, and portable hosts read any nonzero exit as a
+# failed command; the terminal outcome is distinguished by `status` and
+# `mergeAutomationDisposition` in the result JSON, not by the exit code.
+EXIT_CODE_REVIEW_CLEAN = 0
 
 # Finish modes. "merge" is the full resolver contract: the run is not complete
 # until the PR is merged. "fix_only" stops at the merge gate: the resolver keeps

--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -43,13 +43,35 @@ EXIT_CODE_MERGED = 0
 EXIT_CODE_BLOCKED = 2
 EXIT_CODE_ATTEMPTS_EXHAUSTED = 3
 EXIT_CODE_FAILED = 4
+EXIT_CODE_REVIEW_CLEAN = 5
+
+# Finish modes. "merge" is the full resolver contract: the run is not complete
+# until the PR is merged. "fix_only" stops at the merge gate: the resolver keeps
+# remediating comments, CI, and conflicts, but reports `review_clean` instead of
+# merging once nothing is left to address.
+FINISH_MODE_MERGE = "merge"
+FINISH_MODE_FIX_ONLY = "fix_only"
+FINISH_MODES = (FINISH_MODE_MERGE, FINISH_MODE_FIX_ONLY)
 
 MERGE_AUTOMATION_DISPOSITION_MERGED = "merged"
 MERGE_AUTOMATION_DISPOSITION_ALREADY_MERGED = "already_merged"
+MERGE_AUTOMATION_DISPOSITION_REVIEW_CLEAN = "review_clean"
 MERGE_AUTOMATION_DISPOSITION_REENTER_GATE = "reenter_gate"
 MERGE_AUTOMATION_DISPOSITION_REQUEST_REVIEW = "request_review"
 MERGE_AUTOMATION_DISPOSITION_MANUAL_REVIEW = "manual_review"
 MERGE_AUTOMATION_DISPOSITION_FAILED = "failed"
+
+def normalize_finish_mode(value: Any) -> str:
+    """Return a supported finish mode, defaulting to the full merge contract."""
+
+    candidate = normalize_text(value).lower()
+    if candidate == FINISH_MODE_FIX_ONLY:
+        return FINISH_MODE_FIX_ONLY
+    if candidate in {"", FINISH_MODE_MERGE}:
+        return FINISH_MODE_MERGE
+    raise ValueError(
+        f"unsupported finish mode '{candidate}'; expected one of {list(FINISH_MODES)}"
+    )
 
 def now_utc_iso() -> str:
     return datetime.now(UTC).isoformat()
@@ -262,6 +284,8 @@ def merge_automation_disposition_for_result(
         "wait_for_automated_review_and_retry_finalize",
     }:
         return MERGE_AUTOMATION_DISPOSITION_REENTER_GATE
+    if normalized_status == MERGE_AUTOMATION_DISPOSITION_REVIEW_CLEAN:
+        return MERGE_AUTOMATION_DISPOSITION_REVIEW_CLEAN
     if normalized_status == "merged" and normalized_outcome == "merged":
         if normalized_reason == "already_merged":
             return MERGE_AUTOMATION_DISPOSITION_ALREADY_MERGED

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -33,13 +33,17 @@ from pr_resolve_contract import (  # noqa: E402
     EXIT_CODE_BLOCKED,
     EXIT_CODE_FAILED,
     EXIT_CODE_MERGED,
+    EXIT_CODE_REVIEW_CLEAN,
     FINALIZE_ONLY_RETRY_REASONS,
+    FINISH_MODE_FIX_ONLY,
+    FINISH_MODES,
     FULL_REMEDIATION_REASONS,
     RESULT_SCHEMA_VERSION,
     REVIEW_REQUEST_REASONS,
     build_gated_continuation,
     current_execution_ref,
     merge_automation_disposition_for_result,
+    normalize_finish_mode,
     normalize_text,
     now_utc_iso,
     remediation_next_step,
@@ -279,7 +283,18 @@ def main() -> None:
         action="store_false",
         help="Do not require a fresh automated review for the current head SHA.",
     )
+    parser.add_argument(
+        "--finish-mode",
+        default=os.environ.get("PR_RESOLVER_FINISH_MODE", "") or "merge",
+        choices=list(FINISH_MODES),
+        help=(
+            "'merge' finishes by merging the PR once the gate passes. "
+            "'fix_only' stops at a passing gate and reports review_clean "
+            "without merging."
+        ),
+    )
     args = parser.parse_args()
+    finish_mode = normalize_finish_mode(args.finish_mode)
 
     snapshot_script = Path(__file__).with_name("pr_resolve_snapshot.py")
     snapshot_path = Path(args.snapshot_path)
@@ -378,6 +393,20 @@ def main() -> None:
             sys.exit(EXIT_CODE_MERGED)
 
         if action == "merge_now":
+            if finish_mode == FINISH_MODE_FIX_ONLY:
+                # Nothing is left to address and the gate is open, but this run
+                # was not granted merge authority. Report the clean state as a
+                # terminal success instead of merging.
+                _write_result(
+                    result_path,
+                    snapshot=snapshot,
+                    decision="merge gate passed; finish mode is fix_only",
+                    merge_outcome="skipped",
+                    status="review_clean",
+                    reason="finish_mode_fix_only",
+                )
+                print("Merge gate passed; no comments left to address (not merging).")
+                sys.exit(EXIT_CODE_REVIEW_CLEAN)
             if args.dry_run:
                 _write_result(
                     result_path,

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -23,7 +23,9 @@ from pr_resolve_contract import (  # noqa: E402
     EXIT_CODE_BLOCKED,
     EXIT_CODE_FAILED,
     EXIT_CODE_MERGED,
+    EXIT_CODE_REVIEW_CLEAN,
     FINALIZE_ONLY_RETRY_REASONS,
+    FINISH_MODES,
     FULL_REMEDIATION_REASONS,
     RESULT_SCHEMA_VERSION,
     classify_retry_action,
@@ -55,7 +57,13 @@ def _read_json(path: Path) -> dict[str, Any] | None:
 
 def _normalize_status(payload: dict[str, Any]) -> str:
     status = normalize_text(payload.get("status")).lower()
-    if status in {"merged", "blocked", "failed", "attempts_exhausted"}:
+    if status in {
+        "merged",
+        "review_clean",
+        "blocked",
+        "failed",
+        "attempts_exhausted",
+    }:
         return status
     merge_outcome = normalize_text(payload.get("merge_outcome")).lower()
     if merge_outcome == "merged":
@@ -238,6 +246,26 @@ def run_orchestration(
                 finished_at=now_utc_iso(),
             )
             return result, EXIT_CODE_MERGED
+
+        if finalize_status == "review_clean":
+            # fix_only finish mode: the merge gate opened with nothing left to
+            # address, so the loop is complete without a merge side effect.
+            result = _build_result(
+                status="review_clean",
+                decision="review clean; merge gate passed without merging",
+                merge_outcome="skipped",
+                final_reason=reason or "finish_mode_fix_only",
+                next_step="done",
+                max_attempts=max_attempts,
+                finalize_max_retries=finalize_max_retries,
+                fix_max_iterations=fix_max_iterations,
+                min_attempts_before_exhausted=min_attempts_before_exhausted,
+                history=history,
+                escalations=escalations,
+                started_at=started_at,
+                finished_at=now_utc_iso(),
+            )
+            return result, EXIT_CODE_REVIEW_CLEAN
 
         if finalize_status == "failed":
             result = _build_result(
@@ -669,6 +697,16 @@ def main() -> None:
         action="store_false",
         help="Do not require a fresh automated review for the current head SHA.",
     )
+    parser.add_argument(
+        "--finish-mode",
+        default=os.environ.get("PR_RESOLVER_FINISH_MODE", "") or "merge",
+        choices=list(FINISH_MODES),
+        help=(
+            "'merge' finishes by merging the PR once the gate passes. "
+            "'fix_only' stops at a passing gate and reports review_clean "
+            "without merging."
+        ),
+    )
     args = parser.parse_args()
 
     finalize_script = Path(__file__).with_name("pr_resolve_finalize.py")
@@ -689,6 +727,8 @@ def main() -> None:
             str(snapshot_path),
             "--result-path",
             str(finalize_result_path),
+            "--finish-mode",
+            args.finish_mode,
             "--strict-exit-codes",
         ]
         if args.pr:

--- a/.agents/skills/pr-resolver/schemas/pr_resolver_result.schema.json
+++ b/.agents/skills/pr-resolver/schemas/pr_resolver_result.schema.json
@@ -37,6 +37,7 @@
       "type": "string",
       "enum": [
         "merged",
+        "review_clean",
         "blocked",
         "attempts_exhausted",
         "failed",
@@ -61,6 +62,7 @@
       "enum": [
         "merged",
         "already_merged",
+        "review_clean",
         "reenter_gate",
         "request_review",
         "manual_review",

--- a/api_service/data/presets/pr-review-resolve.yaml
+++ b/api_service/data/presets/pr-review-resolve.yaml
@@ -1,8 +1,8 @@
 slug: pr-review-resolve
-title: Review, Fix, and Merge PR
-description: Run an automated review, fix every actionable comment, request a fresh
-  review for each new head, and merge the pull request when the latest review is
-  clean.
+title: Fix and Review Loop
+description: Request an automated review for every new head, fix every actionable
+  comment, and repeat until the pull request is clean. Optionally finish with a
+  final pr-resolver pass that merges the pull request.
 scope: global
 tags:
 - github
@@ -14,7 +14,7 @@ requiredCapabilities:
 - gh
 annotations:
   sourceSkill: pr-resolver
-  output: merged-pull-request
+  output: reviewed-pull-request
   # The workflow itself publishes nothing: `pr-resolver` owns every commit, push,
   # and merge, and the parent-owned MoonMind.MergeAutomation child owns the
   # review request side effect and the durable wait for its result.
@@ -24,7 +24,12 @@ annotations:
       enabled: true
       checks: required
       automatedReview: required
-      mergeMethod: '{{ inputs.merge_method }}'
+      # The merge method is a fixed implementation detail of the optional finish
+      # pass, not an operator control.
+      mergeMethod: squash
+      # `merge` runs a final pr-resolver pass with merge authority once nothing
+      # is left to address. `fix_only` stops the loop at that same open gate.
+      finishMode: '{{ "merge" if inputs.finish_with_pr_resolver else "fix_only" }}'
       reviewLoop:
         enabled: true
         provider: '{{ inputs.review_provider }}'
@@ -53,18 +58,18 @@ annotations:
       review_provider:
         type: string
         title: Automated review provider
-        description: Automated reviewer that must review every head SHA before merge.
+        description: Automated reviewer that must review every head SHA before the
+          loop can finish.
         enum:
         - codex
         default: codex
-      merge_method:
-        type: string
-        title: Merge method
-        enum:
-        - squash
-        - merge
-        - rebase
-        default: squash
+      finish_with_pr_resolver:
+        type: boolean
+        title: Finish with pr-resolver
+        description: Run a final pr-resolver pass that merges the pull request once
+          there are no more comments to address. Leave this off to stop the loop at
+          the first clean review without merging.
+        default: false
       advanced_options:
         type: boolean
         title: Advanced options
@@ -81,7 +86,7 @@ annotations:
       expire_after_seconds:
         type: integer
         title: Expire after (seconds)
-        description: Hard deadline for the whole review-and-merge loop.
+        description: Hard deadline for the whole fix-and-review loop.
         default: 86400
         minimum: 600
         maximum: 2592000
@@ -90,8 +95,8 @@ annotations:
       placeholder: '123, a pull request URL, or a head branch'
     review_provider:
       widget: select
-    merge_method:
-      widget: select
+    finish_with_pr_resolver:
+      widget: checkbox
     advanced_options:
       widget: checkbox
     max_review_cycles:
@@ -106,7 +111,7 @@ annotations:
         equals: true
   defaults:
     review_provider: codex
-    merge_method: squash
+    finish_with_pr_resolver: false
     advanced_options: false
     max_review_cycles: 5
     expire_after_seconds: 86400
@@ -125,11 +130,11 @@ inputs:
   type: text
   required: false
   default: codex
-- name: merge_method
-  label: Merge Method
-  type: text
+- name: finish_with_pr_resolver
+  label: Finish With pr-resolver
+  type: boolean
   required: false
-  default: squash
+  default: false
 - name: advanced_options
   label: Advanced Options
   type: boolean
@@ -155,8 +160,8 @@ steps:
 
 
     Record the pull request URL, the exact current head SHA, the head branch, and
-    the base branch so merge automation is bound to that exact revision from its
-    first gate evaluation. If the pull request is closed, merged, or cannot be
+    the base branch so the fix-and-review loop is bound to that exact revision from
+    its first gate evaluation. If the pull request is closed, merged, or cannot be
     resolved to exactly one open pull request, stop and report the blocker instead
     of guessing a target.'
   tool:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,72 +1,27 @@
 [
   {
-    "id": 3862243216,
+    "id": 3860739325,
     "disposition": "addressed",
-    "rationale": "Added the GPU resource to the canonical container-job contract: ResourceLimits.gpu (sharing the one WorkloadGpuRequest contract), the container.run_job tool schema, a non-overridable MOONMIND_CONTAINER_BACKEND_MAX_GPU_COUNT deployment ceiling, and device-request realization in DockerContainerJobBackend.create_container, with tool-schema, model, serialization, ceiling, and create-arg tests."
+    "rationale": "run.py now validates finishMode through _normalize_finish_mode: only an omitted value takes the merge default, and any other unsupported value raises a non-retryable UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE ApplicationError before a resolver child is granted merge authority."
   },
   {
-    "id": 3862243232,
+    "id": 3860739332,
     "disposition": "addressed",
-    "rationale": "Qualification records are now published to a durable root outside the ephemeral workspace (MOONMIND_GPU_QUALIFICATION_RECORD_DIR, default var/gpu_qualification); tools/test_gpu_qualification.sh creates and announces it and runs pytest with -s so each published record path is visible."
+    "rationale": "terminal_evidence.py now applies disposition-specific invariants for review_clean (merged=false and a non-merge action, plus no merge claim in the resolver result) and fails with UNAUTHORIZED_MERGE_EVIDENCE; the Skill's review_clean publish path adds the authoritative remote check that the PR is still unmerged."
   },
   {
-    "id": 3862243240,
+    "id": 3860739342,
     "disposition": "addressed",
-    "rationale": "classify_gpu_launch_failure now requires objective launch-refusal evidence: Docker's own launch-failure exit status (125) in addition to the vendor diagnostic. A started container that exits nonzero while writing NVML/nvidia-container-cli/device-driver text is no longer classified as a device-request refusal; covered by new parametrized tests."
+    "rationale": "publish_evidence.py now matches the real production stage token full_remediation via PR_RESOLVER_REMEDIATION_STAGE, so a remediated fix_only run publishes verified/push/pushed=true instead of no_op_verified. The existing test that encoded the fictional 'full' token was corrected."
   },
   {
-    "id": 3862243248,
+    "id": 3860739355,
     "disposition": "addressed",
-    "rationale": "gpu.count is validated in the before validator against the raw value, so true, \"2\", \" 2 \", 2.0, None, and [] are rejected instead of being coerced into device counts; the redundant after validator was removed."
+    "rationale": "EXIT_CODE_REVIEW_CLEAN is now 0, so pr_resolve_finalize.py and pr_resolve_orchestrate.py exit zero for this documented terminal success with or without --strict-exit-codes; the outcome stays distinguishable through status and mergeAutomationDisposition in the result JSON."
   },
   {
-    "id": 3862243260,
-    "disposition": "addressed",
-    "rationale": "Added a bounded device-availability probe to collection-time preflight: one throwaway container carrying the journey's device request, classified with the production classify_gpu_launch_failure, so a runtime-registered but device-unavailable host skips with an explicit reason."
-  },
-  {
-    "id": 3862243269,
-    "disposition": "addressed",
-    "rationale": "_removes_container_on_exit now returns True on the unrestricted path only for a device-bearing request, so a replayed or retried in-flight CPU-only workload.run keeps its retained-container semantics and its removeContainerOnExit: false metadata. Covered by CPU-only and GPU cleanup tests."
-  },
-  {
-    "id": 3862243276,
-    "disposition": "addressed",
-    "rationale": "_run_docker passes --host MOONMIND_GPU_QUALIFICATION_DOCKER_HOST when configured, so preflight, the device probe, image/volume/container inspection, and teardown all target the same daemon that ran the workload; tools/test_gpu_qualification.sh does the same for its preflight."
-  },
-  {
-    "id": 3862243285,
-    "disposition": "addressed",
-    "rationale": "The dynamically generated declared-output path is exported to the container as MOONMIND_GPU_QUALIFICATION_OUTPUT, and declaredOutputs plus its assertions are declared only when the command agreed to write it (default command, or an override opting in via MOONMIND_GPU_QUALIFICATION_COMMAND_WRITES_OUTPUT)."
-  },
-  {
-    "id": 3862243296,
-    "disposition": "addressed",
-    "rationale": "deviceRequestArgs is now populated from the executed result's metadata.workload.gpu observations through verified_gpu_observations, and record construction is rejected when that terminal evidence is absent, empty, or realized through a different substrate. The host-independence test now supplies the generic executed-workload evidence."
-  },
-  {
-    "id": 3862243307,
-    "disposition": "addressed",
-    "rationale": "moonmind_revision returns None instead of \"unknown\" and build_gpu_qualification_record fails before publishing without an immutable identity; tools/test_gpu_qualification.sh resolves the checkout revision into MOONMIND_BUILD_SHA and fails fast when neither identity is available."
-  },
-  {
-    "id": 5029810043,
+    "id": 5028028248,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review header, no actionable request."
-  },
-  {
-    "id": 3862243315,
-    "disposition": "addressed",
-    "rationale": "verified_gpu_observations validates the request/result authority binding before the record is built: result.requestId, metadata containerName, imageRef, and the realized GPU request must all match the submitted request, so a concurrent or retried run's outcome cannot be recorded under this request's identity."
-  },
-  {
-    "id": 3862243323,
-    "disposition": "addressed",
-    "rationale": "parse_image_digest now parses the RepoDigests JSON array structurally and selects the digest whose normalized registry/repository matches the requested image, so an alias repository's digest is never attributed to the requested reference."
-  },
-  {
-    "id": 3862243331,
-    "disposition": "addressed",
-    "rationale": "The warm-reuse journey writes a unique marker into /work/cache during the first GPU request and requires the second GPU request to read it back, and the cache listing asserts the marker is present, so cache reuse is proven rather than inferred from volume existence."
+    "rationale": "Codex review header comment with no actionable request; its individual findings are tracked as the four review comments above."
   }
 ]

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -111,7 +111,7 @@ free-form instructions.
 | `mergeMethod`         | enum        | `squash` | `merge`|`squash`|`rebase`                                                                                            |
 | `reviewProvider`      | string      |     `""` | Provider-neutral automated reviewer that must review every head SHA (for example `codex`). Empty or `none` disables the loop. |
 | `requireFreshReview`  | bool        |  `false` | Refuse to merge a head SHA that has no fresh review from `reviewProvider`.                                             |
-| `finishMode`          | enum        |  `merge` | `merge` merges once the gate opens; `fix_only` stops at the same open gate and reports `review_clean`. |
+| `finishMode`          | enum        |  `merge` | `merge` merges once the gate opens; `fix_only` stops at the same open gate and reports `review_clean`. Only an omitted value takes the default; any other unsupported value fails validation instead of inheriting merge authority. |
 | `maxIterations`             | int         |        5 | Guardrail to avoid loops (re-evaluate after each fix).                                                                            |
 | `finalizeMaxRetries`        | int         |       60 | Total retries allowed for the orchestration process, including both finalize-only waits and full remediation cycles.              |
 | `finalizeBackoffSeconds`    | int         |       30 | Base sleep for finalize-only retries. The orchestrator uses exponential backoff and caps each sleep at `finalizeMaxSleepSeconds`. |
@@ -172,7 +172,11 @@ was not granted merge authority. It narrows the side effect only: every gate,
 blocker, remediation, and evidence rule is unchanged, so an unresolved blocker
 still produces `manual_review`, `reenter_gate`, `request_review`, or `failed`. Its
 terminal evidence is the usual `artifacts/publish_result.json` with
-`merged = false` and the branch head verified on the remote.
+`merged = false` and the branch head verified on the remote, plus a live check
+that the pull request is still unmerged. Evidence that reports a merge — or that
+cannot verify the remote — is rejected as `UNAUTHORIZED_MERGE_EVIDENCE` or
+published as blocked instead of closing the run successfully. Being a terminal
+success, `review_clean` exits `0`; the result JSON carries the distinction.
 
 The canonical workflow terminal dispositions are `merged`, `already_merged`,
 `review_clean`, `manual_review`, and `failed`. Intermediate waits and remediation

--- a/docs/Steps/SkillGithubPrResolver.md
+++ b/docs/Steps/SkillGithubPrResolver.md
@@ -111,6 +111,7 @@ free-form instructions.
 | `mergeMethod`         | enum        | `squash` | `merge`|`squash`|`rebase`                                                                                            |
 | `reviewProvider`      | string      |     `""` | Provider-neutral automated reviewer that must review every head SHA (for example `codex`). Empty or `none` disables the loop. |
 | `requireFreshReview`  | bool        |  `false` | Refuse to merge a head SHA that has no fresh review from `reviewProvider`.                                             |
+| `finishMode`          | enum        |  `merge` | `merge` merges once the gate opens; `fix_only` stops at the same open gate and reports `review_clean`. |
 | `maxIterations`             | int         |        5 | Guardrail to avoid loops (re-evaluate after each fix).                                                                            |
 | `finalizeMaxRetries`        | int         |       60 | Total retries allowed for the orchestration process, including both finalize-only waits and full remediation cycles.              |
 | `finalizeBackoffSeconds`    | int         |       30 | Base sleep for finalize-only retries. The orchestrator uses exponential backoff and caps each sleep at `finalizeMaxSleepSeconds`. |
@@ -138,8 +139,8 @@ Result should include:
 * Decision summary (actions taken)
 * Merge outcome (merged / skipped / blocked + reason)
 * `mergeAutomationDisposition` for merge automation consumers:
-  `merged`, `already_merged`, `reenter_gate`, `request_review`, `manual_review`,
-  or `failed`
+  `merged`, `already_merged`, `review_clean`, `reenter_gate`, `request_review`,
+  `manual_review`, or `failed`
 
 `reenter_gate` is terminal for the current resolver process but nonterminal for
 its enclosing merge automation. The Skill authors a `gated-continuation/v1`
@@ -165,9 +166,17 @@ must not own a multi-hour external wait. The validated
 exact command, performs the request through one idempotent Activity, and owns
 the durable wait for the result.
 
+`review_clean` is the terminal disposition for `finishMode = fix_only`. It means
+the merge gate is fully open and the Skill withheld the merge because this run
+was not granted merge authority. It narrows the side effect only: every gate,
+blocker, remediation, and evidence rule is unchanged, so an unresolved blocker
+still produces `manual_review`, `reenter_gate`, `request_review`, or `failed`. Its
+terminal evidence is the usual `artifacts/publish_result.json` with
+`merged = false` and the branch head verified on the remote.
+
 The canonical workflow terminal dispositions are `merged`, `already_merged`,
-`manual_review`, and `failed`. Intermediate waits and remediation dispatches stay
-inside workflow state and are not terminal agent dispositions.
+`review_clean`, `manual_review`, and `failed`. Intermediate waits and remediation
+dispatches stay inside workflow state and are not terminal agent dispositions.
 
 ### 4.3 Automated review evidence
 

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -175,6 +175,7 @@ Merge automation is configured in the normalized `MoonMind.UserWorkflow` paramet
   "mergeAutomation": {
     "enabled": true,
     "strategy": "child_workflow_resolver_v1",
+    "finishMode": "merge",
     "resolver": {
       "skill": "pr-resolver",
       "mergeMethod": "squash"
@@ -231,6 +232,31 @@ Two consequences follow, and both are load-bearing:
 
 A run that publishes nothing and enables no merge automation is unaffected: it
 keeps the default queue and starts no gate.
+
+### 9.1.2 Finish mode
+
+`mergeAutomation.finishMode` decides what happens at the **one** moment the gate
+is open and the resolver reports that nothing is left to address:
+
+- **`merge`** (default): the resolver child runs with merge authority. That final
+  `pr-resolver` pass merges the pull request and merge automation terminates
+  `merged` or `already_merged`. This is the historical behavior, and it is the
+  default for every payload recorded before this field existed.
+- **`fix_only`**: the resolver child runs without merge authority. Every
+  remediation, push, verification, review request, and gate check is identical;
+  only the merge is withheld. When the same gate that would authorize a merge
+  opens with nothing left to address, the resolver reports `review_clean` and
+  merge automation terminates `review_clean`.
+
+`fix_only` is a narrowing of authority, never a relaxation of a gate. It cannot
+turn an unresolved blocker, a pending review, a failing check, or a deferred
+comment into success — those still produce `blocked`, `failed`, or
+`manual_review`. `mergeAutomation.finishMode` is the only place the mode is
+configured; the resolver child request derives its merge authority from it, and
+the merge method stays a separate fixed detail of the finish pass.
+
+Because `fix_only` performs no merge, no post-merge Jira or GitHub completion is
+owed and none is attempted.
 
 ### 9.2 Parent publish output
 
@@ -443,6 +469,8 @@ Allowed terminal `status` values:
 
 - `merged`
 - `already_merged`
+- `review_clean` - `finishMode = fix_only` reached an open gate with nothing left
+  to address; the pull request was deliberately not merged
 - `blocked`
 - `failed`
 - `expired`
@@ -772,8 +800,16 @@ Allowed values:
 
 - `merged`
 - `already_merged`
+- `review_clean`
 - `reenter_gate`
 - `request_review`
+
+`review_clean` is reachable only under `finishMode = fix_only`. It asserts that
+the merge gate is fully open and that the resolver chose not to merge because it
+was not granted merge authority. Its terminal evidence is the same
+`artifacts/publish_result.json` contract the merge dispositions use, with
+`merged = false` and the branch head verified on the remote. A resolver run with
+merge authority must never return it.
 
 For `reenter_gate`, a successful resolver child result means the child satisfied
 its durable handoff contract; it does not mean the pull request merged. The
@@ -936,6 +972,11 @@ The parent `MoonMind.UserWorkflow` succeeds only when `MoonMind.MergeAutomation`
 
 - `merged`
 - `already_merged`
+- `review_clean` (only when `finishMode = fix_only` asked for it)
+
+`review_clean` satisfies the parent, but it is not a merge: the required-outcome
+check for "merge automation requested but PR was not merged" applies only when
+`finishMode = merge`.
 
 ### 17.2 Parent failure
 
@@ -1048,9 +1089,9 @@ This feature should not appear as a separate dependency or scheduling surface.
 ### 21.1 `pr-review-resolve` preset
 
 Operators who start from an **existing** pull request use the provider-neutral
-`pr-review-resolve` preset ("Review, Fix, and Merge PR"). It is deliberately
-named around the protocol, not around Codex, because the same request/result
-protocol can carry another automated reviewer.
+`pr-review-resolve` preset ("Fix and Review Loop"). It is deliberately named
+around the protocol, not around Codex, because the same request/result protocol
+can carry another automated reviewer.
 
 The preset:
 
@@ -1063,12 +1104,21 @@ The preset:
   merge;
 - enables merge automation with `reviewLoop.enabled = true` and
   `reviewLoop.provider = codex` by default;
-- exposes merge method, review-cycle budget, and expiry as progressive-disclosure
-  controls.
+- exposes one merge decision, **Finish with pr-resolver**, which selects
+  `finishMode`. Off (the default) expands to `fix_only`: the loop requests
+  reviews and fixes comments until the pull request is clean, then stops. On
+  expands to `merge`: a final `pr-resolver` pass merges the pull request once
+  there are no more comments to address;
+- exposes the review-cycle budget and expiry as progressive-disclosure controls.
 
-Omitted values use the same production path as their explicit equivalents: the
-defaults expand into a complete `mergeAutomationConfig` and require no hidden
-enablement.
+The merge method is **not** an operator control. It is a fixed implementation
+detail of the optional finish pass, pinned to `squash` by the preset.
+
+Merging is the one opt-in default here, because it is the irreversible boundary
+in this journey. Both settings are complete production paths: omitted values
+expand into a complete `mergeAutomationConfig` and require no hidden enablement,
+and neither setting depends on a parameter whose only purpose is to make the
+default work.
 
 ---
 
@@ -1102,4 +1152,5 @@ This design is complete when:
 8. downstream workflow executions depending on the parent workflow naturally wait for merge automation completion,
 9. non-success merge-automation terminal outcomes fail the parent workflow except `canceled`, which cancels the parent workflow,
 10. root and child artifacts expose enough state for the dashboard to explain why a workflow execution is waiting or failed,
-11. with `reviewLoop` enabled, exactly one automated review request is posted per head SHA, only that request's own result opens the gate, and the loop terminates on a clean review + merge, an exhausted cycle budget, repeated no-progress signatures, deferred comments, an unprovable request, or expiry.
+11. with `reviewLoop` enabled, exactly one automated review request is posted per head SHA, only that request's own result opens the gate, and the loop terminates on a clean review + merge, an exhausted cycle budget, repeated no-progress signatures, deferred comments, an unprovable request, or expiry,
+12. with `finishMode = fix_only`, the same loop runs with the same gates and terminates `review_clean` without a merge side effect and without post-merge issue completion, while `finishMode = merge` (including every payload that omits the field) still merges.

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -255,6 +255,13 @@ comment into success — those still produce `blocked`, `failed`, or
 configured; the resolver child request derives its merge authority from it, and
 the merge method stays a separate fixed detail of the finish pass.
 
+Only an **omitted** `finishMode` takes the `merge` default. Any other value that
+is not exactly `merge` or `fix_only` — a typo such as `fix-only`, a differently
+cased `Merge`, or a non-string — fails validation with
+`UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE` before a resolver child is started.
+Widening an unrecognized value into `merge` would silently grant authority for an
+irreversible side effect that the caller never requested.
+
 Because `fix_only` performs no merge, no post-merge Jira or GitHub completion is
 owed and none is attempted.
 
@@ -810,6 +817,23 @@ was not granted merge authority. Its terminal evidence is the same
 `artifacts/publish_result.json` contract the merge dispositions use, with
 `merged = false` and the branch head verified on the remote. A resolver run with
 merge authority must never return it.
+
+Because `review_clean` is a claim that an irreversible side effect did *not*
+happen, it is validated against disposition-specific invariants rather than the
+generic auto-publish rules alone. Terminal evidence is rejected with
+`UNAUTHORIZED_MERGE_EVIDENCE` unless the publish artifact reports
+`merged = false` and a non-`merge` action, and the resolver result itself claims
+no merge outcome. (An unverified remote head is already rejected upstream as
+`MALFORMED_TERMINAL_EVIDENCE` by the shared auto-publish parser.) The Skill
+supplies the authoritative remote half of that proof: its `review_clean` publish
+path reads the live PR state and writes blocked evidence
+(`unmerged_pr_verification_unavailable`) when the PR turns out to be merged or
+its state cannot be read.
+
+`review_clean` is a terminal **success**, so `pr_resolve_finalize.py` and
+`pr_resolve_orchestrate.py` exit `0` for it, exactly as they do for `merged`. The
+outcome is distinguished through `status` and `mergeAutomationDisposition` in the
+result JSON, never through the process exit code.
 
 For `reenter_gate`, a successful resolver child result means the child satisfied
 its durable handoff contract; it does not mean the pull request merged. The

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -1795,6 +1795,11 @@ class PullRequestRefModel(BaseModel):
 
 MergeAutomationPolicySetting = Literal["required", "optional", "disabled"]
 MergeMethod = Literal["merge", "squash", "rebase"]
+# How merge automation finishes once the gate opens and the resolver reports
+# that nothing is left to address. "merge" runs the final pr-resolver pass with
+# merge authority; "fix_only" stops at the open gate without a merge side
+# effect. Histories recorded before this field default to "merge".
+MergeAutomationFinishMode = Literal["merge", "fix_only"]
 PostMergeJiraStrategy = Literal["done_category"]
 
 class MergeAutomationGitHubGateModel(BaseModel):
@@ -2056,6 +2061,9 @@ class MergeAutomationConfigModel(BaseModel):
         default_factory=MergeAutomationReviewLoopModel,
         alias="reviewLoop",
     )
+    # One canonical finish mode for the whole gate. The resolver child request
+    # derives its merge authority from this value; it is never configured twice.
+    finish_mode: MergeAutomationFinishMode = Field("merge", alias="finishMode")
 
 ReadinessBlockerKind = Literal[
     "checks_running",

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -225,7 +225,7 @@ def _pr_resolver_terminal_contract(
         disposition = _pr_resolver_disposition(
             evidence.payload, merge_gate_owned=False
         )
-        if disposition in {"merged", "already_merged"} and (
+        if disposition in {"merged", "already_merged", "review_clean"} and (
             _load_auto_publish_result_payload(workspace_path) is None
         ):
             missing.append("artifacts/publish_result.json")

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -86,11 +86,22 @@ _PR_RESOLVER_BLOCKED_STATUSES: frozenset[str] = frozenset(
     {"blocked", "attempts_exhausted"}
 )
 _PR_RESOLVER_MERGED_STATUSES: frozenset[str] = frozenset({"merged"})
+# fix_only finish mode reaches a clean merge gate without merging.
+_PR_RESOLVER_REVIEW_CLEAN_STATUSES: frozenset[str] = frozenset({"review_clean"})
 _PR_RESOLVER_TERMINAL_STATUSES: frozenset[str] = (
-    _PR_RESOLVER_FAILURE_STATUSES | _PR_RESOLVER_MERGED_STATUSES
+    _PR_RESOLVER_FAILURE_STATUSES
+    | _PR_RESOLVER_MERGED_STATUSES
+    | _PR_RESOLVER_REVIEW_CLEAN_STATUSES
 )
 _PR_RESOLVER_TERMINAL_DISPOSITIONS: frozenset[str] = frozenset(
-    {"merged", "already_merged", "reenter_gate", "manual_review", "hard_failure"}
+    {
+        "merged",
+        "already_merged",
+        "review_clean",
+        "reenter_gate",
+        "manual_review",
+        "hard_failure",
+    }
 )
 _PR_RESOLVER_REENTER_NEXT_STEPS: frozenset[str] = frozenset(
     {

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -32,6 +32,8 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.temporal.workflows.merge_gate import (
         DEFAULT_ACTIVITY_RETRY_POLICY,
+        FINISH_MODE_FIX_ONLY,
+        FINISH_MODE_MERGE,
         TERMINAL_BLOCKER_KINDS,
         _effective_expire_at,
         build_resolver_run_request,
@@ -46,6 +48,7 @@ STATE_EXECUTING = "executing"
 STATE_BLOCKED = "blocked"
 STATE_MERGED = "merged"
 STATE_ALREADY_MERGED = "already_merged"
+STATE_REVIEW_CLEAN = "review_clean"
 STATE_EXPIRED = "expired"
 STATE_FAILED = "failed"
 STATE_CANCELED = "canceled"
@@ -53,9 +56,12 @@ DISPOSITION_REENTER_GATE = "reenter_gate"
 DISPOSITION_REQUEST_REVIEW = "request_review"
 DISPOSITION_MERGED = "merged"
 DISPOSITION_ALREADY_MERGED = "already_merged"
+DISPOSITION_REVIEW_CLEAN = "review_clean"
 DISPOSITION_MANUAL_REVIEW = "manual_review"
 DISPOSITION_FAILED = "failed"
-SUCCESS_DISPOSITIONS = frozenset({DISPOSITION_MERGED, DISPOSITION_ALREADY_MERGED})
+SUCCESS_DISPOSITIONS = frozenset(
+    {DISPOSITION_MERGED, DISPOSITION_ALREADY_MERGED, DISPOSITION_REVIEW_CLEAN}
+)
 NON_SUCCESS_DISPOSITIONS = frozenset({DISPOSITION_MANUAL_REVIEW, DISPOSITION_FAILED})
 ALLOWED_DISPOSITIONS = SUCCESS_DISPOSITIONS | NON_SUCCESS_DISPOSITIONS | {
     DISPOSITION_REENTER_GATE,
@@ -752,6 +758,11 @@ class MoonMindMergeAutomationWorkflow:
             resolver_disposition=resolver_disposition
         )
 
+    def _finish_mode(self) -> str:
+        if self._input is None:
+            return FINISH_MODE_MERGE
+        return self._input.config.finish_mode
+
     def _review_loop_config(self) -> Any:
         return self._input.config.review_loop
 
@@ -1213,6 +1224,7 @@ class MoonMindMergeAutomationWorkflow:
                         if self._review_loop_active()
                         else None
                     ),
+                    finish_mode=self._finish_mode(),
                 )
                 resolver_workflow_id_factory = (
                     deterministic_resolver_idempotency_key
@@ -1403,6 +1415,29 @@ class MoonMindMergeAutomationWorkflow:
                         return await self._finish()
                     self._summary = None
                     self._status = STATE_ALREADY_MERGED
+                    self._publish_visibility()
+                    return await self._finish()
+                if resolver_disposition == DISPOSITION_REVIEW_CLEAN:
+                    if self._finish_mode() != FINISH_MODE_FIX_ONLY:
+                        # This run was granted merge authority. A resolver that
+                        # reports "clean but unmerged" has not done the job it
+                        # was asked to do, and must never close the gate as
+                        # success.
+                        return await self._failed_resolver_summary(
+                            summary=(
+                                "pr-resolver reported review_clean for a run "
+                                "that was granted merge authority."
+                            ),
+                            blocker_kind="resolver_disposition_invalid",
+                        )
+                    # fix_only finish mode: the gate opened with nothing left to
+                    # address. No merge happened, so no post-merge integration
+                    # is owed; the loop is terminally complete.
+                    self._summary = (
+                        "Review loop complete: no actionable comments remain and "
+                        "this run was not configured to merge."
+                    )
+                    self._status = STATE_REVIEW_CLEAN
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MERGED:

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -51,6 +51,8 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_interval=timedelta(minutes=1),
     maximum_attempts=5,
 )
+FINISH_MODE_MERGE = "merge"
+FINISH_MODE_FIX_ONLY = "fix_only"
 MERGE_AUTOMATION_RESOLVER_PRIORITY = 10
 DEFAULT_RESOLVER_TIMEOUT_SECONDS = 9000
 _TOKEN_ASSIGNMENT_PATTERN = re.compile(
@@ -312,6 +314,7 @@ def build_resolver_run_request(
     merge_method: str,
     resolver_template: Mapping[str, Any] | None = None,
     review_loop: Mapping[str, Any] | MergeAutomationReviewLoopModel | None = None,
+    finish_mode: str = FINISH_MODE_MERGE,
 ) -> dict[str, Any]:
     pr = (
         pull_request
@@ -328,10 +331,16 @@ def build_resolver_run_request(
         for item in (template.get("requiredCapabilities") or [])
         if str(item).strip()
     ]
+    normalized_finish_mode = (
+        FINISH_MODE_FIX_ONLY
+        if str(finish_mode or "").strip() == FINISH_MODE_FIX_ONLY
+        else FINISH_MODE_MERGE
+    )
     args = {
         "repo": pr.repo,
         "pr": str(pr.number),
         "mergeMethod": merge_method,
+        "finishMode": normalized_finish_mode,
     }
     if pr.head_branch:
         args["branch"] = pr.head_branch
@@ -369,14 +378,29 @@ def build_resolver_run_request(
         "targetRuntime": target_runtime,
         "task": {
             "instructions": (
-                f"Resolve and merge pull request {pr.url}. "
-                "Use pr-resolver and do not create another pull request."
+                (
+                    f"Resolve and merge pull request {pr.url}. "
+                    if normalized_finish_mode == FINISH_MODE_MERGE
+                    else (
+                        f"Resolve every actionable item on pull request {pr.url} "
+                        "and stop without merging it: this run has no merge "
+                        "authority, so report review_clean once the merge gate "
+                        "opens with nothing left to address. "
+                    )
+                )
+                + "Use pr-resolver and do not create another pull request."
                 + (
                     " This run is owned by a merge-automation review loop: pass "
                     f"--review-provider {parsed_review_loop.provider} and "
                     "--require-fresh-review to every pr_resolve_finalize.py "
                     "invocation, and never post the review request yourself."
                     if review_loop_enabled
+                    else ""
+                )
+                + (
+                    " Pass --finish-mode fix_only to every pr_resolve_finalize.py "
+                    "and pr_resolve_orchestrate.py invocation."
+                    if normalized_finish_mode == FINISH_MODE_FIX_ONLY
                     else ""
                 )
             ),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -512,8 +512,19 @@ DEPENDENCY_RESOLUTION_FAILED = "dependency_failed"
 DEPENDENCY_RESOLUTION_BYPASSED = "bypassed"
 DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE = "manual_override"
 DEPENDENCY_RESOLUTION_WAITING_FOR_RERUN = "waiting_for_successful_rerun"
-MERGE_AUTOMATION_SUCCESS_STATUSES = frozenset({"merged", "already_merged"})
+MERGE_AUTOMATION_MERGED_STATUSES = frozenset({"merged", "already_merged"})
+# fix_only finish mode: merge automation completed its review/fix loop with
+# nothing left to address and no merge authority. Successful, but not a merge.
+MERGE_AUTOMATION_REVIEW_CLEAN_STATUS = "review_clean"
+MERGE_AUTOMATION_SUCCESS_STATUSES = MERGE_AUTOMATION_MERGED_STATUSES | frozenset(
+    {MERGE_AUTOMATION_REVIEW_CLEAN_STATUS}
+)
 MERGE_AUTOMATION_FAILURE_STATUSES = frozenset({"blocked", "failed", "expired"})
+# Terminal pr-resolver dispositions that mean the resolver child finished its
+# job. "review_clean" is the fix_only terminal: complete, but not a merge.
+MERGE_AUTOMATION_RESOLVER_SUCCESS_DISPOSITIONS = frozenset(
+    {"merged", "already_merged", MERGE_AUTOMATION_REVIEW_CLEAN_STATUS}
+)
 MERGE_AUTOMATION_CANCELED_STATUS = "canceled"
 MERGE_AUTOMATION_TERMINAL_STATUSES = (
     MERGE_AUTOMATION_SUCCESS_STATUSES
@@ -10570,7 +10581,7 @@ class MoonMindRunWorkflow:
                         and self._gated_continuation_failure_message(parameters) is None
                     )
                     or self._merge_automation_disposition
-                    in {"merged", "already_merged"}
+                    in MERGE_AUTOMATION_RESOLVER_SUCCESS_DISPOSITIONS
                 )
             ):
                 output_status = "success"
@@ -17660,7 +17671,7 @@ class MoonMindRunWorkflow:
             return "publishMode 'pr' requested but no PR was created"
         if publish_mode == "branch" and self._publish_status is None:
             return "branch publish outcome unknown"
-        if self._merge_automation_requested(parameters) and not self._merge_happened():
+        if self._merge_required(parameters) and not self._merge_happened():
             return "merge automation requested but PR was not merged"
         if self._report_requested(parameters) and not self._report_created:
             return "reportOutput requested but no final report was created"
@@ -17686,16 +17697,26 @@ class MoonMindRunWorkflow:
             self._publish_context.get("mergeAutomationStatus"),
             max_chars=40,
         )
-        if status in MERGE_AUTOMATION_SUCCESS_STATUSES:
+        if status in MERGE_AUTOMATION_MERGED_STATUSES:
             return True
         result = self._publish_context.get("mergeAutomationResult")
         if isinstance(result, Mapping):
             result_status = self._coerce_text(result.get("status"), max_chars=40)
-            return result_status in MERGE_AUTOMATION_SUCCESS_STATUSES
+            return result_status in MERGE_AUTOMATION_MERGED_STATUSES
         return False
 
     def _merge_automation_requested(self, parameters: Mapping[str, Any]) -> bool:
         return self._merge_automation_request(parameters) is not None
+
+    def _merge_required(self, parameters: Mapping[str, Any]) -> bool:
+        """True when merge automation was asked to finish by merging the PR."""
+
+        request = self._merge_automation_request(parameters)
+        if request is None:
+            return False
+        return (
+            self._coerce_text(request.get("finishMode"), max_chars=20) or "merge"
+        ) == "merge"
 
     def _report_requested(self, parameters: Mapping[str, Any]) -> bool:
         candidates = []
@@ -17823,6 +17844,15 @@ class MoonMindRunWorkflow:
                     max_chars=20,
                 )
                 or "squash",
+                "finishMode": (
+                    "fix_only"
+                    if self._coerce_text(
+                        candidate.get("finishMode") or candidate.get("finish_mode"),
+                        max_chars=20,
+                    )
+                    == "fix_only"
+                    else "merge"
+                ),
                 "jiraIssueKey": effective_jira_issue_key,
                 "postMergeJira": post_merge_jira,
                 "postMergeGithub": post_merge_github,
@@ -18143,6 +18173,7 @@ class MoonMindRunWorkflow:
                     "skill": "pr-resolver",
                     "mergeMethod": request.get("mergeMethod") or "squash",
                 },
+                "finishMode": request.get("finishMode") or "merge",
                 "timeouts": timeouts,
                 "postMergeJira": request.get("postMergeJira") or {},
                 "postMergeGithub": request.get("postMergeGithub") or {},

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -525,6 +525,13 @@ MERGE_AUTOMATION_FAILURE_STATUSES = frozenset({"blocked", "failed", "expired"})
 MERGE_AUTOMATION_RESOLVER_SUCCESS_DISPOSITIONS = frozenset(
     {"merged", "already_merged", MERGE_AUTOMATION_REVIEW_CLEAN_STATUS}
 )
+MERGE_AUTOMATION_DEFAULT_FINISH_MODE = "merge"
+# Supported finish modes, mirroring `MergeAutomationFinishMode`. Only an omitted
+# value takes the default; every other unsupported value fails validation
+# instead of silently inheriting merge authority.
+MERGE_AUTOMATION_FINISH_MODES = frozenset(
+    {MERGE_AUTOMATION_DEFAULT_FINISH_MODE, "fix_only"}
+)
 MERGE_AUTOMATION_CANCELED_STATUS = "canceled"
 MERGE_AUTOMATION_TERMINAL_STATUSES = (
     MERGE_AUTOMATION_SUCCESS_STATUSES
@@ -17742,6 +17749,27 @@ class MoonMindRunWorkflow:
                 return True
         return False
 
+    def _normalize_finish_mode(self, value: Any) -> str:
+        """Return a supported finish mode or fail validation.
+
+        Only an omitted (or blank) value inherits the ``merge`` default. A typo
+        such as ``fix-only``, or a malformed non-string, must never be silently
+        widened into merge authority for an irreversible side effect.
+        """
+
+        candidate = self._coerce_text(value, max_chars=20)
+        if candidate is None and (value is None or isinstance(value, str)):
+            return MERGE_AUTOMATION_DEFAULT_FINISH_MODE
+        if candidate in MERGE_AUTOMATION_FINISH_MODES:
+            return candidate
+        raise exceptions.ApplicationError(
+            "Unsupported merge automation finishMode "
+            f"{candidate if candidate is not None else type(value).__name__!r}; "
+            f"expected one of {sorted(MERGE_AUTOMATION_FINISH_MODES)}.",
+            type="UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE",
+            non_retryable=True,
+        )
+
     def _merge_automation_request(
         self,
         parameters: Mapping[str, Any],
@@ -17844,14 +17872,8 @@ class MoonMindRunWorkflow:
                     max_chars=20,
                 )
                 or "squash",
-                "finishMode": (
-                    "fix_only"
-                    if self._coerce_text(
-                        candidate.get("finishMode") or candidate.get("finish_mode"),
-                        max_chars=20,
-                    )
-                    == "fix_only"
-                    else "merge"
+                "finishMode": self._normalize_finish_mode(
+                    candidate.get("finishMode") or candidate.get("finish_mode")
                 ),
                 "jiraIssueKey": effective_jira_issue_key,
                 "postMergeJira": post_merge_jira,

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -303,12 +303,13 @@ def evaluate_terminal_evidence(
         if disposition not in {
             "merged",
             "already_merged",
+            "review_clean",
             "reenter_gate",
             "manual_review",
             "failed",
         }:
             return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
-        if disposition in {"merged", "already_merged"}:
+        if disposition in {"merged", "already_merged", "review_clean"}:
             publish_path = (workspace / "artifacts/publish_result.json").resolve()
             if artifact_spool_path and not publish_path.is_file():
                 publish_path = (

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -81,6 +81,8 @@ def _evaluate_auto_publish_evidence(
             "autoPublishExecutionRef": evidence.execution_ref,
             "autoPublishStatus": evidence.status,
             "autoPublishAction": evidence.action,
+            "autoPublishMerged": evidence.merged,
+            "autoPublishRemoteVerified": evidence.remote_verified,
         }
     )
     if expected_skill_id and evidence.skill_id != expected_skill_id:
@@ -343,6 +345,40 @@ def evaluate_terminal_evidence(
                     publish_evaluation.missing_evidence,
                     {**metadata, **publish_evaluation.metadata},
                 )
+            # Carry the publication facts forward without letting the inner
+            # auto-publish contract identity overwrite this contract's own.
+            publish_metadata = publish_evaluation.metadata
+            metadata = {
+                **metadata,
+                **{
+                    key: value
+                    for key, value in publish_metadata.items()
+                    if key.startswith("autoPublish")
+                },
+            }
+            if disposition == "review_clean":
+                # The generic auto-publish validator accepts any verified
+                # publication, including a merge. `review_clean` is the fix_only
+                # terminal that explicitly withholds merge authority, so it must
+                # additionally prove the irreversible side effect never
+                # happened: no merge in the publish evidence and no merge in the
+                # resolver result. `parse_auto_publish_evidence` already refuses
+                # any unverified remote head above, and the Skill owns the
+                # remote half of the proof — its `review_clean` publish path
+                # reads the live PR state and writes blocked evidence when the
+                # PR turns out to be merged.
+                if (
+                    publish_metadata.get("autoPublishMerged") is not False
+                    or publish_metadata.get("autoPublishAction") == "merge"
+                ):
+                    return _failure("UNAUTHORIZED_MERGE_EVIDENCE", metadata=metadata)
+                result_status = str(payload.get("status") or "").strip()
+                merge_outcome = str(payload.get("merge_outcome") or "").strip()
+                if result_status == "merged" or merge_outcome in {
+                    "merged",
+                    "auto_merge_enabled",
+                }:
+                    return _failure("UNAUTHORIZED_MERGE_EVIDENCE", metadata=metadata)
             return _success(metadata)
         if disposition == "reenter_gate":
             continuation = payload.get("gatedContinuation")

--- a/tests/unit/api/test_pr_review_resolve_preset.py
+++ b/tests/unit/api/test_pr_review_resolve_preset.py
@@ -1,4 +1,4 @@
-"""Catalog-boundary tests for the provider-neutral PR review/resolve preset."""
+"""Catalog-boundary tests for the provider-neutral fix-and-review-loop preset."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ async def _catalog_db(tmp_path):
 
 def _seed_dir(tmp_path) -> Path:
     seed_dir = tmp_path / "presets"
-    seed_dir.mkdir()
+    seed_dir.mkdir(exist_ok=True)
     shutil.copy(_PRESET_DIR / f"{_SLUG}.yaml", seed_dir / f"{_SLUG}.yaml")
     return seed_dir
 
@@ -62,7 +62,24 @@ async def _expand(tmp_path, inputs: dict[str, Any], context: dict[str, Any] | No
             )
 
 
-async def test_defaults_produce_a_complete_review_loop(tmp_path) -> None:
+async def _template(tmp_path) -> dict[str, Any]:
+    async with _catalog_db(tmp_path) as maker:
+        async with maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+            await session.commit()
+            return await service.get_template(
+                slug=_SLUG, scope="global", scope_ref=None
+            )
+
+
+async def test_preset_is_titled_fix_and_review_loop(tmp_path) -> None:
+    template = await _template(tmp_path)
+
+    assert template["title"] == "Fix and Review Loop"
+
+
+async def test_defaults_produce_a_complete_review_loop_without_merging(tmp_path) -> None:
     """Omitted values must exercise the same production path as explicit ones."""
 
     expanded = await _expand(tmp_path, {"pull_request": "350"})
@@ -70,9 +87,10 @@ async def test_defaults_produce_a_complete_review_loop(tmp_path) -> None:
     merge_automation = expanded["publish"]["mergeAutomation"]
     assert expanded["publish"]["mode"] == "none"
     assert merge_automation["enabled"] is True
-    assert merge_automation["mergeMethod"] == "squash"
     assert merge_automation["checks"] == "required"
     assert merge_automation["automatedReview"] == "required"
+    # Merging is opt-in; the default loop stops at the first clean review.
+    assert merge_automation["finishMode"] == "fix_only"
 
     review_loop = merge_automation["reviewLoop"]
     assert review_loop["enabled"] is True
@@ -91,10 +109,12 @@ async def test_defaults_produce_a_complete_review_loop(tmp_path) -> None:
                 }
             },
             "resolver": {"mergeMethod": merge_automation["mergeMethod"]},
+            "finishMode": merge_automation["finishMode"],
             "timeouts": merge_automation["timeouts"],
             "reviewLoop": review_loop,
         }
     )
+    assert config.finish_mode == "fix_only"
     assert config.review_loop.enabled is True
     assert config.review_loop.max_cycles == 5
     assert config.review_loop.max_consecutive_no_progress_cycles == 2
@@ -103,28 +123,71 @@ async def test_defaults_produce_a_complete_review_loop(tmp_path) -> None:
     assert config.timeouts.fallback_poll_seconds == 60
 
 
+async def test_finish_with_pr_resolver_enables_the_final_merge_pass(tmp_path) -> None:
+    expanded = await _expand(
+        tmp_path,
+        {"pull_request": "350", "finish_with_pr_resolver": True},
+    )
+
+    merge_automation = expanded["publish"]["mergeAutomation"]
+    assert merge_automation["finishMode"] == "merge"
+
+    config = MergeAutomationConfigModel.model_validate(
+        {
+            "resolver": {"mergeMethod": merge_automation["mergeMethod"]},
+            "finishMode": merge_automation["finishMode"],
+            "timeouts": merge_automation["timeouts"],
+            "reviewLoop": merge_automation["reviewLoop"],
+        }
+    )
+    assert config.finish_mode == "merge"
+
+
+async def test_merge_method_is_not_an_operator_control(tmp_path) -> None:
+    """The merge method is a fixed detail of the finish pass, not an input."""
+
+    template = await _template(tmp_path)
+
+    assert "merge_method" not in template["inputSchema"]["properties"]
+    assert "merge_method" not in template["uiSchema"]
+    assert "merge_method" not in template["defaults"]
+    assert "merge_method" not in {
+        str(entry.get("name")) for entry in template["inputs"]
+    }
+    assert "finish_with_pr_resolver" in template["inputSchema"]["properties"]
+
+    expanded = await _expand(
+        tmp_path,
+        {
+            "pull_request": "350",
+            "finish_with_pr_resolver": True,
+            "merge_method": "rebase",
+        },
+    )
+
+    assert expanded["publish"]["mergeAutomation"]["mergeMethod"] == "squash"
+
+
 async def test_operator_overrides_flow_into_the_review_loop(tmp_path) -> None:
     expanded = await _expand(
         tmp_path,
         {
             "pull_request": "https://github.com/MoonLadderStudios/MoonMind/pull/350",
-            "merge_method": "rebase",
             "max_review_cycles": "3",
             "expire_after_seconds": "3600",
         },
     )
 
     merge_automation = expanded["publish"]["mergeAutomation"]
-    assert merge_automation["mergeMethod"] == "rebase"
-
     config = MergeAutomationConfigModel.model_validate(
         {
             "resolver": {"mergeMethod": merge_automation["mergeMethod"]},
+            "finishMode": merge_automation["finishMode"],
             "timeouts": merge_automation["timeouts"],
             "reviewLoop": merge_automation["reviewLoop"],
         }
     )
-    assert config.resolver.merge_method == "rebase"
+    assert config.resolver.merge_method == "squash"
     assert config.review_loop.max_cycles == 3
     assert config.timeouts.expire_after_seconds == 3600
 

--- a/tests/unit/test_pr_resolver_finish_mode.py
+++ b/tests/unit/test_pr_resolver_finish_mode.py
@@ -1,0 +1,329 @@
+"""Portable Skill tests for the pr-resolver finish mode.
+
+`fix_only` narrows exactly one thing: the merge side effect. Every gate,
+blocker, and remediation decision stays identical to `merge`.
+"""
+
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_BIN = REPO_ROOT / ".agents" / "skills" / "pr-resolver" / "bin"
+HEAD = "a" * 40
+
+
+def _load_module(script_name: str) -> dict[str, Any]:
+    return runpy.run_path(str(SKILL_BIN / script_name))
+
+
+@pytest.fixture
+def contract_module() -> dict[str, Any]:
+    return _load_module("pr_resolve_contract.py")
+
+
+@pytest.fixture
+def finalize_module() -> dict[str, Any]:
+    return _load_module("pr_resolve_finalize.py")
+
+
+@pytest.fixture
+def orchestrate_module() -> dict[str, Any]:
+    return _load_module("pr_resolve_orchestrate.py")
+
+
+def _mergeable_snapshot() -> dict[str, Any]:
+    """A snapshot whose merge gate is fully open."""
+
+    return {
+        "repository": "MoonLadderStudios/MoonMind",
+        "pr": {
+            "number": 350,
+            "url": "https://github.com/MoonLadderStudios/MoonMind/pull/350",
+            "state": "OPEN",
+            "headRefOid": HEAD,
+            "headRefName": "feature",
+            "mergeStateStatus": "CLEAN",
+            "mergeable": True,
+        },
+        "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+        "commentsFetch": {"succeeded": True},
+        "commentsSummary": {
+            "includeBotReviewComments": True,
+            "hasActionableComments": False,
+        },
+        "automatedReview": {
+            "enabled": True,
+            "provider": "codex",
+            "freshReviewForHead": True,
+            "requestPending": False,
+        },
+        "progressSignature": f"{HEAD}||",
+    }
+
+
+# ---------------------------------------------------------------------------
+# contract
+# ---------------------------------------------------------------------------
+
+
+def test_finish_mode_defaults_to_merge(contract_module) -> None:
+    normalize = contract_module["normalize_finish_mode"]
+
+    assert normalize(None) == "merge"
+    assert normalize("") == "merge"
+    assert normalize("merge") == "merge"
+    assert normalize("MERGE") == "merge"
+
+
+def test_fix_only_finish_mode_is_supported(contract_module) -> None:
+    assert contract_module["normalize_finish_mode"]("fix_only") == "fix_only"
+
+
+def test_unsupported_finish_mode_fails_fast(contract_module) -> None:
+    with pytest.raises(ValueError):
+        contract_module["normalize_finish_mode"]("auto")
+
+
+def test_review_clean_status_maps_to_review_clean_disposition(contract_module) -> None:
+    assert (
+        contract_module["merge_automation_disposition_for_result"](
+            status="review_clean",
+            merge_outcome="skipped",
+            final_reason="finish_mode_fix_only",
+            next_step="done",
+        )
+        == "review_clean"
+    )
+
+
+# ---------------------------------------------------------------------------
+# finalize
+# ---------------------------------------------------------------------------
+
+
+def _run_finalize(
+    finalize_module: dict[str, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *extra_args: str,
+) -> tuple[int, dict[str, Any]]:
+    main = finalize_module["main"]
+    snapshot = _mergeable_snapshot()
+
+    def _write_snapshot(
+        _snapshot_script: Path,
+        _pr: str | None,
+        snapshot_path: Path,
+        **_review_kwargs: Any,
+    ) -> None:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    merged: list[tuple[str, str]] = []
+    monkeypatch.setitem(main.__globals__, "_run_snapshot", _write_snapshot)
+    monkeypatch.setitem(
+        main.__globals__,
+        "_merge_pr",
+        lambda selector, method: merged.append((selector, method)),
+    )
+    monkeypatch.setitem(main.__globals__, "_check_pr_merged", lambda _selector: True)
+    monkeypatch.delenv("PR_RESOLVER_REVIEW_PROVIDER", raising=False)
+    monkeypatch.delenv("PR_RESOLVER_REQUIRE_FRESH_REVIEW", raising=False)
+    monkeypatch.delenv("PR_RESOLVER_FINISH_MODE", raising=False)
+
+    result_path = tmp_path / "result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "350",
+            "--snapshot-path",
+            str(tmp_path / "snapshot.json"),
+            "--result-path",
+            str(result_path),
+            "--review-provider",
+            "codex",
+            "--require-fresh-review",
+            "--strict-exit-codes",
+            *extra_args,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    payload["_merged_calls"] = merged
+    return int(excinfo.value.code), payload
+
+
+def test_default_finalize_still_merges_an_open_gate(
+    finalize_module, tmp_path, monkeypatch
+) -> None:
+    """Omitting --finish-mode must exercise the production merge path."""
+
+    code, payload = _run_finalize(finalize_module, tmp_path, monkeypatch)
+
+    assert code == finalize_module["EXIT_CODE_MERGED"]
+    assert payload["status"] == "merged"
+    assert payload["mergeAutomationDisposition"] == "merged"
+    assert payload["_merged_calls"] == [("350", "squash")]
+
+
+def test_fix_only_finalize_reports_review_clean_without_merging(
+    finalize_module, tmp_path, monkeypatch
+) -> None:
+    code, payload = _run_finalize(
+        finalize_module, tmp_path, monkeypatch, "--finish-mode", "fix_only"
+    )
+
+    assert code == finalize_module["EXIT_CODE_REVIEW_CLEAN"]
+    assert payload["status"] == "review_clean"
+    assert payload["merge_outcome"] == "skipped"
+    assert payload["mergeAutomationDisposition"] == "review_clean"
+    assert payload["final_reason"] == "finish_mode_fix_only"
+    # The whole point: no merge side effect.
+    assert payload["_merged_calls"] == []
+
+
+def test_fix_only_finalize_still_blocks_on_a_missing_fresh_review(
+    finalize_module, tmp_path, monkeypatch
+) -> None:
+    """fix_only must not weaken any gate; it only removes the merge."""
+
+    main = finalize_module["main"]
+    snapshot = _mergeable_snapshot()
+    snapshot["automatedReview"]["freshReviewForHead"] = False
+
+    def _write_snapshot(
+        _snapshot_script: Path,
+        _pr: str | None,
+        snapshot_path: Path,
+        **_review_kwargs: Any,
+    ) -> None:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    monkeypatch.setitem(main.__globals__, "_run_snapshot", _write_snapshot)
+    monkeypatch.delenv("PR_RESOLVER_FINISH_MODE", raising=False)
+    result_path = tmp_path / "result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "350",
+            "--snapshot-path",
+            str(tmp_path / "snapshot.json"),
+            "--result-path",
+            str(result_path),
+            "--review-provider",
+            "codex",
+            "--require-fresh-review",
+            "--finish-mode",
+            "fix_only",
+            "--strict-exit-codes",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert excinfo.value.code == finalize_module["EXIT_CODE_BLOCKED"]
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["mergeAutomationDisposition"] == "request_review"
+
+
+def test_finish_mode_can_come_from_the_environment(
+    finalize_module, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("PR_RESOLVER_FINISH_MODE", "fix_only")
+    main = finalize_module["main"]
+    snapshot = _mergeable_snapshot()
+
+    def _write_snapshot(
+        _snapshot_script: Path,
+        _pr: str | None,
+        snapshot_path: Path,
+        **_review_kwargs: Any,
+    ) -> None:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    monkeypatch.setitem(main.__globals__, "_run_snapshot", _write_snapshot)
+    monkeypatch.setitem(
+        main.__globals__,
+        "_merge_pr",
+        lambda *_args: pytest.fail("fix_only must never merge"),
+    )
+    result_path = tmp_path / "result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "350",
+            "--snapshot-path",
+            str(tmp_path / "snapshot.json"),
+            "--result-path",
+            str(result_path),
+            "--strict-exit-codes",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert excinfo.value.code == finalize_module["EXIT_CODE_REVIEW_CLEAN"]
+    assert (
+        json.loads(result_path.read_text(encoding="utf-8"))["status"] == "review_clean"
+    )
+
+
+# ---------------------------------------------------------------------------
+# orchestrate
+# ---------------------------------------------------------------------------
+
+
+def test_orchestration_returns_review_clean_as_a_terminal_success(
+    orchestrate_module,
+) -> None:
+    run_orchestration = orchestrate_module["run_orchestration"]
+
+    def finalize_runner(_attempt: int) -> dict[str, Any]:
+        return {
+            "status": "review_clean",
+            "merge_outcome": "skipped",
+            "final_reason": "finish_mode_fix_only",
+            "mergeAutomationDisposition": "review_clean",
+        }
+
+    def full_runner(*_args: Any) -> dict[str, Any]:
+        raise AssertionError("review_clean must not escalate to remediation")
+
+    result, exit_code = run_orchestration(
+        finalize_runner=finalize_runner,
+        full_runner=full_runner,
+        sleep_fn=lambda _seconds: None,
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=2,
+        fix_max_iterations=1,
+        min_attempts_before_exhausted=1,
+        base_sleep_seconds=0,
+        max_sleep_seconds=0,
+        max_elapsed_seconds=600,
+        merge_not_ready_grace_retries=0,
+    )
+
+    assert exit_code == orchestrate_module["EXIT_CODE_REVIEW_CLEAN"]
+    assert result["status"] == "review_clean"
+    assert result["merge_outcome"] == "skipped"
+    assert result["mergeAutomationDisposition"] == "review_clean"
+    assert result["next_step"] == "done"

--- a/tests/unit/test_pr_resolver_finish_mode.py
+++ b/tests/unit/test_pr_resolver_finish_mode.py
@@ -327,3 +327,108 @@ def test_orchestration_returns_review_clean_as_a_terminal_success(
     assert result["merge_outcome"] == "skipped"
     assert result["mergeAutomationDisposition"] == "review_clean"
     assert result["next_step"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_review_clean_is_a_zero_exit_success(contract_module) -> None:
+    """`review_clean` is a documented terminal success, so it exits zero.
+
+    Shells, CI runners, and portable hosts read any nonzero exit as a failed
+    command. The outcome is distinguished through the result JSON instead.
+    """
+
+    assert contract_module["EXIT_CODE_REVIEW_CLEAN"] == 0
+    assert contract_module["EXIT_CODE_MERGED"] == 0
+    assert contract_module["EXIT_CODE_BLOCKED"] != 0
+    assert contract_module["EXIT_CODE_ATTEMPTS_EXHAUSTED"] != 0
+    assert contract_module["EXIT_CODE_FAILED"] != 0
+
+
+def test_fix_only_finalize_exits_zero_without_strict_exit_codes(
+    finalize_module, tmp_path, monkeypatch
+) -> None:
+    """Direct (non-strict) use must not report failure for a clean review."""
+
+    main = finalize_module["main"]
+    snapshot = _mergeable_snapshot()
+
+    def _write_snapshot(
+        _snapshot_script: Path,
+        _pr: str | None,
+        snapshot_path: Path,
+        **_review_kwargs: Any,
+    ) -> None:
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+    monkeypatch.setitem(main.__globals__, "_run_snapshot", _write_snapshot)
+    monkeypatch.setitem(
+        main.__globals__,
+        "_merge_pr",
+        lambda *_args: pytest.fail("fix_only must never merge"),
+    )
+    monkeypatch.delenv("PR_RESOLVER_FINISH_MODE", raising=False)
+
+    result_path = tmp_path / "result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "350",
+            "--snapshot-path",
+            str(tmp_path / "snapshot.json"),
+            "--result-path",
+            str(result_path),
+            "--review-provider",
+            "codex",
+            "--require-fresh-review",
+            "--finish-mode",
+            "fix_only",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert int(excinfo.value.code) == 0
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    # The result JSON, not the exit code, carries the terminal distinction.
+    assert payload["status"] == "review_clean"
+    assert payload["merge_outcome"] == "skipped"
+    assert payload["mergeAutomationDisposition"] == "review_clean"
+
+
+def test_orchestration_exits_zero_for_review_clean(orchestrate_module) -> None:
+    run_orchestration = orchestrate_module["run_orchestration"]
+
+    def finalize_runner(_attempt: int) -> dict[str, Any]:
+        return {
+            "status": "review_clean",
+            "merge_outcome": "skipped",
+            "final_reason": "finish_mode_fix_only",
+            "mergeAutomationDisposition": "review_clean",
+        }
+
+    result, exit_code = run_orchestration(
+        finalize_runner=finalize_runner,
+        full_runner=lambda *_args: pytest.fail(
+            "review_clean must not escalate to remediation"
+        ),
+        sleep_fn=lambda _seconds: None,
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=2,
+        fix_max_iterations=1,
+        min_attempts_before_exhausted=1,
+        base_sleep_seconds=0,
+        max_sleep_seconds=0,
+        max_elapsed_seconds=600,
+        merge_not_ready_grace_retries=0,
+    )
+
+    assert exit_code == 0
+    assert result["mergeAutomationDisposition"] == "review_clean"

--- a/tests/unit/test_publish_evidence_helper.py
+++ b/tests/unit/test_publish_evidence_helper.py
@@ -565,3 +565,117 @@ def test_from_pr_resolver_result_fails_closed_for_missing_result(
         == 2
     )
     assert not (tmp_path / "artifacts" / "publish_result.json").exists()
+
+
+def _review_clean_workspace(tmp_path: Path, *, attempt_history: list[dict[str, Any]]):
+    result_path = tmp_path / "var" / "pr_resolver" / "result.json"
+    snapshot_path = tmp_path / "var" / "pr_resolver" / "snapshot.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "status": "review_clean",
+                "merge_outcome": "skipped",
+                "final_reason": "finish_mode_fix_only",
+                "mergeAutomationDisposition": "review_clean",
+                "attempt_history": attempt_history,
+            }
+        ),
+        encoding="utf-8",
+    )
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "repository": "MoonLadderStudios/MoonMind",
+                "pr": {
+                    "url": "https://github.com/o/r/pull/1",
+                    "headRefName": "feature",
+                    "headRefOid": "abc123",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return result_path, snapshot_path
+
+
+def _fake_head_verification(helper_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+
+def test_from_pr_resolver_result_review_clean_is_a_verified_no_op(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """fix_only with nothing to fix: verified branch head, no merge claimed."""
+
+    monkeypatch.chdir(tmp_path)
+    result_path, snapshot_path = _review_clean_workspace(tmp_path, attempt_history=[])
+    _fake_head_verification(helper_module, monkeypatch)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+                "--snapshot",
+                str(snapshot_path),
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.status == "no_op_verified"
+    assert evidence.action == "none"
+    assert evidence.pushed is False
+    assert evidence.merged is False
+    assert evidence.remote_verified is True
+
+
+def test_from_pr_resolver_result_review_clean_after_remediation_reports_a_push(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path, snapshot_path = _review_clean_workspace(
+        tmp_path,
+        attempt_history=[
+            {"stage": "finalize", "status": "blocked", "timestamp": "2026-08-25T00:00:00Z"},
+            {"stage": "full", "status": "ready_for_finalize", "timestamp": "2026-08-25T00:01:00Z"},
+        ],
+    )
+    _fake_head_verification(helper_module, monkeypatch)
+
+    assert (
+        helper_module.main(
+            [
+                "from-pr-resolver-result",
+                "--result",
+                str(result_path),
+                "--snapshot",
+                str(snapshot_path),
+            ]
+        )
+        == 0
+    )
+
+    evidence = parse_auto_publish_evidence(
+        _payload(tmp_path / "artifacts" / "publish_result.json")
+    )
+    assert evidence.status == "verified"
+    assert evidence.action == "push"
+    assert evidence.pushed is True
+    assert evidence.merged is False

--- a/tests/unit/test_publish_evidence_helper.py
+++ b/tests/unit/test_publish_evidence_helper.py
@@ -599,12 +599,22 @@ def _review_clean_workspace(tmp_path: Path, *, attempt_history: list[dict[str, A
     return result_path, snapshot_path
 
 
-def _fake_head_verification(helper_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+def _fake_head_verification(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pr_state: str = "OPEN",
+    merged_at: str | None = None,
+) -> None:
     def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
         if cmd == ["git", "rev-parse", "HEAD"]:
             return _completed("abc123\n")
         if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
             return _completed("abc123\trefs/heads/feature\n")
+        if cmd[:4] == ["gh", "pr", "view", "https://github.com/o/r/pull/1"]:
+            return _completed(
+                json.dumps({"state": pr_state, "mergedAt": merged_at})
+            )
         raise AssertionError(cmd)
 
     monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
@@ -654,7 +664,11 @@ def test_from_pr_resolver_result_review_clean_after_remediation_reports_a_push(
         tmp_path,
         attempt_history=[
             {"stage": "finalize", "status": "blocked", "timestamp": "2026-08-25T00:00:00Z"},
-            {"stage": "full", "status": "ready_for_finalize", "timestamp": "2026-08-25T00:01:00Z"},
+            {
+                "stage": "full_remediation",
+                "status": "ready_for_finalize",
+                "timestamp": "2026-08-25T00:01:00Z",
+            },
         ],
     )
     _fake_head_verification(helper_module, monkeypatch)
@@ -679,3 +693,82 @@ def test_from_pr_resolver_result_review_clean_after_remediation_reports_a_push(
     assert evidence.action == "push"
     assert evidence.pushed is True
     assert evidence.merged is False
+
+
+def test_from_pr_resolver_result_review_clean_blocks_a_merged_pr(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`review_clean` claims no merge happened; prove it against the remote.
+
+    A verified branch head says nothing about the pull request, so a fix_only
+    run that merged anyway would otherwise publish a clean no-merge artifact.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    result_path, snapshot_path = _review_clean_workspace(
+        tmp_path,
+        attempt_history=[
+            {
+                "stage": "full_remediation",
+                "status": "ready_for_finalize",
+                "timestamp": "2026-08-25T00:01:00Z",
+            }
+        ],
+    )
+    _fake_head_verification(
+        helper_module,
+        monkeypatch,
+        pr_state="MERGED",
+        merged_at="2026-08-25T00:02:00Z",
+    )
+
+    helper_module.main(
+        [
+            "from-pr-resolver-result",
+            "--result",
+            str(result_path),
+            "--snapshot",
+            str(snapshot_path),
+        ]
+    )
+
+    payload = _payload(tmp_path / "artifacts" / "publish_result.json")
+    assert payload["status"] == "blocked"
+    assert payload["blockedReason"] == "unmerged_pr_verification_unavailable"
+    assert payload["merged"] is False
+
+
+def test_from_pr_resolver_result_review_clean_blocks_unreadable_pr_state(
+    helper_module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result_path, snapshot_path = _review_clean_workspace(tmp_path, attempt_history=[])
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return _completed("abc123\n")
+        if cmd == ["git", "ls-remote", "origin", "refs/heads/feature"]:
+            return _completed("abc123\trefs/heads/feature\n")
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _completed("", returncode=1)
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(helper_module.subprocess, "run", fake_run)
+
+    helper_module.main(
+        [
+            "from-pr-resolver-result",
+            "--result",
+            str(result_path),
+            "--snapshot",
+            str(snapshot_path),
+        ]
+    )
+
+    payload = _payload(tmp_path / "artifacts" / "publish_result.json")
+    assert payload["status"] == "blocked"
+    assert payload["blockedReason"] == "unmerged_pr_verification_unavailable"

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -368,3 +368,67 @@ def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:
     assert payload["cycleCount"] == 3
     assert payload["resolverHistory"][0]["workflowId"] == "resolver-1"
     assert payload["expireAt"] == "2026-04-17T00:00:00Z"
+
+def test_build_resolver_run_request_defaults_to_merge_finish_mode() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+    )
+
+    task = request["initial_parameters"]["task"]
+    assert task["skill"]["args"]["finishMode"] == "merge"
+    assert "Resolve and merge pull request" in task["instructions"]
+    assert "--finish-mode fix_only" not in task["instructions"]
+
+def test_build_resolver_run_request_withholds_merge_authority_for_fix_only() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        finish_mode="fix_only",
+    )
+
+    task = request["initial_parameters"]["task"]
+    assert task["skill"]["args"]["finishMode"] == "fix_only"
+    assert "stop without merging it" in task["instructions"]
+    assert "--finish-mode fix_only" in task["instructions"]
+    assert "Resolve and merge pull request" not in task["instructions"]
+    # The merge method still travels with the run so an enabled finish pass is
+    # not left guessing.
+    assert task["skill"]["args"]["mergeMethod"] == "squash"
+
+def test_build_resolver_run_request_normalizes_unknown_finish_mode() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        finish_mode="",
+    )
+
+    assert (
+        request["initial_parameters"]["task"]["skill"]["args"]["finishMode"] == "merge"
+    )
+
+def test_fix_only_finish_mode_preserves_the_review_loop_instructions() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        finish_mode="fix_only",
+        review_loop={
+            "enabled": True,
+            "provider": "codex",
+            "requireFreshReviewForEveryHead": True,
+        },
+    )
+
+    task = request["initial_parameters"]["task"]
+    assert task["skill"]["args"]["reviewProvider"] == "codex"
+    assert task["skill"]["args"]["requireFreshReview"] is True
+    assert "--review-provider codex" in task["instructions"]
+    assert "--finish-mode fix_only" in task["instructions"]

--- a/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
+++ b/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
@@ -179,3 +179,108 @@ def test_parent_run_summary_projects_merge_automation_visibility() -> None:
             "resolverAttempts": ["resolver-artifact"],
         },
     }
+
+def _fix_only_parameters() -> dict[str, object]:
+    return {
+        "publishMode": "none",
+        "task": {
+            "publish": {
+                "mergeAutomation": {
+                    "enabled": True,
+                    "mergeMethod": "squash",
+                    "finishMode": "fix_only",
+                }
+            }
+        },
+    }
+
+def test_merge_automation_request_defaults_to_the_merge_finish_mode() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(_enabled_parameters())
+
+    assert request is not None
+    assert request["finishMode"] == "merge"
+
+def test_merge_automation_request_carries_the_fix_only_finish_mode() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(_fix_only_parameters())
+
+    assert request is not None
+    assert request["finishMode"] == "fix_only"
+
+def test_merge_gate_start_payload_carries_the_finish_mode() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._publish_context["branch"] = "feature"
+    workflow._publish_context["baseRef"] = "main"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters=_fix_only_parameters(),
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/350",
+        head_sha="abc123",
+        parent_workflow_id="mm:parent",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    config = payload["mergeAutomationConfig"]
+    assert config["finishMode"] == "fix_only"
+    # The merge method still travels so an enabled finish pass is unambiguous.
+    assert config["resolver"]["mergeMethod"] == "squash"
+
+def test_merge_gate_start_payload_defaults_the_finish_mode_to_merge() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters=_enabled_parameters(),
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/350",
+        head_sha="abc123",
+        parent_workflow_id="mm:parent",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["mergeAutomationConfig"]["finishMode"] == "merge"
+
+def test_review_clean_is_a_merge_automation_child_success() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    assert workflow._merge_automation_child_succeeded({"status": "review_clean"}) is True
+    assert workflow._merge_automation_child_status_valid({"status": "review_clean"}) is True
+
+def test_review_clean_is_not_reported_as_a_merge() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._publish_context["mergeAutomationStatus"] = "review_clean"
+
+    assert workflow._merge_happened() is False
+
+def test_fix_only_run_is_not_failed_for_an_unmerged_pull_request() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._publish_context["mergeAutomationStatus"] = "review_clean"
+    parameters = _fix_only_parameters()
+
+    assert workflow._merge_required(parameters) is False
+    assert (
+        workflow._missing_required_outcome_reason(
+            parameters=parameters,
+            publish_mode="none",
+        )
+        is None
+    )
+
+def test_merge_finish_mode_still_requires_a_merged_pull_request() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._publish_context["mergeAutomationStatus"] = "review_clean"
+    parameters = _enabled_parameters()
+
+    assert workflow._merge_required(parameters) is True
+    assert (
+        workflow._missing_required_outcome_reason(
+            parameters=parameters,
+            publish_mode="none",
+        )
+        == "merge automation requested but PR was not merged"
+    )

--- a/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
+++ b/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from temporalio.exceptions import ApplicationError
 
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
@@ -284,3 +285,81 @@ def test_merge_finish_mode_still_requires_a_merged_pull_request() -> None:
         )
         == "merge automation requested but PR was not merged"
     )
+
+
+def _finish_mode_parameters(finish_mode: object) -> dict[str, object]:
+    return {
+        "publishMode": "none",
+        "task": {
+            "publish": {
+                "mergeAutomation": {
+                    "enabled": True,
+                    "mergeMethod": "squash",
+                    "finishMode": finish_mode,
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "finish_mode",
+    ["fix-only", "fixonly", "FIX_ONLY", "Merge", "auto", "none", "no_merge"],
+)
+def test_unsupported_finish_mode_is_rejected_instead_of_granting_merge(
+    finish_mode: str,
+) -> None:
+    """An unsupported value must never be widened into merge authority.
+
+    Silently coercing a typo such as `fix-only` to `merge` hands the resolver
+    permission to perform an irreversible merge that the caller never asked for.
+    """
+
+    workflow = MoonMindRunWorkflow()
+
+    with pytest.raises(ApplicationError) as excinfo:
+        workflow._merge_automation_request(_finish_mode_parameters(finish_mode))
+
+    assert excinfo.value.type == "UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE"
+    assert excinfo.value.non_retryable is True
+
+
+@pytest.mark.parametrize("finish_mode", [None, "", "   "])
+def test_omitted_finish_mode_keeps_the_merge_default(finish_mode: object) -> None:
+    """The default survives only for an omitted value, not for a bad one."""
+
+    workflow = MoonMindRunWorkflow()
+
+    request = workflow._merge_automation_request(_finish_mode_parameters(finish_mode))
+
+    assert request is not None
+    assert request["finishMode"] == "merge"
+
+
+@pytest.mark.parametrize("finish_mode", [17, True, ["fix_only"], {"mode": "fix_only"}])
+def test_malformed_finish_mode_is_rejected(finish_mode: object) -> None:
+    """A non-string payload is malformed input, not an omitted value."""
+
+    workflow = MoonMindRunWorkflow()
+
+    with pytest.raises(ApplicationError) as excinfo:
+        workflow._merge_automation_request(_finish_mode_parameters(finish_mode))
+
+    assert excinfo.value.type == "UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE"
+
+
+def test_unsupported_finish_mode_never_reaches_the_merge_gate_payload() -> None:
+    """Validation must fail before the child gate is handed merge authority."""
+
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    workflow._publish_context["branch"] = "feature"
+
+    with pytest.raises(ApplicationError):
+        workflow._build_merge_gate_start_payload(
+            parameters=_finish_mode_parameters("fix-only"),
+            pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/350",
+            head_sha="abc123",
+            parent_workflow_id="mm:parent",
+            parent_run_id="run-1",
+        )

--- a/tests/unit/workflows/temporal/test_run_review_loop_gate_handoff.py
+++ b/tests/unit/workflows/temporal/test_run_review_loop_gate_handoff.py
@@ -37,6 +37,7 @@ def _review_loop_parameters() -> dict[str, Any]:
                     "checks": "required",
                     "automatedReview": "required",
                     "mergeMethod": "squash",
+                    "finishMode": "fix_only",
                     "reviewLoop": {
                         "enabled": True,
                         "provider": "codex",
@@ -144,6 +145,28 @@ def test_review_loop_policy_survives_the_gate_start_payload() -> None:
     assert payload["idempotencyKey"].endswith(f":3771:{_HEAD_SHA}")
     gate_github = payload["mergeAutomationConfig"]["gate"]["github"]
     assert gate_github["automatedReview"] == "required"
+    # The preset's default withholds merge authority; the gate must carry that
+    # decision instead of quietly re-granting it.
+    assert payload["mergeAutomationConfig"]["finishMode"] == "fix_only"
+
+
+def test_finish_with_pr_resolver_grants_merge_authority_to_the_gate() -> None:
+    """Turning the preset control on must reach the gate as finishMode merge."""
+
+    workflow = MoonMindRunWorkflow()
+    parameters = _review_loop_parameters()
+    parameters["workflow"]["publish"]["mergeAutomation"]["finishMode"] = "merge"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters=parameters,
+        pull_request_url=_PR_URL,
+        head_sha=_HEAD_SHA,
+        parent_workflow_id="mm:review-loop",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["mergeAutomationConfig"]["finishMode"] == "merge"
 
 
 def test_gate_payload_is_withheld_without_an_exact_head_sha() -> None:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -679,7 +679,7 @@ async def test_create_execution_routes_review_loop_runs_that_publish_nothing(
         await service.create_execution(
             workflow_type="MoonMind.UserWorkflow",
             owner_id=uuid4(),
-            title="Review, fix, and merge PR",
+            title="Fix and review loop",
             input_artifact_ref=None,
             plan_artifact_ref=None,
             manifest_artifact_ref=None,

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
@@ -797,3 +797,122 @@ async def test_pre_review_loop_start_input_still_runs(
         harness.readiness_payloads[0]["mergeAutomationConfig"]["reviewLoop"]["enabled"]
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_fix_only_finish_mode_ends_the_loop_without_merging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The loop terminates successfully once nothing is left to address."""
+
+    payload = _payload()
+    payload["mergeAutomationConfig"]["finishMode"] = "fix_only"
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[
+            _ready(HEAD_1, automatedReviewComplete=True),
+        ],
+        child_results=[
+            {"status": "success", "mergeAutomationDisposition": "review_clean"}
+        ],
+    )
+
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+
+    assert result["status"] == "review_clean"
+    assert result["blockers"] == []
+    assert "no actionable comments remain" in result["summary"]
+    # The resolver child was launched without merge authority.
+    args = harness.child_payloads[0]["initial_parameters"]["task"]["skill"]["args"]
+    assert args["finishMode"] == "fix_only"
+
+
+@pytest.mark.asyncio
+async def test_fix_only_finish_mode_still_runs_the_review_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Withholding merge authority must not weaken the request/fix cycle."""
+
+    payload = _payload()
+    payload["mergeAutomationConfig"]["finishMode"] = "fix_only"
+
+    def child_results(child_workflow_id: str, attempt: int) -> dict[str, Any]:
+        if attempt == 1:
+            return _request_review_result(
+                child_workflow_id=child_workflow_id, head_sha=HEAD_2
+            )
+        return {"status": "success", "mergeAutomationDisposition": "review_clean"}
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[
+            _ready(HEAD_1),
+            _awaiting_review(HEAD_2),
+            _ready(
+                HEAD_2,
+                automatedReviewComplete=True,
+                automatedReviewCompletionKind="review",
+                automatedReviewCompletionId=45678,
+                automatedReviewCompletedAt="2026-08-24T22:19:00Z",
+            ),
+        ],
+        child_results=child_results,
+        request_results=[_posted(HEAD_2)],
+    )
+
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+
+    assert result["status"] == "review_clean"
+    assert len(harness.request_payloads) == 1
+    assert result["reviewLoop"]["cycles"] == 1
+    for child_payload in harness.child_payloads:
+        args = child_payload["initial_parameters"]["task"]["skill"]["args"]
+        assert args["finishMode"] == "fix_only"
+        assert args["reviewProvider"] == "codex"
+
+
+@pytest.mark.asyncio
+async def test_merge_finish_mode_is_the_default_for_existing_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-flight payload without finishMode keeps its merge authority."""
+
+    payload = _payload()
+    assert "finishMode" not in payload["mergeAutomationConfig"]
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1, automatedReviewComplete=True)],
+        child_results=[{"status": "success", "mergeAutomationDisposition": "merged"}],
+    )
+
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+
+    assert result["status"] == "merged"
+    args = harness.child_payloads[0]["initial_parameters"]["task"]["skill"]["args"]
+    assert args["finishMode"] == "merge"
+
+
+@pytest.mark.asyncio
+async def test_review_clean_is_rejected_when_merge_authority_was_granted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run asked to merge must not close the gate as an unmerged success."""
+
+    payload = _payload()
+    payload["mergeAutomationConfig"]["finishMode"] = "merge"
+
+    _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1, automatedReviewComplete=True)],
+        child_results=[
+            {"status": "success", "mergeAutomationDisposition": "review_clean"}
+        ],
+    )
+
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+
+    assert result["status"] == "failed"
+    assert result["blockers"][0]["kind"] == "resolver_disposition_invalid"
+    assert "granted merge authority" in result["summary"]

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -630,3 +630,196 @@ def test_pr_resolver_rejects_an_unknown_terminal_disposition(tmp_path: Path) -> 
         ).failure_code
         == "MALFORMED_TERMINAL_EVIDENCE"
     )
+
+
+def _review_clean_contract() -> dict[str, str]:
+    return {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+
+
+def _write_review_clean_evidence(
+    tmp_path: Path,
+    *,
+    result_overrides: dict[str, object] | None = None,
+    publish_overrides: dict[str, object] | None = None,
+) -> None:
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result: dict[str, object] = {
+        "mergeAutomationDisposition": "review_clean",
+        "executionRef": "step-1",
+        "status": "review_clean",
+        "merge_outcome": "skipped",
+    }
+    result.update(result_overrides or {})
+    result_path.write_text(json.dumps(result), encoding="utf-8")
+
+    publish_path = tmp_path / "artifacts/publish_result.json"
+    publish_path.parent.mkdir(parents=True, exist_ok=True)
+    publish: dict[str, object] = {
+        "schemaVersion": "moonmind.publish.auto.v1",
+        "mode": "auto",
+        "owner": "agent",
+        "skillId": "pr-resolver",
+        "executionRef": "step-1",
+        "status": "verified",
+        "action": "push",
+        "repository": "MoonLadderStudios/MoonMind",
+        "branch": "feature",
+        "localHead": "abc123",
+        "remoteBranchHead": "abc123",
+        "remoteVerified": True,
+        "pushed": True,
+        "merged": False,
+        "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/350",
+        "blockedReason": None,
+        "verificationCommands": ["git ls-remote origin refs/heads/feature"],
+    }
+    publish.update(publish_overrides or {})
+    publish_path.write_text(json.dumps(publish), encoding="utf-8")
+
+
+def test_review_clean_rejects_publish_evidence_that_merged_the_pr(
+    tmp_path: Path,
+) -> None:
+    """A fix_only run that merged must never close as a no-merge success.
+
+    The generic auto-publish validator accepts `status=verified`, `action=merge`,
+    `merged=true`, so without disposition-specific invariants an unauthorized
+    irreversible merge would be reported as `review_clean`.
+    """
+
+    _write_review_clean_evidence(
+        tmp_path,
+        publish_overrides={
+            "action": "merge",
+            "merged": True,
+            "verificationCommands": ["gh pr view <pr-url> --json state"],
+        },
+    )
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.failure_code == "UNAUTHORIZED_MERGE_EVIDENCE"
+
+
+@pytest.mark.parametrize(
+    "publish_overrides",
+    [
+        {"merged": True},
+        {"action": "merge"},
+    ],
+)
+def test_review_clean_requires_unmerged_publish_evidence(
+    tmp_path: Path, publish_overrides: dict[str, object]
+) -> None:
+    _write_review_clean_evidence(tmp_path, publish_overrides=publish_overrides)
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.failure_code == "UNAUTHORIZED_MERGE_EVIDENCE"
+
+
+def test_review_clean_still_requires_a_verified_remote_head(tmp_path: Path) -> None:
+    """The remote-head invariant stays owned by the auto-publish parser."""
+
+    _write_review_clean_evidence(
+        tmp_path, publish_overrides={"remoteVerified": False}
+    )
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.failure_code == "MALFORMED_TERMINAL_EVIDENCE"
+
+
+@pytest.mark.parametrize(
+    "result_overrides",
+    [
+        {"status": "merged"},
+        {"merge_outcome": "merged"},
+        {"merge_outcome": "auto_merge_enabled"},
+    ],
+)
+def test_review_clean_rejects_a_resolver_result_that_claims_a_merge(
+    tmp_path: Path, result_overrides: dict[str, object]
+) -> None:
+    _write_review_clean_evidence(tmp_path, result_overrides=result_overrides)
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is False
+    assert evaluation.failure_code == "UNAUTHORIZED_MERGE_EVIDENCE"
+
+
+def test_review_clean_accepts_a_remediated_push_without_a_merge(
+    tmp_path: Path,
+) -> None:
+    """The ordinary fix_only terminal: remediation pushed, nothing merged."""
+
+    _write_review_clean_evidence(tmp_path)
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is True
+    assert evaluation.metadata["mergeAutomationDisposition"] == "review_clean"
+    assert evaluation.metadata["autoPublishMerged"] is False
+
+
+def test_merged_disposition_still_accepts_merge_publish_evidence(
+    tmp_path: Path,
+) -> None:
+    """The no-merge invariants must not leak into the merged disposition."""
+
+    _write_review_clean_evidence(
+        tmp_path,
+        result_overrides={
+            "mergeAutomationDisposition": "merged",
+            "status": "merged",
+            "merge_outcome": "merged",
+        },
+        publish_overrides={"action": "merge", "merged": True},
+    )
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is True
+    assert evaluation.metadata["mergeAutomationDisposition"] == "merged"
+
+
+def test_review_clean_success_keeps_the_resolver_contract_identity(
+    tmp_path: Path,
+) -> None:
+    """Publication facts must not overwrite this contract's own identity."""
+
+    _write_review_clean_evidence(tmp_path)
+
+    evaluation = evaluate_terminal_evidence(
+        _review_clean_contract(), workspace_path=str(tmp_path)
+    )
+
+    assert evaluation.satisfied is True
+    assert evaluation.metadata["terminalContractId"] == "pr_resolver_terminal.v1"
+    assert (
+        evaluation.metadata["terminalContractEvidencePath"]
+        == "var/pr_resolver/result.json"
+    )
+    assert evaluation.metadata["autoPublishAction"] == "push"

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -545,3 +545,88 @@ def test_pr_resolver_terminal_rejects_stale_execution(tmp_path: Path) -> None:
 
     assert result.satisfied is False
     assert result.failure_code == "STALE_TERMINAL_EVIDENCE"
+
+
+def test_pr_resolver_review_clean_requires_publish_evidence(tmp_path: Path) -> None:
+    """fix_only success still has to prove its verified branch head."""
+
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "mergeAutomationDisposition": "review_clean",
+                "executionRef": "step-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    missing_publish = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+    assert missing_publish.failure_code == "INCOMPLETE_TERMINAL_CONTRACT"
+
+    publish_path = tmp_path / "artifacts/publish_result.json"
+    publish_path.parent.mkdir(parents=True, exist_ok=True)
+    publish_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": "moonmind.publish.auto.v1",
+                "mode": "auto",
+                "owner": "agent",
+                "skillId": "pr-resolver",
+                "executionRef": "step-1",
+                "status": "no_op_verified",
+                "action": "none",
+                "repository": "MoonLadderStudios/MoonMind",
+                "branch": "feature",
+                "localHead": "abc123",
+                "remoteBranchHead": "abc123",
+                "remoteVerified": True,
+                "pushed": False,
+                "merged": False,
+                "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/350",
+                "blockedReason": None,
+                "verificationCommands": [
+                    "git ls-remote origin refs/heads/feature",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    evaluation = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+    assert evaluation.satisfied
+    assert evaluation.metadata["mergeAutomationDisposition"] == "review_clean"
+
+
+def test_pr_resolver_rejects_an_unknown_terminal_disposition(tmp_path: Path) -> None:
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "mergeAutomationDisposition": "review_kinda_clean",
+                "executionRef": "step-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        evaluate_terminal_evidence(
+            contract, workspace_path=str(tmp_path)
+        ).failure_code
+        == "MALFORMED_TERMINAL_EVIDENCE"
+    )


### PR DESCRIPTION
## Summary

Renames the `pr-review-resolve` preset to **Fix and Review Loop** and makes merging a deliberate, operator-selected step instead of the preset's headline behavior.

The preset's core journey is now what its name says: request an automated review for every new head, fix every actionable comment, repeat until the pull request is clean. A new **Finish with pr-resolver** checkbox decides whether a final `pr-resolver` pass merges the pull request once there are no more comments to address.

The merge method is no longer exposed. It is a fixed implementation detail of the optional finish pass, pinned to `squash`.

## How it works

One canonical field, `mergeAutomation.finishMode`, carries the decision through the gate:

| `finishMode` | Behavior |
| --- | --- |
| `merge` (default) | Today's behavior. The resolver child runs with merge authority; the final `pr-resolver` pass merges and merge automation terminates `merged` / `already_merged`. |
| `fix_only` | The identical loop with identical gates, minus merge authority. When the same gate that would authorize a merge opens with nothing left to address, the resolver reports `review_clean` and merge automation terminates `review_clean`. |

`fix_only` narrows authority; it never relaxes a gate. A pending review, failing check, conflict, or deferred comment still produces `blocked`, `failed`, `manual_review`, `reenter_gate`, or `request_review` exactly as before. Because no merge happens, no post-merge Jira/GitHub completion is owed or attempted.

## Skill semantics stay in the Skill

`pr-resolver` gains a `finishMode` input and a `--finish-mode` flag on `pr_resolve_finalize.py` / `pr_resolve_orchestrate.py`, plus the `review_clean` terminal disposition. The Skill still owns snapshot collection, comment classification, blocker priority, remediation selection, and merge gating — the workflow only supplies the authority and consumes the declared terminal contract. Terminal evidence for `review_clean` is the usual `artifacts/publish_result.json`, with the exact remote branch head verified and `merged: false`.

## Safety

- **Replay-safe by construction.** Any merge-automation payload recorded without `finishMode` validates as `merge` and merges exactly as before. Covered by a regression test.
- **Fails closed.** A resolver run that *was* granted merge authority but reports `review_clean` is rejected as `resolver_disposition_invalid` rather than closing the gate as success.
- **`review_clean` is not a merge.** It satisfies the parent workflow, but `_merge_happened()` stays literal and the "PR was not merged" required-outcome check still fires whenever `finishMode` is `merge`.
- **Merging is the one opt-in default**, because it is the irreversible boundary in this journey. Both settings are complete production paths — omitted values expand into a full `mergeAutomationConfig` with no hidden enablement.

## Testing

Ran the suites the CI impact selector picks for these files (`unit_fast`, `api_component`, `temporal_boundary`, `reliability_journey`):

- Touched-area suites (preset catalog, merge gate, merge automation, run.py boundary, terminal evidence, publish evidence, adapters, new resolver finish-mode tests): **488 passed**
- `reliability_journey` (`tests/integration/reliability`): **111 passed**
- `temporal_boundary` (`tests/unit/workflows/temporal`): **3590 passed**
- `unit_fast`: **6942 passed**
- All CI preflight policy checks pass (terminology, workflow terminology, removed capability semantics, status domain audit, status token audit, workflow names)

New coverage: finish-mode normalization and fail-fast on unsupported values; `fix_only` finalize reports `review_clean` without merging and still blocks on a missing fresh review; orchestration treats `review_clean` as terminal success; the resolver child request withholds/grants merge authority correctly; the merge-automation loop terminates `review_clean` while still running the full review cycle; `review_clean` is rejected under merge authority; preset defaults and the `finish_with_pr_resolver` override; merge method is absent from every operator surface; publish and terminal evidence for `review_clean`.

Not verified locally: `tests/unit/api/routers/test_executions.py` does not finish within a 900s budget in this environment. Confirmed pre-existing — unmodified `main` times out on the same file at the same pace — and this change touches nothing that file exercises beyond adding one defaulted optional field to `MergeAutomationConfigModel`. Individual tests from it pass. Required CI runs it on Linux.

Environment-only failures, each reproduced on unmodified `main` or proven to be a local worktree artifact, not this change: the `omnigent`/`moonspec` git submodules are not checked out in this worktree (34 tests), and a Windows-created git worktree's `.git` gitdir pointer is unreadable from WSL, which breaks tests that shell out to `git` (`test_agent_session_deployment_safety.py`, `test_update_moonmind_skill.py` — both pass once the pointer is WSL-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)