### PR TITLE
fix(workflows): preserve preset publish policy

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16897,6 +16897,91 @@ describe("Task Create MM-578 Preset expansion", () => {
     );
   });
 
+  it("preserves a publish override when a later submit-time preset has no policy", async () => {
+    const workflowPublish = {
+      mode: "pr",
+      mergeAutomation: { enabled: true },
+    };
+    let expansionCount = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/presets/mm-578-preset:expand?scope=global",
+        )
+      ) {
+        expansionCount += 1;
+        const stepId = `tpl:mm-578-preset:override:${expansionCount}`;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: stepId,
+                title: `Expanded preset ${expansionCount}`,
+                type: "tool",
+                repositoryOperation: "read",
+                instructions: `Resolve preset ${expansionCount}.`,
+                tool: {
+                  type: "tool",
+                  id: "github.resolve_pull_request_target",
+                  inputs: { pullRequest: "3783" },
+                },
+              },
+            ],
+            ...(expansionCount === 1 ? { publish: workflowPublish } : {}),
+            appliedTemplate: {
+              slug: "mm-578-preset",
+              presetDigest: "digest-1",
+              stepIds: [stepId],
+            },
+            capabilities: ["gh"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const firstStep = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    await chooseMm578Preset(firstStep);
+    fireEvent.click(within(firstStep).getByRole("button", { name: "Expand" }));
+    expect(await screen.findByDisplayValue("Resolve preset 1.")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Publish Mode"), {
+      target: { value: "branch" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
+    const secondStep = (await screen.findByText("Step 2")).closest(
+      "section",
+    ) as HTMLElement;
+    await chooseMm578Preset(secondStep);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest() as {
+      payload: {
+        publishMode?: string;
+        mergeAutomation?: Record<string, unknown>;
+        task: { publish?: Record<string, unknown> };
+      };
+    };
+    expect(expansionCount).toBe(2);
+    expect(request.payload.publishMode).toBe("branch");
+    expect(request.payload).not.toHaveProperty("mergeAutomation");
+    expect(request.payload.task.publish).toEqual({ mode: "branch" });
+  });
+
   it("submits Jira Orchestrate preset runs with the executable first-step skill", async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16737,6 +16737,166 @@ describe("Task Create MM-578 Preset expansion", () => {
     fetchSpy.mockRestore();
   });
 
+  it("carries submit-time preset workflow publish policy into execution creation", async () => {
+    const workflowPublish = {
+      mode: "none",
+      mergeAutomation: {
+        enabled: true,
+        checks: "required",
+        automatedReview: "required",
+        mergeMethod: "squash",
+        finishMode: "fix_only",
+        reviewLoop: {
+          enabled: true,
+          provider: "codex",
+          requestMode: "pr_comment",
+          requireFreshReviewForEveryHead: true,
+          requestAfterRemediation: true,
+          maxCycles: 5,
+          maxConsecutiveNoProgressCycles: 2,
+        },
+        timeouts: {
+          fallbackPollSeconds: 60,
+          expireAfterSeconds: 86400,
+        },
+      },
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/presets?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "pr-review-resolve",
+                scope: "global",
+                title: "Fix and Review Loop",
+                description: "Resolve and review an existing pull request.",
+                presetDigest: "digest-pr-review-resolve",
+                inputs: [
+                  {
+                    name: "pull_request",
+                    label: "Pull Request",
+                    type: "text",
+                    required: true,
+                  },
+                ],
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (url.startsWith("/api/presets/pr-review-resolve?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "pr-review-resolve",
+            scope: "global",
+            title: "Fix and Review Loop",
+            description: "Resolve and review an existing pull request.",
+            presetDigest: "digest-pr-review-resolve",
+            inputs: [
+              {
+                name: "pull_request",
+                label: "Pull Request",
+                type: "text",
+                required: true,
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/presets/pr-review-resolve:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:pr-review-resolve:01:replay",
+                title: "Resolve target pull request",
+                type: "tool",
+                repositoryOperation: "read",
+                instructions: "Resolve pull request 242.",
+                tool: {
+                  type: "tool",
+                  id: "github.resolve_pull_request_target",
+                  inputs: {
+                    repository: "MoonLadderStudios/MoonMind",
+                    pullRequest: "242",
+                  },
+                },
+              },
+            ],
+            publish: workflowPublish,
+            appliedTemplate: {
+              slug: "pr-review-resolve",
+              presetDigest: "digest-pr-review-resolve",
+              inputs: { pull_request: "242" },
+              stepIds: ["tpl:pr-review-resolve:01:replay"],
+            },
+            capabilities: ["git", "gh"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(presetSelect.options).some(
+          (option) => option.value === "global::::pr-review-resolve",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::pr-review-resolve" },
+    });
+    fireEvent.change(await within(step).findByLabelText("Pull Request"), {
+      target: { value: "242" },
+    });
+
+    // Reproduce the escaped failure path: submit without manually expanding.
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest() as {
+      payload: {
+        publishMode?: string;
+        mergeAutomation?: Record<string, unknown>;
+        task: {
+          publish?: Record<string, unknown>;
+          appliedStepTemplates?: Array<Record<string, unknown>>;
+        };
+      };
+    };
+    expect(request.payload.publishMode).toBe("none");
+    expect(request.payload).not.toHaveProperty("mergeAutomation");
+    expect(request.payload.task.publish).toEqual(workflowPublish);
+    expect(request.payload.task.appliedStepTemplates?.[0]).not.toHaveProperty(
+      "workflowPublish",
+    );
+  });
+
   it("submits Jira Orchestrate preset runs with the executable first-step skill", async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -9746,10 +9746,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     steps: StepState[];
     appliedTemplates: AppliedTemplateState[];
     warnings: string[];
+    workflowPublish: Record<string, unknown> | null;
   }> {
     let nextSubmissionSteps = steps.map((step) => ({ ...step }));
     const nextAppliedTemplates = [...appliedTemplates];
     const warnings: string[] = [];
+    let workflowPublish: Record<string, unknown> | null = null;
     let generatedStepIndex = nextStepNumber;
 
     for (let index = 0; index < nextSubmissionSteps.length; index += 1) {
@@ -9865,6 +9867,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         if (appliedTemplate) {
           nextAppliedTemplates.push(appliedTemplate);
         }
+        if (expansion.workflowPublish) {
+          workflowPublish = cloneJsonRecord(expansion.workflowPublish);
+        }
         warnings.push(...expansion.warnings);
         nextSubmissionSteps = [
           ...nextSubmissionSteps.slice(0, index),
@@ -9903,6 +9908,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       steps: nextSubmissionSteps,
       appliedTemplates: nextAppliedTemplates,
       warnings,
+      workflowPublish,
     };
   }
 
@@ -9920,6 +9926,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 
     let submissionSteps = steps;
     let submissionAppliedTemplates = appliedTemplates;
+    let submitExpandedWorkflowPublish: Record<string, unknown> | null = null;
     const clearSubmitBusy = () => {
       submitExpansionInFlightRef.current = false;
       setIsSubmitting(false);
@@ -10169,6 +10176,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         });
         submissionSteps = expanded.steps;
         submissionAppliedTemplates = expanded.appliedTemplates;
+        submitExpandedWorkflowPublish = expanded.workflowPublish;
         if (expanded.warnings.length > 0) {
           setSubmitMessage(expanded.warnings.join(" "), "pending");
         } else {
@@ -10211,19 +10219,19 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     const presetWorkflowPublish = workflowPublishForAppliedTemplates(
       activeSubmissionAppliedTemplates,
     );
-    const presetPublishMode = normalizePublishModeForSubmit(
-      String(presetWorkflowPublish?.mode || ""),
-    );
     const presetPublishSelection = publishModeSelectionForWorkflowPublish(
       presetWorkflowPublish,
+    );
+    const submitExpandedPublishMode = normalizePublishModeForSubmit(
+      String(submitExpandedWorkflowPublish?.mode || ""),
     );
     // A preset expanded during this submit has not yet had a chance to update
     // the visible form control. Use its workflow-level policy for this request.
     // For an already-applied preset, a different visible mode is an explicit
     // operator override and therefore wins over the annotation.
     const requestedPublishMode =
-      unresolvedPresetSteps.length > 0 && presetPublishMode
-        ? presetPublishMode
+      submitExpandedWorkflowPublish && submitExpandedPublishMode
+        ? submitExpandedPublishMode
         : formPublishMode;
     const effectiveSubmissionSkillId = primarySkillId;
     const effectivePublishSkillId = resolveEffectivePublishSkillId(
@@ -10257,13 +10265,18 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           )
           ? "none"
           : requestedPublishMode;
+    const selectedWorkflowPublish =
+      submitExpandedWorkflowPublish ||
+      (normalizePublishModeSelection(publishMode) === presetPublishSelection
+        ? presetWorkflowPublish
+        : null);
     const effectiveWorkflowPublish =
-      presetWorkflowPublish &&
-      presetPublishMode === effectivePublishMode &&
-      (unresolvedPresetSteps.length > 0 ||
-        normalizePublishModeSelection(publishMode) === presetPublishSelection)
+      selectedWorkflowPublish &&
+      normalizePublishModeForSubmit(
+        String(selectedWorkflowPublish.mode || ""),
+      ) === effectivePublishMode
         ? {
-            ...presetWorkflowPublish,
+            ...selectedWorkflowPublish,
             mode: effectivePublishMode,
           }
         : { mode: effectivePublishMode };

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1025,6 +1025,7 @@ interface ExpandedStepPayload {
 
 interface PresetExpandResponse {
   steps?: ExpandedStepPayload[];
+  publish?: Record<string, unknown>;
   appliedTemplate?: {
     slug?: string;
     presetDigest?: string;
@@ -1226,6 +1227,7 @@ interface PresetExpansionState {
   assumptions: string[];
   capabilities: string[];
   warnings: string[];
+  workflowPublish?: Record<string, unknown>;
   appliedTemplate?: PresetExpandResponse["appliedTemplate"];
 }
 
@@ -1238,6 +1240,8 @@ interface AppliedTemplateState {
   capabilities: string[];
   composition?: Record<string, unknown>;
   authoredPresets?: Array<Record<string, unknown>>;
+  /** Create-page-only copy of the preset's expanded workflow publish policy. */
+  workflowPublish?: Record<string, unknown>;
 }
 
 function readDashboardConfig(payload: BootPayload): DashboardConfig {
@@ -2496,6 +2500,26 @@ function activeAppliedTemplatesForSteps(
   });
 }
 
+function workflowPublishForAppliedTemplates(
+  appliedTemplates: AppliedTemplateState[],
+): Record<string, unknown> | null {
+  for (let index = appliedTemplates.length - 1; index >= 0; index -= 1) {
+    const publish = appliedTemplates[index]?.workflowPublish;
+    if (publish && Object.keys(publish).length > 0) {
+      return cloneJsonRecord(publish);
+    }
+  }
+  return null;
+}
+
+function appliedTemplatePayloadsForSubmit(
+  appliedTemplates: AppliedTemplateState[],
+): Array<Omit<AppliedTemplateState, "workflowPublish">> {
+  return appliedTemplates.map(({ workflowPublish: _workflowPublish, ...template }) =>
+    template,
+  );
+}
+
 function templateCapabilitiesForStep(
   appliedTemplates: AppliedTemplateState[],
   step: StepState,
@@ -3396,6 +3420,16 @@ function normalizePublishModeForSubmit(value: string | null | undefined): string
 
 function isMergeAutomationPublishMode(value: string | null | undefined): boolean {
   return normalizePublishModeSelection(value) === PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE;
+}
+
+function publishModeSelectionForWorkflowPublish(
+  publish: Record<string, unknown> | null | undefined,
+): string {
+  const mode = normalizePublishModeForSubmit(String(publish?.mode || ""));
+  const mergeAutomation = recordValue(publish?.mergeAutomation);
+  return mode === "pr" && mergeAutomation.enabled === true
+    ? PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE
+    : mode;
 }
 
 function templateEnumOptionLabel(
@@ -9122,6 +9156,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             .map((warning) => String(warning).trim())
             .filter(Boolean)
         : [],
+      ...(expanded.publish && typeof expanded.publish === "object"
+        ? { workflowPublish: cloneJsonRecord(expanded.publish) }
+        : {}),
       appliedTemplate: expanded.appliedTemplate,
     };
   }
@@ -9162,6 +9199,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         : {}),
       ...(Array.isArray(appliedTemplate.authoredPresets)
         ? { authoredPresets: appliedTemplate.authoredPresets }
+        : {}),
+      ...(expansion.workflowPublish
+        ? { workflowPublish: cloneJsonRecord(expansion.workflowPublish) }
         : {}),
     };
   }
@@ -9230,6 +9270,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       attachmentSignature(selectedObjectiveAttachmentFiles),
     );
     recordAppliedPreset(preset, detail, expansion, expandedSteps);
+    const expandedPublishSelection = publishModeSelectionForWorkflowPublish(
+      expansion.workflowPublish,
+    );
+    if (pageMode.mode === "create" && expandedPublishSelection) {
+      setPublishMode(expandedPublishSelection);
+    }
     const autoFillSuffix =
       expansion.assumptions.length > 0
         ? ` Auto-filled ${expansion.assumptions.length} input(s): ${expansion.assumptions.join(", ")}.`
@@ -10076,8 +10122,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    const normalizedPublishMode = normalizePublishModeForSubmit(publishMode);
-    if (!["auto", "none", "branch", "pr"].includes(normalizedPublishMode)) {
+    const formPublishMode = normalizePublishModeForSubmit(publishMode);
+    if (!["auto", "none", "branch", "pr"].includes(formPublishMode)) {
       setSubmitMessage("Publish mode must be one of: auto, none, branch, pr.");
       clearSubmitBusy();
       return;
@@ -10162,6 +10208,23 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       submissionSteps,
     );
     submissionAppliedTemplates = activeSubmissionAppliedTemplates;
+    const presetWorkflowPublish = workflowPublishForAppliedTemplates(
+      activeSubmissionAppliedTemplates,
+    );
+    const presetPublishMode = normalizePublishModeForSubmit(
+      String(presetWorkflowPublish?.mode || ""),
+    );
+    const presetPublishSelection = publishModeSelectionForWorkflowPublish(
+      presetWorkflowPublish,
+    );
+    // A preset expanded during this submit has not yet had a chance to update
+    // the visible form control. Use its workflow-level policy for this request.
+    // For an already-applied preset, a different visible mode is an explicit
+    // operator override and therefore wins over the annotation.
+    const requestedPublishMode =
+      unresolvedPresetSteps.length > 0 && presetPublishMode
+        ? presetPublishMode
+        : formPublishMode;
     const effectiveSubmissionSkillId = primarySkillId;
     const effectivePublishSkillId = resolveEffectivePublishSkillId(
       primarySkillId,
@@ -10170,7 +10233,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     const effectivePublishSkillDetailForSubmit =
       skillsQuery.data?.detailsById[effectivePublishSkillId.trim()] || null;
     if (
-      normalizedPublishMode === "auto" &&
+      requestedPublishMode === "auto" &&
       !isSelfManagedPublishSkill(
         effectivePublishSkillId,
         effectivePublishSkillDetailForSubmit,
@@ -10193,7 +10256,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             effectivePublishSkillDetailForSubmit,
           )
           ? "none"
-          : normalizedPublishMode;
+          : requestedPublishMode;
+    const effectiveWorkflowPublish =
+      presetWorkflowPublish &&
+      presetPublishMode === effectivePublishMode &&
+      (unresolvedPresetSteps.length > 0 ||
+        normalizePublishModeSelection(publishMode) === presetPublishSelection)
+        ? {
+            ...presetWorkflowPublish,
+            mode: effectivePublishMode,
+          }
+        : { mode: effectivePublishMode };
     if (effectivePublishMode === "branch" && !effectiveBranch) {
       setSubmitMessage(
         "Choose a branch before saving or rerunning this publish-mode workflow.",
@@ -11094,7 +11167,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           : {}),
       },
       publish: {
-        mode: effectivePublishMode,
+        ...effectiveWorkflowPublish,
       },
       ...(produceReport || pageMode.mode !== "create"
         ? {
@@ -11111,7 +11184,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         : {}),
       ...(normalizedSteps.length > 0 ? { steps: normalizedSteps } : {}),
       ...(submissionAppliedTemplates.length > 0
-        ? { appliedStepTemplates: submissionAppliedTemplates }
+        ? {
+            appliedStepTemplates: appliedTemplatePayloadsForSubmit(
+              submissionAppliedTemplates,
+            ),
+          }
         : {}),
       ...(submissionAuthoredPresets.length > 0
         ? { authoredPresets: submissionAuthoredPresets }


### PR DESCRIPTION
## Summary

- preserve workflow-level publish policies returned by preset expansion
- submit merge-automation configuration on the automatic expansion path
- add a regression test for the failed pr-review-resolve submission shape

## Verification

- npm run ui:typecheck
- npx eslint -c frontend/eslint.config.mjs frontend/src/entrypoints/workflow-start.tsx frontend/src/entrypoints/workflow-start.test.tsx
- npm run ui:test -- frontend/src/entrypoints/workflow-start.test.tsx
- npm run ui:build:check
- bash ./tools/test_unit.sh --python-only tests/unit/api/test_pr_review_resolve_preset.py tests/unit/workflows/temporal/test_run_merge_gate_start.py
- deployed asset verification for /workflows/start