### PR TITLE
Fix GitHub story output and managed workspace resolution

### DIFF
--- a/moonmind/workflows/adapters/omnigent_agent_adapter.py
+++ b/moonmind/workflows/adapters/omnigent_agent_adapter.py
@@ -21,6 +21,10 @@ from moonmind.omnigent.failure_classification import (
     OmnigentFailureReason,
     classify_omnigent_failure,
 )
+from moonmind.omnigent.repository_sources import (
+    RepositorySourceError,
+    normalize_repository_source,
+)
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunHandle,
@@ -456,8 +460,16 @@ def _find_repository_url(payload: Mapping[str, Any] | None) -> str | None:
         return None
     for key in ("repository", "repositoryUrl", "repoUrl", "gitUrl"):
         value = payload.get(key)
-        if isinstance(value, str) and _is_git_url_with_optional_branch(value):
-            return value
+        if isinstance(value, str):
+            if _is_git_url_with_optional_branch(value):
+                return value
+            try:
+                normalized, source_kind = normalize_repository_source(value)
+            except RepositorySourceError:
+                normalized = ""
+                source_kind = ""
+            if source_kind in {"github_https", "remote"} and normalized:
+                return normalized
         if isinstance(value, Mapping):
             nested = _find_repository_url(value)
             if nested:

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -3232,7 +3232,6 @@ def _github_labels(
     *,
     story: Mapping[str, Any],
     github_payload: Mapping[str, Any],
-    marker_label: str,
 ) -> list[str]:
     labels: list[str] = []
     for source in (github_payload, story):
@@ -3240,8 +3239,6 @@ def _github_labels(
             label = _string(item.get("name") if isinstance(item, Mapping) else item)
             if label:
                 labels.append(label)
-    if marker_label:
-        labels.append(marker_label)
     return list(dict.fromkeys(labels))
 
 
@@ -3511,7 +3508,6 @@ async def create_github_issues_from_stories(
         )
 
     service = github_service_factory()
-    marker_label = _workflow_marker_label(inputs=inputs, context=_context)
     created: list[dict[str, Any]] = []
     issue_mappings: list[dict[str, Any]] = []
     for index, story in enumerate(stories, start=1):
@@ -3526,7 +3522,6 @@ async def create_github_issues_from_stories(
             labels=_github_labels(
                 story=story,
                 github_payload=github_payload,
-                marker_label=marker_label,
             ),
             github_token=None,
         )

--- a/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_omnigent_agent_adapter.py
@@ -131,6 +131,30 @@ def test_managed_repository_task_normalizes_repo_url_and_branch() -> None:
     )
 
 
+def test_managed_repository_task_normalizes_github_slug() -> None:
+    req = _request(
+        workspaceSpec={
+            "repository": "MoonLadderStudios/Tactics",
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": "710b70b2b7957c3094f196ce",
+                "relativePath": "repo",
+            },
+        },
+        parameters={
+            "repository": "MoonLadderStudios/Tactics",
+            "omnigent": {"session": {"hostType": "managed"}},
+        },
+    )
+
+    selection = build_omnigent_selection(req)
+
+    assert (
+        selection.session.workspace
+        == "https://github.com/MoonLadderStudios/Tactics.git"
+    )
+
+
 def test_managed_repository_task_uses_starting_branch_not_target_branch() -> None:
     req = _request(
         workspaceSpec={

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -1619,11 +1619,7 @@ async def test_create_github_issues_from_reconciled_story_breakdown():
     request = service.create_issue_requests[0]
     assert request["repo"] == "MoonLadderStudios/MoonMind"
     assert request["title"] == "Create GitHub issue story output"
-    assert request["labels"] == [
-        "moonmind",
-        "MM-1068",
-        "moonmind-workflow-mm-1068-run",
-    ]
+    assert request["labels"] == ["moonmind", "MM-1068"]
     assert "Source Document: docs/Workflows/SkillAndPlanContracts.md" in request["body"]
     assert "Source Title: MM-1063: Update Presets" in request["body"]
     assert "Source Sections:" in request["body"]
@@ -1631,6 +1627,29 @@ async def test_create_github_issues_from_reconciled_story_breakdown():
     assert "DESIGN-REQ-014" in request["body"]
     assert "One issue is created." in request["body"]
     assert request["github_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_github_issues_does_not_synthesize_workflow_label():
+    service = _FakeGitHubService()
+
+    result = await create_github_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/Tactics",
+            "workflowId": "mm:04cd8f17-f248-42d2-874e-d1bbf8dc039a",
+            "stories": [
+                {
+                    "id": "STORY-001",
+                    "summary": "Authorize the deterministic background catalog",
+                    "description": "Create the remaining implementation story.",
+                }
+            ],
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert service.create_issue_requests[0]["labels"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- apply only explicitly configured labels when creating GitHub issues, preventing provider rejection of synthetic workflow labels
- normalize provider-neutral GitHub repository slugs before creating managed Omnigent workspaces
- add regression coverage for the escaped workflow and the Tactics repository workspace

## Verification

- `./tools/test_unit.sh tests/unit/workflows/adapters/test_omnigent_agent_adapter.py tests/unit/workflows/temporal/test_story_output_tools.py`
- 204 targeted Python tests passed
- 1,222 frontend tests passed; 238 skipped
- exact recovery workflow `mm:dad50a19-0cf0-46e3-b6b9-c9421d230436` completed and created all five requested GitHub issues