### PR TITLE
Switch the Cancel, Remediate, and Rerun action buttons on the Workflows page to icons instead of words

### DIFF
--- a/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.responsive.test.tsx
@@ -75,6 +75,31 @@ describe('WorkflowRowActionsMenu responsive layout', () => {
   });
 });
 
+describe('Promoted row action buttons', () => {
+  it('gives the icon-only row actions the same square footprint as the kebab trigger', () => {
+    // The promoted Cancel/Rerun/Remediate controls render an icon instead of a
+    // word, so they must be square and centered rather than keeping the
+    // text-button padding that made the actions column wide and ragged.
+    const buttonBlock = cssRuleBlock('.workflow-row-actions-inline-button');
+    expect(buttonBlock).toContain('justify-content: center;');
+    expect(buttonBlock).toContain('padding: 0;');
+
+    const triggerBlock = cssRuleBlock('.td-workflow-actions-trigger-compact');
+    for (const declaration of ['width: 2rem;', 'height: 2rem;', 'border-radius: 0.45rem;']) {
+      expect(buttonBlock).toContain(declaration);
+      expect(triggerBlock).toContain(declaration);
+    }
+
+    // Text-button leftovers would either re-widen the control or shrink the glyph.
+    expect(buttonBlock).not.toContain('font-size:');
+    expect(buttonBlock).not.toContain('white-space:');
+
+    const iconBlock = cssRuleBlock('.workflow-row-actions-inline-icon');
+    expect(iconBlock).toContain('width: 1.05rem;');
+    expect(iconBlock).toContain('height: 1.05rem;');
+  });
+});
+
 describe('Workflow list table dropdown overflow', () => {
   it('centers the row actions trigger in the desktop actions column', () => {
     const headerBlock = cssRuleBlock('.queue-table-actions-header-inner');

--- a/frontend/src/components/WorkflowRowActionsMenu.test.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.test.tsx
@@ -74,6 +74,37 @@ describe('WorkflowRowActionsMenu', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  // The actions column is narrow, so the promoted row actions render as icons.
+  // The action name must survive as the accessible name and the hover tooltip,
+  // otherwise the buttons become unlabeled to screen readers and unidentifiable
+  // to sighted operators.
+  it('renders the promoted row actions as labeled icon-only buttons', () => {
+    const { container } = renderWithClient(
+      <WorkflowRowActionsMenu
+        workflowId="wf-123"
+        apiBase="/api"
+        actionsEnabled
+        taskEditingEnabled
+      />,
+    );
+
+    for (const label of ['Cancel', 'Rerun', 'Remediate']) {
+      const button = screen.getByRole('button', { name: label });
+      expect(button.classList.contains('workflow-row-actions-inline-button')).toBe(true);
+      expect(button.getAttribute('aria-label')).toBe(label);
+      expect(button.getAttribute('title')).toContain(label);
+      expect(button.textContent).toBe('');
+      const icon = button.querySelector('svg.workflow-row-actions-inline-icon');
+      expect(icon).not.toBeNull();
+      expect(icon?.getAttribute('aria-hidden')).toBe('true');
+    }
+
+    // Every promoted control is icon-only; nothing in the row cluster renders
+    // the action name as visible text.
+    const controls = container.querySelector('.workflow-row-actions-controls');
+    expect(controls?.textContent).toBe('');
+  });
+
   // Regression guard: the row detail endpoint runs a Temporal sync, so a
   // Workflows page of 50-100 rows must not fan out one request per row just by
   // rendering. Promoting Cancel/Rerun/Remediate onto the row must not turn the

--- a/frontend/src/components/WorkflowRowActionsMenu.tsx
+++ b/frontend/src/components/WorkflowRowActionsMenu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Ban, RotateCcw, Wrench, type LucideIcon } from 'lucide-react';
 import { z } from 'zod';
 
 import { DashboardActionDialog } from './DashboardActionDialog';
@@ -78,9 +79,19 @@ const KEBAB_ICON = (
   </svg>
 );
 
-// Actions promoted out of the overflow menu onto the row itself. Everything
-// not listed here stays behind the kebab.
-const INLINE_ACTION_IDS = new Set(['cancel', 'rerun', 'create-remediation-task']);
+/**
+ * Actions promoted out of the overflow menu onto the row itself, each with the
+ * icon it renders as. The row is a narrow table cell, so the promoted controls
+ * are icon-only; the action name stays reachable as the accessible name and the
+ * hover tooltip. Everything not listed here stays behind the kebab.
+ */
+const INLINE_ACTION_ICONS = {
+  cancel: Ban,
+  rerun: RotateCcw,
+  'create-remediation-task': Wrench,
+} as const satisfies Record<string, LucideIcon>;
+
+const INLINE_ACTION_IDS = new Set(Object.keys(INLINE_ACTION_ICONS));
 
 const ACTION_AVAILABILITY_PENDING_REASON = 'Checking availability…';
 const DEFAULT_WORKFLOW_ACTION_ERROR = 'The workflow action could not be completed.';
@@ -559,20 +570,24 @@ export function WorkflowRowActionsMenu({
       onFocus={armActions}
     >
       <div className="workflow-row-actions-controls">
-        {inlineItems.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            className={`secondary workflow-row-actions-inline-button${
-              item.danger ? ' workflow-row-actions-inline-button--danger' : ''
-            }`}
-            disabled={Boolean(item.disabledReason)}
-            title={item.disabledReason || undefined}
-            onClick={item.onSelect}
-          >
-            {item.label}
-          </button>
-        ))}
+        {inlineItems.map((item) => {
+          const Icon = INLINE_ACTION_ICONS[item.id as keyof typeof INLINE_ACTION_ICONS];
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={`secondary workflow-row-actions-inline-button${
+                item.danger ? ' workflow-row-actions-inline-button--danger' : ''
+              }`}
+              disabled={Boolean(item.disabledReason)}
+              aria-label={item.label}
+              title={item.disabledReason ? `${item.label} — ${item.disabledReason}` : item.label}
+              onClick={item.onSelect}
+            >
+              <Icon className="workflow-row-actions-inline-icon" aria-hidden="true" />
+            </button>
+          );
+        })}
         <WorkflowActionsMenu
           items={menuItems}
           triggerContent={KEBAB_ICON}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -9035,16 +9035,28 @@ button.workflow-workspace-sidebar-row:active {
   flex-wrap: nowrap;
 }
 
+/*
+ * Promoted row actions (Cancel, Rerun, Remediate) are icon-only so the actions
+ * column stays narrow. Match the kebab trigger's square footprint so the whole
+ * cluster reads as one row of equal-sized controls.
+ */
 .workflow-row-actions-inline-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   min-width: 0;
+  width: 2rem;
   height: 2rem;
-  padding: 0 0.6rem;
+  padding: 0;
   border-radius: 0.45rem;
-  font-size: 0.78rem;
   line-height: 1;
-  white-space: nowrap;
+}
+
+.workflow-row-actions-inline-icon {
+  display: block;
+  width: 1.05rem;
+  height: 1.05rem;
+  stroke-width: 2;
 }
 
 .workflow-row-actions-inline-button--danger {


### PR DESCRIPTION
Switch the Cancel, Remediate, and Rerun action buttons on the Workflows page to icons instead of words