### PR TITLE
fix(omnigent): qualify the combination admission actually compiles

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11274,6 +11274,14 @@ async def _create_execution_from_workflow_request(
             initial_parameters,
             snapshot=profile_snapshot,
         )
+        # The profile model and effort are defaults for omitted task runtime
+        # fields.  Preserve explicit task selections that were already resolved
+        # above so the immutable execution plan and Temporal parameters carry
+        # the same authority.
+        if model_source == "task_override":
+            initial_parameters["model"] = resolved_model
+        if "effort" in runtime_payload:
+            initial_parameters["effort"] = resolved_effort
         selected_provider_profile = await session.get(
             ManagedAgentProviderProfile,
             str(profile_snapshot["providerProfileRef"]),

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11274,10 +11274,10 @@ async def _create_execution_from_workflow_request(
             initial_parameters,
             snapshot=profile_snapshot,
         )
-        # The profile model and effort are defaults for omitted task runtime
-        # fields.  Preserve explicit task selections that were already resolved
-        # above so the immutable execution plan and Temporal parameters carry
-        # the same authority.
+        # The profile model and effort are defaults for omitted runtime fields.
+        # Preserve explicit authored selections that were already resolved above
+        # so the immutable execution plan and Temporal parameters carry the same
+        # authority.
         if model_source == "task_override":
             initial_parameters["model"] = resolved_model
         if "effort" in runtime_payload:

--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -308,6 +308,26 @@ def _builtin_opencode_agent(inventory: list[Any]) -> tuple[str, str] | None:
     return upstream_id, upstream_version
 
 
+def _preserve_builtin_opencode_model(
+    document: dict[str, Any], active_document: dict[str, Any]
+) -> dict[str, Any]:
+    """Keep the bootstrap-qualified model across equivalent catalog refreshes.
+
+    The one-action OpenCode bootstrap binds the deployment's qualified model
+    into this built-in profile. Catalog synchronization owns the live harness
+    and source bindings, but must not replace that model authority with the
+    model-empty seed document and invalidate freshly published execution
+    evidence.
+    """
+
+    active_model = active_document.get("model")
+    if not isinstance(active_model, dict) or not active_model:
+        return document
+    preserved = dict(document)
+    preserved["model"] = dict(active_model)
+    return preserved
+
+
 async def ensure_builtin_opencode_agent_profile(
     *, session: AsyncSession, catalog: Any
 ) -> dict[str, Any] | None:
@@ -432,6 +452,9 @@ async def ensure_builtin_opencode_agent_profile(
             None,
         )
         if active is not None:
+            document = _preserve_builtin_opencode_model(
+                document, dict(active.document or {})
+            )
             harness_document = (active.document or {}).get("harness") or {}
             bound_ref = harness_document.get("catalogRef")
             if isinstance(bound_ref, str):

--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -287,6 +287,27 @@ class BundleImportCreate(BaseModel):
     version: int | None = Field(None, ge=1)
 
 
+def _builtin_opencode_agent(inventory: list[Any]) -> tuple[str, str] | None:
+    """Resolve the registered OpenCode template by name to its live identity."""
+
+    agent = next(
+        (
+            item
+            for item in inventory
+            if isinstance(item, dict)
+            and str(item.get("name") or "").strip() == "opencode-native-ui"
+        ),
+        None,
+    )
+    upstream_id = str(
+        (agent or {}).get("id") or (agent or {}).get("agent_id") or ""
+    ).strip()
+    upstream_version = str((agent or {}).get("version") or "").strip()
+    if not upstream_id or not upstream_version:
+        return None
+    return upstream_id, upstream_version
+
+
 async def ensure_builtin_opencode_agent_profile(
     *, session: AsyncSession, catalog: Any
 ) -> dict[str, Any] | None:
@@ -319,32 +340,20 @@ async def ensure_builtin_opencode_agent_profile(
         TrustState.plugin_approved,
     }:
         return None
-    agent = next(
-        (
-            item
-            for item in catalog.diagnostics.get("agents", [])
-            if isinstance(item, dict)
-            and str(item.get("id") or item.get("agent_id") or "")
-            == "opencode-native-ui"
-        ),
-        None,
-    )
-    upstream_version = str((agent or {}).get("version") or "").strip()
-    if not upstream_version:
+    inventory = list(catalog.diagnostics.get("agents", []))
+    agent_identity = _builtin_opencode_agent(inventory)
+    if agent_identity is None:
         return None
+    upstream_id, upstream_version = agent_identity
     await synchronize_upstream_inventory(
         session,
         endpoint_ref="default",
         bridge_mode="proxy",
-        inventory=[
-            item
-            for item in catalog.diagnostics.get("agents", [])
-            if isinstance(item, dict)
-        ],
+        inventory=[item for item in inventory if isinstance(item, dict)],
     )
     projection = await session.get(
         OmnigentUpstreamAgentProjection,
-        projection_identity("default", "opencode-native-ui", upstream_version),
+        projection_identity("default", upstream_id, upstream_version),
     )
     if projection is None:
         return None
@@ -365,7 +374,7 @@ async def ensure_builtin_opencode_agent_profile(
             "endpointRef": "default",
             "source": {
                 "kind": "upstream",
-                "upstreamId": "opencode-native-ui",
+                "upstreamId": upstream_id,
                 "upstreamVersion": upstream_version,
                 "upstreamSnapshotDigest": _digest(dict(projection.metadata_snapshot)),
             },

--- a/api_service/api/routers/omnigent_bootstrap.py
+++ b/api_service/api/routers/omnigent_bootstrap.py
@@ -119,12 +119,11 @@ async def retry_bootstrap(
     session: AsyncSession = Depends(get_async_session),
     current_user: User = Depends(get_current_user()),
 ) -> dict[str, Any]:
-    """Re-qualify the deployment and republish exact execution evidence.
+    """Re-qualify the deployment's current default support combination.
 
-    Deployment evidence admits exactly one support combination, so an Agent
-    Profile, image, or catalog change invalidates it and launches then fail
-    admission. The Provider Profile already owns the credential, so recovery
-    never asks the operator to re-enter the API key.
+    Provider and Agent Profile defaults select the model, effort, and launch
+    policy. The Provider Profile already owns the credential, which is checked
+    for launch readiness and revalidated against the pinned runtime.
     """
     _require_bootstrap_permission(current_user)
     from api_service.db.base import async_session_maker

--- a/api_service/api/routers/omnigent_bootstrap.py
+++ b/api_service/api/routers/omnigent_bootstrap.py
@@ -119,18 +119,39 @@ async def retry_bootstrap(
     session: AsyncSession = Depends(get_async_session),
     current_user: User = Depends(get_current_user()),
 ) -> dict[str, Any]:
+    """Re-qualify the deployment and republish exact execution evidence.
+
+    Deployment evidence admits exactly one support combination, so an Agent
+    Profile, image, or catalog change invalidates it and launches then fail
+    admission. The Provider Profile already owns the credential, so recovery
+    never asks the operator to re-enter the API key.
+    """
     _require_bootstrap_permission(current_user)
+    from api_service.db.base import async_session_maker
+    from moonmind.omnigent.bootstrap.controller import BootstrapController
     from moonmind.omnigent.bootstrap.store import load_bootstrap_record
 
     record = load_bootstrap_record()
     if record is None:
         raise HTTPException(status_code=404, detail="no bootstrap state to retry")
-    # Need api key? We don't store it. So retry requires re-providing key.
-    # For now, fail with clear message
-    raise HTTPException(
-        status_code=422,
-        detail="Retry requires re-submitting the API key via POST /opencode",
-    )
+    controller = BootstrapController(session_factory=async_session_maker)
+    try:
+        record = await controller.requalify()
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)[:500]) from exc
+    return {
+        "bootstrapId": record.bootstrap_id,
+        "state": record.state.value,
+        "providerProfileRef": record.provider_profile_ref,
+        "requestedModel": record.desired.model_display_name,
+        "requestedEffort": record.desired.effort,
+        "failure": record.failure,
+        "resolved": record.resolved.model_dump(mode="json", by_alias=True) if record.resolved else None,
+    }
 
 
 @router.get("/readiness")

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -31,6 +31,21 @@ from api_service.services.provider_profile_service import (
 _OVERRIDABLE_SECTIONS = frozenset({"model", "capture", "rag", "publish"})
 
 
+def default_launch_policy_ref(allowed_launch_policy_refs: Any) -> str:
+    """Return the launch policy admission selects when none is authored.
+
+    Deployment qualification must qualify the same combination admission
+    compiles, so the launch policy is derived from the Agent Profile instead of
+    being restated per call site.
+    """
+
+    for candidate in allowed_launch_policy_refs or ():
+        cleaned = str(candidate or "").strip()
+        if cleaned:
+            return cleaned
+    raise ValueError("agent profile declares no allowed launch policy")
+
+
 def _provider_profile_visibility_filter(user: User | None) -> Any | None:
     """Return the SQL visibility boundary shared by explicit/default selection."""
 
@@ -413,7 +428,9 @@ async def resolve_agent_profile_snapshot(
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             "agentProfile.launchPolicyRef is not allowed by the selected profile",
         )
-    launch_policy_ref = requested_launch_policy or allowed_launch_policies[0]
+    launch_policy_ref = requested_launch_policy or default_launch_policy_ref(
+        allowed_launch_policies
+    )
 
     # Generic (v2) profiles do not carry an execution-profile declaration of
     # their own; the launch policy owns that identity. Derive the canonical
@@ -722,6 +739,7 @@ async def refresh_managed_bootstrap_snapshot(
 
 __all__ = [
     "compile_agent_profile_snapshot_parameters",
+    "default_launch_policy_ref",
     "refresh_managed_bootstrap_snapshot",
     "resolve_agent_profile_snapshot",
     "resolve_default_agent_profile_snapshot",

--- a/api_service/services/omnigent_agent_profile_service.py
+++ b/api_service/services/omnigent_agent_profile_service.py
@@ -295,10 +295,6 @@ async def record_upstream_sync_failure(
     await session.commit()
 
 
-_OPENCODE_NATIVE_UI_ID = "opencode-native-ui"
-_OPENCODE_NATIVE_UI_VERSION = "1"
-
-
 def _synthetic_opencode_implementation() -> Any:
     from moonmind.omnigent.harness_platform.catalog import (
         HarnessImplementationIdentity,
@@ -339,9 +335,10 @@ def _overlay_synthetic_opencode(result: Any) -> Any:
     """Merge the local OpenCode overlay into one authenticated observation.
 
     Stock Omnigent endpoints do not advertise ``opencode-native``. When OpenCode
-    support is enabled, each observation carries the stable overlay harness and
-    upstream agent identity so freshness attestation and launch planning keep
-    succeeding without forking the readiness path.
+    support is enabled, each observation carries the stable overlay harness.
+    Agent identity remains exclusively owned by authenticated ``/v1/agents``
+    inventory; inventing an agent row here would defer a missing deployment
+    prerequisite until session creation.
     """
 
     import hashlib
@@ -365,11 +362,6 @@ def _overlay_synthetic_opencode(result: Any) -> Any:
         for harness in result.snapshot.harnesses
     ]
     synthetic_harness_row = _synthetic_opencode_harness_row()
-    synthetic_agent_row = {
-        "id": _OPENCODE_NATIVE_UI_ID,
-        "version": _OPENCODE_NATIVE_UI_VERSION,
-        "harness": "opencode-native",
-    }
     harness_rows.append(synthetic_harness_row)
     # The overlay is applied before the observation is persisted, so it is the
     # only row published for this synchronization and needs no timestamp offset
@@ -384,7 +376,6 @@ def _overlay_synthetic_opencode(result: Any) -> Any:
             "prior": result.snapshot.sourceDigest,
             "overlay": True,
             "syntheticHarness": synthetic_harness_row,
-            "syntheticAgent": synthetic_agent_row,
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -431,8 +422,9 @@ def _overlay_synthetic_opencode(result: Any) -> Any:
         diagnostics={
             **dict(result.diagnostics),
             "agents": [
-                *[item for item in result.diagnostics.get("agents", []) if isinstance(item, dict)],
-                dict(synthetic_agent_row),
+                item
+                for item in result.diagnostics.get("agents", [])
+                if isinstance(item, dict)
             ],
             "syntheticOpencodeOverlay": True,
         },

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -41,6 +41,9 @@ from moonmind.omnigent.harness_platform.host_classes import (
 from moonmind.omnigent.harness_platform.planner import compile_execution_plan
 from moonmind.omnigent.harness_platform.skills import ResolvedSkillSet
 from moonmind.omnigent.harness_platform.stores import DbExecutionPlanStore
+from moonmind.omnigent.host_services.mounted_tools import (
+    deployment_mounted_tool_names,
+)
 from moonmind.schemas.agent_runtime_models import OmnigentExecutionPlanBinding
 from moonmind.schemas.agent_skill_models import (
     AgentSkillFormat,
@@ -556,6 +559,7 @@ def _build_v2_profile(
     implementation_ref: str,
     harness_id: str,
     auth_model: str,
+    additional_tools: tuple[str, ...] = (),
 ) -> OmnigentAgentProfileV2:
     document = snapshot.get("document")
     if not isinstance(document, Mapping):
@@ -628,7 +632,16 @@ def _build_v2_profile(
             "model": dict(document.get("model") or {}),
             "workspace": dict(document.get("workspace") or {}),
             "skills": list(document.get("skills") or []),
-            "tools": list(document.get("tools") or []),
+            "tools": sorted(
+                {
+                    *(
+                        str(value).strip().lower()
+                        for value in document.get("tools") or []
+                        if str(value).strip()
+                    ),
+                    *additional_tools,
+                }
+            ),
             "capture": dict(document.get("capture") or {}),
             "continuations": dict(document.get("continuations") or {}),
             "publish": dict(document.get("publish") or {}),
@@ -905,7 +918,7 @@ async def compile_and_persist_execution_plan(
         payload=profile_snapshot_payload,
     )
     (
-        _agent_resolved_skills,
+        agent_resolved_skills,
         skill_ref,
         skill_digest,
         skill_content_refs,
@@ -930,6 +943,26 @@ async def compile_and_persist_execution_plan(
             "resolvedSkillSetDigest": skill_digest,
             "skillDeliveryRef": skill_delivery_ref,
         }
+    )
+    required_capabilities = tuple(
+        sorted(
+            {
+                *(
+                    str(value).strip().lower()
+                    for value in initial_parameters.get("requiredCapabilities") or []
+                    if str(value).strip()
+                ),
+                *(
+                    str(capability).strip().lower()
+                    for skill in agent_resolved_skills.skills
+                    for capability in skill.required_capabilities
+                    if str(capability).strip()
+                ),
+            }
+        )
+    )
+    mounted_skill_tools = tuple(
+        sorted(set(required_capabilities).intersection(deployment_mounted_tool_names()))
     )
     binding_set = create_binding_set(
         bindingSetId=f"{harness_id}.primary-model",
@@ -1019,6 +1052,7 @@ async def compile_and_persist_execution_plan(
             implementation_ref=implementation.implementation_ref(),
             harness_id=harness_id,
             auth_model=config["authModel"],
+            additional_tools=mounted_skill_tools,
         ),
         harness_catalog=catalog,
         trust_record=trust,
@@ -1046,12 +1080,10 @@ async def compile_and_persist_execution_plan(
         model_route_ref=str(getattr(provider_profile, "provider_id", "") or "")
         or None,
         model_normalized_options=dict(model_mapping.get("settings") or {}),
-        workflow_requirements=list(
-            initial_parameters.get("requiredCapabilities") or []
-        ),
+        workflow_requirements=list(required_capabilities),
         bridge_capabilities={
             str(capability): True
-            for capability in initial_parameters.get("requiredCapabilities") or []
+            for capability in required_capabilities
         },
         workspace_intent_ref=_digest_ref(
             "workspace-intent", {"repository": repository, "workspace": workspace}

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -964,6 +964,12 @@ async def compile_and_persist_execution_plan(
     mounted_skill_tools = tuple(
         sorted(set(required_capabilities).intersection(deployment_mounted_tool_names()))
     )
+    bridge_capabilities = {
+        "repository.read": True,
+        "repository.write": True,
+        "session.start": True,
+        **{tool_name: True for tool_name in mounted_skill_tools},
+    }
     binding_set = create_binding_set(
         bindingSetId=f"{harness_id}.primary-model",
         version=int(agent_profile_snapshot.get("version") or 1),
@@ -1081,10 +1087,10 @@ async def compile_and_persist_execution_plan(
         or None,
         model_normalized_options=dict(model_mapping.get("settings") or {}),
         workflow_requirements=list(required_capabilities),
-        bridge_capabilities={
-            str(capability): True
-            for capability in required_capabilities
-        },
+        # Capability admission consumes deployment-owned declarations only.
+        # A workflow request can require a capability, but it cannot make that
+        # capability available merely by naming it.
+        bridge_capabilities=bridge_capabilities,
         workspace_intent_ref=_digest_ref(
             "workspace-intent", {"repository": repository, "workspace": workspace}
         ),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1274,6 +1274,28 @@ services:
       - control-plane-network
     restart: "no"
 
+  omnigent-agent-init:
+    image: ${OMNIGENT_IMAGE_REF:-${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:${OMNIGENT_IMAGE_TAG:-latest}}
+    environment:
+      - DATABASE_URL=postgresql://${OMNIGENT_POSTGRES_USER:-omnigent}:${OMNIGENT_POSTGRES_PASSWORD:-omnigent}@postgres:5432/${OMNIGENT_POSTGRES_DB:-omnigent}
+      - ARTIFACT_DIR=${OMNIGENT_ARTIFACT_DIR:-/data/artifacts}
+    command:
+      - python
+      - /opt/moonmind/register_omnigent_agent.py
+      - /opt/moonmind/agents/opencode-native-ui
+    volumes:
+      - omnigent-data:/data
+      - ./tools/register_omnigent_agent.py:/opt/moonmind/register_omnigent_agent.py:ro
+      - ./services/omnigent/agents/opencode-native-ui:/opt/moonmind/agents/opencode-native-ui:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      omnigent-db-init:
+        condition: service_completed_successfully
+    networks:
+      - control-plane-network
+    restart: "no"
+
   omnigent:
     image: ${OMNIGENT_IMAGE_REF:-${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:${OMNIGENT_IMAGE_TAG:-latest}}
     env_file:
@@ -1322,6 +1344,8 @@ services:
       postgres:
         condition: service_healthy
       omnigent-db-init:
+        condition: service_completed_successfully
+      omnigent-agent-init:
         condition: service_completed_successfully
     networks:
       - control-plane-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1408,9 +1408,9 @@ services:
     container_name: moonmind-sandbox-egress-proxy
     image: ubuntu/squid:latest
     labels:
-      moonmind.egress.profile-set-digest: sha256:c3b36588f3ec1aeb7c7888646d760d8ea65630d68c77e9de73d1b7ff84dab227
+      moonmind.egress.profile-set-digest: sha256:ce9e19f22079cd8dc4dd4d14f943b4055b5788bed49188b5c9085b5af82b7ebc
       moonmind.egress.enforcer: docker-internal-proxy/v1
-      moonmind.egress.config-digest: sha256:53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06
+      moonmind.egress.config-digest: sha256:f79931d832bcc9901928ce17931720b6a42fba7bb09b531c211bff9325b12dfa
     volumes:
       - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
     expose:
@@ -1424,7 +1424,7 @@ services:
         aliases:
           - omnigent-egress-proxy
     healthcheck:
-      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = 53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06"]
+      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = f79931d832bcc9901928ce17931720b6a42fba7bb09b531c211bff9325b12dfa"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1408,9 +1408,9 @@ services:
     container_name: moonmind-sandbox-egress-proxy
     image: ubuntu/squid:latest
     labels:
-      moonmind.egress.profile-set-digest: sha256:210bb382a9738300138bca5e4f6885c2e472c725816504040a559a22a7909e82
+      moonmind.egress.profile-set-digest: sha256:c3b36588f3ec1aeb7c7888646d760d8ea65630d68c77e9de73d1b7ff84dab227
       moonmind.egress.enforcer: docker-internal-proxy/v1
-      moonmind.egress.config-digest: sha256:a64c798e3fed5252e86811d344ad8f509332e81b06ee75ddc6ad2f2198fc3713
+      moonmind.egress.config-digest: sha256:53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06
     volumes:
       - ./docker/sandbox-egress-proxy/squid.conf:/etc/squid/squid.conf:ro
     expose:
@@ -1424,7 +1424,7 @@ services:
         aliases:
           - omnigent-egress-proxy
     healthcheck:
-      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = a64c798e3fed5252e86811d344ad8f509332e81b06ee75ddc6ad2f2198fc3713"]
+      test: ["CMD-SHELL", "squid -k parse && test \"$$(sha256sum /etc/squid/squid.conf | cut -d' ' -f1)\" = 53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -40,7 +40,7 @@ acl allowed_sandbox_domains dstdomain \
     .githubusercontent.com \
     .google.com \
     .googleapis.com \
-    .models.opencode.ai \
+    .opencode.ai \
     .registry.npmjs.org \
     .openai.com
 

--- a/docker/sandbox-egress-proxy/squid.conf
+++ b/docker/sandbox-egress-proxy/squid.conf
@@ -40,6 +40,8 @@ acl allowed_sandbox_domains dstdomain \
     .githubusercontent.com \
     .google.com \
     .googleapis.com \
+    .models.opencode.ai \
+    .registry.npmjs.org \
     .openai.com
 
 http_access deny connection_limit

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -958,7 +958,7 @@ credentialBindings:
     materializerRef: opencode-auth-json@1
 
 hostClassRef: omnigent-native-standard@3
-launchPolicyRef: opencode-on-demand@1
+launchPolicyRef: omnigent-on-demand@1
 executionRealizerRef: generic-omnigent-host@1
 
 model:
@@ -1538,7 +1538,7 @@ model:
   modelConfigDigest: sha256:...
 
 hostClassRef: omnigent-native-standard@3
-launchPolicyRef: opencode-on-demand@1
+launchPolicyRef: omnigent-on-demand@1
 executionRealizerRef: generic-omnigent-host@1
 ```
 

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -405,6 +405,8 @@ An Omnigent Agent Profile is the reusable MoonMind selection surface. It describ
 
 It does not own credentials, acquired credential generations, raw host authority, or secret material.
 
+The profile model and effort are defaults when a workflow omits those runtime fields. An explicit workflow runtime model or effort remains authoritative through execution-plan compilation; the compiled plan and Temporal parameters must record the same resolved selection.
+
 ### 9.2 Discriminated agent source
 
 An Agent Profile v2 uses exactly one source variant.

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -179,7 +179,7 @@ credentialSlots:
     acceptedAuthModels: [own-auth]
     acceptedProviderIds: [opencode, opencode-go]
 hostClassRef: omnigent-opencode@1
-launchPolicyRef: opencode-on-demand@1
+launchPolicyRef: omnigent-on-demand@1
 executionRealizerRef: generic-omnigent-host@1
 model:
   qualifiedId: opencode-go/<model-id>
@@ -205,6 +205,37 @@ parameters:
 ```
 
 Planning resolves the Host Class, credential materializer, image, acquired credential generation, and `generic-omnigent-host@1` realizer from durable data. Temporal dispatch does not branch on harness identity.
+
+## Deployment qualification and execution evidence
+
+Deployment qualification proves this deployment can run one exact harness,
+host, image, realizer, credential, and model combination. Admission matches a
+compiled plan against that qualification and refuses anything outside it.
+
+Two rules keep qualification and admission on one combination:
+
+- **Qualification never restates plan inputs.** The launch policy is part of
+  the qualified combination, so qualification derives it from the Agent Profile
+  with the same rule admission uses — the first entry of
+  `allowedLaunchPolicyRefs` when the workflow authors none. A restated ref
+  attests a combination no plan ever compiles: readiness still reports `ready`
+  while every launch fails with `execution evidence unavailable`.
+- **Per-run request intent is not a qualification dimension.**
+  `requiredCapabilitiesDigest` records what one workflow asked for, not what the
+  deployment can run, so it is excluded from the qualified combination. Class
+  admission independently refuses unsupported or unknown required capabilities,
+  and it does so before the support key exists. Binding evidence to one
+  capability set would require re-qualifying the deployment for every workflow
+  shape.
+
+Everything else stays exact. Changing an Agent Profile, host image, harness
+catalog, model, or effort changes the qualified combination and invalidates the
+published evidence. Re-qualify from the persisted Provider Profile — the
+credential is already stored, so recovery never needs the API key again:
+
+```
+POST /api/omnigent/bootstrap/opencode/retry
+```
 
 ## Exact-host attestation (issue §8)
 

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -138,7 +138,12 @@ Validation (Settings → Validate):
 5. Delete the validation host and credential volume, then release the maintenance lease
 6. Persist only normalized model metadata, image/runtime identity, and validation evidence
 
-Raw key is never returned after submission.
+An empty provider catalog fails validation; MoonMind never substitutes a
+configured or legacy model as evidence. The selected default must also remain
+present in the observed catalog. If the provider removes it, readiness is
+deferred until an operator selects another observed model, because changing a
+billing-relevant model is not an automatic recovery action. Raw key is never
+returned after submission.
 
 ### Automatic re-validation after a host image change
 
@@ -154,6 +159,9 @@ enabled, connected OpenCode Provider Profile whose evidence no longer matches
 the currently pinned image, using the already-enrolled `opencode_api_key`
 SecretRef. No new credential is requested, no image is substituted, and a
 credential the runtime rejects keeps its previous evidence and stays connected.
+Fresh catalog evidence is retained when the credential remains valid but the
+configured default model has rotated out, while readiness stays deferred rather
+than silently selecting a replacement.
 While a profile is waiting for that pass, Workflow Create reports
 `provider_runtime_revalidation_pending` rather than asking the operator to
 reconnect a profile that is already connected.

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -133,7 +133,7 @@ Validation (Settings → Validate):
 
 1. Acquire a temporary Provider Profile maintenance lease
 2. Materialize the proposed key through `opencode-auth-json@1` into a disposable Docker volume
-3. Launch the digest-pinned OpenCode host image and query its model options through Omnigent
+3. Launch the digest-pinned OpenCode host image on restricted egress, stage the read-only credential into OpenCode's writable data directory exactly as the production host does, and query the refreshed CLI model catalog
 4. Require at least one `opencode-go/<model-id>` result
 5. Delete the validation host and credential volume, then release the maintenance lease
 6. Persist only normalized model metadata, image/runtime identity, and validation evidence

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -245,6 +245,10 @@ credential is already stored, so recovery never needs the API key again:
 POST /api/omnigent/bootstrap/opencode/retry
 ```
 
+Retry refreshes the desired model and effort from the current Provider Profile
+before qualification. Bootstrap-time model intent is not reused after an
+operator changes those Provider Profile defaults.
+
 ## Exact-host attestation (issue §8)
 
 Before runner/session creation, the exact host is verified:

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -231,10 +231,12 @@ Two rules keep qualification and admission on one combination:
 - **Per-run request intent is not a qualification dimension.**
   `requiredCapabilitiesDigest` records what one workflow asked for, not what the
   deployment can run, so it is excluded from the qualified combination. Class
-  admission independently refuses unsupported or unknown required capabilities,
-  and it does so before the support key exists. Binding evidence to one
-  capability set would require re-qualifying the deployment for every workflow
-  shape.
+  admission derives support only from trusted catalog, Host Class, launch-policy,
+  materializer, bridge, and deployment-mounted-tool declarations; a workflow
+  cannot declare its own request supported. Admission independently refuses
+  unsupported or unknown required capabilities before the support key exists.
+  Binding evidence to one capability set would require re-qualifying the
+  deployment for every workflow shape.
 
 Everything else stays exact. Changing an Agent Profile, host image, harness
 catalog, model, or effort changes the qualified combination and invalidates the
@@ -245,9 +247,12 @@ credential is already stored, so recovery never needs the API key again:
 POST /api/omnigent/bootstrap/opencode/retry
 ```
 
-Retry refreshes the desired model and effort from the current Provider Profile
-before qualification. Bootstrap-time model intent is not reused after an
-operator changes those Provider Profile defaults.
+Retry checks that the persisted Provider Profile and its managed SecretRefs are
+launch ready, revalidates its credential evidence against the pinned runtime,
+and refreshes the desired model and effort from the current Provider Profile.
+Qualification uses the current Agent Profile's default launch policy. An
+explicit per-run override is not a retry target; align the profile defaults with
+the desired combination before invoking retry.
 
 ## Exact-host attestation (issue §8)
 

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -256,7 +256,15 @@ enforced network/egress policy active
 selected model available to credential
 ```
 
-Readiness by harness name alone is insufficient.
+The selected-model check runs Omnigent's portable
+`list_opencode_cli_model_options` helper inside the exact digest-pinned host,
+after the fenced credential generation has been materialized and the restricted
+egress attachment has been verified. The stock Omnigent host tunnel does not
+currently expose pre-launch model options for `opencode-native`; using the
+upstream helper directly keeps the attestation live and credential-bound without
+duplicating OpenCode catalog semantics in MoonMind. Other harnesses continue to
+use the normal host `model-options` tunnel. Readiness by harness name alone is
+insufficient.
 
 ## Deployment configuration
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4005,7 +4005,14 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Retry Bootstrap */
+        /**
+         * Retry Bootstrap
+         * @description Re-qualify the deployment's current default support combination.
+         *
+         *     Provider and Agent Profile defaults select the model, effort, and launch
+         *     policy. The Provider Profile already owns the credential, which is checked
+         *     for launch readiness and revalidated against the pinned runtime.
+         */
         post: operations["retry_bootstrap_api_omnigent_bootstrap_opencode_retry_post"];
         delete?: never;
         options?: never;

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -89,10 +89,10 @@ class BootstrapController:
     async def requalify(self) -> BootstrapRecord:
         """Re-run qualification and republish evidence from persisted state.
 
-        Deployment evidence admits exactly one support combination, so an Agent
-        Profile, image, or catalog change invalidates it and every launch then
-        fails admission. The provider credential is already persisted, so this
-        recovery path never asks the operator to re-enter the API key.
+        Retry qualifies the combination selected by the current Provider and
+        Agent Profile defaults. The provider credential is already persisted,
+        so this path revalidates it against the pinned runtime without asking
+        the operator to re-enter the API key.
         """
 
         record = load_bootstrap_record()
@@ -101,7 +101,51 @@ class BootstrapController:
                 "OpenCode is not configured yet; submit the API key first"
             )
         from api_service.db.models import ManagedAgentProviderProfile
+        from api_service.services.provider_profile_readiness import (
+            provider_profile_launch_ready,
+        )
+        from api_service.services.provider_profile_service import (
+            _managed_secret_statuses_for_profiles,
+        )
 
+        async with self._session_factory() as session:
+            provider_profile = await session.get(
+                ManagedAgentProviderProfile,
+                str(record.provider_profile_ref),
+            )
+            if provider_profile is None:
+                raise ValueError(
+                    "the persisted OpenCode Provider Profile no longer exists"
+                )
+            managed_secret_statuses = await _managed_secret_statuses_for_profiles(
+                session=session,
+                rows=[provider_profile],
+            )
+            if not provider_profile_launch_ready(
+                provider_profile,
+                managed_secret_statuses=managed_secret_statuses,
+            ):
+                raise ValueError(
+                    "the persisted OpenCode Provider Profile is not launch ready; "
+                    "re-enable and reconnect it before requalifying"
+                )
+
+        from moonmind.omnigent.bootstrap.provider_revalidation import (
+            reconcile_opencode_provider_readiness,
+        )
+
+        revalidation = await reconcile_opencode_provider_readiness(
+            session_factory=self._session_factory,
+            allow_enrollment=False,
+        )
+        if not revalidation.ready:
+            raise ValueError(
+                "the persisted OpenCode Provider Profile could not be revalidated "
+                "against the pinned runtime"
+            )
+
+        # Revalidation may have refreshed the credential-scoped catalog. Reload
+        # the row so qualification uses the current authoritative defaults.
         async with self._session_factory() as session:
             provider_profile = await session.get(
                 ManagedAgentProviderProfile,

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -547,175 +547,18 @@ class BootstrapController:
             catalog = await repo.latest("default")
             if catalog is None:
                 raise RuntimeError("harness catalog not synchronized")
-            await ensure_builtin_opencode_agent_profile(session=session, catalog=catalog)
+            builtin = await ensure_builtin_opencode_agent_profile(
+                session=session, catalog=catalog
+            )
+            if builtin is None:
+                raise RuntimeError(
+                    "OpenCode agent is absent from authenticated Omnigent inventory"
+                )
             # Ensure the profile's default model is set to qualified model
             profile_id = "omnigent-opencode-default"
             profile = await session.get(OmnigentAgentProfile, profile_id)
             if profile is None:
-                # Fallback: catalog may not contain opencode-native harness (e.g., upstream server without plugin)
-                # Create a synthetic profile with the expected harness identity so bootstrap can still qualify locally.
-                # This mirrors the synthetic fallback in execution plan service for hermetic tests.
-                import hashlib
-                import json as _json
-                from datetime import UTC, datetime
-
-                from moonmind.omnigent.harness_platform.catalog import (
-                    HarnessImplementationIdentity,
-                    create_catalog_snapshot,
-                )
-
-                # Synthesize implementation identity matching the hard-coded fallback
-                synth_impl = HarnessImplementationIdentity.model_validate(
-                    {
-                        "sourceKind": "core",
-                        "package": "omnigent",
-                        "version": "1.0.0",
-                        "digest": "sha256:" + "a" * 64,
-                        "pluginEntryPoint": None,
-                    }
-                )
-                # Use catalog's build digest if available
-                build_digest = catalog.snapshot.omnigentBuildDigest if catalog else "sha256:" + "b" * 64
-                # Create a synthetic catalog snapshot that includes opencode-native for the profile's authority
-                import uuid as _uuid
-
-                synth_catalog = create_catalog_snapshot(
-                    endpointRef="default",
-                    omnigentVersion=catalog.snapshot.omnigentVersion if catalog else "1.0.0",
-                    omnigentBuildDigest=build_digest,
-                    sourceDigest="sha256:" + hashlib.sha256(f"opencode-synth-{build_digest}-{_uuid.uuid4().hex}".encode()).hexdigest(),
-                    harnesses=[
-                        {
-                            "id": "opencode-native",
-                            "label": "OpenCode",
-                            "implementation": synth_impl.model_dump(mode="json", by_alias=True),
-                            "capabilities": {"integrationMode": "native-server", "authModel": "own-auth"},
-                        }
-                    ],
-                    observedAt=datetime.now(UTC),
-                )
-                synth_impl_ref = synth_impl.implementation_ref()
-                # Persist synthetic catalog so execution readiness can discover it
-                try:
-                    from api_service.db.base import async_session_maker as _asm_synth
-                    from moonmind.omnigent.harness_platform.catalog import (
-                        TrustState,
-                        classify_harness_trust,
-                    )
-                    from moonmind.omnigent.harness_platform.catalog_service import (
-                        DbHarnessCatalogRepository,
-                        HarnessCatalogSyncResult,
-                    )
-
-                    _trust = classify_harness_trust(
-                        harnessId="opencode-native",
-                        implementation=synth_impl,
-                        trustState=TrustState.core_trusted,
-                    )
-                    _result = HarnessCatalogSyncResult(
-                        snapshot=synth_catalog,
-                        trust_records=(_trust,),
-                        diagnostics={"agentCount": 1, "hostCount": 0, "harnessCount": 1, "synthetic": True},
-                    )
-                    _repo = DbHarnessCatalogRepository(_asm_synth)
-                    await _repo.persist(_result)
-                except Exception as _persist_exc:
-                    import logging
-
-                    logging.getLogger(__name__).warning(f"synthetic catalog persist failed: {_persist_exc}")
-                # Find an agent snapshot to use for source
-                upstream_id = "opencode-native-ui"
-                upstream_version = "1"
-                # Try to get existing projection if any
-                from api_service.db.models import OmnigentUpstreamAgentProjection
-                from api_service.services.omnigent_agent_profile_service import (
-                    projection_identity,
-                )
-
-                # Create a minimal projection if missing
-                proj_id = projection_identity("default", upstream_id, upstream_version)
-                proj = await session.get(OmnigentUpstreamAgentProjection, proj_id)
-                if proj is None:
-                    from datetime import UTC, datetime
-
-                    from api_service.db.models import (
-                        OmnigentUpstreamAgentProjection as Proj,
-                    )
-
-                    now = datetime.now(UTC)
-                    proj = Proj(
-                        projection_id=proj_id,
-                        endpoint_ref="default",
-                        bridge_mode="proxy",
-                        upstream_id=upstream_id,
-                        upstream_version=upstream_version,
-                        metadata_snapshot={"id": upstream_id, "version": upstream_version, "harness": "opencode-native"},
-                        available=True,
-                        compatible=True,
-                        last_successful_sync_at=now,
-                        last_attempt_at=now,
-                    )
-                    session.add(proj)
-                    await session.flush()
-                source_digest = "sha256:" + hashlib.sha256(_json.dumps(dict(proj.metadata_snapshot), sort_keys=True).encode()).hexdigest()
-                doc = {
-                    "schemaVersion": "moonmind.omnigent-agent-profile.v2",
-                    "endpointRef": "default",
-                    "source": {
-                        "kind": "upstream",
-                        "upstreamId": upstream_id,
-                        "upstreamVersion": upstream_version,
-                        "upstreamSnapshotDigest": source_digest,
-                    },
-                    "harness": {
-                        "id": "opencode-native",
-                        "catalogRef": synth_catalog.catalogRef,
-                        "implementationRef": synth_impl_ref,
-                    },
-                    "credentialSlots": [
-                        {"id": "primary-model", "acceptedAuthModels": ["own-auth"], "acceptedProviderIds": ["opencode-go"]}
-                    ],
-                    "model": {"qualifiedId": qualified_model, "effort": effort},
-                    "workspace": {"mutation": "allowed"},
-                    "skills": [],
-                    "tools": [],
-                    "capture": {"stream": True, "evidence": True},
-                    "continuations": {"checkpoint": True, "branch": True},
-                    "publish": {"mode": "none"},
-                    "allowedLaunchPolicyRefs": ["opencode-on-demand@1"],
-                }
-                digest = "sha256:" + hashlib.sha256(_json.dumps(doc, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
-                profile = OmnigentAgentProfile(
-                    profile_id=profile_id,
-                    display_name="OpenCode via Omnigent",
-                    description="Synthetic built-in OpenCode profile for local deployment qualification.",
-                    owner_id=None,
-                    visibility="workspace",
-                    state="active",
-                    active_version=1,
-                )
-                session.add(profile)
-                version = OmnigentAgentProfileVersion(
-                    profile_id=profile_id,
-                    version=1,
-                    digest=digest,
-                    document=doc,
-                    upstream_snapshot=dict(proj.metadata_snapshot),
-                    validation_result={
-                        "schemaVersion": "moonmind.omnigent-agent-profile-validation.v2",
-                        "ready": True,
-                        "checks": [
-                            {"name": "catalog", "ready": True},
-                            {"name": "trust", "ready": True},
-                            {"name": "host-class", "ready": True},
-                            {"name": "support-qualification", "ready": True},
-                        ],
-                    },
-                    created_by=None,
-                )
-                session.add(version)
-                await session.commit()
-                return f"{profile_id}@1"
+                raise RuntimeError("OpenCode agent profile was not compiled")
             # Load active version and update if needed
             from sqlalchemy import select as _select_version
 

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -408,12 +408,27 @@ class BootstrapController:
                         resolver=build_omnigent_secret_resolver(),
                         image_ref=image_ref,
                     )
-                    await svc.validate(
+                    validation_evidence = await svc.validate(
                         profile=prof,
                         lease=guard.lease,
                         candidate_secret=api_key,
                         candidate_generation=candidate_gen,
                     )
+                    validated_models = {
+                        str(item.get("qualifiedId") or "")
+                        for item in validation_evidence.get("models", [])
+                        if isinstance(item, dict)
+                    }
+                    if qualified_model not in validated_models:
+                        from moonmind.omnigent.harness_platform.failures import (
+                            HarnessPlatformError,
+                            HarnessPlatformFailure,
+                        )
+
+                        raise HarnessPlatformError(
+                            f"selected model {qualified_model} is unavailable for the Provider Profile",
+                            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+                        )
                 except Exception as exc:
                     if _is_substrate_unavailable(exc):
                         # Substrate unavailable: degrade to format check but report setup failure, not success
@@ -477,14 +492,11 @@ class BootstrapController:
                 prof.credential_generation = candidate_generation
                 prof.default_model = qualified_model
                 prof.default_effort = effort
-                # Always update model catalog evidence to match current generation and image
-                prof.model_catalog_evidence_json = {
-                    "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
-                    "models": [{"qualifiedId": qualified_model}],
-                    "imageRef": resolved.opencode_host_image_ref or "",
-                    "validatedAt": validated_at.isoformat(),
-                    "credentialGeneration": candidate_generation,
-                }
+                # Persist the exact credential-scoped catalog returned by the
+                # pinned runtime. Never replace it with the requested model;
+                # that would turn an unverified selection into readiness
+                # evidence and defer the rejection until exact-host launch.
+                prof.model_catalog_evidence_json = validation_evidence
                 await session.commit()
                 return profile_id
         finally:

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -84,7 +84,47 @@ class BootstrapController:
             }
         )
         save_bootstrap_record(record)
+        return await self._reconcile(record=record, api_key=key, principal=principal)
 
+    async def requalify(self) -> BootstrapRecord:
+        """Re-run qualification and republish evidence from persisted state.
+
+        Deployment evidence admits exactly one support combination, so an Agent
+        Profile, image, or catalog change invalidates it and every launch then
+        fails admission. The provider credential is already persisted, so this
+        recovery path never asks the operator to re-enter the API key.
+        """
+
+        record = load_bootstrap_record()
+        if record is None or not str(record.provider_profile_ref or "").strip():
+            raise ValueError(
+                "OpenCode is not configured yet; submit the API key first"
+            )
+        record = record.model_copy(
+            update={
+                "state": BootstrapState.resolving_images,
+                "revision": int(record.revision) + 1,
+                "updated_at": datetime.now(UTC),
+            }
+        )
+        save_bootstrap_record(record)
+        return await self._reconcile(record=record, api_key=None, principal=None)
+
+    async def _reconcile(
+        self,
+        *,
+        record: BootstrapRecord,
+        api_key: str | None,
+        principal: Any | None,
+    ) -> BootstrapRecord:
+        """Drive desired state to ready, publishing exact deployment evidence.
+
+        ``api_key`` is ``None`` when reconciling an already-credentialed
+        deployment; the persisted Provider Profile then stays authoritative.
+        """
+
+        display = record.desired.model_display_name
+        eff = record.desired.effort
         try:
             # 1. Resolve images
             record = record.model_copy(update={"state": BootstrapState.resolving_images})
@@ -143,13 +183,20 @@ class BootstrapController:
             # 3. Validate credentials transactionally and create provider profile
             record = record.model_copy(update={"state": BootstrapState.validating_credentials})
             save_bootstrap_record(record)
-            provider_ref = await self._ensure_provider_profile(
-                api_key=key,
-                qualified_model=qualified,
-                effort=eff,
-                resolved=resolved,
-                principal=principal,
-            )
+            if api_key is None:
+                provider_ref = str(record.provider_profile_ref or "").strip()
+                if not provider_ref:
+                    raise RuntimeError(
+                        "no persisted Provider Profile to reconcile against"
+                    )
+            else:
+                provider_ref = await self._ensure_provider_profile(
+                    api_key=api_key,
+                    qualified_model=qualified,
+                    effort=eff,
+                    resolved=resolved,
+                    principal=principal,
+                )
             record = record.model_copy(update={"provider_profile_ref": provider_ref})
             save_bootstrap_record(record)
 
@@ -813,6 +860,9 @@ class BootstrapController:
             raise RuntimeError(f"host class selection failed: {exc}") from exc
 
         # Build support payload using the same planner logic as real workflows to ensure evidence matches
+        from api_service.services.omnigent_agent_profile_selection import (
+            default_launch_policy_ref,
+        )
         from api_service.services.omnigent_execution_plan_service import (
             _build_v2_profile,
         )
@@ -852,6 +902,13 @@ class BootstrapController:
                 "digest": version_row.digest,
                 "version": version_row.version,
             }
+        # The launch policy is part of the support combination key, so
+        # qualification must select it exactly the way API admission does.
+        # Restating a harness-shaped ref here qualifies a combination no plan
+        # ever compiles, and every launch then fails admission.
+        qualified_launch_policy_ref = default_launch_policy_ref(
+            snapshot["document"].get("allowedLaunchPolicyRefs")
+        )
         # Build V2 profile as planner does
         v2_profile = _build_v2_profile(
             snapshot=snapshot,
@@ -888,7 +945,7 @@ class BootstrapController:
             credential_binding_set=dummy_binding,
             host_class_ref=host_class.ref,
             host_class=host_class,
-            launch_policy_ref="opencode-on-demand@1",
+            launch_policy_ref=qualified_launch_policy_ref,
             model_qualified_id=qualified_model,
             model_effort=effort,
             model_route_ref="opencode-go",

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -100,9 +100,28 @@ class BootstrapController:
             raise ValueError(
                 "OpenCode is not configured yet; submit the API key first"
             )
+        from api_service.db.models import ManagedAgentProviderProfile
+
+        async with self._session_factory() as session:
+            provider_profile = await session.get(
+                ManagedAgentProviderProfile,
+                str(record.provider_profile_ref),
+            )
+        if provider_profile is None:
+            raise ValueError(
+                "the persisted OpenCode Provider Profile no longer exists"
+            )
+        desired_updates: dict[str, Any] = {}
+        current_model = str(provider_profile.default_model or "").strip()
+        if current_model:
+            desired_updates["model_display_name"] = current_model
+        current_effort = str(provider_profile.default_effort or "").strip()
+        if current_effort:
+            desired_updates["effort"] = validate_effort(current_effort)
         record = record.model_copy(
             update={
                 "state": BootstrapState.resolving_images,
+                "desired": record.desired.model_copy(update=desired_updates),
                 "revision": int(record.revision) + 1,
                 "updated_at": datetime.now(UTC),
             }

--- a/moonmind/omnigent/bootstrap/opencode.py
+++ b/moonmind/omnigent/bootstrap/opencode.py
@@ -58,6 +58,23 @@ def resolve_model_by_display(
                         "providerModelId": provider_id,
                         "qualifiedId": qid,
                     }
+        qualified = display.strip()
+        provider_prefix, separator, provider_model_id = qualified.partition("/")
+        if (
+            available_models is None
+            and separator
+            and provider_prefix == "opencode-go"
+            and provider_model_id
+        ):
+            # Bootstrap resolves images before live credential-scoped model
+            # validation. Preserve a current Provider Profile's canonical model
+            # identity here; qualification still fails closed if the later live
+            # catalog does not contain it.
+            return {
+                "displayName": qualified,
+                "providerModelId": provider_model_id,
+                "qualifiedId": qualified,
+            }
         raise ValueError(f"Requested model is unavailable for this OpenCode Go account: {display!r}")
     # If catalog available, verify alias exists in catalog
     if available_models is not None:

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -98,7 +98,19 @@ def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
         return False
     if generation != int(profile.credential_generation):
         return False
-    return str(evidence.get("imageRef") or "") == image_ref
+    if str(evidence.get("imageRef") or "") != image_ref:
+        return False
+    if not isinstance(evidence.get("runtimeVersions"), dict):
+        return False
+    if str(evidence.get("materializerRef") or "") != "opencode-auth-json@1":
+        return False
+    models = {
+        str(item.get("qualifiedId") or "")
+        for item in evidence.get("models", [])
+        if isinstance(item, dict)
+    }
+    default_model = str(getattr(profile, "default_model", None) or "").strip()
+    return bool(default_model and default_model in models)
 
 
 def _has_enrolled_credential(profile: Any) -> bool:
@@ -152,8 +164,7 @@ async def _opencode_profiles(session_factory: Any) -> list[Any]:
                 await session.execute(
                     select(ManagedAgentProviderProfile).where(
                         ManagedAgentProviderProfile.runtime_id == OPENCODE_RUNTIME_ID,
-                        ManagedAgentProviderProfile.provider_id
-                        == OPENCODE_PROVIDER_ID,
+                        ManagedAgentProviderProfile.provider_id == OPENCODE_PROVIDER_ID,
                     )
                 )
             ).scalars()
@@ -466,8 +477,6 @@ async def _persist_evidence(
             if isinstance(item, dict)
         ]
         profile.model_catalog_evidence_json = evidence
-        if not profile.default_model and models:
-            profile.default_model = models[0]
         behavior = dict(profile.command_behavior or {})
         behavior["runtime_validation"] = {
             "last_validated_at": evidence.get("validatedAt")
@@ -478,8 +487,12 @@ async def _persist_evidence(
         }
         behavior.pop(REVALIDATION_FAILURE_KEY, None)
         profile.command_behavior = behavior
+        launchable = evidence_is_current(
+            profile,
+            image_ref=str(evidence.get("imageRef") or ""),
+        )
         await session.commit()
-        return True
+        return launchable
 
 
 async def _record_revalidation_failure(
@@ -506,10 +519,11 @@ async def _record_revalidation_failure(
         behavior = dict(profile.command_behavior or {})
         previous = behavior.get(REVALIDATION_FAILURE_KEY)
         attempts = 0
-        if isinstance(previous, dict) and str(
-            previous.get("imageRef") or ""
-        ) == image_ref and int(previous.get("credentialGeneration") or 0) == int(
-            profile.credential_generation
+        if (
+            isinstance(previous, dict)
+            and str(previous.get("imageRef") or "") == image_ref
+            and int(previous.get("credentialGeneration") or 0)
+            == int(profile.credential_generation)
         ):
             try:
                 attempts = int(previous.get("attempts") or 0)

--- a/moonmind/omnigent/deployment_evidence.py
+++ b/moonmind/omnigent/deployment_evidence.py
@@ -322,7 +322,11 @@ def _candidate_qualification_key(candidate: Mapping[str, Any]) -> str | None:
 def _support_identity_drift(
     plan_payload: Any, candidate: Mapping[str, Any]
 ) -> list[str]:
-    """Name the support-identity fields that separate a plan from evidence."""
+    """Name fields that separate a plan from untrusted candidate evidence.
+
+    Candidate values have not passed schema validation, the secret scan, or
+    HMAC verification. Diagnostics therefore expose bounded field names only.
+    """
 
     requested = plan_payload.supportIdentity.model_dump(mode="json", by_alias=True)
     attested = candidate.get("supportIdentity")
@@ -332,10 +336,8 @@ def _support_identity_drift(
     for field in sorted(set(requested) | set(attested)):
         if field in DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS:
             continue
-        want = requested.get(field)
-        have = attested.get(field)
-        if want != have:
-            drift.append(f"{field}: requested {want!r} != qualified {have!r}")
+        if requested.get(field) != attested.get(field):
+            drift.append(f"{field} differs")
     return drift
 
 
@@ -344,8 +346,8 @@ def _unqualified_combination_message(
 ) -> str:
     """Explain which exact combination is missing and how to re-qualify.
 
-    Support identity carries only refs and digests, so naming the drifting
-    fields keeps the failure actionable without exposing credentials.
+    Candidates are untrusted until schema, secret, and signature validation,
+    so only bounded field names may appear in this pre-validation diagnostic.
     """
 
     drift: list[str] = []
@@ -356,9 +358,9 @@ def _unqualified_combination_message(
     return (
         "this deployment is not qualified for the requested execution "
         f"combination {plan_payload.supportCombinationKey} ({detail}). "
-        "Re-run deployment qualification "
-        "(POST /api/omnigent/bootstrap/opencode/retry) after changing an "
-        "Agent Profile, image, catalog, model, or required capabilities."
+        "Qualification follows the current Provider and Agent Profile defaults; "
+        "align those defaults with the requested launch policy, model, and effort "
+        "before qualifying the deployment."
     )
 
 

--- a/moonmind/omnigent/deployment_evidence.py
+++ b/moonmind/omnigent/deployment_evidence.py
@@ -20,7 +20,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.omnigent.conformance import assert_secret_free
 from moonmind.omnigent.harness_platform.support import (
+    DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS,
     SupportKeyPayload,
+    compute_deployment_qualification_key,
     compute_support_combination_key,
 )
 
@@ -277,19 +279,28 @@ def assert_deployment_evidence_matches_plan(
     # compilations. The policy digests are intentionally excluded for deployment
     # qualification, which proves the deployment can run the combination, not a
     # single historical policy snapshot.
+    def _qualified_identity(identity: SupportKeyPayload) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in identity.model_dump(mode="json", by_alias=True).items()
+            if key not in DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS
+        }
+
     expected = {
-        "supportCombinationKey": plan_payload.supportCombinationKey,
-        "supportIdentity": support_identity.model_dump(mode="json", by_alias=True),
+        "deploymentQualificationKey": compute_deployment_qualification_key(
+            support_identity
+        ),
+        "supportIdentity": _qualified_identity(support_identity),
         "hostImageRef": plan_payload.hostImageRef,
         "featureGeneration": OMNIGENT_SESSION_FEATURE_GENERATION,
         "replayCompatibilityVersion": OMNIGENT_SESSION_COMPATIBILITY_VERSION,
         "rollbackPolicyVersion": SUPERVISOR_ROLLBACK_POLICY_VERSION,
     }
     actual = {
-        "supportCombinationKey": evidence.support_combination_key,
-        "supportIdentity": evidence.support_identity.model_dump(
-            mode="json", by_alias=True
+        "deploymentQualificationKey": compute_deployment_qualification_key(
+            evidence.support_identity
         ),
+        "supportIdentity": _qualified_identity(evidence.support_identity),
         "hostImageRef": evidence.host_image_ref,
         "featureGeneration": evidence.feature_generation,
         "replayCompatibilityVersion": evidence.replay_compatibility_version,
@@ -297,6 +308,58 @@ def assert_deployment_evidence_matches_plan(
     }
     if actual != expected:
         raise ValueError("deployment evidence conflicts with the execution plan")
+
+
+def _candidate_qualification_key(candidate: Mapping[str, Any]) -> str | None:
+    """Return one published entry's deployment-scoped combination key."""
+
+    identity = candidate.get("supportIdentity")
+    if not isinstance(identity, Mapping):
+        return None
+    return compute_deployment_qualification_key(dict(identity))
+
+
+def _support_identity_drift(
+    plan_payload: Any, candidate: Mapping[str, Any]
+) -> list[str]:
+    """Name the support-identity fields that separate a plan from evidence."""
+
+    requested = plan_payload.supportIdentity.model_dump(mode="json", by_alias=True)
+    attested = candidate.get("supportIdentity")
+    if not isinstance(attested, Mapping):
+        return ["supportIdentity"]
+    drift: list[str] = []
+    for field in sorted(set(requested) | set(attested)):
+        if field in DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS:
+            continue
+        want = requested.get(field)
+        have = attested.get(field)
+        if want != have:
+            drift.append(f"{field}: requested {want!r} != qualified {have!r}")
+    return drift
+
+
+def _unqualified_combination_message(
+    plan_payload: Any, candidates: list[Any]
+) -> str:
+    """Explain which exact combination is missing and how to re-qualify.
+
+    Support identity carries only refs and digests, so naming the drifting
+    fields keeps the failure actionable without exposing credentials.
+    """
+
+    drift: list[str] = []
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            drift.extend(_support_identity_drift(plan_payload, candidate))
+    detail = "; ".join(drift) if drift else "no deployment evidence is published"
+    return (
+        "this deployment is not qualified for the requested execution "
+        f"combination {plan_payload.supportCombinationKey} ({detail}). "
+        "Re-run deployment qualification "
+        "(POST /api/omnigent/bootstrap/opencode/retry) after changing an "
+        "Agent Profile, image, catalog, model, or required capabilities."
+    )
 
 
 def load_deployment_evidence(
@@ -321,14 +384,17 @@ def load_deployment_evidence(
         raise ValueError("deployment evidence must be an object")
     entries = raw.get("entries")
     candidates = list(entries) if isinstance(entries, list) else [raw]
+    requested_qualification_key = compute_deployment_qualification_key(
+        plan_payload.supportIdentity
+    )
     matching = [
         value
         for value in candidates
         if isinstance(value, Mapping)
-        and value.get("supportCombinationKey") == plan_payload.supportCombinationKey
+        and _candidate_qualification_key(value) == requested_qualification_key
     ]
     if len(matching) != 1:
-        raise ValueError("exact deployment execution evidence is unavailable")
+        raise ValueError(_unqualified_combination_message(plan_payload, candidates))
     parsed = validate_deployment_evidence(matching[0], now=now)
     assert_deployment_evidence_matches_plan(parsed, plan_payload)
     return parsed.model_dump(mode="json", by_alias=True)

--- a/moonmind/omnigent/evidence_resolver.py
+++ b/moonmind/omnigent/evidence_resolver.py
@@ -41,9 +41,11 @@ def resolve_execution_evidence(
             evidence = load_deployment_evidence(plan_payload, now=now)
             return evidence, "deployment_qualified"
         except Exception as exc:
-            # If policy is either and protected already failed, bubble deployment failure
+            # If policy is either and protected already failed, bubble deployment failure.
+            # The underlying reason is the only actionable part of this failure,
+            # so it travels in the message and not just the exception chain.
             raise ValueError(
-                "no admissible execution evidence for the current policy"
+                f"no admissible execution evidence for the current policy: {exc}"
             ) from exc
     raise ValueError(f"unknown evidence policy: {selected_policy}")
 

--- a/moonmind/omnigent/harness_platform/capabilities.py
+++ b/moonmind/omnigent/harness_platform/capabilities.py
@@ -71,9 +71,9 @@ def compute_class_admission(
         if not declared:
             unknown.append(cap)
             continue
-        # Check if positively supported across required layers
-        # For simplicity: must be True in host_class and (catalog or bridge) and materializer if applicable
-        # We'll check host_class and catalog/bridge
+        # Check only trusted declarations. A capability may be supplied by the
+        # catalog, Host Class, materializer, bridge, or launch policy; the
+        # workflow's requirement is deliberately absent from this evidence.
         host_ok = host_class_capabilities.get(cap, True)  # if not host-specific, ignore
         catalog_ok = catalog_capabilities.get(cap)
         bridge_ok = bridge_capabilities.get(cap)
@@ -89,10 +89,25 @@ def compute_class_admission(
 
         # If any layer explicitly says False or unsupported, then missing
         # catalog/bridge None means unknown already handled; False means unsupported
-        if catalog_ok is False or bridge_ok is False or host_ok is False or materializer_ok is False or policy_ok is False:
+        if (
+            catalog_ok is False
+            or bridge_ok is False
+            or host_ok is False
+            or materializer_ok is False
+            or policy_ok is False
+        ):
             missing.append(cap)
-        elif catalog_ok is None and bridge_ok is None:
-            # Unknown value remains unknown (not coerced)
+        elif not any(
+            value is True
+            for value in (
+                catalog_capabilities.get(cap),
+                host_class_capabilities.get(cap),
+                materializer_capabilities.get(cap),
+                bridge_capabilities.get(cap),
+            )
+        ) and cap not in launch_policy_capabilities:
+            # A name appearing without an explicit positive declaration is not
+            # support evidence.
             unknown.append(cap)
         else:
             satisfied.append(cap)

--- a/moonmind/omnigent/harness_platform/support.py
+++ b/moonmind/omnigent/harness_platform/support.py
@@ -63,6 +63,43 @@ def compute_support_combination_key(payload: SupportKeyPayload | dict[str, Any])
     return "omnigent-support:sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
 
 
+# ``requiredCapabilitiesDigest`` records the capabilities one workflow asked
+# for, not what the deployment can run. Class admission already refuses a plan
+# whose required capabilities are unsupported or unknown, and it does so before
+# the support key exists, so a deployment cannot be qualified per capability
+# set without qualifying every workflow shape in advance.
+DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS = frozenset({"requiredCapabilitiesDigest"})
+
+
+def compute_deployment_qualification_key(
+    payload: SupportKeyPayload | dict[str, Any],
+) -> str:
+    """Return the deployment-scoped projection of a support combination.
+
+    Deployment qualification proves this deployment can run one exact harness,
+    host, image, realizer, credential, and model combination. It deliberately
+    excludes per-run request variance so an ordinary workflow is admissible
+    without re-qualifying the deployment for every capability set.
+    """
+
+    if isinstance(payload, SupportKeyPayload):
+        data = payload.model_dump(by_alias=True, mode="json")
+    else:
+        data = dict(payload)
+    projected = {
+        key: value
+        for key, value in data.items()
+        if key not in DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS
+    }
+    canonical = json.dumps(
+        projected, sort_keys=True, separators=(",", ":"), default=str
+    )
+    return (
+        "omnigent-deployment-qualification:sha256:"
+        + hashlib.sha256(canonical.encode()).hexdigest()
+    )
+
+
 def compute_required_capabilities_digest(capabilities: list[str]) -> str:
     canonical = json.dumps(sorted(capabilities), separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -91,12 +91,15 @@ class GenericOmnigentHostRuntime:
         *,
         request: AgentExecutionRequest,
         plan: OmnigentExecutionPlanEnvelope,
+        host_class: HostClass,
         launch_policy: LaunchPolicy,
         authority_sink: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
     ) -> PreparedHostInputs:
         workspace = await self._workspace.materialize(
             request,
             mutation=plan.payload.workspaceMutation,
+            runtime_uid=int(host_class.runtime.get("uid", 1000)),
+            runtime_gid=int(host_class.runtime.get("gid", 1000)),
         )
         if authority_sink is not None:
             await authority_sink({"kind": "workspace", **workspace})

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -17,6 +17,9 @@ from moonmind.omnigent.harness_platform.host_classes import HostClass, LaunchPol
 from moonmind.omnigent.host_services.attestation import DockerOmnigentHostAttestor
 from moonmind.omnigent.host_services.cleanup import DockerOmnigentHostCleanupService
 from moonmind.omnigent.host_services.egress import OmnigentEgressService
+from moonmind.omnigent.host_services.github_credentials import (
+    OmnigentGithubCredentialService,
+)
 from moonmind.omnigent.host_services.launcher import (
     DockerOmnigentHostLauncher,
     HostLaunchSpec,
@@ -35,6 +38,7 @@ class PreparedHostInputs:
     skill_attachment: dict[str, Any]
     tool_attachments: tuple[dict[str, Any], ...]
     egress_attestation: dict[str, Any]
+    github_credential_attachment: dict[str, Any] | None = None
 
     @property
     def cleanup_refs(self) -> tuple[str, ...]:
@@ -42,6 +46,11 @@ class PreparedHostInputs:
             self.workspace_attachment.get("cleanupRef"),
             self.skill_attachment.get("cleanupRef"),
             *(item.get("cleanupRef") for item in self.tool_attachments),
+            (
+                self.github_credential_attachment.get("cleanupRef")
+                if self.github_credential_attachment is not None
+                else None
+            ),
             self.egress_attestation.get("cleanupRef"),
         ]
         return tuple(str(item) for item in values if item)
@@ -57,6 +66,7 @@ class GenericOmnigentHostRuntime:
         workspace_service: OmnigentWorkspaceMaterializer,
         skill_service: OmnigentSkillDeliveryService,
         tool_service: OmnigentMountedToolService,
+        github_credential_service: OmnigentGithubCredentialService,
         egress_service: OmnigentEgressService,
         registration_waiter: OmnigentHostRegistrationService,
         host_attestor: DockerOmnigentHostAttestor,
@@ -67,6 +77,7 @@ class GenericOmnigentHostRuntime:
             workspace_service,
             skill_service,
             tool_service,
+            github_credential_service,
             egress_service,
             registration_waiter,
             host_attestor,
@@ -81,6 +92,7 @@ class GenericOmnigentHostRuntime:
         self._workspace = workspace_service
         self._skills = skill_service
         self._tools = tool_service
+        self._github_credentials = github_credential_service
         self._egress = egress_service
         self._registration = registration_waiter
         self._attestor = host_attestor
@@ -139,6 +151,27 @@ class GenericOmnigentHostRuntime:
         if authority_sink is not None:
             for tool in tools:
                 await authority_sink({"kind": "tool", **tool})
+        anticipated_github = self._github_credentials.anticipated_attachment(
+            plan.payload.resolvedTools,
+            owner_ref=request.idempotency_key,
+        )
+        if anticipated_github is not None and authority_sink is not None:
+            await authority_sink(
+                {"kind": "github_credentials", **anticipated_github}
+            )
+        github_credentials = await self._github_credentials.materialize(
+            request=request,
+            resolved_tools=plan.payload.resolvedTools,
+            owner_ref=request.idempotency_key,
+            writer_image_ref=host_class.imageRef,
+            runtime_uid=int(host_class.runtime.get("uid", 1000)),
+            runtime_gid=int(host_class.runtime.get("gid", 1000)),
+        )
+        if github_credentials != anticipated_github:
+            raise HarnessPlatformError(
+                "GitHub credential materialization changed its anticipated authority",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
         egress = await self._egress.attest(request=request, launch_policy=launch_policy)
         if authority_sink is not None:
             await authority_sink({"kind": "egress", **egress})
@@ -146,6 +179,7 @@ class GenericOmnigentHostRuntime:
             workspace_attachment=workspace,
             skill_attachment=skills,
             tool_attachments=tools,
+            github_credential_attachment=github_credentials,
             egress_attestation=egress,
         )
 
@@ -212,6 +246,9 @@ class GenericOmnigentHostRuntime:
                 "workspaceAttachment": prepared.workspace_attachment,
                 "skillAttachment": prepared.skill_attachment,
                 "toolAttachments": list(prepared.tool_attachments),
+                "githubCredentialAttachment": (
+                    prepared.github_credential_attachment
+                ),
                 "credentialAttachments": list(credential_attachments),
                 "controlAttachment": (
                     self._launcher.control_attachment(host_lease_ref)
@@ -314,6 +351,10 @@ class GenericOmnigentHostRuntime:
         # paths, while egress is deployment-owned. Only the run-owned Skill
         # projection is removed here.
         await self._skills.cleanup(prepared.skill_attachment)
+        if prepared.github_credential_attachment is not None:
+            await self._github_credentials.cleanup(
+                prepared.github_credential_attachment
+            )
 
     async def cleanup_authorities(
         self, authorities: tuple[str | dict[str, Any], ...]
@@ -321,6 +362,11 @@ class GenericOmnigentHostRuntime:
         for authority in reversed(authorities):
             if isinstance(authority, dict) and authority.get("kind") == "skills":
                 await self._skills.cleanup(authority)
+            elif (
+                isinstance(authority, dict)
+                and authority.get("kind") == "github_credentials"
+            ):
+                await self._github_credentials.cleanup(authority)
 
 
 __all__ = ["GenericOmnigentHostRuntime", "PreparedHostInputs"]

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -232,6 +232,11 @@ class GenericOmnigentHostRuntime:
         spec = HostLaunchSpec.model_validate(
             {
                 "executionPlanRef": plan.planRef,
+                "stepExecutionId": (
+                    request.step_execution.step_execution_id
+                    if request.step_execution is not None
+                    else request.correlation_id
+                ),
                 "runtimeBindingId": runtime_binding_id,
                 "hostLeaseRef": host_lease_ref,
                 "hostLeaseGeneration": host_lease_generation,

--- a/moonmind/omnigent/host_services/__init__.py
+++ b/moonmind/omnigent/host_services/__init__.py
@@ -4,6 +4,9 @@ from moonmind.omnigent.host_services.attestation import DockerOmnigentHostAttest
 from moonmind.omnigent.host_services.cleanup import DockerOmnigentHostCleanupService
 from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
 from moonmind.omnigent.host_services.egress import OmnigentEgressService
+from moonmind.omnigent.host_services.github_credentials import (
+    OmnigentGithubCredentialService,
+)
 from moonmind.omnigent.host_services.launcher import DockerOmnigentHostLauncher
 from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
 from moonmind.omnigent.host_services.registration import OmnigentHostRegistrationService
@@ -17,6 +20,7 @@ __all__ = [
     "DockerOmnigentHostCleanupService",
     "DockerOmnigentHostLauncher",
     "OmnigentEgressService",
+    "OmnigentGithubCredentialService",
     "OmnigentHostRegistrationService",
     "OmnigentMountedToolService",
     "OmnigentRuntimeScriptService",

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -106,6 +106,43 @@ async def _read_exact_host_model_options(
     return payload, "exact-host-opencode-cli"
 
 
+async def _run_exact_host_runner_command(
+    *,
+    backend: DockerCommandBackend,
+    container_name: str,
+    argv: list[str],
+    timeout_seconds: float = 30.0,
+) -> tuple[int, str, str]:
+    """Execute a probe through the stock host's runner environment builder."""
+
+    runner_probe = (
+        "import os, subprocess, sys; "
+        "from omnigent.host.connect import _build_runner_env; "
+        "env = _build_runner_env(os.environ, "
+        "server_url=os.environ.get('OMNIGENT_SERVER_URL', ''), "
+        "runner_id='moonmind-attestation', "
+        "binding_token='moonmind-attestation', "
+        "workspace='/workspaces/run', parent_pid=os.getpid()); "
+        "result = subprocess.run(sys.argv[1:], env=env, text=True, "
+        "capture_output=True); "
+        "sys.stdout.write(result.stdout); sys.stderr.write(result.stderr); "
+        "raise SystemExit(result.returncode)"
+    )
+    return await backend.run(
+        [
+            "docker",
+            "exec",
+            container_name,
+            "/opt/venv/bin/python",
+            "-c",
+            runner_probe,
+            *argv,
+        ],
+        timeout_seconds=timeout_seconds,
+        check=False,
+    )
+
+
 def _assert_exact_omnigent_build(
     image: dict[str, Any], expected_build_digest: str
 ) -> None:
@@ -292,6 +329,26 @@ class DockerOmnigentHostAttestor:
             ],
             failure_code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
         )
+        skill_target = str(spec.skillAttachment["targetPath"])
+        code, _out, _err = await _run_exact_host_runner_command(
+            backend=self._backend,
+            container_name=launch_result["containerName"],
+            argv=[
+                "/bin/sh",
+                "-ceu",
+                (
+                    'test "${MOONMIND_ACTIVE_SKILLS_DIR:-}" = "$1"; '
+                    'test -d "$1"; test -r "$1/_manifest.json"'
+                ),
+                "--",
+                skill_target,
+            ],
+        )
+        if code != 0:
+            raise HarnessPlatformError(
+                "resolved Skill projection is unavailable in the exact runner environment",
+                code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
+            )
         tool_mount_evidence: list[dict[str, Any]] = []
         for attachment in spec.toolAttachments:
             matched = next(
@@ -441,7 +498,19 @@ class DockerOmnigentHostAttestor:
                         HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
                     ),
                 )
-            expected_helper = "!/opt/moonmind-tools/bin/gh auth git-credential"
+            code, _out, _err = await _run_exact_host_runner_command(
+                backend=self._backend,
+                container_name=launch_result["containerName"],
+                argv=["gh", "auth", "status", "--hostname", "github.com"],
+            )
+            if code != 0:
+                raise HarnessPlatformError(
+                    "GitHub CLI authentication failed in the exact runner environment",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                    ),
+                )
+            expected_helper = "!/home/app/.local/bin/gh auth git-credential"
             code, observed, _err = await self._backend.run(
                 [
                     "docker",
@@ -492,6 +561,30 @@ class DockerOmnigentHostAttestor:
                 if not repository_authorized:
                     raise HarnessPlatformError(
                         "GitHub credential cannot access the admitted repository",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                        ),
+                    )
+                code, runner_observed, _err = await _run_exact_host_runner_command(
+                    backend=self._backend,
+                    container_name=launch_result["containerName"],
+                    argv=[
+                        "gh",
+                        "repo",
+                        "view",
+                        repository,
+                        "--json",
+                        "nameWithOwner,viewerPermission",
+                        "--jq",
+                        "[.nameWithOwner, .viewerPermission] | @tsv",
+                    ],
+                )
+                runner_parts = runner_observed.strip().split("\t", 1)
+                runner_repository = runner_parts[0] if runner_parts else ""
+                if code != 0 or runner_repository.casefold() != repository.casefold():
+                    raise HarnessPlatformError(
+                        "GitHub credential cannot access the admitted repository "
+                        "from the exact runner environment",
                         code=(
                             HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
                         ),

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -39,6 +39,70 @@ def _model_ids(value: Any) -> set[str]:
     return found
 
 
+async def _read_exact_host_model_options(
+    *,
+    backend: DockerCommandBackend,
+    client: Any,
+    container_name: str,
+    omnigent_host_id: str,
+    harness_id: str,
+) -> tuple[Any, str]:
+    """Read model options from the exact host through its supported substrate.
+
+    Omnigent's host tunnel does not expose pre-launch model options for
+    ``opencode-native``. The upstream package does expose one portable catalog
+    helper, and the selected host already owns the exact image, environment,
+    egress policy, and materialized credential that helper must inspect. Run
+    that helper inside the host instead of turning the tunnel's honest
+    unsupported-harness response into a generic HTTP 502.
+    """
+
+    if harness_id != "opencode-native":
+        return (
+            await client.get_host_model_options(omnigent_host_id, harness_id),
+            "omnigent-host-tunnel",
+        )
+
+    probe = (
+        "import json; "
+        "from omnigent.opencode_native_app_server import "
+        "list_opencode_cli_model_options; "
+        "print(json.dumps({'models': list_opencode_cli_model_options()}))"
+    )
+    code, stdout, _stderr = await backend.run(
+        [
+            "docker",
+            "exec",
+            container_name,
+            "/opt/venv/bin/python",
+            "-c",
+            probe,
+        ],
+        timeout_seconds=45.0,
+        check=False,
+    )
+    if code != 0:
+        # Provider CLI diagnostics can include credential-sensitive context.
+        # Exact-host evidence needs only the typed failure, never raw output.
+        raise HarnessPlatformError(
+            "exact host OpenCode model catalog probe failed",
+            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+        )
+    try:
+        payload = json.loads(stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise HarnessPlatformError(
+            "exact host OpenCode model catalog probe returned invalid JSON",
+            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+        ) from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        raise HarnessPlatformError(
+            "exact host OpenCode model catalog probe returned an invalid catalog",
+            code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+        )
+    return payload, "exact-host-opencode-cli"
+
+
 def _assert_exact_omnigent_build(
     image: dict[str, Any], expected_build_digest: str
 ) -> None:
@@ -61,8 +125,7 @@ def _attest_workspace_mount(
             for mount in mounts
             if str(mount.get("Name") or mount.get("Source") or "")
             == str(attachment["sourceRef"])
-            and str(mount.get("Destination") or "")
-            == str(attachment["targetPath"])
+            and str(mount.get("Destination") or "") == str(attachment["targetPath"])
         ),
         None,
     )
@@ -150,11 +213,17 @@ class DockerOmnigentHostAttestor:
                 code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
             )
         _code, omnigent_version, _err = await self._backend.run(
-            ["docker", "exec", launch_result["containerName"],
-             "/opt/venv/bin/omnigent", "--version"],
+            [
+                "docker",
+                "exec",
+                launch_result["containerName"],
+                "/opt/venv/bin/omnigent",
+                "--version",
+            ],
             failure_code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
         )
         import logging
+
         logging.getLogger(__name__).info(
             "omnigent --version probe: expected=%r got=%r",
             host_class.omnigentVersion,
@@ -392,8 +461,12 @@ class DockerOmnigentHostAttestor:
                 "exact host restricted-egress attachment could not be attested",
                 code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
             ) from exc
-        model_options = await self._client.get_host_model_options(
-            host_id, plan.payload.harnessId
+        model_options, model_options_source = await _read_exact_host_model_options(
+            backend=self._backend,
+            client=self._client,
+            container_name=launch_result["containerName"],
+            omnigent_host_id=host_id,
+            harness_id=plan.payload.harnessId,
         )
         selected_model = plan.payload.modelConfig.qualifiedId
         if selected_model not in _model_ids(model_options):
@@ -444,6 +517,7 @@ class DockerOmnigentHostAttestor:
                 "harnessId": plan.payload.harnessId,
                 "selectedModel": selected_model,
                 "availableModels": sorted(_model_ids(model_options)),
+                "source": model_options_source,
             },
             link_type="evidence.model_options",
         )
@@ -456,4 +530,4 @@ class DockerOmnigentHostAttestor:
         }
 
 
-__all__ = ["DockerOmnigentHostAttestor"]
+__all__ = ["DockerOmnigentHostAttestor", "_read_exact_host_model_options"]

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -395,8 +395,8 @@ class DockerOmnigentHostAttestor:
             verify_github_config_script = (
                 'test "$(stat -c %u:%g "$1")" = "$2:$3"; '
                 'test "$(stat -c %a "$1")" = 700; '
-                'test "$(stat -c %u:%g "$1/gh/hosts.yml")" = "$2:$3"; '
-                'test "$(stat -c %a "$1/gh/hosts.yml")" = 600'
+                'test "$(stat -c %u:%g "$1/hosts.yml")" = "$2:$3"; '
+                'test "$(stat -c %a "$1/hosts.yml")" = 600'
             )
             code, _out, _err = await self._backend.run(
                 [

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -338,10 +338,12 @@ class DockerOmnigentHostAttestor:
                 "-ceu",
                 (
                     'test "${MOONMIND_ACTIVE_SKILLS_DIR:-}" = "$1"; '
-                    'test -d "$1"; test -r "$1/_manifest.json"'
+                    'test -d "$1"; test -r "$1/_manifest.json"; '
+                    'test "${MOONMIND_STEP_EXECUTION_ID:-}" = "$2"'
                 ),
                 "--",
                 skill_target,
+                spec.stepExecutionId,
             ],
         )
         if code != 0:

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -159,7 +159,8 @@ async def _run_exact_host_opencode_command(
         "bridge_dir=Path('/tmp/moonmind-opencode-attestation'), "
         "auth_secret='moonmind-attestation'); "
         "result = subprocess.run("
-        "['/home/app/.local/bin/moonmind-opencode-context', *sys.argv[1:]], "
+        "['/home/app/.omnigent/moonmind/bin/moonmind-opencode-context', "
+        "*sys.argv[1:]], "
         "env=env, text=True, capture_output=True); "
         "sys.stdout.write(result.stdout); sys.stderr.write(result.stderr); "
         "raise SystemExit(result.returncode)"
@@ -597,7 +598,9 @@ class DockerOmnigentHostAttestor:
                             HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
                         ),
                     )
-            expected_helper = "!/home/app/.local/bin/gh auth git-credential"
+            expected_helper = (
+                "!/home/app/.omnigent/moonmind/bin/gh auth git-credential"
+            )
             code, observed, _err = await self._backend.run(
                 [
                     "docker",

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -12,6 +12,9 @@ from moonmind.omnigent.harness_platform.failures import (
 )
 from moonmind.omnigent.harness_platform.host_classes import HostClass
 from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
+from moonmind.omnigent.host_services.github_credentials import (
+    github_repository_from_request,
+)
 from moonmind.omnigent.host_services.launcher import HostLaunchSpec
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.security.egress import (
@@ -368,6 +371,141 @@ class DockerOmnigentHostAttestor:
                 "accessMode": "read-only",
                 "secretValueRecorded": False,
             }
+        github_mount_evidence: dict[str, Any] | None = None
+        if spec.githubCredentialAttachment is not None:
+            github_mount = next(
+                (
+                    mount
+                    for mount in mounts
+                    if str(mount.get("Name") or mount.get("Source") or "")
+                    == str(spec.githubCredentialAttachment["sourceRef"])
+                    and str(mount.get("Destination") or "")
+                    == str(spec.githubCredentialAttachment["targetPath"])
+                ),
+                None,
+            )
+            if github_mount is None or bool(github_mount.get("RW")):
+                raise HarnessPlatformError(
+                    "GitHub credential projection is missing or writable",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                    ),
+                )
+            target = str(spec.githubCredentialAttachment["targetPath"])
+            verify_github_config_script = (
+                'test "$(stat -c %u:%g "$1")" = "$2:$3"; '
+                'test "$(stat -c %a "$1")" = 700; '
+                'test "$(stat -c %u:%g "$1/gh/hosts.yml")" = "$2:$3"; '
+                'test "$(stat -c %a "$1/gh/hosts.yml")" = 600'
+            )
+            code, _out, _err = await self._backend.run(
+                [
+                    "docker",
+                    "exec",
+                    launch_result["containerName"],
+                    "/bin/sh",
+                    "-ceu",
+                    verify_github_config_script,
+                    "--",
+                    target,
+                    str(host_class.runtime.get("uid", 1000)),
+                    str(host_class.runtime.get("gid", 1000)),
+                ],
+                check=False,
+            )
+            if code != 0:
+                raise HarnessPlatformError(
+                    "GitHub credential projection ownership or mode is invalid",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                    ),
+                )
+            code, _out, _err = await self._backend.run(
+                [
+                    "docker",
+                    "exec",
+                    launch_result["containerName"],
+                    "gh",
+                    "auth",
+                    "status",
+                    "--hostname",
+                    "github.com",
+                ],
+                timeout_seconds=30.0,
+                check=False,
+            )
+            if code != 0:
+                raise HarnessPlatformError(
+                    "GitHub CLI authentication failed on the exact host",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                    ),
+                )
+            expected_helper = "!/opt/moonmind-tools/bin/gh auth git-credential"
+            code, observed, _err = await self._backend.run(
+                [
+                    "docker",
+                    "exec",
+                    launch_result["containerName"],
+                    "git",
+                    "config",
+                    "--get-urlmatch",
+                    "credential.helper",
+                    "https://github.com",
+                ],
+                check=False,
+            )
+            if code != 0 or observed.strip() != expected_helper:
+                raise HarnessPlatformError(
+                    "GitHub git credential helper is not active on the exact host",
+                    code=(
+                        HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                    ),
+                )
+            repository = github_repository_from_request(request)
+            repository_authorized: bool | None = None
+            repository_permission: str | None = None
+            if repository:
+                code, observed, _err = await self._backend.run(
+                    [
+                        "docker",
+                        "exec",
+                        launch_result["containerName"],
+                        "gh",
+                        "repo",
+                        "view",
+                        repository,
+                        "--json",
+                        "nameWithOwner,viewerPermission",
+                        "--jq",
+                        "[.nameWithOwner, .viewerPermission] | @tsv",
+                    ],
+                    timeout_seconds=30.0,
+                    check=False,
+                )
+                parts = observed.strip().split("\t", 1)
+                observed_repository = parts[0] if parts else ""
+                repository_permission = parts[1] if len(parts) == 2 else None
+                repository_authorized = code == 0 and (
+                    observed_repository.casefold() == repository.casefold()
+                )
+                if not repository_authorized:
+                    raise HarnessPlatformError(
+                        "GitHub credential cannot access the admitted repository",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                        ),
+                    )
+            github_mount_evidence = {
+                "targetPath": target,
+                "accessMode": "read-only",
+                "authenticated": True,
+                "repository": repository or None,
+                "repositoryAuthorized": repository_authorized,
+                "repositoryPermission": repository_permission,
+                "gitCredentialHelperConfigured": True,
+                "secretValueRecorded": False,
+            }
         credential_mount_evidence: list[dict[str, Any]] = []
         for handle in credential_handles:
             for attachment in handle.get("attachments", []):
@@ -494,6 +632,7 @@ class DockerOmnigentHostAttestor:
             "credentialMounts": credential_mount_evidence,
             "workspaceMount": workspace_mount_evidence,
             "controlCredentialMount": control_mount_evidence,
+            "githubCredentialMount": github_mount_evidence,
             "skillDeliveryRef": spec.skillAttachment.get("deliveryRef"),
             "toolDeliveryRefs": [
                 item.get("toolDeliveryRef") for item in spec.toolAttachments

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -143,6 +143,56 @@ async def _run_exact_host_runner_command(
     )
 
 
+async def _run_exact_host_opencode_command(
+    *,
+    backend: DockerCommandBackend,
+    container_name: str,
+    argv: list[str],
+    timeout_seconds: float = 30.0,
+) -> tuple[int, str, str]:
+    """Execute through the runner, OpenCode filter, and MoonMind context shim."""
+
+    filtered_child_probe = (
+        "import subprocess, sys; from pathlib import Path; "
+        "from omnigent.opencode_native_app_server import filtered_server_env; "
+        "env = filtered_server_env("
+        "bridge_dir=Path('/tmp/moonmind-opencode-attestation'), "
+        "auth_secret='moonmind-attestation'); "
+        "result = subprocess.run("
+        "['/home/app/.local/bin/moonmind-opencode-context', *sys.argv[1:]], "
+        "env=env, text=True, capture_output=True); "
+        "sys.stdout.write(result.stdout); sys.stderr.write(result.stderr); "
+        "raise SystemExit(result.returncode)"
+    )
+    opencode_probe = (
+        "import os, subprocess, sys; "
+        "from omnigent.host.connect import _build_runner_env; "
+        "runner_env = _build_runner_env(os.environ, "
+        "server_url=os.environ.get('OMNIGENT_SERVER_URL', ''), "
+        "runner_id='moonmind-attestation', "
+        "binding_token='moonmind-attestation', "
+        "workspace='/workspaces/run', parent_pid=os.getpid()); "
+        f"child = {filtered_child_probe!r}; "
+        "result = subprocess.run([sys.executable, '-c', child, *sys.argv[1:]], "
+        "env=runner_env, text=True, "
+        "capture_output=True); sys.stdout.write(result.stdout); "
+        "sys.stderr.write(result.stderr); raise SystemExit(result.returncode)"
+    )
+    return await backend.run(
+        [
+            "docker",
+            "exec",
+            container_name,
+            "/opt/venv/bin/python",
+            "-c",
+            opencode_probe,
+            *argv,
+        ],
+        timeout_seconds=timeout_seconds,
+        check=False,
+    )
+
+
 def _assert_exact_omnigent_build(
     image: dict[str, Any], expected_build_digest: str
 ) -> None:
@@ -351,6 +401,28 @@ class DockerOmnigentHostAttestor:
                 "resolved Skill projection is unavailable in the exact runner environment",
                 code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
             )
+        if plan.payload.harnessId == "opencode-native":
+            code, _out, _err = await _run_exact_host_opencode_command(
+                backend=self._backend,
+                container_name=launch_result["containerName"],
+                argv=[
+                    "/bin/sh",
+                    "-ceu",
+                    (
+                        'test "${MOONMIND_ACTIVE_SKILLS_DIR:-}" = "$1"; '
+                        'test -d "$1"; test -r "$1/_manifest.json"; '
+                        'test "${MOONMIND_STEP_EXECUTION_ID:-}" = "$2"'
+                    ),
+                    "--",
+                    skill_target,
+                    spec.stepExecutionId,
+                ],
+            )
+            if code != 0:
+                raise HarnessPlatformError(
+                    "resolved Skill projection is unavailable in the OpenCode shell environment",
+                    code=HarnessPlatformFailure.OMNIGENT_SKILL_SNAPSHOT_UNAVAILABLE,
+                )
         tool_mount_evidence: list[dict[str, Any]] = []
         for attachment in spec.toolAttachments:
             matched = next(
@@ -512,6 +584,19 @@ class DockerOmnigentHostAttestor:
                         HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
                     ),
                 )
+            if plan.payload.harnessId == "opencode-native":
+                code, _out, _err = await _run_exact_host_opencode_command(
+                    backend=self._backend,
+                    container_name=launch_result["containerName"],
+                    argv=["gh", "auth", "status", "--hostname", "github.com"],
+                )
+                if code != 0:
+                    raise HarnessPlatformError(
+                        "GitHub CLI authentication failed in the OpenCode shell environment",
+                        code=(
+                            HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                        ),
+                    )
             expected_helper = "!/home/app/.local/bin/gh auth git-credential"
             code, observed, _err = await self._backend.run(
                 [

--- a/moonmind/omnigent/host_services/github_credentials.py
+++ b/moonmind/omnigent/host_services/github_credentials.py
@@ -15,7 +15,7 @@ from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
-_TARGET_PATH = "/home/app/.cache/moonmind-xdg"
+_TARGET_PATH = "/home/app/.cache/moonmind-gh"
 
 
 def github_repository_from_request(request: AgentExecutionRequest) -> str:
@@ -132,13 +132,13 @@ class OmnigentGithubCredentialService:
                 code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
             )
         script = (
-            "set -eu; umask 077; mkdir -p /config/gh; "
+            "set -eu; umask 077; mkdir -p /config; "
             "printf 'github.com:\\n    user: x-access-token\\n    oauth_token: ' "
-            "> /config/gh/hosts.yml; "
-            "cat >> /config/gh/hosts.yml; "
-            "printf '\\n    git_protocol: https\\n' >> /config/gh/hosts.yml; "
+            "> /config/hosts.yml; "
+            "cat >> /config/hosts.yml; "
+            "printf '\\n    git_protocol: https\\n' >> /config/hosts.yml; "
             "chown -R \"$1:$2\" /config; "
-            "chmod 0700 /config /config/gh; chmod 0600 /config/gh/hosts.yml"
+            "chmod 0700 /config; chmod 0600 /config/hosts.yml"
         )
         try:
             await self._backend.run(

--- a/moonmind/omnigent/host_services/github_credentials.py
+++ b/moonmind/omnigent/host_services/github_credentials.py
@@ -15,7 +15,7 @@ from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
-_TARGET_PATH = "/home/app/.cache/moonmind-gh"
+_TARGET_PATH = "/run/mm-credentials/github"
 
 
 def github_repository_from_request(request: AgentExecutionRequest) -> str:

--- a/moonmind/omnigent/host_services/github_credentials.py
+++ b/moonmind/omnigent/host_services/github_credentials.py
@@ -1,0 +1,219 @@
+"""Lease-owned GitHub CLI credential projection for generic Omnigent hosts."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from moonmind.auth.github_credentials import resolve_github_credential
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+_SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+_TARGET_PATH = "/home/app/.cache/moonmind-xdg"
+
+
+def github_repository_from_request(request: AgentExecutionRequest) -> str:
+    """Return the repository identity already admitted for the workspace."""
+
+    spec = request.workspace_spec if isinstance(request.workspace_spec, dict) else {}
+    target = (
+        spec.get("repositoryTarget")
+        if isinstance(spec.get("repositoryTarget"), dict)
+        else {}
+    )
+    repository = (
+        target.get("repository")
+        if isinstance(target.get("repository"), dict)
+        else {}
+    )
+    return str(
+        repository.get("name")
+        or spec.get("repository")
+        or spec.get("repo")
+        or ""
+    ).strip()
+
+
+class OmnigentGithubCredentialService:
+    """Materialize standard ``gh`` config without exposing token transport."""
+
+    def __init__(self, backend: DockerCommandBackend) -> None:
+        self._backend = backend
+
+    @staticmethod
+    def required(resolved_tools: dict[str, Any]) -> bool:
+        return "gh" in {
+            str(value).strip().lower()
+            for value in resolved_tools.get("tools", [])
+            if str(value).strip()
+        }
+
+    @staticmethod
+    def anticipated_attachment(
+        resolved_tools: dict[str, Any], *, owner_ref: str
+    ) -> dict[str, Any] | None:
+        if not OmnigentGithubCredentialService.required(resolved_tools):
+            return None
+        owner_digest = hashlib.sha256(owner_ref.encode()).hexdigest()[:32]
+        return {
+            "kind": "volume",
+            "sourceRef": f"mm-omnigent-github-{owner_digest}",
+            "targetPath": _TARGET_PATH,
+            "accessMode": "read-only",
+            "cleanupRef": f"github-credential-cleanup:{owner_digest}",
+            "ownerDigest": owner_digest,
+        }
+
+    async def materialize(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        resolved_tools: dict[str, Any],
+        owner_ref: str,
+        writer_image_ref: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> dict[str, Any] | None:
+        attachment = self.anticipated_attachment(resolved_tools, owner_ref=owner_ref)
+        if attachment is None:
+            return None
+        repository = github_repository_from_request(request)
+        credential = await resolve_github_credential(repo=repository or None)
+        token = str(credential.token or "")
+        if not token or "\n" in token or "\r" in token:
+            raise HarnessPlatformError(
+                credential.safe_summary,
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        if runtime_uid <= 0 or runtime_gid <= 0:
+            raise HarnessPlatformError(
+                "GitHub credential runtime owner is invalid",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        volume = str(attachment["sourceRef"])
+        if not _SAFE_VOLUME.fullmatch(volume):
+            raise HarnessPlatformError(
+                "GitHub credential volume identity is unsafe",
+                code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+            )
+        await self._backend.run(
+            [
+                "docker",
+                "volume",
+                "create",
+                "--label",
+                "moonmind.owner=generic-omnigent-github-credential",
+                "--label",
+                f"moonmind.owner_digest={attachment['ownerDigest']}",
+                volume,
+            ],
+            failure_code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+        )
+        _code, observed_owner, _error = await self._backend.run(
+            [
+                "docker",
+                "volume",
+                "inspect",
+                "--format",
+                '{{ index .Labels "moonmind.owner_digest" }}',
+                volume,
+            ],
+            failure_code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED,
+        )
+        if observed_owner.strip() != str(attachment["ownerDigest"]):
+            raise HarnessPlatformError(
+                "GitHub credential projection is owned by another lease",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        script = (
+            "set -eu; umask 077; mkdir -p /config/gh; "
+            "printf 'github.com:\\n    user: x-access-token\\n    oauth_token: ' "
+            "> /config/gh/hosts.yml; "
+            "cat >> /config/gh/hosts.yml; "
+            "printf '\\n    git_protocol: https\\n' >> /config/gh/hosts.yml; "
+            "chown -R \"$1:$2\" /config; "
+            "chmod 0700 /config /config/gh; chmod 0600 /config/gh/hosts.yml"
+        )
+        try:
+            await self._backend.run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "-i",
+                    "--network",
+                    "none",
+                    "--mount",
+                    f"type=volume,src={volume},dst=/config",
+                    "--entrypoint",
+                    "/bin/sh",
+                    writer_image_ref,
+                    "-ceu",
+                    script,
+                    "--",
+                    str(runtime_uid),
+                    str(runtime_gid),
+                ],
+                input_bytes=token.encode(),
+                failure_code=(
+                    HarnessPlatformFailure.OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED
+                ),
+            )
+        except BaseException:
+            await self._backend.run(
+                ["docker", "volume", "rm", volume], check=False
+            )
+            raise
+        return attachment
+
+    async def cleanup(self, attachment: dict[str, Any]) -> None:
+        volume = str(attachment.get("sourceRef") or "")
+        owner_digest = str(attachment.get("ownerDigest") or "")
+        if not _SAFE_VOLUME.fullmatch(volume) or not owner_digest:
+            raise HarnessPlatformError(
+                "GitHub credential cleanup authority is unsafe",
+                code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+            )
+        code, observed, error = await self._backend.run(
+            [
+                "docker",
+                "volume",
+                "inspect",
+                "--format",
+                '{{ index .Labels "moonmind.owner_digest" }}',
+                volume,
+            ],
+            check=False,
+        )
+        if code != 0:
+            if "no such" in error.lower():
+                return
+            raise HarnessPlatformError(
+                "GitHub credential cleanup inspection is deferred",
+                code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+            )
+        if observed.strip() != owner_digest:
+            raise HarnessPlatformError(
+                "stale owner cannot clean a newer GitHub credential projection",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        code, _out, _err = await self._backend.run(
+            ["docker", "volume", "rm", volume], check=False
+        )
+        if code != 0:
+            raise HarnessPlatformError(
+                "GitHub credential cleanup is deferred",
+                code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
+            )
+
+
+__all__ = [
+    "OmnigentGithubCredentialService",
+    "github_repository_from_request",
+]

--- a/moonmind/omnigent/host_services/launcher.py
+++ b/moonmind/omnigent/host_services/launcher.py
@@ -26,6 +26,10 @@ class HostLaunchSpec(BaseModel):
         "moonmind.omnigent-host-launch.v1", alias="schemaVersion"
     )
     executionPlanRef: str = Field(alias="executionPlanRef")
+    stepExecutionId: str = Field(
+        alias="stepExecutionId",
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,510}[A-Za-z0-9]$",
+    )
     runtimeBindingId: str = Field(alias="runtimeBindingId")
     hostLeaseRef: str = Field(alias="hostLeaseRef")
     hostLeaseGeneration: int = Field(alias="hostLeaseGeneration", ge=1)
@@ -222,6 +226,7 @@ class DockerOmnigentHostLauncher:
         script, runtime_environment = self._scripts.build_entrypoint(
             credential_handles=credential_handles,
             skill_attachment=spec.skillAttachment,
+            step_execution_id=spec.stepExecutionId,
             tool_attachments=spec.toolAttachments,
             github_credential_attachment=spec.githubCredentialAttachment,
             control_attachment=spec.controlAttachment,

--- a/moonmind/omnigent/host_services/launcher.py
+++ b/moonmind/omnigent/host_services/launcher.py
@@ -45,6 +45,9 @@ class HostLaunchSpec(BaseModel):
     credentialAttachments: tuple[dict[str, Any], ...] = Field(
         default_factory=tuple, alias="credentialAttachments"
     )
+    githubCredentialAttachment: dict[str, Any] | None = Field(
+        None, alias="githubCredentialAttachment"
+    )
     controlAttachment: dict[str, Any] | None = Field(None, alias="controlAttachment")
     stateAttachment: dict[str, Any] = Field(alias="stateAttachment")
     labels: dict[str, str]
@@ -220,6 +223,7 @@ class DockerOmnigentHostLauncher:
             credential_handles=credential_handles,
             skill_attachment=spec.skillAttachment,
             tool_attachments=spec.toolAttachments,
+            github_credential_attachment=spec.githubCredentialAttachment,
             control_attachment=spec.controlAttachment,
         )
         command = [
@@ -284,6 +288,11 @@ class DockerOmnigentHostLauncher:
             spec.skillAttachment,
             *spec.toolAttachments,
             *spec.credentialAttachments,
+            *(
+                [spec.githubCredentialAttachment]
+                if spec.githubCredentialAttachment is not None
+                else []
+            ),
             *([spec.controlAttachment] if spec.controlAttachment is not None else []),
             spec.stateAttachment,
         ]

--- a/moonmind/omnigent/host_services/mounted_tools.py
+++ b/moonmind/omnigent/host_services/mounted_tools.py
@@ -15,6 +15,43 @@ from moonmind.omnigent.harness_platform.failures import (
 from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
 
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
+_DEFAULT_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "services/omnigent/tools/manifest.lock.json"
+)
+
+
+def load_mounted_tool_manifest(
+    manifest_path: str | Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Load the deployment-owned tool names and pinned metadata."""
+
+    path = Path(manifest_path or _DEFAULT_MANIFEST_PATH).resolve()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rows = payload["tools"]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise HarnessPlatformError(
+            "deployment mounted-tool manifest is unavailable",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+        ) from exc
+    if not isinstance(rows, list):
+        raise HarnessPlatformError(
+            "deployment mounted-tool manifest is malformed",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+        )
+    return {
+        str(row.get("name") or "").strip().lower(): dict(row)
+        for row in rows
+        if isinstance(row, dict) and str(row.get("name") or "").strip()
+    }
+
+
+def deployment_mounted_tool_names(
+    manifest_path: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Return the executable capability names available to new plans."""
+
+    return tuple(sorted(load_mounted_tool_manifest(manifest_path)))
 
 
 class OmnigentMountedToolService:
@@ -33,11 +70,7 @@ class OmnigentMountedToolService:
         volume_ref: str | None = None,
     ) -> None:
         self._backend = backend
-        self._manifest_path = Path(
-            manifest_path
-            or Path(__file__).resolve().parents[3]
-            / "services/omnigent/tools/manifest.lock.json"
-        ).resolve()
+        self._manifest_path = Path(manifest_path or _DEFAULT_MANIFEST_PATH).resolve()
         self._volume_ref = str(
             volume_ref
             or os.getenv("MOONMIND_OMNIGENT_TOOLS_VOLUME_REF")
@@ -45,24 +78,7 @@ class OmnigentMountedToolService:
         ).strip()
 
     def _manifest(self) -> dict[str, dict[str, Any]]:
-        try:
-            payload = json.loads(self._manifest_path.read_text(encoding="utf-8"))
-            rows = payload["tools"]
-        except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
-            raise HarnessPlatformError(
-                "deployment mounted-tool manifest is unavailable",
-                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-            ) from exc
-        if not isinstance(rows, list):
-            raise HarnessPlatformError(
-                "deployment mounted-tool manifest is malformed",
-                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-            )
-        return {
-            str(row.get("name") or "").strip(): dict(row)
-            for row in rows
-            if isinstance(row, dict) and str(row.get("name") or "").strip()
-        }
+        return load_mounted_tool_manifest(self._manifest_path)
 
     async def materialize(self, resolved_tools: dict[str, Any]) -> list[dict[str, Any]]:
         delivery_ref = str(resolved_tools.get("toolDeliveryRef") or "").strip()
@@ -125,4 +141,8 @@ class OmnigentMountedToolService:
         ]
 
 
-__all__ = ["OmnigentMountedToolService"]
+__all__ = [
+    "OmnigentMountedToolService",
+    "deployment_mounted_tool_names",
+    "load_mounted_tool_manifest",
+]

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -50,6 +50,7 @@ class OmnigentRuntimeScriptService:
         *,
         credential_handles: list[dict[str, Any]],
         skill_attachment: dict[str, Any],
+        step_execution_id: str,
         tool_attachments: tuple[dict[str, Any], ...] = (),
         github_credential_attachment: dict[str, Any] | None = None,
         control_attachment: dict[str, Any] | None = None,
@@ -66,6 +67,7 @@ class OmnigentRuntimeScriptService:
         environment = {
             "MOONMIND_CREDENTIAL_GENERATION_CHECKS": ",".join(generation_checks),
             "MOONMIND_ACTIVE_SKILLS_DIR": str(skill_attachment["targetPath"]),
+            "MOONMIND_STEP_EXECUTION_ID": step_execution_id,
         }
         tool_bins = [
             str(item["targetPath"]).rstrip("/") + "/bin"
@@ -121,6 +123,7 @@ class OmnigentRuntimeScriptService:
             environment.update(_GITHUB_RUNTIME_ENV)
         passthrough_names = {
             "MOONMIND_ACTIVE_SKILLS_DIR",
+            "MOONMIND_STEP_EXECUTION_ID",
             *(_OPENCODE_RUNTIME_ENV if has_opencode_materializer else {}),
             *(_OPENCODE_PROXY_ENV_NAMES if has_opencode_materializer else {}),
             *(

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+_RUNTIME_BIN_DIR = "/home/app/.omnigent/moonmind/bin"
+_RUNTIME_CONTEXT_DIR = "/home/app/.omnigent/moonmind/runtime-context"
+
 _OPENCODE_RUNTIME_ENV = {
     # MoonMind qualifies the exact pinned image + credential + model before
     # launch. Re-fetching mutable catalog data inside every session duplicates
@@ -36,7 +39,7 @@ _OPENCODE_PROXY_ENV_NAMES = frozenset(
 _GITHUB_RUNTIME_ENV = {
     "GIT_CONFIG_COUNT": "1",
     "GIT_CONFIG_KEY_0": "credential.https://github.com.helper",
-    "GIT_CONFIG_VALUE_0": "!/home/app/.local/bin/gh auth git-credential",
+    "GIT_CONFIG_VALUE_0": f"!{_RUNTIME_BIN_DIR}/gh auth git-credential",
     "GH_CONFIG_DIR": "/home/app/.config/gh",
     "GH_PROMPT_DISABLED": "1",
     "GH_NO_UPDATE_NOTIFIER": "1",
@@ -69,13 +72,20 @@ class OmnigentRuntimeScriptService:
             "MOONMIND_ACTIVE_SKILLS_DIR": str(skill_attachment["targetPath"]),
             "MOONMIND_STEP_EXECUTION_ID": step_execution_id,
         }
+        staging_dir = "/run/mm-credentials/opencode"
+        opencode_data = "/home/app/.local/share/opencode"
+        has_opencode_materializer = any(
+            str(attachment.get("targetPath") or "").rstrip("/") == staging_dir
+            for handle in credential_handles
+            for attachment in handle.get("attachments", [])
+        )
         tool_bins = [
             str(item["targetPath"]).rstrip("/") + "/bin"
             for item in tool_attachments
             if item.get("targetPath")
         ]
-        if github_credential_attachment is not None:
-            tool_bins.insert(0, "/home/app/.local/bin")
+        if has_opencode_materializer or github_credential_attachment is not None:
+            tool_bins.insert(0, _RUNTIME_BIN_DIR)
         # Always include the Omnigent venv so `docker exec` probes (attestation,
         # version checks) resolve the omnigent binary without a full PATH.
         environment["PATH"] = ":".join(
@@ -105,16 +115,9 @@ class OmnigentRuntimeScriptService:
         # Stage harness credentials from read-only volumes into the writable
         # tmpfs home. OpenCode needs to create repos/, cache/ etc. inside its
         # data directory, which a read-only credential mount would block.
-        staging_dir = "/run/mm-credentials/opencode"
-        opencode_data = "/home/app/.local/share/opencode"
-        runtime_context_dir = "/home/app/.moonmind/runtime-context"
-        opencode_context_wrapper = "/home/app/.local/bin/moonmind-opencode-context"
-        opencode_wrapper = "/home/app/.local/bin/opencode"
-        has_opencode_materializer = any(
-            str(attachment.get("targetPath") or "").rstrip("/") == staging_dir
-            for handle in credential_handles
-            for attachment in handle.get("attachments", [])
-        )
+        runtime_context_dir = _RUNTIME_CONTEXT_DIR
+        opencode_context_wrapper = f"{_RUNTIME_BIN_DIR}/moonmind-opencode-context"
+        opencode_wrapper = f"{_RUNTIME_BIN_DIR}/opencode"
         if has_opencode_materializer:
             environment.update(_OPENCODE_RUNTIME_ENV)
         if github_credential_attachment is not None:
@@ -155,7 +158,9 @@ class OmnigentRuntimeScriptService:
             + opencode_data
             + " "
             + runtime_context_dir
-            + " /home/app/.local/bin; "
+            + " "
+            + _RUNTIME_BIN_DIR
+            + "; "
             "cp "
             '"' + staging_dir + '/auth.json" '
             + opencode_data + "/auth.json; "
@@ -182,7 +187,9 @@ class OmnigentRuntimeScriptService:
             "'  export GH_NO_EXTENSION_UPDATE_NOTIFIER=1' "
             "'  export GIT_CONFIG_COUNT=1' "
             "'  export GIT_CONFIG_KEY_0=credential.https://github.com.helper' "
-            "'  export GIT_CONFIG_VALUE_0=\"!/home/app/.local/bin/gh auth git-credential\"' "
+            "'  export GIT_CONFIG_VALUE_0=\"!"
+            + _RUNTIME_BIN_DIR
+            + "/gh auth git-credential\"' "
             "'fi' 'exec \"$@\"' > "
             + opencode_context_wrapper
             + "; "
@@ -203,12 +210,12 @@ class OmnigentRuntimeScriptService:
             "/home/app/.config/gh/hosts.yml; "
             "chmod 0700 /home/app/.config/gh; "
             "chmod 0600 /home/app/.config/gh/hosts.yml; "
-            "mkdir -p /home/app/.local/bin; "
+            "mkdir -p " + _RUNTIME_BIN_DIR + "; "
             "printf '%s\\n' '#!/bin/sh' "
             "'export GH_CONFIG_DIR=/home/app/.config/gh' "
             "'exec /opt/moonmind-tools/bin/gh \"$@\"' "
-            "> /home/app/.local/bin/gh; "
-            "chmod 0700 /home/app/.local/bin/gh; fi; "
+            "> " + _RUNTIME_BIN_DIR + "/gh; "
+            "chmod 0700 " + _RUNTIME_BIN_DIR + "/gh; fi; "
             'if [ -n "${MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE:-}" ]; then '
             'test -r "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"; '
             'OMNIGENT_API_TOKEN=$(cat "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"); '

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -38,10 +38,10 @@ _GITHUB_RUNTIME_ENV = {
     "GIT_CONFIG_COUNT": "1",
     "GIT_CONFIG_KEY_0": "credential.https://github.com.helper",
     "GIT_CONFIG_VALUE_0": "!/opt/moonmind-tools/bin/gh auth git-credential",
+    "GH_CONFIG_DIR": "/home/app/.cache/moonmind-gh",
     "GH_PROMPT_DISABLED": "1",
     "GH_NO_UPDATE_NOTIFIER": "1",
     "GH_NO_EXTENSION_UPDATE_NOTIFIER": "1",
-    "XDG_CONFIG_HOME": "/home/app/.cache/moonmind-xdg",
 }
 
 
@@ -114,7 +114,7 @@ class OmnigentRuntimeScriptService:
         if github_credential_attachment is not None:
             if (
                 str(github_credential_attachment.get("targetPath") or "")
-                != _GITHUB_RUNTIME_ENV["XDG_CONFIG_HOME"]
+                != _GITHUB_RUNTIME_ENV["GH_CONFIG_DIR"]
             ):
                 raise ValueError("GitHub credential attachment target is unsupported")
             environment.update(_GITHUB_RUNTIME_ENV)

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -107,6 +107,9 @@ class OmnigentRuntimeScriptService:
         # data directory, which a read-only credential mount would block.
         staging_dir = "/run/mm-credentials/opencode"
         opencode_data = "/home/app/.local/share/opencode"
+        runtime_context_dir = "/home/app/.moonmind/runtime-context"
+        opencode_context_wrapper = "/home/app/.local/bin/moonmind-opencode-context"
+        opencode_wrapper = "/home/app/.local/bin/opencode"
         has_opencode_materializer = any(
             str(attachment.get("targetPath") or "").rstrip("/") == staging_dir
             for handle in credential_handles
@@ -148,12 +151,52 @@ class OmnigentRuntimeScriptService:
             "if [ -d "
             '"' + staging_dir + '"'
             " ]; then "
-            "mkdir -p " + opencode_data + "; "
+            "mkdir -p "
+            + opencode_data
+            + " "
+            + runtime_context_dir
+            + " /home/app/.local/bin; "
             "cp "
             '"' + staging_dir + '/auth.json" '
             + opencode_data + "/auth.json; "
             "chown 1000:1000 " + opencode_data + "/auth.json; "
-            "chmod 0600 " + opencode_data + "/auth.json; fi; "
+            "chmod 0600 " + opencode_data + "/auth.json; "
+            "printf '%s\\n' \"$MOONMIND_ACTIVE_SKILLS_DIR\" > "
+            + runtime_context_dir
+            + "/active-skills-dir; "
+            "printf '%s\\n' \"$MOONMIND_STEP_EXECUTION_ID\" > "
+            + runtime_context_dir
+            + "/step-execution-id; "
+            "chmod 0600 " + runtime_context_dir + "/*; "
+            "printf '%s\\n' '#!/bin/sh' "
+            "'export MOONMIND_ACTIVE_SKILLS_DIR=$(cat "
+            + runtime_context_dir
+            + "/active-skills-dir)' "
+            "'export MOONMIND_STEP_EXECUTION_ID=$(cat "
+            + runtime_context_dir
+            + "/step-execution-id)' "
+            "'if [ -r /home/app/.config/gh/hosts.yml ]; then' "
+            "'  export GH_CONFIG_DIR=/home/app/.config/gh' "
+            "'  export GH_PROMPT_DISABLED=1' "
+            "'  export GH_NO_UPDATE_NOTIFIER=1' "
+            "'  export GH_NO_EXTENSION_UPDATE_NOTIFIER=1' "
+            "'  export GIT_CONFIG_COUNT=1' "
+            "'  export GIT_CONFIG_KEY_0=credential.https://github.com.helper' "
+            "'  export GIT_CONFIG_VALUE_0=\"!/home/app/.local/bin/gh auth git-credential\"' "
+            "'fi' 'exec \"$@\"' > "
+            + opencode_context_wrapper
+            + "; "
+            "printf '%s\\n' '#!/bin/sh' "
+            "'exec "
+            + opencode_context_wrapper
+            + " /usr/local/bin/opencode \"$@\"' > "
+            + opencode_wrapper
+            + "; "
+            "chmod 0700 "
+            + opencode_context_wrapper
+            + " "
+            + opencode_wrapper
+            + "; fi; "
             "if [ -d /run/mm-credentials/github ]; then "
             "mkdir -p /home/app/.config/gh; "
             "cp /run/mm-credentials/github/hosts.yml "

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -38,7 +38,7 @@ _GITHUB_RUNTIME_ENV = {
     "GIT_CONFIG_COUNT": "1",
     "GIT_CONFIG_KEY_0": "credential.https://github.com.helper",
     "GIT_CONFIG_VALUE_0": "!/opt/moonmind-tools/bin/gh auth git-credential",
-    "GH_CONFIG_DIR": "/home/app/.cache/moonmind-gh",
+    "GH_CONFIG_DIR": "/home/app/.config/gh",
     "GH_PROMPT_DISABLED": "1",
     "GH_NO_UPDATE_NOTIFIER": "1",
     "GH_NO_EXTENSION_UPDATE_NOTIFIER": "1",
@@ -114,7 +114,7 @@ class OmnigentRuntimeScriptService:
         if github_credential_attachment is not None:
             if (
                 str(github_credential_attachment.get("targetPath") or "")
-                != _GITHUB_RUNTIME_ENV["GH_CONFIG_DIR"]
+                != "/run/mm-credentials/github"
             ):
                 raise ValueError("GitHub credential attachment target is unsupported")
             environment.update(_GITHUB_RUNTIME_ENV)
@@ -149,6 +149,12 @@ class OmnigentRuntimeScriptService:
             + opencode_data + "/auth.json; "
             "chown 1000:1000 " + opencode_data + "/auth.json; "
             "chmod 0600 " + opencode_data + "/auth.json; fi; "
+            "if [ -d /run/mm-credentials/github ]; then "
+            "mkdir -p /home/app/.config/gh; "
+            "cp /run/mm-credentials/github/hosts.yml "
+            "/home/app/.config/gh/hosts.yml; "
+            "chmod 0700 /home/app/.config/gh; "
+            "chmod 0600 /home/app/.config/gh/hosts.yml; fi; "
             'if [ -n "${MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE:-}" ]; then '
             'test -r "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"; '
             'OMNIGENT_API_TOKEN=$(cat "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"); '

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from typing import Any
 
 
+_OPENCODE_RUNTIME_ENV = {
+    # MoonMind qualifies the exact pinned image + credential + model before
+    # launch. Re-fetching mutable catalog data inside every session duplicates
+    # that authority and can block ``opencode serve`` before its loopback API is
+    # ready. The compiled catalog remains available to the pinned binary.
+    "OPENCODE_DISABLE_MODELS_FETCH": "1",
+    # Omnigent supplies its policy bridge as an explicit configured plugin.
+    # OpenCode's unrelated built-in auth plugins are not part of this host
+    # class and add another unbounded initialization surface.
+    "OPENCODE_DISABLE_DEFAULT_PLUGINS": "1",
+    # The host image is digest-pinned; an in-session updater must not mutate or
+    # delay that runtime after its deployment qualification has passed.
+    "OPENCODE_DISABLE_AUTOUPDATE": "1",
+}
+
+
 class OmnigentRuntimeScriptService:
     def build_entrypoint(
         self,
@@ -63,6 +79,16 @@ class OmnigentRuntimeScriptService:
         # data directory, which a read-only credential mount would block.
         staging_dir = "/run/mm-credentials/opencode"
         opencode_data = "/home/app/.local/share/opencode"
+        has_opencode_materializer = any(
+            str(attachment.get("targetPath") or "").rstrip("/") == staging_dir
+            for handle in credential_handles
+            for attachment in handle.get("attachments", [])
+        )
+        if has_opencode_materializer:
+            environment.update(_OPENCODE_RUNTIME_ENV)
+            environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(
+                sorted(_OPENCODE_RUNTIME_ENV)
+            )
         script = (
             "set -eu; "
             "unset OPENAI_API_KEY ANTHROPIC_API_KEY OPENCODE_AUTH_CONTENT "

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 _OPENCODE_RUNTIME_ENV = {
     # MoonMind qualifies the exact pinned image + credential + model before
     # launch. Re-fetching mutable catalog data inside every session duplicates
@@ -37,7 +36,7 @@ _OPENCODE_PROXY_ENV_NAMES = frozenset(
 _GITHUB_RUNTIME_ENV = {
     "GIT_CONFIG_COUNT": "1",
     "GIT_CONFIG_KEY_0": "credential.https://github.com.helper",
-    "GIT_CONFIG_VALUE_0": "!/opt/moonmind-tools/bin/gh auth git-credential",
+    "GIT_CONFIG_VALUE_0": "!/home/app/.local/bin/gh auth git-credential",
     "GH_CONFIG_DIR": "/home/app/.config/gh",
     "GH_PROMPT_DISABLED": "1",
     "GH_NO_UPDATE_NOTIFIER": "1",
@@ -73,6 +72,8 @@ class OmnigentRuntimeScriptService:
             for item in tool_attachments
             if item.get("targetPath")
         ]
+        if github_credential_attachment is not None:
+            tool_bins.insert(0, "/home/app/.local/bin")
         # Always include the Omnigent venv so `docker exec` probes (attestation,
         # version checks) resolve the omnigent binary without a full PATH.
         environment["PATH"] = ":".join(
@@ -119,6 +120,7 @@ class OmnigentRuntimeScriptService:
                 raise ValueError("GitHub credential attachment target is unsupported")
             environment.update(_GITHUB_RUNTIME_ENV)
         passthrough_names = {
+            "MOONMIND_ACTIVE_SKILLS_DIR",
             *(_OPENCODE_RUNTIME_ENV if has_opencode_materializer else {}),
             *(_OPENCODE_PROXY_ENV_NAMES if has_opencode_materializer else {}),
             *(
@@ -154,7 +156,13 @@ class OmnigentRuntimeScriptService:
             "cp /run/mm-credentials/github/hosts.yml "
             "/home/app/.config/gh/hosts.yml; "
             "chmod 0700 /home/app/.config/gh; "
-            "chmod 0600 /home/app/.config/gh/hosts.yml; fi; "
+            "chmod 0600 /home/app/.config/gh/hosts.yml; "
+            "mkdir -p /home/app/.local/bin; "
+            "printf '%s\\n' '#!/bin/sh' "
+            "'export GH_CONFIG_DIR=/home/app/.config/gh' "
+            "'exec /opt/moonmind-tools/bin/gh \"$@\"' "
+            "> /home/app/.local/bin/gh; "
+            "chmod 0700 /home/app/.local/bin/gh; fi; "
             'if [ -n "${MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE:-}" ]; then '
             'test -r "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"; '
             'OMNIGENT_API_TOKEN=$(cat "$MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"); '

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -20,6 +20,21 @@ _OPENCODE_RUNTIME_ENV = {
     "OPENCODE_DISABLE_AUTOUPDATE": "1",
 }
 
+# The on-demand host receives these values from the sandbox egress boundary.
+# Omnigent deliberately filters the host environment before spawning a runner,
+# so their *names* must survive the host -> runner hop. The OpenCode server then
+# inherits the values through its own restricted environment builder.
+_OPENCODE_PROXY_ENV_NAMES = frozenset(
+    {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+
 
 class OmnigentRuntimeScriptService:
     def build_entrypoint(
@@ -87,7 +102,7 @@ class OmnigentRuntimeScriptService:
         if has_opencode_materializer:
             environment.update(_OPENCODE_RUNTIME_ENV)
             environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(
-                sorted(_OPENCODE_RUNTIME_ENV)
+                sorted({*_OPENCODE_RUNTIME_ENV, *_OPENCODE_PROXY_ENV_NAMES})
             )
         script = (
             "set -eu; "

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -34,6 +34,15 @@ _OPENCODE_PROXY_ENV_NAMES = frozenset(
         "no_proxy",
     }
 )
+_GITHUB_RUNTIME_ENV = {
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "credential.https://github.com.helper",
+    "GIT_CONFIG_VALUE_0": "!/opt/moonmind-tools/bin/gh auth git-credential",
+    "GH_PROMPT_DISABLED": "1",
+    "GH_NO_UPDATE_NOTIFIER": "1",
+    "GH_NO_EXTENSION_UPDATE_NOTIFIER": "1",
+    "XDG_CONFIG_HOME": "/home/app/.cache/moonmind-xdg",
+}
 
 
 class OmnigentRuntimeScriptService:
@@ -43,6 +52,7 @@ class OmnigentRuntimeScriptService:
         credential_handles: list[dict[str, Any]],
         skill_attachment: dict[str, Any],
         tool_attachments: tuple[dict[str, Any], ...] = (),
+        github_credential_attachment: dict[str, Any] | None = None,
         control_attachment: dict[str, Any] | None = None,
     ) -> tuple[str, dict[str, str]]:
         generation_checks: list[str] = []
@@ -101,8 +111,25 @@ class OmnigentRuntimeScriptService:
         )
         if has_opencode_materializer:
             environment.update(_OPENCODE_RUNTIME_ENV)
+        if github_credential_attachment is not None:
+            if (
+                str(github_credential_attachment.get("targetPath") or "")
+                != _GITHUB_RUNTIME_ENV["XDG_CONFIG_HOME"]
+            ):
+                raise ValueError("GitHub credential attachment target is unsupported")
+            environment.update(_GITHUB_RUNTIME_ENV)
+        passthrough_names = {
+            *(_OPENCODE_RUNTIME_ENV if has_opencode_materializer else {}),
+            *(_OPENCODE_PROXY_ENV_NAMES if has_opencode_materializer else {}),
+            *(
+                _GITHUB_RUNTIME_ENV
+                if github_credential_attachment is not None
+                else {}
+            ),
+        }
+        if passthrough_names:
             environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(
-                sorted({*_OPENCODE_RUNTIME_ENV, *_OPENCODE_PROXY_ENV_NAMES})
+                sorted(passthrough_names)
             )
         script = (
             "set -eu; "

--- a/moonmind/omnigent/host_services/skills.py
+++ b/moonmind/omnigent/host_services/skills.py
@@ -17,6 +17,7 @@ from moonmind.omnigent.host_services.workspace import (
     DaemonCommandRunner,
     resolve_daemon_workspace_root,
 )
+from moonmind.omnigent.settings import OMNIGENT_RUNTIME_ACTIVE_SKILLS_DIR
 from moonmind.workflows.skills.run_projection import (
     load_resolved_skillset,
     materialize_run_skill_snapshot,
@@ -90,7 +91,7 @@ class OmnigentSkillDeliveryService:
         attachment = {
             "kind": "bind",
             "sourceRef": str(daemon_visible),
-            "targetPath": "/opt/moonmind/skills_active",
+            "targetPath": OMNIGENT_RUNTIME_ACTIVE_SKILLS_DIR,
             "accessMode": "read-only",
             "deliveryRef": resolved_skills["skillDeliveryRef"],
             "digest": expected_digest,

--- a/moonmind/omnigent/host_services/workspace.py
+++ b/moonmind/omnigent/host_services/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from pathlib import Path
@@ -12,8 +13,12 @@ from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformFailure,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
 from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
     daemon_visible_workspace_path,
+    resolve_sandbox_workspace_locator,
 )
 
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
@@ -106,23 +111,53 @@ class OmnigentWorkspaceMaterializer:
             candidate = Path(authored).resolve()
             preexisting_authority = True
         elif isinstance(locator, dict):
-            workspace_id = str(locator.get("workspaceId") or "").strip()
-            relative = str(
-                locator.get("relativePath")
-                or ("repo" if workspace_id else "")
-            ).strip()
-            if not relative:
+            try:
+                sandbox_locator = SandboxWorkspaceLocator.model_validate(locator)
+            except ValueError as exc:
                 raise HarnessPlatformError(
-                    "sandbox workspace locator has no durable relative path",
+                    "sandbox workspace locator is invalid",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+                ) from exc
+            step_execution = getattr(request, "step_execution", None)
+            owner_workflow_id = str(
+                getattr(step_execution, "workflow_id", None)
+                or getattr(request, "correlation_id", "")
+            ).strip()
+            owner_step_execution_id = str(
+                getattr(step_execution, "step_execution_id", None)
+                or getattr(request, "idempotency_key", "")
+            ).strip()
+            if not owner_workflow_id or not owner_step_execution_id:
+                raise HarnessPlatformError(
+                    "sandbox workspace owner identity is unavailable",
                     code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
                 )
-            # Sandbox workspaces are scoped by their durable workspace id so
-            # concurrent runs never share one checkout directory.
-            candidate = (
-                (self._root / workspace_id / relative)
-                if workspace_id
-                else (self._root / relative)
-            ).resolve()
+            expected_workspace_id = hashlib.sha256(
+                f"{owner_workflow_id}:{owner_step_execution_id}".encode("utf-8")
+            ).hexdigest()[:24]
+            candidate = resolve_sandbox_workspace_locator(
+                sandbox_locator,
+                workspace_root=self._root,
+                expected_workspace_id=expected_workspace_id,
+                must_exist=False,
+            )
+            owner_record = SandboxWorkspaceRecord(
+                workspace_id=sandbox_locator.workspace_id,
+                workflow_id=owner_workflow_id,
+                step_execution_id=owner_step_execution_id,
+                relative_path=sandbox_locator.relative_path,
+            )
+            record_store = SandboxWorkspaceRecordStore(self._root)
+            record_store.ensure(owner_record)
+            resolve_sandbox_workspace_locator(
+                sandbox_locator,
+                workspace_root=self._root,
+                expected_workspace_id=expected_workspace_id,
+                owner_record=owner_record,
+                expected_workflow_id=owner_workflow_id,
+                expected_step_execution_id=owner_step_execution_id,
+                must_exist=False,
+            )
             # Sandbox workspaces are runtime-owned: when the authoritative
             # checkout does not exist yet, this lifecycle materializes it by
             # cloning the requested repository branch with launch-time auth.

--- a/moonmind/omnigent/host_services/workspace.py
+++ b/moonmind/omnigent/host_services/workspace.py
@@ -96,6 +96,8 @@ class OmnigentWorkspaceMaterializer:
         request: AgentExecutionRequest,
         *,
         mutation: str = "allowed",
+        runtime_uid: int = 1000,
+        runtime_gid: int = 1000,
     ) -> dict[str, Any]:
         if mutation not in {"allowed", "read_only", "checkpoint_branch"}:
             raise HarnessPlatformError(
@@ -178,7 +180,12 @@ class OmnigentWorkspaceMaterializer:
                     "authoritative workspace path does not exist",
                     code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
                 )
-            await self._prepare_sandbox_workspace(candidate, spec=spec)
+            await self._prepare_sandbox_workspace(
+                candidate,
+                spec=spec,
+                runtime_uid=runtime_uid,
+                runtime_gid=runtime_gid,
+            )
         if not candidate.is_dir() or candidate.is_symlink():
             raise HarnessPlatformError(
                 "authoritative workspace is unavailable or unsafe",
@@ -206,7 +213,12 @@ class OmnigentWorkspaceMaterializer:
         }
 
     async def _prepare_sandbox_workspace(
-        self, candidate: Path, *, spec: dict[str, Any]
+        self,
+        candidate: Path,
+        *,
+        spec: dict[str, Any],
+        runtime_uid: int,
+        runtime_gid: int,
     ) -> None:
         """Clone the requested repository branch into a fresh sandbox dir.
 
@@ -243,10 +255,22 @@ class OmnigentWorkspaceMaterializer:
             )
         rel = candidate.relative_to(self._root)
         await self._clone_into_volume(
-            rel=rel, source=clone_source, branch=branch
+            rel=rel,
+            source=clone_source,
+            branch=branch,
+            runtime_uid=runtime_uid,
+            runtime_gid=runtime_gid,
         )
 
-    async def _clone_into_volume(self, *, rel: Path, source: str, branch: str) -> None:
+    async def _clone_into_volume(
+        self,
+        *,
+        rel: Path,
+        source: str,
+        branch: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> None:
         """Clone into the agent-workspaces volume through the Docker daemon.
 
         The worker image deliberately ships without a host ``git``; the same
@@ -254,9 +278,6 @@ class OmnigentWorkspaceMaterializer:
         performs the authenticated clone inside a disposable container.
         """
 
-        from moonmind.workflows.temporal.runtime.git_auth import (
-            build_github_token_git_environment,
-        )
         from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
             resolve_github_token_for_launch,
         )
@@ -274,18 +295,34 @@ class OmnigentWorkspaceMaterializer:
         authed_source = source.replace(
             "https://", f"https://x-access-token:{token}@", 1
         )
+        image = os.getenv("MOONMIND_WORKSPACE_GIT_IMAGE", "alpine/git:v2.43.0")
         argv = build_daemon_git_clone_argv(
             volume=self._workspace_volume,
             target_in_volume=rel.as_posix(),
             source=authed_source,
             branch=branch,
-            image=os.getenv("MOONMIND_WORKSPACE_GIT_IMAGE", "alpine/git:v2.43.0"),
+            image=image,
         )
         code, _stdout, stderr = await self._runner(argv)
         if code != 0:
             detail = (stderr or "").strip()[-300:]
             raise HarnessPlatformError(
                 "sandbox workspace clone failed for the requested branch"
+                + (f": {detail}" if detail else ""),
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        ownership_argv = build_daemon_workspace_chown_argv(
+            volume=self._workspace_volume,
+            target_in_volume=rel.as_posix(),
+            runtime_uid=runtime_uid,
+            runtime_gid=runtime_gid,
+            image=image,
+        )
+        code, _stdout, stderr = await self._runner(ownership_argv)
+        if code != 0:
+            detail = (stderr or "").strip()[-300:]
+            raise HarnessPlatformError(
+                "sandbox workspace ownership handoff failed"
                 + (f": {detail}" if detail else ""),
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
@@ -311,6 +348,49 @@ def build_daemon_git_clone_argv(
     return argv
 
 
+def build_daemon_workspace_chown_argv(
+    *,
+    volume: str,
+    target_in_volume: str,
+    runtime_uid: int,
+    runtime_gid: int,
+    image: str,
+) -> list[str]:
+    """Build the bounded ownership handoff for a daemon-created checkout."""
+
+    if not _SAFE_VOLUME.fullmatch(volume):
+        raise HarnessPlatformError(
+            "agent workspace volume name is unavailable or unsafe",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+        )
+    target = Path(target_in_volume)
+    if (
+        target.is_absolute()
+        or not target.parts
+        or ".." in target.parts
+        or runtime_uid <= 0
+        or runtime_gid <= 0
+    ):
+        raise HarnessPlatformError(
+            "sandbox workspace ownership target is unavailable or unsafe",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+        )
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{volume}:/work",
+        "--entrypoint",
+        "/bin/chown",
+        image,
+        "-R",
+        "--",
+        f"{runtime_uid}:{runtime_gid}",
+        "/work/" + target.as_posix(),
+    ]
+
+
 def _rmdir_if_empty(path: Path) -> None:
     try:
         if path.is_dir() and not any(path.iterdir()):
@@ -325,6 +405,7 @@ def _rmdir_if_empty(path: Path) -> None:
 __all__ = [
     "OmnigentWorkspaceMaterializer",
     "build_daemon_git_clone_argv",
+    "build_daemon_workspace_chown_argv",
     "normalize_github_clone_source",
     "resolve_daemon_workspace_root",
 ]

--- a/moonmind/omnigent/opencode_runtime_validation.py
+++ b/moonmind/omnigent/opencode_runtime_validation.py
@@ -44,6 +44,24 @@ def _models(value: Any) -> set[str]:
     return found
 
 
+def _validated_models(value: Any) -> list[str]:
+    """Return observed OpenCode Go models or reject the validation result.
+
+    A successful CLI exit with no provider models is not evidence that a
+    configured fallback model exists.  Persisting such a fallback lets
+    planning admit a model that the exact host later rejects, so the runtime
+    validation boundary must fail closed here.
+    """
+
+    models = sorted(_models(value))
+    if not models:
+        raise HarnessPlatformError(
+            "pinned OpenCode runtime returned no OpenCode Go models",
+            code=HarnessPlatformFailure.OMNIGENT_PROVIDER_PROFILE_INCOMPATIBLE,
+        )
+    return models
+
+
 class OpenCodeProviderRuntimeValidationService:
     def __init__(
         self,
@@ -114,8 +132,7 @@ class OpenCodeProviderRuntimeValidationService:
                 "executionProfileRef": profile.profile_id,
                 "correlationId": f"opencode-validation-{profile.profile_id}",
                 "idempotencyKey": (
-                    f"opencode-validation-{profile.profile_id}-"
-                    f"{generation}"
+                    f"opencode-validation-{profile.profile_id}-" f"{generation}"
                 ),
             }
         )
@@ -157,7 +174,9 @@ class OpenCodeProviderRuntimeValidationService:
                 ),
             ]
             code, stdout, _stderr = await self._backend.run(argv, timeout_seconds=120)
-            if code != 0 and "Unable to find image" in _stderr.decode("utf-8", errors="replace"):
+            if code != 0 and "Unable to find image" in _stderr.decode(
+                "utf-8", errors="replace"
+            ):
                 # Fail closed: never substitute a mutable tag for a digest-pinned image.
                 raise HarnessPlatformError(
                     f"pinned OpenCode image {self._image_ref} not found: {_stderr.decode('utf-8', errors='replace')[:500]}",
@@ -173,24 +192,7 @@ class OpenCodeProviderRuntimeValidationService:
                 parsed: Any = json.loads(text)
             except json.JSONDecodeError:
                 parsed = text
-            models = sorted(_models(parsed))
-            if not models:
-                # Fallback for local dev: when opencode-go provider is not listing models (e.g., region-limited or API key not yet validated via network),
-                # still consider the pinned model as available if the raw output is not an explicit auth error.
-                # Check if output contains any model-like string or is empty due to network
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(
-                    f"opencode models returned no opencode-go models, using fallback for {profile.provider_id} with key generation {generation}, raw output preview: {text[:1000]!r}"
-                )
-                # Use the expected qualified model as fallback
-                # Try to get from profile's default model or use the standard muse spark
-                fallback_qualified = getattr(profile, "default_model", None) or "opencode-go/muse-spark-1.2-contributor"
-                if fallback_qualified and fallback_qualified.startswith("opencode-go/"):
-                    models = [fallback_qualified]
-                else:
-                    models = ["opencode-go/muse-spark-1.2-contributor"]
+            models = _validated_models(parsed)
             versions: dict[str, str] = {}
             for binary in ("opencode", "omnigent"):
                 version_code, version_out, _version_err = await self._backend.run(
@@ -206,7 +208,9 @@ class OpenCodeProviderRuntimeValidationService:
                         "--version",
                     ]
                 )
-                if version_code != 0 and "Unable to find image" in _version_err.decode("utf-8", errors="replace"):
+                if version_code != 0 and "Unable to find image" in _version_err.decode(
+                    "utf-8", errors="replace"
+                ):
                     # Fail closed: never substitute a mutable tag for version check.
                     raise HarnessPlatformError(
                         f"pinned image {self._image_ref} not found for {binary} version check: {_version_err.decode('utf-8', errors='replace')[:500]}",
@@ -239,7 +243,12 @@ class OpenCodeProviderRuntimeValidationService:
                 except HarnessPlatformError as _cleanup_exc:
                     # Preserve generation fences: do not force-remove volumes that may belong to another operation
                     msg = str(_cleanup_exc).lower()
-                    if "generation" in msg or "fenced" in msg or "deferred" in msg or "cleanup" in msg:
+                    if (
+                        "generation" in msg
+                        or "fenced" in msg
+                        or "deferred" in msg
+                        or "cleanup" in msg
+                    ):
                         import logging
 
                         logging.getLogger(__name__).warning(
@@ -250,4 +259,4 @@ class OpenCodeProviderRuntimeValidationService:
                         raise
 
 
-__all__ = ["OpenCodeProviderRuntimeValidationService"]
+__all__ = ["OpenCodeProviderRuntimeValidationService", "_validated_models"]

--- a/moonmind/omnigent/opencode_runtime_validation.py
+++ b/moonmind/omnigent/opencode_runtime_validation.py
@@ -25,7 +25,10 @@ from moonmind.omnigent.secret_resolution import (
     ScopedSecretBundle,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
-from moonmind.security.egress import OMNIGENT_EGRESS_NETWORK_REF
+from moonmind.security.egress import (
+    OMNIGENT_EGRESS_NETWORK_REF,
+    omnigent_proxy_env,
+)
 
 
 def _models(value: Any) -> set[str]:
@@ -60,6 +63,60 @@ def _validated_models(value: Any) -> list[str]:
             code=HarnessPlatformFailure.OMNIGENT_PROVIDER_PROFILE_INCOMPATIBLE,
         )
     return models
+
+
+def _model_probe_argv(
+    *, image_ref: str, credential_source: str, credential_target: str
+) -> list[str]:
+    """Build the exact pinned-runtime catalog probe command.
+
+    The credential materializer deliberately mounts a read-only staging
+    directory. OpenCode reads ``auth.json`` from its writable data directory,
+    so validation must perform the same staging step as the real host before
+    invoking catalog discovery.
+    """
+
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        OMNIGENT_EGRESS_NETWORK_REF,
+        "--read-only",
+        "--user",
+        "1000:1000",
+        "--tmpfs",
+        "/home/app:rw,uid=1000,gid=1000,mode=0700",
+        "--tmpfs",
+        "/tmp:rw,uid=1000,gid=1000,mode=1777",
+        "--mount",
+        (f"type=volume,src={credential_source}," f"dst={credential_target},readonly"),
+        "--env",
+        "HOME=/home/app",
+    ]
+    for item in omnigent_proxy_env():
+        argv.extend(("--env", item))
+    stage_and_probe = (
+        "set -eu; "
+        "unset OPENAI_API_KEY ANTHROPIC_API_KEY OPENCODE_AUTH_CONTENT "
+        "OPENCODE_CONFIG OPENCODE_CONFIG_CONTENT; "
+        "mkdir -p /home/app/.local/share/opencode; "
+        'cp "$1/auth.json" /home/app/.local/share/opencode/auth.json; '
+        "chmod 0600 /home/app/.local/share/opencode/auth.json; "
+        "exec opencode models --refresh"
+    )
+    argv.extend(
+        (
+            "--entrypoint",
+            "/bin/sh",
+            image_ref,
+            "-ceu",
+            stage_and_probe,
+            "--",
+            credential_target,
+        )
+    )
+    return argv
 
 
 class OpenCodeProviderRuntimeValidationService:
@@ -149,30 +206,11 @@ class OpenCodeProviderRuntimeValidationService:
                 )
             )
             attachment = handle.attachments[0]
-            argv = [
-                "docker",
-                "run",
-                "--rm",
-                "--network",
-                OMNIGENT_EGRESS_NETWORK_REF,
-                "--read-only",
-                "--user",
-                "1000:1000",
-                "--mount",
-                (
-                    f"type=volume,src={attachment.sourceRef},"
-                    f"dst={attachment.targetPath},readonly"
-                ),
-                "--entrypoint",
-                "/bin/sh",
-                self._image_ref,
-                "-ceu",
-                (
-                    "unset OPENAI_API_KEY ANTHROPIC_API_KEY OPENCODE_AUTH_CONTENT "
-                    "OPENCODE_CONFIG OPENCODE_CONFIG_CONTENT; "
-                    "opencode models 2>&1 | head -n 500"
-                ),
-            ]
+            argv = _model_probe_argv(
+                image_ref=self._image_ref,
+                credential_source=attachment.sourceRef,
+                credential_target=attachment.targetPath,
+            )
             code, stdout, _stderr = await self._backend.run(argv, timeout_seconds=120)
             if code != 0 and "Unable to find image" in _stderr.decode(
                 "utf-8", errors="replace"
@@ -259,4 +297,8 @@ class OpenCodeProviderRuntimeValidationService:
                         raise
 
 
-__all__ = ["OpenCodeProviderRuntimeValidationService", "_validated_models"]
+__all__ = [
+    "OpenCodeProviderRuntimeValidationService",
+    "_model_probe_argv",
+    "_validated_models",
+]

--- a/moonmind/omnigent/production.py
+++ b/moonmind/omnigent/production.py
@@ -49,6 +49,7 @@ from moonmind.omnigent.host_services import (
     DockerOmnigentHostCleanupService,
     DockerOmnigentHostLauncher,
     OmnigentEgressService,
+    OmnigentGithubCredentialService,
     OmnigentHostRegistrationService,
     OmnigentMountedToolService,
     OmnigentRuntimeScriptService,
@@ -240,6 +241,7 @@ def build_generic_omnigent_execution_services(
             artifact_gateway=artifacts,
         ),
         tool_service=OmnigentMountedToolService(backend=docker),
+        github_credential_service=OmnigentGithubCredentialService(docker),
         egress_service=OmnigentEgressService(backend=docker, artifacts=artifacts),
         registration_waiter=OmnigentHostRegistrationService(
             client=client, expected_owner=expected_owner

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -353,6 +353,7 @@ class GenericOmnigentHostRealizer:
             prepared = await self._host_runtime.prepare(
                 request=request,
                 plan=plan,
+                host_class=host_class,
                 launch_policy=launch_policy,
                 authority_sink=record_prepared,
             )

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -24,7 +24,7 @@ CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
 # Digest of the reviewed, mounted Squid policy. Attestation compares this
 # deployment-owned value with both the container label and the live file.
-EGRESS_CONFIG_DIGEST = "sha256:53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06"
+EGRESS_CONFIG_DIGEST = "sha256:f79931d832bcc9901928ce17931720b6a42fba7bb09b531c211bff9325b12dfa"
 # Deployment-owned network names. Compose resolves these same overrides when it
 # creates the networks (``restricted-egress-network`` /
 # ``sandbox-egress-network``), so an operator that sets the documented override
@@ -326,7 +326,7 @@ DEFAULT_EGRESS_PROFILE = EgressProfile.model_validate(
                 "githubusercontent.com",
                 "google.com",
                 "googleapis.com",
-                "models.opencode.ai",
+                "opencode.ai",
                 "registry.npmjs.org",
                 "openai.com",
             )

--- a/moonmind/security/egress.py
+++ b/moonmind/security/egress.py
@@ -24,7 +24,7 @@ CommandRunner = Callable[[Sequence[str]], Awaitable[tuple[int, bytes, bytes]]]
 ENFORCER_IMPLEMENTATION = "docker-internal-proxy/v1"
 # Digest of the reviewed, mounted Squid policy. Attestation compares this
 # deployment-owned value with both the container label and the live file.
-EGRESS_CONFIG_DIGEST = "sha256:a64c798e3fed5252e86811d344ad8f509332e81b06ee75ddc6ad2f2198fc3713"
+EGRESS_CONFIG_DIGEST = "sha256:53338efd0904cd7305752061a616202d51901c8b0e3c0262379299f4e86a7b06"
 # Deployment-owned network names. Compose resolves these same overrides when it
 # creates the networks (``restricted-egress-network`` /
 # ``sandbox-egress-network``), so an operator that sets the documented override
@@ -326,6 +326,8 @@ DEFAULT_EGRESS_PROFILE = EgressProfile.model_validate(
                 "githubusercontent.com",
                 "google.com",
                 "googleapis.com",
+                "models.opencode.ai",
+                "registry.npmjs.org",
                 "openai.com",
             )
         ],

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2809,8 +2809,21 @@ class TemporalSandboxActivities:
                 return True
         return False
 
+    @staticmethod
+    def _workspace_archive_excludes(relative: Path) -> bool:
+        return any(part in {".git", "__pycache__"} for part in relative.parts) or (
+            relative.parts[:2]
+            in {
+                (".agents", "skills"),
+                (".gemini", "skills"),
+            }
+        )
+
     def _workspace_has_traversal(self, workspace: Path) -> bool:
         for path in workspace.rglob("*"):
+            relative = path.relative_to(workspace)
+            if self._workspace_archive_excludes(relative):
+                continue
             try:
                 if path.is_symlink():
                     target = path.resolve()
@@ -3092,12 +3105,7 @@ class TemporalSandboxActivities:
         with tarfile.open(fileobj=output, mode="w:gz") as archive:
             for path in sorted(workspace.rglob("*")):
                 relative = path.relative_to(workspace)
-                if any(part in {".git", "__pycache__"} for part in relative.parts):
-                    continue
-                if relative.parts[:2] in {
-                    (".agents", "skills"),
-                    (".gemini", "skills"),
-                }:
+                if self._workspace_archive_excludes(relative):
                     continue
                 if path.is_dir():
                     continue

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2797,6 +2797,10 @@ class TemporalSandboxActivities:
         return [context_ref] if context_ref else []
 
     def _workspace_has_unsafe_skill_projection(self, workspace: Path) -> bool:
+        try:
+            workspace_uid = workspace.lstat().st_uid
+        except OSError:
+            return True
         for relative in (".agents/skills", ".gemini/skills"):
             candidate = workspace / relative
             if not candidate.exists():
@@ -2805,7 +2809,10 @@ class TemporalSandboxActivities:
                 info = candidate.lstat()
             except OSError:
                 continue
-            if info.st_uid == 0 or candidate.is_symlink():
+            # A projection owned by a different principal than the authoritative
+            # workspace is unsafe. UID 0 alone is not evidence of a mismatch:
+            # hermetic CI legitimately creates the whole workspace as root.
+            if info.st_uid != workspace_uid or candidate.is_symlink():
                 return True
         return False
 

--- a/services/omnigent/agents/opencode-native-ui/config.yaml
+++ b/services/omnigent/agents/opencode-native-ui/config.yaml
@@ -1,0 +1,21 @@
+spec_version: 1
+name: opencode-native-ui
+description: OpenCode coding agent exposed through the Omnigent native host.
+
+executor:
+  type: omnigent
+  config:
+    harness: opencode-native
+
+prompt: |
+  You are an OpenCode coding agent. Follow the supplied task, the repository's
+  checked-in agent instructions, and the authority boundaries of the runtime.
+  Work only in the supplied workspace, verify the result with the relevant
+  tests, and report concrete terminal evidence.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -544,7 +544,7 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         "." + "".join(parts)
         for parts in [
             ("github", ".com"),
-            ("models", ".opencode", ".ai"),
+            ("opencode", ".ai"),
             ("openai", ".com"),
             ("registry", ".npmjs", ".org"),
         ]

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -1119,6 +1119,17 @@ def test_omnigent_shared_postgres_compose_topology_for_mm_970():
     assert "omnigent-data:/data" in omnigent_service["volumes"]
     assert "omnigent-data" in compose["volumes"]
 
+    agent_init = services["omnigent-agent-init"]
+    assert agent_init["restart"] == "no"
+    assert agent_init["depends_on"]["omnigent-db-init"]["condition"] == (
+        "service_completed_successfully"
+    )
+    assert "omnigent-data:/data" in agent_init["volumes"]
+    assert (
+        omnigent_service["depends_on"]["omnigent-agent-init"]["condition"]
+        == "service_completed_successfully"
+    )
+
     omnigent_env = _env_map(omnigent_service["environment"])
     assert omnigent_service["image"] == (
         "${OMNIGENT_IMAGE_REF:-${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:"

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -544,7 +544,9 @@ def test_sandbox_worker_compose_egress_is_restricted_for_mm_785():
         "." + "".join(parts)
         for parts in [
             ("github", ".com"),
+            ("models", ".opencode", ".ai"),
             ("openai", ".com"),
+            ("registry", ".npmjs", ".org"),
         ]
     }
     assert "http_access deny all" in squid_config

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -306,6 +306,55 @@ async def test_checkpoint_capture_preserves_internal_symlinks(tmp_path: Path) ->
     assert link_info.linkname == "target.txt"
 
 
+async def test_checkpoint_capture_ignores_traversal_in_excluded_skill_projection(
+    tmp_path: Path,
+) -> None:
+    store = InMemoryArtifactStore()
+    root = _workspace_root(tmp_path)
+    repo = _repo(root)
+    external_snapshot = tmp_path / "resolved-skill-snapshot"
+    external_snapshot.mkdir()
+    (external_snapshot / "SKILL.md").write_text("resolved\n", encoding="utf-8")
+    skill_projection = repo / ".agents" / "skills"
+    skill_projection.mkdir(parents=True)
+    (skill_projection / "_shared").symlink_to(
+        external_snapshot,
+        target_is_directory=True,
+    )
+    sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
+
+    capture = await sandbox.workspace_capture_checkpoint(
+        {
+            "identity": _identity().model_dump(by_alias=True),
+            "boundary": "after_execution",
+            "kind": "worktree_archive",
+            "workspacePath": str(repo),
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "idem-excluded-skill-projection",
+        }
+    )
+
+    assert capture["status"] == "captured"
+    archive_bytes = store.get_bytes(capture["workspace"]["archiveRef"])
+    with tarfile.open(fileobj=BytesIO(archive_bytes), mode="r:gz") as archive:
+        assert not any(name.startswith(".agents/skills") for name in archive.getnames())
+
+    (repo / "unsafe-link").symlink_to(external_snapshot, target_is_directory=True)
+    unsafe = await sandbox.workspace_capture_checkpoint(
+        {
+            "identity": _identity().model_dump(by_alias=True),
+            "boundary": "after_execution",
+            "kind": "worktree_archive",
+            "workspacePath": str(repo),
+            "artifactNamespace": "checkpoint",
+            "idempotencyKey": "idem-included-external-link",
+        }
+    )
+
+    assert unsafe["status"] == "unsafe"
+    assert unsafe["failureCode"] == "unsafe_checkpoint"
+
+
 async def test_git_patch_checkpoint_rejects_unsupported_file_options(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -282,7 +282,7 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         for parts in [
             ("github", ".com"),
             ("anthropic", ".com"),
-            ("models", ".opencode", ".ai"),
+            ("opencode", ".ai"),
             ("registry", ".npmjs", ".org"),
         ]
     }

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -282,6 +282,8 @@ def test_sandbox_worker_uses_internal_egress_network_for_mm_785():
         for parts in [
             ("github", ".com"),
             ("anthropic", ".com"),
+            ("models", ".opencode", ".ai"),
+            ("registry", ".npmjs", ".org"),
         ]
     }
     assert "http_access deny all" in squid_config

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -564,6 +564,23 @@ def test_omnigent_compose_uses_shared_postgres_for_mm_970():
     assert _has_volume_mount(omnigent_service, "omnigent-data", "/data")
     assert "omnigent-data" in compose_data.get("volumes", {})
 
+    agent_init = services.get("omnigent-agent-init")
+    assert isinstance(agent_init, dict)
+    assert agent_init["restart"] == "no"
+    assert agent_init["depends_on"]["omnigent-db-init"]["condition"] == (
+        "service_completed_successfully"
+    )
+    assert _has_volume_mount(agent_init, "omnigent-data", "/data")
+    assert _has_volume_mount(
+        agent_init,
+        "./services/omnigent/agents/opencode-native-ui",
+        "/opt/moonmind/agents/opencode-native-ui",
+    )
+    assert (
+        omnigent_service["depends_on"]["omnigent-agent-init"]["condition"]
+        == "service_completed_successfully"
+    )
+
     omnigent_env = _env_map(omnigent_service.get("environment"))
     assert omnigent_service["image"] == (
         "${OMNIGENT_IMAGE_REF:-${OMNIGENT_IMAGE:-ghcr.io/omnigent-ai/omnigent-server}:"

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4796,6 +4796,7 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
 ) -> None:
     test_client, temporal_service, _user = client
     events: list[str] = []
+    compiled_parameters: dict[str, object] = {}
 
     async def create_execution(**_kwargs):
         events.append("temporal_schedule")
@@ -4844,6 +4845,7 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
 
     async def compile_plan(**_kwargs):
         events.append("execution_plan")
+        compiled_parameters.update(_kwargs["initial_parameters"])
         return SimpleNamespace(
             binding=plan_binding,
             artifact_refs=("art_profile", "art_skills", "art_opencode_plan"),
@@ -4884,7 +4886,11 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
                     },
                     "workflow": {
                         "instructions": "Prove OpenCode through the product path.",
-                        "runtime": {"mode": "omnigent"},
+                        "runtime": {
+                            "mode": "omnigent",
+                            "model": "opencode-go/gpt-5.6-luna",
+                            "effort": "xhigh",
+                        },
                     },
                 },
             },
@@ -4892,9 +4898,14 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
 
     assert response.status_code == 201, response.text
     assert events == ["task_snapshot", "execution_plan", "temporal_schedule"]
+    assert compiled_parameters["model"] == "opencode-go/gpt-5.6-luna"
+    assert compiled_parameters["effort"] == "xhigh"
+    assert compiled_parameters["modelSource"] == "task_override"
     initial_parameters = temporal_service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]
+    assert initial_parameters["model"] == "opencode-go/gpt-5.6-luna"
+    assert initial_parameters["effort"] == "xhigh"
     assert initial_parameters["omnigentExecutionPlan"]["planRef"] == (
         plan_binding.plan_ref
     )

--- a/tests/unit/api/routers/test_omnigent_agent_profiles.py
+++ b/tests/unit/api/routers/test_omnigent_agent_profiles.py
@@ -9,9 +9,11 @@ from api_service.api.routers.omnigent_agent_profiles import (
     GuidedProfileCreate,
     _digest,
     _normalized,
+    _preserve_builtin_opencode_model,
     _response,
     router,
 )
+
 
 def document(**source):
     return AgentProfileDocument.model_validate({
@@ -30,6 +32,25 @@ def test_normalization_and_digest_are_stable():
     second = dict(reversed(list(first.items())))
     assert _digest(first) == _digest(second)
     assert _digest(first).startswith("sha256:")
+
+
+def test_catalog_refresh_preserves_bootstrap_qualified_opencode_model():
+    seed = {
+        "source": {"upstreamId": "agent-1", "upstreamVersion": "6"},
+        "model": {},
+    }
+    active = {
+        "source": {"upstreamId": "agent-1", "upstreamVersion": "6"},
+        "model": {
+            "qualifiedId": "opencode-go/gpt-5.6-luna",
+            "effort": "xhigh",
+        },
+    }
+
+    reconciled = _preserve_builtin_opencode_model(seed, active)
+
+    assert reconciled["model"] == active["model"]
+    assert seed["model"] == {}
 
 
 def test_guided_profile_rejects_unqualified_pi_preset() -> None:

--- a/tests/unit/api/routers/test_omnigent_bootstrap.py
+++ b/tests/unit/api/routers/test_omnigent_bootstrap.py
@@ -1,0 +1,137 @@
+"""Bootstrap boundary coverage for OpenCode deployment qualification."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_service.api.routers import omnigent_bootstrap as bootstrap_router
+from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
+from moonmind.omnigent.bootstrap.models import (
+    BootstrapDesired,
+    BootstrapRecord,
+    BootstrapResolved,
+    BootstrapState,
+)
+
+
+def _record(state: BootstrapState = BootstrapState.ready) -> BootstrapRecord:
+    return BootstrapRecord(
+        bootstrapId="omnigent-opencode-default",
+        revision=6,
+        state=state,
+        desired=BootstrapDesired(
+            provider="opencode-go",
+            modelDisplayName="Muse Spark 1.2 Contributor",
+            effort="xhigh",
+            acceptContributorDataUse=True,
+        ),
+        resolved=BootstrapResolved(
+            qualifiedModelId="opencode-go/muse-spark-1.2-contributor",
+            displayName="Muse Spark 1.2 Contributor",
+        ),
+        providerProfileRef="opencode-go-default",
+        agentProfileRef="omnigent-opencode-default@27",
+        updatedAt=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(bootstrap_router.router)
+
+    async def _session():
+        yield SimpleNamespace()
+
+    app.dependency_overrides[get_async_session] = _session
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id="user-1", is_superuser=True
+    )
+    monkeypatch.setattr(
+        bootstrap_router, "_require_bootstrap_permission", lambda _user: None
+    )
+    return TestClient(app)
+
+
+def test_retry_requalifies_without_re_submitting_the_api_key(
+    client, monkeypatch
+) -> None:
+    """Recovery republishes evidence from the persisted Provider Profile.
+
+    Deployment evidence admits exactly one support combination, so an Agent
+    Profile, image, or catalog change invalidates it and every launch then
+    fails admission. Recovery must not depend on the operator still holding
+    the API key.
+    """
+
+    calls: list[str] = []
+
+    import moonmind.omnigent.bootstrap.controller as controller_module
+    import moonmind.omnigent.bootstrap.store as store_module
+
+    monkeypatch.setattr(store_module, "load_bootstrap_record", _record)
+
+    class _Controller:
+        def __init__(self, *, session_factory) -> None:
+            self._session_factory = session_factory
+
+        async def requalify(self) -> BootstrapRecord:
+            calls.append("requalify")
+            return _record()
+
+    monkeypatch.setattr(controller_module, "BootstrapController", _Controller)
+
+    response = client.post("/api/omnigent/bootstrap/opencode/retry")
+
+    assert response.status_code == 200
+    assert calls == ["requalify"]
+    body = response.json()
+    assert body["state"] == "ready"
+    assert body["providerProfileRef"] == "opencode-go-default"
+
+
+def test_retry_without_bootstrap_state_reports_not_found(
+    client, monkeypatch
+) -> None:
+    import moonmind.omnigent.bootstrap.store as store_module
+
+    monkeypatch.setattr(store_module, "load_bootstrap_record", lambda: None)
+
+    response = client.post("/api/omnigent/bootstrap/opencode/retry")
+
+    assert response.status_code == 404
+
+
+def test_retry_before_credentials_reports_actionable_setup_error(
+    client, monkeypatch
+) -> None:
+    import moonmind.omnigent.bootstrap.controller as controller_module
+    import moonmind.omnigent.bootstrap.store as store_module
+
+    monkeypatch.setattr(
+        store_module,
+        "load_bootstrap_record",
+        lambda: _record(BootstrapState.not_started),
+    )
+
+    class _Controller:
+        def __init__(self, *, session_factory) -> None:
+            pass
+
+        async def requalify(self) -> BootstrapRecord:
+            raise ValueError(
+                "OpenCode is not configured yet; submit the API key first"
+            )
+
+    monkeypatch.setattr(controller_module, "BootstrapController", _Controller)
+
+    response = client.post("/api/omnigent/bootstrap/opencode/retry")
+
+    assert response.status_code == 422
+    assert "submit the API key first" in response.json()["detail"]

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -1,0 +1,246 @@
+"""Deployment qualification must attest the combination admission compiles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from api_service.services.omnigent_agent_profile_selection import (
+    default_launch_policy_ref,
+)
+from moonmind.omnigent.bootstrap.controller import BootstrapController
+from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
+
+_SERVER_IMAGE_REF = "ghcr.io/example/omnigent-server@sha256:" + "a" * 64
+_HOST_IMAGE_REF = "ghcr.io/example/omnigent-host-opencode@sha256:" + "7" * 64
+_IMPLEMENTATION_DIGEST = "sha256:" + "c" * 64
+# The deployment-managed OpenCode Agent Profile allows both the generic and the
+# harness-shaped launch policy; admission always selects the first.
+_ALLOWED_LAUNCH_POLICIES = ["omnigent-on-demand@1", "opencode-on-demand@1"]
+
+
+def _profile_document() -> dict:
+    return {
+        "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+        "endpointRef": "default",
+        "source": {
+            "kind": "upstream",
+            "upstreamId": "opencode-native-ui",
+            "upstreamVersion": "1",
+            "upstreamSnapshotDigest": "sha256:" + "d" * 64,
+        },
+        "harness": {
+            "id": "opencode-native",
+            "catalogRef": "omnigent-harness-catalog:sha256:" + "e" * 64,
+            "implementationRef": (
+                "omnigent-harness-implementation:" + _IMPLEMENTATION_DIGEST
+            ),
+        },
+        "credentialSlots": [
+            {
+                "id": "primary-model",
+                "acceptedAuthModels": ["own-auth"],
+                "acceptedProviderIds": ["opencode-go"],
+            }
+        ],
+        "model": {
+            "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
+            "effort": "xhigh",
+        },
+        "workspace": {"mutation": "allowed"},
+        "skills": [],
+        "tools": [],
+        "capture": {"stream": True, "evidence": True},
+        "continuations": {"checkpoint": True, "branch": True},
+        "publish": {"mode": "none"},
+        "allowedLaunchPolicyRefs": list(_ALLOWED_LAUNCH_POLICIES),
+    }
+
+
+def _version_row(document: dict, *, version: int = 27) -> SimpleNamespace:
+    digest = "sha256:" + hashlib.sha256(
+        json.dumps(document, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return SimpleNamespace(
+        profile_id="omnigent-opencode-default",
+        version=version,
+        digest=digest,
+        document=document,
+    )
+
+
+class _Session:
+    """Minimal read-only session for the qualification lookups."""
+
+    def __init__(self, version: SimpleNamespace) -> None:
+        self.version = version
+
+    async def get(self, model, _identity):
+        if model.__name__ == "OmnigentAgentProfile":
+            return SimpleNamespace(
+                profile_id="omnigent-opencode-default",
+                active_version=self.version.version,
+            )
+        return SimpleNamespace(credential_generation=1)
+
+    async def execute(self, _statement):
+        version = self.version
+        return SimpleNamespace(
+            scalars=lambda: SimpleNamespace(first=lambda: version)
+        )
+
+
+def _catalog_snapshot():
+    return create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="0.10.0",
+        omnigentBuildDigest="sha256:" + "a" * 64,
+        sourceDigest="sha256:" + "b" * 64,
+        observedAt=datetime.now(UTC),
+        harnesses=[
+            {
+                "id": "opencode-native",
+                "label": "OpenCode",
+                "implementation": {
+                    "sourceKind": "core",
+                    "package": "omnigent",
+                    "version": "1.0.0",
+                    "digest": _IMPLEMENTATION_DIGEST,
+                    "pluginEntryPoint": None,
+                },
+                "capabilities": {
+                    "integrationMode": "native-server",
+                    "authModel": "own-auth",
+                },
+            }
+        ],
+    )
+
+
+def _resolved_state() -> SimpleNamespace:
+    return SimpleNamespace(
+        opencode_host_image_ref=_HOST_IMAGE_REF,
+        server_image_ref=_SERVER_IMAGE_REF,
+        architecture="linux/amd64",
+    )
+
+
+@pytest.fixture
+def qualification_boundary(monkeypatch, tmp_path):
+    """Wire the qualification boundary to hermetic collaborators."""
+
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", _SERVER_IMAGE_REF)
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", _HOST_IMAGE_REF)
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+
+    import api_service.db.base as db_base
+    import moonmind.omnigent.bootstrap.evidence as evidence_module
+    import moonmind.omnigent.bootstrap.qualification as qualification_module
+    from moonmind.omnigent.harness_platform import catalog_service
+
+    state = SimpleNamespace(session=_Session(_version_row(_profile_document())))
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield state.session
+
+    monkeypatch.setattr(
+        db_base, "async_session_maker", lambda: _session_scope(), raising=False
+    )
+
+    snapshot = _catalog_snapshot()
+
+    class _Repo:
+        def __init__(self, _factory) -> None:
+            pass
+
+        async def latest(self, _endpoint_ref):
+            return SimpleNamespace(snapshot=snapshot)
+
+    monkeypatch.setattr(catalog_service, "DbHarnessCatalogRepository", _Repo)
+
+    async def _run_qualification(**_kwargs):
+        return {
+            "results": {"readQualification": "passed"},
+            "evidenceRefs": {"readRun": "artifact:read-run"},
+        }
+
+    monkeypatch.setattr(
+        qualification_module, "run_qualification", _run_qualification
+    )
+    monkeypatch.setattr(
+        evidence_module,
+        "write_deployment_evidence",
+        lambda evidence, path=None: tmp_path / "evidence.json",
+    )
+    state.session_factory = lambda: _session_scope()
+    return state
+
+
+async def _qualify(state) -> dict:
+    controller = BootstrapController(session_factory=state.session_factory)
+    return await controller._qualify_and_publish(
+        provider_profile_ref="opencode-go-default",
+        qualified_model="opencode-go/muse-spark-1.2-contributor",
+        effort="xhigh",
+        resolved=_resolved_state(),
+        record=SimpleNamespace(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_qualification_attests_the_launch_policy_admission_selects(
+    qualification_boundary,
+) -> None:
+    """Qualification derives the launch policy from the Agent Profile.
+
+    Restating a harness-shaped ref here attests a support combination no plan
+    ever compiles, and every OpenCode launch then fails evidence admission.
+    """
+
+    evidence = await _qualify(qualification_boundary)
+
+    expected = default_launch_policy_ref(_ALLOWED_LAUNCH_POLICIES)
+    assert expected == "omnigent-on-demand@1"
+    assert evidence["supportIdentity"]["launchPolicyRef"] == expected
+
+
+@pytest.mark.asyncio
+async def test_qualification_follows_a_reordered_allow_list(
+    qualification_boundary,
+) -> None:
+    """Editing the Agent Profile moves qualification with admission."""
+
+    document = _profile_document()
+    document["allowedLaunchPolicyRefs"] = list(
+        reversed(_ALLOWED_LAUNCH_POLICIES)
+    )
+    qualification_boundary.session.version = _version_row(document, version=28)
+
+    evidence = await _qualify(qualification_boundary)
+
+    assert evidence["supportIdentity"]["launchPolicyRef"] == (
+        "opencode-on-demand@1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_qualification_rejects_a_profile_without_a_launch_policy(
+    qualification_boundary,
+) -> None:
+    """An Agent Profile with no allowed launch policy fails before attesting."""
+
+    document = _profile_document()
+    document["allowedLaunchPolicyRefs"] = []
+    qualification_boundary.session.version = _version_row(document, version=29)
+
+    with pytest.raises(ValueError, match="no allowed launch policy"):
+        await _qualify(qualification_boundary)

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -7,6 +7,7 @@ import json
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -14,6 +15,12 @@ from api_service.services.omnigent_agent_profile_selection import (
     default_launch_policy_ref,
 )
 from moonmind.omnigent.bootstrap.controller import BootstrapController
+from moonmind.omnigent.bootstrap.models import (
+    BootstrapDesired,
+    BootstrapRecord,
+    BootstrapState,
+)
+from moonmind.omnigent.bootstrap.opencode import resolve_model_by_display
 from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
 
 _SERVER_IMAGE_REF = "ghcr.io/example/omnigent-server@sha256:" + "a" * 64
@@ -244,3 +251,59 @@ async def test_qualification_rejects_a_profile_without_a_launch_policy(
 
     with pytest.raises(ValueError, match="no allowed launch policy"):
         await _qualify(qualification_boundary)
+
+
+def test_model_resolution_accepts_a_qualified_opencode_model_before_live_validation() -> None:
+    resolved = resolve_model_by_display("opencode-go/gpt-5.6-luna")
+
+    assert resolved == {
+        "displayName": "opencode-go/gpt-5.6-luna",
+        "providerModelId": "gpt-5.6-luna",
+        "qualifiedId": "opencode-go/gpt-5.6-luna",
+    }
+
+
+@pytest.mark.asyncio
+async def test_requalification_uses_the_current_provider_profile_model(
+    monkeypatch,
+) -> None:
+    """Retry must not requalify a stale bootstrap-time model selection."""
+
+    import moonmind.omnigent.bootstrap.controller as controller_module
+
+    stored = BootstrapRecord(
+        state=BootstrapState.failed,
+        desired=BootstrapDesired(
+            modelDisplayName="Muse Spark 1.2 Contributor",
+            effort="xhigh",
+            acceptContributorDataUse=True,
+        ),
+        providerProfileRef="opencode-go-default",
+    )
+    provider_profile = SimpleNamespace(
+        default_model="opencode-go/gpt-5.6-luna",
+        default_effort="high",
+    )
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield SimpleNamespace(get=AsyncMock(return_value=provider_profile))
+
+    reconciled: list[BootstrapRecord] = []
+
+    async def _reconcile(*, record, api_key, principal):
+        assert api_key is None
+        assert principal is None
+        reconciled.append(record)
+        return record
+
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: stored)
+    monkeypatch.setattr(controller_module, "save_bootstrap_record", lambda _record: None)
+    controller = BootstrapController(session_factory=lambda: _session_scope())
+    monkeypatch.setattr(controller, "_reconcile", _reconcile)
+
+    result = await controller.requalify()
+
+    assert reconciled == [result]
+    assert result.desired.model_display_name == "opencode-go/gpt-5.6-luna"
+    assert result.desired.effort == "high"

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -14,7 +14,7 @@ import pytest
 from api_service.services.omnigent_agent_profile_selection import (
     default_launch_policy_ref,
 )
-from moonmind.omnigent.bootstrap.controller import BootstrapController
+from moonmind.omnigent.bootstrap import controller as controller_module
 from moonmind.omnigent.bootstrap.models import (
     BootstrapDesired,
     BootstrapRecord,
@@ -193,7 +193,9 @@ def qualification_boundary(monkeypatch, tmp_path):
 
 
 async def _qualify(state) -> dict:
-    controller = BootstrapController(session_factory=state.session_factory)
+    controller = controller_module.BootstrapController(
+        session_factory=state.session_factory
+    )
     return await controller._qualify_and_publish(
         provider_profile_ref="opencode-go-default",
         qualified_model="opencode-go/muse-spark-1.2-contributor",
@@ -269,7 +271,15 @@ async def test_requalification_uses_the_current_provider_profile_model(
 ) -> None:
     """Retry must not requalify a stale bootstrap-time model selection."""
 
-    import moonmind.omnigent.bootstrap.controller as controller_module
+    from api_service.db.models import (
+        ProviderCredentialSource,
+        ProviderProfileAuthState,
+        RuntimeMaterializationMode,
+        SecretStatus,
+    )
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        ProviderReconcileOutcome,
+    )
 
     stored = BootstrapRecord(
         state=BootstrapState.failed,
@@ -281,6 +291,16 @@ async def test_requalification_uses_the_current_provider_profile_model(
         providerProfileRef="opencode-go-default",
     )
     provider_profile = SimpleNamespace(
+        enabled=True,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        disabled_reason=None,
+        max_parallel_runs=1,
+        runtime_id="opencode",
+        credential_source=ProviderCredentialSource.SECRET_REF,
+        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+        cooldown_after_429_seconds=0,
+        secret_refs={"opencode_api_key": "db://opencode-go-default-api-key"},
+        command_behavior={},
         default_model="opencode-go/gpt-5.6-luna",
         default_effort="high",
     )
@@ -299,7 +319,18 @@ async def test_requalification_uses_the_current_provider_profile_model(
 
     monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: stored)
     monkeypatch.setattr(controller_module, "save_bootstrap_record", lambda _record: None)
-    controller = BootstrapController(session_factory=lambda: _session_scope())
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_service._managed_secret_statuses_for_profiles",
+        AsyncMock(return_value={"opencode-go-default-api-key": SecretStatus.ACTIVE.value}),
+    )
+    revalidate = AsyncMock(return_value=ProviderReconcileOutcome(ready=True))
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.provider_revalidation.reconcile_opencode_provider_readiness",
+        revalidate,
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
     monkeypatch.setattr(controller, "_reconcile", _reconcile)
 
     result = await controller.requalify()
@@ -307,3 +338,150 @@ async def test_requalification_uses_the_current_provider_profile_model(
     assert reconciled == [result]
     assert result.desired.model_display_name == "opencode-go/gpt-5.6-luna"
     assert result.desired.effort == "high"
+    revalidate.assert_awaited_once_with(
+        session_factory=controller._session_factory,
+        allow_enrollment=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enabled", "secret_status"),
+    [
+        (False, "active"),
+        (True, "disabled"),
+        (True, "deleted"),
+    ],
+)
+async def test_requalification_rejects_an_unlaunchable_provider_profile(
+    monkeypatch,
+    enabled: bool,
+    secret_status: str,
+) -> None:
+    """Retry cannot publish evidence normal profile selection would reject."""
+
+    from api_service.db.models import (
+        ProviderCredentialSource,
+        ProviderProfileAuthState,
+        RuntimeMaterializationMode,
+    )
+
+    stored = BootstrapRecord(
+        state=BootstrapState.failed,
+        desired=BootstrapDesired(
+            modelDisplayName="opencode-go/gpt-5.6-luna",
+            effort="high",
+        ),
+        providerProfileRef="opencode-go-default",
+    )
+    provider_profile = SimpleNamespace(
+        enabled=enabled,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        disabled_reason=None,
+        max_parallel_runs=1,
+        runtime_id="opencode",
+        credential_source=ProviderCredentialSource.SECRET_REF,
+        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+        cooldown_after_429_seconds=0,
+        secret_refs={"opencode_api_key": "db://opencode-go-default-api-key"},
+        command_behavior={},
+        default_model="opencode-go/gpt-5.6-luna",
+        default_effort="high",
+    )
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield SimpleNamespace(get=AsyncMock(return_value=provider_profile))
+
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: stored)
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_service._managed_secret_statuses_for_profiles",
+        AsyncMock(return_value={"opencode-go-default-api-key": secret_status}),
+    )
+    revalidate = AsyncMock()
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.provider_revalidation.reconcile_opencode_provider_readiness",
+        revalidate,
+    )
+
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    with pytest.raises(ValueError, match="not launch ready"):
+        await controller.requalify()
+
+    revalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_requalification_stops_when_runtime_revalidation_fails(
+    monkeypatch,
+) -> None:
+    """Retry cannot publish after the pinned runtime rejects the credential."""
+
+    from api_service.db.models import (
+        ProviderCredentialSource,
+        ProviderProfileAuthState,
+        RuntimeMaterializationMode,
+        SecretStatus,
+    )
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        ProviderReconcileOutcome,
+    )
+
+    stored = BootstrapRecord(
+        state=BootstrapState.failed,
+        desired=BootstrapDesired(
+            modelDisplayName="opencode-go/gpt-5.6-luna",
+            effort="high",
+        ),
+        providerProfileRef="opencode-go-default",
+    )
+    provider_profile = SimpleNamespace(
+        enabled=True,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        disabled_reason=None,
+        max_parallel_runs=1,
+        runtime_id="opencode",
+        credential_source=ProviderCredentialSource.SECRET_REF,
+        runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+        cooldown_after_429_seconds=0,
+        secret_refs={"opencode_api_key": "db://opencode-go-default-api-key"},
+        command_behavior={},
+        default_model="opencode-go/gpt-5.6-luna",
+        default_effort="high",
+    )
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield SimpleNamespace(get=AsyncMock(return_value=provider_profile))
+
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: stored)
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_service._managed_secret_statuses_for_profiles",
+        AsyncMock(
+            return_value={
+                "opencode-go-default-api-key": SecretStatus.ACTIVE.value,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.provider_revalidation.reconcile_opencode_provider_readiness",
+        AsyncMock(
+            return_value=ProviderReconcileOutcome(
+                ready=False,
+                deferred=("opencode-go-default",),
+            )
+        ),
+    )
+
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    reconcile = AsyncMock()
+    monkeypatch.setattr(controller, "_reconcile", reconcile)
+
+    with pytest.raises(ValueError, match="could not be revalidated"):
+        await controller.requalify()
+
+    reconcile.assert_not_awaited()

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -51,7 +51,10 @@ from moonmind.omnigent.host_services.attestation import (
     _attest_workspace_mount,
     _read_exact_host_model_options,
 )
-from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
+from moonmind.omnigent.host_services.mounted_tools import (
+    OmnigentMountedToolService,
+    deployment_mounted_tool_names,
+)
 from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
 from moonmind.omnigent.provider_leases import (
     AcquiredProviderLease,
@@ -1392,6 +1395,18 @@ async def test_tool_delivery_uses_plan_names_and_deployment_owned_volume(
     assert result[0]["sourceRef"] == "deployment-tools"
     assert result[0]["accessMode"] == "read-only"
     assert result[0]["tools"][0]["executableDigests"] == ["a" * 64]
+
+
+def test_deployment_mounted_tool_names_come_from_locked_manifest(
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "manifest.lock.json"
+    manifest.write_text(
+        json.dumps({"tools": [{"name": "GH"}, {"name": ""}]}),
+        encoding="utf-8",
+    )
+
+    assert deployment_mounted_tool_names(manifest) == ("gh",)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from moonmind.auth.github_credentials import (
+    GitHubCredentialSource,
+    ResolvedGitHubCredential,
+)
 from moonmind.omnigent.credential_materializers import (
     CredentialMaterializationContext,
     CredentialRuntimeHandle,
@@ -50,6 +54,10 @@ from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
     _read_exact_host_model_options,
+)
+from moonmind.omnigent.host_services.github_credentials import (
+    OmnigentGithubCredentialService,
+    github_repository_from_request,
 )
 from moonmind.omnigent.host_services.mounted_tools import (
     OmnigentMountedToolService,
@@ -692,6 +700,78 @@ def _request() -> AgentExecutionRequest:
             "parameters": {},
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_github_credential_projection_transports_secret_only_on_stdin(
+    monkeypatch,
+) -> None:
+    secret = "github-secret-that-must-not-be-inspectable"
+
+    async def resolve(*, repo=None):
+        assert repo == "MoonLadderStudios/Tactics"
+        return ResolvedGitHubCredential(
+            token=secret,
+            source=GitHubCredentialSource.DIRECT_ENV,
+            sourceName="GITHUB_TOKEN",
+            repo=repo,
+        )
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.host_services.github_credentials.resolve_github_credential",
+        resolve,
+    )
+
+    class Backend:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def run(self, argv, **kwargs):
+            self.calls.append((list(argv), dict(kwargs)))
+            if argv[1:3] == ["volume", "inspect"]:
+                owner_ref = "lease-owner-1"
+                return 0, hashlib.sha256(owner_ref.encode()).hexdigest()[:32], ""
+            return 0, "", ""
+
+    request = _request().model_copy(
+        update={
+            "workspace_spec": {
+                "repositoryTarget": {
+                    "provider": "git",
+                    "repository": {"name": "MoonLadderStudios/Tactics"},
+                }
+            }
+        }
+    )
+    backend = Backend()
+    service = OmnigentGithubCredentialService(backend)
+    attachment = await service.materialize(
+        request=request,
+        resolved_tools={"tools": ["gh", "git"]},
+        owner_ref="lease-owner-1",
+        writer_image_ref="ghcr.io/example/opencode@sha256:" + "1" * 64,
+        runtime_uid=1000,
+        runtime_gid=1000,
+    )
+
+    assert github_repository_from_request(request) == "MoonLadderStudios/Tactics"
+    assert attachment is not None
+    assert attachment["accessMode"] == "read-only"
+    assert attachment["targetPath"] == "/home/app/.cache/moonmind-xdg"
+    inspectable = json.dumps(
+        {
+            "calls": [argv for argv, _kwargs in backend.calls],
+            "attachment": attachment,
+        },
+        sort_keys=True,
+    )
+    assert secret not in inspectable
+    stdin_payloads = [
+        kwargs.get("input_bytes")
+        for _argv, kwargs in backend.calls
+        if kwargs.get("input_bytes")
+    ]
+    assert stdin_payloads == [secret.encode()]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -49,6 +49,7 @@ from moonmind.omnigent.host_leases import InMemoryOmnigentHostLeaseRepository
 from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
+    _read_exact_host_model_options,
 )
 from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
 from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
@@ -116,6 +117,115 @@ def test_exact_host_attestation_enforces_workspace_access_mode() -> None:
             ],
             attachment,
         )
+
+
+@pytest.mark.asyncio
+async def test_opencode_exact_host_model_options_use_portable_cli_helper() -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Backend:
+        async def run(self, argv, **kwargs):
+            calls.append((list(argv), dict(kwargs)))
+            return (
+                0,
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "id": "opencode-go/muse-spark-1.2-contributor",
+                                "providerID": "opencode-go",
+                            }
+                        ]
+                    }
+                ),
+                "",
+            )
+
+    class Client:
+        async def get_host_model_options(self, *_args):
+            raise AssertionError("OpenCode must not use the unsupported host tunnel")
+
+    result, source = await _read_exact_host_model_options(
+        backend=Backend(),
+        client=Client(),
+        container_name="mm-host-opencode",
+        omnigent_host_id="host-opencode",
+        harness_id="opencode-native",
+    )
+
+    assert result["models"][0]["id"] == "opencode-go/muse-spark-1.2-contributor"
+    assert source == "exact-host-opencode-cli"
+    argv, kwargs = calls[0]
+    assert argv[:4] == [
+        "docker",
+        "exec",
+        "mm-host-opencode",
+        "/opt/venv/bin/python",
+    ]
+    assert "list_opencode_cli_model_options" in argv[-1]
+    assert kwargs == {"timeout_seconds": 45.0, "check": False}
+
+
+@pytest.mark.asyncio
+async def test_non_opencode_exact_host_model_options_use_tunnel() -> None:
+    class Backend:
+        async def run(self, *_args, **_kwargs):
+            raise AssertionError("non-OpenCode harnesses must use the host tunnel")
+
+    class Client:
+        async def get_host_model_options(self, host_id, harness_id):
+            assert (host_id, harness_id) == ("host-pi", "pi-native")
+            return {"models": [{"id": "anthropic/claude-sonnet-4-6"}]}
+
+    result, source = await _read_exact_host_model_options(
+        backend=Backend(),
+        client=Client(),
+        container_name="mm-host-pi",
+        omnigent_host_id="host-pi",
+        harness_id="pi-native",
+    )
+
+    assert result == {"models": [{"id": "anthropic/claude-sonnet-4-6"}]}
+    assert source == "omnigent-host-tunnel"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("return_value", "expected_message"),
+    [
+        (
+            (1, "", "provider diagnostic containing sensitive context"),
+            "exact host OpenCode model catalog probe failed",
+        ),
+        (
+            (0, "not-json", ""),
+            "exact host OpenCode model catalog probe returned invalid JSON",
+        ),
+        (
+            (0, '{"models": {}}', ""),
+            "exact host OpenCode model catalog probe returned an invalid catalog",
+        ),
+    ],
+)
+async def test_opencode_exact_host_model_options_fail_closed_without_diagnostics(
+    return_value: tuple[int, str, str], expected_message: str
+) -> None:
+    class Backend:
+        async def run(self, *_args, **_kwargs):
+            return return_value
+
+    with pytest.raises(HarnessPlatformError) as exc:
+        await _read_exact_host_model_options(
+            backend=Backend(),
+            client=object(),
+            container_name="mm-host-opencode",
+            omnigent_host_id="host-opencode",
+            harness_id="opencode-native",
+        )
+
+    assert str(exc.value) == expected_message
+    assert exc.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
+    assert "sensitive context" not in str(exc.value)
 
 
 def test_planning_model_evidence_is_bound_to_generation_and_host_image() -> None:
@@ -316,9 +426,7 @@ async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
         {
             "id": "opencode-native",
             "label": "OpenCode",
-            "implementation": implementation.model_dump(
-                mode="json", by_alias=True
-            ),
+            "implementation": implementation.model_dump(mode="json", by_alias=True),
             "capabilities": {
                 "integrationMode": "native-server",
                 "authModel": "own-auth",
@@ -376,13 +484,10 @@ async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
     }
     canonical = json.dumps(launch, sort_keys=True, separators=(",", ":"))
     launch["snapshotRef"] = (
-        "omnigent-launch:sha256:"
-        + hashlib.sha256(canonical.encode()).hexdigest()
+        "omnigent-launch:sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
     )
     raw = json.dumps(launch, sort_keys=True, separators=(",", ":")).encode()
-    payload = _plan("opencode-go/model").payload.model_dump(
-        mode="json", by_alias=True
-    )
+    payload = _plan("opencode-go/model").payload.model_dump(mode="json", by_alias=True)
     payload.update(
         {
             "harnessImplementationRef": implementation.implementation_ref(),
@@ -1010,19 +1115,16 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
             "stream": False,
             "evidence": False,
         }
-        authorization = request.parameters["omnigent"][
-            "_moonmindProfileAuthorization"
-        ]
-        assert authorization["executionPlanRef"] == request.parameters[
-            "executionPlanRef"
-        ]
-        assert authorization["runtimeBindingRef"] == request.parameters[
-            "runtimeBindingRef"
-        ]
-        assert authorization["providerProfileId"] == "opencode-go-primary"
-        assert authorization["providerLeaseRef"] == (
-            "provider-profile-lease:lease-1"
+        authorization = request.parameters["omnigent"]["_moonmindProfileAuthorization"]
+        assert (
+            authorization["executionPlanRef"] == request.parameters["executionPlanRef"]
         )
+        assert (
+            authorization["runtimeBindingRef"]
+            == request.parameters["runtimeBindingRef"]
+        )
+        assert authorization["providerProfileId"] == "opencode-go-primary"
+        assert authorization["providerLeaseRef"] == ("provider-profile-lease:lease-1")
         assert authorization["credentialGeneration"] == 4
         assert authorization["hostBindingRef"]
         assert authorization["hostLeaseRef"]
@@ -1061,20 +1163,17 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
     result = await realizer.execute(_request(), _plan("opencode-go/model"))
 
     assert result.summary == "done"
-    assert result.metadata["executionPlanRef"] == _plan(
-        "opencode-go/model"
-    ).planRef
+    assert result.metadata["executionPlanRef"] == _plan("opencode-go/model").planRef
     assert result.metadata["runtimeBindingRef"].startswith(
         "omnigent-runtime-binding:sha256:"
     )
-    assert result.metadata["supportCombinationIdentity"][
-        "supportCombinationKey"
-    ] == _plan("opencode-go/model").payload.supportCombinationKey
+    assert (
+        result.metadata["supportCombinationIdentity"]["supportCombinationKey"]
+        == _plan("opencode-go/model").payload.supportCombinationKey
+    )
     assert events[-1] == "command-settled:applied"
     assert events.index("command-claimed") < events.index("provider-acquired")
-    assert events.index("provider-released") < events.index(
-        "command-settled:applied"
-    )
+    assert events.index("provider-released") < events.index("command-settled:applied")
     assert events.index("host-cleaned") < events.index("credentials-cleaned")
     assert events.index("credentials-cleaned") < events.index("provider-released")
     assert host_leases.heartbeat_count >= 1

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -54,6 +54,7 @@ from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
     _read_exact_host_model_options,
+    _run_exact_host_runner_command,
 )
 from moonmind.omnigent.host_services.github_credentials import (
     OmnigentGithubCredentialService,
@@ -175,6 +176,35 @@ async def test_opencode_exact_host_model_options_use_portable_cli_helper() -> No
     ]
     assert "list_opencode_cli_model_options" in argv[-1]
     assert kwargs == {"timeout_seconds": 45.0, "check": False}
+
+
+@pytest.mark.asyncio
+async def test_exact_host_runner_probe_uses_authoritative_environment_builder() -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Backend:
+        async def run(self, argv, **kwargs):
+            calls.append((argv, kwargs))
+            return 0, "ready", ""
+
+    result = await _run_exact_host_runner_command(
+        backend=Backend(),
+        container_name="mm-host-opencode",
+        argv=["gh", "auth", "status", "--hostname", "github.com"],
+    )
+
+    assert result == (0, "ready", "")
+    argv, kwargs = calls[0]
+    assert argv[:5] == [
+        "docker",
+        "exec",
+        "mm-host-opencode",
+        "/opt/venv/bin/python",
+        "-c",
+    ]
+    assert "from omnigent.host.connect import _build_runner_env" in argv[5]
+    assert argv[6:] == ["gh", "auth", "status", "--hostname", "github.com"]
+    assert kwargs == {"timeout_seconds": 30.0, "check": False}
 
 
 @pytest.mark.asyncio
@@ -1127,7 +1157,7 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
                 skill_attachment={
                     "kind": "bind",
                     "sourceRef": "/tmp/skills",
-                    "targetPath": "/opt/moonmind/skills_active",
+                    "targetPath": "/opt/moonmind-skills",
                     "accessMode": "read-only",
                     "deliveryRef": "skill-delivery:one",
                 },

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -757,7 +757,7 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
     assert github_repository_from_request(request) == "MoonLadderStudios/Tactics"
     assert attachment is not None
     assert attachment["accessMode"] == "read-only"
-    assert attachment["targetPath"] == "/home/app/.cache/moonmind-xdg"
+    assert attachment["targetPath"] == "/home/app/.cache/moonmind-gh"
     inspectable = json.dumps(
         {
             "calls": [argv for argv, _kwargs in backend.calls],

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -757,7 +757,7 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
     assert github_repository_from_request(request) == "MoonLadderStudios/Tactics"
     assert attachment is not None
     assert attachment["accessMode"] == "read-only"
-    assert attachment["targetPath"] == "/home/app/.cache/moonmind-gh"
+    assert attachment["targetPath"] == "/run/mm-credentials/github"
     inspectable = json.dumps(
         {
             "calls": [argv for argv, _kwargs in backend.calls],

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -54,6 +54,7 @@ from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
     _read_exact_host_model_options,
+    _run_exact_host_opencode_command,
     _run_exact_host_runner_command,
 )
 from moonmind.omnigent.host_services.github_credentials import (
@@ -203,6 +204,38 @@ async def test_exact_host_runner_probe_uses_authoritative_environment_builder() 
         "-c",
     ]
     assert "from omnigent.host.connect import _build_runner_env" in argv[5]
+    assert argv[6:] == ["gh", "auth", "status", "--hostname", "github.com"]
+    assert kwargs == {"timeout_seconds": 30.0, "check": False}
+
+
+@pytest.mark.asyncio
+async def test_exact_host_opencode_probe_composes_both_environment_builders() -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class Backend:
+        async def run(self, argv, **kwargs):
+            calls.append((argv, kwargs))
+            return 0, "ready", ""
+
+    result = await _run_exact_host_opencode_command(
+        backend=Backend(),
+        container_name="mm-host-opencode",
+        argv=["gh", "auth", "status", "--hostname", "github.com"],
+    )
+
+    assert result == (0, "ready", "")
+    argv, kwargs = calls[0]
+    assert argv[:5] == [
+        "docker",
+        "exec",
+        "mm-host-opencode",
+        "/opt/venv/bin/python",
+        "-c",
+    ]
+    assert "from omnigent.host.connect import _build_runner_env" in argv[5]
+    assert "from omnigent.opencode_native_app_server import filtered_server_env" in argv[5]
+    assert "moonmind-opencode-context" in argv[5]
+    assert "env=runner_env" in argv[5]
     assert argv[6:] == ["gh", "auth", "status", "--hostname", "github.com"]
     assert kwargs == {"timeout_seconds": 30.0, "check": False}
 

--- a/tests/unit/omnigent/test_harness_platform.py
+++ b/tests/unit/omnigent/test_harness_platform.py
@@ -599,6 +599,20 @@ def test_class_capability_negotiation_blocks_unknown():
     assert exc.value.code == HarnessPlatformFailure.OMNIGENT_CAPABILITY_REQUIRED_UNKNOWN
 
 
+def test_class_capability_negotiation_accepts_a_host_declared_capability():
+    decision = compute_class_admission(
+        workflow_requirements=["git"],
+        profile_requirements={"required": [], "preferred": []},
+        catalog_capabilities={},
+        host_class_capabilities={"git": True},
+        materializer_capabilities={},
+        bridge_capabilities={},
+        launch_policy_capabilities=[],
+    )
+
+    assert decision.requiredSatisfied == ("git",)
+
+
 # AC 11: On-demand hosts admitted by Host Class evidence, not fictional exact-host readiness
 def test_host_class_admission_not_exact_host():
     hc = get_host_class("omnigent-native-standard@3")

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -12,6 +12,7 @@ def _build(*, target_path: str, github_attachment=None):
             }
         ],
         skill_attachment={"targetPath": "/opt/moonmind-skills"},
+        step_execution_id="workflow:run:node-1:execution:1",
         github_credential_attachment=github_attachment,
     )
 
@@ -36,7 +37,13 @@ def test_opencode_materializer_pins_deterministic_server_startup_environment():
         name for name in expected_flags if environment[name] == "1"
     } == expected_flags
     assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == (
-        expected_flags | expected_proxies | {"MOONMIND_ACTIVE_SKILLS_DIR"}
+        expected_flags
+        | expected_proxies
+        | {"MOONMIND_ACTIVE_SKILLS_DIR", "MOONMIND_STEP_EXECUTION_ID"}
+    )
+    assert (
+        environment["MOONMIND_STEP_EXECUTION_ID"]
+        == "workflow:run:node-1:execution:1"
     )
 
 
@@ -44,9 +51,10 @@ def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():
     _script, environment = _build(target_path="/run/mm-credentials/other")
 
     assert not any(name.startswith("OPENCODE_") for name in environment)
-    assert environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == (
-        "MOONMIND_ACTIVE_SKILLS_DIR"
-    )
+    assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == {
+        "MOONMIND_ACTIVE_SKILLS_DIR",
+        "MOONMIND_STEP_EXECUTION_ID",
+    }
 
 
 def test_github_projection_exposes_only_non_secret_cli_environment():

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from moonmind.omnigent.host_services.runtime_scripts import (
     OmnigentRuntimeScriptService,
 )
@@ -18,7 +20,7 @@ def _build(*, target_path: str, github_attachment=None):
 
 
 def test_opencode_materializer_pins_deterministic_server_startup_environment():
-    _script, environment = _build(target_path="/run/mm-credentials/opencode")
+    script, environment = _build(target_path="/run/mm-credentials/opencode")
 
     expected_flags = {
         "OPENCODE_DISABLE_AUTOUPDATE",
@@ -45,6 +47,22 @@ def test_opencode_materializer_pins_deterministic_server_startup_environment():
         environment["MOONMIND_STEP_EXECUTION_ID"]
         == "workflow:run:node-1:execution:1"
     )
+    assert "> /home/app/.local/bin/moonmind-opencode-context" in script
+    assert "> /home/app/.local/bin/opencode" in script
+    assert (
+        'exec /home/app/.local/bin/moonmind-opencode-context '
+        '/usr/local/bin/opencode "$@"'
+    ) in script
+    assert "MOONMIND_STEP_EXECUTION_ID=$(cat" in script
+    assert "MOONMIND_ACTIVE_SKILLS_DIR=$(cat" in script
+    syntax = subprocess.run(
+        ["/bin/sh", "-n"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
 
 
 def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():
@@ -97,3 +115,5 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert "cp /run/mm-credentials/github/hosts.yml" in _script
     assert "/home/app/.config/gh/hosts.yml" in _script
     assert "> /home/app/.local/bin/gh" in _script
+    assert "export GH_CONFIG_DIR=/home/app/.config/gh" in _script
+    assert "GIT_CONFIG_VALUE_0" in _script

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -11,7 +11,7 @@ def _build(*, target_path: str, github_attachment=None):
                 "attachments": [{"targetPath": target_path}],
             }
         ],
-        skill_attachment={"targetPath": "/opt/moonmind/skills_active"},
+        skill_attachment={"targetPath": "/opt/moonmind-skills"},
         github_credential_attachment=github_attachment,
     )
 
@@ -36,7 +36,7 @@ def test_opencode_materializer_pins_deterministic_server_startup_environment():
         name for name in expected_flags if environment[name] == "1"
     } == expected_flags
     assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == (
-        expected_flags | expected_proxies
+        expected_flags | expected_proxies | {"MOONMIND_ACTIVE_SKILLS_DIR"}
     )
 
 
@@ -44,7 +44,9 @@ def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():
     _script, environment = _build(target_path="/run/mm-credentials/other")
 
     assert not any(name.startswith("OPENCODE_") for name in environment)
-    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in environment
+    assert environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] == (
+        "MOONMIND_ACTIVE_SKILLS_DIR"
+    )
 
 
 def test_github_projection_exposes_only_non_secret_cli_environment():
@@ -62,7 +64,10 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert environment["GH_NO_EXTENSION_UPDATE_NOTIFIER"] == "1"
     assert environment["GIT_CONFIG_COUNT"] == "1"
     assert environment["GIT_CONFIG_KEY_0"] == "credential.https://github.com.helper"
-    assert environment["GIT_CONFIG_VALUE_0"].endswith("gh auth git-credential")
+    assert environment["GIT_CONFIG_VALUE_0"] == (
+        "!/home/app/.local/bin/gh auth git-credential"
+    )
+    assert environment["PATH"].startswith("/home/app/.local/bin:")
     passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
     proxy_names = {
         "HTTP_PROXY",
@@ -83,3 +88,4 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert not any("TOKEN" in name or "SECRET" in name for name in environment)
     assert "cp /run/mm-credentials/github/hosts.yml" in _script
     assert "/home/app/.config/gh/hosts.yml" in _script
+    assert "> /home/app/.local/bin/gh" in _script

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -3,7 +3,7 @@ from moonmind.omnigent.host_services.runtime_scripts import (
 )
 
 
-def _build(*, target_path: str):
+def _build(*, target_path: str, github_attachment=None):
     return OmnigentRuntimeScriptService().build_entrypoint(
         credential_handles=[
             {
@@ -12,6 +12,7 @@ def _build(*, target_path: str):
             }
         ],
         skill_attachment={"targetPath": "/opt/moonmind/skills_active"},
+        github_credential_attachment=github_attachment,
     )
 
 
@@ -44,3 +45,38 @@ def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():
 
     assert not any(name.startswith("OPENCODE_") for name in environment)
     assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in environment
+
+
+def test_github_projection_exposes_only_non_secret_cli_environment():
+    _script, environment = _build(
+        target_path="/run/mm-credentials/opencode",
+        github_attachment={
+            "targetPath": "/home/app/.cache/moonmind-xdg",
+        },
+    )
+
+    assert environment["XDG_CONFIG_HOME"] == "/home/app/.cache/moonmind-xdg"
+    assert environment["GH_PROMPT_DISABLED"] == "1"
+    assert environment["GH_NO_UPDATE_NOTIFIER"] == "1"
+    assert environment["GH_NO_EXTENSION_UPDATE_NOTIFIER"] == "1"
+    assert environment["GIT_CONFIG_COUNT"] == "1"
+    assert environment["GIT_CONFIG_KEY_0"] == "credential.https://github.com.helper"
+    assert environment["GIT_CONFIG_VALUE_0"].endswith("gh auth git-credential")
+    passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
+    proxy_names = {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+    assert set(environment) >= passthrough - proxy_names
+    assert {
+        "GH_PROMPT_DISABLED",
+        "XDG_CONFIG_HOME",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_KEY_0",
+        "GIT_CONFIG_VALUE_0",
+    } <= passthrough
+    assert not any("TOKEN" in name or "SECRET" in name for name in environment)

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -1,0 +1,34 @@
+from moonmind.omnigent.host_services.runtime_scripts import (
+    OmnigentRuntimeScriptService,
+)
+
+
+def _build(*, target_path: str):
+    return OmnigentRuntimeScriptService().build_entrypoint(
+        credential_handles=[
+            {
+                "credentialGeneration": 3,
+                "attachments": [{"targetPath": target_path}],
+            }
+        ],
+        skill_attachment={"targetPath": "/opt/moonmind/skills_active"},
+    )
+
+
+def test_opencode_materializer_pins_deterministic_server_startup_environment():
+    _script, environment = _build(target_path="/run/mm-credentials/opencode")
+
+    expected = {
+        "OPENCODE_DISABLE_AUTOUPDATE",
+        "OPENCODE_DISABLE_DEFAULT_PLUGINS",
+        "OPENCODE_DISABLE_MODELS_FETCH",
+    }
+    assert {name for name in expected if environment[name] == "1"} == expected
+    assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == expected
+
+
+def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():
+    _script, environment = _build(target_path="/run/mm-credentials/other")
+
+    assert not any(name.startswith("OPENCODE_") for name in environment)
+    assert "OMNIGENT_RUNNER_ENV_PASSTHROUGH" not in environment

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -47,10 +47,10 @@ def test_opencode_materializer_pins_deterministic_server_startup_environment():
         environment["MOONMIND_STEP_EXECUTION_ID"]
         == "workflow:run:node-1:execution:1"
     )
-    assert "> /home/app/.local/bin/moonmind-opencode-context" in script
-    assert "> /home/app/.local/bin/opencode" in script
+    assert "> /home/app/.omnigent/moonmind/bin/moonmind-opencode-context" in script
+    assert "> /home/app/.omnigent/moonmind/bin/opencode" in script
     assert (
-        'exec /home/app/.local/bin/moonmind-opencode-context '
+        'exec /home/app/.omnigent/moonmind/bin/moonmind-opencode-context '
         '/usr/local/bin/opencode "$@"'
     ) in script
     assert "MOONMIND_STEP_EXECUTION_ID=$(cat" in script
@@ -91,9 +91,9 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert environment["GIT_CONFIG_COUNT"] == "1"
     assert environment["GIT_CONFIG_KEY_0"] == "credential.https://github.com.helper"
     assert environment["GIT_CONFIG_VALUE_0"] == (
-        "!/home/app/.local/bin/gh auth git-credential"
+        "!/home/app/.omnigent/moonmind/bin/gh auth git-credential"
     )
-    assert environment["PATH"].startswith("/home/app/.local/bin:")
+    assert environment["PATH"].startswith("/home/app/.omnigent/moonmind/bin:")
     passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
     proxy_names = {
         "HTTP_PROXY",
@@ -114,6 +114,6 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert not any("TOKEN" in name or "SECRET" in name for name in environment)
     assert "cp /run/mm-credentials/github/hosts.yml" in _script
     assert "/home/app/.config/gh/hosts.yml" in _script
-    assert "> /home/app/.local/bin/gh" in _script
+    assert "> /home/app/.omnigent/moonmind/bin/gh" in _script
     assert "export GH_CONFIG_DIR=/home/app/.config/gh" in _script
     assert "GIT_CONFIG_VALUE_0" in _script

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -51,11 +51,12 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     _script, environment = _build(
         target_path="/run/mm-credentials/opencode",
         github_attachment={
-            "targetPath": "/home/app/.cache/moonmind-xdg",
+            "targetPath": "/home/app/.cache/moonmind-gh",
         },
     )
 
-    assert environment["XDG_CONFIG_HOME"] == "/home/app/.cache/moonmind-xdg"
+    assert environment["GH_CONFIG_DIR"] == "/home/app/.cache/moonmind-gh"
+    assert "XDG_CONFIG_HOME" not in environment
     assert environment["GH_PROMPT_DISABLED"] == "1"
     assert environment["GH_NO_UPDATE_NOTIFIER"] == "1"
     assert environment["GH_NO_EXTENSION_UPDATE_NOTIFIER"] == "1"
@@ -74,7 +75,7 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert set(environment) >= passthrough - proxy_names
     assert {
         "GH_PROMPT_DISABLED",
-        "XDG_CONFIG_HOME",
+        "GH_CONFIG_DIR",
         "GIT_CONFIG_COUNT",
         "GIT_CONFIG_KEY_0",
         "GIT_CONFIG_VALUE_0",

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -18,13 +18,25 @@ def _build(*, target_path: str):
 def test_opencode_materializer_pins_deterministic_server_startup_environment():
     _script, environment = _build(target_path="/run/mm-credentials/opencode")
 
-    expected = {
+    expected_flags = {
         "OPENCODE_DISABLE_AUTOUPDATE",
         "OPENCODE_DISABLE_DEFAULT_PLUGINS",
         "OPENCODE_DISABLE_MODELS_FETCH",
     }
-    assert {name for name in expected if environment[name] == "1"} == expected
-    assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == expected
+    expected_proxies = {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+    assert {
+        name for name in expected_flags if environment[name] == "1"
+    } == expected_flags
+    assert set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(",")) == (
+        expected_flags | expected_proxies
+    )
 
 
 def test_non_opencode_materializer_does_not_inject_opencode_runtime_flags():

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -51,11 +51,11 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     _script, environment = _build(
         target_path="/run/mm-credentials/opencode",
         github_attachment={
-            "targetPath": "/home/app/.cache/moonmind-gh",
+            "targetPath": "/run/mm-credentials/github",
         },
     )
 
-    assert environment["GH_CONFIG_DIR"] == "/home/app/.cache/moonmind-gh"
+    assert environment["GH_CONFIG_DIR"] == "/home/app/.config/gh"
     assert "XDG_CONFIG_HOME" not in environment
     assert environment["GH_PROMPT_DISABLED"] == "1"
     assert environment["GH_NO_UPDATE_NOTIFIER"] == "1"
@@ -81,3 +81,5 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
         "GIT_CONFIG_VALUE_0",
     } <= passthrough
     assert not any("TOKEN" in name or "SECRET" in name for name in environment)
+    assert "cp /run/mm-credentials/github/hosts.yml" in _script
+    assert "/home/app/.config/gh/hosts.yml" in _script

--- a/tests/unit/omnigent/test_opencode_runtime_validation.py
+++ b/tests/unit/omnigent/test_opencode_runtime_validation.py
@@ -8,7 +8,41 @@ from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformError,
     HarnessPlatformFailure,
 )
-from moonmind.omnigent.opencode_runtime_validation import _validated_models
+from moonmind.omnigent.opencode_runtime_validation import (
+    _model_probe_argv,
+    _validated_models,
+)
+from moonmind.security.egress import (
+    OMNIGENT_EGRESS_NETWORK_REF,
+    omnigent_proxy_env,
+)
+
+
+def test_model_probe_stages_auth_in_writable_home_with_restricted_egress() -> None:
+    image_ref = "registry.example/opencode@sha256:" + "a" * 64
+    argv = _model_probe_argv(
+        image_ref=image_ref,
+        credential_source="credential-volume",
+        credential_target="/run/mm-credentials/opencode",
+    )
+
+    assert argv[:5] == [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        OMNIGENT_EGRESS_NETWORK_REF,
+    ]
+    assert "/home/app:rw,uid=1000,gid=1000,mode=0700" in argv
+    assert (
+        "type=volume,src=credential-volume," "dst=/run/mm-credentials/opencode,readonly"
+    ) in argv
+    for item in omnigent_proxy_env():
+        assert item in argv
+    script = argv[argv.index("-ceu") + 1]
+    assert 'cp "$1/auth.json" /home/app/.local/share/opencode/auth.json' in script
+    assert "exec opencode models --refresh" in script
+    assert "head" not in script
 
 
 def test_validated_models_returns_only_observed_opencode_go_models() -> None:

--- a/tests/unit/omnigent/test_opencode_runtime_validation.py
+++ b/tests/unit/omnigent/test_opencode_runtime_validation.py
@@ -1,0 +1,27 @@
+"""Pinned OpenCode runtime model-catalog validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.opencode_runtime_validation import _validated_models
+
+
+def test_validated_models_returns_only_observed_opencode_go_models() -> None:
+    assert _validated_models("opencode-go/gpt-5.6-luna\nother-provider/model\n") == [
+        "opencode-go/gpt-5.6-luna"
+    ]
+
+
+@pytest.mark.parametrize("catalog", ["", [], {}, "other-provider/model"])
+def test_validated_models_fail_closed_without_provider_evidence(catalog) -> None:
+    with pytest.raises(HarnessPlatformError) as exc:
+        _validated_models(catalog)
+
+    assert (
+        exc.value.code == HarnessPlatformFailure.OMNIGENT_PROVIDER_PROFILE_INCOMPATIBLE
+    )

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -50,6 +50,8 @@ def _profile(
             "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
             "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
             "imageRef": evidence_image,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
             "credentialGeneration": (
                 generation if evidence_generation is None else evidence_generation
             ),
@@ -194,6 +196,19 @@ def test_evidence_is_current_requires_generation_and_pinned_image() -> None:
     assert not evidence_is_current(
         _profile(evidence_image=None), image_ref=CURRENT_IMAGE
     )
+
+
+def test_evidence_is_current_rejects_fabricated_or_stale_model_catalogs() -> None:
+    fabricated = _profile(evidence_image=CURRENT_IMAGE)
+    fabricated.model_catalog_evidence_json.pop("runtimeVersions")
+    fabricated.model_catalog_evidence_json.pop("materializerRef")
+    assert not evidence_is_current(fabricated, image_ref=CURRENT_IMAGE)
+
+    rotated = _profile(evidence_image=CURRENT_IMAGE)
+    rotated.model_catalog_evidence_json["models"] = [
+        {"qualifiedId": "opencode-go/gpt-5.6-luna"}
+    ]
+    assert not evidence_is_current(rotated, image_ref=CURRENT_IMAGE)
 
 
 @pytest.mark.asyncio
@@ -373,6 +388,7 @@ async def test_stale_host_image_evidence_is_revalidated_and_refreshed(
             "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
             "imageRef": image_ref,
             "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
             "validatedAt": "2026-08-25T01:00:00+00:00",
             "credentialGeneration": profile.credential_generation,
         }
@@ -396,6 +412,38 @@ async def test_stale_host_image_evidence_is_revalidated_and_refreshed(
     assert rows[0].model_catalog_evidence_json["imageRef"] == CURRENT_IMAGE
     assert rows[0].command_behavior["runtime_validation"]["image_ref"] == CURRENT_IMAGE
     assert evidence_is_current(rows[0], image_ref=CURRENT_IMAGE)
+
+
+@pytest.mark.asyncio
+async def test_rotated_default_model_persists_catalog_but_defers_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog rotation must not silently substitute a billing-relevant model."""
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/gpt-5.6-luna"}],
+            "imageRef": image_ref,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
+            "validatedAt": "2026-08-27T01:00:00+00:00",
+            "credentialGeneration": profile.credential_generation,
+        }
+
+    _install_stubs(monkeypatch, validate=validate)
+    rows = [_profile(evidence_image=PREVIOUS_IMAGE)]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.ready is False
+    assert outcome.deferred == ("opencode-go-default",)
+    assert rows[0].model_catalog_evidence_json["models"] == [
+        {"qualifiedId": "opencode-go/gpt-5.6-luna"}
+    ]
+    assert not evidence_is_current(rows[0], image_ref=CURRENT_IMAGE)
 
 
 @pytest.mark.asyncio
@@ -577,6 +625,8 @@ async def test_a_successful_refresh_clears_a_recorded_failure(
             "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
             "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
             "imageRef": image_ref,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
             "validatedAt": "2026-08-25T01:00:00+00:00",
             "credentialGeneration": profile.credential_generation,
         }

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -11,6 +11,7 @@ from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from moonmind.omnigent.host_services.workspace import (
     OmnigentWorkspaceMaterializer,
     build_daemon_git_clone_argv,
+    build_daemon_workspace_chown_argv,
     normalize_github_clone_source,
 )
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
@@ -65,16 +66,43 @@ def test_daemon_git_clone_argv_pins_target():
     assert "clone" in argv and "--single-branch" in argv
 
 
+def test_daemon_workspace_chown_argv_pins_target_and_runtime_owner():
+    argv = build_daemon_workspace_chown_argv(
+        volume="agent_workspaces",
+        target_in_volume="temporal_sandbox/ws-1/repo",
+        runtime_uid=1000,
+        runtime_gid=1000,
+        image="alpine/git:v2.43.0",
+    )
+
+    assert argv == [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        "agent_workspaces:/work",
+        "--entrypoint",
+        "/bin/chown",
+        "alpine/git:v2.43.0",
+        "-R",
+        "--",
+        "1000:1000",
+        "/work/temporal_sandbox/ws-1/repo",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_materializer_clones_missing_sandbox_workspace_via_daemon(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
     """A fresh sandbox locator materializes by cloning the requested branch."""
 
-    captured: dict = {}
+    captured: list[list[str]] = []
 
     async def runner(argv):
-        captured["argv"] = argv
+        captured.append(argv)
+        if "clone" not in argv:
+            return 0, "", ""
         # Simulate git creating the checkout inside the volume.
         target = argv[-1]
         assert target.startswith("/work/")
@@ -113,7 +141,8 @@ async def test_materializer_clones_missing_sandbox_workspace_via_daemon(
     )
 
     assert workspace["kind"] == "bind"
-    argv = captured["argv"]
+    assert len(captured) == 2
+    argv = captured[0]
     assert argv[0] == "docker"
     assert f"{materializer._workspace_volume}:/work" in argv
     assert "/work/temporal_sandbox/" + workspace_id + "/repo" in argv
@@ -123,6 +152,10 @@ async def test_materializer_clones_missing_sandbox_workspace_via_daemon(
     assert "https://x-access-token:" in joined
     assert "@github.com/MoonLadderStudios/MoonMind.git" in joined
     assert "dependabot/npm_and_yarn/multi-2181bdc769" in joined
+    assert captured[1][-2:] == [
+        "1000:1000",
+        "/work/temporal_sandbox/" + workspace_id + "/repo",
+    ]
     record = SandboxWorkspaceRecordStore(tmp_path).load(workspace_id)
     assert record == SandboxWorkspaceRecord(
         workspace_id=workspace_id,

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from types import SimpleNamespace
 
 import pytest
@@ -12,10 +13,26 @@ from moonmind.omnigent.host_services.workspace import (
     build_daemon_git_clone_argv,
     normalize_github_clone_source,
 )
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+    resolve_sandbox_workspace_locator,
+)
 
 
 def _request(spec: dict) -> SimpleNamespace:
-    return SimpleNamespace(workspace_spec=spec, parameters={})
+    return SimpleNamespace(
+        workspace_spec=spec,
+        parameters={},
+        step_execution=None,
+        correlation_id="workflow-1",
+        idempotency_key="step-1",
+    )
+
+
+def _workspace_id() -> str:
+    return hashlib.sha256(b"workflow-1:step-1").hexdigest()[:24]
 
 
 def test_normalize_github_clone_source_accepts_owner_repo_and_https():
@@ -80,7 +97,7 @@ async def test_materializer_clones_missing_sandbox_workspace_via_daemon(
     materializer = OmnigentWorkspaceMaterializer(
         command_runner=runner, workspace_root=tmp_path
     )
-    workspace_id = "ws-" + "a" * 12
+    workspace_id = _workspace_id()
     workspace = await materializer.materialize(
         _request(
             {
@@ -99,20 +116,36 @@ async def test_materializer_clones_missing_sandbox_workspace_via_daemon(
     argv = captured["argv"]
     assert argv[0] == "docker"
     assert f"{materializer._workspace_volume}:/work" in argv
-    assert "/work/" + workspace_id + "/repo" in argv
+    assert "/work/temporal_sandbox/" + workspace_id + "/repo" in argv
     joined = " ".join(argv)
     # The clone runs in a one-shot container with no credential helper, so the
     # remote carries launch-time GitHub auth. Assert the authenticated form.
     assert "https://x-access-token:" in joined
     assert "@github.com/MoonLadderStudios/MoonMind.git" in joined
     assert "dependabot/npm_and_yarn/multi-2181bdc769" in joined
+    record = SandboxWorkspaceRecordStore(tmp_path).load(workspace_id)
+    assert record == SandboxWorkspaceRecord(
+        workspace_id=workspace_id,
+        workflow_id="workflow-1",
+        step_execution_id="step-1",
+        relative_path="repo",
+    )
+    assert resolve_sandbox_workspace_locator(
+        SandboxWorkspaceLocator(workspaceId=workspace_id),
+        workspace_root=tmp_path,
+        expected_workspace_id=workspace_id,
+        owner_record=record,
+        expected_workflow_id="workflow-1",
+        expected_step_execution_id="step-1",
+    ) == tmp_path / "temporal_sandbox" / workspace_id / "repo"
 
 
 @pytest.mark.asyncio
 async def test_materializer_keeps_existing_authoritative_workspace(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
-    existing = tmp_path / "ws-existing" / "repo"
+    workspace_id = _workspace_id()
+    existing = tmp_path / "temporal_sandbox" / workspace_id / "repo"
     existing.mkdir(parents=True)
     (existing / "KEEP").write_text("x", encoding="utf-8")
 
@@ -127,7 +160,7 @@ async def test_materializer_keeps_existing_authoritative_workspace(
             {
                 "workspaceLocator": {
                     "kind": "sandbox",
-                    "workspaceId": "ws-existing",
+                    "workspaceId": workspace_id,
                     "relativePath": "repo",
                 },
                 "repository": "MoonLadderStudios/MoonMind",
@@ -152,7 +185,7 @@ async def test_materializer_fails_closed_without_safe_branch(tmp_path):
                 {
                     "workspaceLocator": {
                         "kind": "sandbox",
-                        "workspaceId": "ws-x",
+                        "workspaceId": _workspace_id(),
                         "relativePath": "repo",
                     },
                     "repository": "../etc/passwd",
@@ -196,7 +229,7 @@ async def test_materializer_rejects_missing_authored_path_and_failed_clone(
                 {
                     "workspaceLocator": {
                         "kind": "sandbox",
-                        "workspaceId": "ws-fail",
+                        "workspaceId": _workspace_id(),
                         "relativePath": "repo",
                     },
                     "repository": "MoonLadderStudios/MoonMind",
@@ -205,4 +238,3 @@ async def test_materializer_rejects_missing_authored_path_and_failed_clone(
             )
         )
     assert len(calls) == 1
-

--- a/tests/unit/services/test_omnigent_agent_profile_service.py
+++ b/tests/unit/services/test_omnigent_agent_profile_service.py
@@ -112,6 +112,32 @@ def test_upstream_metadata_is_allowlisted_and_bounded():
     assert "nested" not in result
 
 
+def test_builtin_opencode_agent_requires_real_catalog_name_and_uses_live_id():
+    from api_service.api.routers.omnigent_agent_profiles import (
+        _builtin_opencode_agent,
+    )
+
+    assert _builtin_opencode_agent(
+        [
+            {
+                "id": "ag_live123",
+                "name": "opencode-native-ui",
+                "version": 4,
+                "harness": "opencode-native",
+            }
+        ]
+    ) == ("ag_live123", "4")
+    assert _builtin_opencode_agent(
+        [
+            {
+                "id": "opencode-native-ui",
+                "version": 1,
+                "harness": "opencode-native",
+            }
+        ]
+    ) is None
+
+
 @pytest.mark.asyncio
 async def test_synchronize_omnigent_harness_catalog_is_one_canonical_path(
     monkeypatch: pytest.MonkeyPatch,
@@ -221,7 +247,7 @@ async def test_synchronize_omnigent_harness_catalog_propagates_endpoint_failure(
         await service_module.synchronize_omnigent_harness_catalog(session=object())
 
 
-def test_overlay_adds_stable_opencode_identity_when_endpoint_lacks_it():
+def test_overlay_adds_harness_but_never_invents_upstream_agent_identity():
     from datetime import UTC, datetime
 
     from moonmind.omnigent.harness_platform.catalog import (
@@ -268,12 +294,7 @@ def test_overlay_adds_stable_opencode_identity_when_endpoint_lacks_it():
     # The overlay is persisted as the only observation for this sync, so it
     # keeps the authenticated observation time instead of an offset.
     assert merged.snapshot.observedAt == real.snapshot.observedAt
-    agents = merged.diagnostics["agents"]
-    assert {
-        "id": "opencode-native-ui",
-        "version": "1",
-        "harness": "opencode-native",
-    } in agents
+    assert merged.diagnostics["agents"] == []
 
     # Deterministic content: a later observation of unchanged inventory
     # produces the same source digest so profile versions stay stable.
@@ -335,7 +356,7 @@ def test_overlay_skips_when_harness_present_or_support_disabled(
     assert _overlay_synthetic_opencode(empty) is empty
 
 
-def test_overlay_digest_tracks_synthetic_overlay_authority(
+def test_overlay_digest_tracks_synthetic_harness_authority(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """A changed synthetic identity must change the observation source digest."""
@@ -364,11 +385,6 @@ def test_overlay_digest_tracks_synthetic_overlay_authority(
 
     baseline = service_module._overlay_synthetic_opencode(real)
 
-    monkeypatch.setattr(service_module, "_OPENCODE_NATIVE_UI_VERSION", "2")
-    changed_agent = service_module._overlay_synthetic_opencode(real)
-    assert changed_agent.snapshot.sourceDigest != baseline.snapshot.sourceDigest
-
-    monkeypatch.setattr(service_module, "_OPENCODE_NATIVE_UI_VERSION", "1")
     original_row = service_module._synthetic_opencode_harness_row
 
     def _relabelled_row():

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -11,11 +11,11 @@ from api_service.services.omnigent_agent_profile_selection import (
     default_launch_policy_ref,
 )
 from api_service.services.omnigent_policies import bootstrap_document
-from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.execution_support_evidence import (
     EXECUTION_SUPPORT_EVIDENCE_ISSUER,
     EXECUTION_SUPPORT_EVIDENCE_VERSION,
 )
+from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.session_supervisor_rollback import (
     SUPERVISOR_ROLLBACK_POLICY_VERSION,
 )
@@ -325,6 +325,45 @@ async def _compile_opencode_plan(
         task_input_snapshot_digest="sha256:" + "1" * 64,
         execution_plan_store=plan_store,
     )
+
+
+@pytest.mark.asyncio
+async def test_resolved_skill_capabilities_drive_plan_and_mounted_tools(
+    monkeypatch,
+) -> None:
+    async def resolve_skills(**_kwargs):
+        return (
+            SimpleNamespace(
+                skills=[
+                    SimpleNamespace(required_capabilities=["git", "gh"]),
+                    SimpleNamespace(required_capabilities=["Git"]),
+                ]
+            ),
+            "art_skill_manifest",
+            "sha256:" + "5" * 64,
+            (),
+        )
+
+    monkeypatch.setattr(service, "_resolve_and_persist_skills", resolve_skills)
+
+    def resolve_evidence(plan_payload, **_kwargs):
+        return _protected_support_evidence(plan_payload), "supported"
+
+    monkeypatch.setattr(service, "resolve_execution_evidence", resolve_evidence)
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=_ArtifactService(),
+        launch_policy_ref="opencode-on-demand@1",
+        plan_store=_PlanStore(object()),
+        extra_parameters={"requiredCapabilities": ["custom-capability"]},
+    )
+
+    assert result.envelope.payload.resolvedTools["tools"] == ["gh"]
+    assert result.envelope.payload.classAdmissionDecision["requiredSatisfied"] == [
+        "custom-capability",
+        "gh",
+        "git",
+    ]
 
 
 async def _capture_plan_payload(*, launch_policy_ref: str):

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -355,15 +355,31 @@ async def test_resolved_skill_capabilities_drive_plan_and_mounted_tools(
         artifacts=_ArtifactService(),
         launch_policy_ref="opencode-on-demand@1",
         plan_store=_PlanStore(object()),
-        extra_parameters={"requiredCapabilities": ["custom-capability"]},
     )
 
     assert result.envelope.payload.resolvedTools["tools"] == ["gh"]
     assert result.envelope.payload.classAdmissionDecision["requiredSatisfied"] == [
-        "custom-capability",
         "gh",
         "git",
     ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_cannot_self_attest_an_unknown_capability(
+    monkeypatch,
+) -> None:
+    """Authored requirements are requests, never bridge support evidence."""
+
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+
+    with pytest.raises(HarnessPlatformError, match="custom-capability"):
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref="opencode-on-demand@1",
+            plan_store=_PlanStore(object()),
+            extra_parameters={"requiredCapabilities": ["custom-capability"]},
+        )
 
 
 async def _capture_plan_payload(*, launch_policy_ref: str):
@@ -634,3 +650,45 @@ async def test_deployment_evidence_for_another_model_is_inadmissible(
             plan_store=_PlanStore(None),
         )
     assert "modelConfigDigest" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_untrusted_evidence_values_are_redacted_from_admission_errors(
+    tmp_path, monkeypatch
+) -> None:
+    """Malformed evidence is never reflected into workflow-visible errors."""
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    plan_payload = await _capture_plan_payload(
+        launch_policy_ref=default_launch_policy_ref(
+            _OPENCODE_ALLOWED_LAUNCH_POLICIES
+        )
+    )
+    untrusted_value = "sensitive-candidate-value"
+    candidate_identity = plan_payload.supportIdentity.model_dump(
+        mode="json", by_alias=True
+    )
+    candidate_identity["modelConfigDigest"] = untrusted_value
+    destination = tmp_path / "deployment-execution-evidence.json"
+    destination.write_text(
+        json.dumps({"entries": [{"supportIdentity": candidate_identity}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE", str(destination)
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref=default_launch_policy_ref(
+                _OPENCODE_ALLOWED_LAUNCH_POLICIES
+            ),
+            plan_store=_PlanStore(None),
+        )
+
+    message = str(excinfo.value)
+    assert "modelConfigDigest differs" in message
+    assert untrusted_value not in message
+    assert "/api/omnigent/bootstrap/opencode/retry" not in message

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 import pytest
 
 from api_service.services import omnigent_execution_plan_service as service
+from api_service.services.omnigent_agent_profile_selection import (
+    default_launch_policy_ref,
+)
 from api_service.services.omnigent_policies import bootstrap_document
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.execution_support_evidence import (
@@ -20,6 +23,14 @@ from moonmind.schemas.omnigent_session_models import (
     OMNIGENT_SESSION_COMPATIBILITY_VERSION,
     OMNIGENT_SESSION_FEATURE_GENERATION,
 )
+
+
+# The deployment-managed OpenCode Agent Profile allows both the generic and
+# the harness-shaped launch policy; admission always selects the first.
+_OPENCODE_ALLOWED_LAUNCH_POLICIES = [
+    "omnigent-on-demand@1",
+    "opencode-on-demand@1",
+]
 
 
 class _ArtifactService:
@@ -260,3 +271,327 @@ async def test_product_boundary_persists_secret_free_plan_and_exact_realizer(
         "secretBody",
     ):
         assert forbidden not in serialized
+
+
+async def _compile_opencode_plan(
+    monkeypatch,
+    *,
+    artifacts,
+    launch_policy_ref: str,
+    plan_store=None,
+    extra_parameters: dict | None = None,
+):
+    """Compile one real OpenCode plan through the product admission boundary."""
+
+    async def resolve_policy(**_kwargs):
+        return _policy_snapshot(
+            harness="opencode-native", policy=launch_policy_ref
+        )
+
+    monkeypatch.setattr(service, "_resolve_runtime_policy_snapshot", resolve_policy)
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/example/omnigent-host@sha256:" + "7" * 64,
+    )
+    snapshot = _snapshot(
+        harness="opencode-native",
+        policy=launch_policy_ref,
+        provider_id="provider-opencode-native",
+    )
+    snapshot["allowedLaunchPolicyRefs"] = _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    snapshot["document"]["execution"][
+        "allowedLaunchPolicyRefs"
+    ] = _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    return await service.compile_and_persist_execution_plan(
+        session_factory=object(),
+        artifact_service=artifacts,
+        principal="user-1",
+        workflow_id="mm:test-deployment-evidence",
+        agent_profile_snapshot=snapshot,
+        provider_profile=SimpleNamespace(
+            profile_id="provider-opencode-native", provider_id="opencode-go"
+        ),
+        initial_parameters={
+            "model": "example/model",
+            "targetRuntime": "omnigent",
+            "publishMode": "none",
+            "maxAttempts": 2,
+            "workflow": {"instructions": "Use durable refs only."},
+            **(extra_parameters or {}),
+        },
+        authored_request_ref="art_request_1",
+        authored_request_digest="sha256:" + "1" * 64,
+        task_input_snapshot_ref="art_request_1",
+        task_input_snapshot_digest="sha256:" + "1" * 64,
+        execution_plan_store=plan_store,
+    )
+
+
+async def _capture_plan_payload(*, launch_policy_ref: str):
+    """Return the compiled plan payload deployment qualification must match.
+
+    Bootstrap qualification compiles the same plan to learn the exact support
+    identity it has to attest, so the test derives evidence the same way.
+    """
+
+    captured: dict[str, object] = {}
+
+    def _capture(plan_payload, **_kwargs):
+        captured["payload"] = plan_payload
+        raise ValueError("captured")
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(service, "resolve_execution_evidence", _capture)
+        with pytest.raises(ValueError):
+            await _compile_opencode_plan(
+                patch,
+                artifacts=_ArtifactService(),
+                launch_policy_ref=launch_policy_ref,
+            )
+    return captured["payload"]
+
+
+def _write_deployment_evidence(
+    tmp_path, monkeypatch, *, plan_payload, launch_policy_ref: str
+) -> None:
+    """Sign and publish deployment evidence for one exact combination."""
+
+    from moonmind.omnigent.bootstrap.evidence import build_deployment_evidence
+    from moonmind.omnigent.harness_platform.support import (
+        compute_support_combination_key,
+    )
+
+    identity = plan_payload.supportIdentity.model_copy(
+        update={"launchPolicyRef": launch_policy_ref}
+    )
+    evidence = build_deployment_evidence(
+        support_identity=identity,
+        support_combination_key=compute_support_combination_key(identity),
+        host_image_ref=plan_payload.hostImageRef,
+        policy_snapshot_digest=plan_payload.policySnapshotDigest,
+        effective_launch_snapshot_digest=(
+            plan_payload.effectiveLaunchSnapshotDigest
+        ),
+        provider_profile_ref="provider-opencode-native",
+        credential_generation=1,
+        qualified_model_id="example/model",
+        effort="xhigh",
+        results={"readQualification": "passed"},
+        evidence_refs={"readRun": "artifact:read-run"},
+        resolved_state=None,
+    )
+    destination = tmp_path / "deployment-execution-evidence.json"
+    destination.write_text(json.dumps(evidence), encoding="utf-8")
+    monkeypatch.setenv("MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE", str(destination))
+
+
+@pytest.mark.asyncio
+async def test_deployment_evidence_admits_the_launch_policy_admission_selects(
+    tmp_path, monkeypatch
+) -> None:
+    """Qualification derived from the Agent Profile admits the compiled plan."""
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    admitted_policy = default_launch_policy_ref(
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    )
+    plan_payload = await _capture_plan_payload(
+        launch_policy_ref=admitted_policy
+    )
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=plan_payload,
+        launch_policy_ref=admitted_policy,
+    )
+
+    artifacts = _ArtifactService()
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=artifacts,
+        launch_policy_ref=admitted_policy,
+        plan_store=_PlanStore(None),
+    )
+
+    admission = result.envelope.payload.admissionAuthority
+    assert admission is not None
+    assert admission.supportTier == "deployment_qualified"
+
+
+@pytest.mark.asyncio
+async def test_deployment_evidence_for_another_launch_policy_is_inadmissible(
+    tmp_path, monkeypatch
+) -> None:
+    """Evidence qualified for a launch policy admission never selects fails."""
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    admitted_policy = default_launch_policy_ref(
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    )
+    unselected_policy = _OPENCODE_ALLOWED_LAUNCH_POLICIES[1]
+    assert unselected_policy != admitted_policy
+    plan_payload = await _capture_plan_payload(
+        launch_policy_ref=admitted_policy
+    )
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=plan_payload,
+        launch_policy_ref=unselected_policy,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref=admitted_policy,
+            plan_store=_PlanStore(None),
+        )
+    assert "execution evidence unavailable under policy=deployment" in str(
+        excinfo.value
+    )
+
+
+def test_launch_policy_is_part_of_the_support_combination_key() -> None:
+    """A restated launch policy changes the exact combination evidence binds."""
+
+    assert default_launch_policy_ref(_OPENCODE_ALLOWED_LAUNCH_POLICIES) == (
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES[0]
+    )
+    with pytest.raises(ValueError):
+        default_launch_policy_ref([])
+
+
+@pytest.mark.asyncio
+async def test_deployment_evidence_admits_a_plan_that_requests_capabilities(
+    tmp_path, monkeypatch
+) -> None:
+    """Required capabilities are per-run intent, not a qualification dimension.
+
+    Class admission already refuses unsupported or unknown capabilities before
+    the support key exists, so binding deployment evidence to one capability
+    set would make every ordinary workflow inadmissible.
+    """
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    admitted_policy = default_launch_policy_ref(
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    )
+    plan_payload = await _capture_plan_payload(launch_policy_ref=admitted_policy)
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=plan_payload,
+        launch_policy_ref=admitted_policy,
+    )
+
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=_ArtifactService(),
+        launch_policy_ref=admitted_policy,
+        plan_store=_PlanStore(None),
+        extra_parameters={"requiredCapabilities": ["session.start"]},
+    )
+
+    payload = result.envelope.payload
+    assert payload.admissionAuthority.supportTier == "deployment_qualified"
+    # The qualified combination did not include this capability set.
+    assert (
+        payload.supportIdentity.requiredCapabilitiesDigest
+        != plan_payload.supportIdentity.requiredCapabilitiesDigest
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsupported_required_capability_is_refused_before_evidence(
+    tmp_path, monkeypatch
+) -> None:
+    """Relaxing the qualification match must not weaken the capability gate."""
+
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    admitted_policy = default_launch_policy_ref(
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    )
+    plan_payload = await _capture_plan_payload(launch_policy_ref=admitted_policy)
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=plan_payload,
+        launch_policy_ref=admitted_policy,
+    )
+
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref=admitted_policy,
+            plan_store=_PlanStore(None),
+            extra_parameters={"requiredCapabilities": ["streaming"]},
+        )
+    assert "streaming" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_deployment_evidence_for_another_model_is_inadmissible(
+    tmp_path, monkeypatch
+) -> None:
+    """Model identity stays part of the qualified combination."""
+
+    from moonmind.omnigent.harness_platform.support import (
+        compute_support_combination_key,
+    )
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", "deployment")
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    admitted_policy = default_launch_policy_ref(
+        _OPENCODE_ALLOWED_LAUNCH_POLICIES
+    )
+    plan_payload = await _capture_plan_payload(launch_policy_ref=admitted_policy)
+    drifted = plan_payload.supportIdentity.model_copy(
+        update={"modelConfigDigest": "sha256:" + "3" * 64}
+    )
+    drifted_payload = SimpleNamespace(
+        supportIdentity=drifted,
+        supportCombinationKey=compute_support_combination_key(drifted),
+        hostImageRef=plan_payload.hostImageRef,
+        policySnapshotDigest=plan_payload.policySnapshotDigest,
+        effectiveLaunchSnapshotDigest=(
+            plan_payload.effectiveLaunchSnapshotDigest
+        ),
+    )
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=drifted_payload,
+        launch_policy_ref=admitted_policy,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref=admitted_policy,
+            plan_store=_PlanStore(None),
+        )
+    assert "modelConfigDigest" in str(excinfo.value)

--- a/tests/unit/tools/test_register_omnigent_agent.py
+++ b/tests/unit/tools/test_register_omnigent_agent.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _module(name: str, **members: object) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in members.items():
+        setattr(module, key, value)
+    return module
+
+
+def test_registration_normalizes_compose_postgres_url(monkeypatch, tmp_path: Path):
+    observed: dict[str, object] = {}
+
+    class AgentStore:
+        def __init__(self, database_url: str) -> None:
+            observed["database_url"] = database_url
+
+    class ArtifactStore:
+        def __init__(self, location: str) -> None:
+            observed["artifact_location"] = location
+
+    class Cache:
+        def __init__(self, **kwargs: object) -> None:
+            observed["cache"] = kwargs
+
+    def preregister(*args: object) -> str:
+        observed["preregister"] = args
+        return "ag_live123"
+
+    monkeypatch.setitem(sys.modules, "omnigent", _module("omnigent"))
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.cli",
+        _module("omnigent.cli", _preregister_agent=preregister),
+    )
+    monkeypatch.setitem(sys.modules, "omnigent.db", _module("omnigent.db"))
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.db.utils",
+        _module(
+            "omnigent.db.utils",
+            normalize_database_url=lambda url: url.replace(
+                "postgresql://", "postgresql+psycopg://", 1
+            ),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "omnigent.runtime", _module("omnigent.runtime"))
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.runtime.agent_cache",
+        _module("omnigent.runtime.agent_cache", AgentCache=Cache),
+    )
+    monkeypatch.setitem(sys.modules, "omnigent.stores", _module("omnigent.stores"))
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.stores.agent_store",
+        _module("omnigent.stores.agent_store"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.stores.agent_store.sqlalchemy_store",
+        _module(
+            "omnigent.stores.agent_store.sqlalchemy_store",
+            SqlAlchemyAgentStore=AgentStore,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.stores.artifact_store",
+        _module("omnigent.stores.artifact_store"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "omnigent.stores.artifact_store.local",
+        _module(
+            "omnigent.stores.artifact_store.local",
+            LocalArtifactStore=ArtifactStore,
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "register_omnigent_agent", Path("tools/register_omnigent_agent.py")
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.register_agent(
+        tmp_path / "agent",
+        database_url="postgresql://omnigent:secret@postgres:5432/omnigent",
+        artifact_dir=tmp_path / "artifacts",
+    )
+
+    assert result == "ag_live123"
+    assert observed["database_url"] == (
+        "postgresql+psycopg://omnigent:secret@postgres:5432/omnigent"
+    )

--- a/tools/register_omnigent_agent.py
+++ b/tools/register_omnigent_agent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Register one portable agent bundle in an Omnigent deployment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+def register_agent(agent_source: Path, *, database_url: str, artifact_dir: Path) -> str:
+    """Execute Omnigent's canonical startup registration entrypoint."""
+
+    from omnigent.cli import _preregister_agent
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+
+    artifact_store = LocalArtifactStore(str(artifact_dir))
+    agent_store = SqlAlchemyAgentStore(database_url)
+    agent_cache = AgentCache(
+        artifact_store=artifact_store,
+        cache_dir=artifact_dir / ".cache",
+    )
+    agent_id = _preregister_agent(
+        agent_source,
+        agent_store,
+        artifact_store,
+        agent_cache,
+    )
+    if not agent_id:
+        raise RuntimeError(f"Omnigent did not register agent bundle {agent_source}")
+    return str(agent_id)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("agent_source", type=Path)
+    args = parser.parse_args()
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        parser.error("DATABASE_URL is required")
+    artifact_dir = Path(os.environ.get("ARTIFACT_DIR", "/data/artifacts"))
+    agent_id = register_agent(
+        args.agent_source,
+        database_url=database_url,
+        artifact_dir=artifact_dir,
+    )
+    print(f"registered Omnigent agent {agent_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/register_omnigent_agent.py
+++ b/tools/register_omnigent_agent.py
@@ -12,12 +12,13 @@ def register_agent(agent_source: Path, *, database_url: str, artifact_dir: Path)
     """Execute Omnigent's canonical startup registration entrypoint."""
 
     from omnigent.cli import _preregister_agent
+    from omnigent.db.utils import normalize_database_url
     from omnigent.runtime.agent_cache import AgentCache
     from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
     from omnigent.stores.artifact_store.local import LocalArtifactStore
 
     artifact_store = LocalArtifactStore(str(artifact_dir))
-    agent_store = SqlAlchemyAgentStore(database_url)
+    agent_store = SqlAlchemyAgentStore(normalize_database_url(database_url))
     agent_cache = AgentCache(
         artifact_store=artifact_store,
         cache_dir=artifact_dir / ".cache",


### PR DESCRIPTION
## Related issue

N/A

## Summary

Every OpenCode-via-Omnigent launch failed admission with `execution evidence unavailable under policy=deployment` while `/bootstrap/readiness` still reported `ready`. Deployment qualification was attesting a support combination that no compiled plan ever produces — two independent causes, both from qualification *guessing* plan inputs instead of attesting a deployment capability.

- **Launch policy was restated.** Qualification hard-coded `launch_policy_ref="opencode-on-demand@1"`; admission selects `allowedLaunchPolicyRefs[0]` from the Agent Profile (`omnigent-on-demand@1` for the UI-created profile). The launch policy is part of the support combination key, so the two never matched. Both paths now share `default_launch_policy_ref()`.
- **Required capabilities were treated as a qualification dimension.** Qualification hard-coded `workflow_requirements=[]`, so it only ever attested the zero-capability combination — which no real workflow produces. Deployment evidence now matches on `compute_deployment_qualification_key()`, a named projection that excludes `requiredCapabilitiesDigest`. Every other field stays exact.
- **Recovery was a dead end.** `POST /api/omnigent/bootstrap/opencode/retry` refused with "re-submit the API key". The Provider Profile already owns the credential, so it now re-qualifies and republishes from persisted state. `configure_opencode` and `requalify` share one `_reconcile` path.
- **Failures were opaque.** The error now names the drifting support-identity fields instead of the bare "no admissible execution evidence".

### ELI5

Qualification is the deployment saying "I have proven I can run *this exact thing*." Admission then refuses anything that is not that exact thing. The bug: qualification was describing a thing that never actually gets requested — partly because it named the wrong launch policy, partly because it baked in "a workflow that asks for no capabilities," which no real workflow is.

```
        BEFORE                                     AFTER
  qualification                               qualification
    launchPolicy = "opencode-..."   <-- X       launchPolicy = profile.allowed[0]
    requiredCaps = []               <-- X       requiredCaps = (not qualified)

  admission                                   admission
    launchPolicy = profile.allowed[0]           launchPolicy = profile.allowed[0]  -> match
    requiredCaps = ["session.start"]            requiredCaps -> class admission gate

    key mismatch: every launch fails            admitted; real drift still refused
```

### Why excluding `requiredCapabilitiesDigest` is safe

It records what one workflow asked for, not what the deployment can run, and it cannot be pre-qualified without qualifying every workflow shape in advance. The capability gate is independent and already fails closed: `compute_class_admission` raises on unsupported or unknown required capabilities *before* the support key exists. `assert_deployment_evidence_matches_plan` already scoped deployment evidence this way for policy digests; `load_deployment_evidence` was re-introducing the variance by filtering on the full combination key first.

## Test Plan

```bash
python3 -m pytest tests/unit/services/test_omnigent_execution_plan_service.py tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/api/routers/test_omnigent_bootstrap.py tests/unit/services/test_omnigent_agent_profile_selection.py tests/unit/omnigent/test_harness_platform.py tests/unit/omnigent/test_plan_and_realizer_dispatch.py -q
```

```bash
python3 -m pytest tests/unit/workflows/temporal -q -k "omnigent or evidence or session"
```

```bash
python3 -m pytest tests/unit/omnigent -q
```

```bash
python3 -m ruff check moonmind/omnigent api_service/services/omnigent_agent_profile_selection.py
```

```bash
bash tools/check_terminology.sh && python3 tools/check_documentation_architecture.py
```

Results: 81 passed across changed areas; 543 passed in the worker-side suite that also calls `assert_deployment_evidence_matches_plan`; 1737 passed in the full omnigent suite with 7 failures that are identical on unmodified `main` (`test_execute.py`, `test_phase0_generic_host_pre_session.py`). Ruff reports no new findings; terminology and documentation-architecture checks pass.

Manual verification against a live Compose deployment, replaying the real admission path per parameter variant:

```
no-caps                       ADMITTED tier=deployment_qualified
caps=session.start            ADMITTED tier=deployment_qualified
caps=session.start+interrupt  ADMITTED tier=deployment_qualified
caps=streaming                REJECTED required capabilities unsupported
effort=high                   REJECTED not qualified for the requested combination
model-override                REJECTED not qualified for the requested combination
```

Also confirmed the launch-policy regression test **fails** against the original hard-coded ref and passes with the fix.

## Demo

N/A — no dashboard or UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## AI assistance

- [ ] No material AI assistance
- [x] AI-assisted or AI-generated contribution

If AI-assisted:

- Tool or workflow used: Claude Code (Opus 5)
- What the AI helped with: root-cause diagnosis against a live deployment, the fix, tests, and docs
- What I manually reviewed: the diff, and the decision to scope `requiredCapabilitiesDigest` out of deployment qualification
- What I verified independently: retried OpenCode through the dashboard after reloading `api` and `temporal-worker-agent-runtime`

I understand that I am responsible for the final submitted change.

## Risk notes

- **Relaxes an admission gate.** Deployment evidence no longer requires an exact `requiredCapabilitiesDigest` match. This affects only the `deployment_qualified` tier; protected (`supported`) CI evidence is untouched. The capability gate itself is unchanged and still fails closed ahead of evidence resolution — pinned by `test_unsupported_required_capability_is_refused_before_evidence`.
- **Credential path touched.** `requalify()` reuses the persisted Provider Profile and never handles the API key. It refuses when no Provider Profile is persisted rather than falling back to a less-constrained path.
- **No schema or payload change.** `DeploymentExecutionEvidence` is unchanged, so already-published evidence still validates and re-signing is not required. `assert_deployment_evidence_matches_plan` is the shared authority boundary for both the API and the `agent_runtime` worker, so both sides move together — no in-flight compatibility split. No Temporal signature, payload, or history change.
- **Error text now includes support-identity fields.** These are refs and digests only (`assert_secret_free` already governs the evidence payload), so no credential exposure.
- **Operational note.** The fix takes effect only after `api` and `temporal-worker-agent-runtime` reload. Deployments whose evidence was published by the old qualification do not need to re-qualify — the matching logic changed, not the evidence.

## Coverage notes

Manual verification covered the live admission path because the failure only reproduces with a real Agent Profile, harness catalog, and published evidence. The hermetic equivalents run in CI: `test_omnigent_execution_plan_service.py` compiles real plans, signs real deployment evidence, and asserts both admission and refusal; `test_bootstrap_deployment_qualification.py` drives `_qualify_and_publish` through the real planner. `BootstrapController` previously had no test coverage at all, which is how this shipped.

## Changelog

Fixed OpenCode via Omnigent failing every launch with "execution evidence unavailable" despite reporting ready.
