### PR TITLE
feat(container-jobs): generic GPU resource requests and NVIDIA execution (MoonLadderStudios/MoonMind#3779)

### DIFF
--- a/api_service/api/routers/container_jobs.py
+++ b/api_service/api/routers/container_jobs.py
@@ -22,7 +22,10 @@ from api_service.db.base import get_async_session
 from api_service.db.models import User
 from api_service.services.container_jobs import ContainerJobService
 from moonmind.config.settings import settings
-from moonmind.mcp.container_job_tool_registry import classify_container_job_error
+from moonmind.mcp.container_job_tool_registry import (
+    classify_container_job_error,
+    classify_gpu_request_error,
+)
 from moonmind.schemas.container_job_models import (
     MAX_ARTIFACT_PAGE_ENTRIES,
     MAX_LOG_PAGE_ENTRIES,
@@ -49,13 +52,26 @@ class _RedactedValidationRoute(APIRoute):
         async def redacted_route_handler(request: Request):
             try:
                 return await route_handler(request)
-            except RequestValidationError:
+            except RequestValidationError as exc:
+                # A refused GPU resource request keeps its stable generic class
+                # so an HTTP caller classifies it exactly as an MCP caller does.
+                # Only the class and a fixed message are returned; the rejected
+                # value never leaves the service.
+                normalized = classify_gpu_request_error(exc)
                 return JSONResponse(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     content={
                         "detail": {
-                            "code": "invalid_request",
-                            "message": "Container-job request validation failed.",
+                            "code": (
+                                normalized.code
+                                if normalized is not None
+                                else "invalid_request"
+                            ),
+                            "message": (
+                                normalized.message
+                                if normalized is not None
+                                else "Container-job request validation failed."
+                            ),
                         }
                     },
                 )

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -4266,6 +4266,11 @@ class ContainerJobRecord(Base):
     authorization_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
         mutable_json_dict(), nullable=True
     )
+    # Compact generic GPU resource observation. NULL for every CPU-only job
+    # (MoonLadderStudios/MoonMind#3779).
+    gpu_observation_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True
+    )
     terminal_outcome_json: Mapped[Optional[dict[str, Any]]] = mapped_column(
         mutable_json_dict(), nullable=True
     )

--- a/api_service/migrations/versions/364_container_job_gpu_observation.py
+++ b/api_service/migrations/versions/364_container_job_gpu_observation.py
@@ -1,0 +1,31 @@
+"""Record the generic GPU resource observation for MoonLadderStudios/MoonMind#3779.
+
+Adds the compact, non-sensitive GPU resource observation to the API-owned
+container-job record. It stays NULL for every CPU-only job, so existing records
+and in-flight jobs are unaffected.
+
+Revision ID: 364_container_job_gpu_obs
+Revises: 363_merge_automation_reviews
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "364_container_job_gpu_obs"
+down_revision: Union[str, None] = "363_merge_automation_reviews"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "container_jobs",
+        sa.Column("gpu_observation_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("container_jobs", "gpu_observation_json")

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -45,6 +45,7 @@ from moonmind.schemas.container_job_models import (
     ContainerJobStatus,
     ContainerJobSubmitRequest,
     ContainerJobWorkflowInput,
+    GpuObservation,
     ImageObservation,
     OwnerIdentity,
     RegistryAuthorization,
@@ -185,6 +186,7 @@ class ContainerJobRepository:
         self, *, owner: OwnerIdentity, job_id: str, state: ContainerJobState,
         backend_kind: str | None = None, backend_ref: str | None = None,
         image: ImageObservation | None = None, terminal: TerminalOutcome | None = None,
+        gpu: GpuObservation | None = None,
         publication: AuxiliaryOutcome | None = None, cleanup: AuxiliaryOutcome | None = None,
         logs_ref: str | None = None, artifacts_ref: str | None = None,
     ) -> ContainerJobRecord:
@@ -198,6 +200,8 @@ class ContainerJobRepository:
             record.backend_ref = backend_ref
         if image is not None:
             record.image_observation_json = image.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if gpu is not None:
+            record.gpu_observation_json = gpu.model_dump(mode="json", by_alias=True, exclude_none=True)
         if terminal is not None:
             record.terminal_outcome_json = terminal.model_dump(mode="json", by_alias=True, exclude_none=True)
         if publication is not None:
@@ -322,6 +326,7 @@ class ContainerJobService:
             jobId=record.job_id, state=record.state, backendKind=record.backend_kind,
             backendRef=record.backend_ref, image=record.image_observation_json,
             authorization=record.authorization_observation_json,
+            gpu=record.gpu_observation_json,
             terminal=record.terminal_outcome_json, publication=record.publication_outcome_json,
             cleanup=record.cleanup_outcome_json, logsRef=record.logs_ref,
             artifactsRef=record.artifacts_ref, updatedAt=record.updated_at or record.created_at,

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,47 @@
 [
   {
-    "id": 3860739325,
-    "disposition": "addressed",
-    "rationale": "run.py now validates finishMode through _normalize_finish_mode: only an omitted value takes the merge default, and any other unsupported value raises a non-retryable UNSUPPORTED_MERGE_AUTOMATION_FINISH_MODE ApplicationError before a resolver child is granted merge authority."
-  },
-  {
-    "id": 3860739332,
-    "disposition": "addressed",
-    "rationale": "terminal_evidence.py now applies disposition-specific invariants for review_clean (merged=false and a non-merge action, plus no merge claim in the resolver result) and fails with UNAUTHORIZED_MERGE_EVIDENCE; the Skill's review_clean publish path adds the authoritative remote check that the PR is still unmerged."
-  },
-  {
-    "id": 3860739342,
-    "disposition": "addressed",
-    "rationale": "publish_evidence.py now matches the real production stage token full_remediation via PR_RESOLVER_REMEDIATION_STAGE, so a remediated fix_only run publishes verified/push/pushed=true instead of no_op_verified. The existing test that encoded the fictional 'full' token was corrected."
-  },
-  {
-    "id": 3860739355,
-    "disposition": "addressed",
-    "rationale": "EXIT_CODE_REVIEW_CLEAN is now 0, so pr_resolve_finalize.py and pr_resolve_orchestrate.py exit zero for this documented terminal success with or without --strict-exit-codes; the outcome stays distinguishable through status and mergeAutomationDisposition in the result JSON."
-  },
-  {
-    "id": 5028028248,
+    "id": 3869810844,
     "disposition": "not-applicable",
-    "rationale": "Codex review header comment with no actionable request; its individual findings are tracked as the four review comments above."
+    "rationale": "Alembic's script loader reads the module-level 'revision' attribute by name; it is the migration contract, not dead code. 54 of 61 migrations in api_service/migrations/versions use the identical pattern."
+  },
+  {
+    "id": 3869810851,
+    "disposition": "not-applicable",
+    "rationale": "'down_revision' is read by Alembic to build the migration graph (tools/check_alembic_graph.py depends on it). Removing it would break the single-head gate."
+  },
+  {
+    "id": 3869810860,
+    "disposition": "not-applicable",
+    "rationale": "'branch_labels' is part of Alembic's required revision-script contract and is read by the framework, not by this module."
+  },
+  {
+    "id": 3869810874,
+    "disposition": "not-applicable",
+    "rationale": "'depends_on' is part of Alembic's required revision-script contract and is read by the framework, not by this module."
+  },
+  {
+    "id": 3869810887,
+    "disposition": "addressed",
+    "rationale": "Confirmed 'datetime' and 'timezone' had no use in tests/unit/api/test_container_job_gpu_transport.py; removed the import."
+  },
+  {
+    "id": 3869824196,
+    "disposition": "addressed",
+    "rationale": "The GPU support probe's 'docker version' failure now raises a fixed caller-safe message ('container backend endpoint is unreachable'); the redacted daemon diagnostic goes only to trusted backend logs. Added tests/unit/workflows/temporal/test_container_job_gpu_resources.py::test_unreachable_endpoint_never_echoes_the_daemon_diagnostic."
+  },
+  {
+    "id": 3869824202,
+    "disposition": "addressed",
+    "rationale": "terminal_gpu_observation now resolves backendSupported=True for the new GPU_BACKEND_SUPPORTED_FAILURE_CLASSES (gpu_runtime_unavailable, gpu_resource_unavailable), which a backend can only reach after the pre-create support report succeeded, so the durable status no longer contradicts evidence obtained at the backend boundary. Covered by test_a_refusal_reports_support_only_when_the_backend_established_it and an added assertion in test_refusal_before_create_still_projects_the_requested_resource."
+  },
+  {
+    "id": 3869824210,
+    "disposition": "addressed",
+    "rationale": "_GPU_LAUNCH_FAILURE_PATTERNS is now matched most-specific-first: the bare 'nvidia-container-cli'/'nvidia-container-runtime' prefixes moved to a last-resort entry, so a working runtime with no usable device classifies as gpu_device_unavailable -> gpu_resource_unavailable. Updated the codified expectation in test_gpu_container_qualification.py and added a canonical-backend case using RUNTIME_PRESENT_DEVICE_UNAVAILABLE_STDERR."
+  },
+  {
+    "id": 5038517424,
+    "disposition": "not-applicable",
+    "rationale": "Codex review summary body; informational only, its three suggestions are tracked as the individual review comments above."
   }
 ]

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -2,7 +2,7 @@
 
 - **Status:** Desired state
 - **Owners:** MoonMind Platform
-- **Last updated:** 2026-08-10
+- **Last updated:** 2026-08-27
 - **Document class:** Canonical declarative design
 
 **Related:**
@@ -12,6 +12,7 @@
 - [`../ExternalAgents/ModelContextProtocol.md`](../ExternalAgents/ModelContextProtocol.md)
 - [`../Omnigent/CombinedStackValidationAndRollback.md`](../Omnigent/CombinedStackValidationAndRollback.md)
 - [`../Workflows/SkillAndPlanContracts.md`](../Workflows/SkillAndPlanContracts.md)
+- [`../Workflows/GpuContainerContract.md`](../Workflows/GpuContainerContract.md)
 
 ---
 
@@ -434,7 +435,12 @@ A backend-neutral request is shaped approximately as follows:
   "resources": {
     "cpu": "4",
     "memory": "8g",
-    "shmSize": "1g"
+    "shmSize": "1g",
+    "gpu": {
+      "vendor": "nvidia",
+      "count": "all",
+      "capabilities": ["compute", "utility"]
+    }
   },
   "timeoutSeconds": 3600,
   "pullPolicy": "if-missing",
@@ -451,8 +457,14 @@ plan before execution. The caller does not provide:
 - a daemon-visible host source path;
 - a Dockerfile, build context, build target, or build argument;
 - Docker socket or data-root mounts;
-- privileged mode, host namespaces, or devices;
+- privileged mode, host namespaces, or arbitrary devices;
 - MoonMind ownership-label overrides.
+
+`resources.gpu` is the one typed device resource a caller may request. It names a
+supported vendor, a device count, and optional bounded driver capabilities, and
+is absent for every CPU-only job. It is not device authority: the caller never
+supplies a device path, a runtime socket, a Docker flag, or privileged mode.
+See [GPU Container Contract](../Workflows/GpuContainerContract.md).
 
 MoonMind enriches every request with owner, workflow, run, step, session,
 expiration, idempotency, and resolved-image metadata.
@@ -639,7 +651,9 @@ Structured jobs apply:
 - dropped Linux capabilities;
 - `no-new-privileges`;
 - no host PID, IPC, user, or network namespace;
-- no arbitrary devices;
+- no arbitrary devices, and no device access at all beyond the typed
+  `resources.gpu` resource request, which is realized as the vendor's Docker
+  device request and bounded by a non-overridable deployment device ceiling;
 - no Docker socket, data-root, or host-root mounts;
 - approved workspace, artifact, scratch, and cache mounts only;
 - MoonMind-owned labels;
@@ -976,6 +990,12 @@ repository_scope_mismatch
 registry_auth_failed
 credential_cleanup_failed
 resource_limit_exceeded
+gpu_request_invalid
+gpu_vendor_unsupported
+gpu_count_unsupported
+gpu_backend_unsupported
+gpu_runtime_unavailable
+gpu_resource_unavailable
 container_start_failed
 workload_failed
 workload_timed_out

--- a/docs/Workflows/GpuContainerContract.md
+++ b/docs/Workflows/GpuContainerContract.md
@@ -2,12 +2,12 @@
 
 **Document Class:** Canonical declarative
 **Status:** Current
-**Updated:** 2026-08-26
+**Updated:** 2026-08-27
 **Audience:** Contributors and runtime authors
 **Authority:** Target semantics for caller-supplied GPU containers on MoonMind's container boundaries
 **Owning Surface:** moonmind/workloads/, moonmind/schemas/container_job_models.py
 **Related Docs:** [Skill and Plan Contracts](SkillAndPlanContracts.md), [Workflow Architecture](WorkflowArchitecture.md)
-**Related Implementation:** `moonmind/workloads/gpu.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/schemas/container_job_models.py`, `moonmind/workflows/temporal/container_job_backend.py` (MoonLadderStudios/MoonMind#3777)
+**Related Implementation:** `moonmind/workloads/gpu.py`, `moonmind/workloads/docker_launcher.py`, `moonmind/schemas/container_job_models.py`, `moonmind/workflows/temporal/container_job_backend.py` (MoonLadderStudios/MoonMind#3777, MoonLadderStudios/MoonMind#3779)
 
 MoonMind executes a caller-supplied NVIDIA GPU container through the same
 container boundaries it uses for every other container. The GPU is a resource
@@ -29,13 +29,21 @@ its semantics to MoonMind.
 |---|---|---|
 | `vendor` | `nvidia` | `nvidia` |
 | `count` | `all` or a positive integer | `all` |
+| `capabilities` | one or more of `compute`, `compat32`, `graphics`, `utility`, `video`, `display` | absent (the vendor's default device capability set) |
 
-An unsupported vendor, a non-positive count, or an unknown field is rejected at
-request validation with an actionable error. `count` is validated before
-coercion, so `true`, `"2"`, and `2.0` are rejected rather than realized as
-device counts the caller never declared. The GPU request travels on the same
-request as the caller's image, command, entrypoint, workdir, environment, cache
-mounts, network mode, timeout, and declared outputs.
+An unsupported vendor, a non-positive count, an unknown capability, an empty
+capability list, or an unknown field is rejected at request validation with an
+actionable error and a stable class (see **Failure classification**). `count` is
+validated before coercion, so `true`, `"2"`, and `2.0` are rejected rather than
+realized as device counts the caller never declared. `capabilities` are bounded
+vendor driver capability names -- never device paths, runtime sockets, or Docker
+options -- and are deduplicated and canonically ordered, so one semantic request
+always serializes to the same durable bytes and the same device request. An
+omitted `capabilities` field stays absent from the serialized request, so a
+request recorded before the field existed is byte-identical to the same request
+made today. The GPU request travels on the same request as the caller's image,
+command, entrypoint, workdir, environment, cache mounts, network mode, timeout,
+and declared outputs.
 
 This one request contract is shared by both container boundaries:
 
@@ -50,16 +58,43 @@ field. The tool schema, the closed request model, the deployment ceiling, and
 the container-job backend all carry the field, so a new plan never depends on
 the replay-only launch path to reach a device.
 
+### Moving an unrestricted GPU request to `container.submit`
+
+The semantic GPU request is the same object on both routes, so the move changes
+only the envelope around it. Nothing about the workload changes: the image
+reference, the command argv, the declared-output relative paths, and the
+artifact interpretation are carried across unmodified.
+
+| Unrestricted field | Canonical field | Note |
+|---|---|---|
+| `resources.gpu` | `spec.resources.gpu` | The identical `WorkloadGpuRequest`; no translation |
+| `image` | `spec.image` | Unchanged caller-owned reference |
+| `command` / `entrypoint` | `spec.command` / `spec.entrypoint` | Unchanged argv |
+| `repoDir` / `artifactsDir` / `scratchDir` (absolute host paths) | `spec.workspaceRef` (a logical #3147 locator) plus `spec.workdir` | The caller stops naming host paths; the workspace is mounted at `/workspace` |
+| `declaredOutputs` (class to relative path) | `spec.outputs` (name and `relativePath`) | Same relative paths, resolved under the job workspace |
+| `cacheMounts` (named volume plus target) | `spec.caches` (`cacheRef` plus target) | The deployment owns the volume; the caller names an approved cache ref |
+| `envOverrides` | `spec.environment` | Sensitive values move to `secretRef` |
+| `timeoutSeconds` | `spec.timeoutSeconds` | Unchanged |
+| result metadata `workload.gpu` | `ContainerJobStatus.gpu` plus the terminal failure class | Bounded observation instead of launcher metadata |
+
+Canonical submission additionally requires an `idempotencyKey` and a `source`
+correlation, and returns a `jobId` to poll instead of a synchronous result.
+
 ## Authority boundaries
 
 - **Canonical container-job path.** `ContainerJobSpec.resources.gpu` is admitted
   by the deployment's non-overridable device ceiling
   (`MOONMIND_CONTAINER_BACKEND_MAX_GPU_COUNT`) and then realized by the
   container-job backend as the vendor's Docker device request. An unset ceiling
-  imposes no MoonMind bound, so host capability remains the gate; a finite
+  imposes no MoonMind bound, so host capability remains the only limit; a finite
   ceiling rejects both a higher count and the unbounded `all` with
-  `resource_limit_exceeded` rather than silently clamping a billing-relevant
-  value; `0` refuses every device request on that deployment.
+  `gpu_count_unsupported` rather than silently clamping a billing-relevant
+  value; `0` refuses every device request on that deployment. Before anything is
+  created, the backend reports whether the selected daemon supports the
+  requested resource at all: a vendor it cannot realize is refused with
+  `gpu_vendor_unsupported`, and a daemon predating the device-request API
+  (Docker Engine 19.03) is refused with `gpu_backend_unsupported` rather than
+  running the caller's workload without the resource it asked for.
 - **Unrestricted container path.** `container.run_container` under
   `workflow_docker_mode=unrestricted` realizes the GPU request as the vendor's
   Docker device request (`--gpus all`, or `--gpus <count>`). Request validation
@@ -97,16 +132,67 @@ metadata. Cleanup never removes the image and never removes named cache volumes,
 so a later request reuses both. `docker run` keeps its default if-missing image
 behavior.
 
-Every run records generic GPU observations under
+Every unrestricted run records generic GPU observations under
 `metadata.workload.gpu`: the caller's request, the realized device-request
 arguments, and a launch failure classification. CPU-only requests record `null`
 there and are otherwise unchanged.
 
+Every canonical container job that requested a GPU records one bounded
+`GpuObservation` in the durable job record (`container_jobs.gpu_observation_json`)
+and projects it as `ContainerJobStatus.gpu`:
+
+| Field | Meaning |
+|---|---|
+| `vendor`, `count`, `capabilities` | The caller's own semantic request, unchanged |
+| `backendSupported` | Whether the selected daemon reported support for the requested resource |
+| `launched` | Whether the container actually started carrying the device request |
+| `failureClass` | The stable generic class when the resource was refused, otherwise absent |
+
+The observation is request-identified: it always describes what the caller
+submitted, so a job refused before the backend reported anything still projects
+the resource it asked for. It deliberately carries no Docker device-request
+structure, flag, device path, endpoint, driver version, or ownership label, so it
+is safe to persist, to project to the caller, and to cross Temporal workflow
+history. A CPU-only job has no observation at all, and its request, Temporal
+payloads, and durable record are byte-identical to before this field existed.
+
+Canonical job cleanup removes only the run-owned container. It never removes the
+image and never removes a deployment-approved shared cache volume, so a device
+count or capability change never invalidates a warm image or cache.
+
 ## Failure classification
 
+### Canonical container-job classes
+
+A canonical job refuses an unsupported GPU resource before the caller's workload
+executes, with one stable generic class. No class names a vendor product, an
+application, or a framework.
+
+| Class | Raised when | Where |
+|---|---|---|
+| `gpu_request_invalid` | The GPU request is malformed: an unknown capability, an empty capability list, an unknown field, or a wrong JSON type | HTTP and MCP submission, before durable identity exists |
+| `gpu_vendor_unsupported` | The requested vendor is not supported by the contract, or not realizable by the selected backend | Submission, then again at the trusted backend |
+| `gpu_count_unsupported` | The device count is not a positive integer or `all`, or exceeds the deployment device ceiling | Submission, then again at the trusted backend |
+| `gpu_backend_unsupported` | The selected daemon has no device-request API, or refused to select a device driver | Trusted backend, before or during container start |
+| `gpu_runtime_unavailable` | The vendor container runtime is missing or failed to initialize | Trusted backend, at container start |
+| `gpu_resource_unavailable` | The runtime is present but exposed no usable device | Trusted backend, at container start |
+
+A submission refusal is classified from the request contract's own typed
+refusal, not from an error string, so HTTP and MCP callers receive the identical
+class and neither response echoes the rejected value. A launch refusal is
+classified from the daemon's own diagnostic through the shared classifier below;
+the diagnostic itself is never echoed, because it can name trusted host paths
+and endpoints. Ordinary image, workspace, launch, execution, timeout,
+cancellation, artifact, and cleanup failures keep their existing classes, and a
+container that started and then exited nonzero remains `execution`.
+
+### Shared launch-refusal evidence
+
 Docker's refusal of the device request is reported distinctly from an ordinary
-container process exit. A refusal carries `failureClass =
-gpu_device_request_rejected` and one of these generic reasons:
+container process exit. On the unrestricted path a refusal carries `failureClass
+= gpu_device_request_rejected` and one of these generic reasons, which the
+canonical backend maps to `gpu_runtime_unavailable`, `gpu_resource_unavailable`,
+or `gpu_backend_unsupported`:
 
 | Reason | Meaning |
 |---|---|
@@ -115,10 +201,13 @@ gpu_device_request_rejected` and one of these generic reasons:
 | `device_request_unsupported` | The daemon or client does not understand the device request |
 | `gpu_device_request_rejected` | The daemon refused the device request for another reason |
 
-A refusal is recognized only from objective launch-refusal evidence: Docker
-itself must report its own launch-failure exit status (125) *and* stderr must
-carry a vendor/runtime diagnostic. A container that started and exited nonzero
-carries no GPU failure class even when its own stderr names NVML,
+A refusal is recognized only from objective launch-refusal evidence: stderr must
+carry a vendor/runtime diagnostic. Where one `docker run` merges the launch phase
+with the application's own exit, Docker must additionally report its own
+launch-failure exit status (125); where the launch phase is its own command --
+the canonical backend's container create and start -- that command's failure
+already cannot be an application exit. A container that started and exited
+nonzero carries no GPU failure class even when its own stderr names NVML,
 `nvidia-container-cli`, or a device driver, because Docker forwards the
 application's output verbatim. An unreachable Docker daemon, an unavailable or
 unauthorized image, and a missing workspace bind are ordinary generic launch
@@ -129,11 +218,18 @@ failures, never GPU refusals.
 Qualification runs in two layers.
 
 **CPU-capable contract fixtures** (`tests/unit/workloads/`,
-`tests/unit/workflows/temporal/test_gpu_container_dispatch.py`) run on any
+`tests/unit/workflows/temporal/test_gpu_container_dispatch.py`,
+`tests/unit/workflows/temporal/test_container_job_gpu_resources.py`,
+`tests/unit/api/test_container_job_gpu_transport.py`) run on any
 runner against a synthetic Docker launcher and cover request validation,
 serialization and dispatch, Docker command construction, workspace and output
 mounts, logs, timeout, cancellation, cleanup, image and command preservation,
-warm reuse, and the negative matrix.
+warm reuse, and the negative matrix. The canonical fixtures additionally cover
+the durable round trip -- HTTP and MCP submission, idempotent replay, the durable
+record, the trusted-worker projection, and the projected status observation --
+the pre-start support report, each stable failure class, and the proof that one
+semantic request realizes the identical device request on both container
+boundaries.
 `tests/unit/workloads/test_gpu_container_genericity_guard.py` statically fails
 if a production GPU module or a qualification fixture acquires a game name, an
 engine filename/argument/cache name, a project image constant, project
@@ -142,7 +238,13 @@ gate/scenario/proof/bundle parsing, or a repository-specific condition.
 **Real NVIDIA integration**
 (`tests/integration/workloads/test_nvidia_container_qualification_journey.py`)
 runs a caller-supplied GPU workload on a deployment-owned GPU host through the
-same trusted Docker boundary used in production. It is marked `requires_gpu`,
+same trusted Docker boundary used in production, on both container boundaries:
+the unrestricted `workload.run` route and the canonical container-job backend
+driven through its real Activity sequence (workspace resolution, image
+acquisition, create, start, observe, evidence publication, removal, cleanup).
+The canonical leg asserts the resolved GPU observation, the collected declared
+output, a surviving image, and that a device count above the deployment ceiling
+is refused with `gpu_count_unsupported` before any workload runs. It is marked `requires_gpu`,
 is excluded from required CI, and skips on a CPU-only runner with an explicit
 environment reason. Preflight probes actual device availability with one bounded
 device-bearing container, so a host with the NVIDIA runtime registered but no
@@ -183,6 +285,8 @@ workspace (`MOONMIND_GPU_QUALIFICATION_RECORD_DIR`, default
 `var/gpu_qualification`), and the operator command prints each published path,
 so a successful qualification always leaves citable evidence behind.
 
-Because the record and the request contract are generic, this qualification is
-rerunnable against a future canonical container path without changing workload
-semantics.
+Because the record and the request contract are generic, the same qualification
+runs against both container boundaries without changing workload semantics: a
+repository-owned skill moves from the unrestricted route to `container.submit`
+by re-enveloping the request, not by rewriting its image, command, or artifact
+interpretation.

--- a/docs/Workflows/GpuContainerContract.md
+++ b/docs/Workflows/GpuContainerContract.md
@@ -150,7 +150,11 @@ and projects it as `ContainerJobStatus.gpu`:
 
 The observation is request-identified: it always describes what the caller
 submitted, so a job refused before the backend reported anything still projects
-the resource it asked for. It deliberately carries no Docker device-request
+the resource it asked for. A refusal the backend can only reach after it
+reported support -- `gpu_runtime_unavailable` and `gpu_resource_unavailable`, both
+raised at container create or start -- reports `backendSupported = true`, because
+the class itself is that evidence and the refusal is raised before an
+observation can be returned. It deliberately carries no Docker device-request
 structure, flag, device path, endpoint, driver version, or ownership label, so it
 is safe to persist, to project to the caller, and to cross Temporal workflow
 history. A CPU-only job has no observation at all, and its request, Temporal
@@ -200,6 +204,13 @@ or `gpu_backend_unsupported`:
 | `gpu_device_unavailable` | The runtime is present but exposed no usable device |
 | `device_request_unsupported` | The daemon or client does not understand the device request |
 | `gpu_device_request_rejected` | The daemon refused the device request for another reason |
+
+The diagnostic is matched most-specific-first. The vendor stack reports a device
+failure *through* its own tooling, so a host with a working runtime and no usable
+device names both the generic `nvidia-container-cli` prefix and a specific device
+condition; the specific condition decides the reason, and a bare vendor-stack
+prefix is the last resort. Otherwise an operator would be directed at repairing a
+runtime that already works instead of at device capacity.
 
 A refusal is recognized only from objective launch-refusal evidence: stderr must
 carry a vendor/runtime diagnostic. Where one `docker run` merges the launch phase

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6836,7 +6836,7 @@ export interface components {
          * ContainerJobFailureClass
          * @enum {string}
          */
-        ContainerJobFailureClass: "validation" | "authorization" | "workspace" | "image" | "image_not_found" | "image_pull_timeout" | "image_pull_auth_failed" | "image_build_not_configured" | "image_build_inputs_unavailable" | "image_build_timeout" | "image_build_failed" | "image_validation_failed" | "image_platform_mismatch" | "image_backend_unavailable" | "launch" | "execution" | "timeout" | "canceled" | "infrastructure" | "temporal_start" | "image_use_denied" | "credential_unresolved" | "repository_scope_mismatch" | "registry_auth_failed" | "credential_cleanup_failed" | "resource_limit_exceeded";
+        ContainerJobFailureClass: "validation" | "authorization" | "workspace" | "image" | "image_not_found" | "image_pull_timeout" | "image_pull_auth_failed" | "image_build_not_configured" | "image_build_inputs_unavailable" | "image_build_timeout" | "image_build_failed" | "image_validation_failed" | "image_platform_mismatch" | "image_backend_unavailable" | "launch" | "execution" | "timeout" | "canceled" | "infrastructure" | "temporal_start" | "image_use_denied" | "credential_unresolved" | "repository_scope_mismatch" | "registry_auth_failed" | "credential_cleanup_failed" | "resource_limit_exceeded" | "gpu_request_invalid" | "gpu_vendor_unsupported" | "gpu_count_unsupported" | "gpu_backend_unsupported" | "gpu_runtime_unavailable" | "gpu_resource_unavailable";
         /** ContainerJobLogEntry */
         ContainerJobLogEntry: {
             /** Sequence */
@@ -6929,6 +6929,7 @@ export interface components {
             backendRef?: string | null;
             image?: components["schemas"]["ImageObservation"] | null;
             authorization?: components["schemas"]["RegistryAuthorization"] | null;
+            gpu?: components["schemas"]["GpuObservation"] | null;
             terminal?: components["schemas"]["TerminalOutcome"] | null;
             publication?: components["schemas"]["AuxiliaryOutcome"];
             cleanup?: components["schemas"]["AuxiliaryOutcome"];
@@ -9223,6 +9224,36 @@ export interface components {
             mode: "indexing" | "publish" | "readiness" | "full_pr_automation";
             /** Basebranch */
             baseBranch?: string | null;
+        };
+        /**
+         * GpuObservation
+         * @description Bounded, non-sensitive observation of one resolved GPU resource request.
+         *
+         *     It records the caller's semantic request, whether the selected backend
+         *     reported support for it, whether the container was launched carrying it, and
+         *     the stable generic classification when it was refused. It deliberately
+         *     carries no Docker device-request structure, flag, device path, endpoint,
+         *     driver version, or ownership label, so it is safe to persist, to project to
+         *     the caller, and to cross Temporal workflow history.
+         */
+        GpuObservation: {
+            /**
+             * Vendor
+             * @constant
+             */
+            vendor: "nvidia";
+            /** Count */
+            count: number | "all";
+            /** Capabilities */
+            capabilities?: ("compute" | "compat32" | "graphics" | "utility" | "video" | "display")[] | null;
+            /** Backendsupported */
+            backendSupported?: boolean | null;
+            /**
+             * Launched
+             * @default false
+             */
+            launched: boolean;
+            failureClass?: components["schemas"]["ContainerJobFailureClass"] | null;
         };
         /**
          * GuidedProfileCreate
@@ -14475,10 +14506,15 @@ export interface components {
          * WorkloadGpuRequest
          * @description Caller-supplied generic GPU resource request for one container.
          *
-         *     This is ordinary request data: the caller names a supported GPU vendor and
-         *     how many devices the container needs. MoonMind realizes it as the vendor's
-         *     Docker device request and never infers it from the image, the command, or
-         *     any repository-specific condition.
+         *     This is ordinary request data: the caller names a supported GPU vendor, how
+         *     many devices the container needs, and optionally which of the vendor
+         *     driver's published capabilities to expose. MoonMind realizes it as the
+         *     vendor's Docker device request and never infers it from the image, the
+         *     command, or any repository-specific condition.
+         *
+         *     ``capabilities`` is absent by default, which requests the vendor's default
+         *     device capability set. Declaring it never widens authority: the values are
+         *     bounded driver capability names, not device paths or Docker options.
          */
         WorkloadGpuRequest: {
             /**
@@ -14492,6 +14528,8 @@ export interface components {
              * @default all
              */
             count: number | "all";
+            /** Capabilities */
+            capabilities?: ("compute" | "compat32" | "graphics" | "utility" | "video" | "display")[] | null;
         };
         /** WorkspaceDefaults */
         WorkspaceDefaults: {

--- a/moonmind/mcp/container_job_tool_registry.py
+++ b/moonmind/mcp/container_job_tool_registry.py
@@ -18,8 +18,10 @@ from moonmind.schemas.container_job_models import (
     MAX_ARTIFACT_PAGE_ENTRIES,
     MAX_LOG_PAGE_ENTRIES,
     ContainerJobCancelRequest,
+    ContainerJobFailureClass,
     ContainerJobLogQuery,
     ContainerJobSubmitRequest,
+    gpu_failure_class_from_validation_error,
 )
 from moonmind.mcp.tool_registry import (
     ToolArgumentsValidationError,
@@ -46,6 +48,40 @@ class ContainerJobToolError(RuntimeError):
         self.http_status = http_status
 
 
+#: Stable caller-facing messages for a refused GPU resource request. The
+#: rejected value itself is never echoed back to the caller.
+_GPU_REQUEST_MESSAGES: dict[ContainerJobFailureClass, str] = {
+    ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED: (
+        "Container-job GPU vendor is not supported."
+    ),
+    ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED: (
+        "Container-job GPU device count is not supported."
+    ),
+    ContainerJobFailureClass.GPU_REQUEST_INVALID: (
+        "Container-job GPU resource request is invalid."
+    ),
+}
+
+
+def classify_gpu_request_error(exc: BaseException) -> ContainerJobToolError | None:
+    """Return the stable GPU classification for a refused submission, if any.
+
+    A GPU resource request is refused before execution with the same stable
+    class over every transport, so a caller can distinguish an unsupported
+    vendor, an unsupported device count, and a malformed request from an
+    unrelated invalid submission.
+    """
+
+    failure_class = gpu_failure_class_from_validation_error(exc)
+    if failure_class is None:
+        return None
+    return ContainerJobToolError(
+        code=failure_class.value,
+        message=_GPU_REQUEST_MESSAGES[failure_class],
+        http_status=422,
+    )
+
+
 def classify_container_job_error(exc: Exception) -> ContainerJobToolError:
     """Map a service/validation error to a stable transport-neutral classification."""
 
@@ -60,7 +96,7 @@ def classify_container_job_error(exc: Exception) -> ContainerJobToolError:
     if isinstance(exc, ContainerJobToolError):
         return exc
     if isinstance(exc, (ValidationError, ToolArgumentsValidationError, ValueError)):
-        return ContainerJobToolError(
+        return classify_gpu_request_error(exc) or ContainerJobToolError(
             code="invalid_request",
             message="Container-job request validation failed.",
             http_status=422,
@@ -323,4 +359,5 @@ __all__ = [
     "ContainerJobToolError",
     "ContainerJobToolRegistry",
     "classify_container_job_error",
+    "classify_gpu_request_error",
 ]

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -10,7 +10,12 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from moonmind.schemas.workload_models import WorkloadGpuRequest
+from moonmind.schemas.workload_models import (
+    WorkloadGpuCapability,
+    WorkloadGpuRequest,
+    WorkloadGpuRequestError,
+    WorkloadGpuVendor,
+)
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
     ManagedWorkspaceLocator,
@@ -125,6 +130,15 @@ class ContainerJobFailureClass(StrEnum):
     REGISTRY_AUTH_FAILED = "registry_auth_failed"
     CREDENTIAL_CLEANUP_FAILED = "credential_cleanup_failed"
     RESOURCE_LIMIT_EXCEEDED = "resource_limit_exceeded"
+    # Generic accelerator/GPU resource outcomes (#3779). Every value describes a
+    # resource-request decision the service made; none names a vendor product,
+    # an application, or a framework.
+    GPU_REQUEST_INVALID = "gpu_request_invalid"
+    GPU_VENDOR_UNSUPPORTED = "gpu_vendor_unsupported"
+    GPU_COUNT_UNSUPPORTED = "gpu_count_unsupported"
+    GPU_BACKEND_UNSUPPORTED = "gpu_backend_unsupported"
+    GPU_RUNTIME_UNAVAILABLE = "gpu_runtime_unavailable"
+    GPU_RESOURCE_UNAVAILABLE = "gpu_resource_unavailable"
 
 
 class AuxiliaryOutcomeState(StrEnum):
@@ -526,6 +540,146 @@ class ImageObservation(ContractModel):
     build_duration_ms: int | None = Field(None, alias="buildDurationMs", ge=0)
 
 
+class GpuObservation(ContractModel):
+    """Bounded, non-sensitive observation of one resolved GPU resource request.
+
+    It records the caller's semantic request, whether the selected backend
+    reported support for it, whether the container was launched carrying it, and
+    the stable generic classification when it was refused. It deliberately
+    carries no Docker device-request structure, flag, device path, endpoint,
+    driver version, or ownership label, so it is safe to persist, to project to
+    the caller, and to cross Temporal workflow history.
+    """
+
+    vendor: WorkloadGpuVendor
+    count: int | Literal["all"]
+    capabilities: tuple[WorkloadGpuCapability, ...] | None = None
+    backend_supported: bool | None = Field(None, alias="backendSupported")
+    launched: bool = False
+    failure_class: ContainerJobFailureClass | None = Field(None, alias="failureClass")
+
+
+#: Stable generic classifications that describe a GPU resource decision. A
+#: terminal outcome carrying one of these is a GPU refusal; anything else is an
+#: ordinary image, workspace, launch, execution, timeout, or cleanup failure.
+GPU_FAILURE_CLASSES: frozenset[ContainerJobFailureClass] = frozenset(
+    {
+        ContainerJobFailureClass.GPU_REQUEST_INVALID,
+        ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED,
+        ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED,
+        ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+        ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE,
+        ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
+    }
+)
+
+
+def gpu_observation(
+    gpu: WorkloadGpuRequest | None,
+    *,
+    backend_supported: bool | None = None,
+    launched: bool = False,
+) -> GpuObservation | None:
+    """Return the backend's observation of ``gpu``, or ``None`` when CPU-only."""
+
+    if gpu is None:
+        return None
+    return GpuObservation(
+        vendor=gpu.vendor,
+        count=gpu.count,
+        capabilities=gpu.capabilities,
+        backendSupported=backend_supported,
+        launched=launched,
+    )
+
+
+def terminal_gpu_observation(
+    *,
+    gpu: WorkloadGpuRequest | None,
+    observed: GpuObservation | None,
+    failure_class: ContainerJobFailureClass | None,
+) -> GpuObservation | None:
+    """Return the terminal GPU observation for one job, or ``None`` when CPU-only.
+
+    The submitted request is always the identity: only the resolved
+    support/launch evidence is taken from ``observed``, so a job that failed
+    before the backend reported anything still projects what it requested. A
+    non-GPU terminal class is dropped here because it belongs to the terminal
+    outcome, not to the GPU resource decision.
+    """
+
+    if gpu is None:
+        return None
+    return GpuObservation(
+        vendor=gpu.vendor,
+        count=gpu.count,
+        capabilities=gpu.capabilities,
+        backendSupported=(
+            observed.backend_supported if observed is not None else None
+        ),
+        launched=bool(observed.launched) if observed is not None else False,
+        failureClass=(
+            failure_class if failure_class in GPU_FAILURE_CLASSES else None
+        ),
+    )
+
+
+_GPU_REQUEST_FAILURE_CLASSES: dict[str, ContainerJobFailureClass] = {
+    "gpu_request_invalid": ContainerJobFailureClass.GPU_REQUEST_INVALID,
+    "gpu_vendor_unsupported": ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED,
+    "gpu_count_unsupported": ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED,
+}
+
+
+def _gpu_request_failure_class(exc: BaseException) -> ContainerJobFailureClass | None:
+    """Map one typed GPU request refusal to its stable failure class."""
+
+    if isinstance(exc, WorkloadGpuRequestError):
+        return _GPU_REQUEST_FAILURE_CLASSES.get(exc.gpu_failure)
+    return None
+
+
+def gpu_failure_class_from_validation_error(
+    exc: BaseException,
+) -> ContainerJobFailureClass | None:
+    """Recover the stable GPU classification from a rejected submission.
+
+    The GPU request contract raises a typed refusal that pydantic preserves in
+    its validation-error context, so the reason is read from that typed value
+    rather than re-derived from an error string. A structural rejection inside
+    the ``gpu`` field -- an unknown field or a wrong JSON type, which pydantic
+    refuses before any validator runs -- classifies as an invalid GPU request.
+    """
+
+    for current in _exception_chain(exc):
+        direct = _gpu_request_failure_class(current)
+        if direct is not None:
+            return direct
+        errors = getattr(current, "errors", None)
+        if not callable(errors):
+            continue
+        try:
+            line_errors = list(errors())
+        except TypeError:
+            continue
+        structural: ContainerJobFailureClass | None = None
+        for line_error in line_errors:
+            if not isinstance(line_error, dict):
+                continue
+            context = line_error.get("ctx")
+            nested = context.get("error") if isinstance(context, dict) else None
+            if isinstance(nested, BaseException):
+                typed = _gpu_request_failure_class(nested)
+                if typed is not None:
+                    return typed
+            location = line_error.get("loc") or ()
+            if "gpu" in tuple(str(part) for part in location):
+                structural = ContainerJobFailureClass.GPU_REQUEST_INVALID
+        if structural is not None:
+            return structural
+    return None
+
+
 class TerminalOutcome(ContractModel):
     exit_code: int | None = Field(None, alias="exitCode")
     failure_class: ContainerJobFailureClass | None = Field(None, alias="failureClass")
@@ -545,6 +699,9 @@ class ContainerJobStatus(TemporalContractModel):
     backend_ref: str | None = Field(None, alias="backendRef", max_length=255)
     image: ImageObservation | None = None
     authorization: RegistryAuthorization | None = None
+    # Absent for every CPU-only job; present whenever the caller requested a
+    # GPU resource, including a job refused before the container started.
+    gpu: GpuObservation | None = None
     terminal: TerminalOutcome | None = None
     publication: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
     cleanup: AuxiliaryOutcome = Field(default_factory=lambda: AuxiliaryOutcome(state="not_attempted"))
@@ -732,6 +889,7 @@ class ContainerJobActivityRequest(TemporalContractModel):
     image_observation: ImageObservation | None = Field(
         None, alias="imageObservation"
     )
+    gpu_observation: GpuObservation | None = Field(None, alias="gpuObservation")
     container_ref: str | None = Field(None, alias="containerRef", max_length=1024)
     egress_attestation_ref: str | None = Field(
         None, alias="egressAttestationRef", max_length=1024
@@ -784,6 +942,7 @@ class ContainerJobActivityResult(TemporalContractModel):
     image_observation: ImageObservation | None = Field(
         None, alias="imageObservation"
     )
+    gpu_observation: GpuObservation | None = Field(None, alias="gpuObservation")
     container_ref: str | None = Field(None, alias="containerRef", max_length=1024)
     running: bool | None = None
     terminal_state: ContainerJobState | None = Field(None, alias="terminalState")

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -574,6 +574,20 @@ GPU_FAILURE_CLASSES: frozenset[ContainerJobFailureClass] = frozenset(
 )
 
 
+#: Stable classifications a trusted backend can only reach *after* it reported
+#: backend support for the request: the daemon accepted the vendor and the
+#: device-request API, and only then refused the actual runtime or device when
+#: the container was created or started. The class is therefore itself the
+#: support evidence, so the observation survives an activity that raised before
+#: it could return the support report it had already obtained.
+GPU_BACKEND_SUPPORTED_FAILURE_CLASSES: frozenset[ContainerJobFailureClass] = frozenset(
+    {
+        ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE,
+        ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
+    }
+)
+
+
 def gpu_observation(
     gpu: WorkloadGpuRequest | None,
     *,
@@ -606,21 +620,31 @@ def terminal_gpu_observation(
     before the backend reported anything still projects what it requested. A
     non-GPU terminal class is dropped here because it belongs to the terminal
     outcome, not to the GPU resource decision.
+
+    A refusal the backend can only reach after it reported support carries that
+    support evidence itself: the activity that obtained the report raised before
+    it could return one, so the durable status would otherwise contradict
+    evidence that was actually obtained at the backend boundary.
     """
 
     if gpu is None:
         return None
+    gpu_failure_class = (
+        failure_class if failure_class in GPU_FAILURE_CLASSES else None
+    )
+    observed_support = observed.backend_supported if observed is not None else None
+    if (
+        observed_support is None
+        and gpu_failure_class in GPU_BACKEND_SUPPORTED_FAILURE_CLASSES
+    ):
+        observed_support = True
     return GpuObservation(
         vendor=gpu.vendor,
         count=gpu.count,
         capabilities=gpu.capabilities,
-        backendSupported=(
-            observed.backend_supported if observed is not None else None
-        ),
+        backendSupported=observed_support,
         launched=bool(observed.launched) if observed is not None else False,
-        failureClass=(
-            failure_class if failure_class in GPU_FAILURE_CLASSES else None
-        ),
+        failureClass=gpu_failure_class,
     )
 
 

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -64,6 +64,33 @@ WorkloadDeviceMode = Literal["none"]
 WorkloadReadinessProbeType = Literal["exec"]
 WorkloadGpuVendor = Literal["nvidia"]
 WORKLOAD_GPU_VENDORS: tuple[WorkloadGpuVendor, ...] = ("nvidia",)
+#: Bounded generic driver capabilities a caller may request for a GPU device.
+#: These are the vendor driver's own published capability names, not MoonMind
+#: vocabulary and not an application type. The declaration order below is the
+#: canonical serialization order, so one semantic request always serializes
+#: identically regardless of how the caller ordered it.
+WorkloadGpuCapability = Literal[
+    "compute",
+    "compat32",
+    "graphics",
+    "utility",
+    "video",
+    "display",
+]
+WORKLOAD_GPU_CAPABILITIES: tuple[WorkloadGpuCapability, ...] = (
+    "compute",
+    "compat32",
+    "graphics",
+    "utility",
+    "video",
+    "display",
+)
+#: Stable reasons a generic GPU resource request is refused at validation.
+WorkloadGpuRequestFailure = Literal[
+    "gpu_request_invalid",
+    "gpu_vendor_unsupported",
+    "gpu_count_unsupported",
+]
 
 def parse_cpu_units(value: str) -> float:
     """Parse a Docker CPU quota-style value for numeric comparison."""
@@ -258,6 +285,20 @@ class UnrestrictedCacheMount(BaseModel):
             raise ValueError("cacheMounts target must be an absolute safe path")
         return self
 
+class WorkloadGpuRequestError(ValueError):
+    """Refused generic GPU resource request carrying its stable failure reason.
+
+    The reason travels with the exception so every transport classifies the same
+    refusal identically instead of re-deriving it from an error string. Pydantic
+    preserves the raised instance in its validation error context, so the reason
+    survives model validation at any nesting depth.
+    """
+
+    def __init__(self, failure: WorkloadGpuRequestFailure, detail: str) -> None:
+        self.gpu_failure: WorkloadGpuRequestFailure = failure
+        super().__init__(detail)
+
+
 def _validate_gpu_count(value: Any) -> None:
     """Reject a device count that only becomes an integer through coercion.
 
@@ -273,21 +314,72 @@ def _validate_gpu_count(value: Any) -> None:
         else isinstance(value, int) and not isinstance(value, bool) and value >= 1
     )
     if not accepted:
-        raise ValueError("gpu.count must be a positive integer or 'all'")
+        raise WorkloadGpuRequestError(
+            "gpu_count_unsupported", "gpu.count must be a positive integer or 'all'"
+        )
+
+
+def _normalized_gpu_capabilities(value: Any) -> tuple[WorkloadGpuCapability, ...]:
+    """Return the bounded, deduplicated, canonically ordered capability list.
+
+    Only the vendor driver's published capability names are accepted. Ordering
+    and duplicates are normalized here so the same semantic request always
+    serializes to the same durable bytes and the same device request.
+    """
+
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise WorkloadGpuRequestError(
+            "gpu_request_invalid",
+            "gpu.capabilities must be a list of supported driver capabilities",
+        )
+    requested: set[str] = set()
+    for entry in value:
+        if not isinstance(entry, str):
+            raise WorkloadGpuRequestError(
+                "gpu_request_invalid",
+                "gpu.capabilities entries must be capability names",
+            )
+        capability = entry.strip().lower()
+        if capability not in WORKLOAD_GPU_CAPABILITIES:
+            allowed = ", ".join(WORKLOAD_GPU_CAPABILITIES)
+            raise WorkloadGpuRequestError(
+                "gpu_request_invalid",
+                f"gpu.capabilities entry {entry!r} is not supported; "
+                f"supported capabilities: {allowed}",
+            )
+        requested.add(capability)
+    if not requested:
+        raise WorkloadGpuRequestError(
+            "gpu_request_invalid",
+            "gpu.capabilities must declare at least one supported driver capability",
+        )
+    return tuple(
+        capability
+        for capability in WORKLOAD_GPU_CAPABILITIES
+        if capability in requested
+    )
 
 class WorkloadGpuRequest(BaseModel):
     """Caller-supplied generic GPU resource request for one container.
 
-    This is ordinary request data: the caller names a supported GPU vendor and
-    how many devices the container needs. MoonMind realizes it as the vendor's
-    Docker device request and never infers it from the image, the command, or
-    any repository-specific condition.
+    This is ordinary request data: the caller names a supported GPU vendor, how
+    many devices the container needs, and optionally which of the vendor
+    driver's published capabilities to expose. MoonMind realizes it as the
+    vendor's Docker device request and never infers it from the image, the
+    command, or any repository-specific condition.
+
+    ``capabilities`` is absent by default, which requests the vendor's default
+    device capability set. Declaring it never widens authority: the values are
+    bounded driver capability names, not device paths or Docker options.
     """
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     vendor: WorkloadGpuVendor = Field("nvidia", alias="vendor")
     count: int | Literal["all"] = Field("all", alias="count")
+    capabilities: tuple[WorkloadGpuCapability, ...] | None = Field(
+        None, alias="capabilities"
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -299,13 +391,19 @@ class WorkloadGpuRequest(BaseModel):
             vendor = str(raw_vendor).strip().lower()
             if vendor not in WORKLOAD_GPU_VENDORS:
                 allowed = ", ".join(WORKLOAD_GPU_VENDORS)
-                raise ValueError(
+                raise WorkloadGpuRequestError(
+                    "gpu_vendor_unsupported",
                     f"gpu.vendor {raw_vendor!r} is not supported; "
-                    f"supported vendors: {allowed}"
+                    f"supported vendors: {allowed}",
                 )
         if "count" in value:
             _validate_gpu_count(value["count"])
-        return value
+        raw_capabilities = value.get("capabilities")
+        if raw_capabilities is None:
+            return value
+        normalized = dict(value)
+        normalized["capabilities"] = _normalized_gpu_capabilities(raw_capabilities)
+        return normalized
 
     @property
     def device_request_value(self) -> str:

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -60,7 +60,9 @@ from moonmind.schemas.container_job_models import (
     MAX_LOG_PAGE_ENTRIES,
     RegistryAuthorization,
     ContainerJobFailureClass,
+    GpuObservation,
     ImageObservation,
+    gpu_observation,
 )
 from moonmind.utils.logging import redact_sensitive_text
 from moonmind.workflows.temporal.container_image_acquisition import (
@@ -79,7 +81,11 @@ from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
     resolve_registry_pull_credentials,
 )
 from moonmind.workloads.docker_launcher import structured_container_security_args
-from moonmind.workloads.gpu import gpu_device_request_args
+from moonmind.workloads.gpu import (
+    GpuLaunchFailureReason,
+    gpu_device_request_args,
+    gpu_launch_refusal,
+)
 from moonmind.security.egress import (
     DEFAULT_EGRESS_PROFILE,
     attest_docker_workload_egress,
@@ -90,6 +96,10 @@ from moonmind.security.egress import (
 )
 from moonmind.security.egress_conformance_evidence import (
     serialize_conformance_evidence,
+)
+from moonmind.schemas.workload_models import (
+    WORKLOAD_GPU_VENDORS,
+    WorkloadGpuRequest,
 )
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
@@ -165,6 +175,22 @@ _FORBIDDEN_MOUNT_SOURCES = (
     "/var/lib/docker",
 )
 _MIN_VOLUME_SUBPATH_DOCKER_MAJOR = 26
+# Docker Engine 19.03 introduced the device-request API that realizes a typed
+# GPU resource. An older daemon accepts the ordinary container request but has
+# no way to attach the requested devices, so a GPU job is refused before start
+# rather than silently executed on a less-capable substrate.
+_MIN_DEVICE_REQUEST_DOCKER_MAJOR = 19
+# Generic mapping from the shared launch-refusal classifier's vendor/runtime
+# reason to the canonical container-job failure class. The classifier owns the
+# diagnostic evidence; this table only names the stable service-level outcome.
+_GPU_LAUNCH_FAILURE_CLASSES: dict[
+    GpuLaunchFailureReason, ContainerJobFailureClass
+] = {
+    "nvidia_runtime_unavailable": ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE,
+    "gpu_device_unavailable": ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
+    "device_request_unsupported": ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+    "gpu_device_request_rejected": ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+}
 _MIB = 1024 * 1024
 _AUTO_ACTIVE_MEMORY_FRACTION = 0.70
 _CAPACITY_LOCK_WAIT_SECONDS = 45.0
@@ -652,10 +678,73 @@ class DockerContainerJobBackend:
             requested_devices = gpu.count
             if requested_devices == "all" or requested_devices > ceilings.max_gpu_count:
                 raise ContainerJobBackendError(
-                    ContainerJobFailureClass.RESOURCE_LIMIT_EXCEEDED,
+                    ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED,
                     f"gpu.count={requested_devices} exceeds the deployment ceiling "
                     f"{ceilings.max_gpu_count} and cannot be raised by a caller",
                 )
+
+    async def _report_gpu_support(
+        self, gpu: WorkloadGpuRequest
+    ) -> GpuObservation:
+        """Return the selected daemon's support report for one GPU request.
+
+        Reports before the container starts, so an unsupported vendor or a
+        daemon without the device-request API is refused with a stable generic
+        class instead of running the caller's workload without the resource it
+        asked for. Runtime and device availability are not observable without a
+        launch; the daemon's own refusal is classified at create/start instead.
+        """
+
+        if gpu.vendor not in WORKLOAD_GPU_VENDORS:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED,
+                f"gpu.vendor={gpu.vendor} is not realizable by the selected "
+                "container backend",
+            )
+        code, stdout, stderr = await self._runner(
+            ("version", "--format", "{{.Server.Version}}")
+        )
+        if code:
+            detail = stderr.decode(errors="replace").strip()[:500]
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.INFRASTRUCTURE,
+                f"container backend endpoint is unreachable: {detail}",
+            )
+        server_version = stdout.decode(errors="replace").strip()
+        major_version = _docker_major_version(server_version)
+        if major_version is None or major_version < _MIN_DEVICE_REQUEST_DOCKER_MAJOR:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+                "selected container backend does not support device requests; "
+                f"daemon reported {server_version or 'unknown'}",
+            )
+        return gpu_observation(gpu, backend_supported=True)
+
+    def _reject_gpu_launch_refusal(
+        self, gpu: WorkloadGpuRequest | None, *, stderr: bytes, exit_code: int
+    ) -> None:
+        """Raise the stable GPU class when the daemon refused the device request.
+
+        The shared launch classifier is the single authority for what counts as a
+        refused device request, so the canonical backend and the unrestricted
+        launcher agree on the evidence. Container create and start are their own
+        commands here, so such a failure is never an application exit. The daemon
+        diagnostic itself is never echoed: it can name trusted host paths and
+        endpoints.
+        """
+
+        failure = gpu_launch_refusal(
+            gpu=gpu,
+            stderr=stderr.decode(errors="replace"),
+            exit_code=exit_code,
+        )
+        if failure is None:
+            return
+        raise ContainerJobBackendError(
+            _GPU_LAUNCH_FAILURE_CLASSES[failure.reason],
+            "selected container backend refused the requested GPU resource "
+            f"({failure.reason})",
+        )
 
     def _capacity_lock_key(self) -> str:
         raw = f"{self._backend_ref}\ncontainer-job-active-memory".encode()
@@ -1697,6 +1786,14 @@ class DockerContainerJobBackend:
             containerRef=name,
             running=running,
             diagnosticsRef=diagnostics_ref,
+            # An owned container that exists is stronger evidence than a
+            # capability report: the daemon already accepted this job's device
+            # request, and a running container already carries it.
+            gpuObservation=gpu_observation(
+                request.request.spec.resources.gpu,
+                backend_supported=True,
+                launched=running,
+            ),
         )
 
     async def _recover_launch_attestation(
@@ -1827,6 +1924,14 @@ class DockerContainerJobBackend:
             raise RuntimeError("resolved workspace and image are required")
         self._enforce_resource_ceilings(request)
         spec = request.request.spec
+        # Report the selected daemon's support for a caller-requested GPU
+        # resource before anything is created, so an unsupported request never
+        # reaches the caller's workload.
+        resolved_gpu = (
+            await self._report_gpu_support(spec.resources.gpu)
+            if spec.resources.gpu is not None
+            else None
+        )
         name = self._name(request)
         if spec.network_mode not in {"none", "bridge"}:
             raise RuntimeError("network mode must be 'none' or policy-approved 'bridge'")
@@ -1979,8 +2084,14 @@ class DockerContainerJobBackend:
         args.append(request.resolved_image_ref)
         args.extend(spec.entrypoint[1:])
         args.extend(spec.command)
-        code, _, _ = await self._runner(args)
+        code, _, create_stderr = await self._runner(args)
         if code:
+            # A refused device request is reported with its stable generic class
+            # before the ordinary launch failure, so a caller can tell an
+            # unavailable GPU resource from an unusable workspace.
+            self._reject_gpu_launch_refusal(
+                spec.resources.gpu, stderr=create_stderr, exit_code=code
+            )
             # Docker mount errors echo the trusted host source. Keep it out of
             # workflow history and caller-visible terminal diagnostics.
             raise RuntimeError("docker create failed for the resolved workspace")
@@ -2005,17 +2116,28 @@ class DockerContainerJobBackend:
             containerRef=name,
             diagnosticsRef=egress_evidence_ref,
             resolvedCacheRefs=tuple(resolved_cache_refs),
+            gpuObservation=resolved_gpu,
         )
 
     async def start_container(self, request: ContainerJobActivityRequest):
         container_name = request.container_ref or self._name(request)
+        requested_gpu = request.request.spec.resources.gpu
         started_at = datetime.now(timezone.utc)
         capacity_lease = await self._acquire_capacity_lock()
         try:
             await self._enforce_active_memory_budget(
                 request, container_name=container_name
             )
-            await self._checked("start", container_name)
+            code, _, start_stderr = await self._runner(("start", container_name))
+            if code:
+                # The daemon resolves a device request when the container
+                # starts, so this is where an unavailable GPU runtime or device
+                # is refused. Classify it before the ordinary launch failure.
+                self._reject_gpu_launch_refusal(
+                    requested_gpu, stderr=start_stderr, exit_code=code
+                )
+                detail = start_stderr.decode(errors="replace").strip()[:1000]
+                raise RuntimeError(f"docker start failed: {detail}")
         finally:
             try:
                 await self._capacity_lock.release(capacity_lease)
@@ -2064,6 +2186,9 @@ class DockerContainerJobBackend:
             containerRef=container_name,
             running=True,
             diagnosticsRef=diagnostics_ref,
+            gpuObservation=gpu_observation(
+                requested_gpu, backend_supported=True, launched=True
+            ),
         )
 
     async def observe_container(self, request: ContainerJobActivityRequest):

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -705,10 +705,21 @@ class DockerContainerJobBackend:
             ("version", "--format", "{{.Server.Version}}")
         )
         if code:
-            detail = stderr.decode(errors="replace").strip()[:500]
+            # This message becomes the caller-visible terminal outcome, and the
+            # daemon's own connection diagnostic can name the deployment-owned
+            # endpoint, its TLS material, or credential-bearing connection
+            # detail. The caller contract stays a fixed string; the redacted
+            # diagnostic goes only to trusted backend logs.
+            logger.warning(
+                "Container-job GPU support probe could not reach the container "
+                "backend endpoint: %s",
+                redact_sensitive_text(
+                    stderr.decode(errors="replace").strip()[:500]
+                ),
+            )
             raise ContainerJobBackendError(
                 ContainerJobFailureClass.INFRASTRUCTURE,
-                f"container backend endpoint is unreachable: {detail}",
+                "container backend endpoint is unreachable",
             )
         server_version = stdout.decode(errors="replace").strip()
         major_version = _docker_major_version(server_version)

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2533,6 +2533,12 @@ def _container_job_projection_writer(backend_kind: str, backend_ref: str):
                     "cacheHit": True,
                     "pullLockWaitMs": 0,
                 }
+            if request.gpu_observation is not None:
+                # Only written when the caller requested a GPU resource, so a
+                # CPU-only job never gains a GPU observation.
+                record.gpu_observation_json = request.gpu_observation.model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                )
             if (
                 request.exit_code is not None
                 or request.failure_class

--- a/moonmind/workflows/temporal/workflows/container_job.py
+++ b/moonmind/workflows/temporal/workflows/container_job.py
@@ -21,6 +21,7 @@ with workflow.unsafe.imports_passed_through():
         TerminalOutcome,
         failure_class_from_exception,
         failure_message_from_exception,
+        terminal_gpu_observation,
     )
     from moonmind.workflows.temporal.activity_catalog import (
         build_default_activity_catalog,
@@ -167,6 +168,9 @@ class MoonMindContainerJobWorkflow:
                     "container_job.reconcile_container", request
                 )
                 request.container_ref = reconciled.container_ref
+                # A reattached container reports its own resolved GPU evidence;
+                # create/start below supersede it for a fresh launch.
+                request.gpu_observation = reconciled.gpu_observation
                 if request.container_ref is None:
                     created = await self._activity(
                         "container_job.create_container", request
@@ -174,6 +178,7 @@ class MoonMindContainerJobWorkflow:
                     request.container_ref = created.container_ref
                     request.egress_attestation_ref = created.diagnostics_ref
                     request.resolved_cache_refs = created.resolved_cache_refs
+                    request.gpu_observation = created.gpu_observation
                 else:
                     # A reconciled container skips create; recover its republished
                     # launch attestation ref so terminal evidence still correlates
@@ -184,6 +189,10 @@ class MoonMindContainerJobWorkflow:
                     started = await self._activity(
                         "container_job.start_container", request
                     )
+                    if started.gpu_observation is not None:
+                        # Launch evidence supersedes the pre-create support
+                        # report for the same requested resource.
+                        request.gpu_observation = started.gpu_observation
                     if started.diagnostics_ref:
                         # The complete row is published only after the actual
                         # workload is running and its endpoint, immutable image,
@@ -255,6 +264,14 @@ class MoonMindContainerJobWorkflow:
         request.exit_code = exit_code
         request.failure_class = failure_class
         request.message = message
+        # A requested GPU resource is always observable, including when the job
+        # was refused before the backend reported anything. CPU-only jobs stay
+        # unchanged: the observation is absent.
+        request.gpu_observation = terminal_gpu_observation(
+            gpu=inp.request.spec.resources.gpu,
+            observed=request.gpu_observation,
+            failure_class=failure_class,
+        )
 
         # Distinguish a workspace-visibility failure as its own status before the
         # terminal FAILED projection so a reader can tell it apart from a launch

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -20983,6 +20983,9 @@ class MoonMindRunWorkflow:
             "state": str(self._get_from_result(snapshot, "state") or ""),
             "logsRef": self._get_from_result(snapshot, "logsRef"),
             "artifactsRef": self._get_from_result(snapshot, "artifactsRef"),
+            # Present only when the caller requested a device resource; the
+            # projection is the bounded observation, never a Docker flag.
+            "gpu": self._get_from_result(snapshot, "gpu"),
         }
         if isinstance(terminal, Mapping):
             outputs.update(

--- a/moonmind/workloads/gpu.py
+++ b/moonmind/workloads/gpu.py
@@ -71,12 +71,17 @@ _NON_GPU_LAUNCH_FAILURE_PATTERNS: tuple[str, ...] = (
 # vendor/runtime diagnostic string, never a product or repository condition.
 # Every pattern is specific enough that a container which started and then wrote
 # GPU-shaped text to stderr cannot be mistaken for a refused device request.
+#
+# Precedence is most-specific-first, because the vendor stack reports a device
+# failure *through* its own tooling: a host with the runtime installed but no
+# usable device emits both the generic ``nvidia-container-cli`` prefix and a
+# specific device diagnostic. Matching the generic prefix first would direct an
+# operator toward repairing a runtime that is already working instead of toward
+# device capacity, so the bare vendor-stack prefixes are the last resort.
 _GPU_LAUNCH_FAILURE_PATTERNS: tuple[tuple[GpuLaunchFailureReason, tuple[str, ...]], ...] = (
     (
         "nvidia_runtime_unavailable",
         (
-            "nvidia-container-cli",
-            "nvidia-container-runtime",
             "unknown or invalid runtime name: nvidia",
             "unknown runtime specified nvidia",
         ),
@@ -103,6 +108,16 @@ _GPU_LAUNCH_FAILURE_PATTERNS: tuple[tuple[GpuLaunchFailureReason, tuple[str, ...
         (
             "could not select device driver",
             "capabilities: [[gpu]]",
+        ),
+    ),
+    (
+        # Last resort: the installed vendor stack reported something no specific
+        # signature above recognized, so the runtime itself is the only evidence
+        # available.
+        "nvidia_runtime_unavailable",
+        (
+            "nvidia-container-cli",
+            "nvidia-container-runtime",
         ),
     ),
 )

--- a/moonmind/workloads/gpu.py
+++ b/moonmind/workloads/gpu.py
@@ -114,11 +114,18 @@ def gpu_device_request_args(gpu: WorkloadGpuRequest) -> list[str]:
     """Return the Docker device-request arguments for a generic GPU request.
 
     ``count: "all"`` yields ``--gpus all``; a numeric count yields
-    ``--gpus <count>``. The vendor is validated by the request contract, so no
-    vendor branching happens here.
+    ``--gpus <count>``. Declared driver capabilities are appended as Docker's
+    own quoted ``capabilities=`` device-request field, whose value is itself
+    comma-separated and therefore must stay quoted inside the option's CSV
+    syntax. The vendor is validated by the request contract, so no vendor
+    branching happens here.
     """
 
-    return [GPU_DEVICE_REQUEST_FLAG, gpu.device_request_value]
+    value = gpu.device_request_value
+    if gpu.capabilities:
+        capabilities = ",".join(gpu.capabilities)
+        value = f'count={value},"capabilities={capabilities}"'
+    return [GPU_DEVICE_REQUEST_FLAG, value]
 
 
 class GpuLaunchFailure(BaseModel):
@@ -134,25 +141,24 @@ class GpuLaunchFailure(BaseModel):
     exit_code: int | None = Field(None, alias="exitCode")
 
 
-def classify_gpu_launch_failure(
+def gpu_launch_refusal(
     *,
     gpu: WorkloadGpuRequest | None,
-    exit_code: int | None,
     stderr: str,
+    exit_code: int | None = None,
 ) -> GpuLaunchFailure | None:
-    """Classify a failed run as a GPU device-request refusal, or not.
+    """Classify a launch-phase failure as a GPU device-request refusal, or not.
 
-    A refusal is recognized only when Docker itself refused to run the
-    container — ``exit_code`` equals :data:`DOCKER_LAUNCH_FAILURE_EXIT_CODE` —
-    *and* stderr carries a specific vendor/runtime diagnostic. Returns ``None``
-    when no GPU was requested, when the run succeeded or was cancelled, when the
-    diagnostic names a non-GPU launch failure such as an unreachable Docker
-    daemon, and when the container started and exited nonzero on its own, which
-    stays an ordinary process exit failure even if the workload wrote
-    GPU-shaped text to stderr.
+    This is the single authority for recognizing a refused device request:
+    stderr must carry a specific vendor/runtime diagnostic. Callers whose launch
+    phase is already its own command — an explicit container create or start —
+    use it directly, because such a failure cannot be an application exit.
+    Returns ``None`` when no GPU was requested, when there is no diagnostic, and
+    when the diagnostic names a non-GPU launch failure such as an unreachable
+    Docker daemon.
     """
 
-    if gpu is None or exit_code != DOCKER_LAUNCH_FAILURE_EXIT_CODE:
+    if gpu is None:
         return None
     haystack = str(stderr or "").lower()
     if not haystack:
@@ -163,6 +169,27 @@ def classify_gpu_launch_failure(
         if any(pattern.lower() in haystack for pattern in patterns):
             return GpuLaunchFailure(reason=reason, exitCode=exit_code)
     return None
+
+
+def classify_gpu_launch_failure(
+    *,
+    gpu: WorkloadGpuRequest | None,
+    exit_code: int | None,
+    stderr: str,
+) -> GpuLaunchFailure | None:
+    """Classify a failed one-shot run as a GPU device-request refusal, or not.
+
+    One ``docker run`` merges the launch phase with the application's own exit,
+    so a refusal is recognized only when Docker itself refused to run the
+    container — ``exit_code`` equals :data:`DOCKER_LAUNCH_FAILURE_EXIT_CODE` —
+    and :func:`gpu_launch_refusal` then recognizes the diagnostic. A container
+    that started and exited nonzero on its own stays an ordinary process exit
+    failure even if the workload wrote GPU-shaped text to stderr.
+    """
+
+    if exit_code != DOCKER_LAUNCH_FAILURE_EXIT_CODE:
+        return None
+    return gpu_launch_refusal(gpu=gpu, stderr=stderr, exit_code=exit_code)
 
 
 def gpu_launch_observations(
@@ -177,7 +204,10 @@ def gpu_launch_observations(
         return None
     failure = classify_gpu_launch_failure(gpu=gpu, exit_code=exit_code, stderr=stderr)
     return {
-        "request": gpu.model_dump(mode="json", by_alias=True),
+        # ``exclude_none`` keeps the observation compact and keeps an omitted
+        # optional request field absent, so evidence recorded for one semantic
+        # request stays byte-identical as the request contract grows.
+        "request": gpu.model_dump(mode="json", by_alias=True, exclude_none=True),
         "deviceRequestArgs": gpu_device_request_args(gpu),
         "launchFailure": (
             failure.model_dump(mode="json", by_alias=True)
@@ -335,7 +365,7 @@ def verified_gpu_observations(
             "qualification records require realized GPU device-request evidence"
         )
     realized_request = observations.get("request")
-    expected_request = gpu.model_dump(mode="json", by_alias=True)
+    expected_request = gpu.model_dump(mode="json", by_alias=True, exclude_none=True)
     if realized_request != expected_request:
         raise ValueError(
             "qualification evidence realized a different GPU request than the "
@@ -442,6 +472,7 @@ __all__ = [
     "classify_gpu_launch_failure",
     "gpu_device_request_args",
     "gpu_launch_observations",
+    "gpu_launch_refusal",
     "moonmind_revision",
     "parse_image_digest",
     "verified_gpu_observations",

--- a/moonmind/workloads/tool_bridge.py
+++ b/moonmind/workloads/tool_bridge.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from moonmind.schemas.workload_models import WORKLOAD_GPU_CAPABILITIES
+
 CONTAINER_RUN_JOB_TOOL = "container.run_job"
 CONTAINER_JOB_TOOL_NAMES = frozenset({CONTAINER_RUN_JOB_TOOL})
 
@@ -116,6 +118,16 @@ def build_container_job_tool_definition_payload(*, name: str) -> dict[str, Any]:
                                     {"type": "string", "const": "all"},
                                 ]
                             },
+                            # Bounded vendor driver capability names. Omitted
+                            # requests receive the vendor's default set.
+                            "capabilities": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string",
+                                    "enum": list(WORKLOAD_GPU_CAPABILITIES),
+                                },
+                            },
                         },
                         "additionalProperties": False,
                     },
@@ -168,6 +180,28 @@ def build_container_job_tool_definition_payload(*, name: str) -> dict[str, Any]:
                     "artifactsRef": {"type": "string"},
                     "exitCode": {"type": "integer"},
                     "failureClass": {"type": "string"},
+                    # Bounded observation of a requested device resource.
+                    # Absent for every CPU-only job.
+                    "gpu": {
+                        "type": "object",
+                        "properties": {
+                            "vendor": {"type": "string"},
+                            "count": {
+                                "oneOf": [
+                                    {"type": "integer"},
+                                    {"type": "string"},
+                                ]
+                            },
+                            "capabilities": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "backendSupported": {"type": "boolean"},
+                            "launched": {"type": "boolean"},
+                            "failureClass": {"type": "string"},
+                        },
+                        "additionalProperties": False,
+                    },
                 },
                 "additionalProperties": False,
             }

--- a/tests/integration/workloads/test_nvidia_container_qualification_journey.py
+++ b/tests/integration/workloads/test_nvidia_container_qualification_journey.py
@@ -588,3 +588,282 @@ async def test_timeout_targets_only_the_run_owned_container(
     await asyncio.sleep(1)
     assert not _container_present(request.container_name)
     assert _image_present(image)
+
+
+# ---------------------------------------------------------------------------
+# Canonical container-job boundary (MoonLadderStudios/MoonMind#3779)
+# ---------------------------------------------------------------------------
+#
+# The same caller-supplied image, command, and generic GPU resource are run
+# again through the canonical asynchronous container-job backend on the same
+# daemon, so the durable destination is qualified on real hardware rather than
+# only the unrestricted route.
+
+
+CANONICAL_WORKSPACE_REF = "gpu-qualification-workspace"
+CANONICAL_CAPABILITIES = ("compute", "utility")
+
+
+def _canonical_job_id() -> str:
+    return f"container-job:{uuid.uuid4().hex}"
+
+
+def _evidence_publisher(root: Path):
+    """Publish bounded evidence to a local root and return its reference.
+
+    The trusted backend only needs an opaque durable reference; the artifact
+    store is not part of what this journey qualifies.
+    """
+
+    async def publish(request: Any, name: str, payload: bytes) -> str:
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        return str(target)
+
+    return publish
+
+
+def _container_job_backend(
+    workspace_root: Path,
+    *,
+    evidence_root: Path,
+    settings_source: dict[str, str] | None = None,
+):
+    from moonmind.config.container_backend_settings import (
+        resolve_container_backend_settings,
+    )
+    from moonmind.workflows.temporal.container_job_backend import (
+        DockerContainerJobBackend,
+    )
+
+    return DockerContainerJobBackend(
+        workspace_root=workspace_root,
+        settings=resolve_container_backend_settings(settings_source or {}),
+        docker_binary=_docker_binary(),
+        docker_host=_docker_host(),
+        backend_ref="gpu-qualification",
+        evidence_publisher=_evidence_publisher(evidence_root),
+        image_lock_root=evidence_root / "locks",
+    )
+
+
+def _canonical_workspace(workspace_root: Path) -> Path:
+    workspace = workspace_root / CANONICAL_WORKSPACE_REF
+    workspace.mkdir(parents=True, exist_ok=True)
+    return workspace
+
+
+def _canonical_request(
+    *,
+    job_id: str,
+    gpu: dict[str, Any] | None,
+    command: tuple[str, ...],
+    declared_output: bool,
+    timeout_seconds: int | None = None,
+):
+    from moonmind.schemas.container_job_models import ContainerJobActivityRequest
+
+    resources: dict[str, Any] = {"cpuMillis": 2000, "memoryMiB": 2048}
+    if gpu is not None:
+        resources["gpu"] = gpu
+    spec: dict[str, Any] = {
+        "image": _env("MOONMIND_GPU_QUALIFICATION_IMAGE"),
+        "workspaceRef": {
+            "kind": "external_state",
+            "artifactRef": CANONICAL_WORKSPACE_REF,
+        },
+        "command": list(command),
+        "networkMode": "none",
+        "resources": resources,
+        "timeoutSeconds": timeout_seconds
+        or int(_env("MOONMIND_GPU_QUALIFICATION_TIMEOUT") or 600),
+        "environment": [
+            {
+                "name": "MOONMIND_GPU_QUALIFICATION_OUTPUT",
+                "value": f"/workspace/{DECLARED_OUTPUT_PATH}",
+            }
+        ],
+    }
+    if declared_output:
+        spec["outputs"] = [
+            {"name": DECLARED_OUTPUT_CLASS, "relativePath": DECLARED_OUTPUT_PATH}
+        ]
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": job_id,
+            "ownershipToken": f"{job_id}:v1",
+            "request": {
+                "idempotencyKey": job_id,
+                "source": {"source": "workflow", "workflowId": job_id},
+                "spec": spec,
+            },
+        }
+    )
+
+
+async def _drive_canonical_job(backend: Any, request: Any) -> dict[str, Any]:
+    """Run one canonical job through the same Activity sequence the workflow uses."""
+
+    resolved = await backend.resolve_workspace(request)
+    request.resolved_workspace_ref = resolved.resolved_workspace_ref
+    request.resolved_workspace_volume_name = resolved.resolved_workspace_volume_name
+    request.resolved_workspace_volume_subpath = (
+        resolved.resolved_workspace_volume_subpath
+    )
+    image = await backend.acquire_image(request)
+    request.resolved_image_ref = image.resolved_image_ref
+
+    created = await backend.create_container(request)
+    request.container_ref = created.container_ref
+    request.gpu_observation = created.gpu_observation
+    started = await backend.start_container(request)
+    if started.gpu_observation is not None:
+        request.gpu_observation = started.gpu_observation
+
+    deadline = request.request.spec.timeout_seconds
+    observed = None
+    for _ in range(deadline * 2):
+        observed = await backend.observe_container(request)
+        if observed.terminal_state is not None:
+            break
+        await asyncio.sleep(0.5)
+    assert observed is not None and observed.terminal_state is not None, (
+        "canonical container job did not reach a terminal state"
+    )
+    request.terminal_state = observed.terminal_state
+    request.exit_code = observed.exit_code
+
+    published = await backend.publish_evidence(request)
+    await backend.remove_container(request)
+    cleaned = await backend.cleanup(request)
+    return {
+        "created": created,
+        "started": started,
+        "observed": observed,
+        "published": published,
+        "cleaned": cleaned,
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_nvidia_container_job_completes_through_the_trusted_backend(
+    workspace_root: Path,
+    tmp_path: Path,
+) -> None:
+    """The canonical container-job backend realizes the same GPU request."""
+
+    workspace = _canonical_workspace(workspace_root)
+    job_id = _canonical_job_id()
+    backend = _container_job_backend(workspace_root, evidence_root=tmp_path / "evidence")
+    request = _canonical_request(
+        job_id=job_id,
+        gpu={
+            "vendor": "nvidia",
+            "count": _gpu_count(),
+            "capabilities": list(CANONICAL_CAPABILITIES),
+        },
+        command=_caller_command(Path("/workspace") / DECLARED_OUTPUT_PATH),
+        declared_output=_declares_fixture_output(),
+    )
+
+    outcome = await _drive_canonical_job(backend, request)
+
+    assert outcome["observed"].terminal_state == "succeeded"
+    assert outcome["observed"].exit_code == 0
+
+    # The resolved GPU resource is reported as supported and launched, and the
+    # observation carries the caller's own semantic request.
+    observation = request.gpu_observation
+    assert observation is not None
+    assert observation.backend_supported is True
+    assert observation.launched is True
+    assert observation.count == _gpu_count()
+    assert observation.capabilities == CANONICAL_CAPABILITIES
+    assert observation.failure_class is None
+
+    # Bounded logs and the declared output are collected through the ordinary
+    # evidence plane, with no GPU-specific lifecycle branch.
+    assert outcome["published"].logs_ref
+    logs = Path(outcome["published"].logs_ref).read_text(encoding="utf-8")
+    assert logs.strip()
+    assert "/var/run/docker.sock" not in logs
+    assert "DOCKER_HOST" not in logs
+    if _declares_fixture_output():
+        assert (workspace / DECLARED_OUTPUT_PATH).is_file()
+        assert outcome["published"].artifacts_ref
+        manifest = json.loads(
+            Path(outcome["published"].artifacts_ref).read_text(encoding="utf-8")
+        )
+        collected = {item["name"]: item for item in manifest["artifacts"]}
+        assert collected[DECLARED_OUTPUT_CLASS]["collectionStatus"] == "collected"
+        assert collected[DECLARED_OUTPUT_CLASS]["sha256"]
+
+    # Cleanup removed only the run-owned container; the image survives.
+    assert outcome["cleaned"].cleanup_succeeded is not False
+    assert not _container_present(str(request.container_ref))
+    assert _image_present(_env("MOONMIND_GPU_QUALIFICATION_IMAGE"))
+
+
+@pytest.mark.asyncio
+async def test_canonical_cpu_only_job_on_the_gpu_host_requests_no_device(
+    workspace_root: Path,
+    tmp_path: Path,
+) -> None:
+    """CPU-only canonical behavior is unchanged on a GPU-capable host."""
+
+    _canonical_workspace(workspace_root)
+    backend = _container_job_backend(
+        workspace_root, evidence_root=tmp_path / "evidence-cpu"
+    )
+    request = _canonical_request(
+        job_id=_canonical_job_id(),
+        gpu=None,
+        command=("sh", "-lc", "echo cpu-only-path"),
+        declared_output=False,
+    )
+
+    outcome = await _drive_canonical_job(backend, request)
+
+    assert outcome["observed"].terminal_state == "succeeded"
+    assert outcome["created"].gpu_observation is None
+    assert outcome["started"].gpu_observation is None
+    assert request.gpu_observation is None
+
+
+@pytest.mark.asyncio
+async def test_canonical_device_count_above_the_ceiling_is_refused_before_execution(
+    workspace_root: Path,
+    tmp_path: Path,
+) -> None:
+    """An unsupported device count fails with its stable class, not a workload."""
+
+    from moonmind.schemas.container_job_models import (
+        ContainerJobFailureClass,
+        failure_class_from_exception,
+    )
+
+    _canonical_workspace(workspace_root)
+    backend = _container_job_backend(
+        workspace_root,
+        evidence_root=tmp_path / "evidence-refused",
+        settings_source={"MOONMIND_CONTAINER_BACKEND_MAX_GPU_COUNT": "0"},
+    )
+    request = _canonical_request(
+        job_id=_canonical_job_id(),
+        gpu={"vendor": "nvidia", "count": 1},
+        command=("sh", "-lc", "echo should-not-run"),
+        declared_output=False,
+    )
+    resolved = await backend.resolve_workspace(request)
+    request.resolved_workspace_ref = resolved.resolved_workspace_ref
+    image = await backend.acquire_image(request)
+    request.resolved_image_ref = image.resolved_image_ref
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.create_container(request)
+
+    assert (
+        failure_class_from_exception(exc_info.value)
+        == ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED
+    )

--- a/tests/unit/api/test_container_job_gpu_transport.py
+++ b/tests/unit/api/test_container_job_gpu_transport.py
@@ -12,7 +12,6 @@ The image, command, and capability values here are fixture data only.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock

--- a/tests/unit/api/test_container_job_gpu_transport.py
+++ b/tests/unit/api/test_container_job_gpu_transport.py
@@ -1,0 +1,434 @@
+"""GPU resource round trip across the container-job transports and record.
+
+Qualification for MoonLadderStudios/MoonMind#3779: a generic GPU resource
+request submitted over authenticated HTTP or MCP must persist in the durable
+API-owned record, replay idempotently, and be projected back as a bounded
+observation -- and an unsupported GPU resource must be refused before execution
+with the same stable generic class on both transports.
+
+The image, command, and capability values here are fixture data only.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.api.routers import container_jobs as http_router
+from api_service.api.routers import mcp_tools as mcp_tools_router
+from api_service.auth_providers import get_current_user
+from api_service.db.models import Base, ContainerJobRecord
+from api_service.services.container_jobs import ContainerJobService
+from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
+    ContainerJobFailureClass,
+    ContainerJobState,
+    GpuObservation,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+CURRENT_USER_DEP = get_current_user()
+_OWNER_ID = "11111111-1111-1111-1111-111111111111"
+FIXTURE_IMAGE = "docker.io/library/qualification-fixture:1.0.0"
+FIXTURE_COMMAND = ("sh", "-lc", "probe --emit report.json")
+GPU_REQUEST = {
+    "vendor": "nvidia",
+    "count": 2,
+    "capabilities": ["utility", "compute"],
+}
+
+
+def _submit_arguments(
+    source: str,
+    *,
+    gpu: dict[str, Any] | None = None,
+    key: str = "idem-gpu-1",
+) -> dict[str, Any]:
+    resources: dict[str, Any] = {"cpuMillis": 100, "memoryMiB": 64}
+    if gpu is not None:
+        resources["gpu"] = gpu
+    return {
+        "idempotencyKey": key,
+        "source": {"source": source, "callerRequestId": "req-1"},
+        "spec": {
+            "image": FIXTURE_IMAGE,
+            "command": list(FIXTURE_COMMAND),
+            "workspaceRef": {"kind": "sandbox", "workspaceId": "run"},
+            "resources": resources,
+        },
+    }
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/gpu-jobs.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+@pytest.fixture
+def temporal():
+    adapter = AsyncMock()
+    adapter.start_container_job.return_value = None
+    adapter.signal_container_job_cancel.return_value = None
+    return adapter
+
+
+def _install_real_service(monkeypatch, module, session_factory, temporal) -> None:
+    """Route a transport at the real durable service over a real session."""
+
+    async def session_dependency():
+        async with session_factory() as session:
+            yield session
+
+    monkeypatch.setattr(
+        module,
+        "ContainerJobService",
+        lambda session, artifacts=None: ContainerJobService(
+            session, temporal=temporal, artifacts=None
+        ),
+    )
+    monkeypatch.setattr(
+        module, "get_temporal_artifact_service", lambda session: None, raising=False
+    )
+    return session_dependency
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools_router.settings.feature_flags, "container_jobs_enabled", True
+    )
+    monkeypatch.setattr(
+        http_router.settings.feature_flags, "container_jobs_enabled", True
+    )
+
+
+@pytest.fixture
+def http_app(monkeypatch, session_factory, temporal) -> FastAPI:
+    dependency = _install_real_service(
+        monkeypatch, http_router, session_factory, temporal
+    )
+    app = FastAPI()
+    app.include_router(http_router.router)
+    app.dependency_overrides[CURRENT_USER_DEP] = lambda: SimpleNamespace(id=_OWNER_ID)
+    app.dependency_overrides[http_router.get_async_session] = dependency
+    return app
+
+
+@pytest.fixture
+def mcp_app(monkeypatch, session_factory, temporal) -> FastAPI:
+    dependency = _install_real_service(
+        monkeypatch, mcp_tools_router, session_factory, temporal
+    )
+    app = FastAPI()
+    app.include_router(mcp_tools_router.router, prefix="/api")
+    app.dependency_overrides[CURRENT_USER_DEP] = lambda: SimpleNamespace(id=_OWNER_ID)
+    monkeypatch.setattr(mcp_tools_router, "_jira_registry", None)
+    monkeypatch.setattr(mcp_tools_router, "_jules_registry", None)
+    app.dependency_overrides[mcp_tools_router.get_async_session] = dependency
+    return app
+
+
+async def _record(session_factory, job_id: str) -> ContainerJobRecord:
+    async with session_factory() as session:
+        result = await session.execute(
+            select(ContainerJobRecord).where(ContainerJobRecord.job_id == job_id)
+        )
+        return result.scalar_one()
+
+
+async def _project(
+    monkeypatch, session_factory, *, job_id: str, gpu: GpuObservation | None
+) -> None:
+    """Run the trusted worker's projection writer for one job."""
+
+    from moonmind.workflows.temporal import worker_runtime
+
+    @asynccontextmanager
+    async def session_context():
+        async with session_factory() as session:
+            yield session
+
+    monkeypatch.setattr(worker_runtime, "get_async_session_context", session_context)
+    write = worker_runtime._container_job_projection_writer("docker-engine", "system")
+    request = ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": job_id,
+            "ownershipToken": f"{job_id}:v1",
+            "request": _submit_arguments("http", gpu=GPU_REQUEST),
+            "state": ContainerJobState.SUCCEEDED.value,
+            "exitCode": 0,
+            "gpuObservation": (
+                gpu.model_dump(mode="json", by_alias=True, exclude_none=True)
+                if gpu is not None
+                else None
+            ),
+        }
+    )
+    await write(request)
+
+
+async def test_http_submit_persists_and_projects_the_gpu_resource(
+    http_app, monkeypatch, session_factory, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        submitted = await client.post(
+            "/api/v1/container-jobs",
+            json=_submit_arguments("http", gpu=GPU_REQUEST),
+        )
+        assert submitted.status_code == 200
+        job_id = submitted.json()["jobId"]
+
+        record = await _record(session_factory, job_id)
+        # The durable request is the caller's own semantic GPU request,
+        # normalized to one canonical serialization.
+        assert record.request_json["spec"]["resources"]["gpu"] == {
+            "vendor": "nvidia",
+            "count": 2,
+            "capabilities": ["compute", "utility"],
+        }
+        assert record.gpu_observation_json is None
+
+        await _project(
+            monkeypatch,
+            session_factory,
+            job_id=job_id,
+            gpu=GpuObservation(
+                vendor="nvidia",
+                count=2,
+                capabilities=("compute", "utility"),
+                backendSupported=True,
+                launched=True,
+            ),
+        )
+
+        status = await client.get(f"/api/v1/container-jobs/{job_id}")
+
+    assert status.status_code == 200
+    payload = status.json()
+    assert payload["state"] == "succeeded"
+    assert payload["gpu"] == {
+        "vendor": "nvidia",
+        "count": 2,
+        "capabilities": ["compute", "utility"],
+        "backendSupported": True,
+        "launched": True,
+        "failureClass": None,
+    }
+    # The public projection carries no Docker flag, device path, or endpoint.
+    assert "--gpus" not in status.text
+    assert "deviceRequest" not in status.text
+
+
+async def test_replayed_gpu_submission_keeps_one_durable_identity(
+    http_app, session_factory, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        first = await client.post(
+            "/api/v1/container-jobs",
+            json=_submit_arguments("http", gpu=GPU_REQUEST),
+        )
+        # The same semantic request in a different capability order replays.
+        replay = await client.post(
+            "/api/v1/container-jobs",
+            json=_submit_arguments(
+                "http",
+                gpu={"vendor": "nvidia", "count": 2, "capabilities": ["compute", "utility"]},
+            ),
+        )
+        conflicting = await client.post(
+            "/api/v1/container-jobs",
+            json=_submit_arguments(
+                "http", gpu={"vendor": "nvidia", "count": 4}
+            ),
+        )
+
+    assert first.status_code == 200
+    assert replay.status_code == 200
+    assert replay.json()["jobId"] == first.json()["jobId"]
+    assert replay.json()["replayed"] is True
+    assert conflicting.status_code == 409
+
+
+async def test_cpu_only_status_projects_no_gpu_observation(
+    http_app, monkeypatch, session_factory, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        submitted = await client.post(
+            "/api/v1/container-jobs", json=_submit_arguments("http")
+        )
+        job_id = submitted.json()["jobId"]
+        record = await _record(session_factory, job_id)
+        assert "gpu" not in record.request_json["spec"]["resources"]
+
+        await _project(monkeypatch, session_factory, job_id=job_id, gpu=None)
+        status = await client.get(f"/api/v1/container-jobs/{job_id}")
+
+    assert status.status_code == 200
+    assert status.json().get("gpu") is None
+    record = await _record(session_factory, job_id)
+    assert record.gpu_observation_json is None
+
+
+async def test_mcp_submit_persists_the_gpu_resource(
+    mcp_app, session_factory, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=mcp_app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/mcp",
+            headers={"Accept": "application/json"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "container.submit",
+                    "arguments": _submit_arguments("mcp", gpu=GPU_REQUEST),
+                },
+            },
+        )
+
+    result = response.json()["result"]
+    assert result["isError"] is False
+    record = await _record(session_factory, result["structuredContent"]["jobId"])
+    assert record.request_json["spec"]["resources"]["gpu"]["capabilities"] == [
+        "compute",
+        "utility",
+    ]
+
+
+async def test_mcp_submit_schema_publishes_the_bounded_capability_values(
+    mcp_app, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=mcp_app), base_url="http://testserver"
+    ) as client:
+        listed = await client.post(
+            "/api/mcp",
+            headers={"Accept": "application/json"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+
+    tools = {tool["name"]: tool for tool in listed.json()["result"]["tools"]}
+    schema = tools["container.submit"]["inputSchema"]
+    gpu_schema = schema["$defs"]["WorkloadGpuRequest"]
+    assert gpu_schema["properties"]["vendor"]["const"] == "nvidia"
+    assert "capabilities" in gpu_schema["properties"]
+    assert "devices" not in gpu_schema["properties"]
+
+
+@pytest.mark.parametrize(
+    ("gpu", "expected"),
+    [
+        ({"vendor": "amd", "count": 1}, ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED),
+        ({"count": 0}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        (
+            {"count": 1, "capabilities": ["render"]},
+            ContainerJobFailureClass.GPU_REQUEST_INVALID,
+        ),
+    ],
+)
+async def test_http_refuses_an_unsupported_gpu_resource_with_a_stable_class(
+    http_app, session_factory, enabled, gpu: dict[str, Any], expected
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/v1/container-jobs", json=_submit_arguments("http", gpu=gpu)
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == expected.value
+    # Refused before any durable identity or Temporal handoff exists.
+    async with session_factory() as session:
+        assert (await session.execute(select(ContainerJobRecord))).all() == []
+
+
+@pytest.mark.parametrize(
+    ("gpu", "expected"),
+    [
+        ({"vendor": "amd", "count": 1}, ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED),
+        ({"count": 0}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        (
+            {"count": 1, "capabilities": ["render"]},
+            ContainerJobFailureClass.GPU_REQUEST_INVALID,
+        ),
+    ],
+)
+async def test_mcp_refuses_an_unsupported_gpu_resource_with_a_stable_class(
+    mcp_app, enabled, gpu: dict[str, Any], expected
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=mcp_app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/mcp",
+            headers={"Accept": "application/json"},
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "container.submit",
+                    "arguments": _submit_arguments("mcp", gpu=gpu),
+                },
+            },
+        )
+
+    result = response.json()["result"]
+    assert result["isError"] is True
+    assert result["structuredContent"]["code"] == expected.value
+
+
+async def test_refusal_response_never_echoes_the_rejected_value(
+    http_app, enabled
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        response = await client.post(
+            "/api/v1/container-jobs",
+            json=_submit_arguments(
+                "http", gpu={"count": 1, "capabilities": ["not-a-capability"]}
+            ),
+        )
+
+    assert response.status_code == 422
+    assert "not-a-capability" not in response.text
+
+
+async def test_ordinary_invalid_submission_is_not_classified_as_a_gpu_refusal(
+    http_app, enabled
+) -> None:
+    bad = _submit_arguments("http", gpu=GPU_REQUEST)
+    bad["spec"]["image"] = ""
+    async with AsyncClient(
+        transport=ASGITransport(app=http_app), base_url="http://testserver"
+    ) as client:
+        response = await client.post("/api/v1/container-jobs", json=bad)
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_request"

--- a/tests/unit/api_service/test_container_jobs_migration.py
+++ b/tests/unit/api_service/test_container_jobs_migration.py
@@ -94,3 +94,31 @@ def test_observations_migration_adds_and_drops_columns(monkeypatch) -> None:
             for column in sa.inspect(connection).get_columns("container_jobs")
         }
         assert not (added & columns)
+
+
+def test_gpu_observation_migration_adds_and_drops_column(monkeypatch) -> None:
+    base = importlib.import_module(
+        "api_service.migrations.versions.338_container_jobs_contract"
+    )
+    gpu = importlib.import_module(
+        "api_service.migrations.versions.364_container_job_gpu_observation"
+    )
+    assert gpu.down_revision == "363_merge_automation_reviews"
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        operations = Operations(MigrationContext.configure(connection))
+        monkeypatch.setattr(base, "op", operations)
+        monkeypatch.setattr(gpu, "op", operations)
+        base.upgrade()
+        gpu.upgrade()
+        columns = {
+            column["name"]
+            for column in sa.inspect(connection).get_columns("container_jobs")
+        }
+        assert "gpu_observation_json" in columns
+        gpu.downgrade()
+        columns = {
+            column["name"]
+            for column in sa.inspect(connection).get_columns("container_jobs")
+        }
+        assert "gpu_observation_json" not in columns

--- a/tests/unit/workflows/temporal/test_container_job_gpu_resources.py
+++ b/tests/unit/workflows/temporal/test_container_job_gpu_resources.py
@@ -1,0 +1,1090 @@
+"""Canonical container-job GPU resource qualification.
+
+Qualification for MoonLadderStudios/MoonMind#3779: a caller-supplied generic
+GPU resource request must travel the canonical container-job contracts, be
+realized by the trusted Docker backend as the vendor's device request, be
+refused before the caller's workload with stable generic classifications, and be
+observable as bounded evidence -- while CPU-only jobs stay byte-identical.
+
+Every image, command, and capability value here is fixture data. MoonMind never
+selects them and never interprets what the caller's workload does.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from moonmind.config.container_backend_settings import (
+    resolve_container_backend_settings,
+)
+from moonmind.schemas.container_job_models import (
+    GPU_FAILURE_CLASSES,
+    ContainerJobActivityRequest,
+    ContainerJobActivityResult,
+    ContainerJobFailureClass,
+    ContainerJobSubmitRequest,
+    ContainerJobWorkflowInput,
+    GpuObservation,
+    ResolvedContainerLaunchPlan,
+    failure_class_from_exception,
+    gpu_failure_class_from_validation_error,
+    terminal_gpu_observation,
+)
+from moonmind.schemas.workload_models import (
+    WORKLOAD_GPU_CAPABILITIES,
+    UnrestrictedContainerRequest,
+    WorkloadGpuRequest,
+)
+from moonmind.workflows.temporal.container_job_backend import (
+    DockerContainerJobBackend,
+)
+from moonmind.workflows.temporal.workflows.container_job import (
+    MoonMindContainerJobWorkflow,
+)
+from moonmind.workloads.gpu import gpu_device_request_args
+
+JOB_ID = "container-job:0123456789abcdef0123456789abcdef"
+
+# Fixture data only: MoonMind never selects this image or command.
+FIXTURE_IMAGE = "docker.io/library/qualification-fixture:1.0.0"
+FIXTURE_COMMAND = ("sh", "-lc", "probe --emit report.json")
+
+# Generic vendor/runtime diagnostics a daemon emits when it refuses a device
+# request. Each is host evidence, never a MoonMind condition.
+RUNTIME_UNAVAILABLE_STDERR = (
+    b"docker: Error response from daemon: failed to create task: "
+    b"nvidia-container-cli: initialization error\n"
+)
+DEVICE_UNAVAILABLE_STDERR = (
+    b"docker: Error response from daemon: failed to initialize NVML: "
+    b"Unknown Error\n"
+)
+DRIVER_UNSELECTABLE_STDERR = (
+    b'docker: Error response from daemon: could not select device driver "" '
+    b"with capabilities: [[gpu]]\n"
+)
+DEVICE_REQUEST_UNSUPPORTED_STDERR = b"unknown flag: --gpus\n"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spec(**overrides: Any) -> dict[str, Any]:
+    spec: dict[str, Any] = {
+        "image": FIXTURE_IMAGE,
+        "workspaceRef": {"kind": "sandbox", "workspaceId": "art_workspace"},
+        "command": list(FIXTURE_COMMAND),
+        "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+        "timeoutSeconds": 60,
+    }
+    spec.update(overrides)
+    return spec
+
+
+def _submission(*, gpu: dict[str, Any] | None = None) -> ContainerJobSubmitRequest:
+    resources: dict[str, Any] = {"cpuMillis": 1000, "memoryMiB": 512}
+    if gpu is not None:
+        resources["gpu"] = gpu
+    return ContainerJobSubmitRequest.model_validate(
+        {
+            "idempotencyKey": "issue-3779",
+            "source": {"source": "workflow", "workflowId": "mm:3779"},
+            "spec": _spec(resources=resources),
+        }
+    )
+
+
+def _activity_request(
+    tmp_path, *, gpu: dict[str, Any] | None = None
+) -> ContainerJobActivityRequest:
+    resources: dict[str, Any] = {"cpuMillis": 1000, "memoryMiB": 512}
+    if gpu is not None:
+        resources["gpu"] = gpu
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": JOB_ID,
+            "ownershipToken": f"{JOB_ID}:v1",
+            "request": _submission(gpu=gpu).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+            "resolvedWorkspaceRef": str(tmp_path / "art_workspace"),
+            "resolvedImageRef": "sha256:" + "a" * 64,
+        }
+    )
+
+
+def _workflow_input(*, gpu: dict[str, Any] | None = None) -> dict[str, Any]:
+    return ContainerJobWorkflowInput.model_validate(
+        {
+            "jobId": JOB_ID,
+            "observeIntervalSeconds": 1,
+            "request": _submission(gpu=gpu).model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+        }
+    ).model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def _runner(
+    commands: list[tuple[str, ...]],
+    *,
+    server_version: bytes = b"27.0.0",
+    failures: dict[str, tuple[int, bytes]] | None = None,
+):
+    """Return a recording Docker runner with optional per-command failures."""
+
+    failures = failures or {}
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:3] == ("inspect", "--format", "{{json .Config.Labels}}"):
+            return 1, b"", b"no such container"
+        if args[0] == "version":
+            return 0, server_version, b""
+        if args[0] in failures:
+            code, stderr = failures[args[0]]
+            return code, b"", stderr
+        if args[0] == "info":
+            return 0, str(64 * 1024**3).encode(), b""
+        return 0, b"", b""
+
+    return runner
+
+
+def _backend(tmp_path, runner, **kwargs) -> DockerContainerJobBackend:
+    (tmp_path / "art_workspace").mkdir(exist_ok=True)
+    return DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=runner, **kwargs
+    )
+
+
+def _device_request(create: tuple[str, ...]) -> str:
+    return create[create.index("--gpus") + 1]
+
+
+# ---------------------------------------------------------------------------
+# Request contract
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_spec_accepts_the_generic_vendor_count_and_capabilities() -> None:
+    submission = _submission(
+        gpu={
+            "vendor": "nvidia",
+            "count": "all",
+            "capabilities": ["graphics", "compute", "utility"],
+        }
+    )
+
+    gpu = submission.spec.resources.gpu
+    assert gpu is not None
+    assert gpu.vendor == "nvidia"
+    assert gpu.count == "all"
+    # Deduplicated and canonically ordered, so one semantic request always
+    # serializes to the same durable bytes.
+    assert gpu.capabilities == ("compute", "graphics", "utility")
+
+
+def test_capability_request_serialization_is_deterministic() -> None:
+    first = _submission(gpu={"capabilities": ["utility", "compute", "utility"]})
+    second = _submission(gpu={"capabilities": ["compute", "utility"]})
+
+    assert first.model_dump(mode="json", by_alias=True, exclude_none=True) == (
+        second.model_dump(mode="json", by_alias=True, exclude_none=True)
+    )
+    assert first.model_dump(mode="json", by_alias=True, exclude_none=True)["spec"][
+        "resources"
+    ]["gpu"] == {"vendor": "nvidia", "count": "all", "capabilities": ["compute", "utility"]}
+
+
+def test_omitted_capabilities_stay_absent_from_the_durable_request() -> None:
+    """An omitted optional field must not change already-recorded bytes."""
+
+    payload = _submission(gpu={"count": 2}).model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+
+    assert payload["spec"]["resources"]["gpu"] == {"vendor": "nvidia", "count": 2}
+
+
+def test_cpu_only_request_serialization_is_unchanged() -> None:
+    payload = _submission().model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    assert "gpu" not in payload["spec"]["resources"]
+
+
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        {"capabilities": []},
+        {"capabilities": "compute"},
+        {"capabilities": ["render"]},
+        {"capabilities": [1]},
+        {"capabilities": ["compute"], "deviceIds": [0]},
+    ],
+)
+def test_malformed_capability_request_is_refused_as_an_invalid_gpu_request(
+    gpu: dict[str, Any],
+) -> None:
+    with pytest.raises(Exception) as exc_info:
+        _submission(gpu=gpu)
+
+    assert (
+        gpu_failure_class_from_validation_error(exc_info.value)
+        == ContainerJobFailureClass.GPU_REQUEST_INVALID
+    )
+
+
+@pytest.mark.parametrize(
+    ("gpu", "expected"),
+    [
+        ({"vendor": "amd"}, ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED),
+        ({"vendor": "gpu"}, ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED),
+        ({"count": 0}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        ({"count": -1}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        ({"count": "2"}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        ({"count": True}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+        ({"count": "most"}, ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED),
+    ],
+)
+def test_unsupported_vendor_and_count_carry_their_stable_class(
+    gpu: dict[str, Any], expected: ContainerJobFailureClass
+) -> None:
+    with pytest.raises(Exception) as exc_info:
+        _submission(gpu=gpu)
+
+    assert gpu_failure_class_from_validation_error(exc_info.value) == expected
+
+
+def test_public_contract_still_forbids_device_and_authority_fields() -> None:
+    for forbidden in ({"devices": ["/dev/nvidia0"]}, {"privileged": True}):
+        with pytest.raises(Exception):
+            ContainerJobSubmitRequest.model_validate(
+                {
+                    "idempotencyKey": "issue-3779",
+                    "source": {"source": "workflow"},
+                    "spec": _spec(
+                        resources={
+                            "cpuMillis": 1000,
+                            "memoryMiB": 512,
+                            "gpu": {"count": "all", **forbidden},
+                        }
+                    ),
+                }
+            )
+
+
+def test_gpu_request_survives_temporal_payloads_and_the_launch_plan() -> None:
+    gpu = {"vendor": "nvidia", "count": 2, "capabilities": ["compute", "utility"]}
+    workflow_input = _workflow_input(gpu=gpu)
+
+    replayed = ContainerJobWorkflowInput.model_validate(
+        json.loads(json.dumps(workflow_input))
+    )
+    plan = ResolvedContainerLaunchPlan(
+        jobId=JOB_ID,
+        backendKind="docker-engine",
+        backendRef="system",
+        resolvedWorkspaceRef="/workspaces/art_workspace",
+        spec=replayed.request.spec,
+    )
+    round_tripped = ResolvedContainerLaunchPlan.model_validate(
+        json.loads(json.dumps(plan.model_dump(mode="json", by_alias=True)))
+    )
+
+    assert replayed.request.spec.resources.gpu == WorkloadGpuRequest.model_validate(gpu)
+    assert round_tripped.spec.resources.gpu == replayed.request.spec.resources.gpu
+
+
+def test_gpu_observation_crosses_the_activity_boundary_unchanged() -> None:
+    observation = GpuObservation(
+        vendor="nvidia",
+        count="all",
+        capabilities=("compute", "utility"),
+        backendSupported=True,
+        launched=True,
+    )
+    result = ContainerJobActivityResult(gpuObservation=observation)
+
+    replayed = ContainerJobActivityResult.model_validate(
+        json.loads(json.dumps(result.model_dump(mode="json", by_alias=True)))
+    )
+
+    assert replayed.gpu_observation == observation
+
+
+# ---------------------------------------------------------------------------
+# Trusted Docker backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("gpu", "expected"),
+    [
+        ({"count": "all"}, "all"),
+        ({"count": 2}, "2"),
+        (
+            {"count": "all", "capabilities": ["compute", "utility"]},
+            'count=all,"capabilities=compute,utility"',
+        ),
+        (
+            {"count": 3, "capabilities": ["utility", "compute", "graphics"]},
+            'count=3,"capabilities=compute,graphics,utility"',
+        ),
+    ],
+)
+async def test_backend_realizes_the_requested_device_request(
+    tmp_path, gpu: dict[str, Any], expected: str
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+
+    result = await backend.create_container(_activity_request(tmp_path, gpu=gpu))
+
+    create = next(command for command in commands if command[0] == "create")
+    assert _device_request(create) == expected
+    assert result.gpu_observation is not None
+    assert result.gpu_observation.backend_supported is True
+    assert result.gpu_observation.launched is False
+
+
+@pytest.mark.asyncio
+async def test_device_request_needs_no_privileged_mode_or_device_mount(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+
+    await backend.create_container(
+        _activity_request(tmp_path, gpu={"count": "all", "capabilities": ["compute"]})
+    )
+
+    create = next(command for command in commands if command[0] == "create")
+    assert "--device" not in create
+    assert "--privileged" not in create
+    assert "--privileged=false" in create
+    assert not any(token.startswith("/dev/") for token in create)
+
+
+@pytest.mark.asyncio
+async def test_backend_reports_support_before_creating_the_container(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+
+    await backend.create_container(_activity_request(tmp_path, gpu={"count": "all"}))
+
+    families = [command[0] for command in commands]
+    assert families.index("version") < families.index("create")
+
+
+@pytest.mark.asyncio
+async def test_cpu_only_job_reports_no_gpu_support_and_requests_no_device(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+
+    result = await backend.create_container(_activity_request(tmp_path))
+
+    create = next(command for command in commands if command[0] == "create")
+    assert "--gpus" not in create
+    assert result.gpu_observation is None
+    assert not any(command[0] == "version" for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_daemon_without_device_request_support_is_refused_before_create(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands, server_version=b"18.09.9"))
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.create_container(_activity_request(tmp_path, gpu={"count": 1}))
+
+    assert (
+        failure_class_from_exception(exc_info.value)
+        == ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED
+    )
+    assert not any(command[0] == "create" for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_device_count_above_the_deployment_ceiling_is_refused(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+    bounded = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_MAX_GPU_COUNT": "1"}
+    )
+    backend = _backend(tmp_path, _runner(commands), settings=bounded)
+
+    for requested in (2, "all"):
+        with pytest.raises(Exception) as exc_info:
+            await backend.create_container(
+                _activity_request(tmp_path, gpu={"count": requested})
+            )
+        assert (
+            failure_class_from_exception(exc_info.value)
+            == ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED
+        )
+    assert not any(command[0] == "create" for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_backend_refuses_a_vendor_it_cannot_realize(tmp_path) -> None:
+    """The backend is its own authority, not only the request contract."""
+
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+    request = _activity_request(tmp_path, gpu={"count": 1})
+    object.__setattr__(request.request.spec.resources.gpu, "vendor", "amd")
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.create_container(request)
+
+    assert (
+        failure_class_from_exception(exc_info.value)
+        == ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED
+    )
+    assert not any(command[0] == "create" for command in commands)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        (
+            RUNTIME_UNAVAILABLE_STDERR,
+            ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE,
+        ),
+        (
+            DEVICE_UNAVAILABLE_STDERR,
+            ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
+        ),
+        (
+            DRIVER_UNSELECTABLE_STDERR,
+            ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+        ),
+        (
+            DEVICE_REQUEST_UNSUPPORTED_STDERR,
+            ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED,
+        ),
+    ],
+)
+async def test_start_refusal_is_classified_before_caller_execution(
+    tmp_path, stderr: bytes, expected: ContainerJobFailureClass
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(
+        tmp_path, _runner(commands, failures={"start": (125, stderr)})
+    )
+    request = _activity_request(tmp_path, gpu={"count": "all"})
+    request.container_ref = "moonmind-container-job-owned"
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.start_container(request)
+
+    assert failure_class_from_exception(exc_info.value) == expected
+    assert failure_class_from_exception(exc_info.value) in GPU_FAILURE_CLASSES
+    # The daemon diagnostic can name trusted host paths; it never leaves here.
+    assert "Error response from daemon" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_create_refusal_of_the_device_request_is_classified(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(
+        tmp_path,
+        _runner(commands, failures={"create": (125, DRIVER_UNSELECTABLE_STDERR)}),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.create_container(_activity_request(tmp_path, gpu={"count": 1}))
+
+    assert (
+        failure_class_from_exception(exc_info.value)
+        == ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_gpu_launch_failure_stays_a_generic_launch_failure(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(
+        tmp_path,
+        _runner(
+            commands,
+            failures={
+                "create": (
+                    125,
+                    b"docker: Error response from daemon: invalid mount config\n",
+                )
+            },
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="docker create failed") as exc_info:
+        await backend.create_container(_activity_request(tmp_path, gpu={"count": 1}))
+
+    assert failure_class_from_exception(exc_info.value) is None
+
+
+@pytest.mark.asyncio
+async def test_started_gpu_container_records_launch_evidence(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+    request = _activity_request(
+        tmp_path, gpu={"count": 2, "capabilities": ["compute"]}
+    )
+    request.container_ref = "moonmind-container-job-owned"
+
+    result = await backend.start_container(request)
+
+    assert result.gpu_observation is not None
+    assert result.gpu_observation.launched is True
+    assert result.gpu_observation.count == 2
+    assert result.gpu_observation.capabilities == ("compute",)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_of_a_gpu_job_removes_only_the_run_owned_container(
+    tmp_path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+    request = _activity_request(
+        tmp_path, gpu={"count": "all", "capabilities": ["compute"]}
+    )
+    request.container_ref = "moonmind-container-job-owned"
+
+    await backend.cleanup(request)
+
+    assert not any(command[0] in {"rmi", "image"} for command in commands)
+    assert not any(
+        command[:2] == ("volume", "rm") for command in commands
+    )
+
+
+# ---------------------------------------------------------------------------
+# Durable workflow boundary
+# ---------------------------------------------------------------------------
+
+
+def _result_for(name: str) -> ContainerJobActivityResult:
+    if name == "container_job.resolve_workspace":
+        return ContainerJobActivityResult(
+            resolvedWorkspaceRef="/workspaces/art_workspace",
+            workspaceProbe="visible",
+        )
+    if name == "container_job.acquire_image":
+        return ContainerJobActivityResult(resolvedImageRef="sha256:" + "a" * 64)
+    if name == "container_job.reconcile_container":
+        return ContainerJobActivityResult(containerRef=None, running=False)
+    if name == "container_job.create_container":
+        return ContainerJobActivityResult(containerRef="owned:3779")
+    if name == "container_job.observe_container":
+        return ContainerJobActivityResult(terminalState="succeeded", exitCode=0)
+    return ContainerJobActivityResult()
+
+
+@pytest.mark.asyncio
+async def test_terminal_projection_carries_the_resolved_gpu_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = MoonMindContainerJobWorkflow()
+    projections: list[ContainerJobActivityRequest] = []
+
+    async def activity(name, request):
+        if name == "container_job.project_status":
+            projections.append(request.model_copy(deep=True))
+        if name == "container_job.create_container":
+            return ContainerJobActivityResult(
+                containerRef="owned:3779",
+                gpuObservation=GpuObservation(
+                    vendor="nvidia",
+                    count="all",
+                    capabilities=("compute", "utility"),
+                    backendSupported=True,
+                ),
+            )
+        if name == "container_job.start_container":
+            return ContainerJobActivityResult(
+                containerRef="owned:3779",
+                running=True,
+                gpuObservation=GpuObservation(
+                    vendor="nvidia",
+                    count="all",
+                    capabilities=("compute", "utility"),
+                    backendSupported=True,
+                    launched=True,
+                ),
+            )
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    result = await job.run(
+        _workflow_input(gpu={"count": "all", "capabilities": ["compute", "utility"]})
+    )
+
+    assert result["state"] == "succeeded"
+    terminal = projections[-1]
+    assert terminal.gpu_observation is not None
+    assert terminal.gpu_observation.launched is True
+    assert terminal.gpu_observation.backend_supported is True
+    assert terminal.gpu_observation.capabilities == ("compute", "utility")
+    assert terminal.gpu_observation.failure_class is None
+
+
+@pytest.mark.asyncio
+async def test_refusal_before_create_still_projects_the_requested_resource(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.schemas.container_job_models import ContainerJobBackendError
+
+    job = MoonMindContainerJobWorkflow()
+    projections: list[ContainerJobActivityRequest] = []
+
+    async def activity(name, request):
+        if name == "container_job.project_status":
+            projections.append(request.model_copy(deep=True))
+            return ContainerJobActivityResult()
+        if name == "container_job.create_container":
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE,
+                "selected container backend refused the requested GPU resource",
+            )
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    result = await job.run(_workflow_input(gpu={"count": 4}))
+
+    assert result["state"] == "failed"
+    assert result["terminal"]["failureClass"] == "gpu_runtime_unavailable"
+    terminal = projections[-1]
+    assert terminal.gpu_observation is not None
+    assert terminal.gpu_observation.count == 4
+    assert terminal.gpu_observation.launched is False
+    assert (
+        terminal.gpu_observation.failure_class
+        == ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE
+    )
+
+
+@pytest.mark.asyncio
+async def test_cpu_only_job_projects_no_gpu_observation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = MoonMindContainerJobWorkflow()
+    projections: list[ContainerJobActivityRequest] = []
+
+    async def activity(name, request):
+        if name == "container_job.project_status":
+            projections.append(request.model_copy(deep=True))
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    result = await job.run(_workflow_input())
+
+    assert result["state"] == "succeeded"
+    assert all(
+        projection.gpu_observation is None for projection in projections
+    )
+
+
+def test_an_ordinary_execution_failure_is_not_reported_as_a_gpu_failure() -> None:
+    observation = terminal_gpu_observation(
+        gpu=WorkloadGpuRequest(count=1),
+        observed=GpuObservation(
+            vendor="nvidia", count=1, backendSupported=True, launched=True
+        ),
+        failure_class=ContainerJobFailureClass.EXECUTION,
+    )
+
+    assert observation is not None
+    assert observation.failure_class is None
+    assert observation.launched is True
+
+
+# ---------------------------------------------------------------------------
+# One request contract across both container boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_and_unrestricted_paths_realize_one_device_request(
+    tmp_path,
+) -> None:
+    """A repository skill can move boundaries without changing GPU semantics."""
+
+    gpu = {"vendor": "nvidia", "count": 2, "capabilities": ["compute", "utility"]}
+    paths = {
+        name: tmp_path / name for name in ("repo", "artifacts", "scratch")
+    }
+    for path in paths.values():
+        path.mkdir(exist_ok=True)
+    unrestricted = UnrestrictedContainerRequest.model_validate(
+        {
+            "toolName": "container.run_container",
+            "agentRunId": "task-3779",
+            "stepId": "gpu-step",
+            "attempt": 1,
+            "repoDir": str(paths["repo"]),
+            "artifactsDir": str(paths["artifacts"]),
+            "scratchDir": str(paths["scratch"]),
+            "image": FIXTURE_IMAGE,
+            "command": list(FIXTURE_COMMAND),
+            "networkMode": "none",
+            "timeoutSeconds": 60,
+            "resources": {"gpu": gpu},
+        }
+    )
+    canonical = _submission(gpu=gpu)
+
+    # One semantic request, one realization, on both boundaries.
+    assert unrestricted.resources.gpu == canonical.spec.resources.gpu
+    expected = gpu_device_request_args(canonical.spec.resources.gpu)
+
+    commands: list[tuple[str, ...]] = []
+    backend = _backend(tmp_path, _runner(commands))
+    await backend.create_container(_activity_request(tmp_path, gpu=gpu))
+    create = next(command for command in commands if command[0] == "create")
+    assert [
+        "--gpus",
+        _device_request(create),
+    ] == expected
+
+    # The image and command the caller supplied are unchanged on both paths.
+    assert canonical.spec.image == unrestricted.image == FIXTURE_IMAGE
+    assert list(canonical.spec.command) == list(unrestricted.command)
+    assert create[-len(FIXTURE_COMMAND) :] == FIXTURE_COMMAND
+
+
+def test_status_contract_projects_one_bounded_gpu_observation() -> None:
+    from datetime import datetime, timezone
+
+    from moonmind.schemas.container_job_models import ContainerJobStatus
+
+    status = ContainerJobStatus(
+        jobId=JOB_ID,
+        state="succeeded",
+        gpu=GpuObservation(
+            vendor="nvidia", count="all", backendSupported=True, launched=True
+        ),
+        updatedAt=datetime.now(timezone.utc),
+    )
+
+    payload = status.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload["gpu"] == {
+        "vendor": "nvidia",
+        "count": "all",
+        "backendSupported": True,
+        "launched": True,
+    }
+
+
+def test_capability_vocabulary_is_bounded_and_vendor_neutral() -> None:
+    """The bounded list is driver capability names, not MoonMind vocabulary."""
+
+    assert WORKLOAD_GPU_CAPABILITIES == (
+        "compute",
+        "compat32",
+        "graphics",
+        "utility",
+        "video",
+        "display",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reattached_gpu_container_reports_its_realized_resource(
+    tmp_path,
+) -> None:
+    """A reconciled container skips create, so it reports the evidence itself."""
+
+    commands: list[tuple[str, ...]] = []
+    ownership = f"{JOB_ID}:v1".encode()
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:3] == ("inspect", "--format", "{{json .Config.Labels}}"):
+            return 0, b'{"moonmind.ownership":"' + ownership + b'"}', b""
+        if args[:3] == ("inspect", "--format", "{{.State.Running}}"):
+            return 0, b"true", b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+
+    result = await backend.reconcile_container(
+        _activity_request(tmp_path, gpu={"count": 2, "capabilities": ["compute"]})
+    )
+
+    assert result.gpu_observation is not None
+    assert result.gpu_observation.launched is True
+    assert result.gpu_observation.backend_supported is True
+    assert result.gpu_observation.count == 2
+    assert result.gpu_observation.capabilities == ("compute",)
+
+
+@pytest.mark.asyncio
+async def test_reattached_container_projection_survives_a_skipped_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = MoonMindContainerJobWorkflow()
+    projections: list[ContainerJobActivityRequest] = []
+    created = 0
+
+    async def activity(name, request):
+        nonlocal created
+        if name == "container_job.project_status":
+            projections.append(request.model_copy(deep=True))
+        if name == "container_job.create_container":
+            created += 1
+        if name == "container_job.reconcile_container":
+            return ContainerJobActivityResult(
+                containerRef="owned:3779",
+                running=True,
+                gpuObservation=GpuObservation(
+                    vendor="nvidia",
+                    count="all",
+                    backendSupported=True,
+                    launched=True,
+                ),
+            )
+        return _result_for(name)
+
+    monkeypatch.setattr(job, "_activity", activity)
+    result = await job.run(_workflow_input(gpu={"count": "all"}))
+
+    assert result["state"] == "succeeded"
+    assert created == 0
+    assert projections[-1].gpu_observation is not None
+    assert projections[-1].gpu_observation.launched is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reports_no_gpu_evidence_for_a_cpu_only_job(tmp_path) -> None:
+    commands: list[tuple[str, ...]] = []
+    ownership = f"{JOB_ID}:v1".encode()
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[:3] == ("inspect", "--format", "{{json .Config.Labels}}"):
+            return 0, b'{"moonmind.ownership":"' + ownership + b'"}', b""
+        if args[:3] == ("inspect", "--format", "{{.State.Running}}"):
+            return 0, b"true", b""
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+
+    result = await backend.reconcile_container(_activity_request(tmp_path))
+
+    assert result.gpu_observation is None
+
+
+# ---------------------------------------------------------------------------
+# Parent workflow tool dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_job_dispatch_submits_and_reports_the_gpu_resource(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parent workflow's container tool carries the request and evidence."""
+
+    from datetime import datetime, timezone
+
+    from moonmind.workflows.temporal.workflows import run as run_workflow_module
+    from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+    submitted: list[dict[str, Any]] = []
+    job_id = JOB_ID
+
+    async def fake_execute_activity(activity_type, payload, **kwargs):
+        if activity_type == "container_job.submit":
+            submitted.append(payload)
+            return {"jobId": job_id, "state": "queued"}
+        if activity_type == "container_job.status":
+            return {
+                "jobId": job_id,
+                "state": "failed",
+                "terminal": {
+                    "exitCode": None,
+                    "failureClass": "gpu_resource_unavailable",
+                    "message": "selected container backend refused the requested "
+                    "GPU resource (gpu_device_unavailable)",
+                },
+                "gpu": {
+                    "vendor": "nvidia",
+                    "count": 2,
+                    "capabilities": ["compute", "utility"],
+                    "backendSupported": True,
+                    "launched": False,
+                    "failureClass": "gpu_resource_unavailable",
+                },
+            }
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        type(
+            "WorkflowInfo",
+            (),
+            {
+                "namespace": "default",
+                "workflow_id": "wf-3779",
+                "run_id": "run-1",
+                "search_attributes": {},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc)
+    )
+
+    result = await workflow._execute_container_job_tool(
+        node_inputs={
+            "idempotencyKey": "wf-3779:gpu-step:1",
+            "spec": {
+                "image": FIXTURE_IMAGE,
+                "command": list(FIXTURE_COMMAND),
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "run"},
+                "resources": {
+                    "cpuMillis": 1000,
+                    "memoryMiB": 512,
+                    "gpu": {
+                        "vendor": "nvidia",
+                        "count": 2,
+                        "capabilities": ["utility", "compute"],
+                    },
+                },
+            },
+        },
+        node_id="gpu-step",
+        execution_ordinal=1,
+    )
+
+    assert len(submitted) == 1
+    # The submitted request carries the caller's normalized GPU resource, and
+    # the caller's image and command are untouched.
+    spec = submitted[0]["request"]["spec"]
+    assert spec["resources"]["gpu"] == {
+        "vendor": "nvidia",
+        "count": 2,
+        "capabilities": ["compute", "utility"],
+    }
+    assert spec["image"] == FIXTURE_IMAGE
+    assert spec["command"] == list(FIXTURE_COMMAND)
+
+    assert result["status"] == "FAILED"
+    assert result["outputs"]["failureClass"] == "gpu_resource_unavailable"
+    assert result["outputs"]["gpu"]["launched"] is False
+    assert result["outputs"]["gpu"]["capabilities"] == ["compute", "utility"]
+
+
+@pytest.mark.asyncio
+async def test_run_job_dispatch_reports_no_gpu_output_for_a_cpu_only_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from datetime import datetime, timezone
+
+    from moonmind.workflows.temporal.workflows import run as run_workflow_module
+    from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+    async def fake_execute_activity(activity_type, payload, **kwargs):
+        if activity_type == "container_job.submit":
+            return {"jobId": JOB_ID, "state": "queued"}
+        if activity_type == "container_job.status":
+            return {
+                "jobId": JOB_ID,
+                "state": "succeeded",
+                "terminal": {"exitCode": 0},
+            }
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", fake_execute_activity
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        type(
+            "WorkflowInfo",
+            (),
+            {
+                "namespace": "default",
+                "workflow_id": "wf-3779",
+                "run_id": "run-1",
+                "search_attributes": {},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc)
+    )
+
+    result = await workflow._execute_container_job_tool(
+        node_inputs={
+            "idempotencyKey": "wf-3779:cpu-step:1",
+            "spec": {
+                "image": FIXTURE_IMAGE,
+                "command": list(FIXTURE_COMMAND),
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "run"},
+                "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+            },
+        },
+        node_id="cpu-step",
+        execution_ordinal=1,
+    )
+
+    assert result["status"] == "COMPLETED"
+    assert "gpu" not in result["outputs"]
+
+
+def test_run_job_tool_schema_publishes_the_capability_and_observation_fields() -> None:
+    from moonmind.workloads.tool_bridge import (
+        build_container_job_tool_definition_payload,
+    )
+
+    payload = build_container_job_tool_definition_payload(name="container.run_job")
+    gpu_input = payload["inputs"]["schema"]["properties"]["spec"]["properties"][
+        "resources"
+    ]["properties"]["gpu"]
+    gpu_output = payload["outputs"]["schema"]["properties"]["gpu"]
+
+    assert gpu_input["properties"]["capabilities"]["items"]["enum"] == list(
+        WORKLOAD_GPU_CAPABILITIES
+    )
+    assert gpu_input["additionalProperties"] is False
+    assert set(gpu_output["properties"]) == {
+        "vendor",
+        "count",
+        "capabilities",
+        "backendSupported",
+        "launched",
+        "failureClass",
+    }
+    # The workflow-facing contract exposes no Docker flag or device authority.
+    for schema in (gpu_input, gpu_output):
+        assert "devices" not in schema["properties"]
+        assert "deviceRequestArgs" not in schema["properties"]

--- a/tests/unit/workflows/temporal/test_container_job_gpu_resources.py
+++ b/tests/unit/workflows/temporal/test_container_job_gpu_resources.py
@@ -62,6 +62,14 @@ DEVICE_UNAVAILABLE_STDERR = (
     b"docker: Error response from daemon: failed to initialize NVML: "
     b"Unknown Error\n"
 )
+# An installed runtime with no usable device reports the device failure through
+# the vendor's own CLI, so this diagnostic names both the generic CLI prefix and
+# the specific device condition.
+RUNTIME_PRESENT_DEVICE_UNAVAILABLE_STDERR = (
+    b"docker: Error response from daemon: failed to create task: "
+    b"nvidia-container-cli: device error: failed to initialize NVML: "
+    b"no devices were found\n"
+)
 DRIVER_UNSELECTABLE_STDERR = (
     b'docker: Error response from daemon: could not select device driver "" '
     b"with capabilities: [[gpu]]\n"
@@ -419,6 +427,46 @@ async def test_daemon_without_device_request_support_is_refused_before_create(
 
 
 @pytest.mark.asyncio
+async def test_unreachable_endpoint_never_echoes_the_daemon_diagnostic(
+    tmp_path,
+) -> None:
+    """The support probe's caller-visible message is a fixed string.
+
+    ``docker version`` stderr can name the deployment-owned daemon URI, its
+    certificate paths, or credential-bearing connection detail, and this message
+    becomes the durable terminal outcome the status API projects.
+    """
+
+    commands: list[tuple[str, ...]] = []
+    endpoint_detail = (
+        b"Cannot connect to the Docker daemon at "
+        b"tcp://gpu-host.internal:2376 (client cert "
+        b"/etc/docker/certs.d/client.pem)\n"
+    )
+
+    async def runner(args):
+        args = tuple(args)
+        commands.append(args)
+        if args[0] == "version":
+            return 1, b"", endpoint_detail
+        return 0, b"", b""
+
+    backend = _backend(tmp_path, runner)
+
+    with pytest.raises(Exception) as exc_info:
+        await backend.create_container(_activity_request(tmp_path, gpu={"count": 1}))
+
+    assert (
+        failure_class_from_exception(exc_info.value)
+        == ContainerJobFailureClass.INFRASTRUCTURE
+    )
+    message = str(exc_info.value)
+    for secret in ("gpu-host.internal", "2376", "certs.d", "client.pem", "tcp://"):
+        assert secret not in message
+    assert not any(command[0] == "create" for command in commands)
+
+
+@pytest.mark.asyncio
 async def test_device_count_above_the_deployment_ceiling_is_refused(tmp_path) -> None:
     commands: list[tuple[str, ...]] = []
     bounded = resolve_container_backend_settings(
@@ -467,6 +515,12 @@ async def test_backend_refuses_a_vendor_it_cannot_realize(tmp_path) -> None:
         ),
         (
             DEVICE_UNAVAILABLE_STDERR,
+            ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
+        ),
+        (
+            # A working runtime with no usable device must direct the operator
+            # at device capacity, not at repairing the runtime.
+            RUNTIME_PRESENT_DEVICE_UNAVAILABLE_STDERR,
             ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE,
         ),
         (
@@ -674,6 +728,10 @@ async def test_refusal_before_create_still_projects_the_requested_resource(
     assert terminal.gpu_observation is not None
     assert terminal.gpu_observation.count == 4
     assert terminal.gpu_observation.launched is False
+    # The refusal is only reachable after the backend reported support, so the
+    # durable status must not contradict evidence obtained at that boundary even
+    # though the activity raised before it could return an observation.
+    assert terminal.gpu_observation.backend_supported is True
     assert (
         terminal.gpu_observation.failure_class
         == ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE
@@ -699,6 +757,35 @@ async def test_cpu_only_job_projects_no_gpu_observation(
     assert all(
         projection.gpu_observation is None for projection in projections
     )
+
+
+@pytest.mark.parametrize(
+    ("failure_class", "expected_support"),
+    [
+        (ContainerJobFailureClass.GPU_RUNTIME_UNAVAILABLE, True),
+        (ContainerJobFailureClass.GPU_RESOURCE_UNAVAILABLE, True),
+        # Reachable from the pre-create support report itself, so support was
+        # never established and must stay unknown.
+        (ContainerJobFailureClass.GPU_BACKEND_UNSUPPORTED, None),
+        (ContainerJobFailureClass.GPU_VENDOR_UNSUPPORTED, None),
+        (ContainerJobFailureClass.GPU_COUNT_UNSUPPORTED, None),
+    ],
+)
+def test_a_refusal_reports_support_only_when_the_backend_established_it(
+    failure_class: ContainerJobFailureClass, expected_support: bool | None
+) -> None:
+    """A refused job's durable status agrees with the evidence it obtained."""
+
+    observation = terminal_gpu_observation(
+        gpu=WorkloadGpuRequest(count=2),
+        observed=None,
+        failure_class=failure_class,
+    )
+
+    assert observation is not None
+    assert observation.backend_supported is expected_support
+    assert observation.launched is False
+    assert observation.failure_class == failure_class
 
 
 def test_an_ordinary_execution_failure_is_not_reported_as_a_gpu_failure() -> None:

--- a/tests/unit/workloads/test_gpu_container_genericity_guard.py
+++ b/tests/unit/workloads/test_gpu_container_genericity_guard.py
@@ -31,6 +31,12 @@ GPU_BEARING_MODULES: tuple[Path, ...] = (
     Path("moonmind/schemas/container_job_models.py"),
     Path("moonmind/config/container_backend_settings.py"),
     Path("moonmind/workflows/temporal/container_job_backend.py"),
+    Path("moonmind/workflows/temporal/workflows/container_job.py"),
+    Path("moonmind/workflows/temporal/worker_runtime.py"),
+    Path("moonmind/mcp/container_job_tool_registry.py"),
+    Path("api_service/services/container_jobs.py"),
+    Path("api_service/api/routers/container_jobs.py"),
+    Path("api_service/db/models.py"),
     Path("moonmind/workloads/docker_launcher.py"),
     Path("moonmind/workloads/registry.py"),
     Path("moonmind/workloads/tool_bridge.py"),
@@ -41,6 +47,8 @@ GPU_BEARING_MODULES: tuple[Path, ...] = (
 QUALIFICATION_FIXTURES: tuple[Path, ...] = (
     Path("tests/unit/workloads/test_gpu_container_qualification.py"),
     Path("tests/unit/workflows/temporal/test_gpu_container_dispatch.py"),
+    Path("tests/unit/workflows/temporal/test_container_job_gpu_resources.py"),
+    Path("tests/unit/api/test_container_job_gpu_transport.py"),
     Path("tests/integration/workloads/test_nvidia_container_qualification_journey.py"),
 )
 

--- a/tests/unit/workloads/test_gpu_container_qualification.py
+++ b/tests/unit/workloads/test_gpu_container_qualification.py
@@ -1118,7 +1118,13 @@ async def test_qualification_record_captures_generic_evidence(
     assert payload["requestSchemaVersion"] == GPU_CONTAINER_REQUEST_SCHEMA_VERSION
     assert payload["imageRef"] == QUALIFICATION_IMAGE
     assert payload["imageDigest"] == "sha256:" + "a" * 64
-    assert payload["gpuRequest"] == {"vendor": "nvidia", "count": 2}
+    # The published record keeps null optional fields, so an omitted
+    # capability request is recorded as explicitly absent.
+    assert payload["gpuRequest"] == {
+        "vendor": "nvidia",
+        "count": 2,
+        "capabilities": None,
+    }
     assert payload["deviceRequestArgs"] == ["--gpus", "2"]
     assert payload["status"] == "succeeded"
     assert payload["exitCode"] == 0
@@ -1168,7 +1174,9 @@ def _executed_workload_metadata(
                 "request": (
                     gpu_request
                     if gpu_request is not None
-                    else gpu.model_dump(mode="json", by_alias=True)
+                    else gpu.model_dump(
+                        mode="json", by_alias=True, exclude_none=True
+                    )
                 ),
                 "deviceRequestArgs": (
                     device_request_args

--- a/tests/unit/workloads/test_gpu_container_qualification.py
+++ b/tests/unit/workloads/test_gpu_container_qualification.py
@@ -787,11 +787,14 @@ async def test_started_container_writing_gpu_text_is_not_a_device_refusal(
             "nvidia_runtime_unavailable",
         ),
         (
+            # The vendor stack reports a device failure through its own CLI, so
+            # the specific device signature decides the reason, not the generic
+            # ``nvidia-container-cli`` prefix that accompanies it.
             (
                 "nvidia-container-cli: device error: Failed to initialize NVML: "
                 "no devices were found."
             ),
-            "nvidia_runtime_unavailable",
+            "gpu_device_unavailable",
         ),
         (
             "docker: Error response from daemon: detected 0 devices for the request.",


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3779 — Container Jobs: Add generic GPU resource requests and NVIDIA execution

Closes MoonLadderStudios/MoonMind#3779

## Summary

The assessment for this issue recorded `PARTIALLY_IMPLEMENTED`: the canonical Container Jobs service already accepted a generic NVIDIA GPU resource request end to end (shared `WorkloadGpuRequest`, the non-overridable deployment device ceiling, and the trusted-backend `--gpus all` / `--gpus <n>` argv landed under #3777). The remaining backlog was in the capability model, the failure-classification plane, and the evidence plane. This change completes it. The request contract, device ceiling, and canonical backend argv from #3777 are unchanged.

- **Bounded driver capabilities.** `WorkloadGpuRequest` now carries an optional bounded `capabilities` field (`compute`, `compat32`, `graphics`, `utility`, `video`, `display`) with pre-coercion validation, dedupe, and canonical ordering. An omitted field stays absent from serialization, so already-recorded GPU requests and CPU-only requests serialize byte-identically. Realized as Docker's quoted `capabilities=` device-request field.
- **Stable generic failure classes.** Adds the six required classes — `gpu_request_invalid`, `gpu_vendor_unsupported`, `gpu_count_unsupported`, `gpu_backend_unsupported`, `gpu_runtime_unavailable`, `gpu_resource_unavailable`. Submission refusals are classified from the contract's own typed refusal and surfaced identically over HTTP and MCP without echoing the rejected value; the device ceiling now rejects with `gpu_count_unsupported`. No `unreal_*` / `cuda_*` or otherwise application-specific vocabulary is introduced.
- **Backend support reporting and pre-execution rejection.** The trusted Docker backend reports daemon support (vendor plus device-request API) before container create, and classifies a daemon refusal at create/start through the shared launch classifier — so an unavailable GPU runtime or device fails *before* the caller's workload runs instead of degrading into an untyped launch failure.
- **Bounded GPU observation, persisted and projected.** One compact `GpuObservation` is produced at reconcile/create/start, threaded through the Activity and workflow payloads, stored in `container_jobs.gpu_observation_json` (migration `364_container_job_gpu_obs`), projected as `ContainerJobStatus.gpu`, and reported by the `container.run_job` workflow tool dispatch. It carries no Docker device-request structure, flag, device path, endpoint, socket, or ownership label.
- **Docs and journey coverage.** Documents the unrestricted → canonical `container.submit` mapping and the canonical failure classes in `docs/Workflows/GpuContainerContract.md` and `docs/ManagedAgents/DockerBackendService.md`, and extends the NVIDIA qualification journey with a canonical container-job leg gated on a real GPU host (`requires_gpu`, excluded from required CI).

Privileged mode, arbitrary device mounts, Docker endpoints/sockets, and ownership-label control remain contract-forbidden; job cleanup still removes only the run-owned container and temporary data, never the image or caller-declared shared cache volumes.

## Tests run

Controlling suites (all PASS):

- `pytest tests/unit/api/test_container_job_gpu_transport.py tests/unit/workflows/temporal/test_container_job_gpu_resources.py tests/unit/workflows/temporal/test_container_job_backend.py tests/unit/workloads/test_gpu_container_genericity_guard.py tests/unit/workloads/test_gpu_container_qualification.py tests/unit/api_service/test_container_jobs_migration.py tests/unit/api/test_container_jobs_transport.py` — 251 passed
- `python3 tools/check_alembic_graph.py` — single head `364_container_job_gpu_obs`
- `npm run api:types && git diff --exit-code -- frontend/src/generated/openapi.ts` — regenerated bundle byte-identical to the committed one
- frontend typecheck (`tsc --noEmit`), frontend lint (`eslint`), and `./tools/test_unit.sh --dashboard-only`

Advisory regression sweep:

- `pytest tests/unit/workflows/temporal tests/unit/api tests/unit/api_service tests/unit/schemas tests/unit/mcp tests/unit/workloads` — 6303 passed, 1 xfailed, 5 failed. All 5 failures are `tests/unit/api/routers/test_executions.py` `IllegalStateChangeError` from asyncpg pool teardown; the failing subset varies per run and reproduces on baseline `66fd3a411`. No container-job, GPU, schema, MCP, or workload test failed.
- `pytest tests/integration/reliability -m reliability_journey` — 109 passed, 2 failed. Both are `test_escaped_failure_journeys.py` `WORKSPACE_AUTHORITY_MISMATCH` (remote daemon mode requires `WORKFLOW_WORKSPACE_DAEMON_ROOT`), reproducing identically on baseline `66fd3a411`.

Not run in this environment (environment blockers, not results):

- Hermetic `integration_ci` (`./tools/test_integration.sh`) — `docker-compose.test.yaml` requires a `.env` that does not exist in this managed agent workspace, and the host's only reachable Docker daemon runs the live deployment executing this job.
- GPU qualification (`./tools/test_gpu_qualification.sh`) — requires a deployment-owned NVIDIA host, an NVIDIA container runtime, and `MOONMIND_GPU_QUALIFICATION_IMAGE`. Excluded from required CI by design; the new canonical leg skips with an explicit environment reason on CPU-only runners.
- `tests/unit/omnigent` and `tests/unit/agents/test_moonspec_acceptance_assessment.py` — the `omnigent/` and `moonspec/` submodules are not checked out here, so those suites fail on missing pinned upstream sources both before and after this change.

## Remaining risks

- **Real GPU execution is unverified in CI.** The `--gpus`/`capabilities=` argv and the daemon-support probe are covered by unit tests against a faked Docker client, but no NVIDIA hardware executed a canonical container job in this run. First real qualification depends on the deployment-owned GPU host running `./tools/test_gpu_qualification.sh`.
- **Daemon refusal classification depends on Docker error text.** Mapping a daemon refusal to `gpu_runtime_unavailable` vs `gpu_resource_unavailable` reads the Engine's error message. A future Docker Engine wording change could reclassify a refusal into the generic bucket; the failure still occurs before the caller's workload runs, so the safety boundary holds, only the class precision would degrade.
- **New durable column.** `container_jobs.gpu_observation_json` is added by migration `364_container_job_gpu_obs` and is nullable, so in-flight and historical CPU-only jobs read back as no observation. The migration gate confirms a single head, but the migration has only been exercised against the unit migration test, not a production-sized table.
- **Hermetic integration seam unexercised here.** The container-jobs integration boundary (worker topology, compose foundation) was not run in this workspace; required CI is the first place that seam executes for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
