### PR TITLE
fix(workflows): preserve GitHub orchestration metadata

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -17316,6 +17316,127 @@ describe("Task Create MM-578 Preset expansion", () => {
     ).toEqual({ mode: "pr", mergeAutomation: { enabled: true } });
   });
 
+  it("preserves GitHub orchestration runtime metadata from preset expansion", async () => {
+    const githubOrchestration = {
+      task: {
+        repository: "MoonLadderStudios/Tactics",
+        runtime: { mode: "codex_cli" },
+        publish: {
+          mode: "pr",
+          mergeAutomation: { enabled: true },
+        },
+      },
+    };
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/presets?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "github-issue-breakdown-implement",
+                scope: "global",
+                title: "GitHub Issue Breakdown and Implement",
+                description: "Create dependent GitHub issue workflows.",
+                latestVersion: "1",
+                version: "1",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/presets/github-issue-breakdown-implement?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            slug: "github-issue-breakdown-implement",
+            scope: "global",
+            title: "GitHub Issue Breakdown and Implement",
+            description: "Create dependent GitHub issue workflows.",
+            latestVersion: "1",
+            version: "1",
+            inputs: [],
+          }),
+        } as Response);
+      }
+      if (
+        url.startsWith(
+          "/api/presets/github-issue-breakdown-implement:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:github-issue-breakdown-implement:1:01",
+                title: "Create GitHub issue workflows",
+                instructions: "Create one implementation workflow per issue.",
+                skill: {
+                  id: "story.create_github_issue_implement_workflows",
+                  args: {},
+                },
+                githubOrchestration,
+              },
+            ],
+            appliedTemplate: {
+              slug: "github-issue-breakdown-implement",
+              version: "1",
+            },
+            capabilities: ["git", "gh"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(within(step).getByLabelText("Instructions"), {
+      target: { value: "Break down the GitHub issue and implement each story." },
+    });
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(
+        Array.from(presetSelect.options).some(
+          (option) =>
+            option.value === "global::::github-issue-breakdown-implement",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::github-issue-breakdown-implement" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest();
+    const payload = request.payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(
+      (task.steps as Array<Record<string, unknown>>)[0]
+        ?.githubOrchestration,
+    ).toEqual(githubOrchestration);
+  });
+
   it("does not force none publish mode from stale Jira Breakdown preset provenance", async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1021,6 +1021,7 @@ interface ExpandedStepPayload {
   story_output?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
   jira_orchestration?: Record<string, unknown>;
+  githubOrchestration?: Record<string, unknown>;
 }
 
 interface PresetExpandResponse {
@@ -1209,6 +1210,7 @@ interface StepState {
   source?: Record<string, unknown>;
   storyOutput?: Record<string, unknown>;
   jiraOrchestration?: Record<string, unknown>;
+  githubOrchestration?: Record<string, unknown>;
   runtimeCommand?: Record<string, unknown>;
 }
 
@@ -2289,6 +2291,9 @@ function createStepStateEntriesFromTemporalDraft(
     const hasJiraOrchestration =
       step.jiraOrchestration &&
       Object.keys(step.jiraOrchestration).length > 0;
+    const hasGithubOrchestration =
+      step.githubOrchestration &&
+      Object.keys(step.githubOrchestration).length > 0;
     const toolPayload = step.tool || {};
     const presetPayload = step.preset || {};
     const presetKey =
@@ -2369,6 +2374,9 @@ function createStepStateEntriesFromTemporalDraft(
         : {}),
       ...(hasJiraOrchestration
         ? { jiraOrchestration: step.jiraOrchestration }
+        : {}),
+      ...(hasGithubOrchestration
+        ? { githubOrchestration: step.githubOrchestration }
         : {}),
       ...(step.runtimeCommand && Object.keys(step.runtimeCommand).length > 0
         ? { runtimeCommand: step.runtimeCommand }
@@ -3476,6 +3484,7 @@ function mapExpandedStepToState(
   const jiraOrchestration =
     nonEmptyRecordValue(step.jiraOrchestration) ||
     nonEmptyRecordValue(step.jira_orchestration);
+  const githubOrchestration = nonEmptyRecordValue(step.githubOrchestration);
   const annotations = nonEmptyRecordValue(step.annotations);
   const source =
     nonEmptyRecordValue(step.source) ||
@@ -3516,6 +3525,7 @@ function mapExpandedStepToState(
     ...(normalizedSource ? { source: normalizedSource } : {}),
     ...(storyOutput ? { storyOutput } : {}),
     ...(jiraOrchestration ? { jiraOrchestration } : {}),
+    ...(githubOrchestration ? { githubOrchestration } : {}),
   });
 }
 
@@ -10997,6 +11007,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             Boolean(
               sourceStep.jiraOrchestration &&
                 Object.keys(sourceStep.jiraOrchestration).length > 0,
+            ) ||
+            Boolean(
+              sourceStep.githubOrchestration &&
+                Object.keys(sourceStep.githubOrchestration).length > 0,
             );
           const shouldSubmitStepType =
             submittedStepType === "tool" ||
@@ -11027,6 +11041,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             ...(sourceStep.jiraOrchestration &&
             Object.keys(sourceStep.jiraOrchestration).length > 0
               ? { jiraOrchestration: sourceStep.jiraOrchestration }
+              : {}),
+            ...(sourceStep.githubOrchestration &&
+            Object.keys(sourceStep.githubOrchestration).length > 0
+              ? { githubOrchestration: sourceStep.githubOrchestration }
               : {}),
             ...entry.payload,
           };

--- a/frontend/src/lib/temporalTaskEditing.test.ts
+++ b/frontend/src/lib/temporalTaskEditing.test.ts
@@ -299,6 +299,38 @@ describe("buildTemporalSubmissionDraftFromExecution runtime command metadata", (
     });
   });
 
+  it("preserves GitHub orchestration metadata from saved workflow steps", () => {
+    const githubOrchestration = {
+      task: {
+        repository: "MoonLadderStudios/MoonMind",
+        runtime: { mode: "codex_cli" },
+        publish: {
+          mode: "pr",
+          mergeAutomation: { enabled: true },
+        },
+      },
+    };
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:github-orchestration-edit",
+      workflowType: "MoonMind.UserWorkflow",
+      targetRuntime: "codex_cli",
+      inputParameters: {
+        workflow: {
+          instructions: "Create downstream GitHub issue workflows.",
+          steps: [
+            {
+              id: "create-github-workflows",
+              instructions: "Queue one workflow per issue.",
+              githubOrchestration,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps[0]?.githubOrchestration).toEqual(githubOrchestration);
+  });
+
   it("reconstructs canonical workflow steps from execution parameters", () => {
     const draft = buildTemporalSubmissionDraftFromExecution({
       workflowId: "mm:canonical-workflow",

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -162,6 +162,7 @@ export type TemporalSubmissionDraft = {
     annotations?: Record<string, unknown>;
     storyOutput?: Record<string, unknown>;
     jiraOrchestration?: Record<string, unknown>;
+    githubOrchestration?: Record<string, unknown>;
     runtimeCommand?: Record<string, unknown>;
   }>;
   appliedTemplates: Array<{
@@ -561,6 +562,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     step.jiraOrchestration,
     step.jira_orchestration,
   );
+  const githubOrchestration = objectValue(step.githubOrchestration);
   const runtimeCommand = firstObjectValue(
     step.runtimeCommand,
     step.runtime_command,
@@ -628,6 +630,9 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     ...(Object.keys(annotations).length > 0 ? { annotations } : {}),
     ...(Object.keys(storyOutput).length > 0 ? { storyOutput } : {}),
     ...(Object.keys(jiraOrchestration).length > 0 ? { jiraOrchestration } : {}),
+    ...(Object.keys(githubOrchestration).length > 0
+      ? { githubOrchestration }
+      : {}),
     ...(Object.keys(runtimeCommand).length > 0 ? { runtimeCommand } : {}),
   };
 
@@ -650,6 +655,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     Object.keys(annotations).length > 0 ||
     Object.keys(storyOutput).length > 0 ||
     Object.keys(jiraOrchestration).length > 0 ||
+    Object.keys(githubOrchestration).length > 0 ||
     Object.keys(runtimeCommand).length > 0;
   return hasContent ? result : null;
 }


### PR DESCRIPTION
# Summary

- Preserve expanded `githubOrchestration` metadata through workflow-start state and `/api/executions` submission.
- Preserve the same metadata when reconstructing edit and rerun drafts.
- Add escaped-regression coverage for the GitHub issue breakdown preset handoff.

# Root cause

Five recent downstream GitHub issue workflows failed because the workflow-start UI dropped the preset-owned orchestration block. That removed the explicitly selected `codex_cli` runtime before the story fan-out step created child executions. The children then reached the default Omnigent path without an immutable execution target and failed with `omnigent_contract_error`.

This change carries the canonical orchestration block unchanged; it does not introduce a fallback or substitute a runtime.

# Verification

- `npm run ui:test -- frontend/src/lib/temporalTaskEditing.test.ts frontend/src/entrypoints/workflow-start.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:lint`
- `npm run ui:build:check`