### PR TITLE
feat(provider-profiles): scope selection by runtime and enforce runtime ownership at launch (MoonLadderStudios/MoonMind#3788)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -79,6 +79,12 @@ from api_service.db.models import (
     WorkflowCheckpointBranchTurn,
 )
 from api_service.services.checkpoint_branches import prepare_checkpoint_branch_workspace
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileNotFoundError,
+    ProviderProfileRuntimeMismatchError,
+    load_provider_profile_for_runtime,
+    require_provider_profile_runtime,
+)
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
     refresh_managed_bootstrap_snapshot,
@@ -7817,45 +7823,26 @@ def _require_provider_profile_runtime(
     profile_id: str,
     selected_runtime: str | None,
 ) -> None:
-    """Reject a Provider Profile that is not owned by the selected runtime.
+    """Map the shared Provider Profile runtime invariant onto HTTP 409.
 
-    Provider Profiles are runtime-owned launch contracts: ``runtime_id`` decides
-    credential materialization, environment and file shaping, command behavior,
-    and model tiers, so the same upstream provider needs one profile per
-    runtime. Enforcing the relationship here keeps alternate clients from
-    bypassing the runtime-scoped selectors in the dashboard.
-
-    ``omnigent`` is an execution facade rather than a Provider Profile owner:
-    the profile it launches stays owned by the underlying managed runtime, and
-    compatibility is enforced against the selected execution target by
-    ``api_service.services.omnigent_agent_profile_selection``.
+    The rule itself lives in
+    :mod:`api_service.services.provider_profile_runtime` so that every
+    launch-authoring boundary — execution submission, step authoring, and
+    recurring-schedule authoring — enforces one contract instead of a copy per
+    router.
     """
 
-    if profile is None or not selected_runtime:
-        return
-    canonical_runtime = normalize_runtime_id(selected_runtime)
-    if canonical_runtime == "omnigent":
-        return
-    raw_profile_runtime = str(getattr(profile, "runtime_id", "") or "").strip()
-    if not raw_profile_runtime:
-        return
-    profile_runtime = normalize_runtime_id(raw_profile_runtime)
-    if profile_runtime == canonical_runtime:
-        return
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail={
-            "code": "provider_profile_runtime_mismatch",
-            "message": (
-                f"Provider Profile {profile_id!r} belongs to runtime "
-                f"{profile_runtime!r} and cannot be used with runtime "
-                f"{canonical_runtime!r}."
-            ),
-            "profileId": profile_id,
-            "profileRuntime": profile_runtime,
-            "selectedRuntime": canonical_runtime,
-        },
-    )
+    try:
+        require_provider_profile_runtime(
+            profile=profile,
+            profile_id=profile_id,
+            selected_runtime=selected_runtime,
+        )
+    except ProviderProfileRuntimeMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
 
 
 async def _load_provider_profile_for_runtime(
@@ -7871,18 +7858,19 @@ async def _load_provider_profile_for_runtime(
     anything, so an incompatible pair can never reach a launch.
     """
 
-    session_get = getattr(session, "get", None)
-    if session is None or not callable(session_get):
-        return None
-    profile = await session_get(ManagedAgentProviderProfile, profile_id)
-    if profile is None:
-        raise _invalid_workflow_request(not_found_message)
-    _require_provider_profile_runtime(
-        profile=profile,
-        profile_id=profile_id,
-        selected_runtime=selected_runtime,
-    )
-    return profile
+    try:
+        return await load_provider_profile_for_runtime(
+            session=session,
+            profile_id=profile_id,
+            selected_runtime=selected_runtime,
+        )
+    except ProviderProfileNotFoundError as exc:
+        raise _invalid_workflow_request(not_found_message) from exc
+    except ProviderProfileRuntimeMismatchError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
 
 
 async def _load_default_provider_profile_for_runtime(
@@ -12091,6 +12079,13 @@ async def _handle_recurring_schedule(
             agent_profile_selection=agent_profile_selection,
             actor=user,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # The service re-checks the invariant it owns; keep the 409 contract
+        # identical to the one this router already raises while authoring.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except RecurringWorkflowValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11459,6 +11459,14 @@ async def _create_execution_from_workflow_request(
             scheduled_for=scheduled_for_dt,
             _workflow_id=reserved_workflow_id,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Provider Profiles are runtime-owned: the shared invariant is
+        # enforced at TemporalExecutionService.create_execution, and every
+        # authoring path surfaces the identical 409 contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionValidationError as exc:
         message = str(exc)
         raise HTTPException(
@@ -13657,6 +13665,14 @@ async def create_execution(
                 "code": "invalid_execution_request",
                 "message": str(exc),
             },
+        ) from exc
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Provider Profiles are runtime-owned: the shared invariant is
+        # enforced at TemporalExecutionService.create_execution, and every
+        # authoring path surfaces the identical 409 contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
         ) from exc
     except TemporalExecutionValidationError as exc:
         raise HTTPException(
@@ -17269,6 +17285,14 @@ async def continue_in_new_workflow(
             integration=None,
             _workflow_id=reserved_workflow_id,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Provider Profiles are runtime-owned: the shared invariant is
+        # enforced at TemporalExecutionService.create_execution, and every
+        # authoring path surfaces the identical 409 contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -18112,6 +18136,14 @@ async def rerun_execution(
             integration=None,
             _workflow_id=reserved_workflow_id,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Provider Profiles are runtime-owned: the shared invariant is
+        # enforced at TemporalExecutionService.create_execution, and every
+        # authoring path surfaces the identical 409 contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7811,6 +7811,80 @@ def _resolve_runtime_model_effort(
     return resolved_model, model_source, requested_effort, None
 
 
+def _require_provider_profile_runtime(
+    *,
+    profile: Any,
+    profile_id: str,
+    selected_runtime: str | None,
+) -> None:
+    """Reject a Provider Profile that is not owned by the selected runtime.
+
+    Provider Profiles are runtime-owned launch contracts: ``runtime_id`` decides
+    credential materialization, environment and file shaping, command behavior,
+    and model tiers, so the same upstream provider needs one profile per
+    runtime. Enforcing the relationship here keeps alternate clients from
+    bypassing the runtime-scoped selectors in the dashboard.
+
+    ``omnigent`` is an execution facade rather than a Provider Profile owner:
+    the profile it launches stays owned by the underlying managed runtime, and
+    compatibility is enforced against the selected execution target by
+    ``api_service.services.omnigent_agent_profile_selection``.
+    """
+
+    if profile is None or not selected_runtime:
+        return
+    canonical_runtime = normalize_runtime_id(selected_runtime)
+    if canonical_runtime == "omnigent":
+        return
+    raw_profile_runtime = str(getattr(profile, "runtime_id", "") or "").strip()
+    if not raw_profile_runtime:
+        return
+    profile_runtime = normalize_runtime_id(raw_profile_runtime)
+    if profile_runtime == canonical_runtime:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                f"Provider Profile {profile_id!r} belongs to runtime "
+                f"{profile_runtime!r} and cannot be used with runtime "
+                f"{canonical_runtime!r}."
+            ),
+            "profileId": profile_id,
+            "profileRuntime": profile_runtime,
+            "selectedRuntime": canonical_runtime,
+        },
+    )
+
+
+async def _load_provider_profile_for_runtime(
+    *,
+    session: Any,
+    profile_id: str,
+    selected_runtime: str | None,
+    not_found_message: str,
+) -> ManagedAgentProviderProfile | None:
+    """Load an explicitly requested Provider Profile for *selected_runtime*.
+
+    The runtime relationship is validated before the caller persists or launches
+    anything, so an incompatible pair can never reach a launch.
+    """
+
+    session_get = getattr(session, "get", None)
+    if session is None or not callable(session_get):
+        return None
+    profile = await session_get(ManagedAgentProviderProfile, profile_id)
+    if profile is None:
+        raise _invalid_workflow_request(not_found_message)
+    _require_provider_profile_runtime(
+        profile=profile,
+        profile_id=profile_id,
+        selected_runtime=selected_runtime,
+    )
+    return profile
+
+
 async def _load_default_provider_profile_for_runtime(
     *,
     session: Any,
@@ -8728,6 +8802,13 @@ async def _resolve_step_runtime_selections(
                     f"Provider profile not found for inherited task profile on "
                     f"payload.workflow.steps[{index}]: {task_profile_id!r}."
                 )
+            # A step may override the runtime while inheriting the task profile,
+            # so the ownership check runs against the step's effective runtime.
+            _require_provider_profile_runtime(
+                profile=provider_profile,
+                profile_id=effective_profile_id,
+                selected_runtime=canonical_step_runtime,
+            )
 
         (
             resolved_model,
@@ -11046,11 +11127,12 @@ async def _create_execution_from_workflow_request(
     # selection order as the ProviderProfileManager.
     _provider_profile = None
     if raw_profile_id and session is not None:
-        _provider_profile = await session.get(ManagedAgentProviderProfile, raw_profile_id)
-        if _provider_profile is None:
-            raise _invalid_workflow_request(
-                f"Provider profile not found: {raw_profile_id!r}."
-            )
+        _provider_profile = await _load_provider_profile_for_runtime(
+            session=session,
+            profile_id=raw_profile_id,
+            selected_runtime=canonical_target_runtime,
+            not_found_message=f"Provider profile not found: {raw_profile_id!r}.",
+        )
     elif _runtime_model_tier(runtime_payload) is not None:
         _provider_profile = await _load_default_provider_profile_for_runtime(
             session=session,
@@ -11734,16 +11816,13 @@ async def _resolve_recurring_runtime_metadata(
         raw_requested_model = str(raw_requested_model)
 
     provider_profile = None
-    session_get = getattr(session, "get", None)
-    if raw_profile_id and callable(session_get):
-        provider_profile = await session_get(
-            ManagedAgentProviderProfile,
-            raw_profile_id,
+    if raw_profile_id:
+        provider_profile = await _load_provider_profile_for_runtime(
+            session=session,
+            profile_id=raw_profile_id,
+            selected_runtime=canonical_target_runtime,
+            not_found_message=f"Provider profile not found: {raw_profile_id!r}.",
         )
-        if provider_profile is None:
-            raise _invalid_workflow_request(
-                f"Provider profile not found: {raw_profile_id!r}."
-            )
     elif _runtime_model_tier(runtime_payload) is not None:
         provider_profile = await _load_default_provider_profile_for_runtime(
             session=session,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -18554,6 +18554,17 @@ async def recover_execution(
             canonical,
             recovery_target=request,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # A recovery destination inherits the source execution's authored
+        # runtime and Provider Profile. A pair persisted before the shared
+        # invariant existed is rejected at
+        # TemporalExecutionService.create_execution, and this route returns
+        # the identical 409 contract every other launch-authoring path
+        # returns rather than surfacing an unmapped server error.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionRecoveryCheckpointError as exc:
         reasons = [reason for reason in str(exc).split(",") if reason]
         raise HTTPException(
@@ -18651,6 +18662,17 @@ async def recover_execution_from_failed_step(
             failed_run_recovery_manifest=manifest_payload,
             admitted_checkpoint_resume_decision=admission,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # A recovery destination inherits the source execution's authored
+        # runtime and Provider Profile. A pair persisted before the shared
+        # invariant existed is rejected at
+        # TemporalExecutionService.create_execution, and this route returns
+        # the identical 409 contract every other launch-authoring path
+        # returns rather than surfacing an unmapped server error.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionRecoveryCheckpointError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -18768,6 +18790,17 @@ async def recover_execution_from_selected_step(
             selected_start_step_id=request.selected_start_step_id,
             admitted_checkpoint_resume_decision=admission,
         )
+    except ProviderProfileRuntimeMismatchError as exc:
+        # A recovery destination inherits the source execution's authored
+        # runtime and Provider Profile. A pair persisted before the shared
+        # invariant existed is rejected at
+        # TemporalExecutionService.create_execution, and this route returns
+        # the identical 409 contract every other launch-authoring path
+        # returns rather than surfacing an unmapped server error.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionRecoveryCheckpointError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -21,6 +21,9 @@ from api_service.db.models import (
     RecurringWorkflowScopeType,
     User,
 )
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+)
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
     RecurringWorkflowAuthorizationError,
@@ -517,6 +520,13 @@ def _recurring_sort_value(
     return definition.updated_at or _MIN_AWARE_DATETIME
 
 def _map_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, ProviderProfileRuntimeMismatchError):
+        # Provider Profiles are runtime-owned launch contracts; the shared
+        # invariant raises one error contract for every authoring boundary.
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        )
     if isinstance(exc, RecurringWorkflowNotFoundError):
         return HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api_service/api/routers/workflow_proposals.py
+++ b/api_service/api/routers/workflow_proposals.py
@@ -14,6 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.auth_providers import get_current_user, get_current_user_optional
 from api_service.db.base import get_async_session
 from api_service.db.models import User
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+)
 from moonmind.schemas.workflow_proposal_models import (
     WorkflowProposalCreateRequest,
     WorkflowProposalDismissRequest,
@@ -568,6 +571,15 @@ async def promote_proposal(
             idempotency_key=f"proposal-promote-{proposal_id}",
         )
 
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Promotion is a launch-authoring boundary. The shared
+        # runtime-ownership invariant runs before the proposal is marked
+        # promoted, and every authoring path returns the identical 409
+        # contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except WorkflowProposalStatusError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -649,6 +661,15 @@ async def provider_decision(
             )
         else:
             proposal = await service.get_proposal(proposal_id)
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Promotion is a launch-authoring boundary. The shared
+        # runtime-ownership invariant runs before the proposal is marked
+        # promoted, and every authoring path returns the identical 409
+        # contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except WorkflowProposalStatusError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -779,6 +800,15 @@ async def github_provider_decision(
             )
         else:
             proposal = await service.get_proposal(proposal_id)
+    except ProviderProfileRuntimeMismatchError as exc:
+        # Promotion is a launch-authoring boundary. The shared
+        # runtime-ownership invariant runs before the proposal is marked
+        # promoted, and every authoring path returns the identical 409
+        # contract.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except WorkflowProposalStatusError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -359,18 +359,36 @@ async def resolve_agent_profile_snapshot(
         if compatible_provider is not None:
             # A Provider Profile stays owned by its managed runtime even when it
             # launches through Omnigent, so the requested profile must be one the
-            # harness can actually materialize for that runtime. This is the same
-            # capability boundary the execution-readiness projection uses to build
+            # selected harness can actually materialize under every launch policy
+            # the profile allows. Proving only that *some* materializer exists for
+            # the pair would accept a profile the readiness projection excludes:
+            # `codex-oauth-home@1` is registered for `codex_cli/openai` but is not
+            # accepted by the `pi-native` harness. This is the same capability
+            # boundary the readiness projection uses to build
             # `compatibleProviderProfiles`, not a second compatibility source.
+            from moonmind.omnigent.harness_platform.host_classes import (
+                get_launch_policy,
+            )
             from moonmind.omnigent.harness_platform.materializers import (
                 materializer_ref_for_provider,
+                validate_binding_materializer,
             )
 
+            harness_selection = document.get("harness") or {}
             try:
-                materializer_ref_for_provider(
+                materializer_ref = materializer_ref_for_provider(
                     compatible_provider.runtime_id,
                     compatible_provider.provider_id,
                 )
+                for policy_ref in document.get("allowedLaunchPolicyRefs") or ():
+                    validate_binding_materializer(
+                        materializer_ref=materializer_ref,
+                        harness_implementation_ref=str(
+                            harness_selection.get("implementationRef") or ""
+                        ),
+                        harness_id=str(harness_selection.get("id") or "") or None,
+                        host_mode=get_launch_policy(policy_ref).hostMode,
+                    )
             except HarnessPlatformError as exc:
                 raise HTTPException(
                     status.HTTP_409_CONFLICT,

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -27,6 +27,7 @@ from api_service.services.provider_profile_readiness import (
 from api_service.services.provider_profile_service import (
     _managed_secret_statuses_for_profiles,
 )
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 
 _OVERRIDABLE_SECTIONS = frozenset({"model", "capture", "rag", "publish"})
 
@@ -355,6 +356,31 @@ async def resolve_agent_profile_snapshot(
             and compatible_provider.provider_id not in accepted_provider_ids
         ):
             compatible_provider = None
+        if compatible_provider is not None:
+            # A Provider Profile stays owned by its managed runtime even when it
+            # launches through Omnigent, so the requested profile must be one the
+            # harness can actually materialize for that runtime. This is the same
+            # capability boundary the execution-readiness projection uses to build
+            # `compatibleProviderProfiles`, not a second compatibility source.
+            from moonmind.omnigent.harness_platform.materializers import (
+                materializer_ref_for_provider,
+            )
+
+            try:
+                materializer_ref_for_provider(
+                    compatible_provider.runtime_id,
+                    compatible_provider.provider_id,
+                )
+            except HarnessPlatformError as exc:
+                raise HTTPException(
+                    status.HTTP_409_CONFLICT,
+                    (
+                        f"selected Provider Profile "
+                        f"{compatible_provider.profile_id!r} belongs to runtime "
+                        f"{compatible_provider.runtime_id!r} and is not "
+                        f"compatible with the selected Omnigent execution target"
+                    ),
+                ) from exc
     else:
         requirements = document["providerRequirements"]
         provider_query = select(ManagedAgentProviderProfile).where(

--- a/api_service/services/provider_profile_runtime.py
+++ b/api_service/services/provider_profile_runtime.py
@@ -8,11 +8,18 @@ multi-runtime object.
 
 This module owns the single typed contract for that relationship so every
 launch-authoring boundary enforces the same rule before persisting or launching
-work: direct execution submission, step authoring, and recurring-schedule
-authoring. Routers map :class:`ProviderProfileRuntimeMismatchError` onto an HTTP
-409 with :attr:`ProviderProfileRuntimeMismatchError.detail`; the payload is
-identical across authoring paths so an alternate client cannot find a boundary
-that accepts a pair the runtime-scoped selectors would never offer.
+work. The primary placement is the shared authority handoff every launch
+converges on — :meth:`TemporalExecutionService.create_execution` — which covers
+direct submission, proposal promotion, rerun, continuation, manifest ingest, and
+deployment operations from one call site. Boundaries that durably persist a
+launch target *before* reaching that handoff enforce it themselves as well:
+recurring-schedule authoring (the stored target is what a later schedule action
+launches) and proposal promotion (the proposal is marked promoted before the
+execution is created). Routers map
+:class:`ProviderProfileRuntimeMismatchError` onto an HTTP 409 with
+:attr:`ProviderProfileRuntimeMismatchError.detail`; the payload is identical
+across authoring paths so an alternate client cannot find a boundary that
+accepts a pair the runtime-scoped selectors would never offer.
 """
 
 from __future__ import annotations
@@ -112,6 +119,31 @@ def require_provider_profile_runtime(
         profile_runtime=profile_runtime,
         selected_runtime=canonical_runtime,
     )
+
+
+async def _load_owned_provider_profile(
+    *,
+    session: Any,
+    profile_id: str,
+) -> ManagedAgentProviderProfile | None:
+    """Return the persisted Provider Profile row named by *profile_id*.
+
+    The lookup is typed on purpose. Only a real
+    :class:`~api_service.db.models.ManagedAgentProviderProfile` row carries an
+    authoritative ``runtime_id``; anything else the session hands back names no
+    runtime to compare, so it is treated as "no profile" rather than as a
+    mismatch. Callers that need to distinguish "profile does not exist" from
+    "profile is not runtime-owned" use
+    :func:`load_provider_profile_for_runtime` instead.
+    """
+
+    session_get = getattr(session, "get", None)
+    if session is None or not callable(session_get):
+        return None
+    profile = await session_get(ManagedAgentProviderProfile, profile_id)
+    if not isinstance(profile, ManagedAgentProviderProfile):
+        return None
+    return profile
 
 
 async def load_provider_profile_for_runtime(
@@ -230,10 +262,10 @@ async def require_launch_target_provider_profile_runtime(
         return
     if runtime_id == OMNIGENT_RUNTIME_ID:
         return
-    session_get = getattr(session, "get", None)
-    if session is None or not callable(session_get):
-        return
-    profile = await session_get(ManagedAgentProviderProfile, profile_id)
+    profile = await _load_owned_provider_profile(
+        session=session,
+        profile_id=profile_id,
+    )
     require_provider_profile_runtime(
         profile=profile,
         profile_id=profile_id,

--- a/api_service/services/provider_profile_runtime.py
+++ b/api_service/services/provider_profile_runtime.py
@@ -24,7 +24,7 @@ accepts a pair the runtime-scoped selectors would never offer.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, NamedTuple
 
 from api_service.db.models import ManagedAgentProviderProfile
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
@@ -60,9 +60,17 @@ class ProviderProfileRuntimeMismatchError(ValueError):
         selected_runtime: str,
     ) -> None:
         super().__init__(
-            f"Provider Profile {profile_id!r} belongs to runtime "
-            f"{profile_runtime!r} and cannot be used with runtime "
-            f"{selected_runtime!r}."
+            (
+                f"Provider Profile {profile_id!r} belongs to runtime "
+                f"{profile_runtime!r} and cannot be used with runtime "
+                f"{selected_runtime!r}."
+            )
+            if profile_runtime
+            else (
+                f"Provider Profile {profile_id!r} does not declare an owning "
+                f"runtime and cannot be used with runtime "
+                f"{selected_runtime!r}."
+            )
         )
         self.profile_id = profile_id
         self.profile_runtime = profile_runtime
@@ -98,9 +106,15 @@ def require_provider_profile_runtime(
     """Reject a Provider Profile that is not owned by the selected runtime.
 
     Canonical runtime IDs decide the comparison, so a legacy spelling such as
-    ``codex`` is compared as ``codex_cli``. With no profile, no effective
-    runtime, or an unset ``runtime_id`` there is nothing to compare, and the
-    ``omnigent`` facade defers to the Omnigent selection service.
+    ``codex`` is compared as ``codex_cli``. With no profile or no effective
+    runtime there is nothing to compare, and the ``omnigent`` facade defers to
+    the Omnigent selection service.
+
+    A profile that names no owning runtime is rejected rather than accepted for
+    every runtime. ``runtime_id`` is the field that decides credential
+    materialization and launch strategy, so a blank or whitespace-only value is
+    the ambiguous state this invariant exists to keep out of a launch, not a
+    reason to skip the check.
     """
 
     if profile is None or not selected_runtime:
@@ -110,7 +124,13 @@ def require_provider_profile_runtime(
         return
     raw_profile_runtime = str(getattr(profile, "runtime_id", "") or "").strip()
     if not raw_profile_runtime:
-        return
+        # ``normalize_runtime_id`` substitutes the deployment default for an
+        # empty value, so the unset owner is reported verbatim instead.
+        raise ProviderProfileRuntimeMismatchError(
+            profile_id=profile_id,
+            profile_runtime="",
+            selected_runtime=canonical_runtime,
+        )
     profile_runtime = normalize_runtime_id(raw_profile_runtime)
     if profile_runtime == canonical_runtime:
         return
@@ -196,16 +216,36 @@ def _task_payload(source: Mapping[str, Any]) -> Mapping[str, Any] | None:
     return None
 
 
+class LaunchTargetProfileSelection(NamedTuple):
+    """The runtime/profile selection an authored launch target carries."""
+
+    #: Every distinct canonical runtime the payload names, most authoritative
+    #: first. ``runtime_ids[0]`` is the runtime the worker resolves.
+    runtime_ids: tuple[str, ...]
+    #: The Provider Profile the payload names, if any.
+    profile_id: str | None
+
+
 def resolve_launch_target_profile_selection(
     target: Any,
-) -> tuple[str | None, str | None]:
-    """Return ``(canonical_runtime, profile_id)`` authored in a launch target.
+) -> LaunchTargetProfileSelection:
+    """Return the runtime/profile selection authored in a launch target.
 
-    Mirrors the layered lookup the executions router applies to the same
-    workflow-start payload shape: the runtime block wins over the task block,
-    which wins over the initial parameters, which win over the target envelope.
-    Nested Omnigent Agent Profile selections are deliberately not consulted —
-    they name an Agent Profile, not a Provider Profile.
+    Runtimes are read in the precedence the worker itself applies to the same
+    canonical payload — the runtime block's ``mode`` wins over the task block's
+    ``targetRuntime``, which wins over the initial parameters, which win over
+    the target envelope. Reading these fields in any other order lets a raw
+    submission with conflicting runtime fields satisfy this boundary for one
+    runtime and then execute as another.
+
+    Every distinct runtime the payload names is returned, not only the winner,
+    because a payload that names more than one has no unambiguous authored
+    target: the invariant has to hold for each of them before launch.
+
+    The Provider Profile lookup keeps the layered order the executions router
+    applies to the same workflow-start payload shape. Nested Omnigent Agent
+    Profile selections are deliberately not consulted — they name an Agent
+    Profile, not a Provider Profile.
     """
 
     target_map: Mapping[str, Any] = target if isinstance(target, Mapping) else {}
@@ -223,14 +263,22 @@ def resolve_launch_target_profile_selection(
             runtime_payload = candidate
             break
 
-    raw_runtime = (
-        parameters.get("targetRuntime")
-        or target_map.get("targetRuntime")
-        or runtime_payload.get("mode")
-    )
-    runtime_id: str | None = None
-    if str(raw_runtime or "").strip():
-        runtime_id = normalize_runtime_id(raw_runtime)
+    runtime_ids: list[str] = []
+    for source, key in (
+        (runtime_payload, "mode"),
+        (task_payload, "targetRuntime"),
+        (task_payload, "target_runtime"),
+        (parameters, "targetRuntime"),
+        (parameters, "target_runtime"),
+        (target_map, "targetRuntime"),
+        (target_map, "target_runtime"),
+    ):
+        raw_runtime = source.get(key)
+        if not str(raw_runtime or "").strip():
+            continue
+        canonical_runtime = normalize_runtime_id(raw_runtime)
+        if canonical_runtime not in runtime_ids:
+            runtime_ids.append(canonical_runtime)
 
     profile_id: str | None = None
     for source in (runtime_payload, task_payload, parameters, target_map):
@@ -238,7 +286,10 @@ def resolve_launch_target_profile_selection(
         if profile_id:
             break
 
-    return runtime_id, profile_id
+    return LaunchTargetProfileSelection(
+        runtime_ids=tuple(runtime_ids),
+        profile_id=profile_id,
+    )
 
 
 async def require_launch_target_provider_profile_runtime(
@@ -255,19 +306,25 @@ async def require_launch_target_provider_profile_runtime(
     A named profile that does not exist is left to the launch path that
     resolves it: this boundary owns the runtime relationship, and an absent row
     carries no runtime to compare.
+
+    A payload that names conflicting runtimes is checked against every one of
+    them. Validating only the winner would let a second authored field decide
+    the launch after this boundary approved the pair for a different runtime.
     """
 
-    runtime_id, profile_id = resolve_launch_target_profile_selection(target)
-    if not runtime_id or not profile_id:
+    selection = resolve_launch_target_profile_selection(target)
+    profile_id = selection.profile_id
+    if not selection.runtime_ids or not profile_id:
         return
-    if runtime_id == OMNIGENT_RUNTIME_ID:
+    if all(runtime == OMNIGENT_RUNTIME_ID for runtime in selection.runtime_ids):
         return
     profile = await _load_owned_provider_profile(
         session=session,
         profile_id=profile_id,
     )
-    require_provider_profile_runtime(
-        profile=profile,
-        profile_id=profile_id,
-        selected_runtime=runtime_id,
-    )
+    for runtime_id in selection.runtime_ids:
+        require_provider_profile_runtime(
+            profile=profile,
+            profile_id=profile_id,
+            selected_runtime=runtime_id,
+        )

--- a/api_service/services/provider_profile_runtime.py
+++ b/api_service/services/provider_profile_runtime.py
@@ -1,0 +1,241 @@
+"""Runtime-ownership invariant for Provider Profiles.
+
+Provider Profiles are runtime-owned launch contracts: ``runtime_id`` decides
+provider and credential selection, credential materialization, environment and
+file shaping, command behavior, model and effort tiers, and concurrency policy.
+The same upstream provider therefore needs one profile per runtime rather than a
+multi-runtime object.
+
+This module owns the single typed contract for that relationship so every
+launch-authoring boundary enforces the same rule before persisting or launching
+work: direct execution submission, step authoring, and recurring-schedule
+authoring. Routers map :class:`ProviderProfileRuntimeMismatchError` onto an HTTP
+409 with :attr:`ProviderProfileRuntimeMismatchError.detail`; the payload is
+identical across authoring paths so an alternate client cannot find a boundary
+that accepts a pair the runtime-scoped selectors would never offer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from api_service.db.models import ManagedAgentProviderProfile
+from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
+
+PROVIDER_PROFILE_RUNTIME_MISMATCH_CODE = "provider_profile_runtime_mismatch"
+
+#: ``omnigent`` is an execution facade rather than a Provider Profile owner: the
+#: profile it launches stays owned by the underlying managed runtime, and
+#: compatibility is enforced against the selected execution target by
+#: :mod:`api_service.services.omnigent_agent_profile_selection`.
+OMNIGENT_RUNTIME_ID = "omnigent"
+
+#: Aliases an authored payload may use to name a Provider Profile, in the
+#: precedence order the executions router already applies to the same payload.
+PROVIDER_PROFILE_REF_KEYS: tuple[str, ...] = (
+    "providerProfileRef",
+    "profileId",
+    "providerProfile",
+    "executionProfileRef",
+)
+
+_TASK_PAYLOAD_KEYS: tuple[str, ...] = ("workflow", "task")
+
+
+class ProviderProfileRuntimeMismatchError(ValueError):
+    """A Provider Profile was paired with a runtime that does not own it."""
+
+    def __init__(
+        self,
+        *,
+        profile_id: str,
+        profile_runtime: str,
+        selected_runtime: str,
+    ) -> None:
+        super().__init__(
+            f"Provider Profile {profile_id!r} belongs to runtime "
+            f"{profile_runtime!r} and cannot be used with runtime "
+            f"{selected_runtime!r}."
+        )
+        self.profile_id = profile_id
+        self.profile_runtime = profile_runtime
+        self.selected_runtime = selected_runtime
+
+    @property
+    def detail(self) -> dict[str, Any]:
+        """Return the error contract shared by every authoring boundary."""
+
+        return {
+            "code": PROVIDER_PROFILE_RUNTIME_MISMATCH_CODE,
+            "message": str(self),
+            "profileId": self.profile_id,
+            "profileRuntime": self.profile_runtime,
+            "selectedRuntime": self.selected_runtime,
+        }
+
+
+class ProviderProfileNotFoundError(LookupError):
+    """An explicitly requested Provider Profile does not exist."""
+
+    def __init__(self, profile_id: str) -> None:
+        super().__init__(f"Provider profile not found: {profile_id!r}.")
+        self.profile_id = profile_id
+
+
+def require_provider_profile_runtime(
+    *,
+    profile: Any,
+    profile_id: str,
+    selected_runtime: str | None,
+) -> None:
+    """Reject a Provider Profile that is not owned by the selected runtime.
+
+    Canonical runtime IDs decide the comparison, so a legacy spelling such as
+    ``codex`` is compared as ``codex_cli``. With no profile, no effective
+    runtime, or an unset ``runtime_id`` there is nothing to compare, and the
+    ``omnigent`` facade defers to the Omnigent selection service.
+    """
+
+    if profile is None or not selected_runtime:
+        return
+    canonical_runtime = normalize_runtime_id(selected_runtime)
+    if canonical_runtime == OMNIGENT_RUNTIME_ID:
+        return
+    raw_profile_runtime = str(getattr(profile, "runtime_id", "") or "").strip()
+    if not raw_profile_runtime:
+        return
+    profile_runtime = normalize_runtime_id(raw_profile_runtime)
+    if profile_runtime == canonical_runtime:
+        return
+    raise ProviderProfileRuntimeMismatchError(
+        profile_id=profile_id,
+        profile_runtime=profile_runtime,
+        selected_runtime=canonical_runtime,
+    )
+
+
+async def load_provider_profile_for_runtime(
+    *,
+    session: Any,
+    profile_id: str,
+    selected_runtime: str | None,
+) -> ManagedAgentProviderProfile | None:
+    """Load an explicitly requested Provider Profile for *selected_runtime*.
+
+    Raises :class:`ProviderProfileNotFoundError` when the profile does not
+    exist and :class:`ProviderProfileRuntimeMismatchError` when the pair is
+    invalid, so an incompatible pair can never reach a persist or a launch.
+    """
+
+    session_get = getattr(session, "get", None)
+    if session is None or not callable(session_get):
+        return None
+    profile = await session_get(ManagedAgentProviderProfile, profile_id)
+    if profile is None:
+        raise ProviderProfileNotFoundError(profile_id)
+    require_provider_profile_runtime(
+        profile=profile,
+        profile_id=profile_id,
+        selected_runtime=selected_runtime,
+    )
+    return profile
+
+
+def provider_profile_ref_from_mapping(source: Any) -> str | None:
+    """Return the Provider Profile named directly on *source*, if any."""
+
+    if not isinstance(source, Mapping):
+        return None
+    for key in PROVIDER_PROFILE_REF_KEYS:
+        value = source.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _task_payload(source: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    for key in _TASK_PAYLOAD_KEYS:
+        candidate = source.get(key)
+        if isinstance(candidate, Mapping):
+            return candidate
+    return None
+
+
+def resolve_launch_target_profile_selection(
+    target: Any,
+) -> tuple[str | None, str | None]:
+    """Return ``(canonical_runtime, profile_id)`` authored in a launch target.
+
+    Mirrors the layered lookup the executions router applies to the same
+    workflow-start payload shape: the runtime block wins over the task block,
+    which wins over the initial parameters, which win over the target envelope.
+    Nested Omnigent Agent Profile selections are deliberately not consulted —
+    they name an Agent Profile, not a Provider Profile.
+    """
+
+    target_map: Mapping[str, Any] = target if isinstance(target, Mapping) else {}
+    parameters: Mapping[str, Any] = {}
+    for key in ("initialParameters", "initial_parameters"):
+        candidate = target_map.get(key)
+        if isinstance(candidate, Mapping):
+            parameters = candidate
+            break
+
+    task_payload = _task_payload(parameters) or _task_payload(target_map) or {}
+    runtime_payload: Mapping[str, Any] = {}
+    for candidate in (task_payload.get("runtime"), parameters.get("runtime")):
+        if isinstance(candidate, Mapping):
+            runtime_payload = candidate
+            break
+
+    raw_runtime = (
+        parameters.get("targetRuntime")
+        or target_map.get("targetRuntime")
+        or runtime_payload.get("mode")
+    )
+    runtime_id: str | None = None
+    if str(raw_runtime or "").strip():
+        runtime_id = normalize_runtime_id(raw_runtime)
+
+    profile_id: str | None = None
+    for source in (runtime_payload, task_payload, parameters, target_map):
+        profile_id = provider_profile_ref_from_mapping(source)
+        if profile_id:
+            break
+
+    return runtime_id, profile_id
+
+
+async def require_launch_target_provider_profile_runtime(
+    *,
+    session: Any,
+    target: Any,
+) -> None:
+    """Enforce runtime ownership for an authored launch target.
+
+    Applies to any boundary that persists or launches a workflow-start target,
+    including recurring schedules whose stored ``initialParameters`` are what a
+    later schedule action launches.
+
+    A named profile that does not exist is left to the launch path that
+    resolves it: this boundary owns the runtime relationship, and an absent row
+    carries no runtime to compare.
+    """
+
+    runtime_id, profile_id = resolve_launch_target_profile_selection(target)
+    if not runtime_id or not profile_id:
+        return
+    if runtime_id == OMNIGENT_RUNTIME_ID:
+        return
+    session_get = getattr(session, "get", None)
+    if session is None or not callable(session_get):
+        return
+    profile = await session_get(ManagedAgentProviderProfile, profile_id)
+    require_provider_profile_runtime(
+        profile=profile,
+        profile_id=profile_id,
+        selected_runtime=runtime_id,
+    )

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -31,6 +31,9 @@ from api_service.services.omnigent_agent_profile_selection import (
     refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
 )
+from api_service.services.provider_profile_runtime import (
+    require_launch_target_provider_profile_runtime,
+)
 from moonmind.workflows.recurring.cron import (
     compute_next_occurrence,
     parse_cron_expression,
@@ -928,6 +931,13 @@ class RecurringWorkflowsService:
         timezone_name = validate_timezone_name(timezone)
         name_text = _clean_text(name, field_name="name", required=True) or ""
         target_payload = _normalize_target(_json_object(target, field_name="target"))
+        # The stored target's initialParameters are what a later schedule action
+        # launches, so the runtime/Provider Profile pair is validated here,
+        # before anything is persisted.
+        await require_launch_target_provider_profile_runtime(
+            session=self._session,
+            target=target_payload,
+        )
         policy_payload = _json_object(policy, field_name="policy")
         policy_obj = _normalize_policy(
             policy_payload,
@@ -1137,6 +1147,20 @@ class RecurringWorkflowsService:
             raise RecurringWorkflowConflictError(
                 "recurring workflow changed since it was loaded; refresh and retry"
             )
+
+        # Normalize and validate the replacement target before any field of the
+        # locked definition is mutated, so a rejected edit leaves the stored
+        # target untouched.
+        normalized_target: dict[str, Any] | None = None
+        if target is not None:
+            normalized_target = _normalize_target(
+                _json_object(target, field_name="target")
+            )
+            await require_launch_target_provider_profile_runtime(
+                session=self._session,
+                target=normalized_target,
+            )
+
         changed_schedule = False
         now = datetime.now(UTC)
 
@@ -1160,10 +1184,7 @@ class RecurringWorkflowsService:
         if timezone is not None:
             definition.timezone = validate_timezone_name(timezone)
             changed_schedule = True
-        if target is not None:
-            normalized_target = _normalize_target(
-                _json_object(target, field_name="target")
-            )
+        if normalized_target is not None:
             current_parameters = dict(
                 (definition.target or {}).get("initialParameters") or {}
             )

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1099,8 +1099,12 @@ runtime and the selected execution target; it must never look for
   target's `providerRuntime` and its declared provider requirements.
 - A generic (v2) Agent Profile uses the compatibility or readiness result that
   declares the allowed Provider Profiles. A profile is compatible only when the
-  harness can materialize credentials for that profile's
-  `(runtime_id, provider_id)` pair; being globally enabled is never sufficient.
+  materializer registered for that profile's `(runtime_id, provider_id)` pair is
+  accepted by the *selected* harness under every launch policy the Agent Profile
+  allows; being globally enabled, or merely having some registered materializer,
+  is never sufficient. This is the same capability boundary the readiness
+  projection applies when it builds `compatibleProviderProfiles`, so an API
+  client cannot submit a pair the UI reports as incompatible.
 - An unavailable historical profile may still render while editing an existing
   workflow, but requires replacement before submission.
 
@@ -1125,6 +1129,20 @@ cannot be used with runtime 'codex_cli'.
 The rule is expressed once as a typed contract at the shared authoring
 boundary — `api_service/services/provider_profile_runtime.py` — rather than
 copied per router, so a new authoring path cannot silently omit it.
+
+Two states are ambiguous rather than exempt, and both are rejected:
+
+- A profile whose `runtime_id` is blank or whitespace-only names no owning
+  runtime. Accepting it would make it launchable under every runtime, which is
+  precisely the state this invariant exists to prevent.
+- A payload whose runtime fields disagree — for example a payload-level
+  `targetRuntime` beside a different `workflow.runtime.mode` — has no single
+  authored target. The effective runtime is resolved with the precedence the
+  worker itself applies (`workflow.runtime.mode` first), and the pair is
+  validated against *every* runtime the payload names, so a second field cannot
+  decide the launch after the boundary approved the pair for a different
+  runtime. Deferring to the Omnigent facade requires an unambiguous Omnigent
+  selection.
 
 Its primary placement is the authority handoff every launch converges on,
 `TemporalExecutionService.create_execution`. Direct execution submission (both

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1135,6 +1135,13 @@ cannot find a submission shape that accepts a pair the runtime-scoped selectors
 would never offer. Routers translate the typed rejection into the same 409
 payload.
 
+A recovery destination — typed recovery, failed-step recovery, and
+selected-step recovery — inherits the source execution's authored runtime and
+Provider Profile, so a pair that was persisted before this rule existed, or
+whose profile was later recreated under another runtime, is rejected at the same
+handoff. Those routes return the identical 409 contract rather than an unmapped
+server error, and the source execution is left untouched.
+
 Boundaries that durably persist a launch target *before* reaching that handoff
 enforce the same contract themselves:
 

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1122,6 +1122,15 @@ Provider Profile 'claude_anthropic_oauth' belongs to runtime 'claude_code' and
 cannot be used with runtime 'codex_cli'.
 ```
 
+The rule is expressed once as a typed contract at the shared authoring
+boundary — `api_service/services/provider_profile_runtime.py` — rather than
+copied per router, so a new authoring path cannot silently omit it. Direct
+execution submission, step authoring, and recurring-schedule authoring all
+resolve the pair through that module and surface the same 409 payload. A
+recurring schedule persists the target whose `initialParameters` a later
+schedule action launches, so its create and update paths validate the pair
+before the target is stored, not only when a run is started.
+
 For Omnigent submissions the equivalent rejection comes from the Omnigent
 selection boundary when the requested profile falls outside the selected
 execution target's compatibility set. Existing authorization, visibility,

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -131,6 +131,12 @@ Those cards may be backed by disabled setup-stub Provider Profiles or by a separ
 3. Successful user-initiated setup makes the profile connected and enabled by default.
 4. Failed setup leaves the profile disabled with clear readiness diagnostics.
 
+Settings is also the one administrative exception to runtime-scoped selection.
+It owns an explicit **All runtimes** view of every Provider Profile plus a
+per-runtime filter over that table, while global configuration health stays
+computed from the complete unfiltered collection. See
+[10.5 Runtime-owned selection scope](#105-runtime-owned-selection-scope).
+
 ---
 
 ## 3. Goals
@@ -1032,6 +1038,95 @@ To prevent unintentional cross-provider routing, one or more of the following sh
    - The intended primary provider has higher priority than alternatives.
 
 Disabled setup stubs must never participate in default provider fallback.
+
+### 10.5 Runtime-owned selection scope
+
+> Provider Profiles are runtime-owned launch contracts. A runtime-coupled
+> execution surface must display and accept only profiles compatible with the
+> selected effective runtime. Settings may expose an explicit All-runtimes
+> administrative view.
+
+`runtime_id` is required and stable because the profile owns runtime-specific
+behavior: provider and credential selection, credential materialization,
+environment and file shaping, command behavior, model and effort tiers,
+concurrency and cooldown policy, and default-profile selection for that runtime.
+
+A Provider Profile is therefore never a multi-runtime object. The same upstream
+provider or managed secret is represented by one runtime-specific profile per
+runtime, and those profiles may reference the same managed secret:
+
+```text
+codex_minimax_team
+  runtime_id: codex_cli
+  provider_id: minimax
+  secret_ref: db://MINIMAX_API_KEY
+
+claude_minimax_team
+  runtime_id: claude_code
+  provider_id: minimax
+  secret_ref: db://MINIMAX_API_KEY
+```
+
+#### Execution and workflow-authoring surfaces
+
+For an ordinary managed runtime, a visible profile satisfies:
+
+```text
+visible profile.runtime_id == selected effective runtime
+```
+
+- Execution surfaces do not offer an **All runtimes** option.
+- Surfaces scope the result set server-side with
+  `GET /api/v1/provider-profiles?runtime_id=<canonical runtime>` rather than
+  fetching every profile and filtering only on the client.
+- The query cache key includes the effective runtime, and previous-runtime
+  placeholder data is never selectable, resolvable, or submittable during a
+  runtime-scoped refetch.
+- Changing runtime drops an incompatible selection, then selects the new
+  runtime's launch-ready default profile, or the first eligible profile under
+  the existing deterministic ordering.
+- A runtime with no eligible profile shows a runtime-specific empty state that
+  names the runtime instead of hiding the control.
+
+#### Omnigent compatibility exception
+
+`omnigent` is an orchestration and execution facade, not a Provider Profile
+owner. Omnigent selection is compatibility-based against the underlying managed
+runtime and the selected execution target; it must never look for
+`runtime_id == omnigent`.
+
+- A traditional execution profile filters eligible profiles by the selected
+  target's `providerRuntime` and its declared provider requirements.
+- A generic (v2) Agent Profile uses the compatibility or readiness result that
+  declares the allowed Provider Profiles. A profile is compatible only when the
+  harness can materialize credentials for that profile's
+  `(runtime_id, provider_id)` pair; being globally enabled is never sufficient.
+- An unavailable historical profile may still render while editing an existing
+  workflow, but requires replacement before submission.
+
+#### Server-side correctness boundary
+
+The UI filter alone is not sufficient. Every launch-authoring or submission path
+validates the relationship before persisting or launching, using canonical
+runtime IDs and never inferring compatibility from `provider_id` alone:
+
+```text
+reject when selected_profile.runtime_id != effective_runtime_id
+```
+
+Rejection returns `409 Conflict` with code `provider_profile_runtime_mismatch`,
+identifying both sides of the incompatible pair:
+
+```text
+Provider Profile 'claude_anthropic_oauth' belongs to runtime 'claude_code' and
+cannot be used with runtime 'codex_cli'.
+```
+
+For Omnigent submissions the equivalent rejection comes from the Omnigent
+selection boundary when the requested profile falls outside the selected
+execution target's compatibility set. Existing authorization, visibility,
+readiness, capacity, and secret-resolution validation continue to apply
+unchanged.
 
 ---
 

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1124,12 +1124,35 @@ cannot be used with runtime 'codex_cli'.
 
 The rule is expressed once as a typed contract at the shared authoring
 boundary — `api_service/services/provider_profile_runtime.py` — rather than
-copied per router, so a new authoring path cannot silently omit it. Direct
-execution submission, step authoring, and recurring-schedule authoring all
-resolve the pair through that module and surface the same 409 payload. A
-recurring schedule persists the target whose `initialParameters` a later
-schedule action launches, so its create and update paths validate the pair
-before the target is stored, not only when a run is started.
+copied per router, so a new authoring path cannot silently omit it.
+
+Its primary placement is the authority handoff every launch converges on,
+`TemporalExecutionService.create_execution`. Direct execution submission (both
+the task/workflow envelope and the raw request shape), proposal promotion,
+rerun, continuation, checkpoint branching, manifest ingest, and deployment
+operations all reach a launch through that method, so an alternate client
+cannot find a submission shape that accepts a pair the runtime-scoped selectors
+would never offer. Routers translate the typed rejection into the same 409
+payload.
+
+Boundaries that durably persist a launch target *before* reaching that handoff
+enforce the same contract themselves:
+
+- A recurring schedule persists the target whose `initialParameters` a later
+  schedule action launches, so its create and update paths validate the pair
+  before the target is stored, not only when a run is started.
+- A proposal promotion marks the proposal `promoted` before the execution is
+  created, and its `runtimeMode` override rewrites `targetRuntime` and
+  `workflow.runtime.mode` while leaving any authored Provider Profile ref
+  untouched. The pair is therefore validated on the final payload before that
+  state transition, so a rejected promotion leaves the proposal promotable
+  rather than terminal with no execution behind it.
+
+Enforcement at the launch handoff matters beyond the API surface: the runtime
+node carries `profileId` into the launcher, which selects the launch strategy
+from the profile's `runtime_id`. A mismatched pair that reached launch would
+silently execute the profile's runtime instead of the selected one — a
+billing-relevant runtime substitution.
 
 For Omnigent submissions the equivalent rejection comes from the Omnigent
 selection boundary when the requested profile falls outside the selected

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
-import { formatStatusLabel } from '../../utils/formatters';
+import { formatRuntimeLabel, formatStatusLabel } from '../../utils/formatters';
 
 export interface ProviderProfile {
   profile_id: string;
@@ -64,6 +64,10 @@ interface Notice {
 }
 
 interface ProviderProfilesManagerProps {
+  /**
+   * Rows to display. Settings owns the runtime filter, so this collection is
+   * already scoped to `selectedRuntimeId` when a single runtime is active.
+   */
   profiles: ProviderProfile[];
   secretSlugs: string[];
   onNotice: (notice: Notice | null) => void;
@@ -71,6 +75,16 @@ interface ProviderProfilesManagerProps {
   /** Map of canonical runtime_id → default model from the boot config. */
   defaultTaskModelByRuntime?: Record<string, string>;
   canWriteProviderProfiles?: boolean;
+  /**
+   * Canonical runtime_id of the active administrative filter, or undefined for
+   * the All-runtimes view. It seeds the runtime of a newly created profile and
+   * never overwrites the immutable runtime of an existing one.
+   */
+  selectedRuntimeId?: string | undefined;
+  /** Canonical runtime IDs offered beside the All-runtimes option. */
+  runtimeFilterOptions?: string[];
+  /** Called with a canonical runtime_id, or undefined for All runtimes. */
+  onSelectRuntimeId?: ((runtimeId: string | undefined) => void) | undefined;
 }
 
 interface ProviderProfileFormState {
@@ -155,6 +169,9 @@ interface OAuthSessionState {
 }
 
 export const PROVIDER_PROFILE_QUERY_KEY = ['provider-profiles'] as const;
+/** Sentinel value for the All-runtimes administrative view in Settings. */
+export const ALL_RUNTIMES_FILTER_VALUE = 'all';
+const RUNTIME_FILTER_CONTROL_ID = 'provider-profile-runtime-filter';
 const PROVIDER_PROFILE_REFRESH_STORAGE_KEY = 'moonmind:provider-profile-updated';
 
 function providerProfileModelTiers(profile: ProviderProfile): ProviderModelEffortTier[] {
@@ -199,10 +216,10 @@ function oauthSessionStatesEqual(left: OAuthSessionState, right: OAuthSessionSta
   );
 }
 
-export function defaultFormState(): ProviderProfileFormState {
+export function defaultFormState(runtimeId = ''): ProviderProfileFormState {
   return {
     profileId: '',
-    runtimeId: '',
+    runtimeId,
     providerId: '',
     providerLabel: '',
     defaultModel: '',
@@ -698,14 +715,43 @@ export function ProviderProfilesManager({
   queryClient,
   defaultTaskModelByRuntime = {},
   canWriteProviderProfiles = true,
+  selectedRuntimeId,
+  runtimeFilterOptions = [],
+  onSelectRuntimeId,
 }: ProviderProfilesManagerProps) {
-  const [form, setForm] = useState<ProviderProfileFormState>(() => defaultFormState());
+  const createFormRuntimeSeed = selectedRuntimeId ?? '';
+  const [form, setForm] = useState<ProviderProfileFormState>(() =>
+    defaultFormState(createFormRuntimeSeed),
+  );
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
+  const createFormRuntimeSeedRef = useRef(createFormRuntimeSeed);
   const [oauthSessions, setOauthSessions] = useState<Record<string, OAuthSessionState>>({});
   const [tmateOAuthSession, setTmateOAuthSession] = useState<OAuthSessionState | null>(null);
   const [claudeEnrollment, setClaudeEnrollment] = useState<ClaudeEnrollmentState | null>(null);
   const claudeEnrollmentDrawerRef = useRef<HTMLDivElement | null>(null);
   const claudeEnrollmentProfileIdRef = useRef<string | null>(null);
+
+  const activeRuntimeFilterValue = selectedRuntimeId ?? ALL_RUNTIMES_FILTER_VALUE;
+  // Canonical runtime IDs are the option values; the shared runtime formatter
+  // supplies the display text so Settings never invents a second label source.
+  // The active filter is always offered so the control stays consistent even if
+  // its last profile is deleted.
+  const runtimeFilterChoices = useMemo(() => {
+    const runtimeIds: string[] = [];
+    for (const runtimeId of [...runtimeFilterOptions, selectedRuntimeId ?? '']) {
+      const canonical = runtimeId.trim();
+      if (canonical && !runtimeIds.includes(canonical)) {
+        runtimeIds.push(canonical);
+      }
+    }
+    return [
+      { value: ALL_RUNTIMES_FILTER_VALUE, label: 'All runtimes' },
+      ...runtimeIds.map((runtimeId) => ({
+        value: runtimeId,
+        label: formatRuntimeLabel(runtimeId),
+      })),
+    ] as ReadonlyArray<{ value: string; label: string }>;
+  }, [runtimeFilterOptions, selectedRuntimeId]);
 
   const isEditing = editingProfileId !== null;
   const isCodexOAuthForm =
@@ -747,6 +793,41 @@ export function ProviderProfilesManager({
     claudeEnrollmentProfileIdRef.current = claudeEnrollment?.profile.profile_id ?? null;
   }, [claudeEnrollment?.profile.profile_id]);
 
+  // The runtime filter is the administrative equivalent of "Add Provider
+  // Profile for this runtime": it seeds the create form so a new profile lands
+  // in the runtime the operator is looking at. An explicitly typed runtime is
+  // never overwritten, and an existing profile's immutable runtime is never
+  // touched.
+  useEffect(() => {
+    const previousSeed = createFormRuntimeSeedRef.current;
+    if (previousSeed === createFormRuntimeSeed) {
+      return;
+    }
+    createFormRuntimeSeedRef.current = createFormRuntimeSeed;
+    if (editingProfileId !== null) {
+      return;
+    }
+    setForm((current) =>
+      current.runtimeId === '' || current.runtimeId === previousSeed
+        ? { ...current, runtimeId: createFormRuntimeSeed }
+        : current,
+    );
+  }, [createFormRuntimeSeed, editingProfileId]);
+
+  // A single-runtime view cannot show the row being edited when that row
+  // belongs to another runtime, so close the editor instead of leaving it
+  // pointing at an invisible profile.
+  useEffect(() => {
+    if (editingProfileId === null || !selectedRuntimeId) {
+      return;
+    }
+    if (form.runtimeId === selectedRuntimeId) {
+      return;
+    }
+    setEditingProfileId(null);
+    setForm(defaultFormState(selectedRuntimeId));
+  }, [editingProfileId, form.runtimeId, selectedRuntimeId]);
+
   useEffect(() => {
     const handleProviderProfileRefresh = (event: StorageEvent) => {
       if (event.key !== PROVIDER_PROFILE_REFRESH_STORAGE_KEY || !event.newValue) {
@@ -762,7 +843,7 @@ export function ProviderProfilesManager({
 
   const resetForm = () => {
     setEditingProfileId(null);
-    setForm(defaultFormState());
+    setForm(defaultFormState(createFormRuntimeSeed));
     onNotice(null);
   };
 
@@ -1095,7 +1176,7 @@ export function ProviderProfilesManager({
           : `Provider profile "${submittedForm.profileId.trim()}" created.`,
       });
       setEditingProfileId(null);
-      setForm(defaultFormState());
+      setForm(defaultFormState(createFormRuntimeSeed));
       queryClient.setQueryData<ProviderProfile[]>(
         PROVIDER_PROFILE_QUERY_KEY,
         (currentProfiles = []) => {
@@ -1146,7 +1227,7 @@ export function ProviderProfilesManager({
       onNotice({ level: 'ok', text: `Provider profile "${profileId}" deleted.` });
       if (editingProfileId === profileId) {
         setEditingProfileId(null);
-        setForm(defaultFormState());
+        setForm(defaultFormState(createFormRuntimeSeed));
       }
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
     },
@@ -1449,6 +1530,35 @@ export function ProviderProfilesManager({
         </div>
       </div>
 
+      {onSelectRuntimeId ? (
+        <div className="mt-4 flex flex-col gap-1.5 text-sm md:max-w-xs">
+          <label
+            className="font-medium text-slate-700 dark:text-slate-300"
+            htmlFor={RUNTIME_FILTER_CONTROL_ID}
+          >
+            Provider Profile runtime filter
+          </label>
+          <select
+            id={RUNTIME_FILTER_CONTROL_ID}
+            className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
+            value={activeRuntimeFilterValue}
+            onChange={(event) =>
+              onSelectRuntimeId(
+                event.target.value === ALL_RUNTIMES_FILTER_VALUE
+                  ? undefined
+                  : event.target.value,
+              )
+            }
+          >
+            {runtimeFilterChoices.map((choice) => (
+              <option key={choice.value} value={choice.value}>
+                {choice.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+
       <div className="provider-profiles-table-wrap mt-6 overflow-x-auto">
         <table
           className="provider-profiles-table min-w-full md:divide-y divide-slate-200 dark:divide-slate-800 text-left text-sm"
@@ -1518,7 +1628,9 @@ export function ProviderProfilesManager({
             {profiles.length === 0 ? (
               <tr role="row">
                 <td className="px-3 py-6 text-slate-500 dark:text-slate-400" colSpan={7} role="cell">
-                  No provider profiles configured yet.
+                  {selectedRuntimeId
+                    ? `No provider profiles are configured for ${formatRuntimeLabel(selectedRuntimeId)}.`
+                    : 'No provider profiles configured yet.'}
                 </td>
               </tr>
             ) : (

--- a/frontend/src/entrypoints/settings.test.tsx
+++ b/frontend/src/entrypoints/settings.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 
 import type { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
@@ -51,5 +51,199 @@ describe('Settings Entrypoint', () => {
     expect(screen.getByText('Settings provider profiles loading placeholder').closest('[role="status"]')).toBeTruthy();
     expect(screen.getByText('Settings managed secrets loading placeholder').closest('[role="status"]')).toBeTruthy();
     expect(screen.getAllByTestId('loading-placeholder-table').length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filter', () => {
+  const codexProfile = {
+    profile_id: 'codex_minimax_team',
+    runtime_id: 'codex_cli',
+    provider_id: 'minimax',
+    credential_source: 'secret_ref',
+    runtime_materialization_mode: 'api_key_env',
+    secret_refs: { MINIMAX_API_KEY: 'db://MINIMAX_API_KEY' },
+    max_parallel_runs: 1,
+    cooldown_after_429_seconds: 300,
+    rate_limit_policy: 'backoff',
+    enabled: true,
+    is_default: true,
+  };
+  const claudeProfile = {
+    ...codexProfile,
+    profile_id: 'claude_minimax_team',
+    runtime_id: 'claude_code',
+    is_default: false,
+  };
+
+  const payloadWithRuntimes: BootPayload = {
+    page: 'settings',
+    apiBase: '/api',
+    initialData: {
+      settingsPermissions: ['provider_profiles.write'],
+      runtimeConfig: {
+        system: {
+          // `omnigent` is a facade, never a Provider Profile owner, so it must
+          // not become a runtime filter option.
+          supportedRuntimes: ['omnigent', 'codex_cli', 'claude_code', 'codex_cloud'],
+        },
+      },
+    },
+  } as unknown as BootPayload;
+
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    window.history.pushState({}, 'Settings', '/settings?section=providers-secrets');
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/api/v1/provider-profiles')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [codexProfile, claudeProfile],
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ items: [] }),
+      } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function runtimeFilterControl(): HTMLSelectElement {
+    return screen.getByLabelText(
+      'Provider Profile runtime filter',
+    ) as HTMLSelectElement;
+  }
+
+  function selectRuntimeFilter(runtimeId: string): void {
+    fireEvent.change(runtimeFilterControl(), { target: { value: runtimeId } });
+  }
+
+  // The default profile ID also appears in the global health summary, so row
+  // assertions are scoped to the Provider Profiles table.
+  function providerProfilesTable(): HTMLElement {
+    const section = screen
+      .getByRole('heading', { name: 'Provider Profiles' })
+      .closest('section');
+    expect(section).not.toBeNull();
+    return within(section as HTMLElement).getByRole('table');
+  }
+
+  it('fetches the complete Provider Profile collection and defaults to All runtimes', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+
+    // Settings is the administrative view, so it never scopes the request by
+    // runtime the way an execution surface does.
+    const profileRequests = fetchSpy.mock.calls
+      .map(([requestUrl]) => String(requestUrl))
+      .filter((requestUrl) => requestUrl.startsWith('/api/v1/provider-profiles'));
+    expect(profileRequests).toEqual(['/api/v1/provider-profiles']);
+
+    expect(runtimeFilterControl().value).toBe('all');
+    const table = providerProfilesTable();
+    expect(within(table).getByText('codex_minimax_team')).toBeTruthy();
+    expect(within(table).getByText('claude_minimax_team')).toBeTruthy();
+  });
+
+  it('offers one option per available runtime using canonical IDs and formatted labels', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+
+    const control = runtimeFilterControl();
+    const options = within(control)
+      .getAllByRole('option')
+      .map((option) => ({
+        value: (option as HTMLOptionElement).value,
+        label: option.textContent,
+      }));
+
+    expect(options).toEqual([
+      { value: 'all', label: 'All runtimes' },
+      { value: 'codex_cli', label: 'Codex CLI' },
+      { value: 'claude_code', label: 'Claude Code' },
+      { value: 'codex_cloud', label: 'Codex Cloud' },
+    ]);
+    expect(options.map((option) => option.value)).not.toContain('omnigent');
+  });
+
+  it('shows only matching rows while the global health summary keeps every loaded profile', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+
+    const healthSummary = screen.getByLabelText('Configuration health summary');
+    expect(within(healthSummary).getByText('2')).toBeTruthy();
+
+    selectRuntimeFilter('codex_cli');
+
+    expect(within(providerProfilesTable()).getByText('codex_minimax_team')).toBeTruthy();
+    expect(
+      within(providerProfilesTable()).queryByText('claude_minimax_team'),
+    ).toBeNull();
+    // Filtering the table must not narrow global configuration health.
+    expect(within(healthSummary).getByText('2')).toBeTruthy();
+    expect(within(healthSummary).getByText('2 enabled')).toBeTruthy();
+
+    selectRuntimeFilter('claude_code');
+
+    expect(within(providerProfilesTable()).getByText('claude_minimax_team')).toBeTruthy();
+    expect(
+      within(providerProfilesTable()).queryByText('codex_minimax_team'),
+    ).toBeNull();
+    expect(within(healthSummary).getByText('2')).toBeTruthy();
+  });
+
+  it('prefills the create form runtime from the active filter without touching an existing runtime', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+
+    const runtimeIdInput = () => screen.getByLabelText(/Runtime ID/) as HTMLInputElement;
+    expect(runtimeIdInput().value).toBe('');
+
+    selectRuntimeFilter('claude_code');
+    expect(runtimeIdInput().value).toBe('claude_code');
+
+    selectRuntimeFilter('codex_cli');
+    expect(runtimeIdInput().value).toBe('codex_cli');
+
+    // An explicitly authored runtime survives a later filter change.
+    fireEvent.change(runtimeIdInput(), { target: { value: 'opencode' } });
+    selectRuntimeFilter('claude_code');
+    expect(runtimeIdInput().value).toBe('opencode');
+  });
+
+  it('names the active runtime in the empty state instead of the global message', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    expect(screen.queryByText('No provider profiles configured yet.')).toBeNull();
+
+    selectRuntimeFilter('codex_cloud');
+
+    expect(
+      screen.getByText('No provider profiles are configured for Codex Cloud.'),
+    ).toBeTruthy();
+    expect(screen.queryByText('No provider profiles configured yet.')).toBeNull();
+  });
+
+  it('keeps runtime_id immutable while editing an existing profile', async () => {
+    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+
+    await screen.findByRole('heading', { name: 'Provider Profiles' });
+
+    selectRuntimeFilter('claude_code');
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const runtimeIdInput = screen.getByLabelText(/Runtime ID/) as HTMLInputElement;
+    expect(runtimeIdInput.value).toBe('claude_code');
+    expect(runtimeIdInput.disabled).toBe(true);
   });
 });

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { BootPayload } from '../boot/parseBootPayload';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
@@ -11,11 +11,17 @@ import {
   type WorkerPauseConfig,
 } from '../components/settings/OperationsSettingsSection';
 import {
+  ALL_RUNTIMES_FILTER_VALUE,
   PROVIDER_PROFILE_QUERY_KEY,
   ProviderProfilesManager,
   type ProviderProfile,
 } from '../components/settings/ProviderProfilesManager';
 import { resetDashboardPreferences } from '../utils/dashboardPreferences';
+
+// `omnigent` is an execution facade, not a Provider Profile owner: every
+// profile it launches is owned by the underlying managed runtime, so it is
+// never offered as a Provider Profile runtime filter.
+const NON_PROFILE_OWNING_RUNTIMES = new Set(['omnigent']);
 
 function ProvidersKeyIcon() {
   return (
@@ -146,12 +152,27 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const [notice, setNotice] = useState<Notice | null>(null);
   const [section, setSection] = useState<SettingsSectionId>(() => readSectionFromLocation());
+  // Settings is the administrative exception to runtime-scoped Provider Profile
+  // selection: it enters on the All-runtimes view and can narrow the table to a
+  // single runtime without narrowing global configuration health.
+  const [providerProfileRuntimeFilter, setProviderProfileRuntimeFilter] = useState<string>(
+    ALL_RUNTIMES_FILTER_VALUE,
+  );
   const workerPauseConfig =
     (payload.initialData as { workerPause?: WorkerPauseConfig } | undefined)?.workerPause ??
     null;
+  const runtimeSystemConfig =
+    (payload.initialData as {
+      runtimeConfig?: {
+        system?: {
+          defaultTaskModelByRuntime?: Record<string, string>;
+          supportedRuntimes?: string[];
+        };
+      };
+    } | undefined)?.runtimeConfig?.system ?? {};
   const defaultTaskModelByRuntime: Record<string, string> =
-    (payload.initialData as { runtimeConfig?: { system?: { defaultTaskModelByRuntime?: Record<string, string> } } } | undefined)
-      ?.runtimeConfig?.system?.defaultTaskModelByRuntime ?? {};
+    runtimeSystemConfig.defaultTaskModelByRuntime ?? {};
+  const supportedRuntimes: string[] = runtimeSystemConfig.supportedRuntimes ?? [];
   const settingsPermissions = new Set(
     ((payload.initialData as { settingsPermissions?: string[] } | undefined)
       ?.settingsPermissions ?? []),
@@ -222,6 +243,33 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
     },
   });
 
+  // The complete collection stays the single source for configuration health so
+  // global counts and diagnostics never follow the table filter.
+  const allProviderProfiles = providerProfiles ?? [];
+  const providerProfileRuntimeOptions = useMemo(() => {
+    const runtimeIds: string[] = [];
+    for (const runtimeId of [
+      ...supportedRuntimes,
+      ...allProviderProfiles.map((profile) => profile.runtime_id ?? ''),
+    ]) {
+      const canonical = String(runtimeId ?? '').trim();
+      if (
+        canonical &&
+        !NON_PROFILE_OWNING_RUNTIMES.has(canonical) &&
+        !runtimeIds.includes(canonical)
+      ) {
+        runtimeIds.push(canonical);
+      }
+    }
+    return runtimeIds;
+  }, [supportedRuntimes, allProviderProfiles]);
+  const visibleProviderProfiles =
+    providerProfileRuntimeFilter === ALL_RUNTIMES_FILTER_VALUE
+      ? allProviderProfiles
+      : allProviderProfiles.filter(
+          (profile) => profile.runtime_id === providerProfileRuntimeFilter,
+        );
+
   const fallbackSection = SETTINGS_SECTIONS[0]!;
   const currentSection =
     SETTINGS_SECTIONS.find((candidate) => candidate.id === section) ?? fallbackSection;
@@ -248,7 +296,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       </header>
 
       <ConfigurationHealthSummary
-        providerProfiles={providerProfiles ?? []}
+        providerProfiles={allProviderProfiles}
         secrets={secretsData?.items ?? []}
         isLoading={areProfilesLoading || areSecretsLoading}
         isError={areProfilesErrored || areSecretsErrored}
@@ -341,12 +389,21 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
             </div>
           ) : (
             <ProviderProfilesManager
-              profiles={providerProfiles ?? []}
+              profiles={visibleProviderProfiles}
               secretSlugs={(secretsData?.items ?? []).map((secret) => secret.slug)}
               onNotice={setNotice}
               queryClient={queryClient}
               defaultTaskModelByRuntime={defaultTaskModelByRuntime}
               canWriteProviderProfiles={canWriteProviderProfiles}
+              selectedRuntimeId={
+                providerProfileRuntimeFilter === ALL_RUNTIMES_FILTER_VALUE
+                  ? undefined
+                  : providerProfileRuntimeFilter
+              }
+              runtimeFilterOptions={providerProfileRuntimeOptions}
+              onSelectRuntimeId={(runtimeId) =>
+                setProviderProfileRuntimeFilter(runtimeId ?? ALL_RUNTIMES_FILTER_VALUE)
+              }
             />
           )}
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -21187,6 +21187,38 @@ describe("Task Create runtime switch layout stability", () => {
     expect(screen.queryByRole("option", { name: /Codex Default/ })).toBeNull();
   });
 
+  it("MoonLadderStudios/MoonMind#3788 names the runtime in the empty state when it has no launch-ready profiles", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    await screen.findByLabelText("Provider profile");
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Runtime"), {
+        target: { value: "claude_code" },
+      });
+    });
+
+    // The runtime-scoped refetch is still in flight, so the surface must not
+    // yet claim the runtime has no profiles.
+    expect(
+      screen.queryByText(/No launch-ready Provider Profiles are configured/),
+    ).toBeNull();
+
+    await act(async () => {
+      resolveClaudeProfiles?.([]);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /No launch-ready Provider Profiles are configured for Claude Code\. Configure one in Settings before starting this workflow\./,
+        ),
+      ).toBeTruthy();
+    });
+    // No selector means no way to submit an incompatible profile.
+    expect(screen.queryByLabelText("Provider profile")).toBeNull();
+  });
+
   it("omits task effort when the selected provider profile defines a default effort", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -845,6 +845,48 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     await waitFor(() => expect(readinessRequests).toBe(2));
   });
 
+  it("MoonLadderStudios/MoonMind#3788 reports an Omnigent readiness failure instead of an empty provider-profile state", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        // The readiness projection is the only source of Omnigent-eligible
+        // Provider Profiles, so its failure is what empties the selector.
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+          json: async () => ({ detail: "readiness unavailable" }),
+        } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        // The ordinary profile request still succeeds, so it cannot be the
+        // query that reports the failure.
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), {
+      target: { value: "omnigent" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load provider profiles.")).toBeTruthy();
+    });
+    // Directing the operator to Settings would hide a transient outage behind a
+    // configuration error.
+    expect(
+      screen.queryByText(/No launch-ready Provider Profiles are configured/),
+    ).toBeNull();
+  });
+
   it("gates a busy Omnigent selection and hides unsupported model authority", async () => {
     const payload = {
       ...mockPayload,

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8077,6 +8077,21 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     [persistedObjectiveAttachments, steps],
   );
 
+  // The Provider Profile block must never claim a runtime has no launch-ready
+  // profiles while its runtime-scoped result set is still resolving. During a
+  // runtime switch `keepPreviousData` holds the previous runtime's profiles, so
+  // placeholder data counts as unresolved too.
+  const providerProfilesUnresolvedForRuntime =
+    runtime === "omnigent"
+      ? omnigentCatalogQuery.isPending ||
+        omnigentCatalogQuery.isFetching ||
+        (selectedProfileIsGenericV2 &&
+          (omnigentExecutionReadinessQuery.isPending ||
+            omnigentExecutionReadinessQuery.isFetching))
+      : providerProfilesQuery.isPending ||
+        providerProfilesQuery.isPlaceholderData ||
+        providerProfilesQuery.isFetching;
+
   const providerOptions = [...activeProviderProfiles]
     .sort((left, right) => {
       const leftDefault = Boolean(left.is_default);
@@ -13658,7 +13673,21 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 </p>
               ) : null}
             </div>
-          ) : null}
+          ) : providerProfilesUnresolvedForRuntime ? null : (
+            <div id="queue-provider-profile-wrap">
+              {providerProfilesQuery.isError ? (
+                <p className="small" role="alert" id="queue-auth-profile-hint">
+                  Failed to load provider profiles.
+                </p>
+              ) : (
+                <p className="small" role="alert" id="queue-provider-profile-empty">
+                  No launch-ready Provider Profiles are configured for{" "}
+                  {formatRuntimeLabel(providerProfileRuntime)}. Configure one in
+                  Settings before starting this workflow.
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) ? (

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8102,6 +8102,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         providerProfilesQuery.isPlaceholderData ||
         providerProfilesQuery.isFetching;
 
+  // A settled failure of any request that supplies the runtime's profiles is a
+  // load failure, not an empty result. For Omnigent the list comes from the
+  // readiness projections, so the ordinary profile request can succeed while
+  // the user still has no profiles to choose from.
+  const providerProfilesLoadFailedForRuntime =
+    providerProfilesQuery.isError ||
+    (runtime === "omnigent" &&
+      (omnigentCatalogQuery.isError ||
+        (selectedProfileIsGenericV2 &&
+          omnigentExecutionReadinessQuery.isError)));
+
   const providerOptions = [...activeProviderProfiles]
     .sort((left, right) => {
       const leftDefault = Boolean(left.is_default);
@@ -13693,7 +13704,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             </div>
           ) : providerProfilesUnresolvedForRuntime ? null : (
             <div id="queue-provider-profile-wrap">
-              {providerProfilesQuery.isError ? (
+              {providerProfilesLoadFailedForRuntime ? (
                 <p className="small" role="alert" id="queue-auth-profile-hint">
                   Failed to load provider profiles.
                 </p>

--- a/moonmind/workflows/proposals/repositories.py
+++ b/moonmind/workflows/proposals/repositories.py
@@ -19,6 +19,12 @@ class WorkflowProposalRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
+    @property
+    def session(self) -> AsyncSession:
+        """Expose the unit-of-work session for shared validation contracts."""
+
+        return self._session
+
     async def create_proposal(
         self,
         *,

--- a/moonmind/workflows/proposals/service.py
+++ b/moonmind/workflows/proposals/service.py
@@ -16,6 +16,10 @@ from uuid import UUID
 import httpx
 from pydantic import ValidationError
 
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+    require_launch_target_provider_profile_runtime,
+)
 from moonmind.config import settings
 from moonmind.security import scan_outbound_text
 from moonmind.utils.logging import SecretRedactor
@@ -1863,6 +1867,28 @@ class WorkflowProposalService:
             self._enforce_flat_preset_derived_steps(payload)
         payload = self._enforce_proposal_pr_publish_mode(payload)
         request["payload"] = payload
+
+        # A promotion is a launch-authoring boundary: the runtime override
+        # rewrites ``targetRuntime`` and ``workflow.runtime.mode`` while leaving
+        # any authored Provider Profile ref untouched, so the override itself can
+        # create an incompatible pair. Enforce the shared runtime-ownership
+        # invariant on the final payload before the proposal is durably marked
+        # promoted, otherwise a rejected promotion would leave the proposal in a
+        # terminal state with no execution behind it.
+        try:
+            await require_launch_target_provider_profile_runtime(
+                session=self._repository.session,
+                target={"initialParameters": payload},
+            )
+        except ProviderProfileRuntimeMismatchError:
+            self._append_proposal_event(
+                proposal,
+                "proposal.promotion_failed",
+                reason="provider_profile_runtime_mismatch",
+                runtimeModeOverride=runtime_mode_override,
+            )
+            await self._repository.commit()
+            raise
 
         priority = request.get("priority", 0)
         if priority_override is not None:

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -43,6 +43,9 @@ from api_service.db.models import (
     WorkflowCheckpointBranchOperation,
     WorkflowCheckpointBranchTurn,
 )
+from api_service.services.provider_profile_runtime import (
+    require_launch_target_provider_profile_runtime,
+)
 from moonmind.config.settings import settings
 from moonmind.security import scan_outbound_text
 from moonmind.statuses.compat import (
@@ -1934,6 +1937,20 @@ class TemporalExecutionService:
                     f"{first_error.path}: {first_error.message}"
                 )
             initial_parameters = skill_validation.parameters
+
+        # Provider Profiles are runtime-owned launch contracts, so the
+        # runtime/profile pair has to be valid at the boundary every
+        # launch-authoring caller converges on — direct submission, proposal
+        # promotion, rerun, continuation, checkpoint branching, manifest ingest,
+        # and deployment operations all reach a launch through here. Enforcing
+        # the shared invariant once at this handoff keeps an alternate client
+        # from finding a route that accepts a pair the runtime-scoped selectors
+        # would never offer, and keeps a mismatched profile from silently
+        # deciding the launch strategy later in the runtime launcher.
+        await require_launch_target_provider_profile_runtime(
+            session=self._session,
+            target={"initialParameters": initial_parameters},
+        )
 
         if workflow_type_enum is TemporalWorkflowType.MANIFEST_INGEST:
             if not manifest_artifact_ref:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -84,6 +84,16 @@ from api_service.db.models import (
     TemporalWorkflowType,
 )
 from api_service.services.recurring_workflows_service import RecurringWorkflowValidationError
+from api_service.services.provider_profile_runtime import (
+    require_launch_target_provider_profile_runtime,
+)
+from moonmind.schemas.workflow_recovery_models import (
+    WorkflowRecoveryTargetModel,
+    deterministic_recovery_creation_key,
+)
+from moonmind.workflows.executions.runtime_capabilities import (
+    resolve_runtime_execution_capabilities,
+)
 from moonmind.config.settings import settings
 from moonmind.security.execution_fanout_capabilities import (
     mint_execution_fanout_capability,
@@ -17624,3 +17634,306 @@ async def test_mm3788_raw_create_branch_keeps_the_omnigent_product_boundary(
         assert exc_info.value.status_code == 422
         assert exc_info.value.detail["code"] == "omnigent_product_boundary_required"
         service._client_adapter.start_workflow.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — a recovery destination inherits the source
+# execution's authored runtime and Provider Profile and reaches a launch through
+# the same TemporalExecutionService.create_execution handoff. A pair persisted
+# before the shared invariant existed (or one whose profile was recreated under
+# another runtime) is rejected there, so the recovery routes must surface the
+# identical 409 contract every other launch-authoring path returns instead of an
+# unmapped server error.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_legacy_recovery_parameters() -> dict[str, Any]:
+    """Source parameters carrying a pair persisted before the invariant."""
+
+    return {
+        "targetRuntime": "claude_code",
+        "workflow": {
+            "instructions": "Recover the failed step.",
+            "runtime": {
+                "mode": "claude_code",
+                "providerProfileRef": "codex_minimax_team",
+            },
+        },
+    }
+
+
+def _mm3788_production_recovery_rejection(tmp_path, *, db_name: str):
+    """Raise the rejection the production contract raises for those params.
+
+    The error identity is not hand-written: the real shared contract resolves a
+    real ``ManagedAgentProviderProfile`` row from real persistence and raises
+    :class:`ProviderProfileRuntimeMismatchError` itself, exactly as it does
+    inside ``TemporalExecutionService.create_execution`` on the recovery path.
+    """
+
+    async def _raise(*_args: Any, **_kwargs: Any):
+        db_url = f"sqlite+aiosqlite:///{tmp_path}/{db_name}.db"
+        engine = create_async_engine(db_url, future=True)
+        session_factory = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        try:
+            async with session_factory() as session:
+                session.add(
+                    ManagedAgentProviderProfile(
+                        profile_id="codex_minimax_team",
+                        runtime_id="codex_cli",
+                        provider_id="minimax",
+                    )
+                )
+                await session.commit()
+                await require_launch_target_provider_profile_runtime(
+                    session=session,
+                    target={
+                        "initialParameters": _mm3788_legacy_recovery_parameters()
+                    },
+                )
+        finally:
+            await engine.dispose()
+        raise AssertionError(
+            "the shared contract accepted a cross-runtime recovery pair"
+        )
+
+    return _raise
+
+
+def _mm3788_assert_shared_mismatch_detail(detail: dict[str, Any]) -> None:
+    assert detail == {
+        "code": "provider_profile_runtime_mismatch",
+        "message": (
+            "Provider Profile 'codex_minimax_team' belongs to runtime "
+            "'codex_cli' and cannot be used with runtime 'claude_code'."
+        ),
+        "profileId": "codex_minimax_team",
+        "profileRuntime": "codex_cli",
+        "selectedRuntime": "claude_code",
+    }
+
+
+def _mm3788_typed_recovery_target(canonical):
+    checkpoint_digest = "sha256:mm3788-checkpoint"
+    return WorkflowRecoveryTargetModel.model_validate(
+        {
+            "target": {
+                "kind": "failed_step",
+                "logicalStepId": "implement",
+                "sourceStepExecutionId": "step-execution-1",
+            },
+            "source": {
+                "workflowId": canonical.workflow_id,
+                "runId": canonical.run_id,
+                "planRef": "artifact://plan/source",
+                "planDigest": "sha256:plan",
+                "taskInputSnapshotRef": "artifact://snapshot/source",
+            },
+            "checkpoint": {
+                "ref": "artifact://checkpoint/source",
+                "boundary": "before_execution",
+                "kind": "worktree_archive",
+                "digest": checkpoint_digest,
+                "validationRef": "artifact://checkpoint-validation",
+                "sourceWorkspaceRef": "workspace://source",
+            },
+            "continuation": {"phase": "rerun_failed_step"},
+            "capabilitySnapshot": resolve_runtime_execution_capabilities(
+                "omnigent"
+            ).model_dump(by_alias=True, mode="json"),
+            "preservedStepRefs": [],
+            "sideEffectDispositionRef": "artifact://side-effects",
+            "sideEffectSafe": True,
+            "destination": {
+                "workflowId": "mm:mm3788-recovery-destination",
+                "creationKey": deterministic_recovery_creation_key(
+                    canonical.workflow_id,
+                    canonical.run_id,
+                    "failed_step",
+                    checkpoint_digest,
+                    "rerun_failed_step",
+                ),
+                "runtimeId": "omnigent",
+                "executionProfileRef": "provider-profile:primary",
+                "workspaceReservationId": "workspace-reservation:destination",
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_typed_recovery_route_maps_runtime_mismatch_to_409(
+    tmp_path,
+) -> None:
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.parameters = _mm3788_legacy_recovery_parameters()
+    mock_service.describe_execution.return_value = canonical
+    mock_service.create_typed_recovery_execution.side_effect = (
+        _mm3788_production_recovery_rejection(tmp_path, db_name="mm3788_recover_typed")
+    )
+    user = SimpleNamespace(
+        id=uuid4(),
+        email="mm3788@example.com",
+        is_active=True,
+        is_superuser=True,
+        roles=[],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await executions_module.recover_execution(
+            workflow_id=canonical.workflow_id,
+            request=_mm3788_typed_recovery_target(canonical),
+            service=mock_service,
+            user=user,
+            _submit_enabled=None,
+        )
+
+    assert exc_info.value.status_code == 409
+    _mm3788_assert_shared_mismatch_detail(exc_info.value.detail)
+    mock_service.create_typed_recovery_execution.assert_awaited_once()
+
+
+def _mm3788_failed_step_recovery_context(canonical):
+    """Artifact + session doubles the failed-step recovery routes hydrate."""
+
+    checkpoint_ref = "artifact://resume-checkpoints/source/checkpoint-v1"
+    canonical.memo = {
+        **canonical.memo,
+        "recovery_checkpoint_ref": checkpoint_ref,
+        "failed_run_recovery_manifest_ref": "artifact://recovery/manifest",
+        "task_input_snapshot_ref": "artifact://snapshot/source",
+    }
+    checkpoint_payload = {
+        "schemaVersion": "v1",
+        "source": {"workflowId": canonical.workflow_id, "runId": canonical.run_id},
+        "taskInputSnapshotRef": "artifact://snapshot/source",
+        "planRef": "artifact://plan/source",
+        "planDigest": "sha256:resume-plan",
+        "failedStep": {"logicalStepId": "implement", "order": 2, "attempt": 1},
+        "preservedSteps": [
+            {
+                "logicalStepId": "plan",
+                "order": 1,
+                "status": "completed",
+                "sourceExecutionOrdinal": 1,
+                "artifacts": {"summary": "artifact://completed/plan"},
+                "stateCheckpointRef": "artifact://workspace/before-implement",
+            }
+        ],
+        "recoveryWorkspace": {
+            "branch": "feature/resume",
+            "commit": "abc123",
+            "checkpointRef": checkpoint_ref,
+            "archiveBytes": 100,
+        },
+    }
+    manifest_payload = _valid_failed_run_recovery_manifest_payload(
+        canonical, checkpoint_ref=checkpoint_ref
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            side_effect=[
+                (SimpleNamespace(), json.dumps(manifest_payload).encode()),
+                (SimpleNamespace(), json.dumps(checkpoint_payload).encode()),
+            ]
+        )
+    )
+
+    class Session:
+        async def get(self, model, key):
+            return canonical
+
+        async def commit(self):
+            return None
+
+    return artifact_service, Session()
+
+
+def test_mm3788_failed_step_recovery_route_maps_runtime_mismatch_to_409(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._checkpoint_resume_admission_for_request",
+        lambda **_kwargs: SimpleNamespace(admitted=True),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.parameters = _mm3788_legacy_recovery_parameters()
+    mock_service.describe_execution.return_value = canonical
+    mock_service.create_failed_step_recovery_execution.side_effect = (
+        _mm3788_production_recovery_rejection(
+            tmp_path, db_name="mm3788_recover_failed_step"
+        )
+    )
+    artifact_service, session = _mm3788_failed_step_recovery_context(canonical)
+
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: session
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-failed-step",
+            json={"idempotencyKey": "mm3788-resume-1"},
+        )
+
+    assert response.status_code == 409
+    _mm3788_assert_shared_mismatch_detail(response.json()["detail"])
+    mock_service.create_failed_step_recovery_execution.assert_awaited_once()
+
+
+def test_mm3788_selected_step_recovery_route_maps_runtime_mismatch_to_409(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._checkpoint_resume_admission_for_request",
+        lambda **_kwargs: SimpleNamespace(admitted=True),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    canonical = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    canonical.parameters = _mm3788_legacy_recovery_parameters()
+    mock_service.describe_execution.return_value = canonical
+    mock_service.create_failed_step_recovery_execution.side_effect = (
+        _mm3788_production_recovery_rejection(
+            tmp_path, db_name="mm3788_recover_selected_step"
+        )
+    )
+    artifact_service, session = _mm3788_failed_step_recovery_context(canonical)
+
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: session
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/recover-from-selected-step",
+            json={
+                "idempotencyKey": "mm3788-recover-selected-1",
+                "sourceWorkflowId": canonical.workflow_id,
+                "sourceRunId": canonical.run_id,
+                "selectedStartStepId": "plan",
+            },
+        )
+
+    assert response.status_code == 409
+    _mm3788_assert_shared_mismatch_detail(response.json()["detail"])
+    mock_service.create_failed_step_recovery_execution.assert_awaited_once()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1039,7 +1039,9 @@ async def test_step_runtime_inherits_task_profile_default_model() -> None:
     )
     session = SimpleNamespace(
         get=AsyncMock(
-            return_value=SimpleNamespace(default_model="codex-profile-default")
+            return_value=SimpleNamespace(
+                runtime_id="codex_cli", default_model="codex-profile-default"
+            )
         )
     )
 
@@ -6954,6 +6956,7 @@ def test_create_task_shaped_execution_accepts_provider_profile_alias() -> None:
     app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
         get=AsyncMock(
             return_value=SimpleNamespace(
+                runtime_id="codex_cli",
                 default_model="gpt-5-codex",
             )
         )
@@ -6998,6 +7001,7 @@ def test_create_task_shaped_execution_resolves_model_tier_against_profile() -> N
         get=AsyncMock(
             return_value=SimpleNamespace(
                 profile_id="codex-provider-profile",
+                runtime_id="codex_cli",
                 default_model=None,
                 default_effort=None,
                 model_tiers=[
@@ -7064,6 +7068,7 @@ def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
         get=AsyncMock(
             return_value=SimpleNamespace(
                 profile_id="codex-provider-profile",
+                runtime_id="codex_cli",
                 default_model="legacy-default",
                 default_model_tier=1,
                 model_tiers=[
@@ -7144,6 +7149,7 @@ def test_create_task_shaped_execution_rejects_strict_unavailable_model_tier() ->
         get=AsyncMock(
             return_value=SimpleNamespace(
                 profile_id="codex-provider-profile",
+                runtime_id="codex_cli",
                 default_model=None,
                 default_effort=None,
                 model_tiers=[
@@ -17605,7 +17611,9 @@ async def test_mm3788_step_runtime_selection_accepts_owned_profile() -> None:
 
 
 @asynccontextmanager
-async def _mm3788_raw_branch_context(tmp_path, *, db_name: str):
+async def _mm3788_raw_branch_context(
+    tmp_path, *, db_name: str, profile_runtime_id: str = "codex_cli"
+):
     """Yield a real service over real persistence with one seeded profile."""
 
     original_backend = settings.workflow.temporal_artifact_backend
@@ -17622,7 +17630,7 @@ async def _mm3788_raw_branch_context(tmp_path, *, db_name: str):
             session.add(
                 ManagedAgentProviderProfile(
                     profile_id="codex_minimax_team",
-                    runtime_id="codex_cli",
+                    runtime_id=profile_runtime_id,
                     provider_id="minimax",
                 )
             )
@@ -17758,6 +17766,140 @@ async def test_mm3788_raw_create_branch_keeps_the_omnigent_product_boundary(
 
         assert exc_info.value.status_code == 422
         assert exc_info.value.detail["code"] == "omnigent_product_boundary_required"
+        service._client_adapter.start_workflow.assert_not_awaited()
+
+
+def _mm3788_conflicting_runtime_request(
+    *, target_runtime: str, nested_runtime_mode: str, profile_id: str
+) -> dict[str, Any]:
+    """A raw body whose two runtime fields disagree.
+
+    The worker resolves ``workflow.runtime.mode`` before the payload-level
+    ``targetRuntime``, so this is the shape that decides which runtime actually
+    executes the task.
+    """
+
+    return {
+        "workflowType": "MoonMind.UserWorkflow",
+        "title": "MM-3788 conflicting runtime fields",
+        "initialParameters": {
+            "targetRuntime": target_runtime,
+            "profileId": profile_id,
+            "workflow": {
+                "instructions": "Launch with an explicit provider profile.",
+                "runtime": {
+                    "mode": nested_runtime_mode,
+                    "providerProfileRef": profile_id,
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_honors_the_runtime_block_over_target_runtime(
+    tmp_path,
+) -> None:
+    """The guard resolves the runtime the worker resolves, not the other field.
+
+    ``targetRuntime`` names the profile's own runtime, so reading it first would
+    approve the pair; the worker then executes the task as ``claude_code`` with a
+    Codex-owned profile.
+    """
+
+    async with _mm3788_raw_branch_context(
+        tmp_path, db_name="mm3788_raw_conflict"
+    ) as (session, service, user):
+        with pytest.raises(HTTPException) as exc_info:
+            await _mm3788_post_raw_execution(
+                service=service,
+                session=session,
+                user=user,
+                payload=_mm3788_conflicting_runtime_request(
+                    target_runtime="codex_cli",
+                    nested_runtime_mode="claude_code",
+                    profile_id="codex_minimax_team",
+                ),
+            )
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert detail["code"] == "provider_profile_runtime_mismatch"
+        assert detail["profileRuntime"] == "codex_cli"
+        # The runtime the worker would have executed, not the payload-level one.
+        assert detail["selectedRuntime"] == "claude_code"
+        service._client_adapter.start_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_rejects_a_nested_omnigent_runtime_conflict(
+    tmp_path,
+) -> None:
+    """A nested ``omnigent`` mode does not waive the other authored runtime.
+
+    Deferring to the Omnigent facade is only safe when the payload names nothing
+    else; here ``targetRuntime`` still names a managed runtime that the Omnigent
+    selection service never sees.
+    """
+
+    async with _mm3788_raw_branch_context(
+        tmp_path, db_name="mm3788_raw_nested_omnigent"
+    ) as (session, service, user):
+        with pytest.raises(HTTPException) as exc_info:
+            await _mm3788_post_raw_execution(
+                service=service,
+                session=session,
+                user=user,
+                payload=_mm3788_conflicting_runtime_request(
+                    target_runtime="claude_code",
+                    nested_runtime_mode="omnigent",
+                    profile_id="codex_minimax_team",
+                ),
+            )
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert detail["code"] == "provider_profile_runtime_mismatch"
+        assert detail["profileRuntime"] == "codex_cli"
+        assert detail["selectedRuntime"] == "claude_code"
+        service._client_adapter.start_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_rejects_a_profile_with_no_runtime_owner(
+    tmp_path,
+) -> None:
+    """A whitespace ``runtime_id`` is ambiguous authority, not a free pass.
+
+    ``ProviderProfileCreate.runtime_id`` accepts a blank string, so this row is
+    reachable through the provider-profile API. Treating it as "nothing to
+    compare" would let it launch under every runtime.
+    """
+
+    async with _mm3788_raw_branch_context(
+        tmp_path,
+        db_name="mm3788_raw_unowned",
+        profile_runtime_id="   ",
+    ) as (session, service, user):
+        with pytest.raises(HTTPException) as exc_info:
+            await _mm3788_post_raw_execution(
+                service=service,
+                session=session,
+                user=user,
+                payload=_mm3788_raw_execution_request(
+                    target_runtime="codex_cli", profile_id="codex_minimax_team"
+                ),
+            )
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert detail["code"] == "provider_profile_runtime_mismatch"
+        assert detail["profileRuntime"] == ""
+        assert detail["selectedRuntime"] == "codex_cli"
+        assert detail["message"] == (
+            "Provider Profile 'codex_minimax_team' does not declare an owning "
+            "runtime and cannot be used with runtime 'codex_cli'."
+        )
         service._client_adapter.start_workflow.assert_not_awaited()
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from contextlib import asynccontextmanager
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -16,6 +17,7 @@ from uuid import uuid4
 import pytest
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from temporalio.api.enums.v1 import IndexedValueType
@@ -66,6 +68,7 @@ from moonmind.omnigent.bridge_store import (
 )
 from api_service.db.models import (
     Base,
+    ManagedAgentProviderProfile,
     MoonMindWorkflowState,
     TemporalExecutionCloseStatus,
     TemporalArtifact,
@@ -17455,3 +17458,169 @@ async def test_mm3788_step_runtime_selection_accepts_owned_profile() -> None:
 
     assert steps[0]["runtime"]["mode"] == "claude_code"
     assert steps[0]["runtime"]["profileId"] == "claude_minimax_team"
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — the raw ``CreateExecutionRequest`` branch of
+# POST /api/executions is the alternate-client shape (the dashboard always sends
+# the ``type``/``payload`` envelope). It reaches a launch through the same
+# TemporalExecutionService.create_execution handoff, so the shared
+# runtime-ownership invariant has to reject a mismatched pair there too.
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _mm3788_raw_branch_context(tmp_path, *, db_name: str):
+    """Yield a real service over real persistence with one seeded profile."""
+
+    original_backend = settings.workflow.temporal_artifact_backend
+    original_root = settings.workflow.temporal_artifact_root
+    settings.workflow.temporal_artifact_backend = "local_fs"
+    settings.workflow.temporal_artifact_root = str(tmp_path / "artifacts")
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/{db_name}.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with session_factory() as session:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex_minimax_team",
+                    runtime_id="codex_cli",
+                    provider_id="minimax",
+                )
+            )
+            await session.commit()
+            service = TemporalExecutionService(session)
+            service._client_adapter.start_workflow = AsyncMock(
+                return_value=SimpleNamespace(run_id="run-mm3788-raw")
+            )
+            user = SimpleNamespace(
+                id=uuid4(),
+                email="mm3788@example.com",
+                is_active=True,
+                is_superuser=True,
+                roles=[],
+            )
+            yield session, service, user
+    finally:
+        await engine.dispose()
+        settings.workflow.temporal_artifact_backend = original_backend
+        settings.workflow.temporal_artifact_root = original_root
+
+
+def _mm3788_raw_execution_request(
+    *, target_runtime: str, profile_id: str
+) -> dict[str, Any]:
+    """A raw CreateExecutionRequest body — no ``type``/``payload`` envelope."""
+
+    return {
+        "workflowType": "MoonMind.UserWorkflow",
+        "title": "MM-3788 raw branch launch",
+        "initialParameters": {
+            "targetRuntime": target_runtime,
+            "profileId": profile_id,
+            "workflow": {
+                "instructions": "Launch with an explicit provider profile.",
+                "runtime": {
+                    "mode": target_runtime,
+                    "providerProfileRef": profile_id,
+                },
+            },
+        },
+    }
+
+
+async def _mm3788_post_raw_execution(
+    *, service: TemporalExecutionService, session: AsyncSession, user, payload
+):
+    return await executions_module.create_execution(
+        payload=payload,
+        service=service,
+        session=session,
+        user=user,
+        _submit_enabled=None,
+        principal_context={},
+        authorization=None,
+        execution_fanout=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_rejects_profile_from_another_runtime(
+    tmp_path,
+) -> None:
+    async with _mm3788_raw_branch_context(
+        tmp_path, db_name="mm3788_raw_reject"
+    ) as (session, service, user):
+        with pytest.raises(HTTPException) as exc_info:
+            await _mm3788_post_raw_execution(
+                service=service,
+                session=session,
+                user=user,
+                payload=_mm3788_raw_execution_request(
+                    target_runtime="claude_code", profile_id="codex_minimax_team"
+                ),
+            )
+
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        # The 409 contract is identical to every other authoring boundary.
+        assert detail["code"] == "provider_profile_runtime_mismatch"
+        assert detail["profileId"] == "codex_minimax_team"
+        assert detail["profileRuntime"] == "codex_cli"
+        assert detail["selectedRuntime"] == "claude_code"
+        # Nothing launched and nothing persisted.
+        service._client_adapter.start_workflow.assert_not_awaited()
+        records = (
+            await session.execute(select(TemporalExecutionCanonicalRecord))
+        ).scalars().all()
+        assert records == []
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_accepts_profile_owned_by_the_runtime(
+    tmp_path,
+) -> None:
+    async with _mm3788_raw_branch_context(
+        tmp_path, db_name="mm3788_raw_accept"
+    ) as (session, service, user):
+        response = await _mm3788_post_raw_execution(
+            service=service,
+            session=session,
+            user=user,
+            payload=_mm3788_raw_execution_request(
+                target_runtime="codex_cli", profile_id="codex_minimax_team"
+            ),
+        )
+
+        assert response.workflow_id.startswith("mm:")
+        stored = await session.get(
+            TemporalExecutionCanonicalRecord, response.workflow_id
+        )
+        assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_mm3788_raw_create_branch_keeps_the_omnigent_product_boundary(
+    tmp_path,
+) -> None:
+    """Omnigent is a facade: the raw branch still owns its own 422, not a 409."""
+
+    async with _mm3788_raw_branch_context(
+        tmp_path, db_name="mm3788_raw_omnigent"
+    ) as (session, service, user):
+        with pytest.raises(HTTPException) as exc_info:
+            await _mm3788_post_raw_execution(
+                service=service,
+                session=session,
+                user=user,
+                payload=_mm3788_raw_execution_request(
+                    target_runtime="omnigent", profile_id="codex_minimax_team"
+                ),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail["code"] == "omnigent_product_boundary_required"
+        service._client_adapter.start_workflow.assert_not_awaited()

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -44,6 +44,7 @@ from api_service.api.routers.executions import (
     _workflow_input_snapshot_descriptor_from_record,
     _normalize_task_steps,
     _normalize_task_tool,
+    _resolve_recurring_runtime_metadata,
     _resolve_step_runtime_selections,
     _step_execution_detail_payload,
     _detect_optional_temporal_search_attributes,
@@ -17108,3 +17109,349 @@ def test_chat_binding_unknown_workflow_returns_404(monkeypatch) -> None:
         response = client.get("/api/executions/mm:wf-unknown/chat-binding")
 
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — Provider Profiles are runtime-owned launch
+# contracts, so every launch-authoring path must reject a runtime/profile pair
+# that the runtime-scoped selectors would never offer.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_provider_profile(
+    *, profile_id: str, runtime_id: str
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        profile_id=profile_id,
+        runtime_id=runtime_id,
+        provider_id="minimax",
+        default_model=None,
+        default_effort=None,
+        model_tiers=None,
+        default_model_tier=None,
+    )
+
+
+def _mm3788_client(profile: SimpleNamespace) -> Iterator[tuple[TestClient, AsyncMock]]:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    service.create_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: service
+
+    class _Session:
+        async def get(self, _model: object, profile_id: str) -> object | None:
+            return profile if profile.profile_id == profile_id else None
+
+        async def scalar(self, _stmt: object) -> object | None:
+            # No Omnigent Agent Profile authority is seeded, so the Omnigent
+            # selection service is the one that rejects an Omnigent submission.
+            return None
+
+    app.dependency_overrides[get_async_session] = lambda: _Session()
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+
+    with TestClient(app) as test_client:
+        yield test_client, service
+
+    app.dependency_overrides.clear()
+
+
+def _mm3788_task_request(*, target_runtime: str, profile_id: str) -> dict[str, Any]:
+    return {
+        "type": "workflow",
+        "payload": {
+            "targetRuntime": target_runtime,
+            "workflow": {
+                "title": "MM-3788 runtime scoped launch",
+                "instructions": "Launch with an explicit provider profile.",
+                "runtime": {
+                    "mode": target_runtime,
+                    "providerProfileRef": profile_id,
+                },
+            },
+        },
+    }
+
+
+def test_mm3788_create_execution_rejects_provider_profile_from_another_runtime() -> None:
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+
+    for test_client, service in _mm3788_client(profile):
+        response = test_client.post(
+            "/api/executions",
+            json=_mm3788_task_request(
+                target_runtime="claude_code", profile_id="codex_minimax_team"
+            ),
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_runtime_mismatch"
+    # The response must identify both sides of the incompatible pair.
+    assert detail["profileId"] == "codex_minimax_team"
+    assert detail["profileRuntime"] == "codex_cli"
+    assert detail["selectedRuntime"] == "claude_code"
+    assert "codex_minimax_team" in detail["message"]
+    assert "claude_code" in detail["message"]
+    # The check runs before the launch is created.
+    service.create_execution.assert_not_awaited()
+
+
+def test_mm3788_create_execution_accepts_provider_profile_owned_by_selected_runtime() -> None:
+    profile = _mm3788_provider_profile(
+        profile_id="claude_minimax_team", runtime_id="claude_code"
+    )
+
+    for test_client, service in _mm3788_client(profile):
+        response = test_client.post(
+            "/api/executions",
+            json=_mm3788_task_request(
+                target_runtime="claude_code", profile_id="claude_minimax_team"
+            ),
+        )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["targetRuntime"] == "claude_code"
+    assert initial_parameters["profileId"] == "claude_minimax_team"
+
+
+def test_mm3788_create_execution_rejects_legacy_runtime_alias_mismatch() -> None:
+    """Canonical runtime IDs decide the comparison, not the submitted spelling."""
+
+    profile = _mm3788_provider_profile(
+        profile_id="claude_minimax_team", runtime_id="claude_code"
+    )
+
+    for test_client, _service in _mm3788_client(profile):
+        response = test_client.post(
+            "/api/executions",
+            json=_mm3788_task_request(
+                target_runtime="codex", profile_id="claude_minimax_team"
+            ),
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["selectedRuntime"] == "codex_cli"
+    assert detail["profileRuntime"] == "claude_code"
+
+
+def test_mm3788_create_execution_leaves_omnigent_compatibility_to_the_selection_service() -> None:
+    """`omnigent` is a facade: the profile stays owned by the managed runtime.
+
+    Runtime ownership is therefore not compared here; Omnigent compatibility is
+    enforced against the selected execution target by
+    ``omnigent_agent_profile_selection``.
+    """
+
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+
+    for test_client, service in _mm3788_client(profile):
+        response = test_client.post(
+            "/api/executions",
+            json=_mm3788_task_request(
+                target_runtime="omnigent", profile_id="codex_minimax_team"
+            ),
+        )
+
+    # A `codex_cli` profile under `runtime_id != omnigent` is never a runtime
+    # mismatch: the submission proceeds into the Omnigent selection service,
+    # which owns compatibility against the selected execution target.
+    assert response.status_code == 409
+    assert response.json()["detail"] == "default Omnigent Agent Profile is unavailable"
+    service.create_execution.assert_not_awaited()
+
+
+def test_mm3788_runtime_ownership_check_skips_the_omnigent_facade() -> None:
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+
+    executions_module._require_provider_profile_runtime(
+        profile=profile,
+        profile_id=profile.profile_id,
+        selected_runtime="omnigent",
+    )
+
+
+def test_mm3788_runtime_ownership_check_skips_an_unspecified_runtime() -> None:
+    """With no effective runtime in the request there is nothing to compare."""
+
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+
+    executions_module._require_provider_profile_runtime(
+        profile=profile,
+        profile_id=profile.profile_id,
+        selected_runtime=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_recurring_runtime_metadata_rejects_cross_runtime_profile() -> None:
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+    session = SimpleNamespace(get=AsyncMock(return_value=profile))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_recurring_runtime_metadata(
+            {
+                "workflowType": "MoonMind.UserWorkflow",
+                "initialParameters": {
+                    "targetRuntime": "claude_code",
+                    "workflow": {
+                        "runtime": {
+                            "mode": "claude_code",
+                            "providerProfileRef": "codex_minimax_team",
+                        }
+                    },
+                },
+            },
+            session=session,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "provider_profile_runtime_mismatch"
+    assert exc_info.value.detail["profileRuntime"] == "codex_cli"
+    assert exc_info.value.detail["selectedRuntime"] == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_recurring_runtime_metadata_accepts_owned_profile() -> None:
+    profile = _mm3788_provider_profile(
+        profile_id="claude_minimax_team", runtime_id="claude_code"
+    )
+    session = SimpleNamespace(get=AsyncMock(return_value=profile))
+
+    metadata = await _resolve_recurring_runtime_metadata(
+        {
+            "workflowType": "MoonMind.UserWorkflow",
+            "initialParameters": {
+                "targetRuntime": "claude_code",
+                "workflow": {
+                    "runtime": {
+                        "mode": "claude_code",
+                        "providerProfileRef": "claude_minimax_team",
+                    }
+                },
+            },
+        },
+        session=session,
+    )
+
+    assert metadata["targetRuntime"] == "claude_code"
+    assert metadata["profileId"] == "claude_minimax_team"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_step_runtime_selection_rejects_cross_runtime_profile() -> None:
+    steps = _normalize_task_steps(
+        {
+            "steps": [
+                {
+                    "id": "review",
+                    "instructions": "Review with an incompatible profile.",
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "codex_minimax_team",
+                    },
+                }
+            ]
+        }
+    )
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+    session = SimpleNamespace(get=AsyncMock(return_value=profile))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_step_runtime_selections(
+            steps=steps,
+            task_runtime={"mode": "codex_cli"},
+            task_target_runtime="codex_cli",
+            task_profile_id=None,
+            session=session,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "provider_profile_runtime_mismatch"
+    assert exc_info.value.detail["profileId"] == "codex_minimax_team"
+    assert exc_info.value.detail["selectedRuntime"] == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_step_runtime_selection_rejects_inherited_cross_runtime_profile() -> None:
+    """A step that overrides the runtime cannot inherit another runtime's profile."""
+
+    steps = _normalize_task_steps(
+        {
+            "steps": [
+                {
+                    "id": "review",
+                    "instructions": "Inherit the task profile under a new runtime.",
+                    "runtime": {"mode": "claude_code"},
+                }
+            ]
+        }
+    )
+    profile = _mm3788_provider_profile(
+        profile_id="codex_minimax_team", runtime_id="codex_cli"
+    )
+    session = SimpleNamespace(get=AsyncMock(return_value=profile))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_step_runtime_selections(
+            steps=steps,
+            task_runtime={"mode": "codex_cli"},
+            task_target_runtime="codex_cli",
+            task_profile_id="codex_minimax_team",
+            session=session,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["profileId"] == "codex_minimax_team"
+    assert exc_info.value.detail["selectedRuntime"] == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_step_runtime_selection_accepts_owned_profile() -> None:
+    steps = _normalize_task_steps(
+        {
+            "steps": [
+                {
+                    "id": "review",
+                    "instructions": "Review with the runtime's own profile.",
+                    "runtime": {
+                        "mode": "claude_code",
+                        "profileId": "claude_minimax_team",
+                    },
+                }
+            ]
+        }
+    )
+    profile = _mm3788_provider_profile(
+        profile_id="claude_minimax_team", runtime_id="claude_code"
+    )
+    session = SimpleNamespace(get=AsyncMock(return_value=profile))
+
+    await _resolve_step_runtime_selections(
+        steps=steps,
+        task_runtime={"mode": "codex_cli"},
+        task_target_runtime="codex_cli",
+        task_profile_id=None,
+        session=session,
+    )
+
+    assert steps[0]["runtime"]["mode"] == "claude_code"
+    assert steps[0]["runtime"]["profileId"] == "claude_minimax_team"

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
 from api_service.api.routers import recurring_workflows as recurring_router
 from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    RecurringWorkflowDefinition,
     RecurringWorkflowRunOutcome,
     RecurringWorkflowRunTrigger,
     RecurringWorkflowScheduleType,
@@ -20,6 +28,7 @@ from api_service.db.models import (
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
     RecurringWorkflowConflictError,
+    RecurringWorkflowsService,
     RecurringWorkflowValidationError,
 )
 
@@ -423,3 +432,240 @@ async def test_list_recurring_workflow_runs_hydrates_actual_start_time() -> None
     assert response.items[0].temporal_workflow_id == "workflow-from-schedule"
     assert response.items[0].started_at == started_at
     service.started_at_by_workflow_id.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — the recurring-workflows routes are a launch
+# authoring boundary: the target they persist is what a later schedule action
+# launches, so a mismatched runtime/Provider Profile pair must be rejected here
+# with the same 409 contract the execution-submission path raises.
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _mm3788_session(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'recurring_routes.db'}", future=True
+    )
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with session_maker() as session:
+            session.add_all(
+                [
+                    ManagedAgentProviderProfile(
+                        profile_id="codex_minimax_team",
+                        runtime_id="codex_cli",
+                        provider_id="minimax",
+                    ),
+                    ManagedAgentProviderProfile(
+                        profile_id="claude_minimax_team",
+                        runtime_id="claude_code",
+                        provider_id="minimax",
+                    ),
+                ]
+            )
+            await session.flush()
+            yield session
+    finally:
+        await engine.dispose()
+
+
+def _mm3788_service(session) -> RecurringWorkflowsService:
+    adapter = MagicMock()
+    adapter.create_schedule = AsyncMock(return_value="mm-schedule:id")
+    adapter.update_schedule = AsyncMock()
+    adapter.pause_schedule = AsyncMock()
+    adapter.unpause_schedule = AsyncMock()
+    adapter.delete_schedule = AsyncMock()
+    adapter.resolve_workflow_task_queue = MagicMock(return_value="mm.workflow.user.v2")
+    return RecurringWorkflowsService(session, temporal_client_adapter=adapter)
+
+
+def _mm3788_route_target(*, target_runtime: str, profile_id: str) -> dict:
+    return {
+        "workflowType": "MoonMind.UserWorkflow",
+        "initialParameters": {
+            "targetRuntime": target_runtime,
+            "workflow": {
+                "instructions": "Run the nightly resolver.",
+                "runtime": {"mode": target_runtime, "providerProfileRef": profile_id},
+            },
+        },
+    }
+
+
+def _mm3788_create_payload(target: dict) -> recurring_router.CreateRecurringWorkflowRequest:
+    return recurring_router.CreateRecurringWorkflowRequest(
+        name="MM-3788 schedule",
+        cron="0 6 * * *",
+        timezone="UTC",
+        scopeType="personal",
+        target=target,
+        policy={},
+    )
+
+
+async def _mm3788_create_owned(service, user):
+    return await recurring_router.create_recurring_workflow(
+        payload=_mm3788_create_payload(
+            _mm3788_route_target(
+                target_runtime="claude_code", profile_id="claude_minimax_team"
+            )
+        ),
+        service=service,
+        user=user,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_route_rejects_a_cross_runtime_provider_profile(
+    tmp_path: Path,
+) -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    async with _mm3788_session(tmp_path) as session:
+        service = _mm3788_service(session)
+
+        with pytest.raises(HTTPException) as excinfo:
+            await recurring_router.create_recurring_workflow(
+                payload=_mm3788_create_payload(
+                    _mm3788_route_target(
+                        target_runtime="claude_code",
+                        profile_id="codex_minimax_team",
+                    )
+                ),
+                service=service,
+                user=user,
+            )
+
+        assert excinfo.value.status_code == status.HTTP_409_CONFLICT
+        detail = excinfo.value.detail
+        assert detail["code"] == "provider_profile_runtime_mismatch"
+        assert detail["profileId"] == "codex_minimax_team"
+        assert detail["profileRuntime"] == "codex_cli"
+        assert detail["selectedRuntime"] == "claude_code"
+        assert "codex_minimax_team" in detail["message"]
+        assert "claude_code" in detail["message"]
+        # Nothing was persisted by the rejected request.
+        await session.rollback()
+        stored = (
+            await session.execute(select(RecurringWorkflowDefinition))
+        ).scalars().all()
+        assert stored == []
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_route_accepts_a_profile_owned_by_the_target_runtime(
+    tmp_path: Path,
+) -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    async with _mm3788_session(tmp_path) as session:
+        created = await _mm3788_create_owned(_mm3788_service(session), user)
+
+        assert created.target["initialParameters"]["workflow"]["runtime"][
+            "providerProfileRef"
+        ] == "claude_minimax_team"
+        stored = (
+            await session.execute(select(RecurringWorkflowDefinition))
+        ).scalars().all()
+        assert [item.id for item in stored] == [created.id]
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_route_defers_omnigent_compatibility_to_selection(
+    tmp_path: Path,
+) -> None:
+    """An Omnigent target is not a runtime mismatch; selection owns that check."""
+
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    async with _mm3788_session(tmp_path) as session:
+        created = await recurring_router.create_recurring_workflow(
+            payload=_mm3788_create_payload(
+                _mm3788_route_target(
+                    target_runtime="omnigent", profile_id="codex_minimax_team"
+                )
+            ),
+            service=_mm3788_service(session),
+            user=user,
+        )
+
+        assert created.target["initialParameters"]["targetRuntime"] == "omnigent"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_update_route_rejects_a_cross_runtime_provider_profile(
+    tmp_path: Path,
+) -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    async with _mm3788_session(tmp_path) as session:
+        created = await _mm3788_create_owned(_mm3788_service(session), user)
+        definition_id = created.id
+        stored_target = dict(created.target)
+
+        with pytest.raises(HTTPException) as excinfo:
+            await recurring_router.update_recurring_workflow(
+                definition_id=definition_id,
+                payload=recurring_router.UpdateRecurringWorkflowRequest(
+                    name="Renamed by a rejected edit",
+                    target=_mm3788_route_target(
+                        target_runtime="claude_code",
+                        profile_id="codex_minimax_team",
+                    ),
+                    version=created.version,
+                ),
+                service=_mm3788_service(session),
+                user=user,
+            )
+
+        assert excinfo.value.status_code == status.HTTP_409_CONFLICT
+        assert excinfo.value.detail == {
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                "Provider Profile 'codex_minimax_team' belongs to runtime "
+                "'codex_cli' and cannot be used with runtime 'claude_code'."
+            ),
+            "profileId": "codex_minimax_team",
+            "profileRuntime": "codex_cli",
+            "selectedRuntime": "claude_code",
+        }
+        # The stored target survived the rejected edit unchanged.
+        await session.rollback()
+        reloaded = await session.get(
+            RecurringWorkflowDefinition, definition_id, populate_existing=True
+        )
+        assert reloaded.target == stored_target
+        assert reloaded.name == "MM-3788 schedule"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_update_route_accepts_a_profile_owned_by_the_target_runtime(
+    tmp_path: Path,
+) -> None:
+    user = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    async with _mm3788_session(tmp_path) as session:
+        created = await _mm3788_create_owned(_mm3788_service(session), user)
+
+        updated = await recurring_router.update_recurring_workflow(
+            definition_id=created.id,
+            payload=recurring_router.UpdateRecurringWorkflowRequest(
+                name="Renamed by an accepted edit",
+                target=_mm3788_route_target(
+                    target_runtime="claude_code",
+                    profile_id="claude_minimax_team",
+                ),
+                version=created.version,
+            ),
+            service=_mm3788_service(session),
+            user=user,
+        )
+
+        assert updated.name == "Renamed by an accepted edit"
+        assert updated.target["initialParameters"]["workflow"]["runtime"][
+            "providerProfileRef"
+        ] == "claude_minimax_team"

--- a/tests/unit/api/routers/test_workflow_proposals.py
+++ b/tests/unit/api/routers/test_workflow_proposals.py
@@ -16,6 +16,9 @@ from api_service.api.routers.workflow_proposals import (
     router,
 )
 from api_service.auth_providers import get_current_user, get_current_user_optional
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+)
 from moonmind.workflows.proposals.delivery import github_marker_for_proposal
 from moonmind.workflows.proposals.models import (
     WorkflowProposalOriginSource,
@@ -1089,3 +1092,81 @@ def test_sync_proposal_delivery_endpoint_returns_validation_errors(
 
     assert response.status_code == 400
     assert response.json()["detail"]["code"] == "invalid_request"
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — the promote routes surface the shared
+# runtime-ownership rejection as the same 409 contract every other
+# launch-authoring boundary returns, and no execution is created behind it.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_mismatch() -> ProviderProfileRuntimeMismatchError:
+    return ProviderProfileRuntimeMismatchError(
+        profile_id="codex_minimax_team",
+        profile_runtime="codex_cli",
+        selected_runtime="claude_code",
+    )
+
+
+def test_mm3788_promote_maps_provider_profile_runtime_mismatch_to_409(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, execution_service = client
+    proposal = _build_proposal()
+    service.promote_proposal.side_effect = _mm3788_mismatch()
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/promote",
+        json={"runtimeMode": "claude_code"},
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_runtime_mismatch"
+    assert detail["profileId"] == "codex_minimax_team"
+    assert detail["profileRuntime"] == "codex_cli"
+    assert detail["selectedRuntime"] == "claude_code"
+    # The rejection happens before any execution is created.
+    execution_service.create_execution.assert_not_awaited()
+
+
+def test_mm3788_provider_decision_maps_runtime_mismatch_to_409(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, execution_service = client
+    proposal = _build_proposal()
+    proposal.provider = "jira"
+    proposal.external_key = "MM-3788"
+    service.record_provider_decision_event.return_value = SimpleNamespace(
+        accepted=True,
+        decision="promote",
+        reason=None,
+        actor="reviewer",
+        provider_event_id="evt-mm3788",
+        note=None,
+        priority=None,
+        defer_until=None,
+        runtime_mode="claude",
+        external_state=None,
+        promoted_execution_id=None,
+    )
+    service.promote_proposal.side_effect = _mm3788_mismatch()
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/provider-decision",
+        json={
+            "provider": "jira",
+            "externalKey": "MM-3788",
+            "providerEventId": "evt-mm3788",
+            "actor": "reviewer",
+            "body": "/moonmind promote --runtime claude",
+            "authenticity": {"verified": True, "method": "signature"},
+        },
+    )
+
+    assert response.status_code == 409
+    assert (
+        response.json()["detail"]["code"] == "provider_profile_runtime_mismatch"
+    )
+    execution_service.create_execution.assert_not_awaited()

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -3137,3 +3137,174 @@ async def test_oauth_lifecycle_rejects_non_first_party_profile(
     assert validate_response.json()["detail"] == expected_detail
     assert disconnect_response.status_code == 422
     assert disconnect_response.json()["detail"] == expected_detail
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — runtime-scoped listing is what execution
+# surfaces rely on to never offer a profile owned by another runtime.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_profile_payload(
+    *,
+    profile_id: str,
+    runtime_id: str,
+    enabled: bool = True,
+) -> dict[str, Any]:
+    return {
+        "profile_id": profile_id,
+        "runtime_id": runtime_id,
+        "provider_id": "minimax",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        # The same managed secret may back one profile per runtime.
+        "secret_refs": {"MINIMAX_API_KEY": "env://mm3788_minimax_secret"},
+        "enabled": enabled,
+        "auth_state": "connected" if enabled else "not_configured",
+        "disabled_reason": None if enabled else "missing_credentials",
+        "last_auth_method": "secret_ref",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mm3788_runtime_filter_excludes_other_runtime_profiles(
+    client_app: AsyncClient, _module_db
+) -> None:
+    _override_current_user(is_superuser=True)
+
+    async with client_app as client:
+        codex_response = await client.post(
+            "/api/v1/provider-profiles",
+            json=_mm3788_profile_payload(
+                profile_id="mm3788_codex_minimax", runtime_id="codex_cli"
+            ),
+        )
+        claude_response = await client.post(
+            "/api/v1/provider-profiles",
+            json=_mm3788_profile_payload(
+                profile_id="mm3788_claude_minimax", runtime_id="claude_code"
+            ),
+        )
+        codex_listed = await client.get(
+            "/api/v1/provider-profiles", params={"runtime_id": "codex_cli"}
+        )
+        claude_listed = await client.get(
+            "/api/v1/provider-profiles", params={"runtime_id": "claude_code"}
+        )
+        unfiltered = await client.get("/api/v1/provider-profiles")
+
+    assert codex_response.status_code == 201
+    assert claude_response.status_code == 201
+
+    assert codex_listed.status_code == 200
+    codex_rows = codex_listed.json()
+    assert {row["runtime_id"] for row in codex_rows} == {"codex_cli"}
+    codex_ids = {row["profile_id"] for row in codex_rows}
+    assert "mm3788_codex_minimax" in codex_ids
+    assert "mm3788_claude_minimax" not in codex_ids
+
+    assert claude_listed.status_code == 200
+    claude_rows = claude_listed.json()
+    assert {row["runtime_id"] for row in claude_rows} == {"claude_code"}
+    claude_ids = {row["profile_id"] for row in claude_rows}
+    assert "mm3788_claude_minimax" in claude_ids
+    assert "mm3788_codex_minimax" not in claude_ids
+
+    # Settings keeps the complete administrative view.
+    unfiltered_ids = {row["profile_id"] for row in unfiltered.json()}
+    assert {"mm3788_codex_minimax", "mm3788_claude_minimax"} <= unfiltered_ids
+
+
+@pytest.mark.asyncio
+async def test_mm3788_runtime_filter_composes_with_enabled_only(
+    client_app: AsyncClient, _module_db
+) -> None:
+    _override_current_user(is_superuser=True)
+
+    async with client_app as client:
+        enabled_response = await client.post(
+            "/api/v1/provider-profiles",
+            json=_mm3788_profile_payload(
+                profile_id="mm3788_compose_enabled",
+                runtime_id="mm3788_compose_runtime",
+            ),
+        )
+        disabled_response = await client.post(
+            "/api/v1/provider-profiles",
+            json=_mm3788_profile_payload(
+                profile_id="mm3788_compose_disabled",
+                runtime_id="mm3788_compose_runtime",
+                enabled=False,
+            ),
+        )
+        other_runtime_response = await client.post(
+            "/api/v1/provider-profiles",
+            json=_mm3788_profile_payload(
+                profile_id="mm3788_compose_other_runtime",
+                runtime_id="mm3788_compose_other",
+            ),
+        )
+        filtered = await client.get(
+            "/api/v1/provider-profiles",
+            params={"runtime_id": "mm3788_compose_runtime", "enabled_only": "true"},
+        )
+        runtime_only = await client.get(
+            "/api/v1/provider-profiles",
+            params={"runtime_id": "mm3788_compose_runtime"},
+        )
+
+    assert enabled_response.status_code == 201
+    assert disabled_response.status_code == 201
+    assert other_runtime_response.status_code == 201
+
+    assert filtered.status_code == 200
+    assert [row["profile_id"] for row in filtered.json()] == [
+        "mm3788_compose_enabled"
+    ]
+
+    assert runtime_only.status_code == 200
+    assert {row["profile_id"] for row in runtime_only.json()} == {
+        "mm3788_compose_enabled",
+        "mm3788_compose_disabled",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mm3788_runtime_filter_still_applies_profile_visibility(
+    client_app: AsyncClient, _module_db
+) -> None:
+    owner = _override_current_user()
+    other_owner_id = uuid4()
+
+    async with db_base.async_session_maker() as session:
+        for profile_id, owner_user_id in (
+            ("mm3788_visible_owned", owner.id),
+            ("mm3788_hidden_other_owner", other_owner_id),
+        ):
+            if await session.get(ManagedAgentProviderProfile, profile_id) is None:
+                session.add(
+                    ManagedAgentProviderProfile(
+                        profile_id=profile_id,
+                        runtime_id="mm3788_visibility_runtime",
+                        provider_id="minimax",
+                        credential_source=ProviderCredentialSource.NONE,
+                        runtime_materialization_mode=(
+                            RuntimeMaterializationMode.COMPOSITE
+                        ),
+                        owner_user_id=owner_user_id,
+                        enabled=True,
+                    )
+                )
+        await session.commit()
+
+    async with client_app as client:
+        listed = await client.get(
+            "/api/v1/provider-profiles",
+            params={"runtime_id": "mm3788_visibility_runtime"},
+        )
+
+    assert listed.status_code == 200
+    listed_ids = {row["profile_id"] for row in listed.json()}
+    assert "mm3788_visible_owned" in listed_ids
+    # Runtime scoping narrows the result set; it never widens visibility.
+    assert "mm3788_hidden_other_owner" not in listed_ids

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -826,9 +826,12 @@ _MM3788_V2_DOCUMENT = {
 class _GenericV2Session(_Session):
     """Session exposing a generic (v2) Agent Profile version."""
 
-    def __init__(self, *, provider_runtime_id: str) -> None:
+    def __init__(
+        self, *, provider_runtime_id: str, harness_id: str = "codex-native"
+    ) -> None:
         super().__init__()
         self.version.document = copy.deepcopy(_MM3788_V2_DOCUMENT)
+        self.version.document["harness"]["id"] = harness_id
         self.provider = SimpleNamespace(
             profile_id="mm3788-openai-profile",
             enabled=True,
@@ -892,3 +895,31 @@ async def test_mm3788_generic_v2_selection_accepts_a_compatible_runtime_profile(
 
     assert snapshot["providerProfileRef"] == "mm3788-openai-profile"
     assert isinstance(session.added[0], OmnigentAgentProfileUsage)
+
+
+@pytest.mark.asyncio
+async def test_mm3788_generic_v2_selection_rejects_a_harness_the_materializer_refuses() -> None:
+    """A registered materializer is not proof of harness compatibility.
+
+    ``codex-oauth-home@1`` exists for ``codex_cli/openai``, so a lookup that only
+    proves registration accepts this pair. The readiness projection excludes it:
+    the materializer does not accept the ``pi-native`` harness, so the UI never
+    offers the profile for this execution target.
+    """
+
+    session = _GenericV2Session(
+        provider_runtime_id="codex_cli", harness_id="pi-native"
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await resolve_agent_profile_snapshot(
+            session,
+            selection=_mm3788_v2_selection(),
+            consumer_type="workflow",
+            consumer_id="mm3788-workflow-harness-reject",
+            user=SimpleNamespace(id=uuid4(), is_superuser=True),
+        )
+
+    assert caught.value.status_code == 409
+    assert "mm3788-openai-profile" in caught.value.detail
+    assert session.added == []

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -1,5 +1,6 @@
 """Authoring-boundary tests for immutable Omnigent profile snapshots."""
 
+import copy
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -787,3 +788,107 @@ async def test_exact_rerun_preserves_operator_owned_profile_snapshot():
         )
         == parameters
     )
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — a Provider Profile launched through Omnigent
+# stays owned by its managed runtime. The generic v2 selection path must reject
+# a profile whose runtime the harness cannot materialize instead of trusting
+# `enabled` and `acceptedProviderIds` alone.
+# ---------------------------------------------------------------------------
+
+_MM3788_V2_DOCUMENT = {
+    "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+    "endpointRef": "default",
+    # A bundle source keeps this fixture focused on runtime compatibility
+    # instead of upstream projection freshness.
+    "source": {
+        "kind": "bundle",
+        "bundleArtifactRef": "artifact://mm3788-bundle",
+        "bundleDigest": "sha256:" + "c" * 64,
+        "importReceiptRef": "omnigent-agent-import:sha256:" + "a" * 64,
+        "importedAgentId": "mm3788-generic-agent",
+        "importedAgentVersion": "1",
+        "importedContentDigest": "sha256:" + "f" * 64,
+    },
+    "harness": {
+        "id": "codex-native",
+        "catalogRef": "omnigent-harness-catalog:sha256:" + "d" * 64,
+        "implementationRef": "omnigent-harness-implementation:sha256:" + "e" * 64,
+    },
+    "credentialSlots": [
+        {"id": "primary-model", "acceptedProviderIds": ["openai"]},
+    ],
+    "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
+}
+
+
+class _GenericV2Session(_Session):
+    """Session exposing a generic (v2) Agent Profile version."""
+
+    def __init__(self, *, provider_runtime_id: str) -> None:
+        super().__init__()
+        self.version.document = copy.deepcopy(_MM3788_V2_DOCUMENT)
+        self.provider = SimpleNamespace(
+            profile_id="mm3788-openai-profile",
+            enabled=True,
+            auth_state=ProviderProfileAuthState.CONNECTED,
+            disabled_reason=None,
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=900,
+            # The runtime under test: it decides credential materialization even
+            # when the launch happens through Omnigent.
+            runtime_id=provider_runtime_id,
+            credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+            runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+            provider_id="openai",
+            volume_ref="codex-oauth",
+            volume_mount_path="/root/.codex",
+            secret_refs={},
+            credential_bindings=[],
+            command_behavior={"auth_readiness": {"launch_ready": True}},
+        )
+
+
+def _mm3788_v2_selection() -> dict:
+    return {
+        "profileId": "team-codex",
+        "version": 2,
+        "providerProfileRef": "mm3788-openai-profile",
+    }
+
+
+@pytest.mark.asyncio
+async def test_mm3788_generic_v2_selection_rejects_profile_from_an_incompatible_runtime() -> None:
+    session = _GenericV2Session(provider_runtime_id="claude_code")
+
+    with pytest.raises(HTTPException) as caught:
+        await resolve_agent_profile_snapshot(
+            session,
+            selection=_mm3788_v2_selection(),
+            consumer_type="workflow",
+            consumer_id="mm3788-workflow-reject",
+            user=SimpleNamespace(id=uuid4(), is_superuser=True),
+        )
+
+    assert caught.value.status_code == 409
+    assert "mm3788-openai-profile" in caught.value.detail
+    assert "claude_code" in caught.value.detail
+    # Nothing is persisted when the pair is rejected.
+    assert session.added == []
+
+
+@pytest.mark.asyncio
+async def test_mm3788_generic_v2_selection_accepts_a_compatible_runtime_profile() -> None:
+    session = _GenericV2Session(provider_runtime_id="codex_cli")
+
+    snapshot = await resolve_agent_profile_snapshot(
+        session,
+        selection=_mm3788_v2_selection(),
+        consumer_type="workflow",
+        consumer_id="mm3788-workflow-accept",
+        user=SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+
+    assert snapshot["providerProfileRef"] == "mm3788-openai-profile"
+    assert isinstance(session.added[0], OmnigentAgentProfileUsage)

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -24,6 +24,9 @@ from api_service.db.models import (
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
 )
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+)
 from api_service.services.recurring_workflows_service import (
     RecurringScheduleRuntimeSummary,
     RecurringWorkflowConflictError,
@@ -1342,3 +1345,292 @@ async def test_runtime_summaries_for_definitions_describes_concurrently(
             service.runtime_summary_for_definition.assert_has_awaits(
                 [call(first), call(second)]
             )
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — a recurring schedule persists the target
+# whose initialParameters a later schedule action launches, so the
+# runtime-owned Provider Profile invariant is enforced before that target is
+# stored, not only on the direct execution-submission path.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_target(
+    *,
+    target_runtime: str,
+    profile_id: str,
+    profile_key: str = "providerProfileRef",
+    in_runtime_block: bool = True,
+) -> dict[str, object]:
+    runtime_block: dict[str, object] = {"mode": target_runtime}
+    initial_parameters: dict[str, object] = {
+        "targetRuntime": target_runtime,
+        "workflow": {
+            "instructions": "Run the nightly resolver.",
+            "runtime": runtime_block,
+        },
+    }
+    if in_runtime_block:
+        runtime_block[profile_key] = profile_id
+    else:
+        initial_parameters[profile_key] = profile_id
+    return {
+        "workflowType": "MoonMind.UserWorkflow",
+        "initialParameters": initial_parameters,
+    }
+
+
+async def _mm3788_create(
+    service: RecurringWorkflowsService,
+    *,
+    target: dict[str, object],
+    owner_user_id,
+    name: str = "MM-3788 schedule",
+) -> RecurringWorkflowDefinition:
+    return await service.create_definition(
+        name=name,
+        description=None,
+        enabled=True,
+        schedule_type="cron",
+        cron="0 6 * * *",
+        timezone="UTC",
+        scope_type="personal",
+        scope_ref=None,
+        owner_user_id=owner_user_id,
+        target=target,
+        policy=None,
+    )
+
+
+async def test_mm3788_create_definition_rejects_provider_profile_from_another_runtime(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="codex_minimax_team",
+                runtime_id="codex_cli",
+                provider_id="minimax",
+            )
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await _mm3788_create(
+                service,
+                target=_mm3788_target(
+                    target_runtime="claude_code", profile_id="codex_minimax_team"
+                ),
+                owner_user_id=uuid4(),
+            )
+
+        assert excinfo.value.detail == {
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                "Provider Profile 'codex_minimax_team' belongs to runtime "
+                "'codex_cli' and cannot be used with runtime 'claude_code'."
+            ),
+            "profileId": "codex_minimax_team",
+            "profileRuntime": "codex_cli",
+            "selectedRuntime": "claude_code",
+        }
+        # Nothing was persisted and no Temporal schedule was created.
+        mock_temporal_adapter.create_schedule.assert_not_awaited()
+        stored = (
+            await session.execute(select(RecurringWorkflowDefinition))
+        ).scalars().all()
+        assert stored == []
+
+
+async def test_mm3788_create_definition_accepts_provider_profile_owned_by_the_runtime(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="claude_minimax_team",
+                runtime_id="claude_code",
+                provider_id="minimax",
+            )
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+
+        definition = await _mm3788_create(
+            service,
+            target=_mm3788_target(
+                target_runtime="claude_code", profile_id="claude_minimax_team"
+            ),
+            owner_user_id=uuid4(),
+        )
+
+        runtime_block = definition.target["initialParameters"]["workflow"]["runtime"]
+        assert runtime_block["providerProfileRef"] == "claude_minimax_team"
+        mock_temporal_adapter.create_schedule.assert_awaited_once()
+
+
+async def test_mm3788_create_definition_rejects_a_legacy_runtime_alias_mismatch(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    """Canonical runtime IDs decide the comparison, not the authored spelling."""
+
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="claude_minimax_team",
+                runtime_id="claude_code",
+                provider_id="minimax",
+            )
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await _mm3788_create(
+                service,
+                # ``profileId`` on initialParameters is the alias the raw target
+                # JSON editor produces; ``codex`` normalizes to ``codex_cli``.
+                target=_mm3788_target(
+                    target_runtime="codex",
+                    profile_id="claude_minimax_team",
+                    profile_key="profileId",
+                    in_runtime_block=False,
+                ),
+                owner_user_id=uuid4(),
+            )
+
+        assert excinfo.value.selected_runtime == "codex_cli"
+        assert excinfo.value.profile_runtime == "claude_code"
+        mock_temporal_adapter.create_schedule.assert_not_awaited()
+
+
+async def test_mm3788_create_definition_leaves_omnigent_compatibility_to_selection(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    """``omnigent`` is a facade: the profile stays owned by a managed runtime."""
+
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="codex_minimax_team",
+                runtime_id="codex_cli",
+                provider_id="minimax",
+            )
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+
+        definition = await _mm3788_create(
+            service,
+            target=_mm3788_target(
+                target_runtime="omnigent", profile_id="codex_minimax_team"
+            ),
+            owner_user_id=uuid4(),
+        )
+
+        assert definition.target["initialParameters"]["targetRuntime"] == "omnigent"
+        mock_temporal_adapter.create_schedule.assert_awaited_once()
+
+
+async def test_mm3788_update_definition_rejects_a_cross_runtime_target(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add_all(
+            [
+                ManagedAgentProviderProfile(
+                    profile_id="codex_minimax_team",
+                    runtime_id="codex_cli",
+                    provider_id="minimax",
+                ),
+                ManagedAgentProviderProfile(
+                    profile_id="claude_minimax_team",
+                    runtime_id="claude_code",
+                    provider_id="minimax",
+                ),
+            ]
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+        owned_target = _mm3788_target(
+            target_runtime="claude_code", profile_id="claude_minimax_team"
+        )
+        definition = await _mm3788_create(
+            service, target=owned_target, owner_user_id=uuid4()
+        )
+        definition_id = definition.id
+        stored_target = dict(definition.target)
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await service.update_definition(
+                definition,
+                name="Renamed by a rejected edit",
+                target=_mm3788_target(
+                    target_runtime="claude_code", profile_id="codex_minimax_team"
+                ),
+                expected_version=definition.version,
+            )
+
+        assert excinfo.value.detail["profileId"] == "codex_minimax_team"
+        assert excinfo.value.detail["profileRuntime"] == "codex_cli"
+        assert excinfo.value.detail["selectedRuntime"] == "claude_code"
+        mock_temporal_adapter.update_schedule.assert_not_awaited()
+        # The rejected edit left the stored definition untouched.
+        await session.rollback()
+        reloaded = await session.get(
+            RecurringWorkflowDefinition,
+            definition_id,
+            populate_existing=True,
+        )
+        assert reloaded.target == stored_target
+        assert reloaded.name == "MM-3788 schedule"
+
+
+async def test_mm3788_update_definition_accepts_a_target_owned_by_its_runtime(
+    tmp_path: Path, mock_temporal_adapter
+) -> None:
+    async with recurring_db(tmp_path) as session_maker, session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id="claude_minimax_team",
+                runtime_id="claude_code",
+                provider_id="minimax",
+            )
+        )
+        await session.flush()
+        service = RecurringWorkflowsService(
+            session, temporal_client_adapter=mock_temporal_adapter
+        )
+        definition = await _mm3788_create(
+            service,
+            target=_mm3788_target(
+                target_runtime="claude_code", profile_id="claude_minimax_team"
+            ),
+            owner_user_id=uuid4(),
+        )
+
+        updated = await service.update_definition(
+            definition,
+            target=_mm3788_target(
+                target_runtime="claude_code",
+                profile_id="claude_minimax_team",
+                profile_key="profileId",
+                in_runtime_block=False,
+            ),
+            expected_version=definition.version,
+        )
+
+        parameters = updated.target["initialParameters"]
+        assert parameters["profileId"] == "claude_minimax_team"
+        mock_temporal_adapter.update_schedule.assert_awaited_once()

--- a/tests/unit/workflows/proposals/test_service.py
+++ b/tests/unit/workflows/proposals/test_service.py
@@ -1,4 +1,5 @@
 import hashlib
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -6,14 +7,22 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
+from api_service.db.models import Base, ManagedAgentProviderProfile
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
+)
 from moonmind.config.settings import settings
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.proposals.models import (
+    WorkflowProposal,
     WorkflowProposalOriginSource,
     WorkflowProposalReviewPriority,
     WorkflowProposalStatus,
 )
+from moonmind.workflows.proposals.repositories import WorkflowProposalRepository
 from moonmind.workflows.proposals.service import (
     WorkflowProposalService,
     WorkflowProposalStatusError,
@@ -2428,3 +2437,163 @@ async def test_record_provider_decision_event_does_not_push_rejected_event_to_pr
     assert result.reason == "action_not_allowed"
     # Rejected/unverified decisions are never pushed to the provider issue.
     assert delivery.calls == []
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — a promotion durably marks the proposal
+# PROMOTED before the execution is created, and the runtimeMode override rewrites
+# the target runtime while leaving the authored Provider Profile ref untouched.
+# The shared runtime-ownership invariant therefore runs on the final payload
+# before that state transition, against real persistence.
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _mm3788_proposals_db(tmp_path: Path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/mm3788_proposals.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with session_factory() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+def _mm3788_proposal_row(*, target_runtime: str, profile_id: str) -> WorkflowProposal:
+    return WorkflowProposal(
+        id=uuid4(),
+        status=WorkflowProposalStatus.OPEN,
+        title="MM-3788 runtime scoped promotion",
+        summary="Promote with an explicit provider profile.",
+        category="tests",
+        tags=[],
+        repository="Moon/Repo",
+        dedup_key="moon/repo:mm3788",
+        dedup_hash="mm3788",
+        review_priority=WorkflowProposalReviewPriority.NORMAL,
+        origin_source=WorkflowProposalOriginSource.QUEUE,
+        origin_metadata={},
+        provider_metadata={},
+        resolved_policy={},
+        workflow_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "targetRuntime": target_runtime,
+                "workflow": {
+                    "instructions": "Refactor logic",
+                    "runtime": {
+                        "mode": target_runtime,
+                        "providerProfileRef": profile_id,
+                    },
+                },
+            }
+        },
+    )
+
+
+async def _mm3788_promotion_service(
+    session: AsyncSession, *, proposal: WorkflowProposal
+) -> WorkflowProposalService:
+    session.add(
+        ManagedAgentProviderProfile(
+            profile_id="codex_minimax_team",
+            runtime_id="codex_cli",
+            provider_id="minimax",
+        )
+    )
+    session.add(proposal)
+    await session.commit()
+    return WorkflowProposalService(
+        WorkflowProposalRepository(session), redactor=SecretRedactor([], "***")
+    )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_promote_rejects_runtime_override_incompatible_with_the_profile(
+    tmp_path: Path,
+) -> None:
+    async with _mm3788_proposals_db(tmp_path) as session:
+        proposal = _mm3788_proposal_row(
+            target_runtime="codex_cli", profile_id="codex_minimax_team"
+        )
+        service = await _mm3788_promotion_service(session, proposal=proposal)
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await service.promote_proposal(
+                proposal_id=proposal.id,
+                promoted_by_user_id=uuid4(),
+                runtime_mode_override="claude_code",
+            )
+
+        assert excinfo.value.detail == {
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                "Provider Profile 'codex_minimax_team' belongs to runtime "
+                "'codex_cli' and cannot be used with runtime 'claude_code'."
+            ),
+            "profileId": "codex_minimax_team",
+            "profileRuntime": "codex_cli",
+            "selectedRuntime": "claude_code",
+        }
+
+        # The proposal is still promotable: the rejected override must not leave
+        # it in a terminal state with no execution behind it.
+        stored = await session.get(WorkflowProposal, proposal.id)
+        assert stored is not None
+        assert stored.status is WorkflowProposalStatus.OPEN
+        assert stored.promoted_at is None
+        assert stored.promoted_by_user_id is None
+        events = stored.provider_metadata.get("observabilityEvents") or []
+        assert events[-1]["reason"] == "provider_profile_runtime_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_mm3788_promote_accepts_runtime_override_that_owns_the_profile(
+    tmp_path: Path,
+) -> None:
+    async with _mm3788_proposals_db(tmp_path) as session:
+        proposal = _mm3788_proposal_row(
+            target_runtime="claude_code", profile_id="codex_minimax_team"
+        )
+        service = await _mm3788_promotion_service(session, proposal=proposal)
+
+        updated, final_request = await service.promote_proposal(
+            proposal_id=proposal.id,
+            promoted_by_user_id=uuid4(),
+            runtime_mode_override="codex_cli",
+        )
+
+        assert updated.status is WorkflowProposalStatus.PROMOTED
+        payload = final_request["payload"]
+        assert payload["targetRuntime"] == "codex"
+        assert payload["workflow"]["runtime"]["mode"] == "codex"
+        assert (
+            payload["workflow"]["runtime"]["providerProfileRef"]
+            == "codex_minimax_team"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mm3788_promote_rejects_stored_pair_without_a_runtime_override(
+    tmp_path: Path,
+) -> None:
+    """An authored mismatch is rejected even with no promotion-time override."""
+
+    async with _mm3788_proposals_db(tmp_path) as session:
+        proposal = _mm3788_proposal_row(
+            target_runtime="claude_code", profile_id="codex_minimax_team"
+        )
+        service = await _mm3788_promotion_service(session, proposal=proposal)
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError):
+            await service.promote_proposal(
+                proposal_id=proposal.id,
+                promoted_by_user_id=uuid4(),
+            )
+
+        stored = await session.get(WorkflowProposal, proposal.id)
+        assert stored is not None
+        assert stored.status is WorkflowProposalStatus.OPEN

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -19,6 +19,7 @@ from temporalio.client import WorkflowExecutionDescription, WorkflowExecutionSta
 
 from api_service.db.models import (
     Base,
+    ManagedAgentProviderProfile,
     MoonMindWorkflowState,
     SettingsOverride,
     TemporalArtifact,
@@ -42,6 +43,9 @@ from api_service.db.models import (
 from api_service.services.checkpoint_branch_service import (
     CheckpointBranchService,
     build_branch_turn_launch_idempotency_key,
+)
+from api_service.services.provider_profile_runtime import (
+    ProviderProfileRuntimeMismatchError,
 )
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.service import (
@@ -8155,3 +8159,227 @@ async def test_failed_poll_marks_integration_error_summary(tmp_path):
 
         assert failed.memo["error_category"] == "integration_error"
         assert failed.awaiting_external is False
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3788 — every launch-authoring caller converges on
+# TemporalExecutionService.create_execution, so the runtime-ownership invariant
+# for Provider Profiles is enforced once at that shared authority handoff rather
+# than once per router.
+# ---------------------------------------------------------------------------
+
+
+def _mm3788_initial_parameters(
+    *, target_runtime: str, profile_id: str
+) -> dict[str, object]:
+    return {
+        "targetRuntime": target_runtime,
+        "workflow": {
+            "title": "MM-3788 runtime scoped launch",
+            "instructions": "Launch with an explicit provider profile.",
+            "runtime": {
+                "mode": target_runtime,
+                "providerProfileRef": profile_id,
+            },
+        },
+    }
+
+
+async def _mm3788_seed_profile(
+    session: AsyncSession, *, profile_id: str, runtime_id: str
+) -> None:
+    session.add(
+        ManagedAgentProviderProfile(
+            profile_id=profile_id,
+            runtime_id=runtime_id,
+            provider_id="minimax",
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_execution_rejects_provider_profile_from_another_runtime(
+    tmp_path,
+):
+    async with temporal_db(tmp_path) as session:
+        await _mm3788_seed_profile(
+            session, profile_id="codex_minimax_team", runtime_id="codex_cli"
+        )
+        service = TemporalExecutionService(session)
+        service._client_adapter.start_workflow = AsyncMock(
+            return_value=SimpleNamespace(run_id="run-mm3788")
+        )
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=uuid4(),
+                title="MM-3788 mismatched pair",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters=_mm3788_initial_parameters(
+                    target_runtime="claude_code", profile_id="codex_minimax_team"
+                ),
+                idempotency_key="mm3788-mismatch",
+            )
+
+        assert excinfo.value.detail == {
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                "Provider Profile 'codex_minimax_team' belongs to runtime "
+                "'codex_cli' and cannot be used with runtime 'claude_code'."
+            ),
+            "profileId": "codex_minimax_team",
+            "profileRuntime": "codex_cli",
+            "selectedRuntime": "claude_code",
+        }
+        # The mismatched pair never reaches Temporal or the execution store.
+        service._client_adapter.start_workflow.assert_not_awaited()
+        records = (
+            await session.execute(select(TemporalExecutionCanonicalRecord))
+        ).scalars().all()
+        assert records == []
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_execution_rejects_profile_id_named_in_initial_parameters(
+    tmp_path,
+):
+    """The alternate-client shape: ``profileId`` alongside ``targetRuntime``."""
+
+    async with temporal_db(tmp_path) as session:
+        await _mm3788_seed_profile(
+            session, profile_id="codex_minimax_team", runtime_id="codex_cli"
+        )
+        service = TemporalExecutionService(session)
+        service._client_adapter.start_workflow = AsyncMock(
+            return_value=SimpleNamespace(run_id="run-mm3788")
+        )
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await service.create_execution(
+                workflow_type="MoonMind.UserWorkflow",
+                owner_id=uuid4(),
+                title="MM-3788 flat profileId",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "targetRuntime": "claude_code",
+                    "profileId": "codex_minimax_team",
+                    "workflow": {"instructions": "Do the work."},
+                },
+                idempotency_key="mm3788-flat-profile-id",
+            )
+
+        assert excinfo.value.detail["selectedRuntime"] == "claude_code"
+        assert excinfo.value.detail["profileRuntime"] == "codex_cli"
+        records = (
+            await session.execute(select(TemporalExecutionCanonicalRecord))
+        ).scalars().all()
+        assert records == []
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_execution_accepts_provider_profile_owned_by_the_runtime(
+    tmp_path,
+):
+    async with temporal_db(tmp_path) as session:
+        await _mm3788_seed_profile(
+            session, profile_id="codex_minimax_team", runtime_id="codex_cli"
+        )
+        service = TemporalExecutionService(session)
+        service._client_adapter.start_workflow = AsyncMock(
+            return_value=SimpleNamespace(run_id="run-mm3788")
+        )
+
+        record = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="MM-3788 owned pair",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_mm3788_initial_parameters(
+                target_runtime="codex_cli", profile_id="codex_minimax_team"
+            ),
+            idempotency_key="mm3788-owned",
+        )
+
+        assert record.workflow_id.startswith("mm:")
+        stored = await session.get(
+            TemporalExecutionCanonicalRecord, record.workflow_id
+        )
+        assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_execution_defers_omnigent_targets_to_omnigent_selection(
+    tmp_path,
+):
+    """``omnigent`` is a facade, not a Provider Profile owner."""
+
+    async with temporal_db(tmp_path) as session:
+        await _mm3788_seed_profile(
+            session, profile_id="codex_minimax_team", runtime_id="codex_cli"
+        )
+        service = TemporalExecutionService(session)
+        service._client_adapter.start_workflow = AsyncMock(
+            return_value=SimpleNamespace(run_id="run-mm3788")
+        )
+
+        record = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="MM-3788 omnigent facade",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_mm3788_initial_parameters(
+                target_runtime="omnigent", profile_id="codex_minimax_team"
+            ),
+            idempotency_key="mm3788-omnigent",
+        )
+
+        stored = await session.get(
+            TemporalExecutionCanonicalRecord, record.workflow_id
+        )
+        assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_mm3788_create_execution_ignores_a_profile_ref_with_no_stored_row(
+    tmp_path,
+):
+    """An unknown ref carries no runtime; profile resolution owns that error."""
+
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter.start_workflow = AsyncMock(
+            return_value=SimpleNamespace(run_id="run-mm3788")
+        )
+
+        record = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="MM-3788 unknown profile ref",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_mm3788_initial_parameters(
+                target_runtime="claude_code", profile_id="never_configured"
+            ),
+            idempotency_key="mm3788-unknown-ref",
+        )
+
+        stored = await session.get(
+            TemporalExecutionCanonicalRecord, record.workflow_id
+        )
+        assert stored is not None

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -8383,3 +8383,82 @@ async def test_mm3788_create_execution_ignores_a_profile_ref_with_no_stored_row(
             TemporalExecutionCanonicalRecord, record.workflow_id
         )
         assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_mm3788_typed_recovery_rejects_a_pair_persisted_before_the_invariant(
+    tmp_path, mock_client_adapter
+):
+    """A recovery destination inherits the source's authored runtime pair.
+
+    Recovery reaches a launch through the same ``create_execution`` handoff, so
+    a pair that was persisted before the invariant existed — or whose profile
+    was later recreated under another runtime — is rejected there rather than
+    silently launching the profile's runtime instead of the selected one.
+    """
+
+    async with temporal_db(tmp_path) as session:
+        await _mm3788_seed_profile(
+            session, profile_id="codex_minimax_team", runtime_id="codex_cli"
+        )
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        source = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title="MM-3788 recovery source",
+            input_artifact_ref="artifact://snapshot/source",
+            plan_artifact_ref="artifact://plan/source",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_mm3788_initial_parameters(
+                target_runtime="codex_cli", profile_id="codex_minimax_team"
+            ),
+            idempotency_key=None,
+        )
+        canonical_source = await session.get(
+            TemporalExecutionCanonicalRecord, source.workflow_id
+        )
+        assert canonical_source is not None
+        stored_parameters = dict(canonical_source.parameters or {})
+        workflow_parameters = dict(stored_parameters.get("workflow") or {})
+        workflow_parameters["runtime"] = {
+            "mode": "claude_code",
+            "providerProfileRef": "codex_minimax_team",
+        }
+        stored_parameters["workflow"] = workflow_parameters
+        stored_parameters["targetRuntime"] = "claude_code"
+        canonical_source.parameters = stored_parameters
+        canonical_source.state = MoonMindWorkflowState.FAILED
+        canonical_source.close_status = TemporalExecutionCloseStatus.FAILED
+        canonical_source.artifact_refs = list(canonical_source.artifact_refs or []) + [
+            "artifact://checkpoint/source",
+            "artifact://checkpoint-validation",
+        ]
+        await session.commit()
+
+        target = _typed_failed_step_recovery_target(
+            source_workflow_id=canonical_source.workflow_id,
+            source_run_id=canonical_source.run_id,
+            destination_workflow_id="mm:mm3788-recovery-destination",
+        )
+
+        with pytest.raises(ProviderProfileRuntimeMismatchError) as excinfo:
+            await service.create_typed_recovery_execution(
+                canonical_source, recovery_target=target
+            )
+
+        assert excinfo.value.detail == {
+            "code": "provider_profile_runtime_mismatch",
+            "message": (
+                "Provider Profile 'codex_minimax_team' belongs to runtime "
+                "'codex_cli' and cannot be used with runtime 'claude_code'."
+            ),
+            "profileId": "codex_minimax_team",
+            "profileRuntime": "codex_cli",
+            "selectedRuntime": "claude_code",
+        }
+        # No recovery destination was created behind the rejection.
+        destination = await session.get(
+            TemporalExecutionCanonicalRecord, "mm:mm3788-recovery-destination"
+        )
+        assert destination is None


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3788 — Scope Provider Profile selection by runtime and add a Settings runtime filter

Closes MoonLadderStudios/MoonMind#3788

## Summary

Provider Profiles are runtime-owned launch contracts, so every runtime-coupled surface must offer only profiles the selected runtime owns, and no authoring path may persist or launch a cross-runtime pair.

**Settings administration**
- `settings.tsx` owns an All-runtimes-by-default runtime filter, derives canonical runtime options from `supportedRuntimes` plus the loaded profiles (excluding the omnigent facade), and passes only the visible rows to `ProviderProfilesManager` while `ConfigurationHealthSummary` keeps the complete unfiltered collection so global health counts stay correct.
- `ProviderProfilesManager` renders the labelled, keyboard-accessible runtime filter above the table, seeds a new profile's runtime from the active filter without overwriting an authored value, and names the runtime in its empty state. `runtime_id` remains immutable while editing.

**Execution surface**
- Workflow Start now shows a runtime-specific empty state instead of hiding the Provider Profile block, gated on a resolved (non-pending, non-placeholder) runtime-scoped result set. The existing runtime-scoped query key, refetch withholding, and compatibility-based Omnigent target handling are left untouched as the reference pattern.

**Server-side correctness boundary**
- One typed contract, `api_service/services/provider_profile_runtime`, owns the runtime-ownership rule. The invariant is enforced at the authority handoff every launch-authoring caller converges on — `TemporalExecutionService.create_execution`, on the final `initial_parameters` before any persist or launch — so one placement covers both branches of `POST /api/executions`, proposal promotion, rerun, continuation, checkpoint branching, manifest ingest, and deployment operations.
- The two boundaries that durably persist a launch target before reaching that handoff enforce it locally as well: recurring-workflow create/update (the raw target JSON editor was previously unvalidated), and `promote_proposal`, which commits the terminal PROMOTED state before the execution exists — a rejection records a `promotion_failed` event and leaves the proposal open.
- All 11 HTTP launch-authoring routes translate the typed error into the same `409 provider_profile_runtime_mismatch` payload naming both the runtime and the profile, including the three recovery routes that previously leaked it as an unmapped 500. `omnigent` stays exempt because it is a facade, not a profile owner.
- The generic v2 Omnigent path now requires a registered credential materializer for the profile's `(runtime_id, provider_id)` pair — the same capability boundary the execution-readiness projection uses to build `compatibleProviderProfiles`.
- `docs/Security/ProviderProfiles.md` states the product rule and the recovery/rerun consequence.

## Tests run

All backend runs used `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist`; the managed container test path is unavailable in this runtime (`MOONMIND_AGENT_RUN_ID is required`), which the container guard in `tools/test_unit.sh` explicitly permits.

- **Focused unit (backend), 8 owning files, `-k mm3788`** — 44 passed, 0 failed. Covers list-filter exclusion in both directions, `enabled_only`/visibility composition, Omnigent v2 accept/reject, recurring create+update, both `POST /api/executions` branches, the omnigent exemption, promotion (service and every mapping route), `create_execution` at the shared handoff, and typed recovery.
- **Negative control** — this round's four test files replayed at the prior head in a throwaway worktree: 11 of 28 selected tests fail (mismatch rejections report DID NOT RAISE; recovery and promote routes leak the typed error unmapped), while all 17 acceptance/exemption tests still pass, so the coverage gates on the production invariant rather than on itself.
- **Targeted no-regression, one file per process at HEAD** — 842 collected, 839 passed, 3 failed (see risks).
- **`create_execution` blast radius** — every unit test file referencing `create_execution` or `TemporalExecutionService`: 281 passed, 0 failed.
- **Launch/recovery route blast radius** — every unit test file exercising an execution, proposal, recurring, rerun, or recover route: 525 passed, 0 failed.
- **Frontend (targeted Vitest)** — 4 files, 221 passed, 0 failed (238 skips are the pre-existing `describe.skip("Task Create Entrypoint")` block).

Combined controlling backend coverage across 32 files: 1645 passed, 3 failed.

## Remaining risks

- **Three pre-existing failures**, disclosed rather than introduced: `tests/unit/api/routers/test_executions.py::test_describe_execution_allows_search_attribute_owner_id_fallback`, `::test_describe_execution_exposes_workflow_and_run_identity`, and `::test_describe_execution_exposes_target_attachment_and_recovery_diagnostics` fail with `sqlalchemy.exc.IllegalStateChangeError`. Reproduced with byte-identical IDs at the branch merge-base `3047c00ba` in a throwaway worktree; root cause is shared module-global session state, unrelated to this branch.
- **Legacy cross-runtime pairs are now a hard blocker on rerun/recovery.** The raw create branch demonstrably accepted such pairs before this branch, so persisted executions carrying one may exist; their rerun, continuation, and recovery now return 409 with the source execution untouched. This is deliberate at a billing-relevant runtime-substitution boundary, is documented, and is covered by a replay-style regression test.
- **Non-HTTP callers of `create_execution`** (child-run creator, remediation rerun, manifest child runs) reach the guard but have no HTTP boundary, so a mismatched pair fails the activity or remediation action rather than returning the shared 409. Fail-fast, but the operator-visible message differs on those paths.
- **Per-router 409 mapping is complete but still manual.** Enforcement is structural (one call site); the contract translation is per-router. All 11 sites were verified by direct read. A shared app-level exception handler would remove the remaining manual step; out of scope here.
- **One ownership comparison still sits outside the shared contract**: the checkpoint-branch turn launch compares `runtimeId` to `profile.runtime_id` as raw strings without `normalize_runtime_id`. Pre-existing and untouched by this branch.
- **Browser/journey coverage and visual verification of the new Settings control did not run** — no browser suite exists in this checkout and headless Chromium cannot start in this runtime. Mitigated by the control reusing sibling class strings in the same component, `dashboardBrand.test.ts` passing unchanged, and no `dashboard.css` rule changing on this branch.
- **Hermetic `integration_ci` not selected by impact** — the branch touches no Docker, compose, database, migration, or integration-boundary asset.
- `origin/main` has advanced by one unrelated commit since the merge-base; the branch has not been rebased so the verified state is the state under review.
