### PR TITLE
fix(workflows): preserve review gates across reruns

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10087,6 +10087,103 @@ def _snapshot_workflow_from_artifact_payload(
     return payload, task
 
 
+async def _exact_rerun_parameters_from_snapshot(
+    *,
+    session: AsyncSession,
+    user: User,
+    record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
+) -> dict[str, Any] | None:
+    """Restore exact task authority before a terminal execution is rerun."""
+
+    snapshot_ref = _workflow_input_snapshot_ref_from_memo(
+        dict(getattr(record, "memo", None) or {})
+    )
+    if not snapshot_ref:
+        return None
+    artifact_id = _artifact_id_from_ref(snapshot_ref)
+    if not artifact_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot is invalid.",
+            },
+        )
+    try:
+        artifact_service = get_temporal_artifact_service(session)
+        _artifact, body = await artifact_service.read(
+            artifact_id=artifact_id,
+            principal=str(getattr(user, "id", "") or "system"),
+            allow_restricted_raw=True,
+        )
+        decoded = json.loads(body.decode("utf-8"))
+    except (PermissionError, TemporalArtifactAuthorizationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot is not authorized.",
+            },
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot is malformed.",
+            },
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot could not be read.",
+            },
+        ) from exc
+    if not isinstance(decoded, Mapping):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot is malformed.",
+            },
+        )
+
+    snapshot_payload, snapshot_task = _snapshot_workflow_from_artifact_payload(
+        decoded
+    )
+    if not snapshot_task:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "exact_rerun_snapshot_unavailable",
+                "message": "Exact rerun task input snapshot has no workflow payload.",
+            },
+        )
+
+    parameters = dict(getattr(record, "parameters", None) or {})
+    for key, value in snapshot_payload.items():
+        if value not in (None, [], ""):
+            parameters[key] = value
+    workflow_payload = dict(snapshot_task)
+    workflow_payload["recovery"] = {
+        "kind": "exact_full_rerun",
+        "sourceWorkflowId": record.workflow_id,
+        "sourceRunId": record.run_id,
+    }
+    parameters["workflow"] = workflow_payload
+    instructions = str(snapshot_task.get("instructions") or "").strip()
+    if instructions:
+        parameters["instructions"] = snapshot_task.get("instructions")
+    publish = snapshot_task.get("publish")
+    if isinstance(publish, Mapping):
+        publish_mode = str(publish.get("mode") or "").strip()
+        if publish_mode:
+            parameters["publishMode"] = publish_mode
+    return parameters
+
+
 def _merge_workflow_preserving_artifact_instructions(
     artifact_task: Mapping[str, Any],
     parameter_task: Mapping[str, Any],
@@ -17586,13 +17683,23 @@ async def update_execution(
             },
         )
 
+    effective_parameters_patch = payload.parameters_patch
+    if exact_plan_rerun:
+        exact_snapshot_parameters = await _exact_rerun_parameters_from_snapshot(
+            session=session,
+            user=user,
+            record=record,
+        )
+        if exact_snapshot_parameters is not None:
+            effective_parameters_patch = exact_snapshot_parameters
+
     try:
         update_result = await service.update_execution(
             workflow_id=workflow_id,
             update_name=payload.update_name,
             input_artifact_ref=payload.input_artifact_ref,
             plan_artifact_ref=payload.plan_artifact_ref,
-            parameters_patch=payload.parameters_patch,
+            parameters_patch=effective_parameters_patch,
             title=payload.title,
             new_manifest_artifact_ref=payload.new_manifest_artifact_ref,
             mode=payload.mode,

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -603,6 +603,7 @@ class PresetExpandResponseSchema(BaseModel):
     )
     capabilities: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+    publish: Optional[dict[str, Any]] = None
     checkpoint_branching: dict[str, Any] = Field(
         default_factory=dict, alias="checkpointBranching"
     )

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -10595,6 +10595,10 @@ export interface components {
             capabilities?: string[];
             /** Warnings */
             warnings?: string[];
+            /** Publish */
+            publish?: {
+                [key: string]: unknown;
+            } | null;
             /** Checkpointbranching */
             checkpointBranching?: {
                 [key: string]: unknown;

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -22,6 +22,12 @@ from pr_resolver_core.review_providers import (
     normalize_reviewer_login,
 )
 
+from moonmind.workflows.provider_failures import (
+    PROVIDER_ERROR_CLASS_RATE_LIMIT,
+    ProviderFailureEvent,
+    build_provider_failure_event,
+)
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -2051,14 +2057,20 @@ class GitHubService:
             }
 
         requested_at = _parse_github_timestamp(review_request.get("requestedAt"))
+        reviews: list[Any] = []
+        review_url: str | None = (
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
+            "?per_page=100"
+        )
         try:
-            response = await client.get(
-                f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
-                "?per_page=100",
-                headers=headers,
-            )
-            response.raise_for_status()
-            reviews = response.json()
+            while review_url:
+                response = await client.get(review_url, headers=headers)
+                response.raise_for_status()
+                page = response.json()
+                if not isinstance(page, list):
+                    break
+                reviews.extend(page)
+                review_url = response.links.get("next", {}).get("url")
         except httpx.HTTPStatusError as exc:
             return {
                 **pending,
@@ -2090,36 +2102,35 @@ class GitHubService:
                 ],
             }
 
-        if isinstance(reviews, list):
-            for review in reviews:
-                if not isinstance(review, dict):
-                    continue
-                user = review.get("user") if isinstance(review.get("user"), dict) else {}
-                if (
-                    normalize_reviewer_login(user.get("login"))
-                    not in record.reviewer_logins
-                ):
-                    continue
-                submitted_at = _parse_github_timestamp(review.get("submitted_at"))
-                if requested_at is not None and (
-                    submitted_at is None or submitted_at <= requested_at
-                ):
-                    continue
-                commit_id = str(review.get("commit_id") or "").strip()
-                if (
-                    commit_id
-                    and requested_head_sha
-                    and commit_id != requested_head_sha
-                ):
-                    continue
-                return {
-                    "complete": True,
-                    "completionKind": "review",
-                    "completionId": review.get("id"),
-                    "completedAt": str(review.get("submitted_at") or "") or None,
-                    "stale": False,
-                    "blockers": [],
-                }
+        for review in reviews:
+            if not isinstance(review, dict):
+                continue
+            user = review.get("user") if isinstance(review.get("user"), dict) else {}
+            if (
+                normalize_reviewer_login(user.get("login"))
+                not in record.reviewer_logins
+            ):
+                continue
+            submitted_at = _parse_github_timestamp(review.get("submitted_at"))
+            if requested_at is not None and (
+                submitted_at is None or submitted_at <= requested_at
+            ):
+                continue
+            commit_id = str(review.get("commit_id") or "").strip()
+            if (
+                commit_id
+                and requested_head_sha
+                and commit_id != requested_head_sha
+            ):
+                continue
+            return {
+                "complete": True,
+                "completionKind": "review",
+                "completionId": review.get("id"),
+                "completedAt": str(review.get("submitted_at") or "") or None,
+                "stale": False,
+                "blockers": [],
+            }
 
         reaction = await self._find_request_clean_review_reaction(
             client=client,
@@ -2139,7 +2150,95 @@ class GitHubService:
                 "stale": False,
                 "blockers": [],
             }
+
+        provider_failure = await self._find_request_provider_failure(
+            client=client,
+            repo=repo,
+            pr_number=pr_number,
+            headers=headers,
+            provider=record,
+            requested_at=requested_at,
+        )
+        if provider_failure is not None:
+            summary = "Automated review provider failed to process the request."
+            if (
+                provider_failure.provider_error_class
+                == PROVIDER_ERROR_CLASS_RATE_LIMIT
+            ):
+                summary = (
+                    "Automated review provider usage is unavailable because its "
+                    "rate or usage limit was reached; retry after provider quota "
+                    "resets."
+                )
+            return {
+                **pending,
+                "complete": None,
+                "blockers": [
+                    {
+                        "kind": "automated_review_request_failed",
+                        "summary": summary,
+                        "retryable": False,
+                        "source": record.provider,
+                        "providerFailure": provider_failure.to_metadata(),
+                    }
+                ],
+            }
         return pending
+
+    async def _find_request_provider_failure(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        repo: str,
+        pr_number: int,
+        headers: dict[str, str],
+        provider: Any,
+        requested_at: datetime | None,
+    ) -> ProviderFailureEvent | None:
+        """Return a sanitized provider failure posted after this request."""
+
+        comments_url: str | None = (
+            f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
+            "?per_page=100"
+        )
+        try:
+            while comments_url:
+                response = await client.get(comments_url, headers=headers)
+                response.raise_for_status()
+                comments = response.json()
+                if not isinstance(comments, list):
+                    return None
+                for comment in comments:
+                    if not isinstance(comment, dict):
+                        continue
+                    user = (
+                        comment.get("user")
+                        if isinstance(comment.get("user"), dict)
+                        else {}
+                    )
+                    if (
+                        normalize_reviewer_login(user.get("login"))
+                        not in provider.reviewer_logins
+                    ):
+                        continue
+                    created_at = _parse_github_timestamp(comment.get("created_at"))
+                    if requested_at is not None and (
+                        created_at is None or created_at <= requested_at
+                    ):
+                        continue
+                    failure = build_provider_failure_event(
+                        reason=comment.get("body")
+                    )
+                    if failure is not None:
+                        return failure
+                comments_url = response.links.get("next", {}).get("url")
+        except (
+            httpx.HTTPStatusError,
+            httpx.TransportError,
+            httpx.TimeoutException,
+        ):
+            return None
+        return None
 
     async def _find_request_clean_review_reaction(
         self,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -821,10 +821,11 @@ def _derive_pr_resolver_failure(
         )
 
     status = _pr_resolver_status(payload)
-    if (
-        _pr_resolver_disposition(payload, merge_gate_owned=merge_gate_owned)
-        == "reenter_gate"
-    ):
+    disposition = _pr_resolver_disposition(
+        payload,
+        merge_gate_owned=merge_gate_owned,
+    )
+    if merge_gate_owned and disposition in {"reenter_gate", "request_review"}:
         return None, None
     if status not in _PR_RESOLVER_FAILURE_STATUSES:
         return None, None
@@ -846,8 +847,7 @@ def _derive_pr_resolver_failure(
     # User fault is intentionally allow-listed and can only come from a terminal
     # artifact that passed identity, freshness, and terminal-shape validation.
     failure_class = "user_error" if (
-        _pr_resolver_disposition(payload, merge_gate_owned=merge_gate_owned)
-        == "manual_review"
+        disposition == "manual_review"
         and normalized_reason in _PR_RESOLVER_USER_ACTIONABLE_REASONS
     ) else "execution_error"
     return failure_class, "; ".join(summary_parts)

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2491,7 +2491,12 @@ class MoonMindAgentRun:
                 raise
             owned_continuation_enabled = True
         continuation_authority = request.terminal_continuation_authority
-        synthetic_reenter_gate_failure = (
+        metadata = dict(evaluated.metadata or {})
+        continuation = metadata.get("gatedContinuation")
+        continuation = continuation if isinstance(continuation, Mapping) else {}
+        continuation_gate_type = str(continuation.get("gateType") or "").strip()
+        continuation_action = str(continuation.get("action") or "").strip()
+        synthetic_continuation_failure = (
             evaluated.failure_class == "execution_error"
             and evaluated.provider_error_code == "PR_RESOLVER_REENTER_GATE"
         )
@@ -2501,14 +2506,12 @@ class MoonMindAgentRun:
             == "continuation_requested"
             and continuation_authority is not None
             and continuation_authority.allows(
-                gate_type="merge_automation", action="reenter_gate"
+                gate_type=continuation_gate_type,
+                action=continuation_action,
             )
-            and synthetic_reenter_gate_failure
+            and synthetic_continuation_failure
         ):
-            metadata = dict(evaluated.metadata or {})
             metrics = dict(evaluated.metrics or {})
-            continuation = metadata.get("gatedContinuation")
-            continuation = continuation if isinstance(continuation, Mapping) else {}
             observability_enabled = workflow.patched(
                 PR_RESOLVER_CONTINUATION_OBSERVABILITY_PATCH_ID
             )
@@ -2524,7 +2527,7 @@ class MoonMindAgentRun:
                     "terminalContractRecoveryOutcome": "durable_parent_handoff",
                     "terminalContractContinuationCount": 0,
                     "gateType": continuation_authority.gate_type,
-                    "gateAction": "reenter_gate",
+                    "gateAction": continuation_action,
                     "gateOwnerWorkflowId": continuation_authority.owner_workflow_id,
                     "gateOwnerRunId": continuation_authority.owner_run_id,
                     "gateOwnerWorkflowType": continuation_authority.owner_workflow_type,

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -23,6 +23,7 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.utils.logging import scrub_github_tokens
 
 TERMINAL_BLOCKER_KINDS = {
+    "automated_review_request_failed",
     "pull_request_closed",
     "stale_revision",
     "policy_denied",
@@ -31,6 +32,7 @@ BASE_KNOWN_BLOCKER_KINDS = {
     "checks_running",
     "checks_failed",
     "automated_review_pending",
+    "automated_review_request_failed",
     "jira_status_pending",
     "pull_request_closed",
     "stale_revision",

--- a/moonmind/workflows/terminal_evidence.py
+++ b/moonmind/workflows/terminal_evidence.py
@@ -307,6 +307,7 @@ def evaluate_terminal_evidence(
             "already_merged",
             "review_clean",
             "reenter_gate",
+            "request_review",
             "manual_review",
             "failed",
         }:
@@ -380,37 +381,82 @@ def evaluate_terminal_evidence(
                 }:
                     return _failure("UNAUTHORIZED_MERGE_EVIDENCE", metadata=metadata)
             return _success(metadata)
-        if disposition == "reenter_gate":
+        if disposition in {"reenter_gate", "request_review"}:
             continuation = payload.get("gatedContinuation")
             if isinstance(continuation, Mapping):
+                expected_schema = (
+                    "gated-continuation/v2"
+                    if disposition == "request_review"
+                    else "gated-continuation/v1"
+                )
                 if (
-                    continuation.get("schemaVersion") != "gated-continuation/v1"
+                    continuation.get("schemaVersion") != expected_schema
                     or continuation.get("gateType") != "merge_automation"
-                    or continuation.get("action") != "reenter_gate"
+                    or continuation.get("action") != disposition
                 ):
                     return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
-                not_before = str(continuation.get("notBefore") or "").strip()
-                retry_after = continuation.get("retryAfterSeconds")
-                if not_before and retry_after is not None:
-                    return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
-                if not_before:
-                    try:
-                        parsed = datetime.fromisoformat(
-                            not_before.replace("Z", "+00:00")
-                        )
-                    except ValueError:
+                if disposition == "request_review":
+                    required_text = (
+                        "provider",
+                        "reason",
+                        "executionRef",
+                        "headSha",
+                    )
+                    if any(
+                        not isinstance(continuation.get(key), str)
+                        or not str(continuation.get(key)).strip()
+                        for key in required_text
+                    ):
                         return _failure(
                             "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
                         )
-                    if parsed.tzinfo is None:
+                    if str(continuation.get("executionRef") or "").strip() != (
+                        expected_execution
+                    ):
+                        return _failure("STALE_TERMINAL_EVIDENCE", metadata=metadata)
+                    head_sha = str(continuation.get("headSha") or "").strip()
+                    if not (7 <= len(head_sha) <= 64) or any(
+                        char not in "0123456789abcdefABCDEF" for char in head_sha
+                    ):
                         return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
-                if retry_after is not None and (
-                    isinstance(retry_after, bool)
-                    or not isinstance(retry_after, int)
-                    or retry_after < 1
-                ):
-                    return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
+                    progress_signature = continuation.get("progressSignature")
+                    if progress_signature is not None and not isinstance(
+                        progress_signature, str
+                    ):
+                        return _failure(
+                            "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+                        )
+                else:
+                    not_before = str(continuation.get("notBefore") or "").strip()
+                    retry_after = continuation.get("retryAfterSeconds")
+                    if not_before and retry_after is not None:
+                        return _failure(
+                            "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+                        )
+                    if not_before:
+                        try:
+                            parsed = datetime.fromisoformat(
+                                not_before.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            return _failure(
+                                "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+                            )
+                        if parsed.tzinfo is None:
+                            return _failure(
+                                "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+                            )
+                    if retry_after is not None and (
+                        isinstance(retry_after, bool)
+                        or not isinstance(retry_after, int)
+                        or retry_after < 1
+                    ):
+                        return _failure(
+                            "MALFORMED_TERMINAL_EVIDENCE", metadata=metadata
+                        )
                 metadata["gatedContinuation"] = dict(continuation)
+            elif disposition == "request_review":
+                return _failure("MALFORMED_TERMINAL_EVIDENCE", metadata=metadata)
             metadata["terminalContractOutcome"] = "continuation_requested"
             return TerminalEvidenceEvaluation(
                 False, metadata=metadata, outcome="continuation_requested"

--- a/tests/integration/workflows/temporal/workflows/test_merge_automation_full_topology.py
+++ b/tests/integration/workflows/temporal/workflows/test_merge_automation_full_topology.py
@@ -13,6 +13,7 @@ from temporalio.api.operatorservice.v1 import AddSearchAttributesRequest
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from moonmind.config.settings import settings
 from moonmind.workflows.temporal.activity_catalog import (
     AGENT_RUNTIME_TASK_QUEUE,
     ARTIFACTS_TASK_QUEUE,
@@ -120,6 +121,15 @@ async def _readiness(_payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+@activity.defn(name="merge_automation.request_automated_review")
+async def _request_automated_review(_payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "status": "requested",
+        "requestCommentId": 98765,
+        "requestedAt": "2026-08-26T23:59:00Z",
+    }
+
+
 _terminal_evidence_calls = 0
 
 
@@ -137,15 +147,16 @@ async def _terminal_evidence(payload: dict[str, Any]) -> dict[str, Any]:
                 "terminalContractOutcome": "continuation_requested",
                 "terminalContractEvidencePath": "var/pr_resolver/result.json",
                 "terminalContractExecutionRef": contract["executionRef"],
-                "mergeAutomationDisposition": "reenter_gate",
+                "mergeAutomationDisposition": "request_review",
                 "gatedContinuation": {
-                    "schemaVersion": "gated-continuation/v1",
+                    "schemaVersion": "gated-continuation/v2",
                     "gateType": "merge_automation",
-                    "action": "reenter_gate",
-                    "reason": "codex_review_grace_wait",
-                    "retryAfterSeconds": 2,
+                    "action": "request_review",
+                    "provider": "codex",
+                    "reason": "fresh_review_required_after_remediation",
                     "executionRef": contract["executionRef"],
                     "headSha": "abcdef1",
+                    "progressSignature": "abcdef1||",
                 },
             },
         }
@@ -198,7 +209,7 @@ async def _register_search_attributes(env: WorkflowEnvironment) -> None:
 
 
 @pytest.mark.asyncio
-async def test_real_three_workflow_topology_waits_then_merges() -> None:
+async def test_real_three_workflow_topology_requests_review_then_merges() -> None:
     global _terminal_evidence_calls
     _terminal_evidence_calls = 0
     parent_id = "mm1209-full-topology"
@@ -230,8 +241,15 @@ async def test_real_three_workflow_topology_waits_then_merges() -> None:
             Worker(env.client, task_queue=AGENT_RUNTIME_TASK_QUEUE, activities=common),
             Worker(
                 env.client,
+                task_queue=(
+                    settings.temporal.activity_agent_runtime_control_task_queue
+                ),
+                activities=[_terminal_evidence],
+            ),
+            Worker(
+                env.client,
                 task_queue=INTEGRATIONS_TASK_QUEUE,
-                activities=[_readiness],
+                activities=[_readiness, _request_automated_review],
             ),
             Worker(
                 env.client,
@@ -268,6 +286,11 @@ async def test_real_three_workflow_topology_waits_then_merges() -> None:
                     },
                     "mergeAutomationConfig": {
                         "timeouts": {"fallbackPollSeconds": 2},
+                        "reviewLoop": {
+                            "enabled": True,
+                            "provider": "codex",
+                            "maxCycles": 2,
+                        },
                     },
                     "resolverTemplate": {"targetRuntime": "claude_code"},
                 },
@@ -341,5 +364,6 @@ async def test_real_three_workflow_topology_waits_then_merges() -> None:
         second_result,
     )
     assert result["cycles"] == 2
-    assert result["continuationCounters"]["continuation_wait_completed"] == 1
+    assert result["continuationCounters"]["continuation_cycle_completed"] == 1
+    assert result["reviewLoop"]["cycles"] == 1
     assert _terminal_evidence_calls == 2

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -13716,7 +13716,9 @@ def test_describe_execution_falls_back_to_managed_run_store_agent_run_id(
 
 def test_request_rerun_update_response_includes_continue_as_new_cause() -> None:
     for test_client, service in _client_with_service():
-        service.describe_execution.return_value = _build_execution_record()
+        service.describe_execution.return_value = _build_execution_record(
+            has_workflow_input_snapshot=False
+        )
         service.update_execution.return_value = {
             "accepted": True,
             "applied": "continue_as_new",
@@ -13737,7 +13739,7 @@ def test_request_rerun_update_response_includes_continue_as_new_cause() -> None:
 
 def test_request_rerun_update_redirects_response_to_created_rerun_execution() -> None:
     for test_client, service in _client_with_service():
-        source_record = _build_execution_record()
+        source_record = _build_execution_record(has_workflow_input_snapshot=False)
         rerun_record = _build_execution_record()
         rerun_record.workflow_id = "mm:rerun-created"
         rerun_record.run_id = "run-rerun"
@@ -13776,6 +13778,7 @@ def test_request_rerun_update_redirects_response_to_created_rerun_execution() ->
 @pytest.mark.asyncio
 async def test_request_rerun_update_flushes_snapshot_reuse_before_serializing_response(
     tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_url = f"sqlite+aiosqlite:///{tmp_path}/rerun_update_response.db"
     engine = create_async_engine(db_url, future=True)
@@ -13852,6 +13855,10 @@ async def test_request_rerun_update_flushes_snapshot_reuse_before_serializing_re
             for source_record in source_records:
                 await session.refresh(source_record)
 
+            monkeypatch.setattr(
+                "api_service.api.routers.executions._exact_rerun_parameters_from_snapshot",
+                AsyncMock(return_value=None),
+            )
             response = await update_execution_route(
                 workflow_id=source_workflow_id,
                 payload=UpdateExecutionRequest(updateName="RequestRerun"),
@@ -13984,6 +13991,122 @@ def test_request_rerun_update_snapshot_hydrates_instructions_from_input_artifact
     assert steps[0]["instructions"] == "First step instructions."
     assert steps[1]["instructions"] == "Second step instructions."
     session.commit.assert_awaited_once()
+
+
+def test_exact_rerun_restores_publish_policy_from_authoritative_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    source_record = _build_execution_record(
+        state=MoonMindWorkflowState.FAILED,
+        has_workflow_input_snapshot=False,
+    )
+    source_record.workflow_id = "mm:wf-1"
+    source_record.run_id = "run-source"
+    source_record.parameters = {
+        "publishMode": "none",
+        "workflow": {"runtime": {"mode": "claude_code"}},
+    }
+    source_record.memo = {
+        **dict(source_record.memo or {}),
+        "task_input_snapshot_ref": "art-snapshot-source",
+        "task_input_snapshot_version": 1,
+        "task_input_snapshot_source_kind": "create",
+    }
+    rerun_record = _build_execution_record()
+    rerun_record.workflow_id = "mm:rerun-created"
+    rerun_record.run_id = "run-rerun"
+    service.describe_execution.side_effect = [source_record, rerun_record]
+    service.update_execution.return_value = {
+        "accepted": True,
+        "applied": "continue_as_new",
+        "message": "Rerun requested. New execution created.",
+        "continue_as_new_cause": "manual_rerun",
+        "workflow_id": "mm:rerun-created",
+    }
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    user = _override_user_dependencies(app, is_superuser=True)
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard, "temporal_workflow_editing_enabled", True
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(
+                SimpleNamespace(artifact_id="art-snapshot-source"),
+                json.dumps(
+                    {
+                        "snapshotVersion": 1,
+                        "draft": {
+                            "repository": "g3-qrtr/crash_server_main",
+                            "targetRuntime": "claude_code",
+                            "requiredCapabilities": ["claude_code", "git", "gh"],
+                            "workflow": {
+                                "instructions": "Resolve pull request 789.",
+                                "runtime": {"mode": "claude_code"},
+                                "publish": {
+                                    "mode": "none",
+                                    "mergeAutomation": {
+                                        "enabled": True,
+                                        "finishMode": "fix_only",
+                                        "reviewLoop": {
+                                            "enabled": True,
+                                            "provider": "codex",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    }
+                ).encode("utf-8"),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+    reuse_snapshot = AsyncMock(return_value="art-snapshot-source")
+    monkeypatch.setattr(
+        "api_service.api.routers.executions._reuse_original_task_input_snapshot_from_source",
+        reuse_snapshot,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/update",
+            json={"updateName": "RequestRerun"},
+        )
+
+    assert response.status_code == 200
+    parameters_patch = service.update_execution.await_args.kwargs[
+        "parameters_patch"
+    ]
+    assert parameters_patch["publishMode"] == "none"
+    assert parameters_patch["workflow"]["publish"] == {
+        "mode": "none",
+        "mergeAutomation": {
+            "enabled": True,
+            "finishMode": "fix_only",
+            "reviewLoop": {"enabled": True, "provider": "codex"},
+        },
+    }
+    assert parameters_patch["workflow"]["recovery"] == {
+        "kind": "exact_full_rerun",
+        "sourceWorkflowId": "mm:wf-1",
+        "sourceRunId": "run-source",
+    }
+    artifact_service.read.assert_awaited_once_with(
+        artifact_id="art-snapshot-source",
+        principal=str(user.id),
+        allow_restricted_raw=True,
+    )
+    reuse_snapshot.assert_awaited_once()
 
 
 def test_task_input_snapshot_artifact_id_strips_input_prefix_without_scheme() -> None:
@@ -14193,7 +14316,9 @@ def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:
 def test_task_editing_update_route_emits_failure_reason_metrics() -> None:
     metrics = Mock()
     for test_client, service in _client_with_service():
-        service.describe_execution.return_value = _build_execution_record()
+        service.describe_execution.return_value = _build_execution_record(
+            has_workflow_input_snapshot=False
+        )
         service.update_execution.side_effect = TemporalExecutionValidationError(
             "Workflow state changed and rerun is no longer available."
         )

--- a/tests/unit/api/routers/test_presets.py
+++ b/tests/unit/api/routers/test_presets.py
@@ -123,6 +123,13 @@ def test_expand_template_success() -> None:
         },
         "capabilities": ["codex", "git"],
         "warnings": [],
+        "publish": {
+            "mode": "none",
+            "mergeAutomation": {
+                "enabled": True,
+                "finishMode": "fix_only",
+            },
+        },
     }
 
     response = client.post(
@@ -136,6 +143,13 @@ def test_expand_template_success() -> None:
     assert payload["appliedTemplate"]["slug"] == "demo"
     assert payload["composition"]["slug"] == "demo"
     assert payload["capabilities"] == ["codex", "git"]
+    assert payload["publish"] == {
+        "mode": "none",
+        "mergeAutomation": {
+            "enabled": True,
+            "finishMode": "fix_only",
+        },
+    }
 
 def test_save_from_workflow_success() -> None:
     client, _, saver = _build_app()

--- a/tests/unit/workflows/adapters/test_github_automated_review.py
+++ b/tests/unit/workflows/adapters/test_github_automated_review.py
@@ -341,6 +341,7 @@ async def test_requested_review_ignores_older_codex_review(monkeypatch):
             ),
             _get(200, []),
             _get(200, []),
+            _get(200, []),
         ]
     )
 
@@ -398,6 +399,64 @@ async def test_requested_review_accepts_review_for_requested_commit(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_requested_review_follows_pagination_for_requested_commit(monkeypatch):
+    """A requested review can arrive after GitHub's first 100 results."""
+
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    second_page_url = (
+        f"https://api.github.com/repos/{_REPO}/pulls/350/reviews"
+        "?page=2&per_page=100"
+    )
+    first_page = _get(
+        200,
+        [
+            {
+                "id": 1,
+                "state": "COMMENTED",
+                "commit_id": _OLD_HEAD,
+                "submitted_at": "2026-08-24T21:00:00Z",
+                "user": {"login": "chatgpt-codex-connector"},
+            }
+        ],
+        headers={"Link": f'<{second_page_url}>; rel="next"'},
+    )
+    mock_client = _client(
+        get_responses=[
+            *_readiness_prefix(),
+            first_page,
+            _get(
+                200,
+                [
+                    {
+                        "id": 45678,
+                        "state": "COMMENTED",
+                        "commit_id": _HEAD,
+                        "submitted_at": "2026-08-24T22:19:00Z",
+                        "user": {"login": "chatgpt-codex-connector[bot]"},
+                    }
+                ],
+            ),
+        ]
+    )
+
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            policy={"checks": "required", "automatedReview": "required"},
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+
+    assert result.ready is True
+    assert result.automated_review_complete is True
+    assert result.automated_review_completion_kind == "review"
+    assert result.automated_review_completion_id == 45678
+    assert mock_client.get.await_args_list[4].args == (second_page_url,)
+
+
+@pytest.mark.asyncio
 async def test_requested_review_rejects_review_for_a_different_commit(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
     mock_client = _client(
@@ -417,6 +476,7 @@ async def test_requested_review_rejects_review_for_a_different_commit(monkeypatc
             ),
             _get(200, []),
             _get(200, []),
+            _get(200, []),
         ]
     )
 
@@ -431,6 +491,78 @@ async def test_requested_review_rejects_review_for_a_different_commit(monkeypatc
         )
 
     assert result.automated_review_complete is False
+
+
+@pytest.mark.asyncio
+async def test_requested_review_surfaces_paginated_provider_usage_failure(monkeypatch):
+    """A provider-authored quota response terminates the request wait."""
+
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    second_page_url = (
+        f"https://api.github.com/repos/{_REPO}/issues/350/comments"
+        "?page=2&per_page=100"
+    )
+    first_page = _get(
+        200,
+        [
+            {
+                "id": 1,
+                "body": "A human mentioned a usage limit.",
+                "created_at": "2026-08-24T22:20:00Z",
+                "user": {"login": "reviewer-a"},
+            }
+        ],
+        headers={"Link": f'<{second_page_url}>; rel="next"'},
+    )
+    mock_client = _client(
+        get_responses=[
+            *_readiness_prefix(),
+            _get(200, []),
+            _get(200, []),
+            _get(200, []),
+            first_page,
+            _get(
+                200,
+                [
+                    {
+                        "id": 99,
+                        "body": (
+                            "You have reached your Codex usage limits for code "
+                            "reviews."
+                        ),
+                        "created_at": "2026-08-24T22:20:01Z",
+                        "user": {
+                            "login": "chatgpt-codex-connector[bot]",
+                            "type": "Bot",
+                        },
+                    }
+                ],
+            ),
+        ]
+    )
+
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            policy={"checks": "required", "automatedReview": "required"},
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+
+    assert result.ready is False
+    assert result.automated_review_complete is None
+    assert [blocker["kind"] for blocker in result.blockers] == [
+        "automated_review_request_failed"
+    ]
+    assert result.blockers[0]["retryable"] is False
+    assert result.blockers[0]["source"] == "codex"
+    assert result.blockers[0]["providerFailure"]["providerErrorClass"] == (
+        "rate_limit"
+    )
+    assert "Codex usage limits" not in result.blockers[0]["summary"]
+    assert mock_client.get.await_args_list[-1].args == (second_page_url,)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -2223,6 +2223,63 @@ async def test_fetch_result_treats_pr_resolver_reenter_gate_as_continuation(
     assert result.failure_class is None
     assert result.metadata["mergeAutomationDisposition"] == "reenter_gate"
 
+
+async def test_fetch_result_treats_pr_resolver_review_request_as_continuation(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    result_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "schema_version": "moonmind.pr-resolver-result.v1",\n'
+            '  "status": "blocked",\n'
+            '  "mergeAutomationDisposition": "request_review",\n'
+            '  "final_reason": "fresh_review_required_after_remediation",\n'
+            '  "next_step": "request_automated_review"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-review-request",
+            agent_id="claude_code",
+            runtime_id="claude_code",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-review-request",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-review-request",
+        pr_resolver_expected=True,
+        pr_resolver_merge_gate_owned=True,
+    )
+
+    assert result.failure_class is None
+    assert result.provider_error_code is None
+    assert result.metadata["mergeAutomationDisposition"] == "request_review"
+
+
 async def test_fetch_result_derives_pr_resolver_reenter_gate_from_next_step(
     tmp_path: Path,
 ):

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -5,6 +5,7 @@ from moonmind.workflows.temporal.activity_runtime import _ACTIVITY_HANDLER_ATTRS
 from moonmind.workflows.temporal.workflows import merge_gate
 from moonmind.workflows.temporal.workflows.merge_gate import (
     DEFAULT_RESOLVER_TIMEOUT_SECONDS,
+    TERMINAL_BLOCKER_KINDS,
     build_resolver_run_request,
     classify_readiness,
     deterministic_resolver_idempotency_key,
@@ -51,6 +52,36 @@ def test_classify_readiness_marks_stale_revision_terminal() -> None:
     assert not evidence.ready
     assert evidence.blockers[0].kind == "stale_revision"
     assert evidence.blockers[0].retryable is False
+
+
+def test_classify_readiness_preserves_review_provider_failure_as_terminal() -> None:
+    evidence = classify_readiness(
+        {
+            "headSha": "abc123",
+            "pullRequestOpen": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": None,
+            "jiraStatusAllowed": True,
+            "policyAllowed": True,
+            "blockers": [
+                {
+                    "kind": "automated_review_request_failed",
+                    "summary": "Automated review provider usage is unavailable.",
+                    "retryable": False,
+                    "source": "codex",
+                }
+            ],
+        },
+        tracked_head_sha="abc123",
+    )
+
+    assert evidence.ready is False
+    assert [blocker.kind for blocker in evidence.blockers] == [
+        "automated_review_request_failed"
+    ]
+    assert evidence.blockers[0].retryable is False
+    assert "automated_review_request_failed" in TERMINAL_BLOCKER_KINDS
 
 def test_classify_readiness_treats_merged_pr_as_terminal_success_evidence() -> None:
     evidence = classify_readiness(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -572,8 +572,33 @@ async def test_terminal_checkpoint_activity_failure_preserves_primary_result(
     }
 
 
+@pytest.mark.parametrize(
+    ("action", "schema_version", "continuation_fields"),
+    [
+        (
+            "reenter_gate",
+            "gated-continuation/v1",
+            {
+                "reason": "codex_review_grace_wait",
+                "notBefore": "2026-07-12T05:05:49Z",
+            },
+        ),
+        (
+            "request_review",
+            "gated-continuation/v2",
+            {
+                "reason": "fresh_review_required_after_remediation",
+                "provider": "codex",
+                "headSha": "abc1234",
+            },
+        ),
+    ],
+)
 async def test_gate_owned_pr_resolver_continuation_bypasses_runtime_capability(
     monkeypatch: pytest.MonkeyPatch,
+    action: str,
+    schema_version: str,
+    continuation_fields: dict[str, str],
 ) -> None:
     _configure_workflow_runtime(monkeypatch)
     run = MoonMindAgentRun()
@@ -588,7 +613,7 @@ async def test_gate_owned_pr_resolver_continuation_bypasses_runtime_capability(
                 "ownerWorkflowId": "merge-automation:1",
                 "ownerRunId": "owner-run-1",
                 "ownerWorkflowType": "MoonMind.MergeAutomation",
-                "allowedActions": ["reenter_gate"],
+                "allowedActions": [action],
                 "source": "validated_temporal_parent",
             },
         }
@@ -602,10 +627,12 @@ async def test_gate_owned_pr_resolver_continuation_bypasses_runtime_capability(
             "metadata": {
                 "terminalContractOutcome": "continuation_requested",
                 "terminalContractExecutionRef": "exec-1",
-                "mergeAutomationDisposition": "reenter_gate",
+                "mergeAutomationDisposition": action,
                 "gatedContinuation": {
-                    "reason": "codex_review_grace_wait",
-                    "notBefore": "2026-07-12T05:05:49Z",
+                    "schemaVersion": schema_version,
+                    "gateType": "merge_automation",
+                    "action": action,
+                    **continuation_fields,
                 },
             },
         }
@@ -624,11 +651,13 @@ async def test_gate_owned_pr_resolver_continuation_bypasses_runtime_capability(
     assert result.metadata["terminalContractContinuationCount"] == 0
     assert result.metrics["continuation_requested"] == 1
     assert result.metrics["continuation_accepted"] == 1
+    assert result.metadata["gateAction"] == action
     assert "continuation_rejected_schema" not in result.metrics
     assert "continuation_rejected_ownership" not in result.metrics
-    assert result.metadata["continuationReason"] == "codex_review_grace_wait"
-    assert result.metadata["continuationNotBefore"] == "2026-07-12T05:05:49Z"
-    assert result.metadata["continuationTimingSource"] == "skill_not_before"
+    assert result.metadata["continuationReason"] == continuation_fields["reason"]
+    if action == "reenter_gate":
+        assert result.metadata["continuationNotBefore"] == "2026-07-12T05:05:49Z"
+        assert result.metadata["continuationTimingSource"] == "skill_not_before"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/test_terminal_evidence.py
+++ b/tests/unit/workflows/test_terminal_evidence.py
@@ -525,6 +525,99 @@ def test_pr_resolver_terminal_classifies_reenter_gate_as_continuation(tmp_path: 
     assert result.metadata["terminalContractExecutionRef"] == "step-1"
 
 
+def test_pr_resolver_terminal_classifies_review_request_as_continuation(
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "mergeAutomationDisposition": "request_review",
+                "executionRef": "step-1",
+                "gatedContinuation": {
+                    "schemaVersion": "gated-continuation/v2",
+                    "gateType": "merge_automation",
+                    "action": "request_review",
+                    "provider": "codex",
+                    "reason": "fresh_review_required_after_remediation",
+                    "executionRef": "step-1",
+                    "headSha": "abc1234",
+                    "progressSignature": "abc1234||",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    contract = {
+        "contractId": "pr_resolver_terminal.v1",
+        "relativePath": "var/pr_resolver/result.json",
+        "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+        "executionRef": "step-1",
+    }
+
+    result = evaluate_terminal_evidence(contract, workspace_path=str(tmp_path))
+
+    assert result.outcome == "continuation_requested"
+    assert result.satisfied is False
+    assert result.failure_code is None
+    assert result.metadata["gatedContinuation"]["action"] == "request_review"
+    assert result.metadata["gatedContinuation"]["provider"] == "codex"
+    assert result.metadata["terminalContractExecutionRef"] == "step-1"
+
+
+@pytest.mark.parametrize(
+    "continuation",
+    [
+        None,
+        {
+            "schemaVersion": "gated-continuation/v1",
+            "gateType": "merge_automation",
+            "action": "request_review",
+            "provider": "codex",
+            "reason": "fresh_review_required_after_remediation",
+            "executionRef": "step-1",
+            "headSha": "abc1234",
+        },
+        {
+            "schemaVersion": "gated-continuation/v2",
+            "gateType": "merge_automation",
+            "action": "request_review",
+            "provider": "",
+            "reason": "fresh_review_required_after_remediation",
+            "executionRef": "step-1",
+            "headSha": "abc1234",
+        },
+    ],
+)
+def test_pr_resolver_terminal_rejects_invalid_review_request_continuation(
+    tmp_path: Path,
+    continuation: dict[str, object] | None,
+) -> None:
+    result_path = tmp_path / "var/pr_resolver/result.json"
+    result_path.parent.mkdir(parents=True)
+    payload: dict[str, object] = {
+        "mergeAutomationDisposition": "request_review",
+        "executionRef": "step-1",
+    }
+    if continuation is not None:
+        payload["gatedContinuation"] = continuation
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = evaluate_terminal_evidence(
+        {
+            "contractId": "pr_resolver_terminal.v1",
+            "relativePath": "var/pr_resolver/result.json",
+            "expectedSchemaVersion": "moonmind.pr-resolver-result.v1",
+            "executionRef": "step-1",
+        },
+        workspace_path=str(tmp_path),
+    )
+
+    assert result.outcome == "terminal_failure"
+    assert result.failure_code == "MALFORMED_TERMINAL_EVIDENCE"
+
+
 def test_pr_resolver_terminal_rejects_stale_execution(tmp_path: Path) -> None:
     result_path = tmp_path / "var/pr_resolver/result.json"
     result_path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- preserve canonical workflow and publish policy when exact-rerunning a completed execution
- accept typed request-review continuations at the managed-agent and Temporal boundaries
- paginate automated-review discovery and surface provider quota failures as terminal blockers
- expose preset publish policy in the expansion schema and generated client contract

## Verification

- targeted workflow/API unit suite: 629 passed
- merge-automation topology integration test: passed
- live rerun recognized a paginated Codex review and later terminated cleanly on a Codex quota response
- git diff --check
