### PR TITLE
Fix Omnigent runtime capability admission

### DIFF
--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from api_service.db.models import TemporalArtifactRetentionClass
+from api_service.services.provider_profile_runtime import OMNIGENT_RUNTIME_ID
 from moonmind.omnigent.evidence_resolver import resolve_execution_evidence
 from moonmind.omnigent.execution_support_evidence import (
     load_protected_execution_support_evidence,  # re-export for hermetic test patching
@@ -670,6 +671,14 @@ async def compile_and_persist_execution_plan(
 ) -> PersistedOmnigentExecutionPlan:
     """Compile and persist one plan before Temporal or provider side effects."""
 
+    target_runtime = (
+        str(initial_parameters.get("targetRuntime") or "").strip().lower()
+    )
+    if target_runtime != OMNIGENT_RUNTIME_ID:
+        raise ValueError(
+            "Omnigent execution-plan compilation requires "
+            "targetRuntime='omnigent'"
+        )
     document = agent_profile_snapshot.get("document")
     if not isinstance(document, Mapping):
         raise ValueError("Agent Profile snapshot document is unavailable")
@@ -1091,6 +1100,10 @@ async def compile_and_persist_execution_plan(
         # A workflow request can require a capability, but it cannot make that
         # capability available merely by naming it.
         bridge_capabilities=bridge_capabilities,
+        # Runtime-mode requirements are satisfied by this trusted compiler
+        # only after it has confirmed that the request reached the canonical
+        # Omnigent product boundary. They are not exact-host tool claims.
+        platform_capabilities={OMNIGENT_RUNTIME_ID: True},
         workspace_intent_ref=_digest_ref(
             "workspace-intent", {"repository": repository, "workspace": workspace}
         ),

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -885,11 +885,13 @@ workflow requirements
 
 The result is an immutable `ClassAdmissionDecision`. It may prove class-level compatibility. It does not claim that an on-demand exact host is already ready.
 
-The decision records both the complete `requiredSatisfied` set and its
-`exactHostRequired` subset. A runtime-mode token such as `omnigent` is admitted
-only by the trusted runtime-selection boundary and remains in the complete set;
-it is not redundantly treated as a CLI or harness feature the exact host must
-advertise. Workflow-authored input never supplies this evidence.
+The v1 `requiredSatisfied` field remains the exact-host capability set consumed
+by every deployed worker. A runtime-mode token such as `omnigent` is admitted
+only by the trusted runtime-selection boundary and recorded through the selected
+plan authority; it is not added to `requiredSatisfied` or redundantly treated as
+a CLI or harness feature the exact host must advertise. Preserving this wire
+shape lets a new API safely submit plans to a pre-cutover worker.
+Workflow-authored input never supplies the runtime-selection evidence.
 
 The plan also records `runtimeValidationRequirements`, which name every fact that must be proven later. Typical requirements include exact harness implementation, vendor CLI version, restricted-egress attachment, mounted Skills, mounted tools, model availability, and intervention support.
 
@@ -906,10 +908,6 @@ ClassAdmissionDecision
 ```
 
 The result is a fenced `ExactHostCapabilityDecision` stored in the runtime binding. Missing, unknown, stale, or mismatched required evidence blocks runner and session creation.
-
-Plans recorded before `exactHostRequired` existed retain their original
-behavior: exact-host validation rechecks their full recorded
-`requiredSatisfied` set.
 
 ### 15.3 Required, preferred, and unknown
 

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -885,6 +885,12 @@ workflow requirements
 
 The result is an immutable `ClassAdmissionDecision`. It may prove class-level compatibility. It does not claim that an on-demand exact host is already ready.
 
+The decision records both the complete `requiredSatisfied` set and its
+`exactHostRequired` subset. A runtime-mode token such as `omnigent` is admitted
+only by the trusted runtime-selection boundary and remains in the complete set;
+it is not redundantly treated as a CLI or harness feature the exact host must
+advertise. Workflow-authored input never supplies this evidence.
+
 The plan also records `runtimeValidationRequirements`, which name every fact that must be proven later. Typical requirements include exact harness implementation, vendor CLI version, restricted-egress attachment, mounted Skills, mounted tools, model availability, and intervention support.
 
 ### 15.2 Exact-host validation decision
@@ -900,6 +906,10 @@ ClassAdmissionDecision
 ```
 
 The result is a fenced `ExactHostCapabilityDecision` stored in the runtime binding. Missing, unknown, stale, or mismatched required evidence blocks runner and session creation.
+
+Plans recorded before `exactHostRequired` existed retain their original
+behavior: exact-host validation rechecks their full recorded
+`requiredSatisfied` set.
 
 ### 15.3 Required, preferred, and unknown
 

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -332,6 +332,14 @@ Minimum readiness:
 3. required model/provider profile constraints are satisfied;
 4. runtime-specific materialization, prompt, Skill bundle, and artifact contracts can be honored.
 
+The trusted runtime-selection boundary supplies this readiness evidence; the
+authored token cannot attest itself. For a hybrid runtime such as Omnigent, the
+runtime token remains in the normalized required-capability set and support
+digest, while exact-host validation separately rechecks only capabilities that
+the selected host must realize. The exact host is still required to prove its
+harness implementation, image, vendor runtime, workspace, network, model, Skill,
+and tool evidence.
+
 ### 7.7 Scoped future capabilities
 
 Coarse names remain valid. Future scoped aliases may refine semantics:

--- a/docs/Workflows/RequiredCapabilities.md
+++ b/docs/Workflows/RequiredCapabilities.md
@@ -334,11 +334,13 @@ Minimum readiness:
 
 The trusted runtime-selection boundary supplies this readiness evidence; the
 authored token cannot attest itself. For a hybrid runtime such as Omnigent, the
-runtime token remains in the normalized required-capability set and support
-digest, while exact-host validation separately rechecks only capabilities that
-the selected host must realize. The exact host is still required to prove its
-harness implementation, image, vendor runtime, workspace, network, model, Skill,
-and tool evidence.
+runtime token remains in the normalized authored requirement and is proven by
+the selected execution-plan authority. It is not added to the v1
+`ClassAdmissionDecision.requiredSatisfied` field or its exact-host support
+digest, because older workers interpret that field as capabilities the selected
+host must advertise. The exact host is still required to prove its harness
+implementation, image, vendor runtime, workspace, network, model, Skill, and
+tool evidence.
 
 ### 7.7 Scoped future capabilities
 

--- a/moonmind/omnigent/harness_platform/capabilities.py
+++ b/moonmind/omnigent/harness_platform/capabilities.py
@@ -18,6 +18,9 @@ class ClassAdmissionDecision(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     requiredSatisfied: tuple[str, ...] = Field(alias="requiredSatisfied")
+    exactHostRequired: tuple[str, ...] = Field(
+        default=(), alias="exactHostRequired"
+    )
     preferredSatisfied: tuple[str, ...] = Field(alias="preferredSatisfied")
     degraded: tuple[str, ...] = ()
     unknown: tuple[str, ...] = ()
@@ -42,6 +45,7 @@ def compute_class_admission(
     materializer_capabilities: dict[str, bool],
     bridge_capabilities: dict[str, bool],
     launch_policy_capabilities: list[str],
+    platform_capabilities: dict[str, bool] | None = None,
 ) -> ClassAdmissionDecision:
     """Compute class-level admission decision.
 
@@ -50,6 +54,7 @@ def compute_class_admission(
     """
     required = set(workflow_requirements) | set(profile_requirements.get("required", []))
     preferred = set(profile_requirements.get("preferred", []))
+    platform_caps = platform_capabilities or {}
 
     # Build effective capability map: true if any source says true
     # For class-level, we intersect: capability must be present in catalog+host+materializer+bridge+policy
@@ -58,6 +63,7 @@ def compute_class_admission(
     degraded: list[str] = []
     unknown: list[str] = []
     missing: list[str] = []
+    exact_host_required: list[str] = []
 
     for cap in required:
         # Unknown if not declared anywhere
@@ -67,17 +73,20 @@ def compute_class_admission(
             or cap in materializer_capabilities
             or cap in bridge_capabilities
             or cap in launch_policy_capabilities
+            or cap in platform_caps
         )
         if not declared:
             unknown.append(cap)
             continue
         # Check only trusted declarations. A capability may be supplied by the
-        # catalog, Host Class, materializer, bridge, or launch policy; the
-        # workflow's requirement is deliberately absent from this evidence.
+        # catalog, Host Class, materializer, bridge, launch policy, or trusted
+        # platform runtime selection; the workflow's requirement is
+        # deliberately absent from this evidence.
         host_ok = host_class_capabilities.get(cap, True)  # if not host-specific, ignore
         catalog_ok = catalog_capabilities.get(cap)
         bridge_ok = bridge_capabilities.get(cap)
         materializer_ok = materializer_capabilities.get(cap, True)
+        platform_ok = platform_caps.get(cap)
         # Launch-policy capabilities must positively include control-plane caps
         policy_ok = True
         if cap in {"interrupt", "terminate", "clear_context", "streaming"}:
@@ -86,6 +95,16 @@ def compute_class_admission(
             policy_ok = True
         else:
             policy_ok = True  # non-policy caps defer to other layers
+        exact_host_supported = any(
+            value is True
+            for value in (
+                catalog_capabilities.get(cap),
+                host_class_capabilities.get(cap),
+                materializer_capabilities.get(cap),
+                bridge_capabilities.get(cap),
+            )
+        ) or cap in launch_policy_capabilities
+        platform_supported = platform_caps.get(cap) is True
 
         # If any layer explicitly says False or unsupported, then missing
         # catalog/bridge None means unknown already handled; False means unsupported
@@ -94,23 +113,22 @@ def compute_class_admission(
             or bridge_ok is False
             or host_ok is False
             or materializer_ok is False
+            or platform_ok is False
             or policy_ok is False
         ):
             missing.append(cap)
-        elif not any(
-            value is True
-            for value in (
-                catalog_capabilities.get(cap),
-                host_class_capabilities.get(cap),
-                materializer_capabilities.get(cap),
-                bridge_capabilities.get(cap),
-            )
-        ) and cap not in launch_policy_capabilities:
+        elif not exact_host_supported and not platform_supported:
             # A name appearing without an explicit positive declaration is not
             # support evidence.
             unknown.append(cap)
         else:
             satisfied.append(cap)
+            # Runtime-selection capabilities are proven by the trusted
+            # platform/adapter boundary. Capabilities realized by the host,
+            # harness, bridge, materializer, or policy must still be attested
+            # by the exact selected host before session creation.
+            if exact_host_supported:
+                exact_host_required.append(cap)
 
     if missing:
         raise HarnessPlatformError(
@@ -134,9 +152,10 @@ def compute_class_admission(
         # Check if available
         catalog_val = catalog_capabilities.get(cap)
         host_val = host_class_capabilities.get(cap)
-        if catalog_val is None and host_val is None:
+        platform_val = platform_caps.get(cap)
+        if catalog_val is None and host_val is None and platform_val is None:
             pref_unknown.append(cap)
-        elif catalog_val is False or host_val is False:
+        elif catalog_val is False or host_val is False or platform_val is False:
             pref_degraded.append(cap)
         else:
             pref_satisfied.append(cap)
@@ -144,6 +163,7 @@ def compute_class_admission(
     return ClassAdmissionDecision.model_validate(
         {
             "requiredSatisfied": sorted(satisfied),
+            "exactHostRequired": sorted(exact_host_required),
             "preferredSatisfied": sorted(pref_satisfied),
             "degraded": sorted(pref_degraded),
             "unknown": sorted(pref_unknown),

--- a/moonmind/omnigent/harness_platform/capabilities.py
+++ b/moonmind/omnigent/harness_platform/capabilities.py
@@ -18,9 +18,6 @@ class ClassAdmissionDecision(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     requiredSatisfied: tuple[str, ...] = Field(alias="requiredSatisfied")
-    exactHostRequired: tuple[str, ...] = Field(
-        default=(), alias="exactHostRequired"
-    )
     preferredSatisfied: tuple[str, ...] = Field(alias="preferredSatisfied")
     degraded: tuple[str, ...] = ()
     unknown: tuple[str, ...] = ()
@@ -63,7 +60,6 @@ def compute_class_admission(
     degraded: list[str] = []
     unknown: list[str] = []
     missing: list[str] = []
-    exact_host_required: list[str] = []
 
     for cap in required:
         # Unknown if not declared anywhere
@@ -122,13 +118,13 @@ def compute_class_admission(
             # support evidence.
             unknown.append(cap)
         else:
-            satisfied.append(cap)
-            # Runtime-selection capabilities are proven by the trusted
-            # platform/adapter boundary. Capabilities realized by the host,
-            # harness, bridge, materializer, or policy must still be attested
-            # by the exact selected host before session creation.
+            # Preserve the v1 wire contract consumed by already-deployed
+            # workers: requiredSatisfied is the exact-host capability set.
+            # Platform-only runtime tokens are proven by the trusted compiler
+            # and selected plan authority, so adding them here would make an
+            # older worker demand a host attestation that cannot exist.
             if exact_host_supported:
-                exact_host_required.append(cap)
+                satisfied.append(cap)
 
     if missing:
         raise HarnessPlatformError(
@@ -163,7 +159,6 @@ def compute_class_admission(
     return ClassAdmissionDecision.model_validate(
         {
             "requiredSatisfied": sorted(satisfied),
-            "exactHostRequired": sorted(exact_host_required),
             "preferredSatisfied": sorted(pref_satisfied),
             "degraded": sorted(pref_degraded),
             "unknown": sorted(pref_unknown),

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -102,6 +102,7 @@ def compile_execution_plan(
     model_normalized_options: dict[str, Any],
     workflow_requirements: list[str] | None = None,
     bridge_capabilities: dict[str, bool] | None = None,
+    platform_capabilities: dict[str, bool] | None = None,
     workspace_intent_ref: str | None = None,
     policy_snapshot_ref: str | None = None,
     policy_snapshot_digest: str | None = None,
@@ -312,6 +313,7 @@ def compile_execution_plan(
         materializer_capabilities=materializer_caps,
         bridge_capabilities=bridge_caps,
         launch_policy_capabilities=policy_caps,
+        platform_capabilities=platform_capabilities,
     )
 
     # 11. Normalize model config + digest

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -1241,12 +1241,8 @@ async def _persist_host_runtime_evidence(
             expected_vendor_runtimes.append(
                 {"name": name, "version": version, "digest": digest}
             )
-    raw_class_decision = plan.payload.classAdmissionDecision
-    class_decision = ClassAdmissionDecision.model_validate(raw_class_decision)
     required_capabilities = list(
-        class_decision.exactHostRequired
-        if "exactHostRequired" in raw_class_decision
-        else class_decision.requiredSatisfied
+        plan.payload.classAdmissionDecision.get("requiredSatisfied") or []
     )
     validate_exact_host_attestation(
         attestation,
@@ -1337,7 +1333,9 @@ async def _persist_host_runtime_evidence(
         },
     )
     exact_decision = validate_exact_host_capabilities(
-        class_decision=class_decision,
+        class_decision=ClassAdmissionDecision.model_validate(
+            plan.payload.classAdmissionDecision
+        ),
         attestation_capabilities={
             str(key): value is True for key, value in capabilities.items()
         },

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -1241,8 +1241,12 @@ async def _persist_host_runtime_evidence(
             expected_vendor_runtimes.append(
                 {"name": name, "version": version, "digest": digest}
             )
+    raw_class_decision = plan.payload.classAdmissionDecision
+    class_decision = ClassAdmissionDecision.model_validate(raw_class_decision)
     required_capabilities = list(
-        plan.payload.classAdmissionDecision.get("requiredSatisfied") or []
+        class_decision.exactHostRequired
+        if "exactHostRequired" in raw_class_decision
+        else class_decision.requiredSatisfied
     )
     validate_exact_host_attestation(
         attestation,
@@ -1333,9 +1337,7 @@ async def _persist_host_runtime_evidence(
         },
     )
     exact_decision = validate_exact_host_capabilities(
-        class_decision=ClassAdmissionDecision.model_validate(
-            plan.payload.classAdmissionDecision
-        ),
+        class_decision=class_decision,
         attestation_capabilities={
             str(key): value is True for key, value in capabilities.items()
         },

--- a/tests/unit/omnigent/test_harness_platform.py
+++ b/tests/unit/omnigent/test_harness_platform.py
@@ -611,6 +611,23 @@ def test_class_capability_negotiation_accepts_a_host_declared_capability():
     )
 
     assert decision.requiredSatisfied == ("git",)
+    assert decision.exactHostRequired == ("git",)
+
+
+def test_class_capability_negotiation_accepts_selected_platform_runtime():
+    decision = compute_class_admission(
+        workflow_requirements=["omnigent"],
+        profile_requirements={"required": [], "preferred": []},
+        catalog_capabilities={},
+        host_class_capabilities={},
+        materializer_capabilities={},
+        bridge_capabilities={},
+        launch_policy_capabilities=[],
+        platform_capabilities={"omnigent": True},
+    )
+
+    assert decision.requiredSatisfied == ("omnigent",)
+    assert decision.exactHostRequired == ()
 
 
 # AC 11: On-demand hosts admitted by Host Class evidence, not fictional exact-host readiness

--- a/tests/unit/omnigent/test_harness_platform.py
+++ b/tests/unit/omnigent/test_harness_platform.py
@@ -611,7 +611,6 @@ def test_class_capability_negotiation_accepts_a_host_declared_capability():
     )
 
     assert decision.requiredSatisfied == ("git",)
-    assert decision.exactHostRequired == ("git",)
 
 
 def test_class_capability_negotiation_accepts_selected_platform_runtime():
@@ -626,8 +625,13 @@ def test_class_capability_negotiation_accepts_selected_platform_runtime():
         platform_capabilities={"omnigent": True},
     )
 
-    assert decision.requiredSatisfied == ("omnigent",)
-    assert decision.exactHostRequired == ()
+    assert decision.requiredSatisfied == ()
+    assert decision.model_dump(mode="json", by_alias=True) == {
+        "requiredSatisfied": [],
+        "preferredSatisfied": [],
+        "degraded": [],
+        "unknown": [],
+    }
 
 
 # AC 11: On-demand hosts admitted by Host Class evidence, not fictional exact-host readiness

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from api_service.services import omnigent_execution_plan_service as service
 from api_service.services.omnigent_agent_profile_selection import (
@@ -31,6 +32,17 @@ _OPENCODE_ALLOWED_LAUNCH_POLICIES = [
     "omnigent-on-demand@1",
     "opencode-on-demand@1",
 ]
+
+
+class _LegacyClassAdmissionDecision(BaseModel):
+    """Exact class-decision shape consumed by the pre-cutover worker."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    requiredSatisfied: tuple[str, ...]
+    preferredSatisfied: tuple[str, ...]
+    degraded: tuple[str, ...] = ()
+    unknown: tuple[str, ...] = ()
 
 
 class _ArtifactService:
@@ -383,10 +395,10 @@ async def test_workflow_cannot_self_attest_an_unknown_capability(
 
 
 @pytest.mark.asyncio
-async def test_selected_omnigent_runtime_satisfies_derived_runtime_capability(
+async def test_selected_omnigent_runtime_is_safe_for_pre_cutover_worker(
     monkeypatch,
 ) -> None:
-    """The trusted Omnigent lane, not authored input, attests its runtime token."""
+    """New API plans preserve the class-decision shape an old worker consumes."""
 
     def resolve_evidence(plan_payload, **_kwargs):
         return _protected_support_evidence(plan_payload), "supported"
@@ -401,8 +413,9 @@ async def test_selected_omnigent_runtime_satisfies_derived_runtime_capability(
     )
 
     decision = result.envelope.payload.classAdmissionDecision
-    assert decision["requiredSatisfied"] == ["omnigent"]
-    assert decision["exactHostRequired"] == []
+    legacy_decision = _LegacyClassAdmissionDecision.model_validate(decision)
+    assert legacy_decision.requiredSatisfied == ()
+    assert "exactHostRequired" not in decision
 
 
 async def _capture_plan_payload(*, launch_policy_ref: str):

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -382,6 +382,29 @@ async def test_workflow_cannot_self_attest_an_unknown_capability(
         )
 
 
+@pytest.mark.asyncio
+async def test_selected_omnigent_runtime_satisfies_derived_runtime_capability(
+    monkeypatch,
+) -> None:
+    """The trusted Omnigent lane, not authored input, attests its runtime token."""
+
+    def resolve_evidence(plan_payload, **_kwargs):
+        return _protected_support_evidence(plan_payload), "supported"
+
+    monkeypatch.setattr(service, "resolve_execution_evidence", resolve_evidence)
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=_ArtifactService(),
+        launch_policy_ref="opencode-on-demand@1",
+        plan_store=_PlanStore(object()),
+        extra_parameters={"requiredCapabilities": ["omnigent"]},
+    )
+
+    decision = result.envelope.payload.classAdmissionDecision
+    assert decision["requiredSatisfied"] == ["omnigent"]
+    assert decision["exactHostRequired"] == []
+
+
 async def _capture_plan_payload(*, launch_policy_ref: str):
     """Return the compiled plan payload deployment qualification must match.
 

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -752,8 +752,7 @@ def _exact_host_evidence_fixture() -> tuple[SimpleNamespace, dict[str, object]]:
             harnessImplementationRef=implementation.implementation_ref(),
             supportIdentity=SimpleNamespace(vendorRuntimeRefs=()),
             classAdmissionDecision={
-                "requiredSatisfied": ["omnigent"],
-                "exactHostRequired": [],
+                "requiredSatisfied": [],
                 "preferredSatisfied": [],
                 "degraded": [],
                 "unknown": [],
@@ -851,46 +850,6 @@ async def test_runtime_binding_exact_capabilities_use_preflight_attestations(
     assert captured["network_attested"] is True
     assert captured["required_capabilities"] == []
     assert refs["cleanup_authority_refs"] == ["art-egress-1"]
-
-
-@pytest.mark.asyncio
-async def test_runtime_binding_legacy_plan_rechecks_all_satisfied_capabilities(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Plans without exactHostRequired retain their recorded exact-host gate."""
-
-    plan, preflight = _exact_host_evidence_fixture()
-    plan.payload.classAdmissionDecision.pop("exactHostRequired")
-    plan.payload.classAdmissionDecision["requiredSatisfied"] = ["git"]
-    preflight["hostRegistrationEvidence"]["capabilities"] = {"git": True}
-    captured: dict[str, object] = {}
-
-    async def persist(**kwargs: object) -> str:
-        return f"art-{kwargs['artifact_type']}"
-
-    from moonmind.omnigent.harness_platform import capabilities
-
-    real_validate = capabilities.validate_exact_host_capabilities
-
-    def capture_validate(**kwargs: object):
-        captured.update(kwargs)
-        return real_validate(**kwargs)
-
-    monkeypatch.setattr(omnigent_session_activities, "_write_json_artifact", persist)
-    monkeypatch.setattr(
-        capabilities,
-        "validate_exact_host_capabilities",
-        capture_validate,
-    )
-    await omnigent_session_activities._persist_host_runtime_evidence(
-        request=SimpleNamespace(),
-        plan=plan,
-        preflight=preflight,
-        model_options={},
-        host_lease_generation=1,
-    )
-
-    assert captured["required_capabilities"] == ["git"]
 
 
 def test_failure_contract_carries_only_typed_bounded_evidence() -> None:

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -752,7 +752,8 @@ def _exact_host_evidence_fixture() -> tuple[SimpleNamespace, dict[str, object]]:
             harnessImplementationRef=implementation.implementation_ref(),
             supportIdentity=SimpleNamespace(vendorRuntimeRefs=()),
             classAdmissionDecision={
-                "requiredSatisfied": [],
+                "requiredSatisfied": ["omnigent"],
+                "exactHostRequired": [],
                 "preferredSatisfied": [],
                 "degraded": [],
                 "unknown": [],
@@ -848,7 +849,48 @@ async def test_runtime_binding_exact_capabilities_use_preflight_attestations(
 
     assert captured["mount_attested"] is True
     assert captured["network_attested"] is True
+    assert captured["required_capabilities"] == []
     assert refs["cleanup_authority_refs"] == ["art-egress-1"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_binding_legacy_plan_rechecks_all_satisfied_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plans without exactHostRequired retain their recorded exact-host gate."""
+
+    plan, preflight = _exact_host_evidence_fixture()
+    plan.payload.classAdmissionDecision.pop("exactHostRequired")
+    plan.payload.classAdmissionDecision["requiredSatisfied"] = ["git"]
+    preflight["hostRegistrationEvidence"]["capabilities"] = {"git": True}
+    captured: dict[str, object] = {}
+
+    async def persist(**kwargs: object) -> str:
+        return f"art-{kwargs['artifact_type']}"
+
+    from moonmind.omnigent.harness_platform import capabilities
+
+    real_validate = capabilities.validate_exact_host_capabilities
+
+    def capture_validate(**kwargs: object):
+        captured.update(kwargs)
+        return real_validate(**kwargs)
+
+    monkeypatch.setattr(omnigent_session_activities, "_write_json_artifact", persist)
+    monkeypatch.setattr(
+        capabilities,
+        "validate_exact_host_capabilities",
+        capture_validate,
+    )
+    await omnigent_session_activities._persist_host_runtime_evidence(
+        request=SimpleNamespace(),
+        plan=plan,
+        preflight=preflight,
+        model_options={},
+        host_lease_generation=1,
+    )
+
+    assert captured["required_capabilities"] == ["git"]
 
 
 def test_failure_contract_carries_only_typed_bounded_evidence() -> None:


### PR DESCRIPTION
## Summary

- recognize the selected Omnigent runtime as a trusted platform capability during plan compilation
- preserve the full capability admission record while limiting exact-host checks to host-realized capabilities
- keep legacy serialized plans safe and add regression coverage for unknown capabilities

## Testing

- `./tools/test_unit.sh tests/unit/omnigent/test_harness_platform.py tests/unit/services/test_omnigent_execution_plan_service.py tests/unit/workflows/temporal/test_omnigent_session_workflow.py --python-only` (106 passed)
- Temporal boundary unit selection (3,685 passed, 9 subtests passed)
- API component unit selection (1,770 passed, 1 xfailed)
- `git diff --check`
