### PR TITLE
Auto-refresh Omnigent default qualification

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -496,6 +496,47 @@ async def _sync_omnigent_provider_readiness(*, allow_enrollment: bool) -> bool:
         return False
 
 
+async def _sync_omnigent_deployment_qualification() -> bool:
+    """Refresh signed execution evidence after managed default drift.
+
+    The built-in OpenCode Agent Profile is compiled from authenticated catalog
+    inventory and can legitimately advance after a deployment refresh. Keep the
+    qualification bound to that new immutable profile instead of requiring an
+    operator to repeat a bootstrap action for an already-enrolled API key.
+    """
+
+    try:
+        from api_service.db.base import async_session_maker
+        from moonmind.omnigent.bootstrap.controller import BootstrapController
+        from moonmind.omnigent.settings import (
+            build_omnigent_gate,
+            generic_host_enabled,
+            opencode_support_enabled,
+        )
+
+        if (
+            not build_omnigent_gate().enabled
+            or not generic_host_enabled()
+            or not opencode_support_enabled()
+        ):
+            return True
+        return await BootstrapController(
+            session_factory=async_session_maker
+        ).reconcile_deployment_qualification()
+    except (OperationalError, ProgrammingError, SQLAlchemyError, OSError) as exc:
+        logger.warning(
+            "OpenCode deployment qualification reconciliation deferred: %s",
+            exc,
+        )
+        return False
+    except Exception as exc:  # pragma: no cover - bounded startup reconciliation
+        logger.warning(
+            "OpenCode deployment qualification reconciliation deferred: %s",
+            exc,
+        )
+        return False
+
+
 @dataclass(frozen=True)
 class OmnigentBootstrapReadiness:
     """Per-leg outcome of one bootstrap reconciliation pass.
@@ -511,6 +552,7 @@ class OmnigentBootstrapReadiness:
     catalog_ready: bool
     schedules_ready: bool
     provider_ready: bool
+    qualification_ready: bool
 
     @property
     def ready(self) -> bool:
@@ -521,6 +563,7 @@ class OmnigentBootstrapReadiness:
             and self.catalog_ready
             and self.schedules_ready
             and self.provider_ready
+            and self.qualification_ready
         )
 
 
@@ -552,6 +595,11 @@ async def _reconcile_omnigent_bootstrap_once(
         if images_ready
         else False
     )
+    qualification_ready = (
+        await _sync_omnigent_deployment_qualification()
+        if images_ready and catalog_ready and provider_ready
+        else False
+    )
     return OmnigentBootstrapReadiness(
         images_ready=images_ready,
         policies_ready=policies_ready,
@@ -559,6 +607,7 @@ async def _reconcile_omnigent_bootstrap_once(
         catalog_ready=catalog_ready,
         schedules_ready=schedules_ready,
         provider_ready=provider_ready,
+        qualification_ready=qualification_ready,
     )
 
 

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -240,8 +240,15 @@ Two rules keep qualification and admission on one combination:
 
 Everything else stays exact. Changing an Agent Profile, host image, harness
 catalog, model, or effort changes the qualified combination and invalidates the
-published evidence. Re-qualify from the persisted Provider Profile — the
-credential is already stored, so recovery never needs the API key again:
+published evidence. The startup and maintenance reconciler detects drift in the
+deployment-managed Agent Profile, Provider Profile defaults, resolved image, or
+signed evidence and automatically re-runs the production qualification from the
+persisted Provider Profile. The normal `OPENCODE_API_KEY` path therefore stays
+launch-ready across service and upstream-agent refreshes without another
+operator action or another copy of the credential.
+
+The retry endpoint remains an explicit recovery control when an earlier
+qualification attempt failed:
 
 ```
 POST /api/omnigent/bootstrap/opencode/retry
@@ -251,8 +258,9 @@ Retry checks that the persisted Provider Profile and its managed SecretRefs are
 launch ready, revalidates its credential evidence against the pinned runtime,
 and refreshes the desired model and effort from the current Provider Profile.
 Qualification uses the current Agent Profile's default launch policy. An
-explicit per-run override is not a retry target; align the profile defaults with
-the desired combination before invoking retry.
+explicit per-run override outside those defaults remains a separate
+qualification target; the automatic reconciler owns only the standard managed
+default combination.
 
 ## Exact-host attestation (issue §8)
 

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import UTC, datetime
 from typing import Any
@@ -27,6 +28,8 @@ from moonmind.omnigent.bootstrap.store import (
 from moonmind.omnigent.harness_platform.support import (
     compute_support_combination_key,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BootstrapController:
@@ -172,6 +175,150 @@ class BootstrapController:
         )
         save_bootstrap_record(record)
         return await self._reconcile(record=record, api_key=None, principal=None)
+
+    async def reconcile_deployment_qualification(self) -> bool:
+        """Keep deployment evidence aligned with managed OpenCode defaults.
+
+        Catalog synchronization may advance the built-in Agent Profile after a
+        restart or an upstream agent refresh. Provider revalidation can also
+        advance model, effort, credential-generation, or image authority. The
+        original API-key bootstrap qualified the previous immutable snapshot,
+        so leaving that evidence untouched makes every otherwise-default launch
+        fail admission. Re-run the production qualification only when one of
+        those managed authorities or the signed evidence has actually drifted.
+        """
+
+        record = load_bootstrap_record()
+        if record is None or not str(record.provider_profile_ref or "").strip():
+            # OpenCode has not been enrolled. The console and deployment-key
+            # enrollment paths remain available; there is nothing to qualify.
+            return True
+
+        from sqlalchemy import select
+
+        from api_service.db.models import (
+            ManagedAgentProviderProfile,
+            OmnigentAgentProfile,
+            OmnigentAgentProfileVersion,
+        )
+        from moonmind.omnigent.bootstrap.store import load_resolved_state
+        from moonmind.omnigent.deployment_evidence import (
+            load_deployment_evidence_for_support_combination,
+        )
+
+        drift: list[str] = []
+        provider_profile_ref = str(record.provider_profile_ref)
+        async with self._session_factory() as session:
+            provider_profile = await session.get(
+                ManagedAgentProviderProfile, provider_profile_ref
+            )
+            agent_profile = await session.get(
+                OmnigentAgentProfile, "omnigent-opencode-default"
+            )
+            active_version = None
+            if agent_profile is not None and agent_profile.active_version is not None:
+                active_version = await session.scalar(
+                    select(OmnigentAgentProfileVersion).where(
+                        OmnigentAgentProfileVersion.profile_id
+                        == agent_profile.profile_id,
+                        OmnigentAgentProfileVersion.version
+                        == agent_profile.active_version,
+                    )
+                )
+
+        if provider_profile is None:
+            drift.append("provider_profile")
+        if agent_profile is None or active_version is None:
+            drift.append("agent_profile")
+            current_agent_profile_ref = ""
+        else:
+            current_agent_profile_ref = (
+                f"{agent_profile.profile_id}@{active_version.version}"
+            )
+            if record.agent_profile_ref != current_agent_profile_ref:
+                drift.append("agent_profile_ref")
+
+        resolved = load_resolved_state()
+        if resolved is None:
+            drift.append("resolved_images")
+        else:
+            if (
+                record.resolved.host_image_ref
+                != resolved.opencode_host_image_ref
+            ):
+                drift.append("host_image_ref")
+            if record.resolved.architecture != resolved.architecture:
+                drift.append("architecture")
+            if (
+                resolved.omnigent_build_digest
+                and record.resolved.omnigent_build_digest
+                != resolved.omnigent_build_digest
+            ):
+                drift.append("omnigent_build_digest")
+
+        if provider_profile is not None:
+            current_model = str(provider_profile.default_model or "").strip()
+            current_effort = str(provider_profile.default_effort or "").strip()
+            if (
+                current_model
+                and record.resolved.qualified_model_id != current_model
+            ):
+                drift.append("model")
+            if current_effort and record.desired.effort != current_effort:
+                drift.append("effort")
+
+        evidence = None
+        try:
+            evidence = load_deployment_evidence_for_support_combination(
+                str(record.last_evidence_ref or "")
+            )
+        except ValueError:
+            drift.append("deployment_evidence")
+        if evidence is not None:
+            if (
+                resolved is not None
+                and evidence.host_image_ref != resolved.opencode_host_image_ref
+            ):
+                drift.append("evidence_host_image_ref")
+            if evidence.provider.get("profileRef") != provider_profile_ref:
+                drift.append("evidence_provider_profile")
+            if provider_profile is not None and evidence.provider.get(
+                "credentialGeneration"
+            ) != int(provider_profile.credential_generation):
+                drift.append("evidence_credential_generation")
+            if provider_profile is not None:
+                if evidence.model.get("qualifiedId") != str(
+                    provider_profile.default_model or ""
+                ).strip():
+                    drift.append("evidence_model")
+                if evidence.model.get("effort") != str(
+                    provider_profile.default_effort or ""
+                ).strip():
+                    drift.append("evidence_effort")
+
+        if record.state != BootstrapState.ready:
+            drift.append("bootstrap_state")
+        if not drift:
+            return True
+
+        logger.info(
+            "Refreshing OpenCode deployment qualification after managed "
+            "default drift: fields=%s",
+            ",".join(sorted(set(drift))),
+        )
+        refreshed = await self.requalify()
+        if refreshed.state == BootstrapState.ready:
+            logger.info(
+                "OpenCode deployment qualification now matches Agent Profile %s",
+                refreshed.agent_profile_ref,
+            )
+            return True
+        failure_code = str((refreshed.failure or {}).get("code") or "unknown")
+        logger.warning(
+            "OpenCode deployment qualification refresh deferred: code=%s",
+            failure_code,
+        )
+        return False
 
     async def _reconcile(
         self,

--- a/moonmind/omnigent/deployment_evidence.py
+++ b/moonmind/omnigent/deployment_evidence.py
@@ -364,6 +364,54 @@ def _unqualified_combination_message(
     )
 
 
+def load_deployment_evidence_for_support_combination(
+    support_combination_key: str,
+    *,
+    path: str | Path | None = None,
+    now: datetime | None = None,
+) -> DeploymentExecutionEvidence:
+    """Load one exact, recorded deployment qualification document.
+
+    Bootstrap reconciliation owns the support combination it most recently
+    published. It uses this read boundary to distinguish a still-current
+    qualification from missing, expired, or superseded evidence without
+    compiling a caller-owned execution plan.
+    """
+
+    expected_key = str(support_combination_key or "").strip()
+    if not expected_key.startswith("omnigent-support:sha256:"):
+        raise ValueError("deployment support combination key is unavailable")
+    configured = str(
+        path
+        or os.getenv(
+            _DEPLOYMENT_EVIDENCE_ENV,
+            "/workspace/omnigent-evidence/deployment-execution-evidence.json",
+        )
+    ).strip()
+    if not configured:
+        raise ValueError("deployment execution evidence is not configured")
+    try:
+        raw = json.loads(Path(configured).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("deployment execution evidence is unavailable") from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError("deployment evidence must be an object")
+    entries = raw.get("entries")
+    candidates = list(entries) if isinstance(entries, list) else [raw]
+    matching = [
+        value
+        for value in candidates
+        if isinstance(value, Mapping)
+        and value.get("supportCombinationKey") == expected_key
+    ]
+    if len(matching) != 1:
+        raise ValueError(
+            "exact deployment execution evidence is unavailable for the "
+            "recorded support combination"
+        )
+    return validate_deployment_evidence(matching[0], now=now)
+
+
 def load_deployment_evidence(
     plan_payload: Any,
     *,
@@ -412,6 +460,7 @@ __all__ = [
     "assert_deployment_evidence_matches_plan",
     "get_or_create_signing_key",
     "load_deployment_evidence",
+    "load_deployment_evidence_for_support_combination",
     "sign_deployment_evidence",
     "validate_deployment_evidence",
 ]

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -32,6 +32,7 @@ async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inve
             catalog_ready=ready,
             schedules_ready=ready,
             provider_ready=ready,
+            qualification_ready=ready,
         )
 
     async def refresh_inventory() -> bool:
@@ -120,6 +121,10 @@ async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
         calls.append(f"provider:{allow_enrollment}")
         return True
 
+    async def qualification() -> bool:
+        calls.append("qualification")
+        return True
+
     monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", images)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", policies)
     monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", agent)
@@ -134,6 +139,11 @@ async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
         "_sync_omnigent_provider_readiness",
         provider,
     )
+    monkeypatch.setattr(
+        api_main,
+        "_sync_omnigent_deployment_qualification",
+        qualification,
+    )
 
     assert (
         await api_main._reconcile_omnigent_bootstrap_once(refresh_images=True)
@@ -147,6 +157,7 @@ async def test_bootstrap_reconciliation_refreshes_recurring_schedule_authority(
         "catalog",
         "schedules",
         "provider:True",
+        "qualification",
     ]
 
 

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -18,7 +18,9 @@ from moonmind.omnigent.bootstrap import controller as controller_module
 from moonmind.omnigent.bootstrap.models import (
     BootstrapDesired,
     BootstrapRecord,
+    BootstrapResolved,
     BootstrapState,
+    ResolvedOmnigentDeploymentState,
 )
 from moonmind.omnigent.bootstrap.opencode import resolve_model_by_display
 from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
@@ -220,6 +222,41 @@ async def test_qualification_attests_the_launch_policy_admission_selects(
     expected = default_launch_policy_ref(_ALLOWED_LAUNCH_POLICIES)
     assert expected == "omnigent-on-demand@1"
     assert evidence["supportIdentity"]["launchPolicyRef"] == expected
+
+
+@pytest.mark.asyncio
+async def test_recorded_qualification_loader_selects_and_validates_exact_evidence(
+    qualification_boundary,
+    tmp_path,
+) -> None:
+    from moonmind.omnigent.deployment_evidence import (
+        load_deployment_evidence_for_support_combination,
+    )
+
+    evidence = await _qualify(qualification_boundary)
+    path = tmp_path / "deployment-evidence.json"
+    path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "supportCombinationKey": (
+                            "omnigent-support:sha256:" + "f" * 64
+                        )
+                    },
+                    evidence,
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_deployment_evidence_for_support_combination(
+        evidence["supportCombinationKey"],
+        path=path,
+    )
+
+    assert loaded.support_combination_key == evidence["supportCombinationKey"]
 
 
 @pytest.mark.asyncio
@@ -485,3 +522,159 @@ async def test_requalification_stops_when_runtime_revalidation_fails(
         await controller.requalify()
 
     reconcile.assert_not_awaited()
+
+
+def _ready_bootstrap_record(*, agent_profile_ref: str) -> BootstrapRecord:
+    return BootstrapRecord(
+        state=BootstrapState.ready,
+        desired=BootstrapDesired(
+            modelDisplayName="opencode-go/muse-spark-1.2-contributor",
+            effort="xhigh",
+            acceptContributorDataUse=True,
+        ),
+        resolved=BootstrapResolved(
+            qualifiedModelId="opencode-go/muse-spark-1.2-contributor",
+            hostImageRef=_HOST_IMAGE_REF,
+            omnigentBuildDigest="sha256:" + "a" * 64,
+            architecture="linux/amd64",
+        ),
+        providerProfileRef="opencode-go-default",
+        agentProfileRef=agent_profile_ref,
+        lastEvidenceRef="omnigent-support:sha256:" + "b" * 64,
+    )
+
+
+@pytest.mark.asyncio
+async def test_managed_agent_profile_advance_requalifies_default_deployment(
+    monkeypatch,
+) -> None:
+    """Catalog-owned profile advancement must not strand default launches."""
+
+    provider_profile = SimpleNamespace(
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        default_effort="xhigh",
+        credential_generation=1,
+    )
+    agent_profile = SimpleNamespace(
+        profile_id="omnigent-opencode-default",
+        active_version=8,
+    )
+    active_version = SimpleNamespace(version=8)
+
+    class _QualificationSession:
+        async def get(self, model, _identity):
+            return {
+                "ManagedAgentProviderProfile": provider_profile,
+                "OmnigentAgentProfile": agent_profile,
+            }.get(model.__name__)
+
+        async def scalar(self, _statement):
+            return active_version
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield _QualificationSession()
+
+    current_images = ResolvedOmnigentDeploymentState(
+        serverImageRef=_SERVER_IMAGE_REF,
+        opencodeHostImageRef=_HOST_IMAGE_REF,
+        omnigentBuildDigest="sha256:" + "a" * 64,
+        architecture="linux/amd64",
+    )
+    evidence = SimpleNamespace(
+        host_image_ref=_HOST_IMAGE_REF,
+        provider={"profileRef": "opencode-go-default", "credentialGeneration": 1},
+        model={
+            "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
+            "effort": "xhigh",
+        },
+    )
+    stale = _ready_bootstrap_record(
+        agent_profile_ref="omnigent-opencode-default@7"
+    )
+    refreshed = stale.model_copy(
+        update={"agent_profile_ref": "omnigent-opencode-default@8"}
+    )
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: stale)
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.store.load_resolved_state",
+        lambda: current_images,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.load_deployment_evidence_for_support_combination",
+        lambda _key: evidence,
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    requalify = AsyncMock(return_value=refreshed)
+    monkeypatch.setattr(controller, "requalify", requalify)
+
+    assert await controller.reconcile_deployment_qualification()
+    requalify.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_current_default_qualification_avoids_repeating_live_workload(
+    monkeypatch,
+) -> None:
+    """The maintenance cadence must not re-run qualification without drift."""
+
+    provider_profile = SimpleNamespace(
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        default_effort="xhigh",
+        credential_generation=1,
+    )
+    agent_profile = SimpleNamespace(
+        profile_id="omnigent-opencode-default",
+        active_version=8,
+    )
+
+    class _QualificationSession:
+        async def get(self, model, _identity):
+            return {
+                "ManagedAgentProviderProfile": provider_profile,
+                "OmnigentAgentProfile": agent_profile,
+            }.get(model.__name__)
+
+        async def scalar(self, _statement):
+            return SimpleNamespace(version=8)
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield _QualificationSession()
+
+    current = _ready_bootstrap_record(
+        agent_profile_ref="omnigent-opencode-default@8"
+    )
+    current_images = ResolvedOmnigentDeploymentState(
+        serverImageRef=_SERVER_IMAGE_REF,
+        opencodeHostImageRef=_HOST_IMAGE_REF,
+        omnigentBuildDigest="sha256:" + "a" * 64,
+        architecture="linux/amd64",
+    )
+    evidence = SimpleNamespace(
+        host_image_ref=_HOST_IMAGE_REF,
+        provider={"profileRef": "opencode-go-default", "credentialGeneration": 1},
+        model={
+            "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
+            "effort": "xhigh",
+        },
+    )
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: current)
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.store.load_resolved_state",
+        lambda: current_images,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.load_deployment_evidence_for_support_combination",
+        lambda _key: evidence,
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    requalify = AsyncMock()
+    monkeypatch.setattr(controller, "requalify", requalify)
+
+    assert await controller.reconcile_deployment_qualification()
+    requalify.assert_not_awaited()


### PR DESCRIPTION
Summary
- add deployment qualification as a normal bootstrap maintenance leg
- re-qualify only when managed Agent/Profile defaults, image authority, credential generation, or signed evidence drift
- retain exact evidence matching for non-default overrides
- document the API-key-only default behavior

Tests
- ./tools/test_unit.sh --python-only tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/omnigent/test_execution_support_evidence.py tests/unit/services/test_omnigent_execution_plan_service.py tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
- 50 passed

Risk
- qualification still fails closed; a failed live requalification leaves readiness false and retries on the bounded maintenance cadence.