### PR TITLE
Publish the promised MoonSpec draft PR; decouple and complete the generic Container Jobs contract

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -181,8 +181,11 @@ MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 # Container-job image and cache sources this deployment approves. MoonMind
 # carries no project image, volume, or in-container path of its own: a caller
 # selects a source by its opaque ref, and an undeclared ref fails closed.
-# docker-compose.yaml derives these from the four variables above, so override
-# them only to declare additional sources.
+# docker-compose.yaml derives these from the four variables above. Setting
+# either variable replaces that derived default outright -- declarations are
+# consumed exactly as supplied and are never merged -- so repeat every source
+# you intend to keep alongside any source you add. Unknown keys are rejected at
+# startup, so a misspelling fails instead of silently taking a default.
 # MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=[{"sourceRef":"tactics-unreal","image":"ghcr.io/moonladderstudios/tactics-ue-base:5.8","pullPolicy":"if-missing"}]
 # MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=[{"cacheRef":"unreal-ccache","volumeName":"unreal_ccache_volume","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"unreal_ubt_volume","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]
 

--- a/.env-template
+++ b/.env-template
@@ -178,6 +178,19 @@ MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY="if-missing"
 MOONMIND_UNREAL_CCACHE_VOLUME_NAME="unreal_ccache_volume"
 MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 
+# Container-job image and cache sources this deployment approves. MoonMind
+# carries no project image, volume, or in-container path of its own: a caller
+# selects a source by its opaque ref, and an undeclared ref fails closed.
+# docker-compose.yaml derives these from the four variables above, so override
+# them only to declare additional sources.
+# MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=[{"sourceRef":"tactics-unreal","image":"ghcr.io/moonladderstudios/tactics-ue-base:5.8","pullPolicy":"if-missing"}]
+# MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=[{"cacheRef":"unreal-ccache","volumeName":"unreal_ccache_volume","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"unreal_ubt_volume","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]
+
+# Non-secret deployment values a portable Skill may read from inside a managed
+# session, comma separated. Secret-looking names are refused: secrets travel the
+# credential path instead.
+MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS="MOONMIND_UNREAL_ENGINE_IMAGE"
+
 # Managed-runtime cleanup. These working defaults automatically delete only
 # ownership-verified terminal workspaces/artifacts after retention. Set ENABLED
 # to false for indefinite retention, or DRY_RUN to true to inspect candidates.

--- a/.env-template
+++ b/.env-template
@@ -72,6 +72,12 @@ OPENCODE_API_KEY=""
 # explicit data-use acknowledgement. Set to false to decline; enrollment then
 # stops instead of accepting on your behalf.
 OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE=true
+# How long an observed OpenCode model catalog stays current, in hours. The
+# pinned host image refreshes its catalog from the provider at probe time, so
+# without an interval the deployment keeps whichever catalog the first probe
+# saw and never observes models the provider publishes later. Set to 0 to
+# re-probe only when the credential generation or host image digest changes.
+OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS=6
 # Dedicated OpenCode host (issue 3752). Leave empty to let the deployment
 # resolve the digest from the image and tag below. Set to a digest-pinned GHCR
 # ref to pin it explicitly, e.g.:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,20 +51,6 @@ For AI-assisted or AI-written descriptions:
 - [ ] Existing tests cover this change
 - [ ] Not applicable
 
-## AI assistance
-
-- [ ] No material AI assistance
-- [ ] AI-assisted or AI-generated contribution
-
-If AI-assisted:
-
-- Tool or workflow used:
-- What the AI helped with:
-- What I manually reviewed:
-- What I verified independently:
-
-I understand that I am responsible for the final submitted change.
-
 ## Risk notes
 
 <!--

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -420,23 +420,12 @@ def _revalidation_is_exhausted(provider: Any, selected_classes: Any) -> bool:
     """
 
     from moonmind.omnigent.bootstrap.provider_revalidation import (
-        REVALIDATION_FAILURE_KEY,
+        revalidation_is_exhausted,
     )
 
-    behavior = getattr(provider, "command_behavior", None) or {}
-    record = behavior.get(REVALIDATION_FAILURE_KEY)
-    if not isinstance(record, dict) or record.get("exhausted") is not True:
-        return False
-    try:
-        generation = int(record.get("credentialGeneration") or 0)
-    except (TypeError, ValueError):
-        return False
-    if generation != int(provider.credential_generation):
-        # A rotated credential has not been attempted yet.
-        return False
-    return str(record.get("imageRef") or "") in {
-        item.imageRef for item in selected_classes
-    }
+    return revalidation_is_exhausted(
+        provider, image_refs={item.imageRef for item in selected_classes}
+    )
 
 
 def _valid_server_url(value: str) -> bool:
@@ -1548,6 +1537,9 @@ async def get_omnigent_execution_readiness(
 
     from api_service.db.base import async_session_maker
     from api_service.db.models import OmnigentAgentProfile, OmnigentAgentProfileVersion
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        evidence_observation_is_current,
+    )
     from moonmind.omnigent.harness_platform.agent_profile import validate_agent_profile
     from moonmind.omnigent.harness_platform.catalog import (
         TrustState,
@@ -1707,17 +1699,25 @@ async def get_omnigent_execution_readiness(
                 evidence_generation = int(evidence.get("credentialGeneration") or 0)
             except (TypeError, ValueError):
                 evidence_generation = 0
-            if evidence_generation != int(provider.credential_generation) or str(
-                evidence.get("imageRef") or ""
-            ) not in {item.imageRef for item in selected_classes}:
+            if (
+                evidence_generation != int(provider.credential_generation)
+                or str(evidence.get("imageRef") or "")
+                not in {item.imageRef for item in selected_classes}
+                # An observation older than the configured catalog interval no
+                # longer describes the provider's current models, so it cannot
+                # advertise a target either. The reconciler re-probes it on the
+                # same bounded schedule as image and credential staleness.
+                or not evidence_observation_is_current(evidence)
+            ):
                 if evidence and not _revalidation_is_exhausted(
                     provider, selected_classes
                 ):
                     # The credential is enrolled and connected; only its
                     # runtime-backed evidence trails the currently pinned host
-                    # image or credential generation. The bootstrap reconciler
-                    # re-validates it against the exact selected image, so this
-                    # is a bounded wait rather than a reconnect.
+                    # image, the credential generation, or the catalog
+                    # interval. The bootstrap reconciler re-validates it
+                    # against the exact selected image, so this is a bounded
+                    # wait rather than a reconnect.
                     revalidating.append(provider.profile_id)
                 continue
             observed_models = {

--- a/api_service/services/omnigent_agent_smoke_service.py
+++ b/api_service/services/omnigent_agent_smoke_service.py
@@ -276,6 +276,9 @@ async def _run_v2_profile_readiness_checks(
         OmnigentHarnessCatalogSnapshotRecord,
         OmnigentHarnessTrustRecord,
     )
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        evidence_observation_is_current,
+    )
     from moonmind.omnigent.harness_platform.agent_profile import (
         BundleSource,
         validate_agent_profile,
@@ -496,6 +499,9 @@ async def _run_v2_profile_readiness_checks(
                 != int(provider.credential_generation)
                 or str(evidence.get("imageRef") or "")
                 not in {item.imageRef for item in selected_classes}
+                # Smoke launches the real host, so it must not admit a catalog
+                # the provider may have changed since it was observed.
+                or not evidence_observation_is_current(evidence)
                 or not model
                 or model not in _profile_model_ids(evidence.get("models", []))
             ):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,14 @@ services:
       - TEMPORAL_DASHBOARD_SUBMIT_ENABLED=true
       - TEMPORAL_WORKFLOW_EDITING_ENABLED=${TEMPORAL_WORKFLOW_EDITING_ENABLED:-true}
       - MOONMIND_CONTAINER_JOBS_ENABLED=${MOONMIND_CONTAINER_JOBS_ENABLED:-true}
+      # `ContainerJobService.submit()` resolves the deployment's declared image
+      # sources before it creates durable job identity, so the API must see the
+      # same declarations as the worker that launches the job. Keep these two
+      # values identical to `temporal-worker-agent-runtime`: a ref declared only
+      # on the worker is rejected as unconfigured before the request ever
+      # reaches Temporal.
+      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}"}]}
+      - MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=${MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES:-[{"cacheRef":"unreal-ccache","volumeName":"${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]}
       # Omnigent is a normal local runtime. Operators can still disable or
       # redirect it explicitly, but the canonical Compose path needs no hidden
       # enablement variables.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -699,13 +699,20 @@ services:
       - MOONMIND_DOCKER_STORAGE_CRITICAL_WATERMARK_PERCENT=${MOONMIND_DOCKER_STORAGE_CRITICAL_WATERMARK_PERCENT:-90}
       - MOONMIND_DOCKER_STORAGE_IMAGE_MIN_AGE_HOURS=${MOONMIND_DOCKER_STORAGE_IMAGE_MIN_AGE_HOURS:-168}
       - MOONMIND_DOCKER_STORAGE_BUILD_CACHE_MIN_AGE_HOURS=${MOONMIND_DOCKER_STORAGE_BUILD_CACHE_MIN_AGE_HOURS:-24}
-      # Deployment-approved Unreal image in the shared host daemon.
+      # Deployment-declared container-job image and cache sources. MoonMind
+      # itself carries no project image, volume, or in-container path: a caller
+      # selects one of these by its opaque ref and an unknown ref fails closed.
       # First use pulls a missing image through the trusted deployment daemon;
       # operators may explicitly select `never` when prewarming is required.
       - MOONMIND_UNREAL_ENGINE_IMAGE=${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}
       - MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY=${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}
       - MOONMIND_UNREAL_CCACHE_VOLUME_NAME=${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}
       - MOONMIND_UNREAL_UBT_VOLUME_NAME=${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}
+      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}"}]}
+      - MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=${MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES:-[{"cacheRef":"unreal-ccache","volumeName":"${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]}
+      # Non-secret deployment values portable Skills may read from a managed
+      # session. Secret-looking names are refused; secrets use credentials.
+      - MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS=${MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS:-MOONMIND_UNREAL_ENGINE_IMAGE}
       - MOONMIND_DEPLOYMENT_PROJECT_DIR=${MOONMIND_DEPLOYMENT_PROJECT_DIR:-}
       - MOONMIND_DEPLOYMENT_COMPOSE_FILE=${MOONMIND_DEPLOYMENT_COMPOSE_FILE:-}
       - MOONMIND_DEPLOYMENT_LOCAL_PROJECT_DIR=/workspace/host_project

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -313,11 +313,19 @@ Rules:
   opaque ref and an undeclared ref fails closed;
 - a declaration that is not a JSON array of objects, omits `sourceRef`/`image`
   or `cacheRef`, repeats a ref, reuses a MoonMind-reserved ref, names a
-  non-volume, or gives a non-absolute cache target is a configuration error;
+  non-volume, gives a non-absolute cache target, or carries a key outside its
+  documented schema is a configuration error. Every declaration key defaults to
+  the permissive value when omitted, so a misspelled `readOnly` or `pullPolicy`
+  would otherwise weaken the access policy the deployment asked for;
+- each declaration variable is consumed exactly as supplied and is never merged
+  with the compose-derived default, so a deployment that declares an additional
+  source repeats every source it intends to keep;
 - `resources.shmSize` is caller-owned. It is refused when it exceeds
   `MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB` (default: the memory ceiling)
   rather than clamped, so the realized value always matches the request; an
-  omitted value applies `MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB`;
+  omitted value applies `MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB`, which is
+  itself refused at configuration time when it exceeds that ceiling so an
+  omitted request can never launch above the declared maximum;
 - empty or unreachable Docker endpoints fail service readiness;
 - a missing optional image does not fail service or worker readiness;
 - local-build paths are resolved from an operator-owned deployment root, never

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -281,20 +281,21 @@ dockerBackendService:
         command: ["python", "-c", "import pytest"]
         networkMode: none
 
-    tactics-unreal:
+    # Every other image source is declared by the deployment through
+    # MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES, a JSON array of
+    # {"sourceRef", "image", "pullPolicy"} objects. MoonMind ships no project
+    # image default of its own.
+    <deployment-declared>:
       kind: registry
-      imageFrom: MOONMIND_UNREAL_ENGINE_IMAGE
-      defaultImage: ghcr.io/moonladderstudios/tactics-ue-base:5.8
+      from: MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES
       pullPolicy: if-missing
 
+  # Cache sources are declared the same way, through
+  # MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES, a JSON array of
+  # {"cacheRef", "volumeName", "target", "readOnly"} objects.
   cacheSources:
-    unreal-ccache:
-      volumeFrom: MOONMIND_UNREAL_CCACHE_VOLUME_NAME
-      target: /home/ue4/.ccache
-      readOnly: false
-    unreal-ubt:
-      volumeFrom: MOONMIND_UNREAL_UBT_VOLUME_NAME
-      target: /home/ue4/.config/Epic/UnrealBuildTool
+    <deployment-declared>:
+      from: MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES
       readOnly: false
 
   policy:
@@ -305,6 +306,18 @@ dockerBackendService:
 Rules:
 
 - unsupported backend or image-source kinds are configuration errors;
+- MoonMind owns exactly one image source, its own `moonmind-python-tests`
+  self-test image, and no cache source at all. Every project image, named
+  volume, and in-container cache path is deployment-declared, so MoonMind's
+  generic surfaces name no consuming project. A caller selects a source by its
+  opaque ref and an undeclared ref fails closed;
+- a declaration that is not a JSON array of objects, omits `sourceRef`/`image`
+  or `cacheRef`, repeats a ref, reuses a MoonMind-reserved ref, names a
+  non-volume, or gives a non-absolute cache target is a configuration error;
+- `resources.shmSize` is caller-owned. It is refused when it exceeds
+  `MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB` (default: the memory ceiling)
+  rather than clamped, so the realized value always matches the request; an
+  omitted value applies `MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB`;
 - empty or unreachable Docker endpoints fail service readiness;
 - a missing optional image does not fail service or worker readiness;
 - local-build paths are resolved from an operator-owned deployment root, never

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -313,10 +313,17 @@ Rules:
   opaque ref and an undeclared ref fails closed;
 - a declaration that is not a JSON array of objects, omits `sourceRef`/`image`
   or `cacheRef`, repeats a ref, reuses a MoonMind-reserved ref, names a
-  non-volume, gives a non-absolute cache target, or carries a key outside its
-  documented schema is a configuration error. Every declaration key defaults to
-  the permissive value when omitted, so a misspelled `readOnly` or `pullPolicy`
-  would otherwise weaken the access policy the deployment asked for;
+  non-volume, or carries a key outside its documented schema is a configuration
+  error. Every declaration key defaults to the permissive value when omitted, so
+  a misspelled `readOnly` or `pullPolicy` would otherwise weaken the access
+  policy the deployment asked for;
+- a declared cache `target` is validated by the same public request contract a
+  caller's `CacheMount.target` is: one normalized absolute container path whose
+  every segment is non-empty and carries no `..`. The backend selects a declared
+  source by matching the requested target exactly, so a target only the
+  declaration accepts — a bare `/`, a trailing or doubled slash, a space —
+  would be a cache source no valid job could ever select. It fails at
+  configuration time rather than at the launch boundary;
 - each declaration variable is consumed exactly as supplied and is never merged
   with the compose-derived default, so a deployment that declares an additional
   source repeats every source it intends to keep;

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -320,6 +320,10 @@ Rules:
 - each declaration variable is consumed exactly as supplied and is never merged
   with the compose-derived default, so a deployment that declares an additional
   source repeats every source it intends to keep;
+- both declarations must reach every process that resolves them. The API admits
+  a request by resolving its `imageSourceRef` before it creates durable job
+  identity, and the agent-runtime worker launches it, so a ref declared only on
+  the worker is rejected as unconfigured before the request reaches Temporal;
 - `resources.shmSize` is caller-owned. It is refused when it exceeds
   `MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB` (default: the memory ceiling)
   rather than clamped, so the realized value always matches the request; an

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -148,10 +148,28 @@ deferred until an operator selects another observed model, because changing a
 billing-relevant model is not an automatic recovery action. Raw key is never
 returned after submission.
 
-### Automatic re-validation after a host image change
+### Automatic re-validation after a host image change or catalog interval
 
-Model catalog evidence is bound to the exact digest-pinned host image that
-produced it and to the credential generation that was active at the time.
+Model catalog evidence answers two separate questions, and both must hold for a
+persisted observation to stay authoritative.
+
+The first is **launchable identity**: evidence is bound to the exact
+digest-pinned host image that produced it, to the credential generation that
+was active at the time, to the `opencode-auth-json@1` materializer, and it must
+contain the profile's selected default model.
+
+The second is **observation age**. The pinned host image ships a bundled model
+catalog and refreshes it from the provider at probe time, so identity alone
+would freeze whichever catalog the first successful probe observed: a healthy
+deployment never changes its credential generation or image digest on its own,
+and models the provider publishes later — contributor tiers included — would
+never reach selection, readiness, or admission.
+`OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS` bounds that age and defaults to `6`, so
+the documented one-value setup keeps observing the provider's current models
+without another operator action. Set it to `0` to re-probe only on an identity
+change. A pass that has just observed the catalog is judged on identity alone;
+the interval decides when to re-probe, not whether a fresh observation counts.
+
 Readiness, planning, and smoke admission all reject evidence that belongs to any
 other image or generation, so re-pulling or rebuilding the OpenCode host image
 invalidates every previously validated Provider Profile.
@@ -159,8 +177,8 @@ invalidates every previously validated Provider Profile.
 MoonMind therefore re-validates automatically. The Omnigent bootstrap
 reconciliation pass re-runs the pinned-runtime validation above for every
 enabled, connected OpenCode Provider Profile whose evidence no longer matches
-the currently pinned image, using the already-enrolled `opencode_api_key`
-SecretRef. No new credential is requested, no image is substituted, and a
+the currently pinned image or has aged past the catalog interval, using the
+already-enrolled `opencode_api_key` SecretRef. No new credential is requested, no image is substituted, and a
 credential the runtime rejects keeps its previous evidence and stays connected.
 Fresh catalog evidence is retained when the credential remains valid but the
 configured default model has rotated out, while readiness stays deferred rather

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -177,6 +177,12 @@ image therefore invalidates every previously validated Provider Profile, and an
 expired catalog stops advertising and launching targets until a refresh
 succeeds instead of admitting a model the provider may have removed.
 
+An observation stamped further than a small clock-skew tolerance into the
+future is rejected the same way. A VM snapshot restore or a backward host-clock
+correction would otherwise give the observation a negative age that satisfies
+any interval for as long as the timestamp stays ahead, keeping an old catalog
+authoritative well past its expiry.
+
 MoonMind therefore re-validates automatically. The Omnigent bootstrap
 reconciliation pass re-runs the pinned-runtime validation above for every
 enabled, connected OpenCode Provider Profile whose evidence no longer matches

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -170,22 +170,35 @@ without another operator action. Set it to `0` to re-probe only on an identity
 change. A pass that has just observed the catalog is judged on identity alone;
 the interval decides when to re-probe, not whether a fresh observation counts.
 
-Readiness, planning, and smoke admission all reject evidence that belongs to any
-other image or generation, so re-pulling or rebuilding the OpenCode host image
-invalidates every previously validated Provider Profile.
+Readiness, planning, and smoke admission all apply both questions: they reject
+evidence that belongs to any other image or generation, and they reject an
+observation older than the interval. Re-pulling or rebuilding the OpenCode host
+image therefore invalidates every previously validated Provider Profile, and an
+expired catalog stops advertising and launching targets until a refresh
+succeeds instead of admitting a model the provider may have removed.
 
 MoonMind therefore re-validates automatically. The Omnigent bootstrap
 reconciliation pass re-runs the pinned-runtime validation above for every
 enabled, connected OpenCode Provider Profile whose evidence no longer matches
 the currently pinned image or has aged past the catalog interval, using the
-already-enrolled `opencode_api_key` SecretRef. No new credential is requested, no image is substituted, and a
-credential the runtime rejects keeps its previous evidence and stays connected.
+already-enrolled `opencode_api_key` SecretRef. No new credential is requested,
+no image is substituted, and a credential the runtime rejects keeps its previous
+evidence and stays connected.
 Fresh catalog evidence is retained when the credential remains valid but the
 configured default model has rotated out, while readiness stays deferred rather
 than silently selecting a replacement.
 While a profile is waiting for that pass, Workflow Create reports
 `provider_runtime_revalidation_pending` rather than asking the operator to
 reconnect a profile that is already connected.
+
+That wait is bounded. Re-validation gets `MAX_REVALIDATION_ATTEMPTS` tries per
+credential generation and host image; once they are spent, the reconciler stops
+probing the provider for that identity and readiness stops reporting a pending
+wait. This is what keeps a provider outage or a revoked key from launching a
+Docker-backed probe on every background pass for as long as the deployment
+runs. Reconnecting the credential or re-pinning the host image is a new
+identity, so it restores the full attempt budget without a separate reset
+action.
 
 ## Agent Profile
 

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -204,7 +204,9 @@ wait. This is what keeps a provider outage or a revoked key from launching a
 Docker-backed probe on every background pass for as long as the deployment
 runs. Reconnecting the credential or re-pinning the host image is a new
 identity, so it restores the full attempt budget without a separate reset
-action.
+action. Only a probe the provider actually answered spends an attempt: when the
+credential maintenance lease cannot be acquired, no probe ran, so the pass
+defers with its budget intact.
 
 ## Agent Profile
 

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -349,6 +349,17 @@ Workflows that include MoonSpec verification gates must use the latest structure
 
 `FULLY_IMPLEMENTED` permits PR publication and downstream trusted side effects. `ADDITIONAL_WORK_NEEDED` keeps the workflow in the bounded remediation loop while a later MoonSpec remediation step remains. Once that retry budget is exhausted, a workflow whose publish mode is `pr` opens a draft pull request annotated with the remaining-work verdict and verification report, then fails with `attention_required: true` and skips downstream promotion or trusted handoff steps. The draft is recoverability evidence, not a successful terminal outcome. A pushed branch or created draft pull request must never be classified as `no_commit`.
 
+Publication feasibility at that gate is a property of the **run**, not of the
+step the gate stopped on. A MoonSpec verification step is read-only: it
+reports a verdict and publishes nothing, so it never carries accepted
+repository evidence of its own. When the stopping step's evidence is merely
+inconclusive, the terminal gate defers to the run-owned published head
+(`pushStatus: pushed` plus branch and head SHA in publish context), which a
+prior step established through authoritative accepted repository evidence.
+Definitive refusals recorded by a step — unauthorized publication, a
+contaminated candidate, or no candidate change — are safety decisions and are
+never overridden by that projection.
+
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 
 The gate distinguishes a verifier judgment from a malformed verdict envelope:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -364,6 +364,15 @@ refusals recorded by a step — unauthorized publication, a contaminated
 candidate, or no candidate change — are safety decisions and are never
 overridden by that projection.
 
+The published head that makes the gate feasible is also the head the draft is
+opened against. Native PR branch resolution prefers the run-owned published
+head over every other candidate, because the remaining candidates are mutable
+step metadata: the read-only verification step the gate stops on may itself
+emit `branch` and `headSha`, and the publish context mirrors whichever step
+wrote last. Deriving the publication target separately from the feasibility
+decision would open a draft for a head the managed push boundary never
+remotely verified.
+
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 
 The gate distinguishes a verifier judgment from a malformed verdict envelope:

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -353,12 +353,16 @@ Publication feasibility at that gate is a property of the **run**, not of the
 step the gate stopped on. A MoonSpec verification step is read-only: it
 reports a verdict and publishes nothing, so it never carries accepted
 repository evidence of its own. When the stopping step's evidence is merely
-inconclusive, the terminal gate defers to the run-owned published head
-(`pushStatus: pushed` plus branch and head SHA in publish context), which a
-prior step established through authoritative accepted repository evidence.
-Definitive refusals recorded by a step — unauthorized publication, a
-contaminated candidate, or no candidate change — are safety decisions and are
-never overridden by that projection.
+inconclusive, the terminal gate defers to the run-owned published head — the
+branch and head SHA a prior step established through authoritative
+`acceptedRepositoryEvidence`, recorded as one atomic projection. Raw
+`pushStatus`, `branch`, and `headSha` keys that any step's metadata may carry
+are not that evidence: `agent_runtime.fetch_result` strips forged accepted
+evidence objects but leaves those raw keys intact, so only the managed push
+boundary's own evidence can make the gate publication-feasible. Definitive
+refusals recorded by a step — unauthorized publication, a contaminated
+candidate, or no candidate change — are safety decisions and are never
+overridden by that projection.
 
 Non-retryable blocking verdicts, including `NO_DETERMINATION`, `BLOCKED`, and `FAILED_UNRECOVERABLE`, block publication without waiting for additional remediation attempts unless the workflow explicitly models the missing evidence as recoverable work inside the same bounded plan.
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -12602,6 +12602,8 @@ export interface components {
              */
             pids: number;
             gpu?: components["schemas"]["WorkloadGpuRequest"] | null;
+            /** Shmsize */
+            shmSize?: string | null;
         };
         /**
          * ResourceListResponse

--- a/moonmind/config/container_backend_settings.py
+++ b/moonmind/config/container_backend_settings.py
@@ -43,6 +43,16 @@ IMAGE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES"
 #: Deployment-declared named-volume cache sources, as a JSON array of
 #: ``{"cacheRef", "volumeName", "target", "readOnly"}`` objects.
 CACHE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES"
+
+#: The complete documented schema of each declaration. A key outside these sets
+#: is a configuration error rather than an ignored field, because every omitted
+#: key falls back to the permissive default.
+_IMAGE_SOURCE_KEYS: Final[frozenset[str]] = frozenset(
+    {"sourceRef", "image", "pullPolicy"}
+)
+_CACHE_SOURCE_KEYS: Final[frozenset[str]] = frozenset(
+    {"cacheRef", "volumeName", "target", "readOnly"}
+)
 PYTHON_TEST_FINGERPRINT_INPUTS: Final[tuple[str, ...]] = (
     ".dockerignore",
     "api_service/Dockerfile",
@@ -260,6 +270,26 @@ def _declaration_objects(
     return tuple(parsed)
 
 
+def _reject_unknown_keys(
+    item: Mapping[str, Any], *, allowed: frozenset[str], field_name: str
+) -> None:
+    """Fail a declaration that carries a key outside its documented schema.
+
+    Every key in these declarations is optional-with-a-default, so a misspelling
+    is silently permissive rather than merely ignored: ``readonly`` mounts a
+    cache read-write, and a misspelled ``pullPolicy`` restores ``if-missing`` for
+    an operator who declared ``never``. A deployment-policy mistake fails during
+    configuration instead of weakening the requested access policy at launch.
+    """
+
+    unknown = sorted(str(key) for key in item if str(key) not in allowed)
+    if unknown:
+        raise ContainerBackendConfigError(
+            f"{field_name} declares unknown key(s) {', '.join(unknown)}; "
+            f"allowed keys: {', '.join(sorted(allowed))}"
+        )
+
+
 def _declared_image_sources(
     raw: object, *, reserved_refs: frozenset[str]
 ) -> tuple[RegistryImageSource, ...]:
@@ -276,6 +306,7 @@ def _declared_image_sources(
         _declaration_objects(raw, field_name=IMAGE_SOURCES_ENV_KEY)
     ):
         field = f"{IMAGE_SOURCES_ENV_KEY}[{index}]"
+        _reject_unknown_keys(item, allowed=_IMAGE_SOURCE_KEYS, field_name=field)
         source_ref = str(item.get("sourceRef") or "").strip()
         image = str(item.get("image") or "").strip()
         if not source_ref or not image:
@@ -316,6 +347,7 @@ def _declared_cache_sources(raw: object) -> tuple[CacheSource, ...]:
         _declaration_objects(raw, field_name=CACHE_SOURCES_ENV_KEY)
     ):
         field = f"{CACHE_SOURCES_ENV_KEY}[{index}]"
+        _reject_unknown_keys(item, allowed=_CACHE_SOURCE_KEYS, field_name=field)
         cache_ref = str(item.get("cacheRef") or "").strip()
         if not cache_ref:
             raise ContainerBackendConfigError(
@@ -428,6 +460,30 @@ def resolve_container_backend_settings(
         minimum=16,
     )
 
+    shm_size_mib = _coerce_int(
+        source.get("MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB"),
+        default=64,
+        minimum=1,
+    )
+    # Defaults to the memory ceiling so an omitted value admits any
+    # shared-memory request the job's own memory ceiling already permits,
+    # and never publishes a shared-memory allowance larger than that.
+    max_shm_size_mib = _coerce_int(
+        source.get("MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB"),
+        default=max_memory_mib,
+        minimum=1,
+    )
+    if shm_size_mib > max_shm_size_mib:
+        # The launch boundary only checks caller-supplied shared-memory values,
+        # so a default above the ceiling would launch every omitted request
+        # above the deployment's own declared maximum. Reject the pair here.
+        raise ContainerBackendConfigError(
+            f"container backend shmSize default {shm_size_mib}MiB exceeds the "
+            f"deployment ceiling {max_shm_size_mib}MiB; lower "
+            "MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB or raise "
+            "MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB"
+        )
+
     return ContainerBackendSettings(
         enabled=_coerce_bool(
             source.get("MOONMIND_CONTAINER_BACKEND_ENABLED"), default=True
@@ -457,19 +513,8 @@ def resolve_container_backend_settings(
             source.get("MOONMIND_CONTAINER_BACKEND_MAX_GPU_COUNT"),
             minimum=0,
         ),
-        shm_size_mib=_coerce_int(
-            source.get("MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB"),
-            default=64,
-            minimum=1,
-        ),
-        # Defaults to the memory ceiling so an omitted value admits any
-        # shared-memory request the job's own memory ceiling already permits,
-        # and never publishes a shared-memory allowance larger than that.
-        max_shm_size_mib=_coerce_int(
-            source.get("MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB"),
-            default=max_memory_mib,
-            minimum=1,
-        ),
+        shm_size_mib=shm_size_mib,
+        max_shm_size_mib=max_shm_size_mib,
         max_timeout_seconds=_coerce_int(
             source.get("MOONMIND_CONTAINER_BACKEND_MAX_TIMEOUT_SECONDS"),
             default=14400,

--- a/moonmind/config/container_backend_settings.py
+++ b/moonmind/config/container_backend_settings.py
@@ -15,10 +15,11 @@ construction reads these settings.
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Mapping
+from typing import Any, Final, Mapping
 
 #: The only backend kind this deployment supports. A second backend kind
 #: (Podman, containerd, Kubernetes, endpoint pools) is explicitly out of scope.
@@ -33,13 +34,15 @@ _FALSEY: Final[frozenset[str]] = frozenset({"0", "false", "no", "off", ""})
 
 PYTHON_TEST_IMAGE_SOURCE_REF: Final[str] = "moonmind-python-tests"
 PYTHON_TEST_LOCAL_IMAGE: Final[str] = "moonmind-python-tests:local"
-TACTICS_UNREAL_IMAGE_SOURCE_REF: Final[str] = "tactics-unreal"
-DEFAULT_TACTICS_UNREAL_IMAGE: Final[str] = (
-    "ghcr.io/moonladderstudios/tactics-ue-base:5.8"
-)
-UNREAL_CCACHE_CACHE_REF: Final[str] = "unreal-ccache"
-UNREAL_UBT_CACHE_REF: Final[str] = "unreal-ubt"
 PYTHON_TEST_RECIPE_VERSION: Final[str] = "v1"
+
+#: Deployment-declared registry image sources, as a JSON array of
+#: ``{"sourceRef", "image", "pullPolicy"}`` objects.
+IMAGE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES"
+
+#: Deployment-declared named-volume cache sources, as a JSON array of
+#: ``{"cacheRef", "volumeName", "target", "readOnly"}`` objects.
+CACHE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES"
 PYTHON_TEST_FINGERPRINT_INPUTS: Final[tuple[str, ...]] = (
     ".dockerignore",
     "api_service/Dockerfile",
@@ -157,7 +160,11 @@ class ContainerBackendSettings:
     #: ceiling, so host capability remains the only gate; ``0`` refuses every
     #: device request on this deployment.
     max_gpu_count: int | None
+    #: Shared-memory size applied when a caller requests none.
     shm_size_mib: int
+    #: Highest shared-memory size a caller may request, in MiB. A larger
+    #: request is refused at the launch boundary rather than clamped.
+    max_shm_size_mib: int
     max_timeout_seconds: int
     max_output_bytes: int
     max_output_files: int
@@ -215,6 +222,123 @@ def _registry_pull_policy(value: object, *, default: str) -> str:
             "if-missing, always, never"
         )
     return normalized
+
+
+def _mount_target(value: object, *, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if (
+        not normalized.startswith("/")
+        or len(normalized) > 512
+        or ".." in normalized.split("/")
+    ):
+        raise ContainerBackendConfigError(
+            f"{field_name} must be a normalized absolute container path"
+        )
+    return normalized
+
+
+def _declaration_objects(
+    raw: object, *, field_name: str
+) -> tuple[Mapping[str, Any], ...]:
+    """Parse one deployment-declared JSON array of source objects."""
+
+    text = str(raw or "").strip()
+    if not text:
+        return ()
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ContainerBackendConfigError(
+            f"{field_name} must be a JSON array of objects: {exc.msg}"
+        ) from exc
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, Mapping) for item in parsed
+    ):
+        raise ContainerBackendConfigError(
+            f"{field_name} must be a JSON array of objects"
+        )
+    return tuple(parsed)
+
+
+def _declared_image_sources(
+    raw: object, *, reserved_refs: frozenset[str]
+) -> tuple[RegistryImageSource, ...]:
+    """Resolve the deployment's own registry image sources.
+
+    MoonMind ships no project image defaults: a caller selects an image through
+    an opaque ``sourceRef`` and the deployment decides what that ref resolves
+    to. An unknown ref already fails closed in ``image_source``.
+    """
+
+    sources: list[RegistryImageSource] = []
+    seen: set[str] = set()
+    for index, item in enumerate(
+        _declaration_objects(raw, field_name=IMAGE_SOURCES_ENV_KEY)
+    ):
+        field = f"{IMAGE_SOURCES_ENV_KEY}[{index}]"
+        source_ref = str(item.get("sourceRef") or "").strip()
+        image = str(item.get("image") or "").strip()
+        if not source_ref or not image:
+            raise ContainerBackendConfigError(
+                f"{field} requires a non-empty sourceRef and image"
+            )
+        if source_ref in reserved_refs:
+            raise ContainerBackendConfigError(
+                f"{field} sourceRef {source_ref!r} is reserved by MoonMind"
+            )
+        if source_ref in seen:
+            raise ContainerBackendConfigError(
+                f"{field} declares duplicate sourceRef {source_ref!r}"
+            )
+        seen.add(source_ref)
+        sources.append(
+            RegistryImageSource(
+                source_ref=source_ref,
+                image=image,
+                # First use is cold-start provisioning, not an operator-only
+                # prewarm requirement. Private registries still fail through
+                # the normal credential-aware pull contract when authorization
+                # is unavailable; deployments may explicitly select ``never``.
+                pull_policy=_registry_pull_policy(
+                    item.get("pullPolicy"), default="if-missing"
+                ),
+            )
+        )
+    return tuple(sources)
+
+
+def _declared_cache_sources(raw: object) -> tuple[CacheSource, ...]:
+    """Resolve the deployment's own named-volume cache sources."""
+
+    sources: list[CacheSource] = []
+    seen: set[str] = set()
+    for index, item in enumerate(
+        _declaration_objects(raw, field_name=CACHE_SOURCES_ENV_KEY)
+    ):
+        field = f"{CACHE_SOURCES_ENV_KEY}[{index}]"
+        cache_ref = str(item.get("cacheRef") or "").strip()
+        if not cache_ref:
+            raise ContainerBackendConfigError(
+                f"{field} requires a non-empty cacheRef"
+            )
+        if cache_ref in seen:
+            raise ContainerBackendConfigError(
+                f"{field} declares duplicate cacheRef {cache_ref!r}"
+            )
+        seen.add(cache_ref)
+        sources.append(
+            CacheSource(
+                cache_ref=cache_ref,
+                volume_name=_named_volume(
+                    item.get("volumeName"), field_name=f"{field}.volumeName"
+                ),
+                target=_mount_target(
+                    item.get("target"), field_name=f"{field}.target"
+                ),
+                read_only=_coerce_bool(item.get("readOnly"), default=False),
+            )
+        )
+    return tuple(sources)
 
 
 def resolve_container_backend_settings(
@@ -285,45 +409,23 @@ def resolve_container_backend_settings(
             validation_command=("python", "-c", "import pytest"),
         )
 
+    # The python-test image is MoonMind's own self-test surface and is the only
+    # image source MoonMind itself owns. Every other image and cache source is
+    # declared by the deployment, so no project's image, volume, or
+    # in-container path is knowledge this module carries.
     image_sources: list[ImageSource] = [python_test_source]
-    tactics_unreal_image = str(
-        source.get("MOONMIND_UNREAL_ENGINE_IMAGE")
-        or DEFAULT_TACTICS_UNREAL_IMAGE
-    ).strip()
-    image_sources.append(
-        RegistryImageSource(
-            source_ref=TACTICS_UNREAL_IMAGE_SOURCE_REF,
-            image=tactics_unreal_image,
-            # First use is cold-start provisioning, not an operator-only
-            # prewarm requirement. Private registries still fail through the
-            # normal credential-aware pull contract when authorization is
-            # unavailable; deployments may explicitly select ``never``.
-            pull_policy=_registry_pull_policy(
-                source.get("MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY"),
-                default="if-missing",
-            ),
+    image_sources.extend(
+        _declared_image_sources(
+            source.get(IMAGE_SOURCES_ENV_KEY),
+            reserved_refs=frozenset({PYTHON_TEST_IMAGE_SOURCE_REF}),
         )
     )
+    cache_sources = _declared_cache_sources(source.get(CACHE_SOURCES_ENV_KEY))
 
-    cache_sources = (
-        CacheSource(
-            cache_ref=UNREAL_CCACHE_CACHE_REF,
-            volume_name=_named_volume(
-                source.get("MOONMIND_UNREAL_CCACHE_VOLUME_NAME")
-                or "unreal_ccache_volume",
-                field_name="MOONMIND_UNREAL_CCACHE_VOLUME_NAME",
-            ),
-            target="/home/ue4/.ccache",
-        ),
-        CacheSource(
-            cache_ref=UNREAL_UBT_CACHE_REF,
-            volume_name=_named_volume(
-                source.get("MOONMIND_UNREAL_UBT_VOLUME_NAME")
-                or "unreal_ubt_volume",
-                field_name="MOONMIND_UNREAL_UBT_VOLUME_NAME",
-            ),
-            target="/home/ue4/.config/Epic/UnrealBuildTool",
-        ),
+    max_memory_mib = _coerce_int(
+        source.get("MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB"),
+        default=16384,
+        minimum=16,
     )
 
     return ContainerBackendSettings(
@@ -341,11 +443,7 @@ def resolve_container_backend_settings(
             default=8000,
             minimum=1,
         ),
-        max_memory_mib=_coerce_int(
-            source.get("MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB"),
-            default=16384,
-            minimum=16,
-        ),
+        max_memory_mib=max_memory_mib,
         max_active_memory_mib=_coerce_optional_int(
             source.get("MOONMIND_CONTAINER_BACKEND_MAX_ACTIVE_MEMORY_MIB"),
             minimum=16,
@@ -362,6 +460,14 @@ def resolve_container_backend_settings(
         shm_size_mib=_coerce_int(
             source.get("MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB"),
             default=64,
+            minimum=1,
+        ),
+        # Defaults to the memory ceiling so an omitted value admits any
+        # shared-memory request the job's own memory ceiling already permits,
+        # and never publishes a shared-memory allowance larger than that.
+        max_shm_size_mib=_coerce_int(
+            source.get("MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB"),
+            default=max_memory_mib,
             minimum=1,
         ),
         max_timeout_seconds=_coerce_int(

--- a/moonmind/config/container_backend_settings.py
+++ b/moonmind/config/container_backend_settings.py
@@ -21,6 +21,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final, Mapping
 
+from pydantic import ValidationError
+
+from moonmind.schemas.container_job_models import CacheMount
+
 #: The only backend kind this deployment supports. A second backend kind
 #: (Podman, containerd, Kubernetes, endpoint pools) is explicitly out of scope.
 SUPPORTED_CONTAINER_BACKEND_KINDS: Final[frozenset[str]] = frozenset({"docker-engine"})
@@ -235,16 +239,23 @@ def _registry_pull_policy(value: object, *, default: str) -> str:
 
 
 def _mount_target(value: object, *, field_name: str) -> str:
+    """Validate a declared mount target against the public request contract.
+
+    The backend selects a deployment cache source by matching a request's
+    ``CacheMount.target`` against this declared target exactly, so any
+    declaration the request contract would reject creates a cache source no
+    valid job can ever select. Validating through ``CacheMount`` itself keeps
+    one canonical normalization rather than a second, looser copy that fails
+    the operator at launch instead of at configuration time.
+    """
+
     normalized = str(value or "").strip()
-    if (
-        not normalized.startswith("/")
-        or len(normalized) > 512
-        or ".." in normalized.split("/")
-    ):
+    try:
+        return CacheMount(cacheRef="declared", target=normalized).target
+    except ValidationError as exc:
         raise ContainerBackendConfigError(
             f"{field_name} must be a normalized absolute container path"
-        )
-    return normalized
+        ) from exc
 
 
 def _declaration_objects(

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -2643,18 +2643,6 @@ class AppSettings(BaseSettings):
         exclude=True,
         description="Compatibility passthrough for worker capabilities declaration.",
     )
-    moonmind_unreal_ccache_volume_name: Optional[str] = Field(
-        None,
-        alias="MOONMIND_UNREAL_CCACHE_VOLUME_NAME",
-        exclude=True,
-        description="Deployment-owned ccache volume for approved container jobs.",
-    )
-    moonmind_unreal_ubt_volume_name: Optional[str] = Field(
-        None,
-        alias="MOONMIND_UNREAL_UBT_VOLUME_NAME",
-        exclude=True,
-        description="Deployment-owned UBT metadata volume for approved container jobs.",
-    )
     workflow_git_user_name: Optional[str] = Field(
         None,
         validation_alias=AliasChoices(

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -81,16 +81,49 @@ def reset_enrollment_attempts() -> None:
     _ENROLLMENT_ATTEMPTS.clear()
 
 
-def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
-    """Report whether persisted evidence still matches the launchable identity.
+def _observed_within_max_age(
+    evidence: Mapping[str, Any], *, env: Mapping[str, Any] | None, now: datetime
+) -> bool:
+    """Report whether the catalog observation is still inside its interval.
 
-    This mirrors the readiness and planner admission checks exactly: evidence
-    must belong to the profile's current credential generation and to the host
-    image the deployment currently pins.
+    The pinned host image refreshes its model catalog from the provider at
+    probe time, so an observation bound only to credential generation and image
+    digest freezes whichever catalog the first probe saw. Models the provider
+    publishes afterwards -- contributor tiers included -- would never reach
+    selection, readiness, or admission on an otherwise unchanged deployment.
     """
 
-    evidence = profile.model_catalog_evidence_json
-    if not isinstance(evidence, dict):
+    from moonmind.omnigent.settings import opencode_model_catalog_max_age
+
+    max_age = opencode_model_catalog_max_age(env=env)
+    if max_age is None:
+        return True
+    raw = str(evidence.get("validatedAt") or "").strip()
+    if not raw:
+        # An observation that cannot state when it was taken cannot be shown to
+        # be current. Re-probe rather than trust an unbounded snapshot.
+        return False
+    try:
+        observed = datetime.fromisoformat(raw)
+    except ValueError:
+        return False
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=UTC)
+    return now - observed <= max_age
+
+
+def evidence_matches_launchable_identity(
+    evidence: Any, *, profile: Any, image_ref: str
+) -> bool:
+    """Report whether one observation belongs to the launchable identity.
+
+    This mirrors the readiness and planner admission checks exactly: evidence
+    must belong to the profile's current credential generation, to the host
+    image the deployment currently pins, and to the materializer the launch
+    path uses, and it must contain the profile's selected model.
+    """
+
+    if not isinstance(evidence, Mapping):
         return False
     try:
         generation = int(evidence.get("credentialGeneration") or 0)
@@ -111,6 +144,32 @@ def evidence_is_current(profile: Any, *, image_ref: str) -> bool:
     }
     default_model = str(getattr(profile, "default_model", None) or "").strip()
     return bool(default_model and default_model in models)
+
+
+def evidence_is_current(
+    profile: Any,
+    *,
+    image_ref: str,
+    env: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Report whether persisted evidence still answers for this deployment.
+
+    Two separate questions must both hold: the observation belongs to the
+    launchable identity, and it was taken inside the configured catalog
+    interval. Identity alone would keep a first observation forever, because
+    the credential generation and image digest of a healthy deployment never
+    change on their own.
+    """
+
+    evidence = profile.model_catalog_evidence_json
+    if not evidence_matches_launchable_identity(
+        evidence, profile=profile, image_ref=image_ref
+    ):
+        return False
+    return _observed_within_max_age(
+        evidence, env=env, now=now or datetime.now(UTC)
+    )
 
 
 def _has_enrolled_credential(profile: Any) -> bool:
@@ -487,8 +546,11 @@ async def _persist_evidence(
         }
         behavior.pop(REVALIDATION_FAILURE_KEY, None)
         profile.command_behavior = behavior
-        launchable = evidence_is_current(
-            profile,
+        # This pass just observed the catalog, so the refresh interval has
+        # nothing to say about it. Only the launchable identity is in question.
+        launchable = evidence_matches_launchable_identity(
+            evidence,
+            profile=profile,
             image_ref=str(evidence.get("imageRef") or ""),
         )
         await session.commit()
@@ -548,6 +610,7 @@ __all__ = [
     "REVALIDATION_FAILURE_KEY",
     "ProviderReconcileOutcome",
     "evidence_is_current",
+    "evidence_matches_launchable_identity",
     "reconcile_opencode_provider_readiness",
     "reset_enrollment_attempts",
 ]

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Collection, Mapping
 from uuid import uuid4
 
@@ -47,6 +47,11 @@ OPENCODE_SECRET_ROLE = "opencode_api_key"
 # rejecting, which only an operator can fix.
 REVALIDATION_FAILURE_KEY = "runtime_revalidation_failure"
 MAX_REVALIDATION_ATTEMPTS = 3
+
+# Observations are stamped by whichever host ran the probe, so a small forward
+# skew is ordinary clock disagreement rather than a stale catalog. Anything
+# further ahead cannot be shown to have been taken inside the interval.
+MAX_OBSERVATION_CLOCK_SKEW = timedelta(minutes=5)
 
 # Enrollment runs the full bootstrap (image acquisition, catalog sync, pinned
 # runtime validation, qualification). Repeating that forever for configuration
@@ -121,7 +126,15 @@ def evidence_observation_is_current(
         return False
     if observed.tzinfo is None:
         observed = observed.replace(tzinfo=UTC)
-    return (now or datetime.now(UTC)) - observed <= max_age
+    age = (now or datetime.now(UTC)) - observed
+    if age < -MAX_OBSERVATION_CLOCK_SKEW:
+        # A snapshot restore or a backward host-clock correction leaves an
+        # observation stamped in the future. Its negative age would satisfy any
+        # interval for as long as the timestamp stays ahead, keeping a catalog
+        # -- including a model the provider has removed -- authoritative for
+        # that whole window. Treat it as unproven and re-probe instead.
+        return False
+    return age <= max_age
 
 
 def revalidation_is_exhausted(profile: Any, *, image_refs: Collection[str]) -> bool:
@@ -673,6 +686,7 @@ async def _record_revalidation_failure(
 
 
 __all__ = [
+    "MAX_OBSERVATION_CLOCK_SKEW",
     "MAX_REVALIDATION_ATTEMPTS",
     "OPENCODE_PROVIDER_ID",
     "OPENCODE_RUNTIME_ID",

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -28,7 +28,7 @@ import hashlib
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any, Mapping
+from typing import Any, Collection, Mapping
 from uuid import uuid4
 
 from sqlalchemy import select
@@ -81,8 +81,11 @@ def reset_enrollment_attempts() -> None:
     _ENROLLMENT_ATTEMPTS.clear()
 
 
-def _observed_within_max_age(
-    evidence: Mapping[str, Any], *, env: Mapping[str, Any] | None, now: datetime
+def evidence_observation_is_current(
+    evidence: Any,
+    *,
+    env: Mapping[str, Any] | None = None,
+    now: datetime | None = None,
 ) -> bool:
     """Report whether the catalog observation is still inside its interval.
 
@@ -91,6 +94,13 @@ def _observed_within_max_age(
     digest freezes whichever catalog the first probe saw. Models the provider
     publishes afterwards -- contributor tiers included -- would never reach
     selection, readiness, or admission on an otherwise unchanged deployment.
+
+    Every boundary that admits an OpenCode target answers this same question:
+    the bootstrap reconciler, the execution-readiness catalog, pre-session
+    planning, and smoke admission. Enforcing the interval in the reconciler
+    alone would leave the other three advertising and launching from a catalog
+    the provider has since changed -- including a model it has removed --
+    whenever a refresh has not yet succeeded.
     """
 
     from moonmind.omnigent.settings import opencode_model_catalog_max_age
@@ -98,6 +108,8 @@ def _observed_within_max_age(
     max_age = opencode_model_catalog_max_age(env=env)
     if max_age is None:
         return True
+    if not isinstance(evidence, Mapping):
+        return False
     raw = str(evidence.get("validatedAt") or "").strip()
     if not raw:
         # An observation that cannot state when it was taken cannot be shown to
@@ -109,7 +121,36 @@ def _observed_within_max_age(
         return False
     if observed.tzinfo is None:
         observed = observed.replace(tzinfo=UTC)
-    return now - observed <= max_age
+    return (now or datetime.now(UTC)) - observed <= max_age
+
+
+def revalidation_is_exhausted(profile: Any, *, image_refs: Collection[str]) -> bool:
+    """Report whether re-validation gave up on this credential and image.
+
+    Re-validation preserves the enrolled credential and its prior evidence when
+    the pinned runtime rejects it, so a revoked key or a provider outage looks
+    exactly like an attempt in flight. ``_record_revalidation_failure`` records
+    the bounded outcome, and reading it is what keeps the reconciler from
+    probing the provider on every background pass and keeps readiness from
+    promising a wait that finishes automatically.
+
+    The record is scoped to the image and credential generation it was earned
+    against, so re-pinning the host image or reconnecting the credential
+    restores the full attempt budget without a separate reset action.
+    """
+
+    behavior = getattr(profile, "command_behavior", None) or {}
+    record = behavior.get(REVALIDATION_FAILURE_KEY)
+    if not isinstance(record, Mapping) or record.get("exhausted") is not True:
+        return False
+    try:
+        generation = int(record.get("credentialGeneration") or 0)
+    except (TypeError, ValueError):
+        return False
+    if generation != int(profile.credential_generation):
+        # A rotated credential has not been attempted yet.
+        return False
+    return str(record.get("imageRef") or "") in set(image_refs)
 
 
 def evidence_matches_launchable_identity(
@@ -167,9 +208,7 @@ def evidence_is_current(
         evidence, profile=profile, image_ref=image_ref
     ):
         return False
-    return _observed_within_max_age(
-        evidence, env=env, now=now or datetime.now(UTC)
-    )
+    return evidence_observation_is_current(evidence, env=env, now=now)
 
 
 def _has_enrolled_credential(profile: Any) -> bool:
@@ -401,7 +440,9 @@ async def _revalidate_stale_evidence(
 
     A profile the runtime rejects is left untouched and reported as deferred:
     this boundary never downgrades an enrolled credential, and it never records
-    evidence for an image other than the one the deployment selects.
+    evidence for an image other than the one the deployment selects. Once the
+    recorded attempt budget is exhausted for that identity the profile stops
+    being probed at all and is reported as an operator-actionable deferral.
     """
 
     from moonmind.omnigent.opencode_runtime_validation import (
@@ -421,10 +462,31 @@ async def _revalidate_stale_evidence(
     if not stale:
         return ProviderReconcileOutcome(ready=True, checked=checked)
 
-    resolver = build_omnigent_secret_resolver()
+    # An identity this image has already rejected ``MAX_REVALIDATION_ATTEMPTS``
+    # times learns nothing from another Docker-backed probe, and the startup
+    # maintainer re-enters this boundary every 120 seconds for as long as
+    # readiness stays false. Without this the recorded budget bounds nothing:
+    # a provider outage or a revoked key would probe the provider forever.
+    # Re-pinning the image or reconnecting the credential restores the budget.
+    exhausted_ids = {
+        profile.profile_id
+        for profile in stale
+        if revalidation_is_exhausted(profile, image_refs=(image_ref,))
+    }
+    for profile_id in sorted(exhausted_ids):
+        logger.warning(
+            "OpenCode Provider Profile re-validation is exhausted; skipping the "
+            "pinned runtime probe until the credential or host image changes: "
+            "profile_id=%s image_ref=%s",
+            profile_id,
+            image_ref,
+        )
+    pending = [p for p in stale if p.profile_id not in exhausted_ids]
+
+    resolver = build_omnigent_secret_resolver() if pending else None
     refreshed: list[str] = []
-    deferred: list[str] = []
-    for row in stale:
+    deferred: list[str] = sorted(exhausted_ids)
+    for row in pending:
         profile_id = row.profile_id
         operation_id = uuid4().hex
         guard = None
@@ -497,12 +559,20 @@ async def _revalidate_stale_evidence(
             image_ref,
         )
 
+    reasons: list[str] = []
+    if exhausted_ids:
+        reasons.append(
+            "pinned runtime re-validation exhausted; reconnect the credential "
+            "or re-pin the OpenCode host image"
+        )
+    if len(deferred) > len(exhausted_ids):
+        reasons.append("pinned runtime re-validation deferred")
     return ProviderReconcileOutcome(
         ready=not deferred,
         checked=checked,
         refreshed=tuple(refreshed),
         deferred=tuple(deferred),
-        reason=None if not deferred else "pinned runtime re-validation deferred",
+        reason="; ".join(reasons) or None,
     )
 
 
@@ -611,6 +681,8 @@ __all__ = [
     "ProviderReconcileOutcome",
     "evidence_is_current",
     "evidence_matches_launchable_identity",
+    "evidence_observation_is_current",
     "reconcile_opencode_provider_readiness",
     "reset_enrollment_attempts",
+    "revalidation_is_exhausted",
 ]

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -456,6 +456,8 @@ async def _revalidate_stale_evidence(
     evidence for an image other than the one the deployment selects. Once the
     recorded attempt budget is exhausted for that identity the profile stops
     being probed at all and is reported as an operator-actionable deferral.
+    Only an attempt the provider answered spends that budget: a pass that never
+    acquired the credential maintenance lease defers with the budget intact.
     """
 
     from moonmind.omnigent.opencode_runtime_validation import (
@@ -502,8 +504,6 @@ async def _revalidate_stale_evidence(
     for row in pending:
         profile_id = row.profile_id
         operation_id = uuid4().hex
-        guard = None
-        evidence: dict[str, Any] | None = None
         try:
             guard = await acquire_credential_maintenance_guard(
                 runtime_id=OPENCODE_RUNTIME_ID,
@@ -515,6 +515,28 @@ async def _revalidate_stale_evidence(
                     "ownerIsWorkflow": False,
                 },
             )
+        except Exception as exc:
+            # The maintenance lease is a MoonMind-side authority handoff, not a
+            # provider verdict: contention with another maintainer, or a
+            # transient Temporal/profile-manager error, means no probe ran.
+            # Charging it to MAX_REVALIDATION_ATTEMPTS would let three such
+            # deferrals retire a credential the provider never rejected, and
+            # `revalidation_is_exhausted` would then skip the profile until its
+            # credential or host image changes. Preserve the budget and defer to
+            # the startup maintainer's own retry interval.
+            deferred.append(profile_id)
+            logger.warning(
+                "OpenCode Provider Profile re-validation could not acquire the "
+                "credential maintenance lease; the attempt budget is preserved: "
+                "profile_id=%s image_ref=%s error=%s",
+                profile_id,
+                image_ref,
+                exc,
+            )
+            continue
+
+        evidence: dict[str, Any] | None = None
+        try:
             evidence = await OpenCodeProviderRuntimeValidationService(
                 session_factory=session_factory,
                 resolver=resolver,
@@ -530,15 +552,14 @@ async def _revalidate_stale_evidence(
                 exc,
             )
         finally:
-            if guard is not None:
-                try:
-                    await guard.release()
-                except Exception:
-                    logger.warning(
-                        "OpenCode re-validation lease release failed: profile_id=%s",
-                        profile_id,
-                        exc_info=True,
-                    )
+            try:
+                await guard.release()
+            except Exception:
+                logger.warning(
+                    "OpenCode re-validation lease release failed: profile_id=%s",
+                    profile_id,
+                    exc_info=True,
+                )
         if evidence is None:
             await _record_revalidation_failure(
                 session_factory=session_factory,

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -681,6 +681,10 @@ class OmnigentExecutionPlanningService:
         *,
         expected_image_ref: str,
     ) -> None:
+        from moonmind.omnigent.bootstrap.provider_revalidation import (
+            evidence_observation_is_current,
+        )
+
         evidence = provider.model_catalog_evidence_json
         if not isinstance(evidence, Mapping):
             raise HarnessPlatformError(
@@ -699,6 +703,18 @@ class OmnigentExecutionPlanningService:
         if str(evidence.get("imageRef") or "") != expected_image_ref:
             raise HarnessPlatformError(
                 "Provider Profile model evidence belongs to a different host image",
+                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+            )
+        if not evidence_observation_is_current(evidence):
+            # The credential generation and image digest of a healthy
+            # deployment never change on their own, so identity alone would let
+            # this boundary launch from the first catalog it ever observed --
+            # including a model the provider has since removed. The bootstrap
+            # reconciler re-probes on the same interval; refusing here is what
+            # makes that refresh authoritative instead of advisory.
+            raise HarnessPlatformError(
+                "Provider Profile model evidence is older than the configured "
+                "model catalog refresh interval",
                 code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
             )
         raw_models = evidence.get("models")

--- a/moonmind/omnigent/settings.py
+++ b/moonmind/omnigent/settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Mapping
 
 OMNIGENT_DISABLED_MESSAGE = (
@@ -88,6 +89,8 @@ def is_omnigent_enabled(*, env: Mapping[str, Any] | None = None) -> bool:
 
 OPENCODE_API_KEY_ENV = "OPENCODE_API_KEY"
 OPENCODE_CONTRIBUTOR_DATA_USE_ENV = "OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE"
+OPENCODE_MODEL_CATALOG_MAX_AGE_ENV = "OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS"
+OPENCODE_MODEL_CATALOG_DEFAULT_MAX_AGE_HOURS = 6.0
 
 
 def _parse_bool_with_default(
@@ -163,6 +166,44 @@ def opencode_contributor_data_use_accepted(
     return _parse_bool_with_default(
         source.get(OPENCODE_CONTRIBUTOR_DATA_USE_ENV), default=True
     )
+
+
+def opencode_model_catalog_max_age(
+    *, env: Mapping[str, Any] | None = None
+) -> timedelta | None:
+    """Return how long persisted OpenCode model catalog evidence stays current.
+
+    The pinned host image ships a bundled model catalog and refreshes it from
+    the upstream catalog service at probe time. Binding evidence only to the
+    credential generation and the image digest therefore freezes whichever
+    catalog the first successful probe observed: models the provider publishes
+    later never reach selection, readiness, or admission.
+
+    Re-probing on a bounded interval is the default so the documented one-value
+    setup keeps observing the provider's current models, including contributor
+    tiers. ``0`` disables the interval and restores identity-only staleness.
+    """
+
+    source = env if env is not None else os.environ
+    cleaned = _clean(source.get(OPENCODE_MODEL_CATALOG_MAX_AGE_ENV))
+    if not cleaned:
+        hours = OPENCODE_MODEL_CATALOG_DEFAULT_MAX_AGE_HOURS
+    else:
+        try:
+            hours = float(cleaned)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid {OPENCODE_MODEL_CATALOG_MAX_AGE_ENV} value {cleaned!r}: "
+                "expected a non-negative number of hours"
+            ) from exc
+        if hours < 0:
+            raise ValueError(
+                f"invalid {OPENCODE_MODEL_CATALOG_MAX_AGE_ENV} value {cleaned!r}: "
+                "expected a non-negative number of hours"
+            )
+    if hours == 0:
+        return None
+    return timedelta(hours=hours)
 
 
 def omnigent_evidence_policy(
@@ -292,9 +333,12 @@ __all__ = [
     "generic_host_enabled",
     "opencode_support_enabled",
     "opencode_contributor_data_use_accepted",
+    "opencode_model_catalog_max_age",
     "resolved_opencode_api_key",
     "OPENCODE_API_KEY_ENV",
     "OPENCODE_CONTRIBUTOR_DATA_USE_ENV",
+    "OPENCODE_MODEL_CATALOG_DEFAULT_MAX_AGE_HOURS",
+    "OPENCODE_MODEL_CATALOG_MAX_AGE_ENV",
     "omnigent_evidence_policy",
     "OMNIGENT_GENERIC_HOST_ENABLED_ENV",
     "OMNIGENT_OPENCODE_ENABLED_ENV",

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -15,6 +15,7 @@ from moonmind.schemas.workload_models import (
     WorkloadGpuRequest,
     WorkloadGpuRequestError,
     WorkloadGpuVendor,
+    parse_size_bytes,
 )
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
@@ -29,7 +30,7 @@ MAX_TEMPORAL_PAYLOAD_BYTES = 64 * 1024
 MAX_LOG_PAGE_ENTRIES = 500
 MAX_ARTIFACT_PAGE_ENTRIES = 200
 _JOB_ID = re.compile(r"^container-job:[0-9a-f]{32}$")
-_SECRET_KEY = re.compile(r"(?:password|passwd|secret|token|api[_-]?key|auth|credential|docker_host|registry_auth)", re.I)
+SENSITIVE_ENVIRONMENT_KEY_PATTERN = re.compile(r"(?:password|passwd|secret|token|api[_-]?key|auth|credential|docker_host|registry_auth)", re.I)
 _FORBIDDEN_KEYS = {
     "dockerhost", "dockerurl", "socketpath", "tlspath", "hostpath", "sourcepath",
     "privileged", "devices", "pidmode", "ipcmode", "utsmode", "usernsmode",
@@ -181,7 +182,10 @@ class EnvironmentOverride(ContractModel):
     def exactly_one_value(self) -> "EnvironmentOverride":
         if (self.value is None) == (self.secret_ref is None):
             raise ValueError("exactly one of value or secretRef is required")
-        if _SECRET_KEY.search(self.name) and self.value is not None:
+        if (
+            SENSITIVE_ENVIRONMENT_KEY_PATTERN.search(self.name)
+            and self.value is not None
+        ):
             raise ValueError("sensitive environment keys require secretRef")
         return self
 
@@ -200,6 +204,20 @@ class ResourceLimits(ContractModel):
     # request contract is shared with the container launch boundary so a GPU
     # resource has exactly one canonical shape.
     gpu: WorkloadGpuRequest | None = None
+    # A caller-supplied shared-memory size, spelled as a Docker size string so
+    # the contract matches the workload launch boundary. Absent means the
+    # deployment default applies; a request above the deployment ceiling is
+    # refused at the launch boundary rather than clamped, so the realized value
+    # never differs from the value the caller asked for.
+    shm_size: str | None = Field(None, alias="shmSize", max_length=32)
+
+    @field_validator("shm_size")
+    @classmethod
+    def _shm_size_is_a_size(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        parse_size_bytes(value)
+        return value
 
 
 class OutputDeclaration(ContractModel):
@@ -1018,7 +1036,9 @@ def _reject_forbidden(value: Any, path: str = "request") -> None:
     if isinstance(value, dict):
         for raw_key, nested in value.items():
             key = re.sub(r"[^a-z0-9]", "", str(raw_key).lower())
-            if key in _FORBIDDEN_KEYS or _SECRET_KEY.fullmatch(key):
+            if key in _FORBIDDEN_KEYS or SENSITIVE_ENVIRONMENT_KEY_PATTERN.fullmatch(
+                key
+            ):
                 raise ValueError(f"{path}.{raw_key} is forbidden")
             _reject_forbidden(nested, f"{path}.{raw_key}")
     elif isinstance(value, list):

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -192,8 +192,20 @@ class EnvironmentOverride(ContractModel):
 
 class CacheMount(ContractModel):
     cache_ref: str = Field(alias="cacheRef", min_length=1, max_length=255)
-    target: str = Field(pattern=r"^/[A-Za-z0-9._/@+-]+(?:/[A-Za-z0-9._@+-]+)*$", max_length=512)
+    # A normalized absolute container path: every segment is non-empty, so a
+    # bare ``/``, a trailing slash, and a doubled separator are all refused.
+    # The leading segment previously admitted ``/`` itself, which made the
+    # per-segment group unreachable and accepted un-normalized targets that
+    # the deployment's declared cache target could never match exactly.
+    target: str = Field(pattern=r"^/[A-Za-z0-9._@+-]+(?:/[A-Za-z0-9._@+-]+)*$", max_length=512)
     read_only: bool = Field(False, alias="readOnly")
+
+    @field_validator("target")
+    @classmethod
+    def _target_is_normalized(cls, value: str) -> str:
+        if ".." in value.split("/"):
+            raise ValueError("target must be a normalized absolute container path")
+        return value
 
 
 class ResourceLimits(ContractModel):

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -472,12 +472,58 @@ _PROPOSAL_TELEMETRY_TAG_LABELS = {
     "retry": "retry",
 }
 _AUTO_SKILL_SENTINEL = "auto"
-_NON_SECRET_MANAGED_SESSION_ENV_KEYS: tuple[str, ...] = (
-    "MOONMIND_URL",
-    # Non-secret Unreal toolchain image ref consumed by portable skills that submit
-    # typed container jobs through MoonMind's API-owned Docker Backend.
-    "MOONMIND_UNREAL_ENGINE_IMAGE",
+#: Non-secret MoonMind-owned keys every managed session may read.
+_NON_SECRET_MANAGED_SESSION_ENV_KEYS: tuple[str, ...] = ("MOONMIND_URL",)
+
+#: Deployment-declared, comma-separated non-secret environment keys forwarded to
+#: managed sessions. A portable Skill that needs a deployment-owned non-secret
+#: value -- an image ref, a registry host, a project identifier -- is served by
+#: the operator declaring the key here, so MoonMind carries no project's variable
+#: names in its own source.
+_MANAGED_SESSION_ENV_ALLOWLIST_KEY: str = (
+    "MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS"
 )
+_ENV_KEY_SHAPE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+
+
+def _declared_non_secret_managed_session_env_keys() -> tuple[str, ...]:
+    """Resolve the deployment's declared non-secret managed-session env keys.
+
+    Secret-looking names are refused using the same rule that governs plaintext
+    environment values on the container-job contract: secrets travel the
+    credential path, never this one.
+    """
+
+    from moonmind.schemas.container_job_models import (
+        SENSITIVE_ENVIRONMENT_KEY_PATTERN,
+    )
+
+    keys: list[str] = []
+    raw = os.environ.get(_MANAGED_SESSION_ENV_ALLOWLIST_KEY) or ""
+    for candidate in raw.split(","):
+        key = candidate.strip()
+        if not key or key in keys:
+            continue
+        if _ENV_KEY_SHAPE.fullmatch(key) is None:
+            logger.warning(
+                "ignoring malformed managed-session environment key %r declared "
+                "in %s",
+                key,
+                _MANAGED_SESSION_ENV_ALLOWLIST_KEY,
+            )
+            continue
+        if SENSITIVE_ENVIRONMENT_KEY_PATTERN.search(key):
+            logger.warning(
+                "refusing to forward secret-looking managed-session environment "
+                "key %r declared in %s; use the credential path instead",
+                key,
+                _MANAGED_SESSION_ENV_ALLOWLIST_KEY,
+            )
+            continue
+        keys.append(key)
+    return tuple(keys)
+
+
 _MANAGED_SESSION_TELEMETRY_KEYS: tuple[str, ...] = (
     "activityType",
     "agentRunId",
@@ -10015,7 +10061,10 @@ class TemporalAgentRuntimeActivities:
                     profile=profile,
                 )
             )
-        for key in _NON_SECRET_MANAGED_SESSION_ENV_KEYS:
+        for key in (
+            *_NON_SECRET_MANAGED_SESSION_ENV_KEYS,
+            *_declared_non_secret_managed_session_env_keys(),
+        ):
             value = os.environ.get(key)
             if value is not None and value.strip() and key not in environment:
                 environment[key] = value

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -100,6 +100,7 @@ from moonmind.security.egress_conformance_evidence import (
 from moonmind.schemas.workload_models import (
     WORKLOAD_GPU_VENDORS,
     WorkloadGpuRequest,
+    parse_size_bytes,
 )
 from moonmind.schemas.workspace_locator_models import (
     ExternalStateLocator,
@@ -669,6 +670,16 @@ class DockerContainerJobBackend:
                     ContainerJobFailureClass.RESOURCE_LIMIT_EXCEEDED,
                     f"{name}={requested} exceeds the deployment ceiling {ceiling} "
                     "and cannot be raised by a caller",
+                )
+        requested_shm = spec.resources.shm_size
+        if requested_shm is not None:
+            requested_shm_mib = parse_size_bytes(requested_shm) / (1024 * 1024)
+            if requested_shm_mib > ceilings.max_shm_size_mib:
+                raise ContainerJobBackendError(
+                    ContainerJobFailureClass.RESOURCE_LIMIT_EXCEEDED,
+                    f"shmSize={requested_shm} exceeds the deployment ceiling "
+                    f"{ceilings.max_shm_size_mib}MiB and cannot be raised by a "
+                    "caller",
                 )
         gpu = spec.resources.gpu
         if gpu is not None and ceilings.max_gpu_count is not None:
@@ -2028,7 +2039,10 @@ class DockerContainerJobBackend:
             "--memory",
             f"{spec.resources.memory_mib}m",
             "--shm-size",
-            f"{self._settings.shm_size_mib}m",
+            # The caller owns this resource once the deployment ceiling has
+            # admitted it; the deployment default only applies when the request
+            # omits it.
+            spec.resources.shm_size or f"{self._settings.shm_size_mib}m",
             "--pids-limit",
             str(spec.resources.pids),
             "--workdir",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4373,6 +4373,65 @@ class MoonMindRunWorkflow:
             return None
         return branch, head_sha
 
+    def _accepted_published_head(self) -> tuple[str, str] | None:
+        """Return the ``(branch, headSha)`` a managed push boundary accepted.
+
+        ``_publish_context`` mirrors raw ``branch``, ``headSha``, and
+        ``pushStatus`` keys from every step's metadata. ``fetch_result`` strips
+        forged ``acceptedRepositoryEvidence`` objects but leaves those raw keys
+        intact, so a read-only verifier -- or any other non-publishing step --
+        can populate all three without a remote head ever having been verified,
+        and successive steps can leave a mixed tuple behind by overwriting only
+        one of them. Read the atomic projection recorded from accepted evidence
+        instead, so the terminal gate's draft publication is only ever offered
+        a head the managed push boundary itself produced.
+        """
+
+        head = self._publish_context.get("acceptedPublishedHead")
+        if not isinstance(head, Mapping):
+            return None
+        branch = _normalize_git_branch_ref(head.get("branch"))
+        head_sha = self._coerce_text(head.get("headSha"), max_chars=80)
+        if not branch or not head_sha:
+            return None
+        return branch, head_sha
+
+    def _record_accepted_published_head(self, outputs: Mapping[str, Any]) -> None:
+        """Project one step's accepted repository evidence as the run's head.
+
+        Only the managed git-push boundary emits accepted repository evidence,
+        so this is the run's authoritative answer to "a verified remote head
+        exists". Branch and head SHA are recorded together, never key by key.
+        """
+
+        evidence = outputs.get("acceptedRepositoryEvidence")
+        if not isinstance(evidence, Mapping):
+            evidence = outputs.get("accepted_repository_evidence")
+        if not isinstance(evidence, Mapping):
+            return
+        if (
+            evidence.get("publicationAuthorized") is False
+            or evidence.get("candidateContaminated") is True
+        ):
+            # A definitive refusal from the publish boundary retires the
+            # projection rather than leaving an earlier head to answer for it.
+            self._publish_context.pop("acceptedPublishedHead", None)
+            return
+        push_status = str(evidence.get("pushStatus") or "").strip().lower()
+        if push_status not in {"pushed", "published"}:
+            return
+        branch = _normalize_git_branch_ref(evidence.get("branch"))
+        head_sha = self._coerce_text(
+            evidence.get("headSha") or evidence.get("head_sha"),
+            max_chars=80,
+        )
+        if not branch or not head_sha:
+            return
+        self._publish_context["acceptedPublishedHead"] = {
+            "branch": branch,
+            "headSha": head_sha,
+        }
+
     def _published_branch_remediation_workspace_spec(
         self,
         *,
@@ -16515,6 +16574,7 @@ class MoonMindRunWorkflow:
         )
         if head_sha:
             self._publish_context["headSha"] = head_sha
+        self._record_accepted_published_head(outputs)
 
         self._record_report_result(execution_result)
 
@@ -16951,7 +17011,7 @@ class MoonMindRunWorkflow:
             and self._patched_or_false_outside_workflow(
                 RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH
             )
-            and self._workflow_verified_published_head() is not None
+            and self._accepted_published_head() is not None
         ):
             return PublicationFeasibility(
                 feasible=True,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -15827,8 +15827,25 @@ class MoonMindRunWorkflow:
         last_node_inputs: Mapping[str, Any],
         publish_payload: Mapping[str, Any],
     ) -> tuple[str, str]:
+        # The accepted published head is the only branch a managed push
+        # boundary remotely verified for this run, and it is recorded branch
+        # and SHA together. Every other head candidate is raw step metadata:
+        # ``_record_execution_context`` mirrors ``branch``/``push_branch`` from
+        # whichever step ran last, so a read-only verifier -- the step the
+        # MoonSpec terminal gate always trips on -- can name a branch that was
+        # never pushed. The gate resolves publication feasibility from the
+        # accepted head, so publication must target that same head rather than
+        # re-deriving one from mutable metadata.
+        accepted_head: str | None = None
+        if self._patched_or_false_outside_workflow(
+            RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH
+        ):
+            accepted = self._accepted_published_head()
+            if accepted is not None:
+                accepted_head = accepted[0]
         if workflow.patched(NATIVE_PR_BRANCH_DEFAULTS_PATCH):
             head_candidates = (
+                accepted_head,
                 agent_outputs.get("push_branch"),
                 self._publish_context.get("branch"),
                 agent_outputs.get("branch"),
@@ -15848,6 +15865,7 @@ class MoonMindRunWorkflow:
             )
         else:
             head_candidates = (
+                accepted_head,
                 agent_outputs.get("push_branch"),
                 self._publish_context.get("branch"),
                 agent_outputs.get("branch"),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -794,6 +794,9 @@ RUN_WORKFLOW_GATE_TERMINAL_HANDOFF_PATCH = "run-workflow-gate-terminal-handoff-v
 RUN_MOONSPEC_DRAFT_PUBLISH_RECOVERY_HANDOFF_PATCH = (
     "run-moonspec-draft-publish-recovery-handoff-v1"
 )
+RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH = (
+    "run-terminal-gate-published-head-feasibility-v1"
+)
 RUN_AUTHORITATIVE_PUBLISH_OUTCOME_PATCH = "run-authoritative-publish-outcome-v1"
 RUN_AUTHORITATIVE_PR_REQUIREMENT_PATCH = "run-authoritative-pr-requirement-v1"
 RUN_STEP_RETRY_OVERRIDES_PATCH = "run-step-retry-overrides-v1"
@@ -4346,12 +4349,15 @@ class MoonMindRunWorkflow:
         workspace_spec.pop("branch", None)
         return workspace_spec
 
-    def _published_branch_remediation_workspace_spec(
-        self,
-        *,
-        node_inputs: Mapping[str, Any],
-    ) -> dict[str, Any] | None:
-        """Return the workflow-verified published head for external remediation."""
+    def _workflow_verified_published_head(self) -> tuple[str, str] | None:
+        """Return the run-owned published ``(branch, headSha)`` when verified.
+
+        ``pushStatus`` only reaches ``pushed`` once a step produced
+        authoritative accepted repository evidence, so this projection is the
+        run's durable authority for "a verified remote head exists". Steps that
+        publish nothing -- read-only MoonSpec verification in particular --
+        report no push status and leave the projection untouched.
+        """
 
         if (
             str(self._publish_context.get("pushStatus") or "").strip().lower()
@@ -4365,6 +4371,19 @@ class MoonMindRunWorkflow:
         )
         if not branch or not head_sha:
             return None
+        return branch, head_sha
+
+    def _published_branch_remediation_workspace_spec(
+        self,
+        *,
+        node_inputs: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        """Return the workflow-verified published head for external remediation."""
+
+        published_head = self._workflow_verified_published_head()
+        if published_head is None:
+            return None
+        branch, head_sha = published_head
 
         runtime = node_inputs.get("runtime")
         runtime_inputs = runtime if isinstance(runtime, Mapping) else {}
@@ -9377,15 +9396,10 @@ class MoonMindRunWorkflow:
     ) -> None:
         """Pin a downstream fresh workspace to the verified published head."""
 
-        if self._publish_context.get("pushStatus") != "pushed":
+        published_head = self._workflow_verified_published_head()
+        if published_head is None:
             return
-        branch = _normalize_git_branch_ref(self._publish_context.get("branch"))
-        head_sha = self._coerce_text(
-            self._publish_context.get("headSha"),
-            max_chars=80,
-        )
-        if not branch or not head_sha:
-            return
+        branch, head_sha = published_head
 
         repository_target_raw = workspace_spec.get("repositoryTarget")
         repository_target = (
@@ -16918,7 +16932,36 @@ class MoonMindRunWorkflow:
         return self._publication_feasibility(execution_result)["feasible"]
 
     def _publication_feasibility(self, execution_result: Any) -> dict[str, Any]:
-        """Classify accepted repository evidence before selecting a handoff."""
+        """Resolve publication feasibility for the run, not just for one step.
+
+        ``_step_publication_feasibility`` classifies the evidence a single step
+        produced. The MoonSpec terminal gate always trips on a read-only
+        verification step, which pushes nothing and therefore always classifies
+        as ``publication_state_ambiguous``. That made the mandated draft
+        publication handoff unreachable and orphaned pushed remediation heads,
+        so an ambiguous step classification defers to the run's durable
+        published head. Definitive negatives (unauthorized, contaminated, no
+        candidate change) are preserved -- they are safety decisions, not
+        missing knowledge.
+        """
+
+        feasibility = self._step_publication_feasibility(execution_result)
+        if (
+            feasibility.get("reason") == "publication_state_ambiguous"
+            and self._patched_or_false_outside_workflow(
+                RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH
+            )
+            and self._workflow_verified_published_head() is not None
+        ):
+            return PublicationFeasibility(
+                feasible=True,
+                reason="verified_remote_head",
+                evidenceRefs=tuple(feasibility.get("evidenceRefs") or ()),
+            ).model_dump(by_alias=True)
+        return feasibility
+
+    def _step_publication_feasibility(self, execution_result: Any) -> dict[str, Any]:
+        """Classify accepted repository evidence produced by a single step."""
 
         if self._extract_pull_request_url(execution_result):
             return PublicationFeasibility(

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
@@ -8,5 +8,6 @@
   "verificationGateRunFeasibilityReason": "verified_remote_head",
   "verificationGateTerminalHandoff": "draft_publication",
   "verificationGateUnpatchedTerminalHandoff": "artifact_backed",
-  "draftPullRequestIsDraft": true
+  "draftPullRequestIsDraft": true,
+  "verificationGateUnverifiedFeasibilityReason": "publication_state_ambiguous"
 }

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
@@ -9,5 +9,8 @@
   "verificationGateTerminalHandoff": "draft_publication",
   "verificationGateUnpatchedTerminalHandoff": "artifact_backed",
   "draftPullRequestIsDraft": true,
-  "verificationGateUnverifiedFeasibilityReason": "publication_state_ambiguous"
+  "verificationGateUnverifiedFeasibilityReason": "publication_state_ambiguous",
+  "verificationGateContaminatedPublishContextBranch": "moonspec-verify-scratch-53e35d1e",
+  "verificationGateDraftHeadBranch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+  "verificationGateDraftBaseBranch": "main"
 }

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/expected-outcome.json
@@ -3,5 +3,10 @@
   "acceptedEvidenceAuthority": "agent_runtime.fetch_result",
   "publicationFeasible": true,
   "publicationFeasibilityReason": "verified_remote_head",
-  "terminalHandoff": "draft_publication"
+  "terminalHandoff": "draft_publication",
+  "verificationGateStepFeasibilityReason": "publication_state_ambiguous",
+  "verificationGateRunFeasibilityReason": "verified_remote_head",
+  "verificationGateTerminalHandoff": "draft_publication",
+  "verificationGateUnpatchedTerminalHandoff": "artifact_backed",
+  "draftPullRequestIsDraft": true
 }

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
@@ -59,6 +59,20 @@
           "remoteVerified": true
         }
       },
+      "contaminatingVerificationStepOutputs": {
+        "summary": "MoonSpec verification report",
+        "branch": "moonspec-verify-scratch-53e35d1e",
+        "headSha": "b31f0a9e6d2c4718ae5039c8f1720d64a9e3b5c7",
+        "moonSpecVerify": {
+          "schemaVersion": 1,
+          "verdict": "ADDITIONAL_WORK_NEEDED",
+          "confidence": "HIGH",
+          "gateResultRef": "art_01M13KMEQB4J3GA51HD4RMBBSY"
+        }
+      },
+      "publishPayload": {
+        "prBaseBranch": "main"
+      },
       "unverifiedPublishContext": {
         "pushStatus": "pushed",
         "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "escaped-failure-replay/v1",
-  "incident": "verified pushed branches were orphaned after MoonSpec remediation exhaustion",
+  "incident": "verified pushed branches were orphaned after MoonSpec remediation exhaustion, including when the gate tripped on a read-only verification step that published nothing of its own",
   "publishMode": "pr",
   "draftPublicationPolicy": "draft_pr_on_additional_work_needed",
   "cases": [
@@ -24,6 +24,55 @@
         "push_head_sha": "669cc50ce4b2aba63f0d68ecf1abf4daa793f9b8",
         "push_commit_count": 3,
         "remote_verified": true
+      }
+    }
+  ],
+  "verificationGateCases": [
+    {
+      "workflowId": "mm:53e35d1e-343c-4ebb-9029-9ed823cd090f",
+      "gateLogicalStepId": "issue-implementation-remediation:verification:3",
+      "verdict": "ADDITIONAL_WORK_NEEDED",
+      "verificationStepOutputs": {
+        "summary": "MoonSpec verification report",
+        "moonSpecVerify": {
+          "schemaVersion": 1,
+          "verdict": "ADDITIONAL_WORK_NEEDED",
+          "confidence": "HIGH",
+          "gateResultRef": "art_01M13KMEQB4J3GA51HD4RMBBSY"
+        }
+      },
+      "publishContext": {
+        "pushStatus": "pushed",
+        "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+        "baseRef": "origin/main",
+        "headSha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+        "commitCount": 2
+      }
+    }
+  ],
+  "preservedNegativeCases": [
+    {
+      "reason": "publication_unauthorized",
+      "acceptedRepositoryEvidence": {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "pushed",
+        "publicationAuthorized": false
+      }
+    },
+    {
+      "reason": "candidate_contaminated",
+      "acceptedRepositoryEvidence": {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "pushed",
+        "candidateContaminated": true
+      }
+    },
+    {
+      "reason": "no_candidate_change",
+      "acceptedRepositoryEvidence": {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "no_commits",
+        "commitsAheadOfBase": 0
       }
     }
   ]

--- a/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
+++ b/tests/integration/reliability/replays/draft-publication-authority-gap/manifest.json
@@ -41,7 +41,25 @@
           "gateResultRef": "art_01M13KMEQB4J3GA51HD4RMBBSY"
         }
       },
-      "publishContext": {
+      "remediationStepOutputs": {
+        "summary": "Applied MoonSpec remediation",
+        "push_status": "pushed",
+        "push_branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+        "push_base_ref": "origin/main",
+        "push_head_sha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+        "push_commit_count": 2,
+        "acceptedRepositoryEvidence": {
+          "schemaVersion": "accepted-repository-evidence/v1",
+          "pushStatus": "pushed",
+          "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+          "baseBranch": "origin/main",
+          "headSha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+          "commitsAheadOfBase": 2,
+          "repositoryChanged": true,
+          "remoteVerified": true
+        }
+      },
+      "unverifiedPublishContext": {
         "pushStatus": "pushed",
         "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
         "baseRef": "origin/main",

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -169,6 +169,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     ProfileSlotState,
 )
 from moonmind.workflows.temporal.workflows.run import (
+    NATIVE_PR_BRANCH_DEFAULTS_PATCH,
     RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
@@ -1502,6 +1503,29 @@ def _replay_published_head(case: dict) -> MoonMindRunWorkflow:
     return replayed
 
 
+def _resolve_draft_branches(
+    workflow_run: MoonMindRunWorkflow,
+    case: dict,
+    *,
+    patched: frozenset[str],
+) -> tuple[str, str]:
+    """Resolve the draft's native PR head and base under one patch set."""
+
+    with pytest.MonkeyPatch.context() as branch_patch:
+        branch_patch.setattr(
+            run_workflow_module.workflow,
+            "patched",
+            lambda patch_id: patch_id in patched,
+        )
+        return workflow_run._resolve_native_pr_branches(
+            parameters={},
+            agent_outputs=case["contaminatingVerificationStepOutputs"],
+            workspace_spec={},
+            last_node_inputs={},
+            publish_payload=case["publishPayload"],
+        )
+
+
 async def test_verification_gate_draft_publishes_run_owned_published_head(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1610,6 +1634,49 @@ async def test_verification_gate_draft_publishes_run_owned_published_head(
         assert workflow_run._apply_blocking_moonspec_gate_to_publish() is False
         assert workflow_run._attention_required is True
         assert "draft" in workflow_run._moonspec_draft_publication_body_section().lower()
+
+        # The gate resolves feasibility from the accepted head, so publication
+        # must open the draft against that same head. The read-only
+        # verification step that trips the gate can emit raw branch/headSha
+        # metadata of its own, which `_record_execution_context` mirrors over
+        # the mutable publish context -- publishing that branch would open a
+        # PR for a head the managed push boundary never verified.
+        contaminated = _replay_published_head(case)
+        contaminated._record_execution_context(
+            node_id=case["gateLogicalStepId"],
+            execution_result={
+                "status": "COMPLETED",
+                "outputs": case["contaminatingVerificationStepOutputs"],
+            },
+        )
+        assert (
+            contaminated._publish_context["branch"]
+            == expected["verificationGateContaminatedPublishContextBranch"]
+        )
+        head_branch, base_branch = _resolve_draft_branches(
+            contaminated,
+            case,
+            patched=frozenset(
+                {
+                    RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
+                    NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+                }
+            ),
+        )
+        assert head_branch == expected["verificationGateDraftHeadBranch"]
+        assert base_branch == expected["verificationGateDraftBaseBranch"]
+
+        # In-flight histories that never recorded the patch keep resolving the
+        # head they always did, so replay stays deterministic.
+        unpatched_head, _ = _resolve_draft_branches(
+            contaminated,
+            case,
+            patched=frozenset({NATIVE_PR_BRANCH_DEFAULTS_PATCH}),
+        )
+        assert (
+            unpatched_head
+            == expected["verificationGateContaminatedPublishContextBranch"]
+        )
 
     # Definitive negatives stay negative: the run-owned head answers "we do not
     # know", never "publication was refused".

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -177,6 +177,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PUBLISH_MODE_REPOSITORY_OPERATION_PATCH,
     RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
     RUN_REMEDIATION_EXPLICIT_EVIDENCE_INPUTS_PATCH,
+    RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
@@ -1481,6 +1482,128 @@ async def test_verified_remediation_push_reaches_draft_publication_handoff() -> 
             draft_publication_policy=manifest["draftPublicationPolicy"],
             publication_feasible=feasibility["feasible"],
         ) == expected["terminalHandoff"]
+
+
+async def test_verification_gate_draft_publishes_run_owned_published_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:53e35d1e through the terminal gate's publication authority.
+
+    The MoonSpec gate always trips on a read-only verification step. That step
+    pushes nothing, so its own repository evidence is inconclusive and the
+    mandated draft publication handoff was unreachable -- the run failed and
+    orphaned a branch that really existed on the remote.
+    """
+
+    replay_id = "draft-publication-authority-gap"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    for case in manifest["verificationGateCases"]:
+        execution_result = {
+            "status": "COMPLETED",
+            "outputs": case["verificationStepOutputs"],
+        }
+
+        # The verification step's own evidence is inconclusive, before and
+        # after the fix. That classification is correct for the step.
+        step_scoped = MoonMindRunWorkflow()
+        step_scoped._publish_context.update(case["publishContext"])
+        assert step_scoped._step_publication_feasibility(execution_result)[
+            "reason"
+        ] == expected["verificationGateStepFeasibilityReason"]
+
+        # In-flight histories that never recorded the patch keep replaying the
+        # previous artifact-backed handoff.
+        unpatched = MoonMindRunWorkflow()
+        unpatched._publish_context.update(case["publishContext"])
+        monkeypatch.setattr(
+            unpatched, "_patched_or_false_outside_workflow", lambda _: False
+        )
+        unpatched_feasibility = unpatched._publication_feasibility(execution_result)
+        assert unpatched_feasibility["feasible"] is False
+        assert unpatched_feasibility["reason"] == expected[
+            "verificationGateStepFeasibilityReason"
+        ]
+        assert unpatched._terminal_gate_handoff_kind(
+            publish_mode=manifest["publishMode"],
+            draft_publication_policy=manifest["draftPublicationPolicy"],
+            publication_feasible=unpatched_feasibility["feasible"],
+        ) == expected["verificationGateUnpatchedTerminalHandoff"]
+
+        # New histories resolve feasibility for the run, so the pushed
+        # remediation head reaches the draft publication handoff.
+        workflow_run = MoonMindRunWorkflow()
+        workflow_run._publish_context.update(case["publishContext"])
+        monkeypatch.setattr(
+            workflow_run,
+            "_patched_or_false_outside_workflow",
+            lambda patch_id: patch_id
+            == RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
+        )
+        feasibility = workflow_run._publication_feasibility(execution_result)
+        assert feasibility["feasible"] is True
+        assert feasibility["reason"] == expected[
+            "verificationGateRunFeasibilityReason"
+        ]
+
+        draft_policy = workflow_run._moonspec_draft_publication_policy(
+            environment_blocked_enabled=False,
+            additional_work_enabled=True,
+        )
+        assert draft_policy is None  # no gate verdict recorded yet
+        workflow_run._moonspec_gate_verdict = case["verdict"]
+        draft_policy = workflow_run._moonspec_draft_publication_policy(
+            environment_blocked_enabled=False,
+            additional_work_enabled=True,
+        )
+        assert draft_policy == manifest["draftPublicationPolicy"]
+        assert workflow_run._terminal_gate_handoff_kind(
+            publish_mode=manifest["publishMode"],
+            draft_publication_policy=draft_policy,
+            publication_feasible=feasibility["feasible"],
+        ) == expected["verificationGateTerminalHandoff"]
+
+        # Activating the handoff must release the fail-closed publication block
+        # so the native PR boundary opens a draft instead of skipping.
+        workflow_run._publish_context["moonSpecGate"] = {
+            "verdict": case["verdict"],
+            "gateResultRef": case["verificationStepOutputs"]["moonSpecVerify"][
+                "gateResultRef"
+            ],
+        }
+        workflow_run._activate_moonspec_draft_publication(
+            "MoonSpec verification did not approve publication",
+            policy=draft_policy,
+        )
+        assert workflow_run._apply_blocking_moonspec_gate_to_publish() is False
+        assert workflow_run._attention_required is True
+        assert "draft" in workflow_run._moonspec_draft_publication_body_section().lower()
+
+    # Definitive negatives stay negative: the run-owned head answers "we do not
+    # know", never "publication was refused".
+    for negative in manifest["preservedNegativeCases"]:
+        refused = MoonMindRunWorkflow()
+        refused._publish_context.update(
+            manifest["verificationGateCases"][0]["publishContext"]
+        )
+        monkeypatch.setattr(
+            refused,
+            "_patched_or_false_outside_workflow",
+            lambda patch_id: patch_id
+            == RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
+        )
+        outcome = refused._publication_feasibility(
+            {
+                "outputs": {
+                    "acceptedRepositoryEvidence": negative[
+                        "acceptedRepositoryEvidence"
+                    ]
+                }
+            }
+        )
+        assert outcome["reason"] == negative["reason"]
+        assert outcome["feasible"] is False
 
 
 async def test_completed_batch_turn_is_rejected_at_agent_run_boundary(

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -1484,6 +1484,24 @@ async def test_verified_remediation_push_reaches_draft_publication_handoff() -> 
         ) == expected["terminalHandoff"]
 
 
+def _replay_published_head(case: dict) -> MoonMindRunWorkflow:
+    """Replay the managed push boundary that earned the run's published head.
+
+    Only ``acceptedRepositoryEvidence`` proves a remote head, so the run must
+    record it through the same production path a real remediation step takes.
+    """
+
+    replayed = MoonMindRunWorkflow()
+    replayed._record_execution_context(
+        node_id=case["gateLogicalStepId"],
+        execution_result={
+            "status": "COMPLETED",
+            "outputs": case["remediationStepOutputs"],
+        },
+    )
+    return replayed
+
+
 async def test_verification_gate_draft_publishes_run_owned_published_head(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1507,16 +1525,30 @@ async def test_verification_gate_draft_publishes_run_owned_published_head(
 
         # The verification step's own evidence is inconclusive, before and
         # after the fix. That classification is correct for the step.
-        step_scoped = MoonMindRunWorkflow()
-        step_scoped._publish_context.update(case["publishContext"])
+        step_scoped = _replay_published_head(case)
         assert step_scoped._step_publication_feasibility(execution_result)[
             "reason"
         ] == expected["verificationGateStepFeasibilityReason"]
 
+        # Raw push keys a non-publishing step left in the publish context are
+        # not accepted evidence, so they never upgrade the gate on their own.
+        unverified = MoonMindRunWorkflow()
+        unverified._publish_context.update(case["unverifiedPublishContext"])
+        monkeypatch.setattr(
+            unverified,
+            "_patched_or_false_outside_workflow",
+            lambda patch_id: patch_id
+            == RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
+        )
+        unverified_feasibility = unverified._publication_feasibility(execution_result)
+        assert unverified_feasibility["feasible"] is False
+        assert unverified_feasibility["reason"] == expected[
+            "verificationGateUnverifiedFeasibilityReason"
+        ]
+
         # In-flight histories that never recorded the patch keep replaying the
         # previous artifact-backed handoff.
-        unpatched = MoonMindRunWorkflow()
-        unpatched._publish_context.update(case["publishContext"])
+        unpatched = _replay_published_head(case)
         monkeypatch.setattr(
             unpatched, "_patched_or_false_outside_workflow", lambda _: False
         )
@@ -1533,8 +1565,7 @@ async def test_verification_gate_draft_publishes_run_owned_published_head(
 
         # New histories resolve feasibility for the run, so the pushed
         # remediation head reaches the draft publication handoff.
-        workflow_run = MoonMindRunWorkflow()
-        workflow_run._publish_context.update(case["publishContext"])
+        workflow_run = _replay_published_head(case)
         monkeypatch.setattr(
             workflow_run,
             "_patched_or_false_outside_workflow",
@@ -1583,10 +1614,7 @@ async def test_verification_gate_draft_publishes_run_owned_published_head(
     # Definitive negatives stay negative: the run-owned head answers "we do not
     # know", never "publication was refused".
     for negative in manifest["preservedNegativeCases"]:
-        refused = MoonMindRunWorkflow()
-        refused._publish_context.update(
-            manifest["verificationGateCases"][0]["publishContext"]
-        )
+        refused = _replay_published_head(manifest["verificationGateCases"][0])
         monkeypatch.setattr(
             refused,
             "_patched_or_false_outside_workflow",

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -319,6 +319,8 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
         "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
         "registry.test/opencode@sha256:" + "6" * 64,
     )
+    # Exercise the documented default catalog interval, not an inherited value.
+    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", raising=False)
 
     document = {
         "schemaVersion": "moonmind.omnigent-agent-profile.v2",
@@ -363,6 +365,7 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
             "credentialGeneration": 4,
             "imageRef": "registry.test/opencode@sha256:" + "6" * 64,
             "models": ["opencode-go/test-model"],
+            "validatedAt": datetime.now(UTC).isoformat(),
         },
     )
 
@@ -398,6 +401,32 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
     assert enabled_target.available is True
     assert enabled_target.compatible_host_classes == ["omnigent-opencode@1"]
     assert enabled_target.models == ["opencode-go/test-model"]
+
+    # The pinned host image refreshes its catalog from the provider at probe
+    # time, so an observation older than the configured interval no longer
+    # describes the provider's current models. Advertising a target from it
+    # would keep offering a model the provider may have removed.
+    provider.model_catalog_evidence_json["validatedAt"] = (
+        datetime.now(UTC) - timedelta(hours=9)
+    ).isoformat()
+    expired = await catalog.get_omnigent_execution_readiness(
+        session=Session(), current_user=current_user
+    )
+    expired_target = expired.execution_targets[0]
+    assert expired_target.available is False
+    assert expired_target.models == []
+    expired_codes = {reason.code for reason in expired_target.gate_reasons}
+    # Connected and enrolled: this is a bounded re-validation wait, not a
+    # request to reconnect a profile that is already connected.
+    assert "provider_runtime_revalidation_pending" in expired_codes
+    assert "compatible_provider_profile_unavailable" not in expired_codes
+
+    # ``0`` disables the interval and restores identity-only staleness.
+    monkeypatch.setenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", "0")
+    identity_only = await catalog.get_omnigent_execution_readiness(
+        session=Session(), current_user=current_user
+    )
+    assert identity_only.execution_targets[0].available is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/config/test_container_backend_compose_declarations.py
+++ b/tests/unit/config/test_container_backend_compose_declarations.py
@@ -1,0 +1,99 @@
+"""The default Compose deployment must declare sources everywhere they gate.
+
+``ContainerJobService.submit()`` resolves the deployment's declared image
+sources before it creates durable job identity, so an ``imageSourceRef`` that
+only the worker declares is rejected as unconfigured before the request ever
+reaches Temporal. That breaks the checked-in ``tactics-test`` Skill on the
+documented zero-configuration path, where ``.env`` defines none of these
+variables and Compose supplies the derived default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from moonmind.config.container_backend_settings import (
+    CACHE_SOURCES_ENV_KEY,
+    IMAGE_SOURCES_ENV_KEY,
+    resolve_container_backend_settings,
+)
+
+#: Every service whose process resolves container-backend settings: the API
+#: admits the request, the agent-runtime worker launches it.
+_DECLARING_SERVICES = ("api", "temporal-worker-agent-runtime")
+
+#: Refs the checked-in ``tactics-test`` Skill selects with no configuration.
+_SKILL_IMAGE_SOURCE_REF = "tactics-unreal"
+_SKILL_CACHE_REFS = ("unreal-ccache", "unreal-ubt")
+
+
+def _service_environment(service: str) -> dict[str, str]:
+    compose = yaml.safe_load(Path("docker-compose.yaml").read_text(encoding="utf-8"))
+    environment = compose["services"][service]["environment"]
+    if isinstance(environment, dict):
+        return {str(key): str(value) for key, value in environment.items()}
+    resolved: dict[str, str] = {}
+    for entry in environment:
+        key, _, value = str(entry).partition("=")
+        resolved[key] = value
+    return resolved
+
+
+def _interpolate(value: str) -> str:
+    """Apply Compose's ``${NAME:-default}`` substitution with an empty ``.env``.
+
+    This is the zero-configuration deployment the Skill documents: nothing is
+    set, so every reference collapses to its declared default. Defaults nest and
+    contain JSON braces, so the closing brace is matched by depth rather than by
+    a regular expression.
+    """
+
+    out: list[str] = []
+    index = 0
+    while index < len(value):
+        start = value.find("${", index)
+        if start < 0:
+            out.append(value[index:])
+            break
+        out.append(value[index:start])
+        depth = 0
+        cursor = start + 1
+        while cursor < len(value):
+            if value[cursor] == "{":
+                depth += 1
+            elif value[cursor] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            cursor += 1
+        assert depth == 0, f"unbalanced Compose interpolation in {value!r}"
+        _, separator, default = value[start + 2 : cursor].partition(":-")
+        out.append(_interpolate(default) if separator else "")
+        index = cursor + 1
+    return "".join(out)
+
+
+@pytest.mark.parametrize("service", _DECLARING_SERVICES)
+def test_compose_service_admits_the_checked_in_skill_refs(service: str) -> None:
+    environment = _service_environment(service)
+    declared = {
+        key: _interpolate(environment[key])
+        for key in (IMAGE_SOURCES_ENV_KEY, CACHE_SOURCES_ENV_KEY)
+    }
+
+    settings = resolve_container_backend_settings(declared)
+
+    assert settings.image_source(_SKILL_IMAGE_SOURCE_REF).image
+    for cache_ref in _SKILL_CACHE_REFS:
+        assert settings.cache_source(cache_ref).volume_name
+
+
+def test_compose_declares_identical_sources_for_api_and_worker() -> None:
+    """A ref the worker can launch but the API refuses is never reachable."""
+
+    api, worker = (_service_environment(name) for name in _DECLARING_SERVICES)
+    for key in (IMAGE_SOURCES_ENV_KEY, CACHE_SOURCES_ENV_KEY):
+        assert api[key] == worker[key]

--- a/tests/unit/config/test_container_backend_settings.py
+++ b/tests/unit/config/test_container_backend_settings.py
@@ -6,6 +6,10 @@ import pytest
 
 import json
 
+from pydantic import ValidationError
+
+from moonmind.schemas.container_job_models import CacheMount
+
 from moonmind.config.container_backend_settings import (
     CACHE_SOURCES_ENV_KEY,
     IMAGE_SOURCES_ENV_KEY,
@@ -350,3 +354,45 @@ def test_python_test_recipe_uses_deployment_root_and_optional_max_age(
     assert isinstance(source, LocalImageRecipe)
     assert source.context_root == tmp_path.resolve()
     assert source.max_age_seconds == 3600
+
+
+#: Targets the public ``CacheMount`` request contract refuses. A deployment
+#: that declares one of these creates a cache source no valid job request can
+#: ever select, because the backend matches the declared target exactly.
+UNSELECTABLE_CACHE_TARGETS: tuple[str, ...] = (
+    "/",
+    "/opt/project/cache/",
+    "/opt//project/cache",
+    "//opt/project/cache",
+    "/opt/project cache",
+    "relative/cache",
+    "/opt/../etc",
+)
+
+
+@pytest.mark.parametrize("target", UNSELECTABLE_CACHE_TARGETS)
+def test_declared_cache_target_matches_the_request_contract(target: str) -> None:
+    """A declaration the request contract rejects must fail at configuration.
+
+    Deployment policy and the public job contract have to agree on what a cache
+    target is: the backend selects a declared source by matching a request's
+    ``CacheMount.target`` exactly, so a target only one side accepts is either
+    dead configuration or a mount the operator cannot describe. Failing here
+    keeps the mistake at startup instead of at the launch boundary.
+    """
+
+    with pytest.raises(ContainerBackendConfigError, match="absolute container path"):
+        resolve_container_backend_settings(_declared_env(target=target))
+
+    with pytest.raises(ValidationError):
+        CacheMount(cacheRef=DECLARED_CACHE_REF, target=target)
+
+
+def test_declared_cache_target_accepts_what_a_request_can_select() -> None:
+    target = "/opt/project/cache"
+    source = resolve_container_backend_settings(
+        _declared_env(target=target)
+    ).cache_source(DECLARED_CACHE_REF)
+
+    assert source.target == target
+    assert CacheMount(cacheRef=DECLARED_CACHE_REF, target=target).target == target

--- a/tests/unit/config/test_container_backend_settings.py
+++ b/tests/unit/config/test_container_backend_settings.py
@@ -244,6 +244,77 @@ def test_undeclared_refs_and_malformed_declarations_fail_closed() -> None:
         )
 
 
+def test_declarations_reject_keys_outside_their_documented_schema() -> None:
+    # Every declaration key defaults to the permissive value when omitted, so a
+    # misspelling must fail configuration instead of quietly weakening the
+    # deployment policy the operator declared.
+    with pytest.raises(ContainerBackendConfigError, match="unknown key"):
+        resolve_container_backend_settings(
+            {
+                CACHE_SOURCES_ENV_KEY: json.dumps(
+                    [
+                        {
+                            "cacheRef": DECLARED_CACHE_REF,
+                            "volumeName": "project_build_cache_volume",
+                            "target": "/opt/project/cache",
+                            "readonly": True,
+                        }
+                    ]
+                )
+            }
+        )
+
+    with pytest.raises(ContainerBackendConfigError, match="unknown key"):
+        resolve_container_backend_settings(
+            {
+                IMAGE_SOURCES_ENV_KEY: json.dumps(
+                    [
+                        {
+                            "sourceRef": DECLARED_IMAGE_SOURCE_REF,
+                            "image": DECLARED_IMAGE,
+                            "pullpolicy": "never",
+                        }
+                    ]
+                )
+            }
+        )
+
+    # The documented schemas themselves still resolve.
+    settings = resolve_container_backend_settings(
+        _declared_env(pull_policy="never", read_only=True)
+    )
+    assert settings.image_source(DECLARED_IMAGE_SOURCE_REF).pull_policy == "never"
+    assert settings.cache_source(DECLARED_CACHE_REF).read_only is True
+
+
+def test_shared_memory_default_must_fit_under_its_ceiling() -> None:
+    # ``_enforce_resource_ceilings`` only inspects caller-supplied shmSize, so a
+    # default above the ceiling would launch every omitted request above the
+    # deployment's declared maximum.
+    with pytest.raises(ContainerBackendConfigError, match="shmSize default"):
+        resolve_container_backend_settings(
+            {"MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB": "32"}
+        )
+
+    # Lowering the ceiling is supported when the default is lowered with it.
+    tightened = resolve_container_backend_settings(
+        {
+            "MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB": "32",
+            "MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB": "32",
+        }
+    )
+    assert tightened.shm_size_mib == 32
+    assert tightened.max_shm_size_mib == 32
+
+    with pytest.raises(ContainerBackendConfigError, match="shmSize default"):
+        resolve_container_backend_settings(
+            {
+                "MOONMIND_CONTAINER_BACKEND_SHM_SIZE_MIB": "512",
+                "MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB": "256",
+            }
+        )
+
+
 def test_shared_memory_ceiling_defaults_to_the_memory_ceiling() -> None:
     settings = resolve_container_backend_settings({})
     assert settings.shm_size_mib == 64

--- a/tests/unit/config/test_container_backend_settings.py
+++ b/tests/unit/config/test_container_backend_settings.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import pytest
 
+import json
+
 from moonmind.config.container_backend_settings import (
+    CACHE_SOURCES_ENV_KEY,
+    IMAGE_SOURCES_ENV_KEY,
     PYTHON_TEST_FINGERPRINT_INPUTS,
     PYTHON_TEST_IMAGE_SOURCE_REF,
-    TACTICS_UNREAL_IMAGE_SOURCE_REF,
-    UNREAL_CCACHE_CACHE_REF,
-    UNREAL_UBT_CACHE_REF,
     LocalImageRecipe,
     RegistryImageSource,
     SUPPORTED_CONTAINER_BACKEND_KINDS,
@@ -17,6 +18,38 @@ from moonmind.config.container_backend_settings import (
     ContainerBackendReadinessError,
     resolve_container_backend_settings,
 )
+
+#: A deployment declaration standing in for whatever a real operator approves.
+#: MoonMind must carry no project's image, volume, or in-container path itself.
+DECLARED_IMAGE_SOURCE_REF = "project-toolchain"
+DECLARED_IMAGE = "registry.invalid/example/toolchain:1.0"
+DECLARED_CACHE_REF = "project-build-cache"
+
+
+def _declared_env(
+    *,
+    pull_policy: str | None = None,
+    volume_name: str = "project_build_cache_volume",
+    target: str = "/opt/project/cache",
+    read_only: object = None,
+) -> dict[str, str]:
+    image: dict[str, str] = {
+        "sourceRef": DECLARED_IMAGE_SOURCE_REF,
+        "image": DECLARED_IMAGE,
+    }
+    if pull_policy is not None:
+        image["pullPolicy"] = pull_policy
+    cache: dict[str, object] = {
+        "cacheRef": DECLARED_CACHE_REF,
+        "volumeName": volume_name,
+        "target": target,
+    }
+    if read_only is not None:
+        cache["readOnly"] = read_only
+    return {
+        IMAGE_SOURCES_ENV_KEY: json.dumps([image]),
+        CACHE_SOURCES_ENV_KEY: json.dumps([cache]),
+    }
 
 
 def test_defaults_are_deployment_safe() -> None:
@@ -34,15 +67,12 @@ def test_defaults_are_deployment_safe() -> None:
     assert source.image == "moonmind-python-tests:local"
     assert source.target == "test-runtime"
     assert source.fingerprint_inputs == PYTHON_TEST_FINGERPRINT_INPUTS
-    assert settings.cache_source(UNREAL_CCACHE_CACHE_REF).volume_name == (
-        "unreal_ccache_volume"
-    )
-    assert settings.cache_source(UNREAL_CCACHE_CACHE_REF).target == (
-        "/home/ue4/.ccache"
-    )
-    assert settings.cache_source(UNREAL_UBT_CACHE_REF).target == (
-        "/home/ue4/.config/Epic/UnrealBuildTool"
-    )
+    # MoonMind owns exactly one image source -- its own test image -- and no
+    # cache source at all. Every project source is deployment-declared.
+    assert [item.source_ref for item in settings.image_sources] == [
+        PYTHON_TEST_IMAGE_SOURCE_REF
+    ]
+    assert settings.cache_sources == ()
     for pattern in source.fingerprint_inputs:
         assert any(path.is_file() for path in source.context_root.glob(pattern))
 
@@ -114,49 +144,125 @@ def test_prebuilt_python_test_image_replaces_local_recipe() -> None:
     assert source.pull_policy == "if-missing"
 
 
-def test_tactics_image_pulls_on_first_use_and_reuses_host_cache() -> None:
+def test_declared_image_pulls_on_first_use_and_reuses_declared_cache() -> None:
     settings = resolve_container_backend_settings(
-        {
-            "MOONMIND_UNREAL_ENGINE_IMAGE": (
-                "ghcr.io/moonladderstudios/tactics-ue-base:5.8"
-            ),
-            "MOONMIND_UNREAL_CCACHE_VOLUME_NAME": "shared-ccache",
-            "MOONMIND_UNREAL_UBT_VOLUME_NAME": "shared-ubt",
-        }
+        _declared_env(volume_name="shared-cache", read_only=True)
     )
 
-    source = settings.image_source(TACTICS_UNREAL_IMAGE_SOURCE_REF)
+    source = settings.image_source(DECLARED_IMAGE_SOURCE_REF)
     assert isinstance(source, RegistryImageSource)
-    assert source.image == "ghcr.io/moonladderstudios/tactics-ue-base:5.8"
+    assert source.image == DECLARED_IMAGE
     assert source.pull_policy == "if-missing"
-    assert settings.cache_source(UNREAL_CCACHE_CACHE_REF).volume_name == (
-        "shared-ccache"
-    )
-    assert settings.cache_source(UNREAL_UBT_CACHE_REF).volume_name == "shared-ubt"
+    cache = settings.cache_source(DECLARED_CACHE_REF)
+    assert cache.volume_name == "shared-cache"
+    assert cache.target == "/opt/project/cache"
+    assert cache.read_only is True
 
 
-def test_default_tactics_source_and_invalid_cache_volume_fail_closed() -> None:
-    settings = resolve_container_backend_settings({})
-    source = settings.image_source(TACTICS_UNREAL_IMAGE_SOURCE_REF)
-    assert isinstance(source, RegistryImageSource)
-    assert source.image == "ghcr.io/moonladderstudios/tactics-ue-base:5.8"
-    assert source.pull_policy == "if-missing"
+def test_undeclared_refs_and_malformed_declarations_fail_closed() -> None:
+    empty = resolve_container_backend_settings({})
+    with pytest.raises(ContainerBackendConfigError, match="is not configured"):
+        empty.image_source(DECLARED_IMAGE_SOURCE_REF)
+    with pytest.raises(ContainerBackendConfigError, match="is not configured"):
+        empty.cache_source(DECLARED_CACHE_REF)
 
     prewarmed = resolve_container_backend_settings(
-        {"MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY": "never"}
-    ).image_source(TACTICS_UNREAL_IMAGE_SOURCE_REF)
+        _declared_env(pull_policy="never")
+    ).image_source(DECLARED_IMAGE_SOURCE_REF)
     assert isinstance(prewarmed, RegistryImageSource)
     assert prewarmed.pull_policy == "never"
 
     with pytest.raises(ContainerBackendConfigError, match="named volume"):
-        resolve_container_backend_settings(
-            {"MOONMIND_UNREAL_CCACHE_VOLUME_NAME": "/host/cache"}
-        )
+        resolve_container_backend_settings(_declared_env(volume_name="/host/cache"))
+
+    with pytest.raises(ContainerBackendConfigError, match="absolute container path"):
+        resolve_container_backend_settings(_declared_env(target="relative/cache"))
+
+    with pytest.raises(ContainerBackendConfigError, match="absolute container path"):
+        resolve_container_backend_settings(_declared_env(target="/opt/../etc"))
 
     with pytest.raises(ContainerBackendConfigError, match="pull policy"):
+        resolve_container_backend_settings(_declared_env(pull_policy="sometimes"))
+
+    with pytest.raises(ContainerBackendConfigError, match="JSON array of objects"):
+        resolve_container_backend_settings({IMAGE_SOURCES_ENV_KEY: "not-json"})
+
+    with pytest.raises(ContainerBackendConfigError, match="JSON array of objects"):
         resolve_container_backend_settings(
-            {"MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY": "sometimes"}
+            {CACHE_SOURCES_ENV_KEY: json.dumps({"cacheRef": DECLARED_CACHE_REF})}
         )
+
+    with pytest.raises(ContainerBackendConfigError, match="non-empty sourceRef"):
+        resolve_container_backend_settings(
+            {IMAGE_SOURCES_ENV_KEY: json.dumps([{"image": DECLARED_IMAGE}])}
+        )
+
+    with pytest.raises(ContainerBackendConfigError, match="reserved by MoonMind"):
+        resolve_container_backend_settings(
+            {
+                IMAGE_SOURCES_ENV_KEY: json.dumps(
+                    [
+                        {
+                            "sourceRef": PYTHON_TEST_IMAGE_SOURCE_REF,
+                            "image": DECLARED_IMAGE,
+                        }
+                    ]
+                )
+            }
+        )
+
+    with pytest.raises(ContainerBackendConfigError, match="duplicate sourceRef"):
+        resolve_container_backend_settings(
+            {
+                IMAGE_SOURCES_ENV_KEY: json.dumps(
+                    [
+                        {"sourceRef": DECLARED_IMAGE_SOURCE_REF, "image": "a:1"},
+                        {"sourceRef": DECLARED_IMAGE_SOURCE_REF, "image": "b:1"},
+                    ]
+                )
+            }
+        )
+
+    with pytest.raises(ContainerBackendConfigError, match="duplicate cacheRef"):
+        resolve_container_backend_settings(
+            {
+                CACHE_SOURCES_ENV_KEY: json.dumps(
+                    [
+                        {
+                            "cacheRef": DECLARED_CACHE_REF,
+                            "volumeName": "one",
+                            "target": "/a",
+                        },
+                        {
+                            "cacheRef": DECLARED_CACHE_REF,
+                            "volumeName": "two",
+                            "target": "/b",
+                        },
+                    ]
+                )
+            }
+        )
+
+
+def test_shared_memory_ceiling_defaults_to_the_memory_ceiling() -> None:
+    settings = resolve_container_backend_settings({})
+    assert settings.shm_size_mib == 64
+    assert settings.max_shm_size_mib == settings.max_memory_mib
+
+    tightened = resolve_container_backend_settings(
+        {
+            "MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB": "2048",
+            "MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB": "512",
+        }
+    )
+    assert tightened.max_memory_mib == 2048
+    assert tightened.max_shm_size_mib == 512
+
+    # An omitted shared-memory ceiling still tracks a tightened memory ceiling.
+    derived = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_MAX_MEMORY_MIB": "4096"}
+    )
+    assert derived.max_shm_size_mib == 4096
 
 
 def test_python_test_recipe_uses_deployment_root_and_optional_max_age(

--- a/tests/unit/config/test_generic_container_surface_coupling.py
+++ b/tests/unit/config/test_generic_container_surface_coupling.py
@@ -1,0 +1,81 @@
+"""The generic Container Jobs surfaces must name no consuming project.
+
+MoonMind orchestrates provider- and project-maintained capabilities through
+portable interfaces; a project's image, volume, in-container path, scenario
+name, or gate vocabulary belongs in that project's Skill or in deployment
+configuration, never in MoonMind's own request translation, resource
+realization, lifecycle, or public tool contract.
+
+This mirrors the scan a consuming project runs against the *deployed* MoonMind
+package, so the coupling is refused at MoonMind's own required CI instead of
+being discovered later against an already-published revision.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MOONMIND_PACKAGE_ROOT = Path(__file__).resolve().parents[3] / "moonmind"
+
+#: The generic implementation surfaces whose request translation, resource
+#: realization, lifecycle, and public tool contract must stay project-neutral.
+GENERIC_CONTAINER_SURFACES: tuple[str, ...] = (
+    "config/container_backend_settings.py",
+    "container_job_cli.py",
+    "mcp/container_job_tool_registry.py",
+    "schemas/container_job_models.py",
+    "security/container_job_capabilities.py",
+    "workflows/temporal/container_job_backend.py",
+    "workflows/temporal/workflows/container_job.py",
+    "schemas/workload_models.py",
+    "workloads/__init__.py",
+    "workloads/docker_launcher.py",
+    "workloads/gpu.py",
+)
+
+#: Consuming-project vocabulary that must never appear on a generic surface.
+#: Each entry names the class of coupling so a violation reports what leaked.
+PROHIBITED_PROJECT_COUPLING: dict[str, re.Pattern[str]] = {
+    "project_repository": re.compile(
+        r"MoonLadderStudios/Tactics|\bTactics\b|TACTICS_[A-Z0-9_]+", re.IGNORECASE
+    ),
+    "project_image_or_command": re.compile(
+        r"tactics-(?:ue-render|visual-proof|render-doctor)", re.IGNORECASE
+    ),
+    "project_scenario": re.compile(
+        r"presentation\.character\.melee_sequence|combat\.move_then_melee",
+        re.IGNORECASE,
+    ),
+    "project_gate_or_bundle": re.compile(
+        r"native[-_ ]gate|bundleVerified|observation[-_ ]bundle", re.IGNORECASE
+    ),
+    "engine_policy": re.compile(
+        r"MOONMIND_UNREAL|\bUnreal(?: Engine)?\b|unreal_(?:ccache|ubt)", re.IGNORECASE
+    ),
+    "engine_arguments": re.compile(
+        r"-nullrhi|-vulkan|-renderoffscreen", re.IGNORECASE
+    ),
+}
+
+
+@pytest.mark.parametrize("relative", GENERIC_CONTAINER_SURFACES)
+def test_generic_container_surface_names_no_project(relative: str) -> None:
+    path = MOONMIND_PACKAGE_ROOT / relative
+    # A missing surface fails closed: a renamed module must be re-listed here
+    # rather than silently dropping out of the scan.
+    assert path.is_file(), f"generic container surface is missing: {relative}"
+
+    violations = [
+        f"{relative}:{number} [{coupling}] {line.strip()[:160]}"
+        for number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        )
+        for coupling, pattern in PROHIBITED_PROJECT_COUPLING.items()
+        if pattern.search(line)
+    ]
+    assert not violations, "\n".join(
+        ["generic container surfaces must name no consuming project:", *violations]
+    )

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -306,16 +306,22 @@ async def test_opencode_exact_host_model_options_fail_closed_without_diagnostics
     assert "sensitive context" not in str(exc.value)
 
 
-def test_planning_model_evidence_is_bound_to_generation_and_host_image() -> None:
+def _evidence_provider(*, validated_at: datetime | None = None) -> SimpleNamespace:
     image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
-    provider = SimpleNamespace(
+    return SimpleNamespace(
         credential_generation=4,
         model_catalog_evidence_json={
             "credentialGeneration": 4,
             "imageRef": image_ref,
             "models": [{"qualifiedId": "opencode-go/model"}],
+            "validatedAt": (validated_at or datetime.now(UTC)).isoformat(),
         },
     )
+
+
+def test_planning_model_evidence_is_bound_to_generation_and_host_image() -> None:
+    image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
+    provider = _evidence_provider()
     OmnigentExecutionPlanningService._verify_model_evidence(
         provider,
         "opencode-go/model",
@@ -339,6 +345,53 @@ def test_planning_model_evidence_is_bound_to_generation_and_host_image() -> None
             expected_image_ref="ghcr.io/moonmind/opencode@sha256:" + "b" * 64,
         )
     assert wrong_image.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
+
+
+def test_planning_rejects_a_model_catalog_older_than_the_refresh_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Identity alone would launch from the first catalog ever observed.
+
+    A healthy deployment never changes its credential generation or host image
+    digest on its own, so pre-session planning has to enforce the same
+    observation interval the bootstrap reconciler refreshes on. Otherwise it
+    keeps admitting -- and launching -- a model the provider may have removed.
+    """
+
+    # Exercise the documented default: the interval applies with no env value.
+    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", raising=False)
+    image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
+    expired = _evidence_provider(validated_at=datetime.now(UTC) - timedelta(hours=9))
+
+    with pytest.raises(HarnessPlatformError) as stale:
+        OmnigentExecutionPlanningService._verify_model_evidence(
+            expired,
+            "opencode-go/model",
+            expected_image_ref=image_ref,
+        )
+    assert stale.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
+    assert "refresh interval" in str(stale.value)
+
+    # The interval is deployment-configurable, and ``0`` restores identity-only
+    # staleness at this boundary exactly as it does at the reconciler.
+    monkeypatch.setenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", "0")
+    OmnigentExecutionPlanningService._verify_model_evidence(
+        expired,
+        "opencode-go/model",
+        expected_image_ref=image_ref,
+    )
+
+    # An observation that cannot say when it was taken is never admitted.
+    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS")
+    undated = _evidence_provider()
+    undated.model_catalog_evidence_json.pop("validatedAt")
+    with pytest.raises(HarnessPlatformError) as undatable:
+        OmnigentExecutionPlanningService._verify_model_evidence(
+            undated,
+            "opencode-go/model",
+            expected_image_ref=image_ref,
+        )
+    assert undatable.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
 
 
 class _Session:

--- a/tests/unit/omnigent/test_omnigent_settings.py
+++ b/tests/unit/omnigent/test_omnigent_settings.py
@@ -136,3 +136,46 @@ def test_native_ui_gate_fails_closed_for_mutable_image_and_serves_when_pinned() 
     )
     assert pinned.ready is True
     assert pinned.reason is None
+
+
+def test_model_catalog_interval_defaults_to_a_bounded_refresh() -> None:
+    """The documented one-value setup must keep observing new provider models.
+
+    A healthy deployment never changes its credential generation or host image
+    digest on its own, so an unbounded observation would pin whichever catalog
+    the first probe saw.
+    """
+
+    from datetime import timedelta
+
+    from moonmind.omnigent.settings import opencode_model_catalog_max_age
+
+    assert opencode_model_catalog_max_age(env={}) == timedelta(hours=6)
+    assert opencode_model_catalog_max_age(
+        env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "0.5"}
+    ) == timedelta(minutes=30)
+
+
+def test_model_catalog_interval_is_disabled_by_zero() -> None:
+    from moonmind.omnigent.settings import opencode_model_catalog_max_age
+
+    assert (
+        opencode_model_catalog_max_age(
+            env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "0"}
+        )
+        is None
+    )
+
+
+def test_model_catalog_interval_rejects_unusable_values() -> None:
+    """An unreadable interval fails fast rather than silently pinning a catalog."""
+
+    import pytest
+
+    from moonmind.omnigent.settings import opencode_model_catalog_max_age
+
+    for value in ("never", "-1"):
+        with pytest.raises(ValueError):
+            opencode_model_catalog_max_age(
+                env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": value}
+            )

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -584,6 +584,62 @@ async def test_unavailable_maintenance_lease_defers_the_pass(
 
 
 @pytest.mark.asyncio
+async def test_lease_failures_never_consume_the_revalidation_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lease contention is not a provider verdict, so it must stay retryable.
+
+    ``acquire_credential_maintenance_guard`` fails on maintainer contention and
+    on transient Temporal/profile-manager errors, and no provider probe runs in
+    either case. Charging those to ``MAX_REVALIDATION_ATTEMPTS`` would let three
+    of them mark the identity exhausted, after which the reconciler skips the
+    profile entirely until its credential or host image changes.
+    """
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        MAX_REVALIDATION_ATTEMPTS,
+        REVALIDATION_FAILURE_KEY,
+        revalidation_is_exhausted,
+    )
+
+    _install_stubs(monkeypatch, acquire_error=RuntimeError("profile is busy"))
+    rows = [_profile()]
+
+    for _ in range(MAX_REVALIDATION_ATTEMPTS + 1):
+        outcome = await reconcile_opencode_provider_readiness(
+            session_factory=_session_factory(rows), controller=_Controller()
+        )
+        assert outcome.deferred == ("opencode-go-default",)
+
+    assert REVALIDATION_FAILURE_KEY not in (rows[0].command_behavior or {})
+    assert not revalidation_is_exhausted(rows[0], image_refs=(CURRENT_IMAGE,))
+
+    # The full budget is intact, so the very next pass still probes the
+    # provider once the lease is available again.
+    probed: list[str] = []
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        probed.append(profile.profile_id)
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": image_ref,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
+            "validatedAt": datetime.now(UTC).isoformat(),
+            "credentialGeneration": profile.credential_generation,
+        }
+
+    _install_stubs(monkeypatch, validate=validate)
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert probed == ["opencode-go-default"]
+    assert outcome.refreshed == ("opencode-go-default",)
+
+
+@pytest.mark.asyncio
 async def test_missing_pinned_image_defers_instead_of_recording_evidence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -10,6 +10,7 @@ boundaries that must not be crossed to get there.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -24,6 +25,9 @@ from moonmind.omnigent.bootstrap.provider_revalidation import (
 CURRENT_IMAGE = "ghcr.io/moonmind/omnigent-host-opencode@sha256:" + "a" * 64
 PREVIOUS_IMAGE = "ghcr.io/moonmind/omnigent-host-opencode@sha256:" + "b" * 64
 API_KEY = "sk-" + "z" * 40
+# Distinguishes "use a fresh observation timestamp" from an explicit ``None``
+# that omits the field entirely.
+_UNSET_VALIDATED_AT = "__unset__"
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +47,7 @@ def _profile(
     auth_state: str = "connected",
     secret_refs: dict[str, str] | None = None,
     command_behavior: dict | None = None,
+    evidence_validated_at: str | None = _UNSET_VALIDATED_AT,
 ) -> SimpleNamespace:
     evidence = None
     if evidence_image is not None:
@@ -56,6 +61,10 @@ def _profile(
                 generation if evidence_generation is None else evidence_generation
             ),
         }
+        if evidence_validated_at is _UNSET_VALIDATED_AT:
+            evidence["validatedAt"] = datetime.now(UTC).isoformat()
+        elif evidence_validated_at is not None:
+            evidence["validatedAt"] = evidence_validated_at
     return SimpleNamespace(
         profile_id=profile_id,
         runtime_id="opencode",
@@ -209,6 +218,67 @@ def test_evidence_is_current_rejects_fabricated_or_stale_model_catalogs() -> Non
         {"qualifiedId": "opencode-go/gpt-5.6-luna"}
     ]
     assert not evidence_is_current(rotated, image_ref=CURRENT_IMAGE)
+
+
+def test_catalog_observation_expires_by_default() -> None:
+    """An unchanged credential and image must not freeze the model catalog.
+
+    The pinned host image refreshes its catalog from the provider at probe
+    time, so binding the observation only to credential generation and image
+    digest keeps whichever catalog the first probe saw. Models the provider
+    publishes later -- contributor tiers included -- would never reach
+    selection, readiness, or admission on an otherwise unchanged deployment.
+    """
+
+    now = datetime.now(UTC)
+    fresh = _profile(
+        evidence_image=CURRENT_IMAGE,
+        evidence_validated_at=(now - timedelta(hours=1)).isoformat(),
+    )
+    assert evidence_is_current(fresh, image_ref=CURRENT_IMAGE, env={}, now=now)
+
+    aged = _profile(
+        evidence_image=CURRENT_IMAGE,
+        evidence_validated_at=(now - timedelta(hours=7)).isoformat(),
+    )
+    assert not evidence_is_current(aged, image_ref=CURRENT_IMAGE, env={}, now=now)
+
+
+def test_catalog_observation_interval_is_operator_configurable() -> None:
+    now = datetime.now(UTC)
+    aged = _profile(
+        evidence_image=CURRENT_IMAGE,
+        evidence_validated_at=(now - timedelta(hours=7)).isoformat(),
+    )
+    assert evidence_is_current(
+        aged,
+        image_ref=CURRENT_IMAGE,
+        env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "24"},
+        now=now,
+    )
+    # ``0`` restores identity-only staleness for a deployment that pins its
+    # catalog deliberately.
+    assert evidence_is_current(
+        aged,
+        image_ref=CURRENT_IMAGE,
+        env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "0"},
+        now=now,
+    )
+
+
+def test_catalog_observation_without_a_timestamp_is_not_current() -> None:
+    """An observation that cannot state its age cannot be shown to be current."""
+
+    undated = _profile(evidence_image=CURRENT_IMAGE, evidence_validated_at=None)
+    assert "validatedAt" not in undated.model_catalog_evidence_json
+    assert not evidence_is_current(undated, image_ref=CURRENT_IMAGE, env={})
+    # Pinning the interval off keeps the historical identity-only contract for
+    # evidence written before the field existed.
+    assert evidence_is_current(
+        undated,
+        image_ref=CURRENT_IMAGE,
+        env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "0"},
+    )
 
 
 @pytest.mark.asyncio
@@ -389,7 +459,9 @@ async def test_stale_host_image_evidence_is_revalidated_and_refreshed(
             "imageRef": image_ref,
             "runtimeVersions": {"opencode": "1.18.11"},
             "materializerRef": "opencode-auth-json@1",
-            "validatedAt": "2026-08-25T01:00:00+00:00",
+            # Production stamps the observation at probe time; a refreshed
+            # profile is only current because the catalog was just observed.
+            "validatedAt": datetime.now(UTC).isoformat(),
             "credentialGeneration": profile.credential_generation,
         }
 

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -710,6 +710,126 @@ async def test_a_successful_refresh_clears_a_recorded_failure(
                 REVALIDATION_FAILURE_KEY: {
                     "imageRef": CURRENT_IMAGE,
                     "credentialGeneration": 3,
+                    "attempts": 1,
+                    "exhausted": False,
+                }
+            }
+        )
+    ]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.refreshed == ("opencode-go-default",)
+    assert REVALIDATION_FAILURE_KEY not in rows[0].command_behavior
+
+
+@pytest.mark.asyncio
+async def test_exhausted_revalidation_stops_probing_the_pinned_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recorded attempt budget must bound provider work, not just reporting.
+
+    The startup maintainer re-enters this boundary every 120 seconds for as
+    long as readiness stays false, so a provider outage or a revoked key would
+    otherwise launch a Docker-backed probe forever.
+    """
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    # ``validate=None`` makes the stub assert if the runtime probe is reached.
+    _install_stubs(monkeypatch)
+    rows = [
+        _profile(
+            command_behavior={
+                REVALIDATION_FAILURE_KEY: {
+                    "imageRef": CURRENT_IMAGE,
+                    "credentialGeneration": 3,
+                    "attempts": 3,
+                    "exhausted": True,
+                }
+            }
+        )
+    ]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=_Controller()
+    )
+
+    assert outcome.refreshed == ()
+    assert outcome.deferred == ("opencode-go-default",)
+    # Not "ready": the profile still cannot launch, and only an operator can
+    # change that. The pass simply stops paying for the same answer.
+    assert outcome.ready is False
+    assert "exhausted" in (outcome.reason or "")
+    assert rows[0].command_behavior[REVALIDATION_FAILURE_KEY]["attempts"] == 3
+
+
+@pytest.mark.asyncio
+async def test_an_expired_catalog_stops_probing_once_attempts_are_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interval-driven staleness inherits the same bounded attempt budget."""
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        MAX_REVALIDATION_ATTEMPTS,
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    attempts: list[str] = []
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        del profile, image_ref
+        attempts.append("probe")
+        raise RuntimeError("provider catalog service is unavailable")
+
+    _install_stubs(monkeypatch, validate=validate)
+    aged = (datetime.now(UTC) - timedelta(hours=9)).isoformat()
+    rows = [_profile(evidence_image=CURRENT_IMAGE, evidence_validated_at=aged)]
+
+    for _ in range(MAX_REVALIDATION_ATTEMPTS + 3):
+        outcome = await reconcile_opencode_provider_readiness(
+            session_factory=_session_factory(rows), controller=_Controller()
+        )
+
+    assert len(attempts) == MAX_REVALIDATION_ATTEMPTS
+    assert rows[0].command_behavior[REVALIDATION_FAILURE_KEY]["exhausted"] is True
+    assert outcome.ready is False
+    assert outcome.deferred == ("opencode-go-default",)
+
+
+@pytest.mark.asyncio
+async def test_a_new_pinned_image_restores_the_revalidation_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exhaustion is scoped to the identity it was earned against."""
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+    )
+
+    async def validate(profile, image_ref, _lease, _kwargs):
+        return {
+            "schemaVersion": "moonmind.provider-model-catalog-evidence.v1",
+            "models": [{"qualifiedId": "opencode-go/muse-spark-1.2-contributor"}],
+            "imageRef": image_ref,
+            "runtimeVersions": {"opencode": "1.18.11"},
+            "materializerRef": "opencode-auth-json@1",
+            "validatedAt": datetime.now(UTC).isoformat(),
+            "credentialGeneration": profile.credential_generation,
+        }
+
+    _install_stubs(monkeypatch, validate=validate)
+    rows = [
+        _profile(
+            command_behavior={
+                REVALIDATION_FAILURE_KEY: {
+                    # Earned against the image the deployment no longer pins.
+                    "imageRef": PREVIOUS_IMAGE,
+                    "credentialGeneration": 3,
                     "attempts": 3,
                     "exhausted": True,
                 }
@@ -722,4 +842,61 @@ async def test_a_successful_refresh_clears_a_recorded_failure(
     )
 
     assert outcome.refreshed == ("opencode-go-default",)
+    assert outcome.ready is True
     assert REVALIDATION_FAILURE_KEY not in rows[0].command_behavior
+
+
+def test_revalidation_is_exhausted_is_scoped_to_image_and_generation() -> None:
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        REVALIDATION_FAILURE_KEY,
+        revalidation_is_exhausted,
+    )
+
+    def _record(**overrides):
+        record = {
+            "imageRef": CURRENT_IMAGE,
+            "credentialGeneration": 3,
+            "attempts": 3,
+            "exhausted": True,
+        }
+        record.update(overrides)
+        return _profile(command_behavior={REVALIDATION_FAILURE_KEY: record})
+
+    assert revalidation_is_exhausted(_record(), image_refs=(CURRENT_IMAGE,))
+    assert not revalidation_is_exhausted(_record(), image_refs=(PREVIOUS_IMAGE,))
+    assert not revalidation_is_exhausted(
+        _record(credentialGeneration=2), image_refs=(CURRENT_IMAGE,)
+    )
+    assert not revalidation_is_exhausted(
+        _record(exhausted=False), image_refs=(CURRENT_IMAGE,)
+    )
+    assert not revalidation_is_exhausted(_profile(), image_refs=(CURRENT_IMAGE,))
+
+
+def test_evidence_observation_is_current_is_the_shared_admission_predicate() -> None:
+    """Every admission boundary asks this one question about observation age."""
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        evidence_observation_is_current,
+    )
+
+    now = datetime(2026, 8, 28, 12, 0, tzinfo=UTC)
+    fresh = {"validatedAt": (now - timedelta(hours=5)).isoformat()}
+    aged = {"validatedAt": (now - timedelta(hours=7)).isoformat()}
+
+    assert evidence_observation_is_current(fresh, env={}, now=now)
+    assert not evidence_observation_is_current(aged, env={}, now=now)
+    # An explicit interval overrides the default in both directions.
+    assert evidence_observation_is_current(
+        aged, env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "12"}, now=now
+    )
+    assert not evidence_observation_is_current(
+        fresh, env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "1"}, now=now
+    )
+    # ``0`` restores identity-only staleness for every boundary at once.
+    assert evidence_observation_is_current(
+        aged, env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "0"}, now=now
+    )
+    # Evidence that cannot state when it was observed is never current.
+    assert not evidence_observation_is_current({}, env={}, now=now)
+    assert not evidence_observation_is_current(None, env={}, now=now)

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -266,6 +266,31 @@ def test_catalog_observation_interval_is_operator_configurable() -> None:
     )
 
 
+def test_catalog_observation_from_the_future_is_not_current() -> None:
+    """A backward clock correction must not keep an old catalog authoritative.
+
+    A ``validatedAt`` ahead of now yields a negative age that satisfies any
+    interval for as long as the timestamp stays ahead, so readiness and
+    planning would keep admitting models the provider may already have removed
+    for days after a VM snapshot restore.
+    """
+
+    now = datetime.now(UTC)
+    ahead = _profile(
+        evidence_image=CURRENT_IMAGE,
+        evidence_validated_at=(now + timedelta(days=3)).isoformat(),
+    )
+    assert not evidence_is_current(ahead, image_ref=CURRENT_IMAGE, env={}, now=now)
+
+    # Ordinary disagreement between the probing host's clock and this one is
+    # tolerated rather than forcing a re-probe on every pass.
+    skewed = _profile(
+        evidence_image=CURRENT_IMAGE,
+        evidence_validated_at=(now + timedelta(minutes=1)).isoformat(),
+    )
+    assert evidence_is_current(skewed, image_ref=CURRENT_IMAGE, env={}, now=now)
+
+
 def test_catalog_observation_without_a_timestamp_is_not_current() -> None:
     """An observation that cannot state its age cannot be shown to be current."""
 
@@ -900,3 +925,13 @@ def test_evidence_observation_is_current_is_the_shared_admission_predicate() -> 
     # Evidence that cannot state when it was observed is never current.
     assert not evidence_observation_is_current({}, env={}, now=now)
     assert not evidence_observation_is_current(None, env={}, now=now)
+    # Neither is evidence stamped beyond the clock-skew tolerance into the
+    # future, at every boundary and for every configured interval.
+    ahead = {"validatedAt": (now + timedelta(days=3)).isoformat()}
+    assert not evidence_observation_is_current(ahead, env={}, now=now)
+    assert not evidence_observation_is_current(
+        ahead, env={"OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS": "720"}, now=now
+    )
+    assert evidence_observation_is_current(
+        {"validatedAt": (now + timedelta(minutes=1)).isoformat()}, env={}, now=now
+    )

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -23,6 +23,7 @@ from moonmind.schemas.container_job_models import (
     MAX_ARTIFACT_PAGE_ENTRIES,
     MAX_LOG_PAGE_ENTRIES,
     ResolvedContainerLaunchPlan,
+    ResourceLimits,
     TerminalOutcome,
     ensure_temporal_safe,
     workspace_locator_identity,
@@ -380,3 +381,29 @@ def test_every_history_facing_contract_enforces_temporal_limit(monkeypatch) -> N
         )
     with pytest.raises(ValidationError, match="payload must serialize"):
         ContainerJobCancelResult(jobId=JOB_ID, state="canceling", accepted=True)
+
+
+def test_resource_limits_admit_and_validate_a_shared_memory_request() -> None:
+    """The generic contract admits the caller-owned shared-memory field.
+
+    A spec that could not express ``resources.shmSize`` rejected it as
+    ``extra_forbidden``, which blocked every caller whose workload needs more
+    shared memory than the deployment default.
+    """
+
+    admitted = ResourceLimits.model_validate(
+        {"cpuMillis": 1000, "memoryMiB": 512, "shmSize": "8g"}
+    )
+    assert admitted.shm_size == "8g"
+    assert admitted.model_dump(by_alias=True)["shmSize"] == "8g"
+
+    # Omitted means "deployment default applies", not "zero".
+    assert ResourceLimits.model_validate(
+        {"cpuMillis": 1000, "memoryMiB": 512}
+    ).shm_size is None
+
+    for invalid in ("", "   ", "8gigs", "-1g", "0"):
+        with pytest.raises(ValidationError):
+            ResourceLimits.model_validate(
+                {"cpuMillis": 1000, "memoryMiB": 512, "shmSize": invalid}
+            )

--- a/tests/unit/schemas/test_container_job_models.py
+++ b/tests/unit/schemas/test_container_job_models.py
@@ -148,6 +148,35 @@ def test_workdir_rejects_traversal(workdir: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "target",
+    ["/", "/cache/", "/cache//pip", "//cache", "/ca che", "/cache/..", "cache"],
+)
+def test_cache_target_requires_a_normalized_absolute_path(target: str) -> None:
+    """A cache target names one exact mount point, so it must be normalized.
+
+    The deployment declares its approved cache targets and the backend selects
+    a source by matching this value exactly. An un-normalized spelling would
+    describe the same mount point under a name no declaration can match, so the
+    request contract refuses it rather than resolving it later.
+    """
+
+    data = payload()
+    data["spec"]["caches"] = [{"cacheRef": "build-cache", "target": target}]
+    with pytest.raises(ValidationError):
+        ContainerJobSubmitRequest.model_validate(data)
+
+
+def test_cache_target_accepts_a_normalized_absolute_path() -> None:
+    data = payload()
+    data["spec"]["caches"] = [
+        {"cacheRef": "build-cache", "target": "/opt/project/cache", "readOnly": True}
+    ]
+    mount = ContainerJobSubmitRequest.model_validate(data).spec.caches[0]
+    assert mount.target == "/opt/project/cache"
+    assert mount.read_only is True
+
+
+@pytest.mark.parametrize(
     "locator,expected_identity,expected_type",
     [
         (

--- a/tests/unit/services/test_omnigent_agent_smoke_service.py
+++ b/tests/unit/services/test_omnigent_agent_smoke_service.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -313,3 +313,155 @@ async def test_readiness_bundle_provenance_fails_for_missing_artifact(session):
     by_name = {check["name"]: check for check in outcome.checks}
     assert by_name["bundle_provenance"]["ready"] is False
     assert "bundle_contents" not in by_name
+
+
+# --------------------------------------------------------------------------
+# Model catalog admission: identity and observation age
+# --------------------------------------------------------------------------
+
+
+def _opencode_v2_document(*, harness, catalog_ref: str) -> dict:
+    return {
+        "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+        "endpointRef": "default",
+        "source": {
+            "kind": "upstream",
+            "upstreamId": "opencode-native-ui",
+            "upstreamVersion": "1",
+            "upstreamSnapshotDigest": "sha256:" + "7" * 64,
+        },
+        "harness": {
+            "id": harness.id,
+            "catalogRef": catalog_ref,
+            "implementationRef": harness.implementation.implementation_ref(),
+        },
+        "credentialSlots": [
+            {"id": "primary-model", "acceptedProviderIds": ["opencode-go"]}
+        ],
+        "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
+        "model": {"qualifiedId": "opencode-go/test-model"},
+    }
+
+
+async def _seed_opencode_smoke_admission(session, *, validated_at: datetime):
+    """Seed the exact rows the v2 provider admission loop reads."""
+
+    from api_service.db.models import (
+        OmnigentHarnessCatalogSnapshotRecord,
+        OmnigentHarnessTrustRecord,
+    )
+    from moonmind.omnigent.harness_platform.catalog import (
+        TrustState,
+        create_catalog_snapshot,
+    )
+
+    snapshot = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="0.11.0",
+        omnigentBuildDigest="sha256:" + "4" * 64,
+        sourceDigest="sha256:" + "5" * 64,
+        harnesses=[
+            {
+                "id": "opencode-native",
+                "label": "OpenCode",
+                "implementation": {
+                    "sourceKind": "core",
+                    "package": "omnigent",
+                    "version": "0.11.0",
+                    "digest": "sha256:" + "3" * 64,
+                },
+                "capabilities": {"integrationMode": "native-server"},
+            }
+        ],
+    )
+    harness = snapshot.harnesses[0]
+    session.add(
+        OmnigentHarnessCatalogSnapshotRecord(
+            catalog_ref=snapshot.catalogRef,
+            endpoint_ref="default",
+            omnigent_version=snapshot.omnigentVersion,
+            omnigent_build_digest=snapshot.omnigentBuildDigest,
+            observed_at=datetime.now(timezone.utc),
+            source_digest=snapshot.sourceDigest,
+            snapshot_json=snapshot.model_dump(mode="json"),
+            diagnostics_json={},
+        )
+    )
+    await session.flush()
+    session.add(
+        OmnigentHarnessTrustRecord(
+            implementation_ref=harness.implementation.implementation_ref(),
+            harness_id=harness.id,
+            catalog_ref=snapshot.catalogRef,
+            trust_state=TrustState.core_trusted.value,
+        )
+    )
+    provider = ManagedAgentProviderProfile(
+        profile_id="opencode-go-primary",
+        runtime_id="opencode",
+        provider_id="opencode-go",
+        credential_source=ProviderCredentialSource.SECRET_REF,
+        runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+        enabled=True,
+        auth_state=ProviderProfileAuthState.CONNECTED,
+        secret_refs={"opencode_api_key": "env://OPENCODE_API_KEY"},
+        credential_generation=4,
+        model_catalog_evidence_json={
+            "credentialGeneration": 4,
+            "imageRef": "registry.test/opencode@sha256:" + "6" * 64,
+            "models": [{"qualifiedId": "opencode-go/test-model"}],
+            "validatedAt": validated_at.isoformat(),
+        },
+    )
+    session.add(provider)
+    await session.commit()
+    return _opencode_v2_document(harness=harness, catalog_ref=snapshot.catalogRef)
+
+
+async def _provider_check(session, document):
+    outcome = await run_profile_readiness_checks(
+        session,
+        document=document,
+        refresh_upstream=_noop_refresh,
+        read_bundle_bytes=_unused_bundle_reader,
+    )
+    return {check["name"]: check for check in outcome.checks}["provider_profile"]
+
+
+async def test_smoke_admission_rejects_an_expired_model_catalog(session, monkeypatch):
+    """Smoke launches the real host, so it must not admit an expired catalog.
+
+    The pinned host image refreshes its catalog from the provider at probe
+    time. Binding admission to the credential generation and image digest alone
+    would let smoke keep launching from the first catalog it ever observed --
+    including a model the provider has since removed -- because neither of
+    those changes on a healthy deployment.
+    """
+
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "registry.test/opencode@sha256:" + "6" * 64,
+    )
+    # Exercise the documented default catalog interval, not an inherited value.
+    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", raising=False)
+    document = await _seed_opencode_smoke_admission(
+        session, validated_at=datetime.now(timezone.utc)
+    )
+
+    assert (await _provider_check(session, document))["ready"] is True
+
+    provider = await session.get(ManagedAgentProviderProfile, "opencode-go-primary")
+    provider.model_catalog_evidence_json = {
+        **provider.model_catalog_evidence_json,
+        "validatedAt": (
+            datetime.now(timezone.utc) - timedelta(hours=9)
+        ).isoformat(),
+    }
+    await session.commit()
+
+    assert (await _provider_check(session, document))["ready"] is False
+
+    # The interval is deployment-configurable; ``0`` restores identity-only
+    # staleness at this boundary exactly as it does at the reconciler.
+    monkeypatch.setenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", "0")
+    assert (await _provider_check(session, document))["ready"] is True

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1869,11 +1869,33 @@ async def test_launch_session_injects_moonmind_url_from_activity_environment(
     assert launched_request.environment["PATH"] == "/usr/bin"
     assert launched_request.environment["MOONMIND_URL"] == "http://api:8000"
 
-async def test_launch_session_injects_unreal_image_refs_from_activity_environment(
+@pytest.mark.parametrize(
+    ("declared", "forwarded"),
+    [
+        ("PROJECT_TOOLCHAIN_IMAGE", True),
+        # Secret-looking names never reach a session through this path.
+        ("PROJECT_REGISTRY_TOKEN", False),
+        # Malformed declarations are ignored rather than forwarded blindly.
+        ("not a key", False),
+    ],
+    ids=["non-secret", "secret-looking", "malformed"],
+)
+async def test_launch_session_injects_declared_non_secret_environment(
     monkeypatch: pytest.MonkeyPatch,
+    declared: str,
+    forwarded: bool,
 ) -> None:
-    pinned = "ghcr.io/moonladderstudios/tactics-ue-base@sha256:abc123"
-    monkeypatch.setenv("MOONMIND_UNREAL_ENGINE_IMAGE", pinned)
+    """A deployment declares which non-secret keys a Skill may read.
+
+    MoonMind used to hardcode one project's variable name here. The allowlist
+    is now operator-declared, so no project is named in MoonMind's source.
+    """
+
+    pinned = "registry.invalid/example/toolchain@sha256:abc123"
+    monkeypatch.setenv(declared, pinned)
+    monkeypatch.setenv(
+        "MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS", f" {declared} , ,{declared}"
+    )
     controller = AsyncMock()
     controller.launch_session = AsyncMock(
         return_value=CodexManagedSessionHandle(
@@ -1904,7 +1926,10 @@ async def test_launch_session_injects_unreal_image_refs_from_activity_environmen
     )
 
     launched_request = controller.launch_session.await_args.args[0]
-    assert launched_request.environment["MOONMIND_UNREAL_ENGINE_IMAGE"] == pinned
+    if forwarded:
+        assert launched_request.environment[declared] == pinned
+    else:
+        assert declared not in launched_request.environment
 
 
 async def test_pre_cutover_ensure_sidecar_activity_remains_executable() -> None:

--- a/tests/unit/workflows/temporal/test_container_image_acquisition.py
+++ b/tests/unit/workflows/temporal/test_container_image_acquisition.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 from temporalio.exceptions import ApplicationError
 
 from moonmind.config.container_backend_settings import (
-    TACTICS_UNREAL_IMAGE_SOURCE_REF,
+    ContainerBackendConfigError,
     resolve_container_backend_settings,
 )
 from moonmind.schemas.container_job_models import (
@@ -236,30 +237,56 @@ async def test_if_missing_absent_pulls_and_records_duration(tmp_path) -> None:
     assert obs.pull_duration_ms is not None and obs.pull_duration_ms >= 0
 
 
+DECLARED_IMAGE_SOURCE_REF = "project-toolchain"
+DECLARED_IMAGE = "registry.invalid/example/toolchain:1.0"
+
+
+def _declared_image_source_env(*, pull_policy: str | None = None) -> dict[str, str]:
+    """One deployment-declared registry image source.
+
+    MoonMind ships no project image defaults, so the deployment declaration is
+    the only way a source ref resolves.
+    """
+
+    declaration: dict[str, str] = {
+        "sourceRef": DECLARED_IMAGE_SOURCE_REF,
+        "image": DECLARED_IMAGE,
+    }
+    if pull_policy is not None:
+        declaration["pullPolicy"] = pull_policy
+    return {
+        "MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES": json.dumps([declaration])
+    }
+
+
 @pytest.mark.asyncio
-async def test_missing_tactics_unreal_source_pulls_on_first_use(tmp_path) -> None:
-    image = "ghcr.io/moonladderstudios/tactics-ue-base:5.8"
+async def test_missing_declared_image_source_pulls_on_first_use(tmp_path) -> None:
     daemon = FakeDaemon()
     backend = _backend(
         daemon,
         tmp_path,
-        settings=resolve_container_backend_settings(
-            {"MOONMIND_UNREAL_ENGINE_IMAGE": image}
-        ),
+        settings=resolve_container_backend_settings(_declared_image_source_env()),
     )
 
     result = await backend.acquire_image(
         _request(
             None,
-            image_source_ref=TACTICS_UNREAL_IMAGE_SOURCE_REF,
+            image_source_ref=DECLARED_IMAGE_SOURCE_REF,
         )
     )
 
-    assert daemon.pulls == [image]
-    assert result.image_observation.image_source_ref == (
-        TACTICS_UNREAL_IMAGE_SOURCE_REF
-    )
+    assert daemon.pulls == [DECLARED_IMAGE]
+    assert result.image_observation.image_source_ref == DECLARED_IMAGE_SOURCE_REF
     assert result.image_observation.provision_action == "pull"
+
+
+@pytest.mark.asyncio
+async def test_undeclared_image_source_ref_fails_closed(tmp_path) -> None:
+    """An image source MoonMind was never told about cannot resolve."""
+
+    settings = resolve_container_backend_settings({})
+    with pytest.raises(ContainerBackendConfigError):
+        settings.image_source(DECLARED_IMAGE_SOURCE_REF)
 
 
 @pytest.mark.asyncio
@@ -282,7 +309,7 @@ async def test_deployment_source_absence_names_operator_remediation(tmp_path) ->
         daemon,
         tmp_path,
         settings=resolve_container_backend_settings(
-            {"MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY": "never"}
+            _declared_image_source_env(pull_policy="never")
         ),
     )
     payload = _request("python:3.13").model_dump(
@@ -291,14 +318,17 @@ async def test_deployment_source_absence_names_operator_remediation(tmp_path) ->
     spec = payload["request"]["spec"]
     spec.pop("image")
     spec.pop("pullPolicy")
-    spec["imageSourceRef"] = "tactics-unreal"
+    spec["imageSourceRef"] = DECLARED_IMAGE_SOURCE_REF
     request = ContainerJobActivityRequest.model_validate(payload)
 
     with pytest.raises(ImageAcquisitionError) as excinfo:
         await backend.acquire_image(request)
 
     assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE_NOT_FOUND
-    assert "deployment image source 'tactics-unreal' is absent" in str(excinfo.value)
+    assert (
+        f"deployment image source {DECLARED_IMAGE_SOURCE_REF!r} is absent"
+        in str(excinfo.value)
+    )
     assert "provision its configured image" in str(excinfo.value)
     assert daemon.pulls == []
 

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -24,6 +24,7 @@ from moonmind.security.egress_conformance_evidence import (
     verify_evidence_digest,
 )
 from moonmind.config.container_backend_settings import (
+    CACHE_SOURCES_ENV_KEY,
     ContainerBackendReadinessError,
     resolve_container_backend_settings,
 )
@@ -901,6 +902,70 @@ async def test_create_rejects_resources_above_deployment_ceiling(tmp_path) -> No
 
 
 @pytest.mark.asyncio
+async def test_create_preserves_the_callers_shared_memory_request(tmp_path) -> None:
+    """The caller owns shmSize once the deployment ceiling has admitted it."""
+
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=_recording_runner(commands),
+    )
+
+    await backend.create_container(
+        _request(
+            tmp_path,
+            resources={"cpuMillis": 1000, "memoryMiB": 512, "shmSize": "8g"},
+        )
+    )
+
+    create = next(c for c in commands if c[0] == "create")
+    assert create[create.index("--shm-size") + 1] == "8g"
+
+
+@pytest.mark.asyncio
+async def test_create_applies_the_deployment_shared_memory_default(tmp_path) -> None:
+    (tmp_path / "art_workspace").mkdir()
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        command_runner=_recording_runner(commands),
+    )
+
+    await backend.create_container(_request(tmp_path))
+
+    create = next(c for c in commands if c[0] == "create")
+    assert create[create.index("--shm-size") + 1] == "64m"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_shared_memory_above_deployment_ceiling(
+    tmp_path,
+) -> None:
+    """Refused, never clamped: the realized value must match the request."""
+
+    (tmp_path / "art_workspace").mkdir()
+    bounded = resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB": "1024"}
+    )
+    commands: list[tuple[str, ...]] = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=bounded,
+        command_runner=_recording_runner(commands),
+    )
+
+    with pytest.raises(RuntimeError, match="shmSize=8g exceeds the deployment ceiling"):
+        await backend.create_container(
+            _request(
+                tmp_path,
+                resources={"cpuMillis": 1000, "memoryMiB": 512, "shmSize": "8g"},
+            )
+        )
+    assert not [c for c in commands if c[0] == "create"]
+
+
+@pytest.mark.asyncio
 async def test_capacity_lock_is_mutually_exclusive_across_workers(
     tmp_path,
 ) -> None:
@@ -1008,24 +1073,59 @@ async def test_start_serializes_and_admits_within_active_memory_budget(
     lock.release.assert_awaited_once_with(lock.acquire.return_value)
 
 
+#: Two deployment-declared cache sources. MoonMind ships none of its own, so a
+#: cache test must declare what the deployment authorizes.
+PRIMARY_CACHE_REF = "build-cache"
+PRIMARY_CACHE_VOLUME = "build_cache_volume"
+PRIMARY_CACHE_TARGET = "/opt/project/cache"
+SECONDARY_CACHE_REF = "toolchain-metadata"
+SECONDARY_CACHE_VOLUME = "toolchain_metadata_volume"
+SECONDARY_CACHE_TARGET = "/opt/project/metadata"
+
+DECLARED_CACHE_SOURCES_ENV = {
+    CACHE_SOURCES_ENV_KEY: json.dumps(
+        [
+            {
+                "cacheRef": PRIMARY_CACHE_REF,
+                "volumeName": PRIMARY_CACHE_VOLUME,
+                "target": PRIMARY_CACHE_TARGET,
+            },
+            {
+                "cacheRef": SECONDARY_CACHE_REF,
+                "volumeName": SECONDARY_CACHE_VOLUME,
+                "target": SECONDARY_CACHE_TARGET,
+            },
+        ]
+    )
+}
+
+
+def _cache_backend(tmp_path, commands):
+    """A backend whose deployment authorizes the two declared cache sources."""
+
+    return DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=resolve_container_backend_settings(DECLARED_CACHE_SOURCES_ENV),
+        command_runner=_recording_runner(commands),
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_mounts_deployment_authorized_cache_refs(tmp_path) -> None:
     (tmp_path / "art_workspace").mkdir()
     commands: list[tuple[str, ...]] = []
-    backend = DockerContainerJobBackend(
-        workspace_root=tmp_path, command_runner=_recording_runner(commands)
-    )
+    backend = _cache_backend(tmp_path, commands)
     request = _request(
         tmp_path,
         caches=[
             {
-                "cacheRef": "unreal-ccache",
-                "target": "/home/ue4/.ccache",
+                "cacheRef": PRIMARY_CACHE_REF,
+                "target": PRIMARY_CACHE_TARGET,
                 "readOnly": False,
             },
             {
-                "cacheRef": "unreal-ubt",
-                "target": "/home/ue4/.config/Epic/UnrealBuildTool",
+                "cacheRef": SECONDARY_CACHE_REF,
+                "target": SECONDARY_CACHE_TARGET,
                 "readOnly": False,
             },
         ],
@@ -1034,17 +1134,17 @@ async def test_create_mounts_deployment_authorized_cache_refs(tmp_path) -> None:
 
     create = next(command for command in commands if command[0] == "create")
     cache_mounts = [
-        item for item in create if item.startswith("type=volume,src=unreal_")
+        item for item in create if item.startswith("type=volume,src=")
     ]
     assert len(cache_mounts) == 2
     assert any(
-        item.startswith("type=volume,src=unreal_ccache_volume-")
-        and item.endswith(",dst=/home/ue4/.ccache")
+        item.startswith(f"type=volume,src={PRIMARY_CACHE_VOLUME}-")
+        and item.endswith(f",dst={PRIMARY_CACHE_TARGET}")
         for item in cache_mounts
     )
     assert any(
-        item.startswith("type=volume,src=unreal_ubt_volume-")
-        and item.endswith("dst=/home/ue4/.config/Epic/UnrealBuildTool")
+        item.startswith(f"type=volume,src={SECONDARY_CACHE_VOLUME}-")
+        and item.endswith(f"dst={SECONDARY_CACHE_TARGET}")
         for item in cache_mounts
     )
     cache_volume_commands = [
@@ -1059,7 +1159,7 @@ async def test_create_mounts_deployment_authorized_cache_refs(tmp_path) -> None:
         any(item.startswith("moonmind.cache_owner=") for item in command)
         for command in cache_volume_commands
     )
-    assert result.resolved_cache_refs == ("unreal-ccache", "unreal-ubt")
+    assert result.resolved_cache_refs == (PRIMARY_CACHE_REF, SECONDARY_CACHE_REF)
 
 
 @pytest.mark.asyncio
@@ -1069,8 +1169,8 @@ async def test_cache_volume_is_scoped_to_the_authorized_owner(tmp_path) -> None:
     second_commands: list[tuple[str, ...]] = []
     cache = [
         {
-            "cacheRef": "unreal-ccache",
-            "target": "/home/ue4/.ccache",
+            "cacheRef": PRIMARY_CACHE_REF,
+            "target": PRIMARY_CACHE_TARGET,
             "readOnly": False,
         }
     ]
@@ -1083,26 +1183,20 @@ async def test_cache_volume_is_scoped_to_the_authorized_owner(tmp_path) -> None:
         }
     )
 
-    await DockerContainerJobBackend(
-        workspace_root=tmp_path,
-        command_runner=_recording_runner(first_commands),
-    ).create_container(first_request)
-    await DockerContainerJobBackend(
-        workspace_root=tmp_path,
-        command_runner=_recording_runner(second_commands),
-    ).create_container(second_request)
+    await _cache_backend(tmp_path, first_commands).create_container(first_request)
+    await _cache_backend(tmp_path, second_commands).create_container(second_request)
 
     first_mount = next(
         item
         for command in first_commands
         for item in command
-        if item.startswith("type=volume,src=unreal_ccache_volume-")
+        if item.startswith(f"type=volume,src={PRIMARY_CACHE_VOLUME}-")
     )
     second_mount = next(
         item
         for command in second_commands
         for item in command
-        if item.startswith("type=volume,src=unreal_ccache_volume-")
+        if item.startswith(f"type=volume,src={PRIMARY_CACHE_VOLUME}-")
     )
     assert first_mount != second_mount
 
@@ -1117,7 +1211,7 @@ async def test_cache_volume_is_scoped_to_the_authorized_owner(tmp_path) -> None:
         ),
         (
             {
-                "cacheRef": "unreal-ccache",
+                "cacheRef": PRIMARY_CACHE_REF,
                 "target": "/different",
                 "readOnly": False,
             },
@@ -1125,8 +1219,8 @@ async def test_cache_volume_is_scoped_to_the_authorized_owner(tmp_path) -> None:
         ),
         (
             {
-                "cacheRef": "unreal-ccache",
-                "target": "/home/ue4/.ccache",
+                "cacheRef": PRIMARY_CACHE_REF,
+                "target": PRIMARY_CACHE_TARGET,
                 "readOnly": True,
             },
             "requires read-write",
@@ -1137,9 +1231,7 @@ async def test_create_rejects_cache_authority_mismatch(
     tmp_path, cache: dict[str, object], match: str
 ) -> None:
     (tmp_path / "art_workspace").mkdir()
-    backend = DockerContainerJobBackend(
-        workspace_root=tmp_path, command_runner=_recording_runner([])
-    )
+    backend = _cache_backend(tmp_path, [])
     with pytest.raises(RuntimeError, match=match):
         await backend.create_container(_request(tmp_path, caches=[cache]))
 

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -13,6 +13,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_BOUNDED_STORY_LOOP_FEEDBACK_PROGRESS_PATCH,
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     RUN_BOUNDED_STORY_LOOP_REMEDIATION_BUDGET_PATCH,
+    RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
     MoonMindRunWorkflow,
     bounded_story_loop_resume_decision,
     bounded_story_loop_scope_guard,
@@ -1403,3 +1404,147 @@ def test_moonspec_gate_context_uses_gate_artifact_for_legacy_remaining_work(
 
     context = workflow._publish_context["moonSpecGate"]
     assert context["remainingWorkRef"] == "artifact://art_verify_legacy"
+
+
+# The MoonSpec terminal gate only ever fires on a read-only verification step.
+# Such a step reports a verdict and pushes nothing, so publication feasibility
+# has to be resolved for the run rather than for that one step.
+_VERIFICATION_STEP_RESULT = {
+    "status": "COMPLETED",
+    "outputs": {
+        "summary": "MoonSpec verification report",
+        "moonSpecVerify": {"schemaVersion": 1, "verdict": "ADDITIONAL_WORK_NEEDED"},
+    },
+}
+_VERIFIED_PUBLISHED_HEAD = {
+    "pushStatus": "pushed",
+    "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+    "baseRef": "origin/main",
+    "headSha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+    "commitCount": 2,
+}
+
+
+def _gate_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    published_head_feasibility: bool,
+    publish_context: dict[str, Any] | None = None,
+) -> MoonMindRunWorkflow:
+    workflow = MoonMindRunWorkflow()
+    workflow._publish_context.update(
+        _VERIFIED_PUBLISHED_HEAD if publish_context is None else publish_context
+    )
+    enabled = (
+        {RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH}
+        if published_head_feasibility
+        else set()
+    )
+    monkeypatch.setattr(
+        run_module.workflow, "patched", lambda patch_id: patch_id in enabled
+    )
+    return workflow
+
+
+def test_terminal_gate_draft_publishes_run_owned_published_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = _gate_workflow(monkeypatch, published_head_feasibility=True)
+
+    # The step's own evidence is still correctly inconclusive.
+    step_scoped = workflow._step_publication_feasibility(_VERIFICATION_STEP_RESULT)
+    assert step_scoped["feasible"] is False
+    assert step_scoped["reason"] == "publication_state_ambiguous"
+
+    feasibility = workflow._publication_feasibility(_VERIFICATION_STEP_RESULT)
+    assert feasibility["feasible"] is True
+    assert feasibility["reason"] == "verified_remote_head"
+
+    workflow._moonspec_gate_verdict = "ADDITIONAL_WORK_NEEDED"
+    policy = workflow._moonspec_draft_publication_policy(
+        environment_blocked_enabled=False,
+        additional_work_enabled=True,
+    )
+    assert policy == "draft_pr_on_additional_work_needed"
+    assert (
+        workflow._terminal_gate_handoff_kind(
+            publish_mode="pr",
+            draft_publication_policy=policy,
+            publication_feasible=feasibility["feasible"],
+        )
+        == "draft_publication"
+    )
+
+
+def test_terminal_gate_keeps_artifact_handoff_for_unpatched_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = _gate_workflow(monkeypatch, published_head_feasibility=False)
+
+    feasibility = workflow._publication_feasibility(_VERIFICATION_STEP_RESULT)
+    assert feasibility["feasible"] is False
+    assert feasibility["reason"] == "publication_state_ambiguous"
+    assert (
+        workflow._terminal_gate_handoff_kind(
+            publish_mode="pr",
+            draft_publication_policy="draft_pr_on_additional_work_needed",
+            publication_feasible=feasibility["feasible"],
+        )
+        == "artifact_backed"
+    )
+
+
+@pytest.mark.parametrize(
+    ("publish_context", "expected_reason"),
+    [
+        ({}, "publication_state_ambiguous"),
+        (
+            {**_VERIFIED_PUBLISHED_HEAD, "pushStatus": "failed"},
+            "publication_state_ambiguous",
+        ),
+        (
+            {"pushStatus": "pushed", "branch": "feature/x"},
+            "publication_state_ambiguous",
+        ),
+    ],
+    ids=["no-published-head", "push-failed", "missing-head-sha"],
+)
+def test_terminal_gate_requires_a_verified_published_head(
+    monkeypatch: pytest.MonkeyPatch,
+    publish_context: dict[str, Any],
+    expected_reason: str,
+) -> None:
+    workflow = _gate_workflow(
+        monkeypatch,
+        published_head_feasibility=True,
+        publish_context=publish_context,
+    )
+
+    feasibility = workflow._publication_feasibility(_VERIFICATION_STEP_RESULT)
+    assert feasibility["feasible"] is False
+    assert feasibility["reason"] == expected_reason
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected_reason"),
+    [
+        ({"pushStatus": "pushed", "publicationAuthorized": False}, "publication_unauthorized"),
+        ({"pushStatus": "pushed", "candidateContaminated": True}, "candidate_contaminated"),
+        ({"pushStatus": "local", "commitsAheadOfBase": 0}, "no_candidate_change"),
+    ],
+    ids=["unauthorized", "contaminated", "no-candidate-change"],
+)
+def test_terminal_gate_preserves_definitive_publication_refusals(
+    monkeypatch: pytest.MonkeyPatch,
+    evidence: dict[str, Any],
+    expected_reason: str,
+) -> None:
+    """A run-owned head answers "unknown", never "refused"."""
+
+    workflow = _gate_workflow(monkeypatch, published_head_feasibility=True)
+
+    feasibility = workflow._publication_feasibility(
+        {"outputs": {"acceptedRepositoryEvidence": evidence}}
+    )
+    assert feasibility["feasible"] is False
+    assert feasibility["reason"] == expected_reason

--- a/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py
@@ -1416,7 +1416,30 @@ _VERIFICATION_STEP_RESULT = {
         "moonSpecVerify": {"schemaVersion": 1, "verdict": "ADDITIONAL_WORK_NEEDED"},
     },
 }
-_VERIFIED_PUBLISHED_HEAD = {
+# Only the managed git-push boundary emits accepted repository evidence, so it
+# is the run's sole authority for "a verified remote head exists". The raw
+# ``branch``/``headSha``/``pushStatus`` keys below survive on any step's
+# metadata, including a read-only verifier's, and prove nothing on their own.
+_ACCEPTED_PUSH_STEP_OUTPUTS = {
+    "summary": "Applied MoonSpec remediation",
+    "push_status": "pushed",
+    "push_branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+    "push_base_ref": "origin/main",
+    "push_head_sha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+    "push_commit_count": 2,
+    "acceptedRepositoryEvidence": {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "pushed",
+        "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+        "baseBranch": "origin/main",
+        "headSha": "5c1837fa677aff381af09601f8d86055f0eccbcd",
+        "commitsAheadOfBase": 2,
+        "repositoryChanged": True,
+        "remoteVerified": True,
+    },
+}
+_ACCEPTED_EVIDENCE = _ACCEPTED_PUSH_STEP_OUTPUTS["acceptedRepositoryEvidence"]
+_UNVERIFIED_PUBLISH_CONTEXT = {
     "pushStatus": "pushed",
     "branch": "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
     "baseRef": "origin/main",
@@ -1430,11 +1453,9 @@ def _gate_workflow(
     *,
     published_head_feasibility: bool,
     publish_context: dict[str, Any] | None = None,
+    accepted_step_outputs: dict[str, Any] | None = _ACCEPTED_PUSH_STEP_OUTPUTS,
 ) -> MoonMindRunWorkflow:
     workflow = MoonMindRunWorkflow()
-    workflow._publish_context.update(
-        _VERIFIED_PUBLISHED_HEAD if publish_context is None else publish_context
-    )
     enabled = (
         {RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH}
         if published_head_feasibility
@@ -1443,6 +1464,13 @@ def _gate_workflow(
     monkeypatch.setattr(
         run_module.workflow, "patched", lambda patch_id: patch_id in enabled
     )
+    if accepted_step_outputs is not None:
+        workflow._record_execution_context(
+            node_id="issue-implementation-remediation:3",
+            execution_result={"status": "COMPLETED", "outputs": accepted_step_outputs},
+        )
+    if publish_context is not None:
+        workflow._publish_context.update(publish_context)
     return workflow
 
 
@@ -1495,34 +1523,86 @@ def test_terminal_gate_keeps_artifact_handoff_for_unpatched_histories(
 
 
 @pytest.mark.parametrize(
-    ("publish_context", "expected_reason"),
+    "accepted_evidence",
     [
-        ({}, "publication_state_ambiguous"),
-        (
-            {**_VERIFIED_PUBLISHED_HEAD, "pushStatus": "failed"},
-            "publication_state_ambiguous",
-        ),
-        (
-            {"pushStatus": "pushed", "branch": "feature/x"},
-            "publication_state_ambiguous",
-        ),
+        None,
+        {**_ACCEPTED_EVIDENCE, "pushStatus": "failed"},
+        {**_ACCEPTED_EVIDENCE, "headSha": ""},
+        {**_ACCEPTED_EVIDENCE, "branch": ""},
     ],
-    ids=["no-published-head", "push-failed", "missing-head-sha"],
+    ids=["no-published-head", "push-failed", "missing-head-sha", "missing-branch"],
 )
 def test_terminal_gate_requires_a_verified_published_head(
     monkeypatch: pytest.MonkeyPatch,
-    publish_context: dict[str, Any],
-    expected_reason: str,
+    accepted_evidence: dict[str, Any] | None,
 ) -> None:
+    outputs = None
+    if accepted_evidence is not None:
+        outputs = {
+            **_ACCEPTED_PUSH_STEP_OUTPUTS,
+            "acceptedRepositoryEvidence": accepted_evidence,
+        }
     workflow = _gate_workflow(
         monkeypatch,
         published_head_feasibility=True,
-        publish_context=publish_context,
+        accepted_step_outputs=outputs,
     )
 
     feasibility = workflow._publication_feasibility(_VERIFICATION_STEP_RESULT)
     assert feasibility["feasible"] is False
-    assert feasibility["reason"] == expected_reason
+    assert feasibility["reason"] == "publication_state_ambiguous"
+
+
+def test_terminal_gate_ignores_unverified_publish_context_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raw push metadata from a non-publishing step is not accepted evidence.
+
+    ``fetch_result`` strips forged ``acceptedRepositoryEvidence`` objects but
+    leaves raw ``push_status``/``branch``/``headSha`` keys intact, and
+    ``_record_execution_context`` promotes those into ``_publish_context``.
+    Upgrading the gate from them would attempt a draft PR for a head the
+    managed push boundary never verified.
+    """
+
+    workflow = _gate_workflow(
+        monkeypatch,
+        published_head_feasibility=True,
+        publish_context=_UNVERIFIED_PUBLISH_CONTEXT,
+        accepted_step_outputs=None,
+    )
+
+    assert workflow._workflow_verified_published_head() is not None
+    assert workflow._accepted_published_head() is None
+
+    feasibility = workflow._publication_feasibility(_VERIFICATION_STEP_RESULT)
+    assert feasibility["feasible"] is False
+    assert feasibility["reason"] == "publication_state_ambiguous"
+
+
+def test_accepted_published_head_is_recorded_as_one_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later read-only step must not overwrite half of the verified head."""
+
+    workflow = _gate_workflow(monkeypatch, published_head_feasibility=True)
+    assert workflow._accepted_published_head() == (
+        "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+        "5c1837fa677aff381af09601f8d86055f0eccbcd",
+    )
+
+    workflow._record_execution_context(
+        node_id="issue-implementation-verification:3",
+        execution_result={
+            "status": "COMPLETED",
+            "outputs": {"branch": "unverified/other", "head_sha": "0" * 40},
+        },
+    )
+
+    assert workflow._accepted_published_head() == (
+        "fetch-github-issue-moonladderstudios-tac-4f8e2aa7",
+        "5c1837fa677aff381af09601f8d86055f0eccbcd",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

Related to MoonLadderStudios/Tactics#2540. Fixes the escaped journey in workflow `mm:53e35d1e-343c-4ebb-9029-9ed823cd090f`.

## Summary

Three changes, plus the pre-existing OpenCode/Omnigent commit this branch started from.

- **Terminal-gate draft publication actually publishes.** `WorkflowPublishing.md` promises that once the remediation budget is exhausted, a `pr`-mode run opens a **draft** PR annotated with the remaining-work verdict. It never could: the gate evaluated publication feasibility from the result of the step it stopped on, and that step is always a *read-only MoonSpec verification* step. Such a step pushes nothing, so its evidence always classified `publication_state_ambiguous`, `_terminal_gate_handoff_kind` always returned `artifact_backed`, and the run failed with a verified branch on the remote and **no PR at all**. Feasibility is now resolved for the *run*: an inconclusive step classification defers to the run-owned published head. Definitive refusals (unauthorized, contaminated candidate, no candidate change) are safety decisions and are never overridden.
- **Generic container surfaces name no consuming project** (Tactics#2540 AC-03, AC-12). `container_backend_settings.py` hardcoded a `tactics-unreal` image source, the `tactics-ue-base:5.8` default, `unreal-ccache`/`unreal-ubt` cache refs and Unreal in-container paths — 20 violations of the consuming project's coupling scan. Image sources, cache sources and the managed-session non-secret env allowlist are now **deployment-declared**. MoonMind keeps one image source of its own (its `moonmind-python-tests` self-test image) and no cache source.
- **`resources.shmSize` is admitted and preserved** (AC-13). `ResourceLimits` could not express shared memory and `ContractModel` forbids extras, so `resources.shmSize: "8g"` was rejected as `extra_forbidden` before reaching the backend, which then hardcoded the 64 MiB deployment default. It is now part of the contract and the backend realizes the caller's value.

### ELI5

Tactics#2540 kept failing after three remediation rounds. The verifier had said from attempt 1 that the *Tactics* work was done and the remaining gaps were inside the installed MoonMind package (`site-packages/moonmind/...`) — `recoverableInCurrentRuntime: false`, zero gaps, `rawRecommendedNextAction: advance`. The agent had the Tactics repo checked out, so it could never close them. Then MoonMind lost the work: the branch was pushed and verified on the remote, but no draft PR was opened.

```
remediation:3  ──> pushes branch, records acceptedRepositoryEvidence  (pushStatus: pushed, 2 commits)
verification:3 ──> read-only; pushes nothing; NO repository evidence
                     │
                     └─ terminal gate asked THIS step "is publication feasible?"
                          → "publication_state_ambiguous" → artifact_backed → FAILED, no PR
                        now asks the RUN
                          → run-owned published head → draft_publication → draft PR
```

## Test Plan

```bash
./tools/test_unit.sh tests/unit/config/ tests/unit/schemas/ tests/unit/workloads/ tests/unit/workflows/temporal/
```

```bash
./tools/test_integration.sh
```

Run locally in a clean worktree (WSL, `python3 -m pytest`):

- `tests/unit/config/ tests/unit/schemas/ tests/unit/workloads/ tests/unit/mcp/ tests/unit/workflows/temporal/` — **4605 passed, 1 failed**. The single failure is `test_agent_session_deployment_safety.py::test_cli_changed_files_file_flags_sensitive_change_without_merge_base`, which fails identically on unmodified `main` in the same worktree (`git ls-files` returns 128 because a Windows-created worktree's `.git` file carries a Windows absolute path). Not caused by this branch.
- Every touched module re-run after the final edits — **1302 passed**.
- `tests/integration/reliability/test_escaped_failure_journeys.py -m reliability_journey` — **105 passed**.
- `tools/verify_test_shard_ownership.py` — exit 0, one CI owner for 13525 provider-free nodes.
- The consuming project's coupling scan re-implemented over the same 11 surfaces — **20 violations → 0**.
- `docker compose config` — exit 0; the JSON declarations interpolate to exactly the previous image/volume/path values.
- Regression proof for the draft-publication fix: with the new fallback disabled, the replay test fails at `assert feasibility["feasible"] is True`.

## Demo

N/A — no dashboard/UI change.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Risk notes

**Temporal replay / in-flight.** The publication-feasibility change is gated behind `run-terminal-gate-published-head-feasibility-v1`, so histories that never recorded the patch replay the previous `artifact_backed` handoff unchanged. `test_verification_gate_draft_publishes_run_owned_published_head` asserts both the patched and unpatched paths.

**Publish path.** This makes MoonMind open a *draft* PR in a case where it previously opened none. It cannot turn a blocked publication into a ready-for-review one: the draft body still carries the "MoonSpec verification incomplete" section, the run still completes with `attention_required: true`, and `_apply_blocking_moonspec_gate_to_publish` still blocks whenever draft publication is not the selected handoff. Definitive per-step refusals are preserved — covered by `test_terminal_gate_preserves_definitive_publication_refusals`.

**Billing-relevant resources.** `shmSize` is refused above `MOONMIND_CONTAINER_BACKEND_MAX_SHM_SIZE_MIB`, never clamped, so the realized value always equals the requested one. The ceiling defaults to the memory ceiling, so it can never publish a shared-memory allowance larger than the job's own memory ceiling, and an omitted setting needs no new magic number.

**Docker / deployment config.** Callers still select an image or cache only by opaque ref; endpoints, socket paths, volumes and in-container paths remain deployment-owned and unreachable from a caller. An undeclared ref still fails closed. Malformed declarations (not a JSON array of objects, missing `sourceRef`/`image`/`cacheRef`, duplicate ref, MoonMind-reserved ref, non-volume name, relative or `..` cache target, invalid pull policy) are configuration errors. `docker-compose.yaml` derives the Unreal declarations from the same four operator variables as before, so the local-first default path is byte-identical.

**Secrets.** `MOONMIND_MANAGED_SESSION_NON_SECRET_ENV_KEYS` lets an operator forward non-secret deployment values into a managed session. Secret-looking names are refused using the same rule that already governs plaintext environment values on the container-job contract (`SENSITIVE_ENVIRONMENT_KEY_PATTERN`, promoted from a private constant rather than duplicated), and malformed keys are ignored with a warning. Both are covered by parametrized tests.

**Operators with a custom `.env`.** A deployment that overrides `MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES` or `..._CACHE_SOURCES` replaces the compose-derived declarations wholesale rather than adding to them; `.env-template` says so.

## Coverage notes

Manual verification covered the parts CI cannot reach from a hermetic runner: `docker compose config` interpolation of the JSON declarations, and re-running the consuming project's coupling scan (fetched from the Tactics remediation head) against this working tree. Both are now also pinned by `tests/unit/config/test_generic_container_surface_coupling.py`, which re-implements that scan over the same 11 surfaces so the coupling is refused in MoonMind's own required CI instead of being discovered later against an already-published revision.

## What this branch does *not* fix

The MoonSpec loop still maps `ADDITIONAL_WORK_NEEDED` to `reattempt_current_step` regardless of `recoverableInCurrentRuntime`. In `mm:53e35d1e` the verifier reported `recoverableInCurrentRuntime: false` on all three attempts — and `rawRecommendedNextAction: advance` on the first two — so the run spent two extra remediation cycles (~40 min) on work no agent in that workspace could reach, and was stopped only by the consecutive-no-progress budget. Changing that mapping is a separate behavioral change to remediation admission and is deliberately out of scope here.

## Changelog

MoonSpec runs whose remediation budget is exhausted now open the draft pull request the publishing contract promises, instead of failing with the pushed branch orphaned. Container-job image and cache sources are deployment-declared, and `resources.shmSize` is caller-owned.
