### PR TITLE
Redesign Settings pages and simplify Provider Profile creation

### DIFF
--- a/docs/UI/ProviderProfileCreation.md
+++ b/docs/UI/ProviderProfileCreation.md
@@ -1,0 +1,618 @@
+# Provider Profile Creation
+
+Status: **Desired-state UI and implementation contract**  
+Owners: MoonMind Engineering  
+Last updated: 2026-08-28
+
+Canonical for: the create and edit experience for Provider Profiles on the **Providers & Secrets** Settings page
+
+**Related design documents:** [Settings Configuration Pages](./SettingsPage.md), [Provider Profiles](../Security/ProviderProfiles.md), [Provider Profile Model and Effort Tier Settings](./ProviderProfileModelEffortTierSettings.md), [Secrets System](../Security/SecretsSystem.md), [OAuth Terminal](../ManagedAgents/OAuthTerminal.md), [Dashboard Design System](./DashboardDesignSystem.md)
+
+> [!NOTE]
+> This document simplifies the Provider Profile form through progressive disclosure. It does not weaken the Provider Profile execution contract. The backend remains authoritative for safe creation presets, validation, credential activation, runtime materialization, and launch readiness.
+
+---
+
+## 1. Purpose
+
+Creating a Provider Profile should ask users for decisions they understand and are likely to change. It should not require them to review every launch-contract field before they can create a normal profile.
+
+The current form exposes low-level credential bindings, volume metadata, rate-limit behavior, routing metadata, and launch-shaping data beside the primary identity and model choices. Most users should not need those fields for a first-party or otherwise supported runtime and provider combination.
+
+The primary product decision is:
+
+> Provider Profile creation uses a focused standard form with a collapsed **Show advanced options** checkbox. Credential implementation details, volume metadata, secondary rate-limit controls, routing metadata, and launch-shaping fields stay behind that control. **Max parallel runs** remains visible in the standard form.
+
+This decision applies most strongly to creation. Editing must still make existing non-default or invalid advanced configuration easy to discover.
+
+---
+
+## 2. Goals
+
+The creation experience must:
+
+1. make the common path understandable without Provider Profile implementation knowledge;
+2. preserve access to every supported expert control;
+3. use backend-provided defaults or omit optional values rather than copying policy into React;
+4. keep credential setup visible while hiding raw credential plumbing;
+5. keep `max_parallel_runs` visible because it is an understandable capacity decision;
+6. avoid creating a profile that appears enabled when credential setup is incomplete;
+7. expose model and effort tier policy as a core profile decision rather than burying it with launch internals;
+8. protect existing advanced values during edit, collapse, validation failure, and save; and
+9. fail safely when no valid creation preset exists for a runtime, provider, and authentication combination.
+
+---
+
+## 3. Non-Goals
+
+This design does not:
+
+- make all Provider Profile fields optional in the backend contract;
+- let the browser invent provider-specific materialization policy;
+- hide credential connection status or the action needed to connect a provider;
+- store raw credentials in the Provider Profile form;
+- treat a missing safe preset as permission to guess `secret_ref` plus `api_key_env`;
+- move model and effort resolution authority into the browser;
+- make `clear_env_keys` a casual user-authored preference; or
+- remove advanced fields from the edit or inspection experience.
+
+---
+
+## 4. Standard Creation Flow
+
+The standard form should read as a short sequence of user decisions.
+
+```text
+Create Provider Profile
+
+Identity
+  Profile ID
+  Runtime
+  Provider
+  Account label
+
+Authentication
+  OAuth | API key | No credentials
+  Connection or setup action
+
+Model & effort tiers
+  One runtime-default tier initially
+  Customize tier policy
+
+Capacity and selection
+  Max parallel runs
+  Use as runtime default
+
+[ ] Show advanced options
+    Credential bindings, volumes, rate limits, routing, and launch shaping
+
+Create profile / Create and connect
+```
+
+### 4.1 Profile ID
+
+`profile_id` is durable and normally immutable after creation. The UI should suggest an ID from runtime, provider, and account label, while keeping the field visible before create so the user can review the permanent identity.
+
+A future separate display-name field may allow the technical ID to move behind advanced options. Until that contract exists, the form should not silently hide an immutable generated identifier.
+
+### 4.2 Runtime and provider
+
+Runtime and provider remain visible and required. They determine the available authentication methods, model capabilities, creation preset, and safe materialization strategy.
+
+Use backend-provided choices rather than unrestricted text fields when the relevant catalog exists. Existing unknown values remain inspectable during edit.
+
+### 4.3 Account label
+
+`account_label` should move out of the current Advanced Options group and remain a visible optional field.
+
+It is a user-facing identity aid, not a launch implementation detail. It becomes important when two profiles use the same runtime and provider but different accounts or credentials.
+
+OAuth may populate the label from validated provider identity. API-key setup may leave it empty or let the user enter a friendly name such as `Team account` or `Personal account`.
+
+### 4.4 Authentication
+
+Credential setup remains visible in the standard flow. The UI presents a high-level method supported by the chosen runtime and provider:
+
+- OAuth;
+- API key; or
+- No credentials, only when the backend explicitly allows it.
+
+The high-level choice drives a guided setup flow. It does not expose raw `credential_source`, `runtime_materialization_mode`, `secret_refs`, `volume_ref`, or `volume_mount_path` as ordinary form fields.
+
+### 4.5 Model and effort tiers
+
+Model and effort tier policy remains outside the general advanced disclosure because it is a core Provider Profile policy.
+
+A new profile begins with one tier whose model and effort use backend-reported runtime defaults. The user may leave that policy unchanged or customize the tier stack through the contract in [Provider Profile Model and Effort Tier Settings](./ProviderProfileModelEffortTierSettings.md).
+
+The standard form must not restore the superseded `default_model` and `default_effort` fields.
+
+### 4.6 Max parallel runs
+
+`max_parallel_runs` remains visible.
+
+It is the one Runtime Limits value most users can reason about directly. The initial value comes from a backend creation preset. The generic fallback is `1` only when the backend contract permits that fallback.
+
+An OAuth home backed by an exclusive mutable identity may lock the value to `1` and explain why.
+
+### 4.7 Runtime default selection
+
+`is_default` may remain visible as `Use as runtime default` because it represents understandable selection intent.
+
+The action must not make a disabled or non-launch-ready profile the runtime default. When creation includes credential setup, default assignment occurs only after readiness succeeds. Otherwise the request remains pending or the checkbox is unavailable with an explanation.
+
+### 4.8 Enabled state
+
+`enabled` is not a normal creation checkbox.
+
+Desired behavior is:
+
+- successful user-initiated OAuth or API-key setup creates or updates a connected profile and enables it when policy permits;
+- a manually created profile without valid credentials is saved disabled;
+- failed setup leaves the profile disabled with diagnostics; and
+- explicit enable or disable remains an edit or collection action after creation.
+
+The UI must not use `enabled: true` as an unconditional client-side form default.
+
+---
+
+## 5. Advanced Options Control
+
+### 5.1 Control shape
+
+Use one native checkbox labeled:
+
+```text
+Show advanced options
+```
+
+Supporting text should say:
+
+```text
+Credential bindings, volumes, rate limits, routing, and launch shaping
+```
+
+The checkbox controls one expandable region through `aria-controls`. Its checked state is local presentation state and is never persisted as Provider Profile data.
+
+This is progressive disclosure inside one form. It is not a tab, route, modal workflow, or alternate profile type.
+
+### 5.2 Initial state
+
+On create, advanced options are collapsed by default.
+
+On edit:
+
+- start collapsed when every advanced value is empty, derived, or equal to the active creation preset;
+- start expanded when any advanced value is non-default, unknown, incompatible, or has a warning or error;
+- automatically expand when server validation targets a hidden control; and
+- preserve the user's explicit open or closed choice for the rest of the current edit session.
+
+### 5.3 Collapsed summary
+
+The collapsed control should summarize effective advanced policy without requiring expansion.
+
+Example:
+
+```text
+Using recommended Codex + OpenAI settings
+API key environment · 300 second backoff · priority 100 · no custom volume
+```
+
+When advanced overrides exist:
+
+```text
+3 advanced overrides
+Custom volume · cooldown 600 seconds · tags configured
+```
+
+The summary uses normalized backend metadata. It does not infer safety from blank browser fields.
+
+### 5.4 Draft preservation
+
+Collapsing the advanced region must not clear, normalize, or omit edited values from the draft.
+
+Resetting an advanced field to its recommended value should be an explicit field action or an explicit `Reset advanced options to recommended` action with a preview.
+
+---
+
+## 6. Field Classification
+
+### 6.1 Standard fields
+
+| Field or concept | Standard behavior | Default authority |
+|---|---|---|
+| `profile_id` | Visible, suggested, reviewable, immutable after create | Frontend may suggest. Backend validates uniqueness and format. |
+| `runtime_id` | Visible required selector | Backend runtime catalog |
+| `provider_id` | Visible required selector | Backend provider catalog |
+| `account_label` | Visible optional friendly label | Empty, OAuth identity, or user value |
+| Authentication method | Visible guided choice | Backend capabilities for runtime and provider |
+| `model_tiers` and `default_model_tier` | Visible core policy, initially one runtime-default tier | Backend tier capabilities and resolution |
+| `max_parallel_runs` | Visible capacity input | Backend creation preset. Baseline may be `1`. |
+| `is_default` | Visible optional intent when readiness permits | User choice plus backend normalization |
+| Credential readiness | Visible status and setup action | Backend validation and activation state |
+
+### 6.2 Advanced fields
+
+| Current field | Advanced treatment | Recommended omitted or initial value |
+|---|---|---|
+| `provider_label` | Hide for catalog-backed providers. Allow an optional custom display override for unknown or custom providers. | `null`. Render the provider catalog label. |
+| `credential_source` | Derived from the visible authentication method. Show as advanced launch-contract metadata. Permit an override only when the backend supports expert manual profiles. | Backend-derived. Never assume one global value. |
+| `runtime_materialization_mode` | Derived from runtime, provider, and authentication method. Advanced override only for supported expert paths. | Backend-derived. Never assume one global value. |
+| `cooldown_after_429_seconds` | Advanced rate-limit control | Omit and let the backend apply the creation preset. Generic contract default is `300`. |
+| `rate_limit_policy` | Advanced rate-limit control | Omit and let the backend apply the creation preset. Generic contract default is `backoff`. |
+| `secret_refs` | Advanced structured credential bindings. Use role-aware SecretRef pickers, not raw JSON as the primary UX. | Empty only when no credential has been connected. A profile with required missing refs remains disabled. |
+| `volume_ref` | Advanced imported or externally managed OAuth volume binding. Normally generated by OAuth enrollment and read-only afterward. | `null` until a volume-backed setup succeeds. |
+| `volume_mount_path` | Advanced runtime-derived volume metadata. Normally read-only when generated. | `null` without a volume. Otherwise backend runtime strategy. |
+| `command_behavior` | Expert launch-shaping options | Omit or `null`, unless the backend strategy supplies required behavior. |
+| User routing tags | Advanced routing metadata | Empty user tag list. Backend-owned system tags are derived separately. |
+| `priority` | Advanced selector ordering | Omit. Backend default is `100`. |
+| `clear_env_keys` | Do not expose as a normal editable advanced preference. Show backend-generated values as read-only launch-safety metadata. | Backend runtime and provider strategy. It may not be safely empty for a known profile type. |
+
+### 6.3 Fields that should not merely be hidden
+
+Some values should be derived or system-managed rather than moved unchanged into a collapsed form.
+
+#### Credential source and materialization
+
+A user understands `OAuth` or `API key`. A user should not have to coordinate values such as `oauth_volume` plus `oauth_home`, or `secret_ref` plus `api_key_env`.
+
+The backend creation preset owns those coherent combinations. An unsupported combination must be rejected rather than saved as a profile that fails later at launch.
+
+#### Clear environment keys
+
+`clear_env_keys` prevents credentials and provider settings from leaking across launch paths. It is correctness and security policy.
+
+For known runtime and provider strategies, the backend must generate and validate it. The UI may expose a read-only list and its source. A future expert override requires explicit backend capability, validation, a warning, and audit. A freeform textarea is not the desired normal contract.
+
+#### Enabled state
+
+Enabled state follows credential activation and policy. Hiding a client-side `Enabled` checkbox while still submitting `true` would not simplify the experience safely. The create workflow must stop submitting unconditional enablement and let the backend return activation state.
+
+---
+
+## 7. Default and Omission Rules
+
+### 7.1 Prefer omission over React-owned defaults
+
+Where the create API supports optional fields, the browser should omit untouched advanced values. The backend applies a runtime, provider, and authentication-specific preset and returns the normalized profile.
+
+The frontend may display a suggested value before save, but it must retain the value's source and preset identity. It must not silently convert every visual suggestion into a client-owned explicit override.
+
+### 7.2 Creation preset
+
+The backend should expose enough metadata for the UI to render the standard form and advanced summary safely.
+
+Conceptual response:
+
+```yaml
+ProviderProfileCreationPreset:
+  version: string
+  runtime_id: string
+  provider_id: string
+  authentication_method: oauth | api_key | none
+  supported: bool
+  fields:
+    credential_source:
+      value: oauth_volume
+      source: runtime_provider_strategy
+      editable: false
+    runtime_materialization_mode:
+      value: oauth_home
+      source: runtime_provider_strategy
+      editable: false
+    max_parallel_runs:
+      value: 1
+      source: exclusive_oauth_identity
+      editable: false
+    cooldown_after_429_seconds:
+      value: 300
+      source: provider_default
+      editable: true
+    rate_limit_policy:
+      value: backoff
+      source: provider_default
+      editable: true
+    priority:
+      value: 100
+      source: system_default
+      editable: true
+    clear_env_keys:
+      value: [OPENAI_API_KEY]
+      source: runtime_provider_strategy
+      editable: false
+  diagnostics: []
+```
+
+The exact endpoint and schema may share an existing capabilities surface. The durable UI requirement is that the backend supplies coherent values, editability, source, lock reason, and diagnostics.
+
+### 7.3 No safe preset
+
+When no safe preset exists for the selected runtime, provider, and authentication method, the UI must not guess.
+
+It should do one of the following based on backend capability:
+
+1. automatically expand advanced options and identify the required expert fields;
+2. offer an explicitly labeled manual profile path; or
+3. block creation and explain that the combination is unsupported.
+
+A generic `secret_ref` plus `api_key_env` fallback is not sufficient for every provider.
+
+### 7.4 Expected baseline values
+
+These are generic contract baselines, not universal frontend constants:
+
+```yaml
+max_parallel_runs: 1
+cooldown_after_429_seconds: 300
+rate_limit_policy: backoff
+priority: 100
+secret_refs: {}
+volume_ref: null
+volume_mount_path: null
+command_behavior: null
+user_tags: []
+account_label: null
+provider_label_override: null
+```
+
+`credential_source`, `runtime_materialization_mode`, `clear_env_keys`, model policy, system tags, and activation state require contextual backend ownership.
+
+---
+
+## 8. Credentials and Volumes
+
+### 8.1 Keep connection UX visible
+
+Collapsing Credentials & Volumes does not mean hiding whether a profile is connected.
+
+The standard form shows:
+
+- selected authentication method;
+- connection state;
+- account label when known;
+- setup, reconnect, or replace action;
+- last validation state where useful; and
+- whether the profile will be enabled after save.
+
+### 8.2 Hide low-level plumbing
+
+The advanced region may show:
+
+- credential source class;
+- materialization mode;
+- role-aware SecretRef bindings;
+- imported or generated volume reference;
+- volume mount path;
+- validation diagnostics; and
+- which values are derived or locked.
+
+It never shows stored secret plaintext.
+
+### 8.3 Guided API-key setup
+
+The API-key flow should:
+
+1. accept the key in a one-way credential dialog;
+2. validate it through the provider-specific backend;
+3. store it through the Secrets System;
+4. bind the resulting SecretRef to the required role;
+5. apply backend-owned materialization and environment-clearing policy;
+6. return normalized readiness; and
+7. clear plaintext input after submission.
+
+### 8.4 Guided OAuth setup
+
+The OAuth flow should own volume creation or registration, mount-path selection, validation, account identity, and activation. The normal form does not ask the user to type a volume name or runtime home path.
+
+An advanced imported-volume workflow may exist where supported, but it must be explicitly distinct from normal OAuth enrollment.
+
+---
+
+## 9. Editing Existing Profiles
+
+### 9.1 Advanced override summary
+
+An existing profile with advanced configuration shows a compact summary beside the checkbox before expansion.
+
+Examples:
+
+- `Custom cooldown and priority`
+- `OAuth volume generated by enrollment`
+- `3 routing tags and custom command behavior`
+- `Launch-safety policy needs attention`
+
+### 9.2 Unknown values
+
+Unknown existing values remain visible and round-trippable. The UI does not erase them merely because the current creation preset no longer advertises them.
+
+Unknown or stale values start the advanced region expanded and receive a diagnostic.
+
+### 9.3 Reset to recommended
+
+`Reset advanced options to recommended` must preview every change before applying it to the draft.
+
+The preview should distinguish:
+
+- fields set to a concrete recommended value;
+- fields changed from explicit override to inherited or omitted;
+- generated security fields that will be recalculated; and
+- changes that affect future launch selection or command construction.
+
+### 9.4 Credential state
+
+Credential replacement, reconnect, rotation, and disconnect remain dedicated actions. Collapsing advanced profile fields must not hide an invalid or disconnected credential state.
+
+---
+
+## 10. Validation and Failure Behavior
+
+1. Validate standard and advanced fields through the same authoritative save path.
+2. Automatically check `Show advanced options` when an error targets a hidden field.
+3. Move focus to the first invalid hidden control after expansion.
+4. Keep every draft value after save failure.
+5. Do not mark a profile connected or enabled until backend activation succeeds.
+6. Treat a preset-version conflict like any other stale policy conflict. Reload metadata and require review.
+7. Show unsupported manual combinations before profile creation when possible.
+8. Preserve unrelated Provider Profile and Managed Secret content when one creation request fails.
+
+---
+
+## 11. Accessibility
+
+The form must:
+
+- use a native checkbox for `Show advanced options`;
+- connect the checkbox to the advanced region with `aria-controls`;
+- expose checked and expanded state correctly;
+- keep the supporting description associated with the checkbox;
+- announce automatic expansion caused by validation;
+- preserve logical focus order when the region opens;
+- avoid removing focused content without moving focus safely;
+- expose derived, locked, default, and override states in text;
+- avoid relying on color alone; and
+- keep guided credential flows keyboard accessible and secret safe.
+
+---
+
+## 12. Responsive Layout
+
+On wide screens, standard identity and capacity controls may use compact grids. The advanced region may group related controls into:
+
+```text
+Credential implementation
+Rate limiting
+Routing and selection
+Launch shaping and diagnostics
+```
+
+On narrow screens:
+
+- every field stacks to one column;
+- the checkbox and its summary remain visible before the advanced content;
+- opening advanced options does not introduce horizontal scrolling;
+- raw identifiers and SecretRefs wrap or scroll inside bounded code fields; and
+- create and cancel actions remain reachable after a long advanced region.
+
+---
+
+## 13. Suggested Component Boundaries
+
+```text
+ProviderProfileForm
+  ProviderProfileIdentityFields
+  ProviderProfileAuthenticationSetup
+  ProviderProfileTierSection
+  ProviderProfileCapacityFields
+  ProviderProfileDefaultSelection
+  ProviderProfileAdvancedToggle
+  ProviderProfileAdvancedSummary
+  ProviderProfileAdvancedRegion
+    CredentialImplementationFields
+    RateLimitFields
+    RoutingMetadataFields
+    LaunchShapingFields
+    LaunchSafetySummary
+  ProviderProfileSaveActions
+```
+
+Suggested helpers:
+
+```text
+useProviderProfileCreationPreset
+buildProviderProfileCreatePayload
+advancedProfileOverrides
+summarizeAdvancedProfilePolicy
+validateProviderProfileDraft
+```
+
+`buildProviderProfileCreatePayload` should distinguish untouched inherited values from explicit overrides. It should not serialize every displayed recommendation as though the user authored it.
+
+---
+
+## 14. Test Contract
+
+### 14.1 Standard creation
+
+- Advanced options are collapsed on create.
+- Runtime, provider, account label, authentication, tier policy, max parallel runs, and runtime-default selection remain available.
+- A safe preset supplies the advanced summary.
+- Untouched advanced values are omitted or submitted according to the backend contract.
+- Profile creation never defaults to enabled when required credentials are missing.
+- Successful guided credential setup enables the profile when policy permits.
+
+### 14.2 Advanced control
+
+- Checking the box reveals every supported advanced group.
+- Unchecking it preserves draft values.
+- The checkbox state is not persisted in the profile payload.
+- Non-default edit state starts expanded.
+- Hidden validation errors expand the region and receive focus.
+- The collapsed summary reflects advanced overrides without exposing secrets.
+
+### 14.3 Field defaults
+
+- Max parallel runs uses the backend recommendation and remains visible.
+- Exclusive OAuth identity locks max parallel runs to one.
+- Cooldown inherits the backend preset when untouched.
+- Rate-limit policy inherits the backend preset when untouched.
+- Priority inherits `100` when the generic backend default applies.
+- Empty volume fields remain null for non-volume profiles.
+- Missing credential refs keep a credential-required profile disabled.
+- Clear environment keys come from backend strategy rather than a browser constant.
+
+### 14.4 Credential behavior
+
+- OAuth setup does not ask for volume ref or mount path in the normal flow.
+- API-key setup stores plaintext only through the one-way credential flow.
+- The normal form does not expose raw SecretRef JSON.
+- Advanced credential bindings show references and role metadata, never plaintext.
+- Connection errors remain visible while advanced options are collapsed.
+
+### 14.5 Editing
+
+- Existing custom advanced values are preserved.
+- Unknown values remain round-trippable.
+- Reset to recommended previews all affected fields.
+- Cancel restores the normalized server profile.
+- Read-only users can inspect effective advanced policy without edit controls.
+
+---
+
+## 15. Acceptance Criteria
+
+The design is correctly implemented when:
+
+1. Provider Profile creation starts with advanced options collapsed.
+2. One `Show advanced options` checkbox controls the low-level region.
+3. The standard form keeps runtime, provider, account label, authentication, model tier policy, max parallel runs, and runtime-default intent visible.
+4. Credentials remain easy to connect without exposing raw credential plumbing.
+5. Credential source and materialization mode are backend-derived for guided paths.
+6. Credentials & Volumes fields live behind advanced options or a dedicated guided credential action.
+7. Cooldown and rate-limit policy live behind advanced options.
+8. Max parallel runs remains outside advanced options.
+9. Command behavior, routing tags, priority, and other current Advanced Options fields remain behind the control.
+10. Account label is treated as a user-facing identity field rather than an advanced launch option.
+11. Clear environment keys are backend-generated launch-safety metadata, not a normal freeform preference.
+12. Untouched advanced values use backend presets or omission instead of duplicated React defaults.
+13. A profile without required validated credentials is not silently created as enabled.
+14. Existing non-default, invalid, or unknown advanced configuration is conspicuous during edit.
+15. Collapsing advanced options never loses draft data.
+16. Hidden validation errors automatically reveal the affected controls.
+17. No secret plaintext appears in the profile payload, URL, summary, or saved UI state.
+18. A missing safe creation preset never falls back to a guessed materialization contract.
+
+---
+
+## 16. Decision Summary
+
+- Provider Profile creation uses progressive disclosure.
+- The default form focuses on identity, authentication, model policy, capacity, and default-selection intent.
+- `max_parallel_runs` remains visible.
+- Cooldown and rate-limit policy move behind advanced options.
+- Raw credential bindings and volume metadata move behind advanced options or are owned by guided setup.
+- Credential source and materialization mode are derived from the selected setup method.
+- Command behavior, tags, and priority remain advanced.
+- Account label moves into the standard identity experience.
+- Clear environment keys become backend-owned, read-only launch-safety metadata.
+- Enabled state follows credential activation and policy instead of a default-true creation checkbox.
+- Backend presets and omission replace global frontend guesses.

--- a/docs/UI/SettingsPage.md
+++ b/docs/UI/SettingsPage.md
@@ -1,298 +1,317 @@
-# Settings Page
+# Settings Configuration Pages
 
-**Related design documents:** [SettingsSystem.md](../Security/SettingsSystem.md), [SecretsSystem.md](../Security/SecretsSystem.md), [ProviderProfiles.md](../Security/ProviderProfiles.md), [OAuthTerminal.md](../ManagedAgents/OAuthTerminal.md), [ManagedAndExternalAgentExecutionModel.md](../Temporal/ManagedAndExternalAgentExecutionModel.md)
+**Related design documents:** [SettingsSystem.md](../Security/SettingsSystem.md), [SecretsSystem.md](../Security/SecretsSystem.md), [ProviderProfiles.md](../Security/ProviderProfiles.md), [ProviderProfileModelEffortTierSettings.md](./ProviderProfileModelEffortTierSettings.md), [OAuthTerminal.md](../ManagedAgents/OAuthTerminal.md), [DashboardDesignSystem.md](./DashboardDesignSystem.md), [DashboardSPAArchitecture.md](./DashboardSPAArchitecture.md)
 
-Status: **Desired-State UI Contract**
-Owners: MoonMind Engineering
-Last Updated: 2026-05-08
+Status: **Desired-State UI Contract**  
+Owners: MoonMind Engineering  
+Last Updated: 2026-08-28
 
 > [!NOTE]
-> This document supersedes `docs/UI/SettingsTab.md` and should live at `docs/UI/SettingsPage.md`.
-> It defines the MoonMind dashboard contract for the Settings page.
-> The security, persistence, resolution, validation, and authorization contract remains owned by [SettingsSystem.md](../Security/SettingsSystem.md).
+> This document supersedes the single `/settings` page with a three-way tab, radio, or segmented section switcher. The existing Settings dropdown remains the only cross-page navigation surface. Its **Configuration** group exposes the three former Settings sections as separate pages.
+>
+> Security, persistence, resolution, validation, and authorization remain owned by [SettingsSystem.md](../Security/SettingsSystem.md) and the related domain documents.
 
 ---
 
 ## 1. Purpose
 
-The dashboard **Settings** page is the human-facing configuration plane for user, workspace, provider, secret, and operational configuration.
+MoonMind Settings is the human-facing configuration plane for user, workspace, provider, secret, and operational configuration.
 
-Settings keeps the main product surface focused on workflow executions, workflow details, proposals, schedules, runs, and other workflow-adjacent surfaces. Configuration that shapes those workflows belongs under one coherent Settings page rather than being split across unrelated top-level destinations.
+Settings is a family of sibling dashboard pages, not one large page with a second navigation layer.
 
-The Settings page replaces the older split where **Settings**, **Secrets**, and **Workers** could behave like separate product areas.
+The central information-architecture decision is:
 
-The central UI decision is:
+> **Providers & Secrets**, **User / Workspace**, and **Operations** are separate pages in the Settings dropdown's **Configuration** group. None of those pages repeats the three destinations as tabs, radio buttons, segmented controls, pills, cards, a sidebar, or another local page switcher.
 
-> The Settings page must be a **data-driven control plane**, not a manually maintained collection of one-off setting forms.
+This gives every configuration surface a durable URL, page title, loading boundary, authorization state, and browser-history entry. It also removes redundant navigation and lets each page load only the data it owns.
 
-This means:
+The existing rendering decision remains:
 
-- section navigation is stable and product-owned;
-- ordinary user/workspace setting rows are rendered from backend-owned descriptors;
-- effective values, defaults, override state, validation rules, source explanations, and reload semantics are loaded from Settings APIs;
-- provider profiles, managed secrets, OAuth state, and operations are loaded as first-class backend resources;
-- the frontend maintains a small renderer palette for known descriptor control types, not bespoke UI code for every setting key; and
-- adding a new eligible setting should normally require backend catalog metadata and validation, not a new hard-coded React panel.
+> Settings is a **data-driven control plane**, not a manually maintained collection of one-off setting forms.
+
+Ordinary user and workspace settings come from backend descriptors. Provider Profiles, Managed Secrets, OAuth state, and Operations remain specialized backend resources or commands.
 
 ---
 
 ## 2. Scope and Authority
 
-### 2.1 What this UI document owns
+This document owns:
 
-This document owns the Settings page user experience contract:
+- placement of configuration pages in the Settings dropdown;
+- the Configuration group and its ordering;
+- canonical routes and legacy redirects;
+- active destination and dropdown-trigger behavior;
+- shared page-shell rules;
+- page-level loading and failure boundaries;
+- descriptor-driven settings rendering;
+- filtering, editing, preview, save, discard, and reset UX;
+- Provider Profile, Managed Secret, OAuth, and Operations placement;
+- permissions, secret-safe behavior, accessibility, and unsaved-change navigation; and
+- migration and acceptance criteria for removing the old page-local switcher.
 
-- page route and section navigation;
-- page-level layout;
-- data-loading behavior;
-- descriptor-driven rendering rules;
-- supported generic controls;
-- scope switching, filtering, editing, preview, save, and reset UX;
-- source, inheritance, lock, diagnostic, and reload indicators;
-- provider profile, managed secret, OAuth, and operations placement inside Settings;
-- secret-safe display behavior;
-- permission and empty-state UX; and
-- acceptance criteria for adding settings without hard-coding each setting in the UI.
+This document does not redefine backend setting eligibility, resolution, persistence, secret storage, provider execution semantics, operational command semantics, authorization, or server validation.
 
-### 2.2 What this UI document does not own
-
-This document does not redefine:
-
-- setting eligibility rules;
-- setting resolution order;
-- scoped override persistence;
-- secret storage, encryption, decryption, or resolution;
-- provider profile execution semantics;
-- operational command semantics;
-- backend authorization; or
-- server-side validation.
-
-Those contracts remain owned by the Settings System, Secrets System, Provider Profiles, OAuth, Operations, and runtime strategy documents.
-
-### 2.3 Implementation-status note
-
-This is a desired-state UI contract. Current implementation may be partially aligned. Rollout sequencing, migrations, and tactical implementation handoffs belong in MoonSpec artifacts or implementation plans, not in this durable UI contract.
+This is a desired-state contract. The current implementation may still use one Settings component, `?section=` routing, and a segmented or radio-based switcher.
 
 ---
 
 ## 3. Design Principles
 
-### 3.1 Backend-owned truth
+### 3.1 One navigation owner
 
-The backend owns which settings exist, which are exposed, how they are typed, which scopes can edit them, how values are validated, whether values are sensitive, and how effective values are resolved.
+The Settings dropdown owns navigation among configuration pages. A page-local control is valid only when it changes state inside the current page, such as user versus workspace scope, a runtime filter, a category filter, or an operation subview.
 
-The frontend renders descriptors and submits user intent. It must not decide that a backend field is safe to expose merely because that field exists.
+### 3.2 Pathname owns page identity
 
-### 3.2 Data-driven rows, not key-specific forms
+The pathname selects the configuration page. Query parameters may select safe filters or scope within that page. Query parameters must not select among the three configuration pages.
 
-The User / Workspace section must render ordinary settings from catalog descriptors. A setting key is an identity, not a frontend branching mechanism.
+### 3.3 Backend-owned truth
 
-The frontend may switch on descriptor shape such as `type`, `ui`, `constraints`, `options`, `read_only`, and `sensitive`. It should not switch on specific keys such as `workflow.default_runtime` except for intentionally documented transitional exceptions.
+The backend owns which settings exist, which are exposed, their types and scopes, validation, sensitivity, effective values, sources, and application semantics. The frontend renders descriptors and submits intent.
 
-### 3.3 Explicit specialist surfaces
+### 3.4 Data-driven rows
 
-Not every configurable object is an ordinary setting row.
+The User / Workspace page renders ordinary settings from catalog descriptors. The frontend may branch on descriptor shape such as `type`, `ui`, `constraints`, `options`, `read_only`, and `sensitive`. It should not branch on individual setting keys except for documented transitional exceptions.
 
-Provider Profiles, Managed Secrets, OAuth credentials, and Operations controls have specialized semantics. They may use specialized managers, but those managers must still load their state and capabilities from backend APIs instead of embedding hidden product policy in the frontend.
+### 3.5 Explicit specialist surfaces
 
-### 3.4 References over secrets
+Provider Profiles, Managed Secrets, OAuth credentials, and Operations controls are not generic setting rows. They may use specialized managers, but options, capabilities, readiness, and policy constraints should still come from backend APIs.
 
-The Settings page must never render stored secret plaintext. Generic setting overrides must not accept raw credentials. Settings that need sensitive material use SecretRef pickers, provider-profile secret-role bindings, or one-way managed-secret creation/replacement flows.
+### 3.6 References over secrets
 
-### 3.5 Explainability
+Stored secret plaintext is never rendered. Generic settings do not accept raw credentials. Sensitive relationships use SecretRef pickers, provider-profile secret-role bindings, or one-way Managed Secret creation and replacement flows.
 
-Every visible effective value should be understandable from the UI. Users should be able to answer:
+### 3.7 Safe independent failure
 
-- what value is active;
-- where it came from;
-- whether it is inherited or overridden;
-- whether it is locked;
-- what scope controls it;
-- what systems it affects;
-- whether a reload, restart, next workflow execution, or next launch is required; and
-- how to reset it to the inherited value when permitted.
-
-### 3.6 Safe degradation
-
-Unknown descriptor fields must not break the Settings page. Unsupported editable controls should degrade to a read-only row with an actionable diagnostic, or to a backend-provided unsupported-control message. The UI must not silently invent a control for an unknown sensitive field.
+Failure on one configuration page must not make the other two unavailable unless the shared dashboard shell itself is unavailable.
 
 ---
 
 ## 4. Information Architecture
 
-The desired top-level dashboard navigation model is:
+The Settings dropdown retains its existing grouped structure. The configuration portion is:
 
 ```text
-Workflows and workflow-adjacent product surfaces
+Settings dropdown
+  Configuration
+    Providers & Secrets
+    User / Workspace
+    Operations
+```
+
+The three entries are sibling dashboard destinations. They are not sections rendered by a parent Settings page.
+
+### 4.1 Configuration group contract
+
+The dropdown must:
+
+1. render the label `Configuration` once;
+2. place the entries in this order: Providers & Secrets, User / Workspace, Operations;
+3. render every entry as a route link;
+4. expose one active entry with `aria-current="page"` or equivalent route semantics;
+5. close after selection;
+6. support the dashboard's keyboard menu behavior;
+7. render the same group and order in the mobile drawer; and
+8. omit the group label when none of its destinations is visible.
+
+Group membership must be explicit or deterministically derived. The implementation must not attach `Configuration` only to one destination key and accidentally repeat or omit the label when multiple children exist.
+
+### 4.2 Dropdown trigger
+
+When any Configuration page is active, the masthead trigger remains:
+
+```text
 Settings
 ```
 
-Within **Settings**, the dashboard exposes section navigation rather than separate top-level tabs.
+with the Settings icon.
 
-```text
-Settings
-  Providers & Secrets
-  User / Workspace
-  Operations
-```
+It does not expand to `Providers & Secrets` or `User / Workspace`. The active page is communicated by the active menu item, URL, document title, and page header.
 
-### 4.1 Providers & Secrets
+### 4.3 No Settings landing page
 
-This section is the primary configuration surface for runtime and provider access.
-
-It contains:
-
-- Provider Profiles as the durable runtime/provider launch contract;
-- Managed Secrets and secret-health surfaces;
-- SecretRef usage and validation surfaces;
-- bindings between secrets and provider-profile roles;
-- OAuth-backed provider-profile lifecycle entry points when applicable;
-- provider credential health, readiness, and validation feedback; and
-- runtime/provider binding diagnostics.
-
-This section should clearly communicate that provider profiles contain references and launch metadata, managed secrets contain encrypted values or external references, OAuth volumes contain runtime-specific credential state, and readiness is a product of profile validity plus secret/OAuth resolvability.
-
-### 4.2 User / Workspace
-
-This section contains schema-driven settings for user and workspace behavior.
-
-It includes:
-
-- user preferences;
-- personal workflow creation defaults;
-- personal runtime and provider profile defaults;
-- workspace workflow defaults;
-- workspace routing defaults;
-- workspace feature flags;
-- non-secret integration defaults;
-- policy knobs that are safe to expose; and
-- SecretRef bindings that are not provider-profile-specific.
-
-This section is the main descriptor-rendered surface. New eligible settings should appear here by adding backend metadata and validation rather than by adding bespoke UI components for each setting.
-
-### 4.3 Operations
-
-This section contains operational controls and status-backed administrative actions.
-
-It includes:
-
-- worker pause/resume controls;
-- drain and quiesce controls;
-- queue and runtime health summaries;
-- maintenance-mode controls;
-- deployment or runtime update controls where authorized;
-- recent operational audit actions; and
-- safe diagnostic switches.
-
-Operations controls are not ordinary preferences. They are explicit commands or statusful controls that must show current state, authorization, expected effect, confirmation requirements, and audit history.
+The dropdown is the configuration index. MoonMind does not need another page that repeats the same three choices as cards. The bare `/settings` route redirects to the default configuration page.
 
 ---
 
-## 5. Routing
+## 5. Routes
 
-Canonical route:
+### 5.1 Canonical routes
 
-```text
-/settings
-```
+| Destination | Canonical route | Suggested destination key |
+|---|---|---|
+| Providers & Secrets | `/settings/providers-secrets` | `settings-providers-secrets` |
+| User / Workspace | `/settings/user-workspace` | `settings-user-workspace` |
+| Operations | `/settings/operations` | `settings-operations` |
 
-Supported section query model:
+All three destinations belong to the Settings dropdown's Configuration group and use the dashboard's utility-page classification.
 
-```text
-/settings?section=providers-secrets
-/settings?section=user-workspace
-/settings?section=operations
-```
+The route registry may map them to three page modules or one shared bundle with three route-owned components. The user-visible contract is three distinct pages.
 
-The default section should be `providers-secrets` unless product analytics or onboarding requirements justify a different default.
+### 5.2 Default redirect
 
-Legacy routes should redirect into the corresponding Settings section:
+`/settings` redirects with replacement history to `/settings/providers-secrets`.
 
-| Legacy route | Target |
+### 5.3 Legacy redirects
+
+| Legacy route | Canonical target |
 |---|---|
-| `/secrets` | `/settings?section=providers-secrets` |
-| `/workers` | `/settings?section=operations` |
-| older Settings tab aliases | `/settings` |
+| `/settings?section=providers-secrets` | `/settings/providers-secrets` |
+| `/settings?section=user-workspace` | `/settings/user-workspace` |
+| `/settings?section=operations` | `/settings/operations` |
+| `/secrets` | `/settings/providers-secrets` |
+| `/workers` | `/settings/operations` |
+| an unknown older Settings alias | `/settings/providers-secrets` unless a safe mapping exists |
 
-Redirects should preserve relevant query parameters where safe.
+Redirects preserve safe page-relevant query parameters and remove `section`.
+
+### 5.4 Page-local URL state
+
+Page-local filters may use query parameters:
+
+```text
+/settings/providers-secrets?runtime=codex
+/settings/user-workspace?scope=workspace
+/settings/user-workspace?scope=user&q=workflow
+/settings/operations?status=paused
+```
+
+Sensitive values never enter paths, query parameters, browser history, page titles, or navigation telemetry.
+
+### 5.5 Page titles
+
+Recommended document titles are:
+
+```text
+Providers & Secrets | MoonMind
+User / Workspace | MoonMind
+Operations | MoonMind
+```
 
 ---
 
-## 6. Page Shell
-
-The Settings page shell is stable and may be hard-coded because it represents product information architecture rather than individual setting fields.
+## 6. Shared Page Shell
 
 Recommended structure:
 
 ```text
-SettingsPage
+ConfigurationPage
   PageHeader
-  SectionSwitcher
-  SectionStatusSummary
-  SectionContent
+  PageStatusSummary
+  PageContent
+  PageDiagnosticsOrAudit
 ```
 
-### 6.1 Page header
+There is no `SectionSwitcher`, tab list, segmented destination control, destination radio group, or duplicate Settings sidebar.
 
-The header should include:
+### 6.1 Header
 
-- title: `Settings`;
-- short description of the selected section;
-- optional deployment/workspace context;
-- optional global warning when settings persistence, catalog loading, or authorization is degraded; and
-- optional link to diagnostics or audit where authorized.
+Each page header includes:
 
-### 6.2 Section switcher
+- an optional `Settings` or `Configuration` overline;
+- the page-specific title;
+- a short page-specific description;
+- optional deployment or workspace context;
+- a page-scoped warning when persistence, catalog loading, authorization, or operational state is degraded; and
+- optional diagnostic or audit links where authorized.
 
-The switcher should expose exactly the primary Settings sections unless the backend or product configuration intentionally adds another section:
+Required titles are `Providers & Secrets`, `User / Workspace`, and `Operations`.
 
-- Providers & Secrets;
-- User / Workspace;
-- Operations.
+### 6.2 Page-specific status summaries
 
-The switcher may show badges for section-level warnings, such as unresolved SecretRefs, blocked provider profiles, pending reloads, or paused workers.
+| Page | Summary emphasis |
+|---|---|
+| Providers & Secrets | launch readiness, profile validity, secret and OAuth health, blocked profiles |
+| User / Workspace | overrides, pending application, locked settings, validation diagnostics |
+| Operations | worker state, drain or pause status, queue and runtime health, pending commands |
 
-### 6.3 Section content
+Do not load all three pages' detailed datasets to reproduce one global health summary on every route. A compact cross-configuration alert may use a dedicated aggregate endpoint.
 
-Each section should follow the same broad pattern:
+### 6.3 Unsaved changes
 
-1. overview copy;
-2. status/readiness summary;
-3. data-driven tables, generated forms, or command cards;
-4. diagnostics and audit affordances; and
-5. high-risk actions grouped into clearly labeled areas.
+Dropdown navigation is real route navigation. When the current page has unsaved changes:
+
+1. detect the dirty draft;
+2. offer `Stay` and `Discard and leave`;
+3. do not mark the destination active until navigation succeeds;
+4. preserve the draft when navigation is canceled; and
+5. navigate immediately when the page is clean or changes were saved.
 
 ---
 
-## 7. Data Loading Model
+## 7. Page Responsibilities
 
-The Settings page loads configuration through backend APIs. It must not directly read data stores from the browser.
+### 7.1 Providers & Secrets
 
-### 7.1 Data sources by section
+This page contains:
 
-| Section | Primary data loaded by UI | Backend-owned data stores or resolvers |
-|---|---|---|
-| Providers & Secrets | provider profiles, managed secret metadata, OAuth volume state, readiness diagnostics | provider profile records, managed secrets, OAuth credential volume state, secret resolvers |
-| User / Workspace | settings catalog descriptors, effective values, overrides, diagnostics, audit entries | settings registry/catalog, settings override rows, environment/config defaults, settings audit rows, managed secret metadata for SecretRefs |
-| Operations | worker state, queue health, runtime health, operation capabilities, command history | operations state stores, queue/workflow state, deployment state, operational audit/event stores |
+- Provider Profiles as the durable runtime and provider launch contract;
+- model and effort tier policy editing inside the normal Provider Profile editor;
+- Managed Secrets and secret-health surfaces;
+- SecretRef role bindings and validation;
+- OAuth-backed profile lifecycle entry points;
+- provider credential health and readiness; and
+- runtime and provider binding diagnostics.
 
-### 7.2 Initial page load
+The page explains that profiles contain references and launch metadata, Managed Secrets contain encrypted values or external references, OAuth volumes contain runtime-specific credential state, and readiness combines profile validity with secret or OAuth resolvability.
 
-The page may use boot payload data for route context, user identity, or deployment feature flags, but boot payload data must not be the authoritative source for the settings catalog.
+A page-local runtime filter may narrow the visible Provider Profile collection. It must not narrow global readiness counts unless the summary is explicitly labeled as filtered.
 
-When the page loads:
+### 7.2 User / Workspace
 
-1. determine the selected section from the query string;
-2. load the minimum section data needed to render the first screen;
-3. defer expensive diagnostics, audit timelines, and resource usage graphs until the section or row needs them;
-4. show section-level skeletons while data loads; and
-5. preserve section and scope selection across browser navigation.
+This page contains descriptor-driven settings for:
 
-### 7.3 User / Workspace catalog load
+- user preferences;
+- personal workflow-creation defaults;
+- personal runtime and Provider Profile defaults;
+- workspace workflow and routing defaults;
+- workspace feature flags;
+- non-secret integration defaults;
+- safe policy controls; and
+- SecretRef bindings not owned by a Provider Profile.
 
-For descriptor-rendered settings, the UI loads catalog data by section and scope.
+This is the canonical generated-settings surface. Adding an eligible ordinary setting should require backend catalog metadata and validation, not a new hard-coded React row.
 
-Desired APIs:
+The user versus workspace scope switch is a page-local control. It may update `?scope=` and must guard dirty drafts before changing scope.
+
+### 7.3 Operations
+
+This page contains explicit administrative commands and statusful controls for:
+
+- worker pause and resume;
+- drain and quiesce;
+- queue and runtime health;
+- maintenance mode;
+- deployment or runtime updates where authorized;
+- recent operational audit actions; and
+- safe diagnostic switches.
+
+Each command card shows current state, expected impact, permitted actions, disabled reason, confirmation requirements, reason input where required, pending transitions, last actor and time, failure state, and recovery or resume action.
+
+The page title `Operations` is distinct from any broader dropdown group also labeled Operations. The group classifies destinations. This page specifically owns configuration and administration controls.
+
+---
+
+## 8. Data Loading Boundaries
+
+| Page | Primary data |
+|---|---|
+| Providers & Secrets | Provider Profiles, Managed Secret metadata, OAuth state, readiness diagnostics |
+| User / Workspace | catalog descriptors, effective values, scoped overrides, diagnostics, audit metadata |
+| Operations | worker state, queue and runtime health, operation capabilities, command history |
+
+On route load:
+
+1. resolve the page from the pathname;
+2. load only the minimum data needed for that page's first screen;
+3. do not fetch sibling-page collections by default;
+4. defer expensive diagnostics, audit timelines, and graphs until needed;
+5. show route-level and region-level loading states; and
+6. preserve page-local scope and filters across browser navigation.
+
+The backend may continue using `section=user-workspace` as catalog classification. It no longer represents a client-side Settings tab.
+
+Desired generated-settings endpoints remain:
 
 ```http
 GET /api/v1/settings/catalog?section=user-workspace&scope=workspace
@@ -301,43 +320,18 @@ GET /api/v1/settings/effective?scope=workspace
 GET /api/v1/settings/effective?scope=user
 GET /api/v1/settings/diagnostics?scope=workspace
 GET /api/v1/settings/audit?key=workflow.default_runtime
+POST /api/v1/settings/preview
+PATCH /api/v1/settings/workspace
+PATCH /api/v1/settings/user
+DELETE /api/v1/settings/workspace/{key}
+DELETE /api/v1/settings/user/{key}
 ```
-
-The catalog response should contain enough information for the UI to render controls, source explanations, read-only state, diagnostics, and reset affordances without hard-coded per-setting knowledge.
-
-### 7.4 Provider and operations loads
-
-Provider Profiles, Managed Secrets, OAuth flows, and Operations may use specialized endpoints because they are resources and commands, not generic setting rows.
-
-Even specialized managers should load capabilities and constraints from backend responses where possible. For example:
-
-- provider profile forms should load runtime/provider options, required secret roles, allowed materialization modes, model defaults, readiness checks, and validation outcomes;
-- managed secret lists should load metadata, status, validation state, and usage references;
-- OAuth panels should load connection state and permitted actions;
-- operations panels should load current state, permitted commands, confirmation requirements, and recent audit entries.
 
 ---
 
-## 8. Descriptor-Driven User / Workspace UI
+## 9. Descriptor-Driven User / Workspace Contract
 
-The User / Workspace section is the canonical generated-settings surface.
-
-### 8.1 Catalog response shape consumed by the UI
-
-The UI expects descriptors grouped by category.
-
-```yaml
-SettingsCatalogResponse:
-  section: user-workspace
-  scope: user | workspace
-  categories:
-    Workflow:
-      - SettingDescriptor
-    Skills:
-      - SettingDescriptor
-```
-
-Each descriptor supplies the information needed to render and edit a row.
+A descriptor carries enough metadata for the frontend to render and explain a setting without key-specific logic:
 
 ```yaml
 SettingDescriptor:
@@ -345,7 +339,7 @@ SettingDescriptor:
   title: string
   description: string | null
   category: string
-  section: providers-secrets | user-workspace | operations
+  section: user-workspace
   type: boolean | string | integer | number | enum | string_list | object | secret_ref
   ui: toggle | input | number | select | tag_editor | key_value | secret_ref_picker | provider_profile_picker | readonly
   scopes: [user | workspace | system | operator]
@@ -354,665 +348,242 @@ SettingDescriptor:
   override_value: any | null
   source: string
   source_explanation: string
-  options: [SettingOption] | null
-  constraints: SettingConstraints | null
+  options: array | null
+  constraints: object | null
   sensitive: boolean
-  secret_role: string | null
   read_only: boolean
   read_only_reason: string | null
-  requires_reload: boolean
-  requires_worker_restart: boolean
-  requires_process_restart: boolean
   apply_mode: string
   activation_state: string
-  active: boolean
   pending_value: any | null
-  affected_process_or_worker: string | null
-  completion_guidance: string | null
   applies_to: [string]
-  depends_on: [SettingDependency]
-  order: integer
-  audit: SettingAuditPolicy
   value_version: integer
-  diagnostics: [SettingDiagnostic]
+  diagnostics: array
 ```
 
-The exact backend schema may evolve, but the UI contract is stable: descriptors carry display metadata, control metadata, current/effective value, scope/source metadata, validation metadata, reload/application semantics, and diagnostics.
+Control selection follows descriptor shape:
 
-### 8.2 Renderer selection
-
-The generated renderer chooses controls by descriptor metadata, not by setting key.
-
-| Descriptor shape | UI behavior |
+| Descriptor | Control |
 |---|---|
-| `type: boolean` or `ui: toggle` | Toggle switch |
-| `type: enum` or `ui: select` | Select using descriptor `options` |
-| `type: integer`, `type: number`, or `ui: number` | Number input using min/max/step constraints when present |
-| `type: string` or `ui: input` | Text input unless sensitivity rules require a specialized control |
-| `type: string_list` or `ui: tag_editor` | Tag editor or comma-separated list editor |
-| `type: object` or `ui: key_value` | Small structured editor for safe key/value values |
-| `type: secret_ref` or `ui: secret_ref_picker` | SecretRef picker backed by managed-secret metadata and supported SecretRef schemes |
-| `ui: provider_profile_picker` | Provider profile selector backed by provider-profile list/readiness data |
-| `ui: readonly`, `read_only: true`, or unsupported editable control | Read-only display with reason or unsupported-control diagnostic |
+| boolean or `toggle` | Toggle |
+| enum or `select` | Select from backend options |
+| integer, number, or `number` | Constrained number input |
+| string or `input` | Text input unless sensitivity requires a specialist control |
+| string list or `tag_editor` | Tag or list editor |
+| object or `key_value` | Safe structured editor |
+| secret ref or `secret_ref_picker` | SecretRef picker |
+| `provider_profile_picker` | Provider Profile selector using backend data |
+| read-only or unsupported editable type | Read-only value with reason or diagnostic |
 
-The renderer may have specialized components for control types. It should not have specialized components for individual setting keys unless explicitly approved as an exception.
+Every row should expose title, description, control or value, stable key, scope, source, inherited or override state, active or pending state, validation, diagnostics, reset when allowed, application semantics, affected systems, and audit link where authorized.
 
-### 8.3 Row layout
+Filtering should support text search, category, modified-only, read-only, diagnostics, source, pending application, and secret-related filters where authorized. Filtering is never the authorization boundary.
 
-Every descriptor row should show:
+Before save, show changed keys, old and proposed values, validation, target scope, expected versions, affected systems, application requirements, dependency warnings, and redaction behavior. The backend preview is authoritative where available.
 
-- title;
-- description;
-- current control or read-only value;
-- stable setting key;
-- source badge;
-- scope badge;
-- active/pending state;
-- default or inherited explanation when useful;
-- reset action when an override exists and reset is allowed;
-- validation errors;
-- diagnostics;
-- reload/restart/application badge when relevant;
-- affected systems;
-- lock reason when read-only; and
-- audit/change-history link where authorized.
-
-Recommended row structure:
-
-```text
-SettingRow
-  Title + source/scope/application badges
-  Description
-  Source explanation
-  Diagnostics
-  Affected systems chips
-  Control
-  Key + reset/history actions
-```
-
-### 8.4 Scope switching
-
-The User / Workspace section should support scope switching between `workspace` and `user` where authorized.
-
-Scope switching must:
-
-- reload catalog/effective values for the selected scope;
-- discard or clearly preserve unsaved draft changes only with explicit user intent;
-- update source labels and reset behavior;
-- make inheritance visible; and
-- avoid presenting user-level controls that are disallowed by workspace policy.
-
-### 8.5 Filtering and search
-
-The generated settings surface should support:
-
-- free-text search over key, title, description, category, and applicable tags;
-- category filtering;
-- modified-only filtering;
-- read-only filtering;
-- diagnostics/error filtering;
-- source filtering where useful;
-- pending reload/restart filtering; and
-- secret-related filtering where authorized.
-
-Filtering is a UI convenience. It must not be used as the security boundary for hiding unauthorized settings. Unauthorized settings should not be returned by the backend, or they should be returned only as read-only/limited metadata according to backend policy.
-
-### 8.6 Change preview
-
-Before saving one or more settings, the UI should show a change preview containing:
-
-- changed keys;
-- old effective values;
-- new proposed values;
-- validation status;
-- source/scope that will be written;
-- expected versions;
-- affected systems;
-- reload/restart/next-boundary requirements;
-- missing dependency warnings; and
-- audit redaction behavior where relevant.
-
-Where a dedicated preview endpoint exists, the UI should use the backend preview rather than reconstructing full effective-value semantics locally.
-
-Desired preview API:
-
-```http
-POST /api/v1/settings/preview
-```
-
-### 8.7 Save and reset
-
-Saving generated settings uses scoped batch updates.
-
-```http
-PATCH /api/v1/settings/workspace
-PATCH /api/v1/settings/user
-```
-
-The payload should include changed keys, expected versions, and an optional reason.
-
-```json
-{
-  "changes": {
-    "workflow.default_publish_mode": "branch",
-    "skills.canary_percent": 25
-  },
-  "expected_versions": {
-    "workflow.default_publish_mode": 3,
-    "skills.canary_percent": 1
-  },
-  "reason": "Updated from Settings."
-}
-```
-
-Resetting removes the scoped override and returns to the inherited effective value.
-
-```http
-DELETE /api/v1/settings/workspace/{key}
-DELETE /api/v1/settings/user/{key}
-```
-
-The UI must not treat reset as deleting the underlying default, managed secret, provider profile, OAuth volume, or audit history.
-
-### 8.8 Draft state
-
-The UI may keep unsaved changes in local state. Draft state must be keyed by setting key and scope.
-
-Draft state should be cleared when:
-
-- a successful save returns fresh values;
-- the user discards changes;
-- the selected scope changes and the user confirms discard; or
-- the catalog version changes in a way that invalidates the draft.
-
-Draft state should not be persisted to local storage unless a future design explicitly addresses sensitive metadata risk.
+Draft state is keyed by setting key and scope. Clear it after successful save, explicit discard, confirmed scope change, confirmed route departure, or incompatible catalog-version change. Do not persist drafts to local storage without a separate sensitive-metadata design.
 
 ---
 
-## 9. Providers & Secrets UI
+## 10. Permissions and Failure States
 
-Providers & Secrets is specialized, but it should still be data-driven.
+The backend controls authorization. The UI reflects it without treating client checks as a security boundary.
 
-### 9.1 Provider profiles
+Each destination should have an independent state when permissions differ:
 
-Provider Profiles are first-class resources. They are not generic setting overrides.
+- `shown` for meaningful accessible content;
+- `unavailable` when product policy wants a visible explanation; or
+- `hidden` when the destination should not be advertised.
 
-The Provider Profiles manager should load and render:
+The Configuration label appears when at least one child is shown or intentionally unavailable. A direct unauthorized route shows a clear unavailable or forbidden state rather than silently redirecting to a sibling page.
 
-- profile id;
-- runtime;
-- provider;
-- provider label;
-- credential source class;
-- runtime materialization mode;
-- default model and model overrides;
-- SecretRef role bindings;
-- OAuth volume metadata;
-- concurrency and cooldown policy;
-- priority;
-- default profile status;
-- enabled/disabled status;
-- readiness summary; and
-- readiness checks.
-
-Provider profile forms may be descriptor-assisted, but they should not reduce provider profiles to arbitrary key/value editing. Provider profiles carry execution semantics and require specialized validation and readiness display.
-
-### 9.2 Secret role binding
-
-When a provider profile requires a secret, the UI should present a role-aware SecretRef picker.
-
-The picker should show:
-
-- role label;
-- required/optional status;
-- compatible secret types or schemes;
-- available managed secrets;
-- external reference schemes such as `env://` where allowed;
-- selected SecretRef;
-- readiness result; and
-- validation status.
-
-The picker must not show secret plaintext.
-
-### 9.3 Managed secrets
-
-The Managed Secrets UI should let authorized users:
-
-- create managed secrets;
-- replace secret values;
-- rotate secrets;
-- disable secrets;
-- re-enable secrets;
-- delete or tombstone secrets where allowed;
-- validate secrets;
-- inspect usage; and
-- copy SecretRefs.
-
-Managed secret creation and replacement may accept plaintext only as a one-way submission. After save, the UI must clear plaintext inputs and display only metadata.
-
-### 9.4 OAuth credential state
-
-OAuth-backed profiles and credential volumes should show:
-
-- connection status;
-- account label;
-- backing volume or reference metadata;
-- validation timestamp;
-- permitted actions;
-- disconnect or reconnect actions where authorized;
-- failure reason with sensitive details redacted; and
-- launch readiness.
-
-### 9.5 Readiness and diagnostics
-
-Providers & Secrets should include a readiness-oriented summary because users visit this section to make runtimes launchable.
-
-Readiness should combine:
-
-- profile schema validity;
-- required fields;
-- SecretRef resolvability;
-- managed secret status;
-- OAuth status;
-- provider-specific validation;
-- enabled/disabled state;
-- concurrency availability; and
-- cooldown state.
-
-Broken SecretRefs, missing OAuth volumes, disabled secrets, and blocked profiles should appear as clear actionable diagnostics.
-
----
-
-## 10. Operations UI
-
-Operations belongs under Settings for discoverability, but operational controls are not ordinary setting rows.
-
-### 10.1 Operation cards
-
-Operational controls should be represented as command cards or statusful control panels. Each card should load current state and permitted actions from backend operations APIs.
-
-Each operation card should show:
-
-- operation name;
-- current state;
-- command impact;
-- allowed actions;
-- disabled/read-only reason when not allowed;
-- required confirmation;
-- reason input when audit requires it;
-- last action and actor;
-- pending transitions;
-- failure reason; and
-- safe rollback or resume action where available.
-
-### 10.2 Worker controls
-
-Worker pause/resume, drain, and quiesce controls should show:
-
-- whether workers are running, draining, quiesced, or paused;
-- queue depth or related metrics where available;
-- whether the system is drained;
-- pause mode;
-- reason;
-- actor and timestamp of latest action;
-- confirmation text; and
-- resume behavior.
-
-### 10.3 Deployment or runtime update controls
-
-Deployment or runtime update controls should show:
-
-- current configured image/version/build where applicable;
-- running image evidence;
-- target options loaded from backend policy;
-- mutable tag warnings;
-- affected services;
-- update mode;
-- confirmation requirements;
-- recent actions;
-- logs or run detail links where authorized; and
-- rollback eligibility.
-
-### 10.4 Operational audit
-
-Operations cards should surface recent operational audit records in context. Sensitive command logs or raw output should be linked only when authorized and redacted according to backend policy.
-
----
-
-## 11. Source, Inheritance, and Application Semantics
-
-The Settings page should make source and application semantics visible without requiring users to understand the resolver internals.
-
-### 11.1 Source badges
-
-Recommended source labels:
-
-```text
-Default
-Config
-Environment
-Workspace override
-User override
-Provider profile
-Secret reference
-Operator locked
-Migrated override
-Deprecated override
-```
-
-Source labels should come from backend source metadata, normalized for display. Unknown source values should be displayed safely rather than hidden.
-
-### 11.2 Inheritance display
-
-When a setting is inherited, the UI should explain the inherited source. Examples:
-
-- `Using workspace default.`
-- `Using deployment config.`
-- `Using built-in default.`
-- `Overridden for this user.`
-- `Locked by operator policy.`
-
-Reset controls should appear only when an override exists at the selected scope and the current user is authorized to remove it.
-
-### 11.3 Application badges
-
-Settings may apply at different boundaries. The UI should display backend-provided application semantics such as:
-
-- applies immediately;
-- applies on next request;
-- applies on next workflow execution;
-- applies on next launch;
-- requires worker reload;
-- requires process restart; or
-- requires manual operation.
-
-Pending values should be shown when a new value has been accepted but is not yet active.
-
----
-
-## 12. Validation and Error Handling
-
-### 12.1 Client-side validation
-
-The frontend may perform lightweight validation using descriptor metadata:
-
-- required value checks;
-- numeric min/max;
-- enum option membership;
-- string length;
-- simple patterns;
-- SecretRef shape; and
-- obvious type coercion errors.
-
-Client-side validation is a convenience only. It is not authoritative.
-
-### 12.2 Server-side validation
-
-All writes must be validated by the backend using the authoritative setting descriptor, scope, constraints, sensitivity rules, version rules, and authorization policy.
-
-The UI should display structured backend errors without exposing submitted plaintext or sensitive values.
-
-Common settings errors include:
-
-- `unknown_setting`;
-- `setting_not_exposed`;
-- `scope_not_allowed`;
-- `read_only_setting`;
-- `operator_locked`;
-- `invalid_setting_value`;
-- `secret_ref_not_resolvable`;
-- `provider_profile_not_found`;
-- `version_conflict`;
-- `permission_denied`; and
-- `requires_confirmation`.
-
-### 12.3 Version conflicts
-
-When a version conflict occurs, the UI should:
-
-1. stop the save;
-2. reload affected descriptors;
-3. show the user that another change occurred;
-4. allow the user to review the latest value; and
-5. require explicit resubmission.
-
-### 12.4 Diagnostics
-
-Diagnostics should be shown close to the affected row or resource. Security-relevant diagnostics must avoid exposing raw secret values or sensitive payloads.
-
-Diagnostics may include:
-
-- unresolved SecretRef;
-- missing managed secret;
-- disabled or revoked secret;
-- missing provider profile;
-- deprecated setting key;
-- migrated override;
-- unsupported control;
-- pending reload;
-- failed validation; and
-- permission limitation.
-
----
-
-## 13. Secret-Safe Behavior
-
-The Settings page must treat secrets as write-only or reference-only metadata.
-
-### 13.1 Generic settings
-
-Generic setting rows must not accept raw secret values. Secret-like settings must use `secret_ref_picker`, provider-profile secret-role binding, or a specialized managed-secret flow.
-
-A SecretRef such as `db://github-token` or `env://GITHUB_TOKEN` may be displayed when authorized, but the referenced plaintext must not be displayed.
-
-### 13.2 Managed secret plaintext
-
-Managed secret creation and replacement flows may accept plaintext input only for submission. After the request completes, the UI must:
-
-- clear the input;
-- avoid caching the plaintext in component state longer than necessary;
-- avoid placing plaintext in URLs, local storage, or logs;
-- show metadata and validation state instead of the value; and
-- rely on the backend for redaction and audit behavior.
-
-### 13.3 Audit redaction
-
-Audit views should use backend-redacted values. If the user lacks permission to view security-relevant metadata, the audit view should show redacted placeholders and redaction reasons instead of SecretRefs or values.
-
----
-
-## 14. Permissions and Authorization UX
-
-The backend is authoritative for authorization. The UI should reflect permission state without relying on frontend checks as the security boundary.
-
-The Settings page should support separate permission states for:
-
-- reading the settings catalog;
-- reading effective settings;
-- writing user settings;
-- writing workspace settings;
-- reading system/operator settings;
-- reading secret metadata;
-- writing or rotating secrets;
-- managing provider profiles;
-- invoking operations; and
-- reading audit history.
-
-When the user lacks permission, the UI should choose the safest available presentation:
+In-page behavior includes:
 
 | Backend state | UI behavior |
 |---|---|
-| Section not visible | Hide section or show unavailable shell according to product policy |
-| Catalog readable but setting not writable | Render read-only row with reason |
-| Secret metadata not readable | Hide SecretRef metadata or show redacted reference state |
-| Audit not readable | Hide audit link |
-| Operation not invokable | Show current state but disable action with reason |
-| Backend returns permission error | Show structured error and do not retry destructive action automatically |
+| catalog readable, setting not writable | Read-only row with reason |
+| secret metadata not readable | Redacted or hidden reference metadata |
+| audit not readable | No audit link |
+| operation not invokable | Current state visible, action disabled with reason |
+| permission error during mutation | Structured error, no automatic destructive retry |
+
+Loading placeholders must not imply values are default, unset, safe, or healthy. Empty states explain the next authorized action. Failures identify the affected page or region and preserve unrelated content where possible.
 
 ---
 
-## 15. Loading, Empty, and Failure States
+## 11. Secret Safety, Validation, and Explainability
 
-### 15.1 Loading states
+Generic settings never accept raw secret values. Managed Secret creation and replacement may accept plaintext only for one-way submission. After submission, clear the field and display metadata and validation state, not the value.
 
-Use skeletons or compact loading cards for:
+The UI may display an authorized SecretRef such as `db://github-token` or `env://GITHUB_TOKEN`, but never its plaintext target.
 
-- section shell loading;
-- catalog loading;
-- provider profile list loading;
-- managed secret metadata loading;
-- operation state loading;
-- audit loading; and
-- diagnostics loading.
+Client validation may use descriptor metadata for required values, numeric bounds, option membership, length, simple patterns, SecretRef shape, and obvious type errors. Backend validation remains authoritative.
 
-Loading placeholders should not imply that values are default, unset, or safe.
+Source and application labels come from backend metadata. Recommended source labels include Default, Config, Environment, Workspace override, User override, Provider Profile, Secret reference, and Operator locked.
 
-### 15.2 Empty states
-
-Empty states should be actionable:
-
-- no provider profiles: explain how to create or import a profile;
-- no managed secrets: explain SecretRefs and create-secret flow;
-- no user/workspace settings returned: explain that no settings are exposed for this scope or the user lacks permission;
-- no operations available: explain that operations are not configured or not authorized;
-- no audit records: explain that no changes have been recorded.
-
-### 15.3 Failure states
-
-Failure states should identify the affected section or row and preserve unrelated content when possible.
-
-Examples:
-
-- settings catalog unavailable;
-- settings persistence unavailable;
-- provider profile service unavailable;
-- managed secret metadata unavailable;
-- operations state unavailable;
-- audit unavailable; and
-- diagnostics unavailable.
-
-The UI should avoid automatic retries for mutation failures that might duplicate operations.
+The UI explains inherited sources and application boundaries such as immediate, next request, next workflow, next launch, worker reload, process restart, or manual operation. Pending accepted values remain visible until active.
 
 ---
 
-## 16. Extensibility Rules
+## 12. Accessibility
 
-### 16.1 Adding a normal user/workspace setting
+The configuration experience must support:
 
-A new ordinary setting should be added by changing backend metadata and validation.
+- keyboard access to the dropdown, every route link, page-local controls, and dialogs;
+- visible focus and Escape-to-close behavior;
+- consistent destination order on desktop and mobile;
+- one active route exposed with route semantics;
+- focus movement to the new page heading where appropriate;
+- associated labels, descriptions, and errors;
+- no reliance on color alone;
+- confirmation and focus restoration for destructive operations; and
+- readable long keys, SecretRefs, and Provider Profile identifiers.
 
-Expected path:
-
-1. backend defines stable setting key;
-2. backend marks setting explicitly exposed;
-3. backend declares title, description, category, section, scopes, type, UI control, constraints, options, sensitivity, application semantics, and audit policy;
-4. backend wires persistence/resolution as needed;
-5. frontend generic renderer displays it automatically;
-6. tests verify that the catalog row appears and save/reset behavior works.
-
-Frontend changes should be unnecessary unless the setting requires a new generic control type.
-
-### 16.2 Adding a new generic control type
-
-A new generic control type may require frontend work, but it should be reusable across many settings.
-
-A new control type must define:
-
-- descriptor `ui` value;
-- supported `type` or value shape;
-- validation hints;
-- accessibility behavior;
-- read-only behavior;
-- draft serialization;
-- display serialization;
-- error display; and
-- fallback behavior for unsupported browsers or permissions.
-
-### 16.3 Adding provider/secret/operations capabilities
-
-Provider, secret, OAuth, and operations capabilities may require specialized UI because they represent resources or commands. Even then, the frontend should load options, allowed actions, readiness, validation, and policy constraints from backend APIs rather than hard-coding policy in the UI.
-
-### 16.4 Forbidden patterns
-
-The following patterns are not allowed for ordinary settings:
-
-- hard-coding a new setting row in `SettingsPage` for each setting key;
-- duplicating backend defaults in the frontend;
-- accepting raw API keys in a generic setting text input;
-- using environment-variable editing as a generic browser UI;
-- hiding unauthorized settings only through frontend filtering;
-- implementing setting validation only in the frontend;
-- silently falling back when a SecretRef is broken; or
-- treating operations commands as simple boolean preferences.
+The three destination links must not use `role="tab"` or radio semantics. They navigate to documents and behave as links.
 
 ---
 
-## 17. Accessibility and Usability Requirements
+## 13. Extensibility Rules
 
-The Settings page should support:
+Adding a normal user or workspace setting should require:
 
-- keyboard navigation through section switcher, filters, rows, controls, and dialogs;
-- clear focus management after save, reset, validation, and modal close;
-- accessible names for all controls;
-- screen-reader-visible descriptions for badges and diagnostics;
-- form errors associated with the relevant controls;
-- no reliance on color alone for source, status, warning, or error meaning;
-- confirmation dialogs for high-risk operations;
-- cancel/discard paths for unsaved drafts; and
-- compact but readable displays for long keys, SecretRefs, and provider profile identifiers.
+1. a stable backend key;
+2. explicit exposure metadata;
+3. title, description, category, scopes, type, UI control, constraints, options, sensitivity, application semantics, and audit policy;
+4. persistence and resolution where needed; and
+5. catalog and save/reset tests.
 
----
+Frontend work is required only for a new reusable control type.
 
-## 18. Observability and Audit UX
+A fourth Configuration page is justified only when it has a distinct user goal, route identity, permission model, loading boundary, and enough durable content to stand alone. A category or small settings group stays within an existing page.
 
-Settings should make change history discoverable without turning the page into an audit console.
+Forbidden patterns include:
 
-Recommended behavior:
-
-- row-level audit link where authorized;
-- section-level recent changes summary;
-- actor, timestamp, scope, key, reason, and redaction state;
-- old/new values only when the backend permits display;
-- affected systems and application mode where available;
-- no plaintext secret display; and
-- diagnostics link for migration or unresolved-reference issues.
-
-Audit and diagnostics should be loaded on demand when they are not needed for initial rendering.
+- page-local tabs, radio cards, pills, segmented controls, sidebars, or cards that repeat the three destinations;
+- `?section=` as page identity;
+- eager loading of every configuration dataset on every route;
+- one hard-coded React row per setting key;
+- frontend copies of backend defaults or authoritative validation;
+- plaintext credential inputs in generic settings;
+- frontend-only authorization filtering;
+- silent fallback for broken SecretRefs; and
+- boolean-preference treatment for operational commands.
 
 ---
 
-## 19. Acceptance Criteria
+## 14. Implementation Migration
 
-The Settings page design is satisfied when all of the following are true:
+### 14.1 Destination registry
 
-1. The canonical UI document is `docs/UI/SettingsPage.md`; the old `SettingsTab.md` path is removed or replaced by a short redirect note.
-2. The page uses `/settings` with `section` query selection for Providers & Secrets, User / Workspace, and Operations.
-3. The User / Workspace section renders ordinary settings from backend catalog descriptors.
-4. Adding a new supported setting descriptor does not require a new hard-coded row in the frontend.
-5. The frontend chooses generic controls from descriptor metadata such as `type`, `ui`, `options`, and `constraints`.
-6. Effective values, defaults, sources, overrides, version information, diagnostics, and application semantics come from backend responses.
-7. The UI supports scope switching between user and workspace where authorized.
-8. The UI supports search, category filtering, modified/read-only/diagnostic filtering, change preview, save, discard, and reset.
-9. Secret-like settings use SecretRef pickers or managed-secret flows, never generic plaintext settings inputs.
-10. Provider Profiles and Managed Secrets remain first-class resource managers inside Providers & Secrets.
-11. Operations controls remain explicit command cards with confirmation, status, authorization, and audit context.
-12. Permissions are reflected in read-only/hidden/disabled states, but backend authorization remains authoritative.
-13. Unknown or unsupported descriptor controls degrade safely rather than failing the page or exposing unsafe inputs.
-14. Audit and diagnostics are available where authorized and are redacted according to backend policy.
-15. The UI does not duplicate backend defaults, validation rules, source resolution, or secret-safety decisions.
+Replace the single Settings destination with:
 
----
-
-## 20. Migration from `SettingsTab.md`
-
-The old document name implies a narrower tab-level IA artifact. The updated design should use `SettingsPage.md` because Settings is now a full dashboard page and configuration plane.
-
-Recommended migration:
-
-```bash
-git mv docs/UI/SettingsTab.md docs/UI/SettingsPage.md
+```text
+settings-providers-secrets -> /settings/providers-secrets
+settings-user-workspace    -> /settings/user-workspace
+settings-operations        -> /settings/operations
 ```
 
-Then replace the file content with this document.
+All three belong to the Configuration group. Local and server-provided destination registries must stay synchronized. Group membership should be explicit metadata or stable grouping logic.
 
-Any references to `docs/UI/SettingsTab.md` should be updated to `docs/UI/SettingsPage.md`. If external links need a transition period, leave a tiny `SettingsTab.md` stub that points to `SettingsPage.md`, but the canonical document should be `SettingsPage.md`.
+### 14.2 Page boundaries
+
+Recommended decomposition:
+
+```text
+ProvidersSecretsSettingsPage
+  ProvidersSecretsHeader
+  ProvidersSecretsHealthSummary
+  ProviderProfilesManager
+  SecretManager
+  OAuth and token validation surfaces
+
+UserWorkspaceSettingsPage
+  UserWorkspaceHeader
+  UserWorkspaceStatusSummary
+  ScopeSwitcher
+  GeneratedSettingsSection
+  User and workspace identity/preferences surfaces
+
+OperationsSettingsPage
+  OperationsHeader
+  OperationsStatusSummary
+  OperationsSettingsSection
+  Operational audit and diagnostics
+```
+
+The pages may initially share one bundle. They must still be route-owned components and must not mount unrelated managers.
+
+### 14.3 Remove old section state
+
+Remove equivalents of:
+
+- `SETTINGS_SECTIONS`;
+- `SettingsSectionId`;
+- `readSectionFromLocation`;
+- `updateSectionInLocation`;
+- local cross-page `section` state;
+- manual `popstate` handling for section selection;
+- the destination radio group or segmented control;
+- descriptions selected from a local section array; and
+- conditional page rendering selected by `section === ...`.
+
+Normal router matching replaces this state.
+
+Move state to the owning page. Runtime filtering stays on Providers & Secrets. User versus workspace scope stays on User / Workspace. Worker command state stays on Operations.
+
+### 14.4 Required tests
+
+Cover:
+
+- three destination-registry entries;
+- one Configuration label and correct ordering;
+- stable Settings trigger behavior;
+- active state for all three routes;
+- desktop and mobile navigation;
+- `/settings` and every legacy redirect;
+- absence of Settings tab or radio navigation;
+- page-specific data loading and no unrelated manager mounting;
+- Back and Forward behavior;
+- dirty-draft route guards;
+- direct-route permissions; and
+- deep links with page-local filters.
+
+---
+
+## 15. Acceptance Criteria
+
+The design is satisfied when:
+
+1. The existing Settings dropdown contains one Configuration group.
+2. It contains route links for Providers & Secrets, User / Workspace, and Operations in that order.
+3. Each destination has its own canonical `/settings/...` pathname.
+4. `/settings` redirects to `/settings/providers-secrets`.
+5. Legacy `?section=` links redirect to the corresponding canonical page.
+6. No configuration page repeats the destinations as tabs, radio buttons, segmented controls, pills, cards, a sidebar, or another local switcher.
+7. The masthead trigger remains `Settings` with the Settings icon while any Configuration page is active.
+8. Desktop and mobile expose the same group and order.
+9. Each page has its own title, header, loading boundary, authorization state, and failure state.
+10. Each page loads only its required primary datasets by default.
+11. Providers & Secrets keeps Provider Profiles, Managed Secrets, OAuth, tier policy, and readiness as first-class surfaces.
+12. User / Workspace renders ordinary settings from backend descriptors and supports authorized scope switching.
+13. Operations uses explicit statusful command cards with confirmation and audit context.
+14. Secret-like settings use SecretRefs or Managed Secret flows, never generic plaintext inputs.
+15. Route navigation protects unsaved drafts.
+16. Unsupported descriptors degrade safely.
+17. A failure on one page does not break sibling Configuration destinations.
+18. Backend authorization, defaults, validation, source resolution, and secret-safety decisions remain authoritative.
+19. Navigation tests and telemetry use canonical destination keys instead of the removed `section` state.
+
+---
+
+## 16. Decision Summary
+
+- Settings is a configuration namespace and dropdown group, not one page with three tabs.
+- Providers & Secrets, User / Workspace, and Operations are sibling pages.
+- Canonical routes are `/settings/providers-secrets`, `/settings/user-workspace`, and `/settings/operations`.
+- `/settings` redirects to Providers & Secrets.
+- The Settings dropdown is the single cross-page navigation owner.
+- The Settings trigger remains stable on all three pages.
+- Query parameters represent page-local state, not page identity.
+- Every page owns its title, status, authorization, loading, queries, and failures.
+- Existing managers can be reused, but the old local section state and switcher are removed.

--- a/docs/UI/SettingsPage.md
+++ b/docs/UI/SettingsPage.md
@@ -39,7 +39,7 @@ This document owns:
 
 - placement of configuration pages in the Settings dropdown;
 - the Configuration group and its ordering;
-- canonical routes and legacy redirects;
+- canonical routes, the default entry point, and legacy path redirects;
 - active destination and dropdown-trigger behavior;
 - shared page-shell rules;
 - page-level loading and failure boundaries;
@@ -140,7 +140,7 @@ It does not expand to `Providers & Secrets` or `User / Workspace`. The active pa
 
 ### 4.3 No Settings landing page
 
-The dropdown is the configuration index. MoonMind does not need another page that repeats the same three choices as cards. The bare `/settings` route redirects to the default configuration page.
+The dropdown is the configuration index. MoonMind does not need another page that repeats the same three choices as cards. The bare `/settings` route resolves to the first configuration page the current user is authorized to see, as defined in section 5.2.
 
 ---
 
@@ -158,24 +158,62 @@ All three destinations belong to the Settings dropdown's Configuration group and
 
 The route registry may map them to three page modules or one shared bundle with three route-owned components. The user-visible contract is three distinct pages.
 
-### 5.2 Default redirect
+### 5.2 Default entry point
 
-`/settings` redirects with replacement history to `/settings/providers-secrets`.
+`/settings` is an entry point, not a destination. It resolves to the first
+destination the backend authorizes for the current user, evaluated in the
+canonical Configuration order:
 
-### 5.3 Legacy redirects
+1. `/settings/providers-secrets`;
+2. `/settings/user-workspace`; then
+3. `/settings/operations`.
 
-| Legacy route | Canonical target |
+Resolution uses replacement history so `/settings` does not become a back-button
+trap. The default must never assume Providers & Secrets is available: when that
+destination is `hidden` or `unavailable` and another destination is `shown`,
+`/settings` resolves to that accessible destination instead.
+
+When no Configuration destination is accessible, `/settings` renders the
+Configuration unavailable state described in section 10 rather than redirecting
+to a forbidden page. This resolution applies only to `/settings` itself; a direct
+request for a specific unauthorized destination still shows that destination's
+own unavailable or forbidden state and is never silently rerouted to a sibling.
+
+### 5.3 Retired `?section=` routing
+
+`?section=` is a superseded internal routing contract, not a supported legacy
+route. MoonMind is pre-release, so the rename is completed rather than aliased:
+the change that introduces the canonical paths also updates every internal
+caller, test, and document that still builds a `?section=` Settings link, and
+deletes the old section-routing code. No redirect table preserves `?section=`,
+because a redirect would let a partial migration keep working and hide the
+remaining callers.
+
+After the rename, `section` carries no page identity. A `section` query
+parameter arriving on a canonical route is ignored and does not select, restore,
+or override the page.
+
+Section 8 covers the separate, still-valid backend use of `section=` as catalog
+classification on the settings API. That server-side parameter is unrelated to
+client routing and is not affected by this rule.
+
+### 5.4 Legacy path redirects
+
+Standalone paths that users may have bookmarked keep a redirect, because they
+are user-visible URLs rather than an internal routing contract:
+
+| Legacy path | Canonical target |
 |---|---|
-| `/settings?section=providers-secrets` | `/settings/providers-secrets` |
-| `/settings?section=user-workspace` | `/settings/user-workspace` |
-| `/settings?section=operations` | `/settings/operations` |
 | `/secrets` | `/settings/providers-secrets` |
 | `/workers` | `/settings/operations` |
-| an unknown older Settings alias | `/settings/providers-secrets` unless a safe mapping exists |
+| an unknown older Settings alias | the default entry point in section 5.2 unless a safe specific mapping exists |
 
-Redirects preserve safe page-relevant query parameters and remove `section`.
+These redirects use replacement history, preserve safe page-relevant query
+parameters, and drop parameters that no longer have meaning on the target page.
+A redirect never lands on a destination the user is not authorized to see; when
+the mapped destination is unavailable, resolution falls back to section 5.2.
 
-### 5.4 Page-local URL state
+### 5.5 Page-local URL state
 
 Page-local filters may use query parameters:
 
@@ -188,7 +226,7 @@ Page-local filters may use query parameters:
 
 Sensitive values never enter paths, query parameters, browser history, page titles, or navigation telemetry.
 
-### 5.5 Page titles
+### 5.6 Page titles
 
 Recommended document titles are:
 
@@ -379,7 +417,7 @@ DELETE /api/v1/settings/user/{key}
 
 ## 9. Descriptor-Driven User / Workspace Contract
 
-A descriptor carries enough metadata for the frontend to render and explain a setting without key-specific logic:
+A descriptor carries enough metadata for the frontend to render and explain a setting without key-specific logic. The backend owns this shape; the fields below are the ones the row contract in this document depends on, and a consumer must not drop a field it renders:
 
 ```yaml
 SettingDescriptor:
@@ -399,15 +437,43 @@ SettingDescriptor:
   options: array | null
   constraints: object | null
   sensitive: boolean
+  secret_role: string | null
   read_only: boolean
   read_only_reason: string | null
   apply_mode: string
   activation_state: string
+  active: boolean
   pending_value: any | null
+  affected_process_or_worker: string | null
+  completion_guidance: string | null
+  requires_reload: boolean
+  requires_worker_restart: boolean
+  requires_process_restart: boolean
   applies_to: [string]
+  depends_on: array
+  order: integer
+  audit: object
   value_version: integer
   diagnostics: array
 ```
+
+These fields are load-bearing for the behavior this document requires:
+
+| Field | Row behavior that depends on it |
+|---|---|
+| `active` | distinguishing an applied value from an accepted-but-pending one |
+| `pending_value` | showing the accepted value awaiting activation |
+| `affected_process_or_worker` | naming the system a pending change is waiting on |
+| `completion_guidance` | telling the operator what completes the activation |
+| `requires_reload`, `requires_worker_restart`, `requires_process_restart` | application-requirement warnings before and after save |
+| `order` | deterministic row ordering within a category |
+| `secret_role` | role-aware SecretRef controls |
+| `depends_on` | dependency warnings in preview and validation |
+| `audit` | whether and how an audit link is offered |
+
+This block is the contract the UI consumes, not an exhaustive mirror of the
+backend model. The backend may add fields; it may not remove one this document
+renders without updating this section in the same change.
 
 Control selection follows descriptor shape:
 
@@ -430,6 +496,24 @@ Filtering should support text search, category, modified-only, read-only, diagno
 Before save, show changed keys, old and proposed values, validation, target scope, expected versions, affected systems, application requirements, dependency warnings, and redaction behavior. The backend preview is authoritative where available.
 
 Draft state is keyed by setting key and scope. Clear it after successful save, explicit discard, confirmed scope change, confirmed route departure, or incompatible catalog-version change. Do not persist drafts to local storage without a separate sensitive-metadata design.
+
+### 9.1 Version conflicts
+
+Saves submit `expected_versions` alongside the changed keys, so the authoritative
+`PATCH` contract can reject the write with `version_conflict` when another
+operator changed the same setting after this page loaded. That is a normal
+concurrency outcome, not a generic failure, and the UI must make it recoverable:
+
+1. stop the save and apply no partial write locally;
+2. reload the affected descriptors;
+3. tell the user that another change occurred, identifying the affected keys;
+4. show the latest value next to the user's proposed value so the user can
+   review the difference; and
+5. require explicit resubmission with refreshed `expected_versions`.
+
+Never auto-retry a `version_conflict` with the stale expected version, and never
+silently overwrite the concurrent change. Unaffected keys in the same submission
+keep their drafts so the user does not lose unrelated edits.
 
 ---
 
@@ -527,114 +611,34 @@ Forbidden patterns include:
 
 ---
 
-## 14. Implementation Migration
+## 14. Ownership Invariants
 
-### 14.1 Destination registry
+These are the durable structural rules the three pages must satisfy. They
+describe the target state, not a sequence of migration steps, and they hold for
+any future change to the Configuration pages.
 
-Replace the single Settings destination with:
+**Destination registry.** Configuration is exactly three sibling destinations,
+each with its own destination key and canonical route as listed in section 5.1.
+The client-side registry and any server-provided registry must agree on those
+entries, their Configuration group membership, and their order. Group membership
+is explicit metadata or deterministically derived, never inferred from a single
+destination key.
 
-```text
-settings-providers-secrets -> /settings/providers-secrets
-settings-user-workspace    -> /settings/user-workspace
-settings-operations        -> /settings/operations
-```
+**Route ownership.** Each destination is owned by a route-matched component.
+Sharing one bundle is allowed; sharing page identity is not. A page must not
+mount managers, panels, or data loaders belonging to a sibling destination, and
+no parent component may select between the three by internal state.
 
-All three belong to the Configuration group. Local and server-provided destination registries must stay synchronized. Group membership should be explicit metadata or stable grouping logic.
+**State ownership.** Page-scoped state lives on the page that owns it: runtime
+filtering on Providers & Secrets, user-versus-workspace scope on User /
+Workspace, and worker command state on Operations. No cross-page selection state
+exists, and browser navigation — not local state — moves between destinations.
 
-### 14.2 Page boundaries
-
-Recommended decomposition:
-
-```text
-ProvidersSecretsSettingsPage
-  ProvidersSecretsHeader
-  ProvidersSecretsHealthSummary
-  ProviderProfilesManager
-  SecretManager
-  OAuth and token validation surfaces
-
-UserWorkspaceSettingsPage
-  UserWorkspaceHeader
-  UserWorkspaceStatusSummary
-  ScopeSwitcher
-  GeneratedSettingsSection
-  User and workspace identity/preferences surfaces
-
-OperationsSettingsPage
-  OperationsHeader
-  OperationsStatusSummary
-  OperationsSettingsSection
-  Operational audit and diagnostics
-```
-
-The pages may initially share one bundle. They must still be route-owned components and must not mount unrelated managers.
-
-### 14.3 Remove old section state
-
-Remove equivalents of:
-
-- `SETTINGS_SECTIONS`;
-- `SettingsSectionId`;
-- `readSectionFromLocation`;
-- `updateSectionInLocation`;
-- local cross-page `section` state;
-- manual `popstate` handling for section selection;
-- the destination radio group or segmented control;
-- descriptions selected from a local section array; and
-- conditional page rendering selected by `section === ...`.
-
-Normal router matching replaces this state.
-
-Move state to the owning page. Runtime filtering stays on Providers & Secrets. User versus workspace scope stays on User / Workspace. Worker command state stays on Operations.
-
-### 14.4 Provider Profile form migration
-
-Refactor the current form into:
-
-```text
-ProviderProfileForm
-  StandardProfileFields
-  ProviderProfileAuthenticationSetup
-  ProviderProfileTierSection
-  MaxParallelRunsField
-  ProviderProfileAdvancedToggle
-  ProviderProfileAdvancedRegion
-```
-
-Migration rules:
-
-1. Move Account label into the standard identity group.
-2. Keep credential connection status and setup actions visible.
-3. Derive credential source and materialization mode from backend capabilities for guided paths.
-4. Move Credentials & Volumes behind advanced options.
-5. Move cooldown and rate-limit policy behind advanced options.
-6. Keep max parallel runs visible.
-7. Keep command behavior, tags, and priority advanced.
-8. Replace editable Clear env keys with backend-generated read-only launch-safety metadata for normal profiles.
-9. Remove unconditional client-side enablement from creation.
-10. Preserve and reveal non-default or invalid advanced fields during edit.
-
-### 14.5 Required tests
-
-Cover:
-
-- three destination-registry entries;
-- one Configuration label and correct ordering;
-- stable Settings trigger behavior;
-- active state for all three routes;
-- desktop and mobile navigation;
-- `/settings` and every legacy redirect;
-- absence of Settings tab or radio navigation;
-- page-specific data loading and no unrelated manager mounting;
-- Back and Forward behavior;
-- dirty-draft route guards;
-- direct-route permissions;
-- deep links with page-local filters;
-- collapsed Provider Profile advanced options on create;
-- visible max parallel runs;
-- backend-owned creation presets and activation;
-- automatic advanced expansion for hidden errors; and
-- preservation of advanced drafts while collapsed.
+**Component ownership.** Provider Profile creation and edit behavior belongs to
+Providers & Secrets and follows `docs/UI/ProviderProfileCreation.md`. The
+generated user and workspace settings surface belongs to User / Workspace and
+follows section 9. Operational commands belong to Operations and are never
+modeled as ordinary boolean preferences.
 
 ---
 
@@ -645,8 +649,8 @@ The design is satisfied when:
 1. The existing Settings dropdown contains one Configuration group.
 2. It contains route links for Providers & Secrets, User / Workspace, and Operations in that order.
 3. Each destination has its own canonical `/settings/...` pathname.
-4. `/settings` redirects to `/settings/providers-secrets`.
-5. Legacy `?section=` links redirect to the corresponding canonical page.
+4. `/settings` resolves to the first Configuration destination the current user is authorized to see, and renders the unavailable state when none is accessible.
+5. `?section=` selects nothing: no client route honors it, and no internal caller, test, or document still builds a `?section=` Settings link.
 6. No configuration page repeats the destinations as tabs, radio buttons, segmented controls, pills, cards, a sidebar, or another local switcher.
 7. The masthead trigger remains `Settings` with the Settings icon while any Configuration page is active.
 8. Desktop and mobile expose the same group and order.
@@ -669,6 +673,8 @@ The design is satisfied when:
 25. A failure on one page does not break sibling Configuration destinations.
 26. Backend authorization, defaults, validation, source resolution, and secret-safety decisions remain authoritative.
 27. Navigation tests and telemetry use canonical destination keys instead of the removed `section` state.
+28. A concurrent-change `version_conflict` stops the save, refreshes the affected descriptors, shows the conflict, and requires explicit resubmission.
+29. Rendered rows keep the descriptor fields section 9 declares load-bearing, including active state, activation guidance, application requirements, and ordering.
 
 ---
 
@@ -677,7 +683,7 @@ The design is satisfied when:
 - Settings is a configuration namespace and dropdown group, not one page with three tabs.
 - Providers & Secrets, User / Workspace, and Operations are sibling pages.
 - Canonical routes are `/settings/providers-secrets`, `/settings/user-workspace`, and `/settings/operations`.
-- `/settings` redirects to Providers & Secrets.
+- `/settings` resolves to the first authorized Configuration destination rather than assuming Providers & Secrets.
 - The Settings dropdown is the single cross-page navigation owner.
 - The Settings trigger remains stable on all three pages.
 - Query parameters represent page-local state, not page identity.

--- a/docs/UI/SettingsPage.md
+++ b/docs/UI/SettingsPage.md
@@ -1,6 +1,6 @@
 # Settings Configuration Pages
 
-**Related design documents:** [SettingsSystem.md](../Security/SettingsSystem.md), [SecretsSystem.md](../Security/SecretsSystem.md), [ProviderProfiles.md](../Security/ProviderProfiles.md), [ProviderProfileModelEffortTierSettings.md](./ProviderProfileModelEffortTierSettings.md), [OAuthTerminal.md](../ManagedAgents/OAuthTerminal.md), [DashboardDesignSystem.md](./DashboardDesignSystem.md), [DashboardSPAArchitecture.md](./DashboardSPAArchitecture.md)
+**Related design documents:** [SettingsSystem.md](../Security/SettingsSystem.md), [SecretsSystem.md](../Security/SecretsSystem.md), [ProviderProfiles.md](../Security/ProviderProfiles.md), [ProviderProfileCreation.md](./ProviderProfileCreation.md), [ProviderProfileModelEffortTierSettings.md](./ProviderProfileModelEffortTierSettings.md), [OAuthTerminal.md](../ManagedAgents/OAuthTerminal.md), [DashboardDesignSystem.md](./DashboardDesignSystem.md), [DashboardSPAArchitecture.md](./DashboardSPAArchitecture.md)
 
 Status: **Desired-State UI Contract**  
 Owners: MoonMind Engineering  
@@ -49,6 +49,8 @@ This document owns:
 - permissions, secret-safe behavior, accessibility, and unsaved-change navigation; and
 - migration and acceptance criteria for removing the old page-local switcher.
 
+The detailed Provider Profile create and edit form is owned by [ProviderProfileCreation.md](./ProviderProfileCreation.md). Model and effort tier editing is owned by [ProviderProfileModelEffortTierSettings.md](./ProviderProfileModelEffortTierSettings.md).
+
 This document does not redefine backend setting eligibility, resolution, persistence, secret storage, provider execution semantics, operational command semantics, authorization, or server validation.
 
 This is a desired-state contract. The current implementation may still use one Settings component, `?section=` routing, and a segmented or radio-based switcher.
@@ -69,6 +71,8 @@ The pathname selects the configuration page. Query parameters may select safe fi
 
 The backend owns which settings exist, which are exposed, their types and scopes, validation, sensitivity, effective values, sources, and application semantics. The frontend renders descriptors and submits intent.
 
+Provider Profile creation follows the same rule. Runtime, provider, authentication, and creation capabilities determine backend-owned presets. The browser must not assume one materialization strategy for every provider.
+
 ### 3.4 Data-driven rows
 
 The User / Workspace page renders ordinary settings from catalog descriptors. The frontend may branch on descriptor shape such as `type`, `ui`, `constraints`, `options`, `read_only`, and `sensitive`. It should not branch on individual setting keys except for documented transitional exceptions.
@@ -77,11 +81,17 @@ The User / Workspace page renders ordinary settings from catalog descriptors. Th
 
 Provider Profiles, Managed Secrets, OAuth credentials, and Operations controls are not generic setting rows. They may use specialized managers, but options, capabilities, readiness, and policy constraints should still come from backend APIs.
 
-### 3.6 References over secrets
+### 3.6 Progressive disclosure
+
+Forms should lead with understandable choices and hide low-level implementation details until requested.
+
+For Provider Profile creation, credential connection remains visible, while raw SecretRefs, volume metadata, materialization details, secondary rate-limit controls, routing metadata, and launch shaping belong behind `Show advanced options`. Max parallel runs remains visible.
+
+### 3.7 References over secrets
 
 Stored secret plaintext is never rendered. Generic settings do not accept raw credentials. Sensitive relationships use SecretRef pickers, provider-profile secret-role bindings, or one-way Managed Secret creation and replacement flows.
 
-### 3.7 Safe independent failure
+### 3.8 Safe independent failure
 
 Failure on one configuration page must not make the other two unavailable unless the shared dashboard shell itself is unavailable.
 
@@ -257,6 +267,44 @@ The page explains that profiles contain references and launch metadata, Managed 
 
 A page-local runtime filter may narrow the visible Provider Profile collection. It must not narrow global readiness counts unless the summary is explicitly labeled as filtered.
 
+#### 7.1.1 Provider Profile creation
+
+Provider Profile creation uses progressive disclosure as defined by [ProviderProfileCreation.md](./ProviderProfileCreation.md).
+
+The standard form keeps these user-facing decisions visible:
+
+- Profile ID, with an auto-generated suggestion and review before creation;
+- runtime;
+- provider;
+- optional account label;
+- high-level authentication method and connection action;
+- model and effort tier policy;
+- max parallel runs; and
+- optional `Use as runtime default` intent when readiness permits.
+
+One unchecked `Show advanced options` checkbox reveals:
+
+- credential source and materialization metadata;
+- structured SecretRef bindings;
+- volume reference and mount metadata;
+- cooldown after provider 429 responses;
+- rate-limit policy;
+- command behavior;
+- routing tags and priority; and
+- launch-shaping diagnostics.
+
+Credential setup itself does not disappear behind the checkbox. OAuth and API-key actions remain visible, while low-level credential plumbing stays advanced or system-generated.
+
+`clear_env_keys` is backend-owned launch-safety metadata. The normal Settings UI may display it read-only, but must not present a freeform textarea as an ordinary preference.
+
+Creation must use backend presets or omit untouched advanced values. It must not blindly submit global React defaults. A profile with required missing credentials is saved disabled, while successful guided setup may enable it when policy permits.
+
+#### 7.1.2 Provider Profile edit behavior
+
+On edit, advanced options start expanded when the profile has non-default, unknown, incompatible, or invalid advanced values. Otherwise they may start collapsed with an effective-policy summary.
+
+Collapsing the region preserves every draft value. A validation error targeting a hidden field automatically expands the region and moves focus to the affected control.
+
 ### 7.2 User / Workspace
 
 This page contains descriptor-driven settings for:
@@ -296,7 +344,7 @@ The page title `Operations` is distinct from any broader dropdown group also lab
 
 | Page | Primary data |
 |---|---|
-| Providers & Secrets | Provider Profiles, Managed Secret metadata, OAuth state, readiness diagnostics |
+| Providers & Secrets | Provider Profiles, Managed Secret metadata, OAuth state, readiness diagnostics, profile creation presets |
 | User / Workspace | catalog descriptors, effective values, scoped overrides, diagnostics, audit metadata |
 | Operations | worker state, queue and runtime health, operation capabilities, command history |
 
@@ -417,6 +465,8 @@ Generic settings never accept raw secret values. Managed Secret creation and rep
 
 The UI may display an authorized SecretRef such as `db://github-token` or `env://GITHUB_TOKEN`, but never its plaintext target.
 
+Provider Profile advanced fields use role-aware SecretRef controls rather than raw JSON as the primary UX. OAuth volume identifiers and paths are normally generated or imported through dedicated backend-supported flows.
+
 Client validation may use descriptor metadata for required values, numeric bounds, option membership, length, simple patterns, SecretRef shape, and obvious type errors. Backend validation remains authoritative.
 
 Source and application labels come from backend metadata. Recommended source labels include Default, Config, Environment, Workspace override, User override, Provider Profile, Secret reference, and Operator locked.
@@ -441,6 +491,8 @@ The configuration experience must support:
 
 The three destination links must not use `role="tab"` or radio semantics. They navigate to documents and behave as links.
 
+The Provider Profile `Show advanced options` control is a native checkbox connected to an expandable form region. It is local form state, not cross-page navigation.
+
 ---
 
 ## 13. Extensibility Rules
@@ -464,7 +516,11 @@ Forbidden patterns include:
 - eager loading of every configuration dataset on every route;
 - one hard-coded React row per setting key;
 - frontend copies of backend defaults or authoritative validation;
+- unconditional client-side `enabled: true` for a credential-required Provider Profile;
+- a global fallback credential source or materialization mode for every provider;
 - plaintext credential inputs in generic settings;
+- raw SecretRef JSON as the primary credential setup UX;
+- freeform `clear_env_keys` as an ordinary Provider Profile preference;
 - frontend-only authorization filtering;
 - silent fallback for broken SecretRefs; and
 - boolean-preference treatment for operational commands.
@@ -531,7 +587,34 @@ Normal router matching replaces this state.
 
 Move state to the owning page. Runtime filtering stays on Providers & Secrets. User versus workspace scope stays on User / Workspace. Worker command state stays on Operations.
 
-### 14.4 Required tests
+### 14.4 Provider Profile form migration
+
+Refactor the current form into:
+
+```text
+ProviderProfileForm
+  StandardProfileFields
+  ProviderProfileAuthenticationSetup
+  ProviderProfileTierSection
+  MaxParallelRunsField
+  ProviderProfileAdvancedToggle
+  ProviderProfileAdvancedRegion
+```
+
+Migration rules:
+
+1. Move Account label into the standard identity group.
+2. Keep credential connection status and setup actions visible.
+3. Derive credential source and materialization mode from backend capabilities for guided paths.
+4. Move Credentials & Volumes behind advanced options.
+5. Move cooldown and rate-limit policy behind advanced options.
+6. Keep max parallel runs visible.
+7. Keep command behavior, tags, and priority advanced.
+8. Replace editable Clear env keys with backend-generated read-only launch-safety metadata for normal profiles.
+9. Remove unconditional client-side enablement from creation.
+10. Preserve and reveal non-default or invalid advanced fields during edit.
+
+### 14.5 Required tests
 
 Cover:
 
@@ -545,8 +628,13 @@ Cover:
 - page-specific data loading and no unrelated manager mounting;
 - Back and Forward behavior;
 - dirty-draft route guards;
-- direct-route permissions; and
-- deep links with page-local filters.
+- direct-route permissions;
+- deep links with page-local filters;
+- collapsed Provider Profile advanced options on create;
+- visible max parallel runs;
+- backend-owned creation presets and activation;
+- automatic advanced expansion for hidden errors; and
+- preservation of advanced drafts while collapsed.
 
 ---
 
@@ -565,14 +653,22 @@ The design is satisfied when:
 9. Each page has its own title, header, loading boundary, authorization state, and failure state.
 10. Each page loads only its required primary datasets by default.
 11. Providers & Secrets keeps Provider Profiles, Managed Secrets, OAuth, tier policy, and readiness as first-class surfaces.
-12. User / Workspace renders ordinary settings from backend descriptors and supports authorized scope switching.
-13. Operations uses explicit statusful command cards with confirmation and audit context.
-14. Secret-like settings use SecretRefs or Managed Secret flows, never generic plaintext inputs.
-15. Route navigation protects unsaved drafts.
-16. Unsupported descriptors degrade safely.
-17. A failure on one page does not break sibling Configuration destinations.
-18. Backend authorization, defaults, validation, source resolution, and secret-safety decisions remain authoritative.
-19. Navigation tests and telemetry use canonical destination keys instead of the removed `section` state.
+12. Provider Profile creation starts with one collapsed `Show advanced options` control.
+13. Credentials & Volumes, cooldown, rate-limit policy, command behavior, tags, and priority are advanced.
+14. Max parallel runs remains visible in the standard Provider Profile form.
+15. Account label remains a visible user-facing identity aid.
+16. Credential connection remains visible while credential implementation details stay advanced or system-generated.
+17. Clear environment keys are backend-owned launch-safety metadata.
+18. Provider Profile creation uses contextual backend presets or omission rather than global frontend guesses.
+19. A credential-required profile is not silently created enabled without successful setup.
+20. User / Workspace renders ordinary settings from backend descriptors and supports authorized scope switching.
+21. Operations uses explicit statusful command cards with confirmation and audit context.
+22. Secret-like settings use SecretRefs or Managed Secret flows, never generic plaintext inputs.
+23. Route navigation protects unsaved drafts.
+24. Unsupported descriptors degrade safely.
+25. A failure on one page does not break sibling Configuration destinations.
+26. Backend authorization, defaults, validation, source resolution, and secret-safety decisions remain authoritative.
+27. Navigation tests and telemetry use canonical destination keys instead of the removed `section` state.
 
 ---
 
@@ -586,4 +682,9 @@ The design is satisfied when:
 - The Settings trigger remains stable on all three pages.
 - Query parameters represent page-local state, not page identity.
 - Every page owns its title, status, authorization, loading, queries, and failures.
+- Provider Profile creation uses one collapsed advanced-options region.
+- Max parallel runs remains visible.
+- Credential plumbing, volumes, secondary rate limits, routing metadata, and launch shaping are advanced or backend-derived.
+- Account label remains visible.
+- Enabled state follows successful credential activation and policy.
 - Existing managers can be reused, but the old local section state and switcher are removed.

--- a/docs/tmp/SettingsConfigurationPagesMigration.md
+++ b/docs/tmp/SettingsConfigurationPagesMigration.md
@@ -1,0 +1,146 @@
+# Settings Configuration Pages: Migration Handoff
+
+**Status:** temporary execution scaffolding. Delete this file when the migration
+is complete.
+
+This is the implementation checklist for the desired state defined in
+`docs/UI/SettingsPage.md`. It names current code symbols and component names on
+purpose, so it goes stale as soon as the migration lands. The canonical document
+keeps only the durable route, ownership, and permission invariants; it must not
+absorb the steps below.
+
+Related: `docs/UI/SettingsPage.md`, `docs/UI/ProviderProfileCreation.md`,
+`docs/Security/SettingsSystem.md`.
+
+---
+
+## 1. Destination registry
+
+Replace the single Settings destination with:
+
+```text
+settings-providers-secrets -> /settings/providers-secrets
+settings-user-workspace    -> /settings/user-workspace
+settings-operations        -> /settings/operations
+```
+
+All three belong to the Configuration group. Local and server-provided destination registries must stay synchronized. Group membership should be explicit metadata or stable grouping logic.
+
+## 2. Page boundaries
+
+Recommended decomposition:
+
+```text
+ProvidersSecretsSettingsPage
+  ProvidersSecretsHeader
+  ProvidersSecretsHealthSummary
+  ProviderProfilesManager
+  SecretManager
+  OAuth and token validation surfaces
+
+UserWorkspaceSettingsPage
+  UserWorkspaceHeader
+  UserWorkspaceStatusSummary
+  ScopeSwitcher
+  GeneratedSettingsSection
+  User and workspace identity/preferences surfaces
+
+OperationsSettingsPage
+  OperationsHeader
+  OperationsStatusSummary
+  OperationsSettingsSection
+  Operational audit and diagnostics
+```
+
+The pages may initially share one bundle. They must still be route-owned components and must not mount unrelated managers.
+
+## 3. Remove old section state
+
+Remove equivalents of:
+
+- `SETTINGS_SECTIONS`;
+- `SettingsSectionId`;
+- `readSectionFromLocation`;
+- `updateSectionInLocation`;
+- local cross-page `section` state;
+- manual `popstate` handling for section selection;
+- the destination radio group or segmented control;
+- descriptions selected from a local section array; and
+- conditional page rendering selected by `section === ...`.
+
+Normal router matching replaces this state.
+
+Move state to the owning page. Runtime filtering stays on Providers & Secrets. User versus workspace scope stays on User / Workspace. Worker command state stays on Operations.
+
+## 4. Provider Profile form migration
+
+Refactor the current form into:
+
+```text
+ProviderProfileForm
+  StandardProfileFields
+  ProviderProfileAuthenticationSetup
+  ProviderProfileTierSection
+  MaxParallelRunsField
+  ProviderProfileAdvancedToggle
+  ProviderProfileAdvancedRegion
+```
+
+Migration rules:
+
+1. Move Account label into the standard identity group.
+2. Keep credential connection status and setup actions visible.
+3. Derive credential source and materialization mode from backend capabilities for guided paths.
+4. Move Credentials & Volumes behind advanced options.
+5. Move cooldown and rate-limit policy behind advanced options.
+6. Keep max parallel runs visible.
+7. Keep command behavior, tags, and priority advanced.
+8. Replace editable Clear env keys with backend-generated read-only launch-safety metadata for normal profiles.
+9. Remove unconditional client-side enablement from creation.
+10. Preserve and reveal non-default or invalid advanced fields during edit.
+
+## 5. Required tests
+
+Cover:
+
+- three destination-registry entries;
+- one Configuration label and correct ordering;
+- stable Settings trigger behavior;
+- active state for all three routes;
+- desktop and mobile navigation;
+- `/settings` resolving to the first authorized destination, including when
+  Providers & Secrets is hidden or unavailable, and the unavailable state when
+  no destination is accessible;
+- `/secrets` and `/workers` path redirects;
+- `?section=` selecting nothing on a canonical route;
+- absence of Settings tab or radio navigation;
+- page-specific data loading and no unrelated manager mounting;
+- Back and Forward behavior;
+- dirty-draft route guards;
+- direct-route permissions;
+- deep links with page-local filters;
+- collapsed Provider Profile advanced options on create;
+- visible max parallel runs;
+- backend-owned creation presets and activation;
+- automatic advanced expansion for hidden errors; and
+- preservation of advanced drafts while collapsed.
+
+---
+
+## 6. Retire `?section=` routing
+
+The canonical document forbids `?section=` as page identity and defines no
+redirect for it, so this migration completes the rename rather than aliasing it.
+In the same change:
+
+1. update every internal caller that builds a `?section=` Settings link,
+   including `frontend/src/entrypoints/dashboard-app.tsx` and
+   `frontend/src/entrypoints/dashboard-alerts.tsx`;
+2. update `frontend/src/entrypoints/settings.test.tsx` and any other test that
+   navigates by `?section=`;
+3. delete the client-side section parsing and writing helpers; and
+4. re-run a repo-wide search for `settings?section=` and confirm no caller,
+   test, fixture, or document remains.
+
+The backend `section=` catalog classification on
+`/api/v1/settings/catalog` is unrelated and stays.


### PR DESCRIPTION
## Summary

- replace the single tabbed Settings page with three route-owned configuration pages
- keep Providers & Secrets, User / Workspace, and Operations together in the existing Settings dropdown's Configuration group
- define canonical routes and redirects for legacy `?section=` links
- prohibit redundant tab, radio, segmented, card, sidebar, or pill navigation inside the pages
- add a dedicated Provider Profile creation contract based on progressive disclosure
- keep authentication, model tier policy, max parallel runs, account identity, and runtime-default intent visible
- put Credentials & Volumes, cooldown, rate-limit policy, command behavior, tags, and priority behind one `Show advanced options` checkbox
- derive credential source, materialization, activation, and launch-safety policy from backend capabilities instead of global React defaults
- make `clear_env_keys` backend-owned read-only launch-safety metadata rather than a normal freeform preference
- define stable Settings trigger behavior, independent data-loading boundaries, permission states, dirty-draft navigation, migration steps, and required tests

## Canonical routes

- `/settings/providers-secrets`
- `/settings/user-workspace`
- `/settings/operations`

`/settings` redirects to `/settings/providers-secrets`.

## Provider Profile standard form

The standard creation path keeps these decisions visible:

- Profile ID
- runtime and provider
- account label
- OAuth, API key, or explicitly supported credential-free setup
- model and effort tier policy
- max parallel runs
- optional runtime-default selection

Advanced options are collapsed on create. Existing non-default, unknown, incompatible, or invalid advanced settings are conspicuous during edit.

## Testing

Documentation-only change. No runtime tests were run.