### PR TITLE
Fix Omnigent credential cleanup redaction fencing

### DIFF
--- a/moonmind/omnigent/credential_materializers.py
+++ b/moonmind/omnigent/credential_materializers.py
@@ -410,36 +410,53 @@ class DockerOpencodeAuthJsonMaterializer:
                 code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_GENERATION_FENCED,
             )
         volume = handle.attachments[0].sourceRef
-        code, stdout, stderr = await self._backend.run(
+        # ``run_runtime_command`` redacts secret-shaped command output before
+        # returning it to callers.  The credential runtime label and volume name
+        # are non-secret authority refs, but both are intentionally caught by
+        # that generic redactor.  Returning either raw value (including in an
+        # inspect error) therefore creates false generation fences and prevents
+        # an already-absent volume from being recognized as idempotent success.
+        # Ask Docker's trusted template evaluator for one bounded attestation:
+        # ``owned`` for the exact generation, ``mismatch`` for a conflicting
+        # owner, and empty output when the exact volume is absent.
+        ownership_attestation = (
+            f"{{{{if eq .Name {json.dumps(volume)}}}}}"
+            "{{if and "
+            '(eq (.Label "moonmind.credential_runtime_ref") '
+            f"{json.dumps(handle.credentialRuntimeRef)}) "
+            '(eq (.Label "moonmind.credential_generation") '
+            f"{json.dumps(str(expected_generation))})"
+            "}}owned{{else}}mismatch{{end}}{{end}}"
+        )
+        code, stdout, _stderr = await self._backend.run(
             [
                 "docker",
                 "volume",
-                "inspect",
+                "ls",
+                "--filter",
+                f"name=^{volume}$",
                 "--format",
-                '{{ index .Labels "moonmind.credential_runtime_ref" }}|{{ index .Labels "moonmind.credential_generation" }}',
-                volume,
+                ownership_attestation,
             ]
         )
         if code != 0:
-            detail = (stderr or stdout).decode("utf-8", errors="replace").lower()
-            if "no such volume" in detail or "no such object" in detail:
-                # Already absent is idempotent cleanup success.
-                return CredentialCleanupResult(
-                    cleanupRef=handle.cleanupRef,
-                    removed=True,
-                    evidence={"alreadyAbsent": True},
-                )
             raise HarnessPlatformError(
-                "credential volume cleanup inspection is deferred",
+                "credential volume cleanup attestation is deferred",
                 code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
             )
-        expected = f"{handle.credentialRuntimeRef}|{expected_generation}"
-        if stdout.decode("utf-8", errors="replace").strip() != expected:
+        observed = stdout.decode("utf-8", errors="replace").strip()
+        if not observed:
+            return CredentialCleanupResult(
+                cleanupRef=handle.cleanupRef,
+                removed=True,
+                evidence={"alreadyAbsent": True},
+            )
+        if observed != "owned":
             raise HarnessPlatformError(
                 "credential volume ownership or generation fence mismatch",
                 code=HarnessPlatformFailure.OMNIGENT_CREDENTIAL_GENERATION_FENCED,
             )
-        code, _stdout, stderr = await self._backend.run(
+        code, _stdout, _stderr = await self._backend.run(
             ["docker", "volume", "rm", volume]
         )
         if code != 0:

--- a/tests/integration/reliability/replays/omnigent-credential-cleanup-redaction/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-credential-cleanup-redaction/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "ownershipAttestation": "owned\n",
+  "volumeRemoved": true,
+  "profileLeaseReleaseEligible": true
+}

--- a/tests/integration/reliability/replays/omnigent-credential-cleanup-redaction/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-credential-cleanup-redaction/manifest.json
@@ -1,0 +1,25 @@
+{
+  "incidentWorkflowId": "resolver:pr:3813:head:3ed9a9172bf1:h:fa6d87bd58b265c0:1",
+  "observedFailure": "OMNIGENT_CREDENTIAL_GENERATION_FENCED retained the sole Provider Profile lease after successful host cleanup",
+  "legacyRedactedInspectOutput": "credential-runtime=[REDACTED]\n",
+  "legacyRedactedMissingOutput": "Error response from daemon: get mm-omnigent-credential-f215c6c6d91c80e054d13247b31e6557=[REDACTED] such volume\n",
+  "expectedGeneration": 1,
+  "handle": {
+    "credentialRuntimeRef": "credential-runtime:sha256:f215c6c6d91c80e054d13247b31e6557b6b9676f2a991453bd8c68d3e77a32c1",
+    "providerProfileRef": "opencode-go-default",
+    "providerLeaseRef": "provider-profile-lease:profile-lease:execution_omnigent:b8fa3668e86495146015a5f289c41051",
+    "credentialGeneration": 1,
+    "materializerRef": "opencode-auth-json@1",
+    "attachments": [
+      {
+        "kind": "volume",
+        "sourceRef": "mm-omnigent-credential-f215c6c6d91c80e054d13247b31e6557",
+        "targetPath": "/run/mm-credentials/opencode",
+        "accessMode": "read-only"
+      }
+    ],
+    "cleanupRef": "credential-cleanup:sha256:f215c6c6d91c80e054d13247b31e6557b6b9676f2a991453bd8c68d3e77a32c1",
+    "attestationRef": "artifact:incident-credential-attestation",
+    "hostOwned": false
+  }
+}

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -795,8 +795,13 @@ class _DockerBackend:
 
     async def run(self, argv, *, input_bytes=None, timeout_seconds=60.0):
         self.calls.append((list(argv), input_bytes))
-        if argv[1:3] == ["volume", "inspect"]:
-            return 0, f"{self.runtime_ref}|{self.generation}\n".encode(), b""
+        if argv[1:3] == ["volume", "ls"]:
+            ownership_template = argv[argv.index("--format") + 1]
+            attested = (
+                self.runtime_ref in ownership_template
+                and json.dumps(self.generation) in ownership_template
+            )
+            return 0, (b"owned\n" if attested else b"mismatch\n"), b""
         return 0, b"", b""
 
 
@@ -1069,6 +1074,128 @@ async def test_opencode_volume_materialization_transports_secret_only_on_stdin()
     cleanup = await materializer.cleanup(handle, 4)
     assert cleanup.removed is True
     assert backend.calls[-1][0][1:3] == ["volume", "rm"]
+
+
+@pytest.mark.asyncio
+async def test_opencode_cleanup_replay_survives_command_output_redaction() -> None:
+    replay_root = (
+        Path(__file__).resolve().parents[2]
+        / "integration"
+        / "reliability"
+        / "replays"
+        / "omnigent-credential-cleanup-redaction"
+    )
+    manifest = json.loads((replay_root / "manifest.json").read_text())
+    expected = json.loads((replay_root / "expected-outcome.json").read_text())
+
+    class RedactingReplayBackend:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def run(self, argv, *, input_bytes=None, timeout_seconds=60.0):
+            del input_bytes, timeout_seconds
+            command = list(argv)
+            self.calls.append(command)
+            if command[1:3] != ["volume", "ls"]:
+                return 0, b"", b""
+            ownership_template = command[command.index("--format") + 1]
+            if (
+                "{{if and" in ownership_template
+                and manifest["handle"]["credentialRuntimeRef"]
+                in ownership_template
+                and json.dumps(str(manifest["expectedGeneration"]))
+                in ownership_template
+            ):
+                return 0, expected["ownershipAttestation"].encode(), b""
+            return 0, manifest["legacyRedactedInspectOutput"].encode(), b""
+
+    backend = RedactingReplayBackend()
+    handle = CredentialRuntimeHandle.model_validate(manifest["handle"])
+
+    result = await DockerOpencodeAuthJsonMaterializer(backend).cleanup(
+        handle,
+        manifest["expectedGeneration"],
+    )
+
+    assert result.removed is expected["volumeRemoved"]
+    assert expected["profileLeaseReleaseEligible"] is True
+    assert backend.calls[-1][1:3] == ["volume", "rm"]
+    inspect_template = backend.calls[0][backend.calls[0].index("--format") + 1]
+    assert "{{if and" in inspect_template
+    assert "owned{{else}}mismatch" in inspect_template
+
+
+@pytest.mark.asyncio
+async def test_opencode_cleanup_replay_treats_redaction_safe_absence_as_cleaned() -> (
+    None
+):
+    replay_root = (
+        Path(__file__).resolve().parents[2]
+        / "integration"
+        / "reliability"
+        / "replays"
+        / "omnigent-credential-cleanup-redaction"
+    )
+    manifest = json.loads((replay_root / "manifest.json").read_text())
+
+    class MissingVolumeBackend:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def run(self, argv, *, input_bytes=None, timeout_seconds=60.0):
+            del input_bytes, timeout_seconds
+            self.calls.append(list(argv))
+            return 0, b"", b""
+
+    backend = MissingVolumeBackend()
+    handle = CredentialRuntimeHandle.model_validate(manifest["handle"])
+    assert "no such volume" not in manifest["legacyRedactedMissingOutput"].lower()
+
+    result = await DockerOpencodeAuthJsonMaterializer(backend).cleanup(
+        handle,
+        manifest["expectedGeneration"],
+    )
+
+    assert result.removed is True
+    assert result.evidence == {"alreadyAbsent": True}
+    assert len(backend.calls) == 1
+    assert backend.calls[0][1:3] == ["volume", "ls"]
+
+
+@pytest.mark.asyncio
+async def test_opencode_cleanup_boolean_attestation_preserves_generation_fence() -> (
+    None
+):
+    backend = _DockerBackend()
+    backend.runtime_ref = "credential-runtime:sha256:" + "a" * 64
+    backend.generation = "2"
+    handle = CredentialRuntimeHandle.model_validate(
+        {
+            "credentialRuntimeRef": backend.runtime_ref,
+            "providerProfileRef": "opencode-go-default",
+            "providerLeaseRef": "provider-profile-lease:test",
+            "credentialGeneration": 1,
+            "materializerRef": "opencode-auth-json@1",
+            "attachments": [
+                {
+                    "kind": "volume",
+                    "sourceRef": "mm-omnigent-credential-test",
+                    "targetPath": "/run/mm-credentials/opencode",
+                    "accessMode": "read-only",
+                }
+            ],
+            "cleanupRef": "credential-cleanup:sha256:" + "a" * 64,
+        }
+    )
+
+    with pytest.raises(HarnessPlatformError) as exc:
+        await DockerOpencodeAuthJsonMaterializer(backend).cleanup(handle, 1)
+
+    assert (
+        exc.value.code
+        == HarnessPlatformFailure.OMNIGENT_CREDENTIAL_GENERATION_FENCED
+    )
+    assert all(call[0][1:3] != ["volume", "rm"] for call in backend.calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace raw credential-volume label inspection with a bounded Docker ownership attestation
- treat an absent run-scoped credential volume as idempotent cleanup success without parsing redacted Docker errors
- add replay coverage for failed workflow `resolver:pr:3813:head:3ed9a9172bf1:h:fa6d87bd58b265c0:1`

## Root cause

MoonMind sanitized trusted Docker command output before the credential materializer compared ownership evidence. The `credential-runtime:sha256:...` authority ref was rewritten to `credential-runtime=[REDACTED]`, which produced a false generation fence. The retained Provider Profile lease then blocked the downstream Omnigent resolver until bounded acquisition attempts expired.

The fix remains entirely at the MoonMind execution boundary and requires no Omnigent host changes.

## Verification

- `./tools/test_unit.sh tests/unit/omnigent/test_generic_platform_production_services.py -q`
- real Docker cleanup with both present and already-absent volumes
- durable janitor replay released the incident Provider Profile lease and marked its runtime binding cleaned