### PR TITLE
docs(omnigent): make the primary runtime-provider strategy explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌙 MoonMind — Safety, resiliency, and observability for Claude Code and Codex CLI
+# 🌙 MoonMind — Safety, resiliency, and observability for AI coding agents
 
 <p align="center">
     <picture>
@@ -7,41 +7,54 @@
     </picture>
 </p>
 
-MoonMind is an open-source framework that makes Claude Code and Codex CLI **safer**, more **resilient**, and more **observable** by wrapping agent CLI runs in Docker containers, using Temporal-based durable workflows, and providing a powerful UI dashboard.
+MoonMind is an open-source framework that makes AI coding agents **safer**, more **resilient**, and more **observable** through Temporal-based durable workflows, explicit Provider Profiles and policies, controlled runtime and container boundaries, and an operational dashboard.
 
-For now, MoonMind is focused on software engineering use cases, but can be used for other use cases as well and this will be made easier in the future (e.g. not requiring a git repo).
+For now, MoonMind is focused on software engineering use cases, but it can be used for other use cases as well. Support for workflows that do not require a Git repository will become easier over time.
 
-MoonMind includes a first-class Codex-through-[Omnigent](https://github.com/omnigent-ai/omnigent) managed-runtime path with profile and policy readiness gating, an on-demand default host, optional static hosting, durable event replay, controls, and artifact harvesting. It is available for normal explicit selection; making it the preselected Codex default remains gated by the protected live support matrix. Direct Codex remains a truthfully labeled migration fallback and historical-read substrate. See the [versioned support and cutover matrix](docs/Omnigent/CodexSupportAndCutover.md). Claude-through-Omnigent parity is deliberately deferred.
+## Runtime direction
+
+**Omnigent is to become MoonMind's primary runtime provider over time.** Codex, Claude Code, OpenCode, and future approved harnesses should converge on one generic Omnigent execution plane rather than accumulating separate MoonMind runtime architectures.
+
+MoonMind will continue to own Temporal orchestration, Provider Profiles, OAuth enrollment, secret references, workspaces, Skills, model and policy selection, publication, checkpoints, remediation, evidence, and cleanup. Omnigent will increasingly provide the host, runner, harness, provider-session, and live interaction substrate beneath those controls.
+
+The migration is deliberately evidence-gated. OpenCode is the first generic-host integration. Codex currently has both direct and profile-bound Omnigent compatibility paths. Claude Code has direct support and Omnigent substrate. These older paths remain truthfully labeled replay, rollback, migration, and historical-read compatibility until their exact generic Omnigent replacements pass conformance and retirement gates.
+
+The intended host direction is one digest-pinned MoonMind Omnigent image reused by Codex, Claude Code, and OpenCode wherever practical. Separate Host Classes, runtime-pack adapters, credential materializers, and support rows preserve strict runtime and credential isolation even when they share the same image digest.
+
+See the canonical [Omnigent Primary Runtime Provider Strategy](docs/Omnigent/PrimaryRuntimeProviderStrategy.md), the [Omnigent Harness Platform Design](docs/Omnigent/OmnigentHarnessPlatformDesign.md), and the [MoonMind Roadmap](docs/MoonMindRoadmap.md).
 
 ## Quick Start
 
 1. [Install Docker Desktop](https://docs.docker.com/get-started/get-docker/)
 2. Install git
 3. `git clone https://github.com/MoonLadderStudios/MoonMind.git`
-4. `cd MoonMind && git submodule update --init --recursive`. This initializes the submodules like Omnigent.
+4. `cd MoonMind && git submodule update --init --recursive`. This initializes submodules such as Omnigent.
 5. Run `docker compose up -d` to start the service
 6. Open [http://localhost:7000](http://localhost:7000). For combined MoonMind plus Omnigent validation, see [Combined Stack Validation and Rollback](docs/Omnigent/CombinedStackValidationAndRollback.md).
 7. In Settings:
     - Add a GitHub personal access token
-    - Add an API key or click OAuth to authenticate a provider profile
-    - Configure any other secrets or settings you want to adjust for your first workflow
-8. Click Create and submit a workflow. Choose Codex via Omnigent when its readiness entry is available; the default changes only through the evidence-gated rollout described in the support matrix.
+    - Add an API key or use OAuth to authenticate a Provider Profile
+    - Configure any other secrets or settings needed for the first workflow
+8. Click Create and submit a workflow. Select only a runtime target whose readiness entry is available. Default migration to Omnigent occurs independently for each qualified combination.
 
 `.env` is optional for normal local startup. Use `.env-template` only when you want to override defaults or preconfigure advanced settings before launch.
 
 ### OAuth Workflow
-If you already have a subscription with a model provider:
+
+When you already have a subscription with a model provider:
 
 1. Go to Settings
 2. Click OAuth next to the profile
 3. Follow the instructions on the new tab
-4. Go back to Settings and click Finalize
+4. Return to Settings and click Finalize
 
-After Finalize, a launch-ready OAuth profile is available to the normal on-demand Omnigent path without additional Compose configuration. Dedicated static hosts are an optional advanced deployment choice; to use one, enable the matching host profile in `.env`, for example `COMPOSE_PROFILES="omnigent-host-codex"`, rerun `docker compose up -d`, and explicitly select its static host policy. The dedicated hosts live in the canonical Compose file, so no platform-specific `COMPOSE_FILE` list is required. See [Combined Stack Validation and Rollback](docs/Omnigent/CombinedStackValidationAndRollback.md#dedicated-oauth-hosts).
+After Finalize, MoonMind owns a launch-ready OAuth Provider Profile and credential generation. An Omnigent-backed runtime reuses that generation without another login ceremony. The host starts non-interactively and receives only the selected runtime's credential material.
+
+Dedicated static hosts remain an optional advanced deployment choice during migration. To use one, enable the matching host profile in `.env`, such as `COMPOSE_PROFILES="omnigent-host-codex"`, rerun `docker compose up -d`, and explicitly select its static host policy. The long-term direction is a shared digest-pinned host image and generic startup path, not one permanent image architecture per runtime.
 
 ## Why MoonMind?
 
-Claude Code and Codex CLI are remarkable agents, but long-running autonomous work needs more than a terminal process:
+AI coding agents are remarkable, but long-running autonomous work needs more than a terminal process:
 
 - Can I close my laptop and trust the workflow to continue?
 - Can I inspect logs, diagnostics, artifacts, and step evidence after the fact?
@@ -50,50 +63,52 @@ Claude Code and Codex CLI are remarkable agents, but long-running autonomous wor
 - What credentials did the agent receive, and what provider and model policy was used?
 - What happened before the run failed, stalled, or hit a rate limit?
 
-MoonMind exists to answer those questions. Progress against each promise below is tracked milestone-by-milestone in the [MoonMind Roadmap](docs/MoonMindRoadmap.md).
+MoonMind exists to answer those questions. Progress against each promise below is tracked milestone by milestone in the [MoonMind Roadmap](docs/MoonMindRoadmap.md).
 
 ### 🛡️ Safety — boundaries the agent can't cross
 
 An autonomous agent with your credentials and a shell is a liability unless something constrains it. MoonMind builds the constraints into the execution substrate rather than trusting the agent to behave:
 
-- **Provider Profiles as policy.** A profile binds runtime, provider, credential source, materialization, concurrency slots, cooldowns, and routing into one declared contract — so model and credential policy is explicit per run, never ambient environment state.
-- **Sandboxed execution.** Managed runtime sessions and specialized workloads run in isolated Docker boundaries with strict capability routing. Containerized build and test jobs are submitted through MoonMind's API-owned Docker Backend Service; agent runtimes never receive the host Docker socket. File allowlists restrict what a run may modify.
-- **Secrets stay out of the blast radius.** Durable contracts carry secret *references*, never raw values; credentials are resolved only at controlled launch boundaries and automatically redacted from logs, artifacts, and outbound text. OAuth credentials live in isolated per-runtime volumes, so one runtime cannot read another's auth state.
-- **Outbound scanning.** A high-security mode adds deterministic secret scans at outbound boundaries — before an agent posts a PR comment, sends a message, pushes a commit, or publishes an artifact.
-- **Fail-fast, not fall-back.** Missing or revoked credentials produce explicit, actionable failures. MoonMind never silently substitutes an alternate credential source or rewrites billing-relevant values like model identifiers.
+- **Provider Profiles as policy.** A profile binds runtime, provider, credential source, materialization, concurrency slots, cooldowns, and routing into one declared contract, so model and credential policy is explicit per run rather than ambient environment state.
+- **Sandboxed execution.** Managed runtime sessions and specialized workloads run in isolated Docker boundaries with strict capability routing. Containerized build and test jobs are submitted through MoonMind's API-owned Docker Backend Service. Agent runtimes never receive the host Docker socket. File allowlists restrict what a run may modify.
+- **Secrets stay out of the blast radius.** Durable contracts carry secret references, never raw values. Credentials are resolved only at controlled launch boundaries and are automatically redacted from logs, artifacts, and outbound text. A shared runtime image never receives every runtime's credentials.
+- **Outbound scanning.** A high-security mode adds deterministic secret scans at outbound boundaries before an agent posts a pull request comment, sends a message, pushes a commit, or publishes an artifact.
+- **Fail fast, not fallback.** Missing or revoked credentials produce explicit, actionable failures. MoonMind never silently substitutes an alternate credential source, runtime, harness, realizer, or billing-relevant model value.
 
-Where this is headed: typed policy envelopes that declare per-run what an agent may touch, governance telemetry that records every privileged action an agent took and why, and a complete audit trail for the secret lifecycle — creation, rotation, reference, and every launch that resolved one. The goal is that granting an agent autonomy never means granting it trust.
+Where this is headed: typed policy envelopes that declare per run what an agent may touch, governance telemetry that records every privileged action an agent took and why, and a complete audit trail for the secret lifecycle, including creation, rotation, reference, and every launch that resolved one. The goal is that granting an agent autonomy never means granting it trust.
 
 ### 🔁 Resiliency — fire and forget, literally
 
 Submit a refactoring job, close your laptop, and let MoonMind handle the rest. Every run is backed by [Temporal](https://temporal.io/), so workflows survive container crashes, worker restarts, and host reboots:
 
-- **Durable step ledger and step-boundary checkpoints.** Long workflows are decomposed into steps whose state, attempts, and outputs are persisted as immutable artifacts. When compatible workspace capture and restore evidence exists, a failed step can resume from the last good step boundary — completed work is never re-bought.
-- **Stuck detection and escalating intervention.** MoonMind detects looping or silently stalled agents and applies escalating responses — soft reset, hard reset, termination — before they burn through your API budget.
+- **Durable step ledger and step-boundary checkpoints.** Long workflows are decomposed into steps whose state, attempts, and outputs are persisted as immutable artifacts. When compatible workspace capture and restore evidence exists, a failed step can resume from the last good step boundary. Completed work is never re-bought.
+- **Stuck detection and escalating intervention.** MoonMind detects looping or silently stalled agents and applies escalating responses before they burn through the API budget.
 - **Rate limits as a first-class citizen.** Runtime strategies recognize provider rate-limit signals in live output and respond with slot-based concurrency control and cooldowns instead of blind retry storms.
-- **Idempotent by design.** Externally visible side effects — starting runs, publishing results, posting to GitHub or Jira — are retry-safe, so a crash mid-operation never produces duplicates.
-- **Scheduled and recurring workflows.** Run heavy jobs overnight when tokens are cheaper, or put issue triage on a cron schedule and get alerted on failure.
+- **Idempotent by design.** Externally visible side effects such as starting runs, publishing results, and posting to GitHub or Jira are retry-safe, so a crash mid-operation does not produce duplicates.
+- **Scheduled and recurring workflows.** Run heavy jobs overnight when tokens are cheaper, or put issue triage on a schedule and get alerted on failure.
 
-Where this is headed: self-healing remediation workflows — already taking shape in the codebase — where a dedicated supervisor can target a failed run, read its durable evidence, and execute typed recovery actions (resume, retry, interrupt, clear) with privilege separation and a full audit trail. The aspiration is a system where a failed run at 3 a.m. is diagnosed, repaired, and resumed before you wake up.
+Where this is headed: self-healing remediation workflows where a dedicated supervisor can target a failed run, read its durable evidence, and execute typed recovery actions with privilege separation and a full audit trail. The aspiration is a system where a failed run at 3 a.m. is diagnosed, repaired, and resumed before you wake up.
 
 ### 🔭 Observability — know what your agent actually did
 
 "It finished" is not an answer. MoonMind treats every run as an evidence-producing process:
 
 - **The dashboard.** Track run status in real time, inspect per-step progress, open step-scoped logs and diagnostics, browse generated artifacts, monitor intervention requests, and audit execution histories from a single UI.
-- **Live logs as a session-aware timeline.** Merged stdout/stderr/system/session events stream over SSE into one ordered, run-global sequence — with durable artifact-backed replay after the run ends. Session boundaries, resets, and epochs are explicit, observable events.
+- **Live logs as a session-aware timeline.** Merged stdout, stderr, system, and session events stream over SSE into one ordered, run-global sequence with durable artifact-backed replay after the run ends. Session boundaries, resets, and epochs are explicit, observable events.
 - **Artifact-first outputs.** Prompts, transcripts, diffs, and diagnostics are stored as immutable, content-addressed artifacts rather than buried in process logs, so every run's evidence outlives the container that produced it.
-- **Correlated structured logs.** Every log line carries correlation IDs tying it to its workflow, run, activity, and trace — "what happened?" is answerable without reading raw worker internals.
+- **Correlated structured logs.** Every log line carries correlation IDs tying it to its workflow, run, activity, and trace. Questions about what happened can be answered without reading raw worker internals.
+- **Exact runtime provenance.** Omnigent-backed evidence identifies the host image, harness implementation, runtime pack, credential materializer, Host Class, launch policy, model configuration, and execution realizer that governed the run.
 
-Where this is headed: end-to-end OpenTelemetry tracing from API request through workflow, activity, and provider call — with token and cost attribution per step, so you can see not just what an agent did but what it cost. The aspiration is that any question about a run — what it changed, what it spent, why it failed — has a durable, queryable answer.
+Where this is headed: end-to-end OpenTelemetry tracing from API request through workflow, activity, and provider call, with token and cost attribution per step. The aspiration is that any question about a run, including what it changed, what it spent, why it failed, and which runtime authority it used, has a durable, queryable answer.
 
 ### 🛰️ Run CLI agents in MoonMind
 
-Other platforms make you rebuild agents in their SDK. MoonMind operates at a higher level of abstraction, running state-of-the-art CLI agents inside a durable operational envelope:
+Other platforms make you rebuild agents in their SDK. MoonMind operates at a higher level of abstraction, placing provider-maintained CLI agents and Omnigent harnesses inside a durable operational envelope:
 
-- **Managed sessions and managed runs.** MoonMind runs owned CLI runtimes on your own infrastructure using your existing subscriptions or API keys.
+- **Omnigent-backed agents.** The long-term normal path resolves an Omnigent Agent Profile, Provider Profile, runtime pack, Host Class, materializer, model, and policy into one immutable execution plan.
+- **Managed compatibility paths.** Direct Codex and Claude Code paths remain available during migration where policy and support status permit them.
 - **Step-based context management.** Agents perform better on small, focused tasks. MoonMind injects the right context into each step and clears it between steps to prevent context-window pollution.
-- **Personal-use friendly defaults.** A fresh local install boots with `docker compose up -d`; enter a few secrets in the dashboard and go — no enterprise secret infrastructure required up front.
+- **Personal-use friendly defaults.** A fresh local install boots with `docker compose up -d`. Enter a few secrets in the dashboard and begin without requiring enterprise secret infrastructure.
 
 ## Architecture
 
@@ -103,21 +118,22 @@ MoonMind runs as a set of decoupled containers from a single `docker-compose.yam
 | --- | --- |
 | **API Service** | FastAPI control plane for the dashboard, `/api/executions`, artifacts, templates, proposals, MCP tools, and the API-owned Docker Backend Service contract. |
 | **Temporal Server** | Durable execution engine with PostgreSQL persistence. |
-| **Worker Fleet** | Specialized isolated workers for orchestration, sandbox execution, LLM calls, managed runtime supervision, external integrations, and durable container-job execution. |
-| **Managed Session Plane** | Workflow-scoped Codex CLI compatibility sessions and profile-bound Codex-through-Omnigent sessions. Omnigent is a normal selectable runtime; its live matrix governs staged preselected-default promotion. Container jobs remain separate from session identity. |
-| **Docker Backend Service** | Authenticated MCP/HTTP container-job surface that resolves workspaces, applies policy, dispatches bounded jobs through Temporal, and uses one deployment-selected Docker daemon whose image cache is reusable across workflows. |
-| **Dashboard** | Operational dashboard for managing workflows, reviewing per-step progress, and inspecting logs, diagnostics, and artifacts. |
-| **Qdrant & MinIO** | Vector database for RAG/memory, and S3-compatible artifact storage. |
-| **Docker Proxy** | Restricted system-Docker access for trusted MoonMind backend execution; it is not exposed to managed sessions or Omnigent runners. |
+| **Worker Fleet** | Specialized isolated workers for orchestration, sandbox execution, LLM calls, runtime supervision, external integrations, and durable container-job execution. |
+| **Omnigent Runtime Plane** | Target primary runtime-provider plane for Codex, Claude Code, OpenCode, and future approved harnesses. It uses immutable Agent Profiles, plans, runtime bindings, Host Classes, runtime packs, materializers, exact-host attestation, canonical sessions, and native Workflow Chat. |
+| **Managed Compatibility Plane** | Direct Codex and Claude Code and the retained legacy Codex profile-bound realizer. These remain explicit migration, rollback, replay, and historical-read paths until retirement criteria pass. |
+| **Docker Backend Service** | Authenticated MCP and HTTP container-job surface that resolves workspaces, applies policy, dispatches bounded jobs through Temporal, and uses one deployment-selected Docker daemon whose image cache is reusable across workflows. |
+| **Dashboard** | Operational dashboard for managing workflows, reviewing per-step progress, and inspecting logs, diagnostics, artifacts, runtime provenance, and recovery state. |
+| **Qdrant and MinIO** | Vector database for RAG and memory, and S3-compatible artifact storage. |
+| **Docker Proxy** | Restricted system-Docker access for trusted MoonMind backend execution. It is not exposed to managed sessions or Omnigent runners. |
 
 ## Contributing
 
 Contributions are welcome, including high-quality AI-assisted pull requests.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation commands, testing expectations, and pull request guidelines. If you are using an AI coding agent, also read [AGENTS.md](AGENTS.md) before making changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation commands, testing expectations, and pull request guidelines. When using an AI coding agent, also read [AGENTS.md](AGENTS.md) before making changes.
 
 ## License
 
-MoonMind is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text and [NOTICE](NOTICE) for the copyright and attribution notice.
+MoonMind is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text and [NOTICE](NOTICE) for copyright and attribution notices.
 
-MoonMind includes Omnigent as a Git submodule at `omnigent/`. Omnigent is separately licensed by the Omnigent project under Apache License 2.0; after running `git submodule update --init --recursive`, see `omnigent/LICENSE` and `omnigent/NOTICE` for its license and attribution notices. Other submodules retain their own upstream licenses.
+MoonMind includes Omnigent as a Git submodule at `omnigent/`. Omnigent is separately licensed by the Omnigent project under Apache License 2.0. After running `git submodule update --init --recursive`, see `omnigent/LICENSE` and `omnigent/NOTICE` for its license and attribution notices. Other submodules retain their own upstream licenses.

--- a/docs/MoonMindRoadmap.md
+++ b/docs/MoonMindRoadmap.md
@@ -1,29 +1,78 @@
 # 🌙 MoonMind Roadmap
 
-> Durable, declarative roadmap for moving MoonMind toward **Omnigent host as the unified managed agent runtime**, with a **Codex-first cutover** held to the cross-cutting goals of **safety, resilience, and observability**.
+> Durable, declarative roadmap for making **Omnigent the primary runtime provider for MoonMind over time**, with the cross-cutting goals of **safety, resilience, and observability**.
 >
-> The destination is Codex CLI running through profile-bound Omnigent hosts from the normal MoonMind Workflow interface. Claude-through-Omnigent work has early substrate but stays outside the supported critical path until the Codex contracts and evidence gates are stable.
+> The destination is not limited to Codex. Codex, Claude Code, OpenCode, and future approved harnesses should enter one generic Omnigent execution plane. The migration remains evidence-gated. Direct and legacy runtime paths continue as explicit compatibility, replay, rollback, and historical-read substrate until their retirement criteria pass.
 >
-> **Document class:** this file is a *canonical declarative document*. It states the durable destination, ownership boundaries, evidence rules, acceptance-claim identifiers, and safety gates that persist across implementation waves. The dated, imperative execution tracker — milestone checklists, PR-by-PR status, tracker maps, and rollout sequencing — is disposable working scaffolding and lives at [`docs/tmp/MoonMindRoadmapExecutionTracker.md`](tmp/MoonMindRoadmapExecutionTracker.md). When the tracker and this declarative roadmap disagree, the declarative design wins.
+> The canonical runtime-provider strategy is [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](Omnigent/PrimaryRuntimeProviderStrategy.md). The harness mechanics are defined by [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](Omnigent/OmnigentHarnessPlatformDesign.md).
+>
+> **Document class:** this file is a *canonical declarative document*. It states the durable destination, ownership boundaries, evidence rules, acceptance-claim identifiers, and safety gates that persist across implementation waves. The dated, imperative execution tracker, milestone checklists, PR-by-PR status, tracker maps, and rollout sequencing are disposable working scaffolding and live at [`docs/tmp/MoonMindRoadmapExecutionTracker.md`](tmp/MoonMindRoadmapExecutionTracker.md). When the tracker and this declarative roadmap disagree, the declarative design wins.
 
 ---
 
 ## Destination
 
-MoonMind orchestrates provider-maintained agents through standard interfaces and runtime adapters. The target runtime is **Omnigent host as the unified managed agent runtime**: a normal UI-authored repository workflow executes in the exact authorized workspace through a policy-selected stock Codex Omnigent host, resumes from MoonMind-owned checkpoint evidence, and is governed by reusable policy and agent-profile versions with enforced network boundaries.
+MoonMind orchestrates provider-maintained agents through standard interfaces and runtime adapters. The target runtime provider is **Omnigent**.
 
-Completed historical milestones have been removed from the active roadmap; the durable acceptance-claim identifiers below stay stable even as active execution milestones are renumbered in the tracker.
+A normal UI-authored repository workflow should eventually execute through:
+
+```text
+external/omnigent
+  -> immutable Omnigent Agent Profile
+  -> compatible Provider Profile
+  -> one generic Omnigent execution plan and runtime binding
+  -> policy-selected Host Class
+  -> trusted runtime pack and credential materializer
+  -> shared digest-pinned MoonMind Omnigent host image where practical
+  -> selected Codex, Claude Code, OpenCode, or future approved harness
+  -> canonical session, turn, Workflow Chat, evidence, and cleanup plane
+```
+
+MoonMind should not retain a permanent separate execution architecture for every provider CLI. Genuine runtime differences belong behind small registered runtime-pack, credential-materializer, and capability adapters.
+
+Completed historical milestones have been removed from the active roadmap. The durable acceptance-claim identifiers below stay stable even as active execution milestones are renumbered in the tracker.
+
+---
+
+## Primary runtime-provider rules
+
+The durable destination follows these rules:
+
+- **Omnigent is the preferred runtime provider.** New managed coding-agent support should enter through the generic Omnigent harness platform unless a reviewed limitation requires another boundary.
+- **MoonMind retains authority.** Temporal orchestration, Provider Profiles, OAuth enrollment, credentials, workspaces, Skills, model and policy selection, publication, checkpoints, remediation, evidence, and cleanup remain MoonMind-owned.
+- **One top-level identity.** Omnigent-backed harnesses use `agentKind=external`, `agentId=omnigent`. Harness identity is nested immutable authority.
+- **One generic lifecycle.** Codex, Claude Code, OpenCode, and future approved harnesses should share execution planning, leases, host realization, sessions, turns, bridge behavior, evidence, publication, and cleanup.
+- **One shared host image where practical.** Codex, Claude Code, and OpenCode should reuse one digest-pinned MoonMind Omnigent host image. Separate Host Classes and support rows may point to the same image digest.
+- **Credentials remain isolated.** A shared image never means shared OAuth homes, API keys, credential mounts, or support authority.
+- **Differences stay at adapters.** Runtime-specific logic should be limited to trusted runtime-pack descriptors, credential materializers, bounded probes, and truthful capability normalization.
+- **Support remains combination-specific.** A binary being present in an image does not qualify its harness. Evidence binds the exact image, harness, runtime pack, materializer, model, policy, architecture, and realizer.
+- **No silent fallback.** An explicit Omnigent plan never silently switches to a direct runtime, legacy realizer, another harness, another Provider Profile, another model, or a broader policy.
+- **Migration preserves history.** Existing plans and Temporal histories retain their recorded realizer and runtime provenance until replay, rollback, and retention criteria permit removal.
 
 ---
 
 ## Target ownership split
 
-- **MoonMind owns** Workflow authoring, Temporal orchestration, workflow/run/step identity, Provider Profile selection and capacity, policy/profile selection, canonical workspaces, checkpoint/resume/branching, remediation, retrieval, durable artifacts, publication, and operator audit evidence.
-- **Omnigent host owns** the live provider process inside the authorized host environment, host-side session resources, provider/harness interactions, and live upstream events.
-- **The MoonMind Omnigent bridge owns** profile-authorized session creation or attachment, event normalization and replay, Workflow Detail projection, controls, resource harvesting, artifact publication, and retry-safe external-state evidence.
-- **Direct Codex remains migration compatibility substrate** while the deployed cutover phase remains `opt_in`. Historical direct provenance must remain truthful, and explicit Omnigent selection must never silently fall back to direct Codex.
-- **The stock proxy topology is the primary supported acceptance path.** Embedded mode remains experimental.
-- **Claude Code remains outside the current Omnigent critical path.** Existing direct Claude support remains available; early Claude-through-Omnigent substrate is not a support claim.
+- **MoonMind owns** Workflow authoring, Temporal orchestration, workflow/run/step identity, Agent Profile and Provider Profile selection, Provider Profile capacity, OAuth enrollment, credential-generation fencing, policy selection, canonical workspaces, Skills and mounted tools, checkpoint/resume/branching, remediation, retrieval, durable artifacts, publication, cleanup, and operator audit evidence.
+- **Omnigent owns** the host and runner protocol, harness discovery, the selected live provider process inside the authorized host environment, provider-session interactions, and live upstream events and resources.
+- **The MoonMind Omnigent bridge owns** profile-authorized session creation or attachment, canonical session and turn correlation, event normalization and replay, Workflow Detail projection, native Workflow Chat authorization, controls, resource harvesting, artifact publication, and retry-safe external-state evidence.
+- **Direct Codex and direct Claude remain migration compatibility substrate** until their supported Omnigent combinations pass the required product and release gates. Historical direct provenance must remain truthful.
+- **The legacy Codex profile-bound Omnigent realizer remains explicit compatibility substrate** until generic Codex parity, rollback, and replay criteria pass.
+- **OpenCode is the first proven generic-host integration**, not a permanent reason to keep a dedicated OpenCode-only host architecture.
+- **The stock proxy topology remains the primary supported browser acceptance path.** Embedded behavior is promoted only through its own compatibility evidence.
+
+---
+
+## Migration shape
+
+The transition follows six durable stages. Detailed execution sequencing belongs in the temporary tracker and GitHub issues.
+
+1. **Shared image reuse.** Promote the OpenCode-derived host image lineage into a neutral shared image and verify Codex, Claude Code, OpenCode, and Omnigent by immutable digest.
+2. **Runtime-pack registration.** Make startup, environment shaping, credential staging, model probing, readiness, and attestation consume versioned trusted runtime-pack descriptors.
+3. **Generic credential materialization.** Complete generic Codex and Claude OAuth materializers while preserving OpenCode's run-owned API-key materializer and strict cross-runtime isolation.
+4. **Generic realizer qualification.** Qualify Codex and Claude combinations on `generic-omnigent-host@1` through deterministic and protected-live evidence.
+5. **Product default migration.** Prefer qualified Omnigent Agent Profiles in Workflow Create, presets, schedules, reruns, branches, remediation, continuation, and Workflow Chat.
+6. **Legacy retirement.** Stop admitting new legacy paths, preserve replay and historical reads, then remove duplicate runtime, Compose, and credential-host code only when machine-checkable retirement criteria pass.
 
 ---
 
@@ -31,9 +80,9 @@ Completed historical milestones have been removed from the active roadmap; the d
 
 Every milestone is additionally gated by these durable properties:
 
-- **Safety.** Credential, filesystem, network, publish, approval, retrieval, and control boundaries are enforced at trusted substrate boundaries. Workflows and hosts receive capabilities, refs, and immutable snapshots — not raw infrastructure authority or reusable credential bodies.
+- **Safety.** Credential, filesystem, network, publish, approval, retrieval, and control boundaries are enforced at trusted substrate boundaries. Workflows and hosts receive capabilities, refs, and immutable snapshots, not raw infrastructure authority or reusable credential bodies.
 - **Resilience.** Runs prefer idempotent retry, evidence-gated resume, branch isolation, bounded degraded mode, and durable cleanup over silent restart-from-scratch. Provider Profiles, billing-relevant settings, constraints, and checkpoint authority are never silently substituted.
-- **Observability.** Live state, terminal outcomes, denials, degraded behavior, artifacts, cleanup, recovery decisions, retrieval delivery, and rollout state are inspectable through MoonMind-owned projections, manifests, audit events, and telemetry rather than a second-source runtime dashboard.
+- **Observability.** Live state, terminal outcomes, denials, degraded behavior, artifacts, cleanup, recovery decisions, retrieval delivery, runtime-pack identity, host-image identity, materializer identity, and rollout state are inspectable through MoonMind-owned projections, manifests, audit events, and telemetry rather than a second-source runtime dashboard.
 
 ---
 
@@ -44,9 +93,10 @@ Roadmap status follows evidence, not issue bookkeeping:
 - A merged implementation or closed issue may establish useful substrate without satisfying its full acceptance claim.
 - A PR whose own verifier reports `ADDITIONAL_WORK_NEEDED`, `BLOCKED`, missing live proof, or unexecuted controlling tests does not close the corresponding roadmap gate.
 - A task that requires credentialed, protected, browser-originated, restart, network-enforcement, or provider-conformance evidence remains open until that evidence is independently resolvable and linked.
-- A workflow file, fake provider, semantic action stub, self-asserted passing field, or caller-supplied expected event list is not live provider proof.
-- “Supported” means the support matrix links passing evidence for that exact combination. “Implemented,” “foundation,” and “designed” are weaker states.
-- Normal product paths must fail closed rather than silently substitute a Provider Profile, host mode, policy, network, credential, runtime, repository state, checkpoint, or retrieval scope.
+- A workflow file, fake provider, semantic action stub, self-asserted passing field, caller-supplied expected event list, or installed CLI is not live provider proof.
+- “Supported” means the support matrix links passing evidence for that exact combination. “Implemented,” “foundation,” “installed,” and “designed” are weaker states.
+- Normal product paths must fail closed rather than silently substitute a Provider Profile, host mode, policy, network, credential, runtime, harness, realizer, repository state, checkpoint, or retrieval scope.
+- One shared image does not allow evidence from one harness to qualify another harness.
 - Issue closure never rewrites historical runtime provenance or removes the obligation to preserve Temporal replay.
 - A closed tracker with known residual work must be reopened or receive a follow-up issue before the roadmap can treat the acceptance claim as owned.
 
@@ -54,7 +104,9 @@ Roadmap status follows evidence, not issue bookkeeping:
 
 ## Declarative design first
 
-Each milestone begins by reconciling the canonical declarative documents that own its target-state contracts. Implementation that discovers drift ends with a documentation reconciliation pass. This roadmap states durable desired state; it is not the sole architecture specification, and it is not the place for dated implementation diaries or phased rollout checklists.
+Each milestone begins by reconciling the canonical declarative documents that own its target-state contracts. Implementation that discovers drift ends with a documentation reconciliation pass. This roadmap states durable desired state. It is not the sole architecture specification, and it is not the place for dated implementation diaries or phased rollout checklists.
+
+The primary runtime-provider strategy owns the long-term direction. The harness platform design owns generic planning and realization mechanics. OAuth, Provider Profile, bridge, control-plane, checkpoint, remediation, and conformance documents own their narrower contracts.
 
 ---
 
@@ -76,15 +128,18 @@ Changing an identifier above is a deliberate owner-approved invariant change. Up
 
 These are shipped, durable capability statements that the roadmap treats as baseline desired state rather than active milestones:
 
-- Omnigent uses the canonical external-agent identity `agentKind=external`, `agentId=omnigent`; `integration.omnigent.execute` can create or reattach a session, post the first message idempotently, stream events, harvest terminal evidence, and return a canonical `AgentRunResult`.
+- Omnigent uses the canonical external-agent identity `agentKind=external`, `agentId=omnigent`.
+- The generic harness platform provides immutable catalogs, Agent Profiles, credential bindings, materializers, Host Classes, execution plans, runtime bindings, support keys, and a generic host realizer.
+- `integration.omnigent.execute` can create or reattach a session, post the first message idempotently, stream events, harvest terminal evidence, and return a canonical `AgentRunResult` for supported combinations.
 - Profile authorization, provider leases, host bindings, host leases, credential generations, lifecycle transitions, and redacted preflight evidence are durable without placing credential bodies in Temporal, bridge, checkpoint, workspace, or artifact payloads.
-- Static and on-demand hosts use complete image references, UID/GID `1000:1000`, `/home/app`, separate provider OAuth and Omnigent state, read-only root filesystems, bounded temporary storage, deterministic ownership labels, and explicit cleanup.
+- Static and on-demand hosts use complete image references, UID/GID `1000:1000`, `/home/app`, separate provider credential and Omnigent state, read-only root filesystems, bounded temporary storage, deterministic ownership labels, and explicit cleanup.
+- OpenCode has the first deployment-backed generic Host Class, materializer, image, and execution path. That foundation should be generalized rather than preserved as a permanent OpenCode-only architecture.
 - The run workflow records per-step Omnigent identity, so Omnigent checkpoint captures select the `external_state_ref` lane, and restore validation rejects stale, mismatched, non-artifact, local-path, or credential-shaped authority.
 - The Checkpoint Branch API and persistence model already support create, turn launch, continue, fork, compare, promote, archive, source checkpoint identity, immutable instruction digests, workspace policy, git binding, and remediation-created branches.
-- Persistent immutable Omnigent policy versions and agent-profile versions exist with authenticated lifecycle APIs, effective-launch linkage, and bridge evidence; complete cross-boundary consumption, approvals, ownership, and product-management journeys remain tracked execution work.
+- Persistent immutable Omnigent policy versions and Agent Profile versions exist with authenticated lifecycle APIs, effective-launch linkage, and bridge evidence. Complete cross-boundary consumption, approvals, ownership, and product-management journeys remain tracked execution work.
 
 ---
 
 ## Where the imperative tracker lives
 
-Milestone-by-milestone status, current-state notes, per-PR disposition, the open/closed tracker map, priority ordering, and rollout sequencing are dated execution scaffolding, not durable desired state. They live in the disposable tracker at [`docs/tmp/MoonMindRoadmapExecutionTracker.md`](tmp/MoonMindRoadmapExecutionTracker.md) and are refreshed or deleted as execution proceeds.
+Milestone-by-milestone status, current-state notes, per-PR disposition, the open and closed tracker map, priority ordering, and rollout sequencing are dated execution scaffolding, not durable desired state. They live in the disposable tracker at [`docs/tmp/MoonMindRoadmapExecutionTracker.md`](tmp/MoonMindRoadmapExecutionTracker.md) and are refreshed or deleted as execution proceeds.

--- a/docs/Omnigent/OmnigentHostOAuth.md
+++ b/docs/Omnigent/OmnigentHostOAuth.md
@@ -1,20 +1,23 @@
 # Omnigent Host OAuth
 
 **Document Class:** Canonical declarative  
-**Status:** Current  
+**Status:** Current desired state  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-07-18  
-**Authority:** Provider Profile, credential-mount, host-binding, host-lease, readiness, and cleanup contract for OAuth-backed Omnigent hosts
+**Last updated:** 2026-08-28  
+**Authority:** Provider Profile, OAuth materialization, host binding, generation fencing, readiness, cleanup, and migration contract for OAuth-backed Omnigent harnesses
 
-Implementation progress belongs in the roadmap, issues, and pull requests. This document defines the durable desired state and the safety invariants that all launch modes must enforce.
+Implementation progress belongs in the roadmap, issues, and pull requests. This document defines the durable desired state and the safety invariants that every OAuth-backed Omnigent launch must enforce.
 
 ## Related documents
 
+- [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
+- [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
 - [`docs/Omnigent/CodexCreateToHostContract.md`](./CodexCreateToHostContract.md)
+- [`docs/Omnigent/CodexSupportAndCutover.md`](./CodexSupportAndCutover.md)
+- [`docs/Omnigent/OpenCodeHost.md`](./OpenCodeHost.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/Security/SecretsSystem.md`](../Security/SecretsSystem.md)
 - [`docs/ManagedAgents/OAuthTerminal.md`](../ManagedAgents/OAuthTerminal.md)
-- [`docs/Omnigent/OmnigentAdapter.md`](./OmnigentAdapter.md)
 - [`docs/Omnigent/OmnigentBridge.md`](./OmnigentBridge.md)
 - [`docs/Omnigent/CombinedStackValidationAndRollback.md`](./CombinedStackValidationAndRollback.md)
 - [`docs/Omnigent/ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md)
@@ -22,108 +25,77 @@ Implementation progress belongs in the roadmap, issues, and pull requests. This 
 - [`docs/Workflows/WorkspaceLocators.md`](../Workflows/WorkspaceLocators.md)
 - [`docs/Workflows/CheckpointBranchSystem.md`](../Workflows/CheckpointBranchSystem.md)
 
----
+## Advance organizer
+
+**One sentence:** MoonMind Settings owns Codex and Claude Code OAuth enrollment, while the generic Omnigent host plane consumes only the selected leased credential generation through small runtime-specific materializers.
+
+**One paragraph:** OAuth is one of the genuine runtime differences that remains after Codex and Claude Code converge on the generic Omnigent lifecycle. MoonMind connects, validates, rotates, repairs, and disconnects each Provider Profile. The immutable execution plan selects an approved OAuth materializer and runtime pack. After capacity is acquired, the generic realizer mounts the profile-owned writable credential state into the shared Omnigent host image, verifies the exact generation and runtime-specific authentication status, and starts no interactive login ceremony. Codex and Claude share planning, leases, hosts, sessions, turns, workspaces, evidence, recovery, and cleanup. They differ only in approved credential paths, runtime probes, and truthful harness capabilities.
 
 ## 1. Purpose
 
-MoonMind Settings enrolls first-party CLI OAuth credentials into durable, provider-specific Docker auth volumes and registers connected Provider Profiles. A profile-bound Omnigent host reuses that verified credential home without a second login ceremony and without extracting access or refresh tokens.
+Omnigent is to become MoonMind's primary runtime provider over time. Codex and Claude Code OAuth support must therefore converge on the generic Omnigent execution plane rather than retain separate permanent host and lifecycle architectures.
 
-The Codex-first operator journey is:
+MoonMind Settings enrolls first-party CLI OAuth credentials into durable provider-specific backing state and registers connected Provider Profiles. An Omnigent execution reuses that verified credential state without a second login ceremony and without extracting access or refresh tokens into workflow data.
+
+The target journey is:
 
 ```text
-Settings -> Connect Codex OAuth
-  -> verified Codex OAuth volume
-  -> connected OpenAI / codex_cli Provider Profile
-  -> executionProfileRef selected for an Omnigent run
-  -> one global Provider Profile lease
-  -> one durable Omnigent host lease
-  -> static Compose or deterministic on-demand Codex host
-  -> exact codex-native host registration and preflight
-  -> one Omnigent session / runner
-  -> evidence harvest and host cleanup
-  -> Provider Profile lease release last
+Settings OAuth connection
+  -> validated runtime-owned Provider Profile
+  -> profile-owned credential state and generation
+  -> immutable Omnigent Agent Profile and execution plan
+  -> Provider Profile capacity lease
+  -> generic OAuth materializer binds the acquired generation
+  -> policy-selected Host Class using the shared Omnigent image
+  -> runtime-pack-specific auth and version preflight
+  -> generic Omnigent host registration
+  -> canonical Omnigent session and turns
+  -> evidence, checkpoint, publication, and cleanup
+  -> credential consumer stops
+  -> Provider Profile lease releases last
 ```
 
-Codex and Claude OAuth hosts use the same profile-bound authority and lifecycle.
-The provider adapter supplies only the runtime identity, OAuth-home location,
-environment, Compose service, readiness command, and harness identity. Claude
-uses `claude_code`, Anthropic, `/home/app/.claude`, and `claude-native`; Codex
-uses `codex_cli`, OpenAI, `/home/app/.codex`, and `codex-native`. Static and
-on-demand selection, capacity, binding, generation drain, exact-host
-registration, bridge authorization, workspace ownership, checkpoints,
-remediation workspaces, evidence, cleanup, and release-last ordering are shared.
-
----
+The current Codex profile-bound path remains a compatibility realizer until the generic Codex support combination has passing parity, rollback, and replay evidence. Direct Codex and direct Claude remain migration and historical-read compatibility according to their own retirement contracts.
 
 ## 2. Scope
 
 This document governs:
 
-- MoonMind Settings enrollment and repair of CLI OAuth profiles;
-- the global one-consumer invariant for mutable OAuth homes;
-- safe `AuthVolumeRef` and `CredentialMountRef` contracts;
-- profile-to-host binding and durable host leases;
-- the canonical static Compose bootstrap path;
-- deterministic on-demand OAuth host materialization for Codex and Claude;
-- exact host registration, harness, and credential readiness;
-- workspace, skill, tool, artifact, cache, temporary-storage, and network boundaries;
-- retry, reconnect, generation drain, janitor, and cleanup ordering;
-- secret-safe lifecycle evidence and checkpoint references.
+- MoonMind Settings enrollment, validation, repair, reconnect, rotation, and disconnect for CLI OAuth profiles
+- the one-consumer invariant for mutable OAuth state
+- Provider Profile ownership, credential generation, capacity, cooldown, and readiness
+- approved generic `codex-oauth-home@1` and `claude-oauth-home@1` materializers
+- profile-owned credential attachments and cleanup behavior
+- runtime-pack-specific authentication and version probes
+- Host Class and launch-policy compatibility
+- static-connected and on-demand host modes
+- exact-host registration, harness, image, credential, model, and capability evidence
+- generation drain, stale-host fencing, retry, cancellation, and janitor behavior
+- bridge, Workflow Chat, checkpoint, remediation, publication, and historical-read integration
+- replay-safe migration from legacy OAuth host implementations
 
-It does not define a token broker, raw-token export, arbitrary workflow-authored Docker mounts, generic multi-profile hosts, or a custom fork of `omnigent-host`.
-
-API-key profiles may eventually use the same binding and host-launch framework, but their secret materialization contract remains owned by Provider Profiles and the Secrets System.
-
----
+It does not define a token broker, raw-token export, workflow-authored mounts, shared OAuth homes, interactive login inside an execution host, or a second Codex or Claude lifecycle coordinator.
 
 ## 3. Governing decisions
 
-1. **MoonMind Settings is the enrollment authority.** OAuth connection, validation, repair, reconnect, and disconnect use the existing OAuth Session and Provider Profile systems.
-2. **The Provider Profile is the selection identity.** Workflows use `executionProfileRef`; they never select credential files or Docker volume names.
-3. **The OAuth home is mutable credential state.** The selected CLI may refresh or rewrite it, so ownership must be exclusive and authorized writes must persist.
-4. **OAuth capacity is one globally per profile.** Direct and Omnigent execution, OAuth maintenance, validation, repair, reconnect, and disconnect share the same purpose-aware Provider Profile capacity ledger for both Codex and Claude.
-5. **One profile maps to at most one active host and one active session.** Host-local counters do not replace Provider Profile authority.
-6. **Host registration credentials are separate from provider OAuth.** The host authenticates to Omnigent independently from Codex authenticating to OpenAI.
-7. **Only safe references cross durable boundaries.** Temporal history, bridge rows, checkpoints, diagnostics, and artifacts never contain OAuth credential bodies.
-8. **Static and on-demand modes use one contract.** Both resolve the same profile, mount path, binding, generation, readiness, bridge authorization, artifact, and cleanup semantics.
-9. **Stock host compatibility is preserved.** MoonMind configures and controls an unchanged published `omnigent-host` image.
-10. **Policy fails closed.** Missing capacity, incompatible profile, stale generation, unresolved workspace, unsupported network posture, or failed preflight never falls back to a different credential or broader launch mode.
+1. **MoonMind Settings is the OAuth enrollment authority.** Omnigent hosts do not ask users to authenticate again.
+2. **Provider Profiles remain runtime-owned.** A Codex Provider Profile belongs to `codex_cli`. A Claude Provider Profile belongs to `claude_code`. Omnigent is the execution facade, not the credential owner.
+3. **The execution plan selects a materializer.** Workflows never select credential files, volume names, mount paths, or login commands.
+4. **OAuth state is mutable profile-owned state.** Codex or Claude may refresh or migrate it. The active authorized consumer requires writable access.
+5. **OAuth capacity is one globally per Provider Profile.** Direct, legacy Omnigent, generic Omnigent, validation, repair, reconnect, rotation, and disconnect share the same capacity ledger.
+6. **One acquired generation governs one consumer.** A stale host cannot continue after credential replacement or reconnect advances the generation.
+7. **Host registration credentials are separate.** Provider OAuth never authenticates the host to the Omnigent server.
+8. **Only safe references cross durable boundaries.** Plans, runtime bindings, Temporal history, artifacts, checkpoints, and diagnostics contain ids, refs, generations, digests, and bounded status only.
+9. **Static and on-demand modes share one contract.** Host mode changes realization, not credential or lifecycle semantics.
+10. **One shared image does not share credentials.** A host gets only the selected runtime's credential bundle.
+11. **Generic lifecycle, specific adapter.** Runtime-specific code is limited to credential materialization, bounded runtime probes, and capability normalization.
+12. **Policy fails closed.** Missing capacity, wrong runtime, stale generation, invalid credential state, unsupported Host Class, failed auth probe, or incomplete cleanup never falls back to another runtime or credential.
 
----
+## 4. Runtime-owned Provider Profiles
 
-## 4. Why OAuth concurrency is fixed at one
+An Omnigent-backed execution does not use `runtime_id=omnigent` for provider credentials.
 
-CLI OAuth homes can contain access tokens, refresh tokens, account metadata, locks, caches, and format-version state that the CLI updates over time. Two processes can race while refreshing, replacing, or migrating the same files even when the upstream provider accepts multiple active access tokens.
-
-The invariant is credential-wide:
-
-```text
-active direct Codex consumers
-+ active Omnigent Codex host consumers
-+ active credential-maintenance consumers
-<= 1
-```
-
-Required enforcement points are:
-
-| Boundary | Required behavior |
-| --- | --- |
-| OAuth Session start/finalize | Acquire credential-maintenance authority and preserve `max_parallel_runs = 1` |
-| Provider Profile API | Reject an OAuth profile configured above one |
-| Settings UI | Display OAuth capacity as fixed rather than editable |
-| Provider Profile Manager | Share one purpose-aware ledger across every consumer type |
-| Omnigent host binding | Permit at most one active host for the profile |
-| Omnigent session launch | Permit at most one active session on that host |
-| Reconnect/disconnect | Drain or explicitly terminate active consumers before mutation |
-| Generation reconciliation | Prevent stale hosts from reusing replaced credential state |
-
-Concurrency greater than one requires a separate provider-specific design proving safe refresh ownership. It is not an operator-tunable default.
-
----
-
-## 5. Canonical Codex Provider Profile
-
-A first-party Codex OAuth profile has this effective shape:
+Representative Codex profile:
 
 ```yaml
 profileId: codex_openai_oauth
@@ -131,465 +103,542 @@ runtimeId: codex_cli
 providerId: openai
 credentialSource: oauth_volume
 runtimeMaterializationMode: oauth_home
-volumeRef: codex_auth_volume
-volumeMountPath: /home/app/.codex
 credentialGeneration: 7
 maxParallelRuns: 1
 enabled: true
 authState: connected
 ```
 
-Profile ids and volume names may be deployment-specific, but runtime, provider, credential source, materialization mode, volume, mount path, and generation must agree. A Claude profile, API-key profile, disabled profile, disconnected profile, or profile with a noncanonical mount fails before host mutation.
-
-Provider Profile readiness remains authoritative. A host binding does not make an otherwise invalid profile launchable.
-
----
-
-## 6. Safe credential references
-
-### 6.1 `AuthVolumeRef`
+Representative Claude profile:
 
 ```yaml
-providerProfileId: codex_openai_oauth
-runtimeId: codex_cli
-providerId: openai
-volumeRef: codex_auth_volume
-credentialGeneration: 7
-ownerUserId: user_123
+profileId: claude_anthropic_oauth
+runtimeId: claude_code
+providerId: anthropic
+credentialSource: oauth_volume
+runtimeMaterializationMode: oauth_home
+credentialGeneration: 4
+maxParallelRuns: 1
+enabled: true
+authState: connected
 ```
 
-`AuthVolumeRef` identifies the approved mutable backing store. It contains no credential body.
+The Omnigent Agent Profile declares compatible Provider Profile runtime, provider, authentication model, materializer, Host Class, and launch policy requirements. Authoring surfaces show only compatible profiles. The backend revalidates compatibility before plan persistence.
 
-`credentialGeneration` changes after successful credential replacement or reconnect. A host or binding created for an older generation is stale and cannot be assigned until reconciled.
+Provider Profile readiness remains authoritative. A host image, Host Class, or existing container cannot make a disconnected or incompatible profile launchable.
 
-### 6.2 `CredentialMountRef`
+## 5. Why OAuth concurrency is fixed at one
+
+CLI OAuth homes can contain access tokens, refresh tokens, account metadata, locks, caches, and format-version state that the CLI updates over time. Two consumers can race while refreshing, replacing, or migrating the same files even when the upstream provider accepts multiple access tokens.
+
+The invariant is profile-wide:
+
+```text
+active direct consumers
++ active legacy Omnigent consumers
++ active generic Omnigent consumers
++ active credential-maintenance consumers
+<= 1
+```
+
+The following boundaries enforce it:
+
+| Boundary | Required behavior |
+| --- | --- |
+| OAuth Session start and finalize | Acquire credential-maintenance authority |
+| Provider Profile API | Reject an OAuth profile configured above one consumer |
+| Settings UI | Display fixed OAuth capacity rather than an editable default |
+| Provider Profile Manager | Share one purpose-aware ledger across all consumer types |
+| Execution admission | Acquire capacity before materializing credentials or mutating a host |
+| Host binding | Permit at most one active credential-bearing host for the profile |
+| Session launch | Permit at most one active provider session under that host and generation unless a later provider-specific proof expands the contract |
+| Reconnect, rotation, and disconnect | Drain or terminate active consumers before replacing state |
+| Generation reconciliation | Fence every host and retry using an older generation |
+| Cleanup | Stop all credential consumers before releasing capacity |
+
+Concurrency above one requires a separate provider-specific design proving safe mutable-state ownership. It is not an operator-tunable default.
+
+## 6. Credential ownership model
+
+Every generic credential materialization handle declares one ownership class:
+
+```text
+run_owned
+profile_owned
+host_owned
+```
+
+### Run-owned
+
+The run creates credential state from a SecretRef and destroys it during cleanup. OpenCode API-key materialization is the reference example.
+
+### Profile-owned
+
+MoonMind Settings owns durable mutable credential state. A run mounts or attaches the selected generation, then unmounts it during cleanup. Ordinary run cleanup never deletes the profile's OAuth state.
+
+Codex and Claude OAuth use this class.
+
+### Host-owned
+
+A connected host owns and manages its authentication outside MoonMind. MoonMind may attest readiness but does not copy or claim the credential body.
+
+Ownership controls cleanup and must be explicit in the secret-free materialization handle. Inferring ownership from a mount path is forbidden.
+
+## 7. Generic materializer contract
+
+An OAuth materializer receives only trusted resolved inputs:
+
+- Provider Profile id
+- acquired Provider Profile lease
+- acquired credential generation
+- runtime id and provider id
+- approved backing-state reference
+- selected Host Class runtime uid, gid, and home
+- selected runtime-pack ref
+- launch policy and host mode
+- execution scope and fencing authority
+
+It returns a secret-free handle containing:
 
 ```yaml
-authVolumeRef:
-  providerProfileId: codex_openai_oauth
-  runtimeId: codex_cli
-  providerId: openai
-  volumeRef: codex_auth_volume
-  credentialGeneration: 7
-  ownerUserId: user_123
+materializerRef: codex-oauth-home@1
+providerProfileRef: codex_openai_oauth
+credentialGeneration: 7
+ownership: profile_owned
+attachments:
+  - kind: volume
+    sourceRef: <safe-volume-ref>
+    targetPath: /home/app/.codex
+    accessMode: read-write
+runtimeEnvironment: {}
+cleanupRef: <safe-cleanup-ref>
+```
+
+A materializer must:
+
+1. Validate the Provider Profile runtime, provider, credential source, and generation.
+2. Validate the selected runtime pack and Host Class allow the materializer.
+3. Refuse stale or conflicting active ownership.
+4. Return only approved attachment targets and access modes.
+5. Persist durable cleanup authority before the first mutable host operation.
+6. Never expose credential files or token bodies through its result.
+7. Support idempotent retry under the same execution and fencing identity.
+8. Refuse input drift under the same idempotency identity.
+9. Unmount or detach profile-owned state without deleting it.
+10. Preserve release-last Provider Profile ordering.
+
+## 8. Codex OAuth materializer
+
+The generic Codex materializer is:
+
+```text
+codex-oauth-home@1
+```
+
+Its canonical attachment is:
+
+```yaml
 targetPath: /home/app/.codex
-accessMode: read_write
+accessMode: read-write
+ownership: profile_owned
 runtimeUid: 1000
 runtimeGid: 1000
 ```
 
-The canonical OAuth home is mounted read/write only into the trusted OAuth enrollment/repair runner or the exclusive profile-bound runtime host. Read/write is required because Codex may refresh or migrate credential state.
+The selected runtime pack must define and attest:
 
-A read-only seed or copy-on-start design is valid only when a separate contract owns refresh, atomic writeback, conflict handling, and generation replacement. Refreshed state must never be silently discarded.
+```text
+harnessId: codex-native
+providerRuntimeId: codex_cli
+binary: codex
+version probe: codex --version
+auth probe: codex login status
+forbidden ambient credentials: unselected OpenAI API-key selectors and other runtime credential homes
+```
 
----
+The materializer does not copy the OAuth home into a run-owned volume. Authorized refreshes must persist to the Provider Profile-owned backing state.
 
-## 7. Durable host binding and lease
+A read-only seed or copy-on-start design is valid only under a separate contract that owns atomic writeback, refresh conflicts, generation advancement, and crash reconciliation. Silent loss of refreshed state is forbidden.
 
-### 7.1 `OmnigentOAuthHostBinding`
+## 9. Claude Code OAuth materializer
+
+The generic Claude materializer is:
+
+```text
+claude-oauth-home@1
+```
+
+Claude credential state may require more than one user-level path, including a directory and a user-level file. The materializer contract therefore supports a credential bundle with multiple approved attachments rather than assuming one directory per runtime.
+
+A representative bundle is:
 
 ```yaml
-bindingRef: omnigent-oauth:codex_openai_oauth
+materializerRef: claude-oauth-home@1
+ownership: profile_owned
+attachments:
+  - targetPath: /home/app/.claude
+    accessMode: read-write
+  - targetPath: /home/app/.claude.json
+    accessMode: read-write
+```
+
+The exact paths must be verified against the pinned Claude Code version in the selected shared image. The materializer cannot add an unregistered path at runtime.
+
+The selected runtime pack must define and attest:
+
+```text
+harnessId: claude-native
+providerRuntimeId: claude_code
+binary: claude
+version probe: claude --version
+auth probe: claude auth status
+forbidden ambient credentials: unselected Anthropic API-key selectors and other runtime credential homes
+```
+
+The same Provider Profile capacity, generation, fencing, cleanup, and release-last rules used for Codex apply to Claude.
+
+## 10. Shared-image isolation
+
+The shared MoonMind Omnigent host image may contain Codex, Claude Code, and OpenCode binaries. The selected host receives only one runtime's credentials.
+
+A Codex host must prove:
+
+- the Codex materializer and generation are present
+- Claude and OpenCode credential attachments are absent
+- conflicting API-key selectors are absent
+- the Host Class declares `codex-native`
+- the runtime pack is the selected Codex pack
+
+A Claude host must prove the equivalent Claude-only credential state.
+
+An OpenCode host must prove that neither OAuth home is mounted.
+
+The image itself is never credential or harness authority.
+
+## 11. Host Classes and runtime packs
+
+Separate Host Classes may reference one shared image digest:
+
+```text
+omnigent-codex@1
+omnigent-claude@1
+omnigent-opencode@2
+```
+
+Each class declares only its approved harness implementations, runtime dependencies, materializers, architectures, integration modes, and features.
+
+The immutable execution plan records:
+
+- harness implementation ref
+- Host Class ref
+- shared image ref
+- runtime-pack ref
+- credential materializer ref
+- Provider Profile selection
+- launch policy
+- model configuration
+- execution realizer
+
+A Host Class that points to the shared image does not authorize every runtime in that image.
+
+## 12. Durable host binding and lease
+
+The generic control plane uses the same host binding and host lease concepts for OAuth and API-key materializers.
+
+A representative OAuth host binding is:
+
+```yaml
+bindingRef: omnigent-host-binding:codex_openai_oauth
 providerProfileId: codex_openai_oauth
 endpointRef: default
-harness: codex-native
-credentialMountRef: <validated CredentialMountRef>
+harnessId: codex-native
+hostClassRef: omnigent-codex@1
+runtimePackRef: codex-native-pack@1
+credentialMaterializerRef: codex-oauth-home@1
+credentialGeneration: 7
 maxHosts: 1
 maxSessionsPerHost: 1
-staticHostId: null
-hostLaunchProfileRef: codex-on-demand
 ```
 
-`staticHostId` and `hostLaunchProfileRef` are mutually exclusive. The binding is durable policy materialization for one profile; it is not a second Provider Profile.
-
-A static binding may learn and retain the exact registered host id. An on-demand binding records the approved launch profile/policy reference and resolves the per-lease host id after registration.
-
-### 7.2 `OmnigentHostLease`
+A representative host lease records:
 
 ```yaml
-leaseId: ohl_<deterministic-digest>
+hostLeaseRef: omnigent-host-lease:...
 providerProfileId: codex_openai_oauth
-providerLeaseId: provider_lease_123
-bindingRef: omnigent-oauth:codex_openai_oauth
+providerLeaseRef: provider-profile-lease:...
+bindingRef: omnigent-host-binding:codex_openai_oauth
 credentialGeneration: 7
-containerName: mm-omnigent-host-ohl...
-omnigentHostId: host_123
-omnigentSessionId: session_123
-bridgeSessionId: bridge_123
+launchGeneration: 1
+containerName: mm-host-...
+omnigentHostId: host_...
 status: assigned
-acquiredAt: 2026-07-18T12:00:00Z
-lastHeartbeatAt: 2026-07-18T12:01:00Z
-expiresAt: 2026-07-18T13:30:00Z
 ```
 
-The host lease is deterministic from provider-lease identity and idempotent for the logical run. Its lifecycle is:
+The host lease is deterministic for the logical execution and fencing generation. Retries inspect and reconcile the existing authority before creating or replacing resources.
+
+## 13. Launch ordering
+
+Every OAuth-backed generic launch follows this order:
+
+1. Verify the immutable execution plan and support combination.
+2. Acquire the selected Provider Profile lease.
+3. Record the acquired credential generation in the runtime binding.
+4. Reserve host-binding and host-lease authority.
+5. Persist cleanup authority for any planned mutation.
+6. Materialize or attach the exact selected OAuth generation.
+7. Prepare workspace, Skills, tools, GitHub credentials, and egress.
+8. Launch the exact Host Class image.
+9. Wait for the exact host registration.
+10. Attest image, Omnigent build, harness implementation, runtime pack, runtime version, mounts, credential generation, auth status, model, Skills, tools, workspace, and egress.
+11. Create or attach the canonical Omnigent session.
+12. Submit the initial or follow-up turn through the canonical turn-command path.
+13. Harvest terminal, event, resource, checkpoint, and publication evidence.
+14. Stop or drain the provider session.
+15. Stop and remove run-owned host state according to policy.
+16. Detach credential attachments.
+17. Preserve profile-owned OAuth backing state.
+18. Complete cleanup evidence.
+19. Release the Provider Profile lease last.
+
+Failure at any point reconciles the same plan and runtime binding. It does not create a second unfenced owner.
+
+## 14. Static-connected hosts
+
+Static-connected mode remains valid for local and controlled deployments during migration.
+
+A static host:
+
+- uses the same shared image and runtime pack as on-demand mode
+- receives only one selected OAuth profile generation
+- registers one exact host identity
+- remains subject to Provider Profile capacity and host leasing
+- cannot act as an unrestricted multi-profile credential host
+- cannot accept another session while the profile capacity contract forbids it
+- must drain or stop its credential consumer before capacity releases
+
+Static Compose service names may remain runtime-specific during migration. Their implementation should converge on one common host template and generic startup entrypoint.
+
+## 15. On-demand hosts
+
+On-demand mode launches a lease-owned container after capacity and durable authority exist.
+
+The container uses:
+
+- the selected digest-pinned shared image
+- deterministic ownership labels and correlation identity
+- non-root uid and gid
+- read-only root filesystem
+- bounded tmpfs and resource limits
+- the policy-selected restricted-egress network
+- one Provider Profile credential bundle
+- one workspace
+- one resolved Skill projection
+- approved mounted tools
+- a separate writable Omnigent state volume
+
+Retries reuse or replace the same host only through current fencing authority. An old host, old activity, or janitor cannot stop or mutate the replacement generation.
+
+## 16. Exact-host readiness
+
+Before session or runner work begins, the exact host must prove:
+
+- configured image ref matches the Host Class
+- image digest and architecture are admitted
+- `moonmind.omnigent.build_digest` matches the pinned Omnigent build
+- Omnigent version matches the catalog authority
+- selected harness implementation matches the plan
+- selected runtime-pack ref is present and supported
+- vendor CLI version matches the declared dependency
+- credential attachments match the selected materializer
+- credential generation matches the acquired generation
+- owner, mode, and target paths are correct
+- non-selected runtime credential state is absent
+- runtime-specific auth probe succeeds without exposing tokens
+- selected model is available when a reliable probe exists
+- workspace, Skills, mounted tools, GitHub credentials, and egress match the plan
+- the exact host registers under the expected owner and endpoint
+
+A host name, harness name, image tag, or successful process start is not readiness evidence.
+
+## 17. Generation rotation and drain
+
+A successful reconnect or credential replacement advances `credentialGeneration`.
+
+After generation advancement:
+
+- new plans select only the new generation
+- old hosts become stale
+- active old-generation work follows explicit drain or termination policy
+- retries cannot rematerialize the old generation as current
+- cleanup for the old generation cannot delete new-generation resources
+- validation and support evidence bound to the old generation becomes stale where generation is part of the support contract
+
+Disconnect requires no remaining credential consumer. Forceful disconnect is a separate approved operation with explicit impact and cleanup evidence.
+
+## 18. Cleanup and janitor behavior
+
+Cleanup distinguishes resource ownership.
+
+Run cleanup may remove:
+
+- run-owned host container
+- run-owned Omnigent state volume
+- run-owned control material
+- run-owned OpenCode credential state
+- run-owned Skill projection
+- run-owned temporary GitHub credential projection
+- run-owned network or egress attachment where policy owns it
+
+Run cleanup may not remove:
+
+- Codex OAuth backing volume
+- Claude OAuth backing state
+- a replacement-generation host or volume
+- another execution's workspace
+- shared image layers
+- deployment-owned policy or network resources
+
+A janitor acts only from durable cleanup authority and current fencing generations. Provider Profile release remains last even when cleanup requires retries.
+
+## 19. Secret-safe evidence
+
+Durable evidence may contain:
+
+- Provider Profile id
+- runtime and provider ids
+- credential source and materializer refs
+- credential generation
+- attachment target paths when approved for operator evidence
+- Host Class, image, runtime-pack, harness, model, policy, and realizer refs
+- auth probe outcome and stable reason code
+- lease, host, session, turn, cleanup, and janitor refs
+- bounded timestamps and digests
+
+Durable evidence may not contain:
+
+- access or refresh tokens
+- OAuth JSON bodies
+- raw credential files
+- secret-bearing environment values
+- Docker inspection output that exposes secret material
+- unbounded CLI authentication output
+- host-local source paths that grant access authority
+
+Auth probes return normalized status. Raw output is discarded or retained only through a separately reviewed protected evidence path with mandatory redaction.
+
+## 20. Migration from legacy implementations
+
+The transition occurs without changing the meaning of existing plans.
+
+### Image reuse first
+
+Codex and Claude static or legacy hosts may point to the same shared image digest before their execution realizer changes. This proves image reuse independently from lifecycle migration.
+
+### Generic materialization second
+
+Add and qualify `codex-oauth-home@1` and `claude-oauth-home@1` under the generic credential registry and runtime-pack contracts.
+
+### Generic realizer third
+
+New approved Agent Profiles may select:
 
 ```text
-allocating -> starting -> ready -> assigned -> draining -> stopped
-                                      \-> failed
+generic-omnigent-host@1
 ```
 
-Durable rows contain identifiers, timestamps, bounded status, and safe evidence only.
+only after exact combination evidence passes.
 
----
+### Product default migration fourth
 
-## 8. Launch-mode contract
+Workflow Create, presets, schedules, reruns, branches, remediation, and continuation prefer the qualified Omnigent-backed target through explicit versioned rollout.
 
-### 8.1 Static Compose bootstrap
+### Retirement last
 
-The canonical `docker-compose.yaml` defines `omnigent-host-codex` behind the matching Compose profile. Supported startup uses `COMPOSE_PROFILES` or an explicit `--profile` flag; superseded OAuth-host overlay files are not part of the supported path.
+Legacy `oauth_host_runtime.py`, profile-bound Codex realization, direct-runtime defaulting, duplicate Compose scripts, and deprecated environment aliases are removed only after:
 
-Static mode is appropriate for local/bootstrap operation. It uses the same Provider Profile lease and host lease as on-demand mode, and MoonMind must still:
+- no new plan selects them
+- active executions and cleanup drain
+- Temporal replay passes
+- historical reads remain available
+- protected live generic parity passes
+- rollback without the legacy path is exercised
+- retention and retirement policy permits removal
 
-- resolve the exact registered host rather than a generic picker;
-- validate the current credential generation;
-- validate `codex-native` capability and login state;
-- allow only one assigned session;
-- bind bridge authorization before session creation;
-- stop or drain the credential consumer before releasing the profile lease.
+Legacy code may remain as a replay-visible wrapper without remaining a selectable product path.
 
-The static host is not an unrestricted shared Omnigent host.
+## 21. Failure behavior
 
-### 8.2 Deterministic on-demand Docker
-
-On-demand mode starts a lease-owned container only after profile capacity is acquired and durable authorization is reserved. The container name, labels, state volume, and workspace key are deterministic from safe run/lease identity.
-
-The host uses the published image selection and explicit image/tag overrides, runs as UID/GID `1000:1000` from `/home/app`, attaches to the configured MoonMind/Omnigent network, and registers with the selected Omnigent endpoint.
-
-A retry inspects the deterministic container and lease before creating anything. It removes a stopped same-lease container only as part of retry-safe replacement and never removes an unrelated container. After terminal cleanup is proven, MoonMind retires the prior live cleanup authority before restarting the lease; the replacement must publish a fresh endpoint attestation while an unexplained live identity change still fails closed.
-
-### 8.3 Product selection authority
-
-The durable desired state uses an explicit host mode compiled from the selected Omnigent agent profile and policy. Static or on-demand selection must be visible, validated, and stamped onto run evidence.
-
-`OMNIGENT_CODEX_HOST_LAUNCH_PROFILE` is a bootstrap compatibility input while the first-class policy/profile surface is incomplete. It may seed a binding when no durable selection exists, but it is not workflow-authored authority and must not require manual `hostId` handling.
-
-### 8.4 Image selection authority
-
-The canonical deployment supports:
+Stable failures include at least:
 
 ```text
-OMNIGENT_IMAGE_REF
-OMNIGENT_HOST_IMAGE_REF
+provider_profile_incompatible
+provider_profile_not_ready
+provider_profile_busy
+credential_generation_stale
+credential_materializer_unavailable
+credential_attachment_invalid
+credential_ownership_conflict
+host_class_unavailable
+runtime_pack_unavailable
+host_image_mismatch
+vendor_runtime_mismatch
+harness_build_mismatch
+authentication_not_ready
+model_unavailable
+host_registration_failed
+egress_unavailable
+cleanup_incomplete
 ```
 
-These complete references are preferred for production and required by credentialed conformance when immutability is part of the selected profile. They may contain digest-pinned published stock images. Legacy `OMNIGENT_IMAGE` plus `OMNIGENT_IMAGE_TAG`, and `OMNIGENT_HOST_IMAGE` plus `OMNIGENT_HOST_IMAGE_TAG`, remain bootstrap-compatible fallbacks.
-
-A policy that requires immutable stock-image evidence fails before launch when only a mutable tag is available. The effective image reference and host architecture are recorded as safe conformance evidence.
-
----
-
-## 9. Host filesystem and mount policy
-
-A profile-bound Codex host receives distinct state classes:
-
-| State | Static target | On-demand target | Ownership and lifecycle |
-| --- | --- | --- | --- |
-| Provider OAuth home | `/home/app/.codex` | `/home/app/.codex` | Canonical profile volume, exclusive read/write, generation-checked |
-| Omnigent identity/state | `/home/app/.omnigent` | `/home/app/.omnigent` | Separate from OAuth; static host-specific or on-demand lease-owned |
-| Workflow workspace | policy-resolved under `/workspaces` | `/workspaces/run` | Workflow-scoped, never durable as a raw host path |
-| Resolved Skill snapshot | `/opt/moonmind-skills` | `/opt/moonmind-skills` | Immutable and read-only |
-| Versioned CLI tools | `/opt/moonmind-tools` | `/opt/moonmind-tools` | Pinned, checksum-validated, read-only |
-| Runtime scripts | `/opt/moonmind` | `/opt/moonmind` | Trusted, read-only |
-| Temporary storage | bounded deployment path | bounded `/tmp` tmpfs | Removable and non-authoritative |
-| Artifact handoff | gateway or declared path | gateway or declared path | Separate from OAuth and host state |
-| Optional caches | explicit policy | explicit policy | Named owner, scope, retention, and invalidation |
-
-On-demand hosts use a read-only root filesystem and bounded temporary storage.
-The current static Compose host does not provide equivalent filesystem
-containment: its root filesystem is writable and its shared `/workspaces` mount
-is writable. Treat static mode as a less-isolated operator-selected deployment
-until its Compose configuration supplies the same protections; do not use
-static-host evidence to claim conformance with the on-demand containment
-boundary.
-
-The workspace source is resolved from canonical workflow authority. Durable payloads use `WorkspaceLocator`; only the owning worker resolves it and translates it to a daemon-visible bind source after containment and identity validation.
-
-Every declared input state materializes through the one owning-worker boundary before any host, volume, or bind mutation: the repository and authored branch/commit, checkpoint/external-state restore inputs, and declared input attachments. Restore inputs and attachments are durable `artifact://` refs — each is dereferenced through the artifact contract under its own dedicated service principal (`service:omnigent_workspace_restore`, `service:omnigent_workspace_attachment`), bounded per ref and cumulatively, and landed under bounded `.moonmind/restore` and `.moonmind/attachments` areas inside the already-containment-checked workspace. A ref that looks like a local path is rejected so an artifact ref is never conflated with a filesystem path.
-
-Daemon-visible translation is a deployment-selected, deterministic contract applied only at the trusted worker/runtime boundary after authorization and materialization, selected by `WORKFLOW_DOCKER_DAEMON_MODE`:
-
-- `local` (default when no daemon root is configured): the daemon shares the worker filesystem, so the worker path is already daemon-visible and returned unchanged; configuring a daemon root remap in this mode fails closed.
-- `remote`: the owning runtime inspects the configured `MOONMIND_AGENT_WORKSPACES_VOLUME_NAME` in the selected Docker daemon, then rebases the worker path from `WORKFLOW_WORKSPACE_ROOT` onto that volume's authoritative absolute mountpoint after a containment check. A missing volume, failed inspection, unsafe volume identity, or non-absolute mountpoint fails before host mutation. The runtime never derives this path from an assumed Docker data-root location.
-
-A denied or interrupted materialization leaves bounded, credential-free reconciliation evidence — the failed authority class, a stable reason code, retryability, whether owned partial state was created, and the reconciliation requirement. Because the durable completion marker is written only after a full materialization, a partially built workspace is rebuilt on the next retry rather than reused, and a retry can never author a second workspace or mutate another run's state.
-
-The current private hashed workspace materialization is an implementation compatibility path, not a second durable workspace model. Convergence with shared `WorkspaceLocator`, daemon-visible resolution, artifact handoff, and cache primitives must preserve the separate long-lived host/session lease.
-
----
-
-## 10. Runtime environment
-
-The Codex host uses:
-
-```text
-HOME=/home/app
-CODEX_HOME=/home/app/.codex
-CODEX_CONFIG_HOME=/home/app/.codex
-CODEX_CONFIG_PATH=/home/app/.codex/config.toml
-CODEX_VOLUME_PATH=/home/app/.codex
-```
-
-Provider-profile materialization is authoritative. Competing credentials and custom-provider overrides are removed before launch, including at least:
-
-```text
-OPENAI_API_KEY
-CODEX_ACCESS_TOKEN
-OPENAI_BASE_URL
-ANTHROPIC_API_KEY
-ANTHROPIC_AUTH_TOKEN
-CLAUDE_API_KEY
-CLAUDE_CODE_OAUTH_TOKEN
-GEMINI_API_KEY
-GOOGLE_API_KEY
-```
-
-Required mounted tools and resolved Skill snapshots are validated before the corresponding execution capability is claimed. GitHub credentials, when required, are resolved independently at a trusted boundary and materialized as owner-only standard `gh` configuration in the isolated on-demand host's lease-owned cache. The raw credential is removed before Omnigent starts; only the non-secret config selector reaches its authoritative runner. A reusable static OAuth host does not receive per-run GitHub mutation credentials.
-
-An on-demand host also receives the exact non-secret step execution identity for
-its current lease. MoonMind forwards `MOONMIND_STEP_EXECUTION_ID` to the runner
-and mounts a generated, execution-owned login profile at
-`/etc/profile.d/moonmind-execution.sh`. Native Codex deliberately filters
-unknown variables from the app-server process, so the login profile restores
-the identity for model-authored shell commands without embedding it in terminal
-arguments or mutable repository files. The profile is validated against the
-run-owned runtime-script snapshot and must fail closed on a missing, unsafe, or
-mismatched identity. Terminal-evidence Skills remain responsible for writing
-their own evidence with this execution ref. When a resolver reaches a terminal
-merge disposition, AgentRun durably publishes both the validated resolver result
-and the Skill-authored `artifacts/publish_result.json` companion. The parent
-consumes that companion by artifact ref as auto-publication evidence, preserving
-the Skill as semantic authority while keeping the authority handoff durable.
-
----
-
-## 11. Network and resource policy
-
-The host attaches only to the network selected by the effective launch policy. The selected network must provide required MoonMind/Omnigent reachability. Network attachment and egress enforcement are distinct: Docker `bridge` or a Compose network name does not prove restricted egress.
-
-The effective launch snapshot governs:
-
-- image and immutable/pinned verification requirements;
-- network attachment and any enforced egress profile;
-- CPU, memory, process, file-descriptor, and temporary-storage limits;
-- read-only root and writable-path exceptions;
-- host and session timeout/lease duration;
-- workspace, artifact, tool, skill, cache, and credential mounts;
-- capture, cleanup, and retention behavior.
-
-If the worker cannot realize the selected policy, launch fails before a less-constrained host is assigned. Provider Profile capacity remains authoritative even when machine or Docker capacity is also exhausted.
-
----
-
-## 12. Readiness contract
-
-A host is assignable only after the exact host environment proves:
-
-1. the Provider Profile is enabled, connected, and launch-ready;
-2. the Provider Profile lease is held for the correct purpose and owner;
-3. the binding and mount refs match the profile and generation;
-4. the credential volume exists at `/home/app/.codex` with expected ownership and write access;
-5. competing credential variables are absent;
-6. `codex login status`, or the canonical registered verifier, reports authenticated state;
-7. required Skill and mounted-tool projections are valid;
-8. exactly one expected online host is registered;
-9. that host advertises `codex-native`;
-10. bridge/server authentication and reachability are valid;
-11. durable bridge authorization contains profile, provider-lease, generation, binding, and host-lease refs;
-12. session creation targets that exact host.
-
-Readiness evidence is reduced to safe structured metadata. Raw credential files, unredacted command output, environment dumps, and tokens are never persisted.
-
----
-
-## 13. Session launch and authorization
-
-Before the first message, MoonMind:
-
-1. reserves the bridge attempt envelope;
-2. acquires the shared Provider Profile lease;
-3. creates or reattaches the host lease;
-4. persists profile authorization before host/session side effects can become ambiguous;
-5. prepares and resolves the exact host;
-6. updates authorization with the exact host id;
-7. creates or reattaches the Omnigent session on that host;
-8. persists session identity and first-message digest state;
-9. posts the first message at most once.
-
-The coordinator injects the exact host target immediately before session creation. A workflow or generic Omnigent UI cannot bypass the profile lease by selecting the profile-bound host directly.
-
----
-
-## 14. Lifecycle evidence
-
-The bridge records bounded lifecycle events for:
-
-```text
-request validation
-profile resolution and readiness
-profile lease wait and acquisition
-host binding and host lease creation
-container start
-credential mount and preflight
-host registration and harness readiness
-bridge authentication
-session creation and first-message post
-session running and resource harvest
-host cleanup
-profile lease release
-terminal outcome
-```
-
-Every lifecycle boundary records an explicit start followed by a bounded completed or failed state. Failure is attributed to the boundary that actually reports it; for example, credential-generation and mount failures are not mislabeled as generic container failures. Workflow Detail projects these records even when the run fails before a provider stream emits any event.
-
-Safe fields include profile, runtime, provider, credential source, volume ref, expected target path, credential generation, provider-lease, binding, host-lease, policy, workspace-locator, container, host, bridge-session, Omnigent-session, artifact, timestamp, status, and bounded redacted error refs.
-
-Workflow Detail uses these events to explain failures even when no normal Omnigent stream starts.
-
----
-
-## 15. Cleanup and janitor semantics
-
-Terminal cleanup occurs after available session evidence is harvested:
-
-1. interrupt or stop the active session as required;
-2. collect final event, snapshot, resource, and diagnostic artifacts;
-3. transition the host lease to draining;
-4. stop the credential consumer;
-5. for on-demand mode, remove the deterministic container and only its lease-owned Omnigent state volume;
-6. for static mode, stop or drain the dedicated Codex host according to policy;
-7. persist terminal host/session and cleanup evidence;
-8. release the host lease;
-9. release the Provider Profile lease last.
-
-If host cleanup fails, the Provider Profile lease remains held or explicitly marked for janitor reconciliation. MoonMind does not report successful release while a credential consumer may still be active.
-
-Cancellation can close the owning workflow before janitor reconciliation has made
-the old host lease terminal. An immediate rerun that reaches host admission during
-that interval waits behind the active lease with
-`OMNIGENT_OAUTH_HOST_PROFILE_BUSY` evidence and retries the same selected profile.
-It does not expose the database uniqueness constraint, reuse the canceled run's
-authority, or select a different profile.
-
-The janitor reconciles expired leases, missing containers, orphan labeled containers, stale credential generations, and force-drain requests. It uses durable bindings and labels and never removes unrelated containers, unrelated state volumes, the canonical OAuth volume, or application data.
-
----
-
-## 16. Reconnect and credential-generation drain
-
-Reconnect, repair, and disconnect mutate or invalidate the OAuth home. They require credential-maintenance authority from the same global capacity ledger.
-
-After successful reconnect:
-
-- the Provider Profile generation increments;
-- the durable host binding refreshes its safe mount ref;
-- active or reusable hosts on the old generation become stale;
-- stale hosts are drained before new assignment;
-- retries and checkpoints compare the recorded generation with the current profile before reattach.
-
-A stale generation never silently upgrades in place while a session is active. Cold restore reacquires the current generation and creates new host/session authority from validated artifact evidence.
-
----
-
-## 17. Checkpoint relationship
-
-A checkpoint may safely reference:
-
-```text
-providerProfileId
-providerLeaseRef
-credentialGeneration
-omnigentEndpointRef
-hostBindingRef
-hostLeaseRef
-omnigentHostId
-bridgeSessionId
-omnigentSessionId
-idempotencyKey
-firstMessageDigest or sent marker
-workspaceLocator
-externalStateRef
-workspace, diff, terminal, diagnostics, and capture artifact refs
-```
-
-It must not contain OAuth files, token values, Docker volume credentials, or daemon-visible absolute paths.
-
-Live reattach is permitted only when the profile lease, generation, host registration, session, bridge authorization, and first-message evidence remain valid. Otherwise MoonMind performs evidence-gated cold restore on a new host lease. Branching obtains independent authority and never concurrently reuses the original OAuth lease.
-
----
-
-## 18. Claude adapter and capability boundary
-
-The canonical Compose file exposes `omnigent-host-claude` as a dedicated static
-host. The shared runtime also launches it on demand. Both modes mount only the
-selected Claude OAuth home at `/home/app/.claude`, clear competing provider
-credentials, validate the selected credential generation in the host
-environment, require exact `claude-native` registration, and retain separate
-Omnigent state, workspace, Skill, tool, artifact, and cache mounts.
-
-Claude reuses the provider-neutral capacity, binding, lease, generation,
-exact-host, bridge, workspace, policy, checkpoint, ContextPack, remediation,
-evidence, cleanup, and janitor contracts. It does not emulate provider events.
-Messages, assistant output, command/tool activity, resources, diagnostics,
-terminal evidence, replay cursors, cancellation, stop, reset, and epoch changes
-use the shared bridge contract when emitted by `claude-native`. Approval or
-elicitation families that the selected stock harness does not advertise are
-unsupported: Workflow Detail retains Claude/harness provenance and must omit or
-label the unavailable control instead of synthesizing a Codex event.
-
-Checkpoint capture is host independent. Live reattach is allowed only while the
-recorded Claude profile lease, generation, host registration, session,
-authorization, and first-message identity remain valid. Any mismatch forces a
-cold restore through a newly acquired Claude-authorized host and session.
-Checkpoint Branches always use a distinct lease/session and an isolated
-candidate workspace. Initial ContextPacks and bounded follow-up retrieval remain
-artifact references supplied through the shared execution request. Typed
-remediation uses the same cumulative remediation workspace head. Provider
-limitations are therefore limited to upstream `claude-native` event and control
-families; they do not weaken checkpoint, workspace, RAG, or remediation
-authority.
-
-Direct Claude remains a distinct supported runtime with truthful historical
-provenance. Existing direct executions and Temporal histories continue to be
-read by their recorded runtime shape; they are never rewritten as Omnigent
-executions. Defaults may move to Claude-through-Omnigent only after the
-credentialed static and on-demand rows in the conformance matrix pass. Rollback
-restores the direct default without changing persisted executions. Retirement
-of direct launch requires zero in-flight direct histories, successful
-historical Workflow Detail reads, replay coverage for the last persisted
-payload shape, stable failure/cooldown/cleanup telemetry, and an operator-visible
-rollback window.
-
----
-
-## 19. Credentialed conformance
-
-`tools/run_omnigent_live_conformance.py` is the credentialed entrypoint for the versioned live matrix. It requires immutable server and host references and an already-enrolled OAuth profile. An operator-provisioned action adapter performs the real live actions; the repository semantic backend is test infrastructure and is not accepted as implicit provider evidence.
-
-Live action results carry durable `evidenceRefs`. Each referenced JSON document is schema-versioned, names its scenario and action, records observed behavior and returned durable identifiers, and is independently resolved and secret-scanned. Missing, opaque, mismatched, malformed, or bare-boolean evidence fails the scenario.
-
-The live runner uses the isolated `moonmind-test-omnigent-live` Compose project. Cleanup always attempts to remove that project's containers and networks and intentionally does not remove volumes, preserving enrolled OAuth and unrelated deployment state. Static restart/replay, published stock-image proxy compatibility, on-demand lifecycle, and failure-path scenarios remain independently gateable.
-
----
-
-## 20. Security invariants
-
-- One OAuth profile has one active credential consumer globally.
-- One profile-bound host mounts one provider OAuth home and serves one active session.
-- Codex OAuth state and Omnigent host identity never share a volume.
-- Host/server authentication and provider OAuth remain separate.
-- No user-authored mount name, host id, network, or daemon path becomes trusted authority.
-- Raw OAuth state never enters Temporal history, bridge rows, checkpoints, logs, diagnostics, artifacts, or UI payloads.
-- Competing provider credentials are removed before launch.
-- Workspace and mount paths are containment-checked at the owning worker.
-- On-demand resources are deterministic, labeled, and removed only by matching lease authority.
-- A policy realization failure cannot degrade to a broader network, writable root, alternate credential, or generic host.
-- Docker daemon administrators remain privileged; this design does not defend against a malicious daemon administrator.
-
----
-
-## 21. Acceptance contract
-
-A Settings-created Codex OAuth Provider Profile can be selected by `executionProfileRef`; MoonMind acquires the global profile lease, resolves an authorized static or on-demand binding, creates one durable host lease, mounts the exact generation at `/home/app/.codex`, proves login and `codex-native` registration, authorizes one bridge session, posts the first message once, harvests durable evidence, cleans the session and host idempotently, preserves the OAuth and application data volumes, and releases Provider Profile capacity last.
-
-Static and on-demand modes expose the same profile, binding, readiness, bridge, artifact, checkpoint, diagnostic, and cleanup evidence. Productized policy/profile selection replaces environment-only launch choice without removing the canonical Compose bootstrap path. Credentialed cutover evidence uses immutable published stock images and the versioned live-conformance evidence contract.
+A failure never silently selects another credential source, generation, runtime, harness, image, Host Class, model, launch policy, or realizer.
+
+## 22. Acceptance criteria
+
+- MoonMind Settings connects and validates Codex and Claude OAuth Provider Profiles without exposing token bodies.
+- Provider Profile runtime ownership remains `codex_cli` or `claude_code` even when execution uses Omnigent.
+- OAuth profile capacity is globally fixed at one across direct, legacy, generic, and maintenance consumers.
+- Generic credential handles declare run-owned, profile-owned, or host-owned state.
+- `codex-oauth-home@1` binds the acquired writable Codex OAuth generation through the generic realizer.
+- `claude-oauth-home@1` binds every required acquired writable Claude credential path through the generic realizer.
+- The shared image receives credentials only for the selected runtime.
+- Exact-host probes validate runtime version and authentication without printing credential bodies.
+- Static and on-demand modes consume the same plan, materializer, runtime-pack, generation, evidence, and cleanup rules.
+- Rotation fences old hosts and retries.
+- Run cleanup preserves profile-owned OAuth backing state.
+- Provider Profile release occurs after every credential consumer stops and cleanup authority is recorded.
+- Generic Codex and Claude support is claimed only for exact combinations with passing conformance evidence.
+- Existing plans and histories retain truthful legacy realizer identity.
+- Explicit generic plans never silently fall back.
+- Duplicate OAuth host architecture is retired only after machine-checkable replay, rollback, drain, and historical-read criteria pass.
+
+## 23. Non-goals
+
+This contract does not permit:
+
+- sharing a Codex OAuth home with Claude Code
+- sharing one profile-owned OAuth home across concurrent hosts
+- exporting tokens into environment variables for ordinary execution
+- copying OAuth homes into artifacts, checkpoints, or workspaces
+- starting interactive OAuth inside a workflow host
+- using `runtime_id=omnigent` as credential ownership
+- selecting arbitrary credential mount paths from workflow input
+- one multi-profile static host with all provider credentials
+- deleting OAuth backing state during run cleanup
+- treating a shared image as shared credential or support authority
+- creating separate permanent Codex and Claude lifecycle coordinators
+- silent fallback to a direct or legacy runtime
+
+## 24. Strategic rule
+
+The long-term architecture is one generic Omnigent host and session plane with minimal runtime-specific adapters.
+
+For OAuth-backed runtimes, the acceptable specialization is limited to:
+
+- Provider Profile compatibility
+- approved credential bundle shape
+- runtime-pack registration
+- version and authentication probes
+- truthful harness capability normalization
+- combination-specific support evidence
+
+All other behavior should converge on the common execution plan, runtime binding, leases, host realization, canonical session and turn control plane, bridge, evidence, recovery, publication, and cleanup.

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -1,33 +1,116 @@
-# OpenCode Host (omnigent-host-opencode)
+# OpenCode Host and Shared Omnigent Runtime Image
 
-**Status:** Implemented; launch remains qualification-gated
+**Status:** OpenCode implementation is current; shared-image migration is desired state  
 **Document Class:** System / Operator Guide  
 **Owners:** MoonMind Platform  
+**Last updated:** 2026-08-28  
+**Authority:** OpenCode runtime contract and transition from `omnigent-host-opencode` to the shared MoonMind Omnigent host image
 
-## Summary
+## Related documents
 
-`omnigent-host-opencode` is the first explicit harness-specific Omnigent host realization. It derives from the same immutable Omnigent host base as the stock host, then adds only the OpenCode CLI at **build time**. No per-workflow `npm install` is required.
+- [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
+- [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
+- [`docs/Omnigent/OmnigentHostOAuth.md`](./OmnigentHostOAuth.md)
+- [`docs/Omnigent/ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md)
+- [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 
+## Advance organizer
+
+**One sentence:** `omnigent-host-opencode` is the first working generic Omnigent host image, and its image lineage should become the shared MoonMind Omnigent host for OpenCode, Codex, and Claude Code rather than remain a permanent OpenCode-only architecture.
+
+**One paragraph:** The current image derives from an immutable stock Omnigent host and adds a pinned OpenCode CLI at build time. The OpenCode Host Class, Provider Profile, materializer, exact-host attestation, and generic realizer remain valid. The next architecture stage publishes the same image lineage under a neutral name, verifies every approved runtime in the exact digest, and allows separate OpenCode, Codex, and Claude Host Classes to reference that digest. Credentials remain strictly isolated. A shared image does not share OAuth homes, API keys, materializers, Host Classes, or support evidence.
+
+## 1. Current and desired state
+
+### Current supported implementation
+
+OpenCode currently uses:
+
+```text
+opencode-native
++ generic-omnigent-host@1
++ opencode-auth-json@1
++ omnigent-opencode@1
++ ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:<digest>
 ```
-ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:<digest>
+
+The image derives from the same immutable Omnigent host base as the stock host and adds the OpenCode CLI at image-build time. No workflow installs OpenCode dynamically.
+
+Conceptually:
+
+```dockerfile
 FROM ghcr.io/omnigent-ai/omnigent-host@sha256:<base-digest>
-RUN npm install -g --no-audit --no-fund 'opencode-ai@1.18.11' && opencode --version
+RUN npm install -g --no-audit --no-fund 'opencode-ai@1.18.11'
+RUN opencode --version
 ```
 
-## Compatibility
+### Desired shared-image implementation
 
-- Omnigent host base: same revision as `OMNIGENT_HOST_IMAGE_REF` (digest-pinned)
-- OpenCode: `1.18.11` (supported range `>=1.17.7,<1.19.0`)
-- Build fails when `opencode --version` is outside the supported range
-- Architecture: `linux/amd64`, `linux/arm64` (multi-arch manifest)
+The image lineage should be renamed and promoted to a neutral shared image such as:
 
-## Host Class
-
+```text
+ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:<digest>
 ```
+
+The shared image should contain and verify the approved versions of:
+
+```text
+omnigent
+codex
+claude
+opencode
+```
+
+During migration, `omnigent-host-opencode` may remain as an alias to the same manifest digest. New documentation, Host Classes, deployment state, and support evidence should use the neutral image identity after cutover.
+
+The image migration does not by itself move Codex or Claude execution to the generic realizer. Those changes require their own runtime-pack, credential-materializer, conformance, rollout, and replay-safe retirement work.
+
+## 2. Governing image rules
+
+The shared image must:
+
+- derive from an immutable compatible Omnigent host base
+- install or inherit every supported runtime at image-build time
+- perform no package installation during workflow launch
+- run as the normal non-root Omnigent host user
+- preserve `/home/app` as the runtime home contract
+- contain no provider credentials
+- publish SBOM and provenance data
+- publish the portable `moonmind.omnigent.build_digest` identity
+- support the architectures claimed by its manifest and Host Classes
+- verify every included CLI and required harness integration in release CI
+- remain digest-pinned at execution-plan and Host Class boundaries
+
+A shared image is an implementation artifact, not a permission boundary. The selected immutable plan still controls which harness, materializer, Provider Profile, model, and runtime pack are authorized.
+
+## 3. Separate Host Classes share the image
+
+OpenCode should retain its own Host Class even when the image becomes shared.
+
+The expected transition is:
+
+```text
+omnigent-opencode@1
+  -> current omnigent-host-opencode digest
+
+omnigent-opencode@2
+  -> shared omnigent-host-moonmind digest
+
+omnigent-codex@1
+  -> shared omnigent-host-moonmind digest
+
+omnigent-claude@1
+  -> shared omnigent-host-moonmind digest
+```
+
+Each class declares only the harnesses and materializers that it authorizes. Separate Host Classes preserve independent support and rollout decisions.
+
+A representative OpenCode class remains:
+
+```yaml
 hostClassId: omnigent-opencode
-version: 1
-ref: omnigent-opencode@1
-imageRef: ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:...
+version: 2
+imageRef: ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:...
 omnigentBuildDigest: sha256:...
 declaredHarnessImplementations:
   - harnessId: opencode-native
@@ -36,181 +119,190 @@ declaredHarnessImplementations:
       - name: opencode
         version: 1.18.11
         digest: sha256:...
-integrationModes: [native-server]
-materializerRefs: [opencode-auth-json@1]
+integrationModes:
+  - native-server
+materializerRefs:
+  - opencode-auth-json@1
 features:
-  workspaceBind, readOnlyRoot, restrictedEgress, mountedSkills, mountedTools, git, tmux, bubblewrap
-runtime: {uid: 1000, gid: 1000, home: /home/app}
+  workspaceBind: true
+  readOnlyRoot: true
+  restrictedEgress: true
+  mountedSkills: true
+  mountedTools: true
+  git: true
+  tmux: true
+  bubblewrap: true
+runtime:
+  uid: 1000
+  gid: 1000
+  home: /home/app
 ```
 
-This class declares **only** `opencode-native`. Codex continues through `codex-profile-bound@1` on its existing `omnigent-codex-current@1` / `omnigent-native-standard@3` classes. No workflow silently switches between them.
+The exact shared digest can be promoted for OpenCode without automatically qualifying Codex or Claude.
 
-## Credential materializer: opencode-auth-json@1
+## 4. OpenCode runtime pack
 
-Trusted boundary writes:
+OpenCode-specific startup and attestation behavior belongs in a trusted versioned runtime pack, not in the generic host lifecycle.
 
+A representative descriptor is:
+
+```yaml
+schemaVersion: moonmind.omnigent-harness-runtime-pack.v1
+ref: opencode-native-pack@1
+harnessId: opencode-native
+providerRuntimeId: opencode
+binary:
+  command: opencode
+  version: 1.18.11
+  supportedRange: ">=1.17.7,<1.19.0"
+credentialMaterializers:
+  - opencode-auth-json@1
+forbiddenAmbientEnvironment:
+  - OPENCODE_AUTH_CONTENT
+  - OPENCODE_CONFIG
+  - OPENCODE_CONFIG_CONTENT
+  - OPENAI_API_KEY
+  - ANTHROPIC_API_KEY
+hostModes:
+  - on-demand
+probes:
+  version: opencode --version
+  models: exact-host OpenCode model catalog helper
 ```
-target: /home/app/.local/share/opencode/auth.json  (0600, uid 1000:1000, parent 0700)
+
+The runtime pack is deployment-owned. Workflows cannot author its commands, paths, environment, or materializer allowlist.
+
+## 5. Credential materializer: `opencode-auth-json@1`
+
+The OpenCode Go API key remains a run-owned credential materialization.
+
+The trusted boundary writes:
+
+```text
+target: /home/app/.local/share/opencode/auth.json
+parent mode: 0700
+file mode: 0600
+owner: 1000:1000
 payload: { "opencode-go": { "key": "<secret>", "type": "api" } }
-providerKey: opencode-go (verified against pinned CLI)
-state: lease-owned Docker volume with generation sidecar
-mount: read-only
-cleanup: remove the run-owned volume without resolving the secret again
+source state: lease-owned Docker volume with generation evidence
+host mount: read-only staging attachment
+runtime behavior: copy into writable tmpfs home before OpenCode starts
+cleanup: remove the run-owned credential volume
 ```
 
-Steps (issue §5):
+The materialization sequence is:
 
-1. Acquire Provider Profile lease
-2. Record acquired generation in fenced runtime binding (sticky)
-3. Resolve only the `opencode_api_key` SecretRef role at the trusted Activity boundary
-4. Create a labeled lease-owned Docker volume
-5. Send the exact OpenCode credential structure to a trusted writer container over stdin
-6. Verify provider key `opencode-go`
-7. Write to `/home/app/.local/share/opencode/auth.json`
-8. Parent `0700`, file `0600`
-9. Ownership `1000:1000`
-10. Mount read-only
-11. Return secret-free handle + cleanup authority
-12. Destroy on cleanup
+1. Acquire the selected Provider Profile lease.
+2. Record the acquired credential generation in the fenced runtime binding.
+3. Resolve only the `opencode_api_key` SecretRef role at the trusted Activity boundary.
+4. Create the labeled run-owned credential volume.
+5. Write the exact OpenCode credential shape through a trusted writer container over stdin.
+6. Verify the provider key `opencode-go`.
+7. Set owner-only modes and runtime ownership.
+8. Mount the credential source read-only.
+9. Stage it into OpenCode's writable runtime home.
+10. Return only a secret-free materialization handle and cleanup authority.
+11. Destroy the run-owned material during cleanup without resolving the secret again.
+12. Release the Provider Profile lease last.
 
-Forbidden ambient credentials are rejected:
+The runtime script rejects or clears conflicting ambient credentials:
 
+```text
+OPENCODE_AUTH_CONTENT
+OPENCODE_CONFIG
+OPENCODE_CONFIG_CONTENT
+OPENAI_API_KEY
+ANTHROPIC_API_KEY
 ```
-OPENCODE_AUTH_CONTENT, OPENCODE_CONFIG, OPENCODE_CONFIG_CONTENT,
-OPENAI_API_KEY, ANTHROPIC_API_KEY
+
+The raw key never enters an execution plan, runtime binding, Temporal history, Docker label, ordinary Docker environment variable, workspace, artifact, or cleanup handle.
+
+## 6. Shared-image credential isolation
+
+When the image also contains Codex and Claude Code, an OpenCode execution must still receive only the OpenCode credential attachment.
+
+Exact-host conformance must prove:
+
+- `/home/app/.codex` is not mounted from a Codex Provider Profile
+- Claude credential paths are not mounted
+- no Codex or Claude API-key environment is inherited
+- the selected runtime pack is `opencode-native-pack@1`
+- the selected materializer is `opencode-auth-json@1`
+- only `opencode-native` is admitted by the selected Host Class
+
+The presence of the other binaries is not a support or authorization signal.
+
+## 7. OpenCode Provider Profile
+
+A normal OpenCode Go Provider Profile has the following effective shape:
+
+```yaml
+profileId: opencode-go-default
+runtimeId: opencode
+providerId: opencode-go
+credentialSource: secret_ref
+runtimeMaterializationMode: auth_json
+secretRole: opencode_api_key
+credentialGeneration: 1
+maxParallelRuns: 1
+queueWhenBusy: true
+enabled: true
+authState: connected
+defaultModel: opencode-go/<model-id>
 ```
 
-Never use `OPENCODE_AUTH_CONTENT`, CLI arguments, labels, generated environment files, or ordinary Docker environment variables for the production secret path. The execution plan, runtime binding, Temporal payloads, Docker inspection data, and cleanup handles contain only references and generations.
+A user may enroll it through Settings with a write-only API-key field. A deployment may also bootstrap it from `OPENCODE_API_KEY`.
 
-## Deployment setup
+The raw key is never returned after submission.
 
-The canonical local path needs one value. Set `OPENCODE_API_KEY` in `.env` and
-start Docker Compose; the Omnigent bootstrap reconciliation does the rest on
-startup and on its ongoing cadence:
+## 8. Provider validation and model discovery
 
-1. resolve the configured OpenCode host image and tag to an immutable digest,
-   read its required `moonmind.omnigent.build_digest` label as the shared
-   server/host build identity, and export both authorities for Host Class
-   selection and launch policy compilation
-   (`OMNIGENT_OPENCODE_HOST_IMAGE_REF` stays optional and overrides image
-   resolution when set; the image manifest digest is not substituted for the
-   distinct build identity);
-2. synchronize the authenticated harness catalog and seed the built-in
-   `omnigent-opencode-default` Agent Profile;
-3. enroll the `opencode-go-default` Provider Profile from `OPENCODE_API_KEY`,
-   running the same pinned-runtime validation as the console action; and
-4. keep that profile's model catalog evidence current as the host image is
-   re-resolved.
+Validation uses the same pinned runtime and materialization behavior as production:
 
-`OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE` defaults to `true` because the stock
-OpenCode Go model is a contributor tier whose enrollment records a data-use
-acknowledgement. Set it to `false` to decline; enrollment then stops with an
-actionable failure instead of acknowledging on the operator's behalf.
+1. Acquire a temporary Provider Profile maintenance lease.
+2. Materialize the proposed key through `opencode-auth-json@1`.
+3. Launch the exact digest-pinned OpenCode Host Class on restricted egress.
+4. Stage the credential into the writable runtime home.
+5. Query the exact-host OpenCode model catalog.
+6. Require at least one `opencode-go/<model-id>` result.
+7. Require the selected default model to appear in the observed catalog.
+8. Delete the validation host and run-owned credential state.
+9. Release the maintenance lease.
+10. Persist only normalized model and runtime evidence.
 
-Enrollment runs the full bootstrap, so it waits for the immutable image and
-harness catalog authorities it depends on, and it is attempted once per distinct
-configuration. Correcting the credential or the acknowledgement produces a new
-configuration and retries; so does restarting the service. Re-validating an
-already-enrolled credential is separate and repeats on every pass.
+MoonMind does not substitute a configured model when the provider catalog is empty. It does not silently select another model when the prior default disappears.
 
-Console enrollment through **Settings → Provider Profiles** remains available and
-is the path for a deployment that does not carry the credential in its
-environment.
+## 9. Revalidation and freshness
 
-## Provider Profile: OpenCode Go
+OpenCode model-catalog evidence binds:
 
-Create in **Settings → Provider Profiles**:
+- the exact host image digest
+- the exact OpenCode runtime version
+- the materializer version
+- the Provider Profile credential generation
+- the selected default model
+- the observation time
 
-- **Profile ID**: e.g. `opencode-go-default`
-- **Runtime**: `opencode`
-- **Provider**: `opencode-go`
-- **Credential source**: `secret_ref`
-- **Secret role**: `opencode_api_key` (`db://<slug>`)
-- **Enabled**: `true` only when `auth_state=connected`
-- **Default qualified model**: e.g. `opencode-go/gpt-5` or any `opencode-go/<model-id>` from discovery
-- **Max parallel runs**: `1` by default
-- **Queue when busy**: `true`
-- **Tags**: optional
+`OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS` bounds observation age and defaults to `6`. A value of `0` revalidates only when image or credential identity changes.
 
-Validation (Settings → Validate):
+Evidence is invalid when:
 
-1. Acquire a temporary Provider Profile maintenance lease
-2. Materialize the proposed key through `opencode-auth-json@1` into a disposable Docker volume
-3. Launch the digest-pinned OpenCode host image on restricted egress, stage the read-only credential into OpenCode's writable data directory exactly as the production host does, and query the refreshed CLI model catalog
-4. Require at least one `opencode-go/<model-id>` result
-5. Delete the validation host and credential volume, then release the maintenance lease
-6. Persist only normalized model metadata, image/runtime identity, and validation evidence
+- the host image changes
+- the OpenCode runtime identity changes
+- the credential generation changes
+- the selected default model is absent
+- the observation exceeds the configured age
+- the observation is implausibly far in the future
 
-An empty provider catalog fails validation; MoonMind never substitutes a
-configured or legacy model as evidence. The selected default must also remain
-present in the observed catalog. If the provider removes it, readiness is
-deferred until an operator selects another observed model, because changing a
-billing-relevant model is not an automatic recovery action. Raw key is never
-returned after submission.
+The bootstrap reconciler revalidates connected profiles through the existing SecretRef. It does not request a new key. While a valid revalidation is pending, authoring reports `provider_runtime_revalidation_pending`.
 
-### Automatic re-validation after a host image change or catalog interval
+Revalidation attempts are bounded per image and credential generation. Failure to acquire the maintenance lease does not spend a provider probe attempt because no probe occurred.
 
-Model catalog evidence answers two separate questions, and both must hold for a
-persisted observation to stay authoritative.
+## 10. Agent Profile
 
-The first is **launchable identity**: evidence is bound to the exact
-digest-pinned host image that produced it, to the credential generation that
-was active at the time, to the `opencode-auth-json@1` materializer, and it must
-contain the profile's selected default model.
+A representative OpenCode Agent Profile remains:
 
-The second is **observation age**. The pinned host image ships a bundled model
-catalog and refreshes it from the provider at probe time, so identity alone
-would freeze whichever catalog the first successful probe observed: a healthy
-deployment never changes its credential generation or image digest on its own,
-and models the provider publishes later — contributor tiers included — would
-never reach selection, readiness, or admission.
-`OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS` bounds that age and defaults to `6`, so
-the documented one-value setup keeps observing the provider's current models
-without another operator action. Set it to `0` to re-probe only on an identity
-change. A pass that has just observed the catalog is judged on identity alone;
-the interval decides when to re-probe, not whether a fresh observation counts.
-
-Readiness, planning, and smoke admission all apply both questions: they reject
-evidence that belongs to any other image or generation, and they reject an
-observation older than the interval. Re-pulling or rebuilding the OpenCode host
-image therefore invalidates every previously validated Provider Profile, and an
-expired catalog stops advertising and launching targets until a refresh
-succeeds instead of admitting a model the provider may have removed.
-
-An observation stamped further than a small clock-skew tolerance into the
-future is rejected the same way. A VM snapshot restore or a backward host-clock
-correction would otherwise give the observation a negative age that satisfies
-any interval for as long as the timestamp stays ahead, keeping an old catalog
-authoritative well past its expiry.
-
-MoonMind therefore re-validates automatically. The Omnigent bootstrap
-reconciliation pass re-runs the pinned-runtime validation above for every
-enabled, connected OpenCode Provider Profile whose evidence no longer matches
-the currently pinned image or has aged past the catalog interval, using the
-already-enrolled `opencode_api_key` SecretRef. No new credential is requested,
-no image is substituted, and a credential the runtime rejects keeps its previous
-evidence and stays connected.
-Fresh catalog evidence is retained when the credential remains valid but the
-configured default model has rotated out, while readiness stays deferred rather
-than silently selecting a replacement.
-While a profile is waiting for that pass, Workflow Create reports
-`provider_runtime_revalidation_pending` rather than asking the operator to
-reconnect a profile that is already connected.
-
-That wait is bounded. Re-validation gets `MAX_REVALIDATION_ATTEMPTS` tries per
-credential generation and host image; once they are spent, the reconciler stops
-probing the provider for that identity and readiness stops reporting a pending
-wait. This is what keeps a provider outage or a revoked key from launching a
-Docker-backed probe on every background pass for as long as the deployment
-runs. Reconnecting the credential or re-pinning the host image is a new
-identity, so it restores the full attempt budget without a separate reset
-action. Only a probe the provider actually answered spends an attempt: when the
-credential maintenance lease cannot be acquired, no probe ran, so the pass
-defers with its budget intact.
-
-## Agent Profile
-
-```
+```yaml
 profileId: omnigent-opencode-default
 version: 1
 digest: sha256:...
@@ -226,19 +318,26 @@ source:
   upstreamSnapshotDigest: sha256:...
 credentialSlots:
   - id: primary-model
-    acceptedAuthModels: [own-auth]
-    acceptedProviderIds: [opencode, opencode-go]
-hostClassRef: omnigent-opencode@1
+    acceptedAuthModels:
+      - own-auth
+    acceptedProviderIds:
+      - opencode
+      - opencode-go
+hostClassRef: omnigent-opencode@2
+runtimePackRef: opencode-native-pack@1
 launchPolicyRef: omnigent-on-demand@1
 executionRealizerRef: generic-omnigent-host@1
 model:
   qualifiedId: opencode-go/<model-id>
-allowedLaunchPolicyRefs: [omnigent-on-demand@1]
+allowedLaunchPolicyRefs:
+  - omnigent-on-demand@1
 ```
 
-The guided editor asks for the preset, model, host policy, workspace mutation, Skills, tools, capture, continuation, and publication behavior. The server resolves the current upstream projection plus exact catalog and implementation authority; users do not author implementation digests.
+Users do not author image digests, harness implementation digests, runtime-pack commands, or credential paths.
 
-Workflow Create persists the immutable profile selection and ordinary product intent:
+## 11. Workflow execution
+
+Workflow Create persists the stable top-level identity and immutable profile selection:
 
 ```yaml
 agentKind: external
@@ -254,189 +353,132 @@ parameters:
     model: opencode-go/<model-id>
 ```
 
-Planning resolves the Host Class, credential materializer, image, acquired credential generation, and `generic-omnigent-host@1` realizer from durable data. Temporal dispatch does not branch on harness identity.
+The trusted planner resolves the runtime pack, Host Class, image, materializer, support key, and `generic-omnigent-host@1` realizer. Temporal and the canonical session lifecycle do not branch on OpenCode as a top-level runtime identity.
 
-## Deployment qualification and execution evidence
+## 12. Exact-host attestation
 
-Deployment qualification proves this deployment can run one exact harness,
-host, image, realizer, credential, and model combination. Admission matches a
-compiled plan against that qualification and refuses anything outside it.
+Before runner or session creation, the exact OpenCode host proves:
 
-Two rules keep qualification and admission on one combination:
-
-- **Qualification never restates plan inputs.** The launch policy is part of
-  the qualified combination, so qualification derives it from the Agent Profile
-  with the same rule admission uses — the first entry of
-  `allowedLaunchPolicyRefs` when the workflow authors none. A restated ref
-  attests a combination no plan ever compiles: readiness still reports `ready`
-  while every launch fails with `execution evidence unavailable`.
-- **Per-run request intent is not a qualification dimension.**
-  `requiredCapabilitiesDigest` records what one workflow asked for, not what the
-  deployment can run, so it is excluded from the qualified combination. Class
-  admission derives support only from trusted catalog, Host Class, launch-policy,
-  materializer, bridge, and deployment-mounted-tool declarations; a workflow
-  cannot declare its own request supported. Admission independently refuses
-  unsupported or unknown required capabilities before the support key exists.
-  Binding evidence to one capability set would require re-qualifying the
-  deployment for every workflow shape.
-
-Everything else stays exact. Changing an Agent Profile, host image, harness
-catalog, model, or effort changes the qualified combination and invalidates the
-published evidence. The startup and maintenance reconciler detects drift in the
-deployment-managed Agent Profile, Provider Profile defaults, resolved image, or
-signed evidence and automatically re-runs the production qualification from the
-persisted Provider Profile. The normal `OPENCODE_API_KEY` path therefore stays
-launch-ready across service and upstream-agent refreshes without another
-operator action or another copy of the credential.
-
-The retry endpoint remains an explicit recovery control when an earlier
-qualification attempt failed:
-
-```
-POST /api/omnigent/bootstrap/opencode/retry
+```text
+shared or transitional image digest matches the selected Host Class
+moonmind.omnigent.build_digest matches the catalog authority
+command -v opencode succeeds
+opencode --version is within >=1.17.7,<1.19.0
+selected runtime pack matches opencode-native
+host advertises the exact opencode-native implementation
+credential generation is the acquired generation
+credential file exists without printing its contents
+credential ownership and modes are correct
+non-selected runtime credentials are absent
+workspace, Skills, and mounted tools match the plan
+restricted egress is active
+selected model is available to the exact credential
 ```
 
-Retry checks that the persisted Provider Profile and its managed SecretRefs are
-launch ready, revalidates its credential evidence against the pinned runtime,
-and refreshes the desired model and effort from the current Provider Profile.
-Qualification uses the current Agent Profile's default launch policy. An
-explicit per-run override outside those defaults remains a separate
-qualification target; the automatic reconciler owns only the standard managed
-default combination.
+The selected-model probe uses Omnigent's portable OpenCode catalog helper inside the exact host when the normal host tunnel does not expose pre-launch OpenCode model options.
 
-## Exact-host attestation (issue §8)
+## 13. Deployment configuration
 
-Before runner/session creation, the exact host is verified:
+### Current transitional configuration
 
-```
-command -v opencode
-opencode --version          # within >=1.17.7,<1.19.0
-host advertises opencode-native
-implementation identity matches plan
-image digest matches Host Class
-Omnigent build matches
-credential file exists at /home/app/.local/share/opencode/auth.json without printing contents
-ownership 1000:1000 and modes 0700/0600
-acquired generation is the one materialized
-Skill delivery and mounted tools match plan
-enforced network/egress policy active
-selected model available to credential
-```
-
-The selected-model check runs Omnigent's portable
-`list_opencode_cli_model_options` helper inside the exact digest-pinned host,
-after the fenced credential generation has been materialized and the restricted
-egress attachment has been verified. The stock Omnigent host tunnel does not
-currently expose pre-launch model options for `opencode-native`; using the
-upstream helper directly keeps the attestation live and credential-bound without
-duplicating OpenCode catalog semantics in MoonMind. Other harnesses continue to
-use the normal host `model-options` tunnel. Readiness by harness name alone is
-insufficient.
-
-## Deployment configuration
-
-```
+```env
 MOONMIND_OMNIGENT_GENERIC_HOST_ENABLED=true
 MOONMIND_OMNIGENT_OPENCODE_ENABLED=true
 OMNIGENT_OPENCODE_HOST_IMAGE_REF=ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:<digest>
-# Optional mutable build/pull coordinates; never launch authority:
 OMNIGENT_OPENCODE_HOST_IMAGE=ghcr.io/moonladderstudios/omnigent-host-opencode
 OMNIGENT_OPENCODE_HOST_IMAGE_TAG=1.18.11
-# Optional only for an independently built, explicitly paired server/host set:
-OMNIGENT_BUILD_DIGEST=sha256:<shared-server-and-host-build-identity>
 ```
 
-- Keep `MOONMIND_OMNIGENT_GENERIC_HOST_ENABLED=false` until the generic services, database migration, Docker backend, endpoint, images, and egress policy are configured.
-- Keep `MOONMIND_OMNIGENT_OPENCODE_ENABLED=false` until the protected OpenCode Go conformance workflow has published evidence for the exact support combination.
-- Build from pinned Omnigent source/base image
-- Publish to GHCR with provenance and digest evidence
-- Make the immutable digest available to the data-driven Host Class selector
-- Resolve mutable build coordinates on each reconciliation pass, but launch
-  only the resulting digest-pinned image after its declared build identity and
-  server/host version pairing have been verified
-- Image is pulled lazily only when an OpenCode workflow requires it; cached layers are reused
+Mutable image and tag coordinates are resolution inputs only. Launch authority is always the resolved digest.
 
-Synchronize the authenticated Omnigent endpoint after deployment or plugin changes:
+### Desired shared-image configuration
+
+```env
+OMNIGENT_RUNTIME_HOST_IMAGE_REF=ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:<digest>
+OMNIGENT_RUNTIME_HOST_IMAGE=ghcr.io/moonladderstudios/omnigent-host-moonmind
+OMNIGENT_RUNTIME_HOST_IMAGE_TAG=<release>
+```
+
+Legacy OpenCode image variables may remain as temporary aliases. Configuration fails closed when both the canonical and alias values are present but identify different images.
+
+`OMNIGENT_BUILD_DIGEST` remains optional operator authority only for an independently paired server and host build. An image manifest digest must not be substituted for the separate portable Omnigent build identity.
+
+## 14. Image release and compatibility
+
+The shared release workflow should:
+
+- resolve an immutable Omnigent base image
+- build `linux/amd64` and `linux/arm64` variants where supported
+- verify `omnigent --version`
+- verify `codex --version`
+- verify `claude --version`
+- verify `opencode --version`
+- verify the expected harness catalog and implementation identities
+- record each vendor runtime independently
+- generate provenance and SBOM data
+- publish a neutral manifest tag and digest
+- optionally publish the transitional `omnigent-host-opencode` alias to the same digest
+
+A new shared image does not automatically replace any Host Class. Each harness promotes the new digest only after its own conformance row passes.
+
+## 15. Qualification and support
+
+OpenCode support remains combination-specific. Qualification binds at least:
 
 ```text
-POST /api/omnigent/harness-catalog/synchronize
+MoonMind commit
+Omnigent server and shared host build
+host image digest and architecture
+opencode-native implementation
+opencode-native-pack version
+OpenCode CLI version
+opencode-auth-json materializer version
+Provider Profile compatibility class
+Agent Profile version
+Host Class and launch policy
+selected model and effort
+execution realizer
+required capabilities
 ```
 
-Synchronization reads `/v1/harnesses`, `/v1/agents`, and `/v1/hosts`, normalizes one immutable build-bound catalog snapshot, and persists exact-implementation trust records plus plugin-load diagnostics. `moonmind.omnigent-execution-readiness.v3` advertises OpenCode only when the same selectors used by planning find a fresh, trusted, host-class-admissible, credential-compatible target and both gates allow it. Otherwise Workflow Create shows the specific `generic_realizer_not_ready` or qualification blocker while Provider Profile setup remains available.
+A shared-image Codex or Claude pass does not qualify OpenCode. An OpenCode pass does not qualify Codex or Claude.
 
-## Generic realizer lifecycle (issue §7)
+## 16. Migration and rollback
 
-`generic-omnigent-host@1` reuses the proven generic parts of the existing profile-bound lifecycle:
+The image transition should proceed in this order:
 
-- Provider Profile leases (deterministic order, release last)
-- Host binding and lease (fenced)
-- Workspace preparation and restore
-- Repository credentials
-- Resolved Skill delivery
-- Mounted MoonMind tools
-- Restricted egress
-- Host registration waits
-- Session creation and reattachment
-- Event streaming and controls
-- Capture and publication
-- Checkpoint and remediation state
-- Cancellation (removes partially created host + credential state)
-- Janitor reconciliation (durable secret-free cleanup authority)
-- Release-last ordering (Provider Profile lease after host+credential cleanup)
+1. Build and verify the neutral shared image.
+2. Publish the old OpenCode image name as an alias when compatibility requires it.
+3. Add `omnigent-opencode@2` pointing to the shared digest.
+4. Qualify OpenCode on the new class without changing its generic lifecycle.
+5. Admit new OpenCode plans to the new class.
+6. Preserve existing `omnigent-opencode@1` plans and evidence.
+7. Remove the old image name only after no active plan, deployment pin, or rollback path requires it.
 
-No separate OpenCode Temporal workflow; no duplication of the Codex coordinator.
+Rollback changes future Host Class selection. It does not rewrite an admitted execution plan or silently use another digest.
 
-## Operator diagnostics (no secret exposure)
+## 17. Non-goals
 
-```bash
-# Image identity (secret-free)
-docker inspect ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:<digest> --format '{{.Id}} {{.RepoDigests}}'
-```
+This document does not authorize:
 
-Use Workflow Detail and the runtime binding's artifact references to inspect bounded catalog, image, host-registration, credential-mount, Skill, tool, egress, harness-readiness, and model-option attestations. Do not inspect `auth.json` or inject a test key into a worker filesystem. Materialization verification occurs inside the trusted writer/host boundary and records only structure, modes, ownership, and generation.
+- sharing OpenCode credentials with Codex or Claude Code
+- one all-powerful Host Class merely because the image contains several CLIs
+- treating installed binaries as production support
+- workflow-authored runtime packs, image refs, probes, mounts, or Docker options
+- package installation during workflow launch
+- silent fallback to Codex, Claude, a direct runtime, another model, or another Provider Profile
+- removal of legacy image and Host Class identities before replay and rollback obligations pass
 
-Check logs for:
+## 18. Strategic rule
 
-- `OMNIGENT_HARNESS_BUILD_MISMATCH` — image/digest/implementation mismatch
-- `OMNIGENT_VENDOR_RUNTIME_MISMATCH` — opencode missing or version outside range
-- `OMNIGENT_CREDENTIAL_GENERATION_FENCED` — stale generation
-- `OMNIGENT_CREDENTIAL_MATERIALIZATION_FAILED` — materializer failure or permission mismatch
-- `OMNIGENT_MODEL_UNAVAILABLE` — selected `opencode-go/<model>` not in catalog
-- `OMNIGENT_HOST_REGISTRATION_TIMEOUT` — the correlated host did not become fresh and online
-- `OMNIGENT_RUNTIME_BINDING_CONFLICT` — stale lifecycle owner or replay conflict
-- `OMNIGENT_CLEANUP_DEFERRED` — durable cleanup remains for the janitor
+OpenCode remains the first concrete generic-host proof. It is not the final architecture boundary.
 
-## Key rotation
+The implementation should be generalized so that the normal differences between OpenCode, Codex, and Claude Code are limited to:
 
-- Rotation before first lease acquisition is allowed (no generation sticky yet)
-- After runtime binding, generation is sticky; newer generation does not update binding
-- Credential-maintenance lane fences/drains bound host+session before activating replacement state
-- Retry reuses recorded generation; no silent adoption of newer generation
-- Hosts and retries using older generation are fenced (`fencing_conflict`)
+- runtime-pack registration
+- credential materialization
+- exact runtime and authentication probes
+- truthful capability normalization
+- combination-specific support evidence
 
-## Cleanup
-
-- Stop or drain the session before removing its host.
-- Remove the fenced host container and verify it no longer consumes credentials.
-- Remove egress/runtime state, then the run-owned credential volume and workspace/Skill/tool projections according to retention policy.
-- Persist terminal cleanup evidence before releasing Provider Profile leases in reverse acquisition order.
-- The janitor claims stale nonterminal bindings with a new fencing generation and replays materializer-specific cleanup using secret-free handles. It never needs the raw key to remove a volume.
-- Provider Profile capacity is always released last.
-
-## Rollback
-
-Existing Codex-through-Omnigent remains on `codex-profile-bound@1` and the mature OAuth host coordinator. There is no execution-time fallback from OpenCode to Codex. Disabling either generic feature gate or removing `OMNIGENT_OPENCODE_HOST_IMAGE_REF` makes OpenCode unlaunchable without affecting Codex.
-
-## Build and publish
-
-See `services/omnigent/opencode-host/Dockerfile` and `.github/workflows/docker-publish-opencode-host.yml`.
-
-```
-docker buildx build --platform linux/amd64,linux/arm64 \
-  --build-arg OMNIGENT_HOST_BASE_IMAGE=ghcr.io/omnigent-ai/omnigent-host@sha256:<base> \
-  --build-arg OMNIGENT_BUILD_DIGEST=sha256:<shared-server-and-host-build-identity> \
-  -f services/omnigent/opencode-host/Dockerfile \
-  -t ghcr.io/moonladderstudios/omnigent-host-opencode:1.18.11 --push .
-```
-
-Provenance and digest are recorded as GHCR attestations and `docker buildx imagetools inspect`.
+Everything else should converge on the shared generic Omnigent host and control plane.

--- a/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
+++ b/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
@@ -1,0 +1,480 @@
+# Omnigent Primary Runtime Provider Strategy
+
+**Status:** Canonical desired state  
+**Document Class:** System / Product Architecture  
+**Owners:** MoonMind Platform  
+**Last updated:** 2026-08-28  
+**Authority:** Long-term runtime-provider direction for MoonMind
+
+## Related documents
+
+- [`docs/MoonMindArchitecture.md`](../MoonMindArchitecture.md)
+- [`docs/MoonMindRoadmap.md`](../MoonMindRoadmap.md)
+- [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
+- [`docs/Omnigent/OmnigentHostOAuth.md`](./OmnigentHostOAuth.md)
+- [`docs/Omnigent/OpenCodeHost.md`](./OpenCodeHost.md)
+- [`docs/Omnigent/CodexSupportAndCutover.md`](./CodexSupportAndCutover.md)
+- [`docs/Omnigent/ControlPlaneAggregates.md`](./ControlPlaneAggregates.md)
+- [`docs/Omnigent/ControlPlaneConcurrencyAndFencing.md`](./ControlPlaneConcurrencyAndFencing.md)
+- [`docs/Omnigent/ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md)
+- [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
+- [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
+
+## Advance organizer
+
+**One sentence:** Omnigent is to become MoonMind's primary runtime provider over time, with Codex, Claude Code, OpenCode, and future approved harnesses entering one generic Omnigent execution plane instead of accumulating separate MoonMind runtime architectures.
+
+**One paragraph:** MoonMind will continue to own durable Temporal orchestration, Provider Profiles, OAuth enrollment, secret references, workspace authority, policies, Skills, publication, evidence, checkpointing, remediation, and cleanup. Omnigent will become the normal host, runner, harness, session, and live interaction substrate beneath those controls. Codex, Claude Code, and OpenCode should share one digest-pinned MoonMind Omnigent host image and one generic host lifecycle wherever technically possible. Genuine differences are isolated behind small trusted runtime-pack descriptors, credential materializers, and exact-host probes. Existing direct and legacy profile-bound paths remain available only as explicit migration, replay, rollback, and historical-read compatibility until evidence-backed retirement criteria pass.
+
+## 1. Decision
+
+MoonMind adopts the following long-term product and architecture decision:
+
+> **Omnigent is the preferred and eventually primary runtime provider for MoonMind-managed coding agents.**
+
+This is a directional commitment, not an immediate claim that every runtime has already completed cutover. A runtime becomes the default Omnigent-backed path only after its exact image, harness, credential, model, policy, lifecycle, and user journey have passing support evidence.
+
+The destination is not a MoonMind runtime implementation for every provider CLI. The destination is one MoonMind-to-Omnigent platform boundary with registered harness integrations.
+
+## 2. What “primary runtime provider” means
+
+“Primary runtime provider” has a specific meaning in this architecture.
+
+Omnigent becomes the normal provider of:
+
+- host registration and runner connectivity
+- harness discovery and execution
+- provider-session creation and attachment
+- live turns, events, tools, approvals, tasks, subagents, terminals, and resources where supported
+- harness-native session behavior
+- the native Workflow Chat application and protocol surface
+
+MoonMind remains the authority for:
+
+- Workflow, run, Step Execution, AgentRun, session, and turn ownership
+- Temporal durability and reconciliation
+- Agent Profile and Provider Profile selection
+- OAuth enrollment, credential generation, capacity, cooldown, and revocation
+- secret resolution and credential materialization
+- repository and workspace authorization
+- Skills, mounted tools, context, and retrieval policy
+- host class, launch, resource, network, and egress policy
+- model and effort selection
+- checkpoint, resume, branch, and remediation decisions
+- publication and approval authority
+- artifacts, evidence, observability, audit, and historical reads
+- cleanup, janitor ownership, fencing, and rollback
+
+Omnigent becoming primary does not transfer MoonMind's security or workflow authority to Omnigent. It consolidates the runtime and harness substrate beneath MoonMind's authority.
+
+## 3. Stable product identity
+
+All Omnigent-backed harnesses use the same top-level execution identity:
+
+```text
+agentKind = external
+agentId   = omnigent
+```
+
+The selected harness remains nested immutable authority:
+
+```text
+codex-native
+claude-native
+opencode-native
+<future approved harness>
+```
+
+MoonMind does not introduce permanent top-level product identities such as `omnigent_codex`, `omnigent_claude`, or `omnigent_opencode`.
+
+The dashboard may display friendly target names, but authoring and execution resolve one Omnigent Agent Profile, one harness implementation, one Provider Profile, one Host Class, one runtime pack, one materializer, one model configuration, one launch policy, and one execution realizer.
+
+## 4. Current transition state
+
+The repository currently contains three important generations of runtime behavior:
+
+1. Direct managed Codex and Claude Code paths.
+2. A proven Codex profile-bound Omnigent specialization with legacy OAuth-host lifecycle code.
+3. A generic Omnigent harness platform and generic host realizer proven first through OpenCode.
+
+The third generation is the destination. The first two remain explicit compatibility implementations while the generic path reaches equivalent or better support.
+
+No current path is silently reclassified as generic. Existing execution plans and Temporal histories continue to invoke the realizer and compatibility version they recorded.
+
+## 5. Governing principles
+
+### 5.1 One generic control plane
+
+Codex, Claude Code, OpenCode, and future approved harnesses should use the same canonical:
+
+- immutable execution plan
+- fenced runtime binding
+- Provider Profile lease coordination
+- host binding and host lease
+- workspace preparation
+- Skill and tool delivery
+- restricted egress realization
+- Omnigent session and turn ownership
+- bridge, event, resource, and Workflow Chat contracts
+- publication and checkpoint integration
+- cancellation, cleanup, and janitor behavior
+
+Adding a harness must not create a new top-level Temporal workflow or another lifecycle coordinator merely because its CLI differs.
+
+### 5.2 One shared host image where practical
+
+MoonMind should reuse one digest-pinned Omnigent runtime host image for Codex, Claude Code, and OpenCode when the image can contain their supported runtime binaries without weakening isolation or producing unmanageable release coupling.
+
+The intended neutral image is conceptually:
+
+```text
+ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:<digest>
+```
+
+The current `omnigent-host-opencode` image lineage is the starting point because it already derives from the stock Omnigent host and adds a pinned OpenCode runtime. During migration, the old image name may remain as an alias to the same manifest digest.
+
+One shared image does not mean one shared credential home, one shared Host Class, or one support claim for every installed harness.
+
+### 5.3 Separate Host Classes may share one image
+
+Each supported harness combination retains an explicit Host Class even when several Host Classes point to the same image digest.
+
+For example:
+
+```text
+omnigent-codex@1     -> shared-image@sha256:...
+omnigent-claude@1    -> shared-image@sha256:...
+omnigent-opencode@2  -> shared-image@sha256:...
+```
+
+Separate Host Classes preserve independent:
+
+- harness declarations
+- runtime dependency requirements
+- materializer allowlists
+- launch-policy compatibility
+- qualification evidence
+- rollout and rollback state
+- support-combination identity
+
+A newly published shared image can therefore be qualified and promoted for one harness without automatically promoting the other harnesses.
+
+### 5.4 Runtime differences belong in a trusted runtime pack
+
+The generic host lifecycle consumes a versioned trusted `HarnessRuntimePack` or equivalent descriptor.
+
+A runtime pack contains only genuine harness-specific details such as:
+
+- harness id
+- provider runtime id
+- binary name and supported version range
+- credential mount and staging requirements
+- forbidden ambient credential variables
+- readiness and authentication probes
+- model-catalog probe when required
+- runner environment passthrough
+- static and on-demand host compatibility
+
+Runtime packs are deployment-owned registrations. Workflows and Agent Profiles cannot author arbitrary commands, mount paths, or environment variables through them.
+
+The generic launcher, runtime script builder, attestor, and cleanup system must consume the selected runtime pack rather than accumulating `if harness == ...` branches.
+
+### 5.5 Credential materialization remains runtime-specific and minimal
+
+Credential formats and mutation behavior genuinely differ. Those differences remain isolated behind approved materializers.
+
+The intended initial set is:
+
+| Harness | Materializer | Credential ownership | Runtime behavior |
+| --- | --- | --- | --- |
+| OpenCode | `opencode-auth-json@1` | Run-owned | Read-only source is staged into a writable runtime home and destroyed after cleanup |
+| Codex | `codex-oauth-home@1` | Provider Profile-owned | Writable OAuth home is mounted exclusively for the acquired generation |
+| Claude Code | `claude-oauth-home@1` | Provider Profile-owned | Writable credential bundle supports every required Claude user-level path |
+
+A credential handle declares whether its backing state is:
+
+```text
+run_owned
+profile_owned
+host_owned
+```
+
+Cleanup follows that ownership. Run-owned secrets are destroyed. Profile-owned OAuth homes are unmounted and released but are not deleted by ordinary run cleanup. Host-owned authentication is observed but not copied or claimed by MoonMind.
+
+### 5.6 MoonMind owns OAuth enrollment
+
+MoonMind Settings remains the user-facing OAuth enrollment authority for Codex and Claude Code.
+
+The normal sequence is:
+
+```text
+Settings OAuth connection
+  -> validated Provider Profile and credential generation
+  -> execution-plan selection
+  -> Provider Profile lease
+  -> generic materializer binds the selected generation
+  -> shared Omnigent host starts non-interactively
+  -> exact-host auth probe succeeds
+```
+
+An Omnigent host must not start another interactive login ceremony. It consumes only the Provider Profile generation selected and leased by MoonMind.
+
+### 5.7 Credential isolation is stricter than image isolation
+
+A shared image may contain several CLIs. A running host receives credentials only for the one selected harness and Provider Profile.
+
+The following must remain true:
+
+- A Codex execution cannot read Claude or OpenCode credential state.
+- A Claude execution cannot read Codex or OpenCode credential state.
+- An OpenCode execution cannot read Codex or Claude credential state.
+- Ambient API-key and configuration selectors are cleared or rejected according to the selected runtime pack.
+- Image contents never grant permission to use an installed harness.
+- Exact plan, Host Class, runtime pack, materializer, and attestation authority determine what the host may run.
+
+### 5.8 Support is exact and evidence-gated
+
+A shared image digest is not proof that every contained harness is supported.
+
+Support remains specific to:
+
+```text
+MoonMind commit
++ Omnigent server and host build
++ shared host image digest and architecture
++ harness implementation
++ runtime-pack version
++ vendor CLI version and digest
++ Agent Profile version
++ Provider Profile compatibility class and credential generation class
++ credential materializer version
++ Host Class and launch policy
++ normalized model configuration
++ execution realizer version
++ required capabilities
+```
+
+Each claimed combination requires deterministic conformance and the protected live evidence required by policy.
+
+### 5.9 No silent fallback
+
+A plan records its execution realizer before side effects.
+
+A generic Codex, Claude, or OpenCode execution that fails does not silently switch to:
+
+- a direct runtime
+- the legacy Codex profile-bound realizer
+- another harness
+- another Provider Profile
+- another host mode
+- another model
+- a broader policy
+
+Rollback changes future admission or creates an explicit new execution. It does not reinterpret the failed plan.
+
+### 5.10 Replay and historical truth outlive cutover
+
+Existing plans and Temporal histories retain their recorded runtime and realizer identities.
+
+Legacy modules may remain as bounded replay-visible wrappers after new selection has moved to the generic realizer. They are removed only after the code-owned retirement checks prove:
+
+- no new plans select them
+- no active execution or cleanup authority uses them
+- supported histories replay
+- historical Workflow Detail and artifacts remain readable
+- rollback no longer depends on them
+- retention policy permits removal
+
+## 6. Target topology
+
+```text
+Workflow authoring
+  -> external/omnigent
+  -> immutable Omnigent Agent Profile
+  -> immutable execution plan
+       harness implementation
+       Provider Profile selection
+       runtime pack
+       credential materializer
+       shared-image Host Class
+       launch policy
+       model configuration
+       generic-omnigent-host@1
+  -> fenced runtime binding
+       acquired Provider Profile generation
+       credential attachments
+       host lease and exact shared image
+       exact-host harness and runtime attestation
+       workspace and Skill realization
+  -> generic Omnigent host lifecycle
+  -> Omnigent runner and selected harness
+  -> canonical Omnigent session and turn control plane
+  -> bridge, Workflow Chat, evidence, publication, checkpoint, and cleanup
+```
+
+Provider-specific logic stops at the registered runtime pack, credential materializer, and truthful capability adapter unless Omnigent exposes a genuinely different protocol.
+
+## 7. Shared image contract
+
+The shared image must:
+
+- derive from an immutable compatible Omnigent host base
+- contain the exact approved Codex, Claude Code, and OpenCode runtimes
+- install runtimes at image-build time, never during a workflow launch
+- run as the normal non-root Omnigent host user
+- preserve the generic `/home/app` runtime contract
+- publish an SBOM and provenance
+- publish the portable Omnigent build identity label
+- expose immutable multi-architecture manifest digests
+- verify every required CLI and Omnigent harness during build and release tests
+- avoid embedding provider credentials
+- avoid making every installed CLI active by default
+
+The image release record should identify each runtime independently. An OpenCode upgrade can produce a new image digest without asserting that the Codex or Claude support row has been requalified.
+
+## 8. Runtime-pack contract
+
+A representative trusted descriptor is:
+
+```yaml
+schemaVersion: moonmind.omnigent-harness-runtime-pack.v1
+ref: codex-native-pack@1
+harnessId: codex-native
+providerRuntimeId: codex_cli
+binary:
+  command: codex
+  supportedVersion: ">=<minimum>,<maximum>"
+credentialMaterializers:
+  - codex-oauth-home@1
+forbiddenAmbientEnvironment:
+  - OPENAI_API_KEY
+probes:
+  version: codex --version
+  authentication: codex login status
+hostModes:
+  - static-connected
+  - on-demand
+```
+
+The exact schema may evolve. The durable rules are:
+
+- references are versioned
+- descriptors contain no secrets
+- descriptors are not workflow-authored
+- commands are bounded and allowlisted by trusted code
+- the execution plan records the selected runtime-pack ref
+- exact-host evidence records the observed pack and runtime identity
+
+## 9. Product selection and defaults
+
+The long-term normal Workflow Create experience is:
+
+1. Select or accept an Omnigent Agent Profile.
+2. Select a compatible Provider Profile.
+3. Select model, effort, workspace, policy, Skills, and publication intent.
+4. Submit one `external/omnigent` execution.
+5. Let the immutable plan select the approved Host Class, runtime pack, materializer, and generic realizer.
+
+Direct Codex and direct Claude Code may remain visible during migration when policy permits them. They must be labeled as direct compatibility paths rather than equal long-term architecture choices.
+
+Default migration is staged independently for:
+
+- Workflow Create
+- presets
+- schedules
+- reruns and edits
+- Checkpoint Branches
+- remediation
+- Workflow Chat and continuation
+
+No default changes until the exact target combination has passing evidence and an operator-visible rollback path.
+
+## 10. Migration stages
+
+### Stage 1: Reuse the image without changing execution ownership
+
+- Publish the OpenCode-derived image under a neutral shared name.
+- Verify Codex, Claude Code, OpenCode, and Omnigent in the exact image.
+- Point current host services and generic launches at the same digest where compatible.
+- Preserve existing execution realizers and credential paths.
+
+### Stage 2: Introduce runtime packs and shared Host Class configuration
+
+- Register trusted runtime-pack descriptors.
+- Generalize host bootstrap and image resolution around one shared image authority.
+- Register separate Codex, Claude, and OpenCode Host Classes that reference the shared digest.
+- Make startup, attestation, and model probing descriptor-driven.
+
+### Stage 3: Generalize credential materialization
+
+- Add credential ownership to materialization handles.
+- Complete `codex-oauth-home@1` for the generic realizer.
+- Complete `claude-oauth-home@1` for the generic realizer.
+- Preserve OpenCode's run-owned API-key materialization.
+- Prove rotation, fencing, cleanup, and cross-runtime isolation.
+
+### Stage 4: Qualify and canary generic Codex and Claude
+
+- Produce exact-artifact and protected-live support evidence.
+- Allow selected new Codex and Claude Agent Profiles to choose `generic-omnigent-host@1`.
+- Canary static and on-demand modes independently.
+- Keep legacy realizers available for recorded work and explicit migration rollback.
+
+### Stage 5: Make Omnigent the normal default
+
+- Prefer supported Omnigent Agent Profiles in new Workflow Create authoring.
+- Migrate presets and schedules through explicit versions.
+- Route continuation, remediation, checkpoint, and Workflow Chat turns through the canonical Omnigent session owner.
+- Keep unsupported combinations unavailable rather than silently using direct runtimes.
+
+### Stage 6: Retire duplicate runtime architecture
+
+- Stop admitting new legacy Codex profile-bound plans after parity and rollback criteria pass.
+- Stop defaulting to direct Codex and direct Claude after their Omnigent combinations pass.
+- Consolidate duplicate Compose startup scripts and environment variables.
+- Reduce legacy modules to replay and historical-read adapters, then remove them only when retirement guards permit it.
+
+## 11. Required acceptance gates
+
+The strategy is complete only when all applicable gates pass:
+
+- One shared image is built and verified by immutable digest for every supported architecture.
+- Separate Host Classes can reference the same digest without conflating support state.
+- Runtime packs drive startup, credential staging, environment, readiness, model discovery, and attestation.
+- The generic host lifecycle contains no top-level provider-specific orchestration branches.
+- Codex and Claude OAuth enrollment remains owned by MoonMind Settings.
+- Generic Codex and Claude materializers preserve exclusive writable OAuth state and acquired generation fencing.
+- OpenCode run-owned credentials remain isolated and are destroyed after cleanup.
+- Non-selected runtime credentials are absent from every exact host.
+- Codex, Claude, and OpenCode normal product journeys run through `generic-omnigent-host@1` for supported combinations.
+- Continuations and other follow-up sources use one canonical session and turn-command boundary.
+- Exact-artifact and protected-live reports identify image, harness, runtime pack, materializer, model, policy, and realizer.
+- New authoring defaults prefer Omnigent only for qualified combinations.
+- Explicit generic selections never silently fall back.
+- Existing histories remain replayable and historically truthful throughout migration.
+- Duplicate runtime and host code is removed only after machine-checkable retirement criteria pass.
+
+## 12. Non-goals
+
+This strategy does not require:
+
+- one Host Class for every harness in the shared image
+- one credential format across runtimes
+- sharing OAuth homes between Codex and Claude Code
+- installing every future Omnigent harness in the shared image
+- allowing workflows to select arbitrary images, runtime packs, probes, or mounts
+- moving MoonMind workflow, policy, credential, workspace, evidence, or cleanup authority into Omnigent
+- claiming support merely because a binary exists in an image
+- removing direct or legacy runtime paths before replay and rollback obligations are satisfied
+- silently converting active or historical executions to another realizer
+
+## 13. Documentation rule
+
+Documents that describe current runtime behavior must distinguish:
+
+- **current supported path**
+- **migration compatibility path**
+- **desired primary path**
+- **qualified support combination**
+
+The phrase “Omnigent is the primary runtime provider” describes the durable destination. Current support claims remain exact and evidence-gated until each migration stage is complete.


### PR DESCRIPTION
## Summary

Reconcile MoonMind's runtime documentation around one explicit long-term decision:

> Omnigent is to become MoonMind's primary runtime provider over time.

This PR distinguishes that durable destination from current support and migration state. It makes clear that MoonMind continues to own Temporal orchestration, Provider Profiles, OAuth enrollment, credentials, workspaces, Skills, policies, evidence, recovery, publication, and cleanup while Omnigent becomes the normal host, runner, harness, session, and live interaction substrate.

## Changes

- Add `docs/Omnigent/PrimaryRuntimeProviderStrategy.md` as the canonical strategy document.
- Update the roadmap so the destination covers Codex, Claude Code, OpenCode, and future approved harnesses rather than a Codex-only cutover.
- Update the README to explain the target Omnigent runtime plane and current compatibility paths.
- Reconcile `OpenCodeHost.md` so the existing OpenCode image lineage becomes the foundation for a neutral shared MoonMind Omnigent host image.
- Reconcile `OmnigentHostOAuth.md` so Codex and Claude OAuth differences live behind generic materializers and runtime packs while MoonMind Settings remains the OAuth authority.

## Governing decisions

- One `external/omnigent` top-level execution identity.
- One generic execution plan, runtime binding, host lifecycle, canonical session and turn plane, bridge, evidence, and cleanup architecture.
- One shared digest-pinned host image for Codex, Claude Code, and OpenCode where practical.
- Separate Host Classes and support rows may reference the same image digest.
- Runtime-specific behavior is limited to trusted runtime-pack descriptors, credential materializers, bounded probes, and capability normalization.
- Codex and Claude OAuth homes remain profile-owned, writable, exclusive, and generation-fenced.
- OpenCode API-key material remains run-owned and destroyed after cleanup.
- No silent fallback between generic, legacy, or direct runtimes.
- Existing plans and Temporal histories retain truthful realizer identity until replay-safe retirement criteria pass.

## Validation

Documentation-only change. Repository CI and documentation contract checks should validate links and pinned roadmap acceptance identifiers.