### PR TITLE
Fix dynamic remediation skill snapshots

### DIFF
--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -59,6 +59,10 @@ from moonmind.services.skill_resolution import (
     AgentSkillResolver,
     SkillResolutionContext,
 )
+from moonmind.workflows.temporal.remediation_loop import (
+    ToolDescriptor,
+    tool_descriptor_selected_skill,
+)
 from pr_resolver_core import IMPLEMENTATION_CONTRACT
 
 _HARNESS_PRODUCT_CONFIG: dict[str, dict[str, str]] = {
@@ -408,17 +412,18 @@ def _selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
         if candidate and candidate != "auto" and candidate not in names:
             names.append(candidate)
 
-    def add_nested_selected_skills(raw: Any) -> None:
-        """Collect skill intent from workflow-owned dynamic execution specs."""
+    def add_remediation_loop_skills(step: Mapping[str, Any]) -> None:
+        """Collect Skills from the typed dynamic remediation contract."""
 
-        if isinstance(raw, Mapping):
-            add(raw.get("selectedSkill") or raw.get("selected_skill"))
-            for value in raw.values():
-                add_nested_selected_skills(value)
+        annotations = step.get("annotations")
+        if not isinstance(annotations, Mapping):
             return
-        if isinstance(raw, (list, tuple)):
-            for value in raw:
-                add_nested_selected_skills(value)
+        loop = annotations.get("remediationLoop")
+        if not isinstance(loop, Mapping) or loop.get("kind") != "remediation_loop":
+            return
+        for field_name in ("remediationTool", "verificationTool"):
+            descriptor = ToolDescriptor.model_validate(loop.get(field_name))
+            add(tool_descriptor_selected_skill(descriptor))
 
     selectors = workflow_mapping.get("skills")
     if isinstance(selectors, Mapping):
@@ -442,11 +447,7 @@ def _selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
             and str(step_tool.get("type") or "").lower() == "skill"
         ):
             add(step_tool)
-    # Remediation and other workflow-owned controllers materialize agent steps
-    # after admission. Their canonical skill identity is declared as a nested
-    # selectedSkill, so it must be frozen into the same immutable run snapshot
-    # before any step launches.
-    add_nested_selected_skills(workflow_mapping)
+        add_remediation_loop_skills(step)
     return names
 
 

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -408,6 +408,18 @@ def _selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
         if candidate and candidate != "auto" and candidate not in names:
             names.append(candidate)
 
+    def add_nested_selected_skills(raw: Any) -> None:
+        """Collect skill intent from workflow-owned dynamic execution specs."""
+
+        if isinstance(raw, Mapping):
+            add(raw.get("selectedSkill") or raw.get("selected_skill"))
+            for value in raw.values():
+                add_nested_selected_skills(value)
+            return
+        if isinstance(raw, (list, tuple)):
+            for value in raw:
+                add_nested_selected_skills(value)
+
     selectors = workflow_mapping.get("skills")
     if isinstance(selectors, Mapping):
         for entry in selectors.get("include") or []:
@@ -430,6 +442,11 @@ def _selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
             and str(step_tool.get("type") or "").lower() == "skill"
         ):
             add(step_tool)
+    # Remediation and other workflow-owned controllers materialize agent steps
+    # after admission. Their canonical skill identity is declared as a nested
+    # selectedSkill, so it must be frozen into the same immutable run snapshot
+    # before any step launches.
+    add_nested_selected_skills(workflow_mapping)
     return names
 
 

--- a/moonmind/workflows/temporal/remediation_loop.py
+++ b/moonmind/workflows/temporal/remediation_loop.py
@@ -58,6 +58,17 @@ class ToolDescriptor(_Contract):
         return value
 
 
+def tool_descriptor_selected_skill(tool: ToolDescriptor) -> str:
+    """Return the Skill identity materialized by one typed tool descriptor."""
+
+    raw = (
+        tool.inputs["selectedSkill"]
+        if "selectedSkill" in tool.inputs
+        else tool.name
+    )
+    return str(raw or "").strip()
+
+
 class RemediationLoopBudgets(_Contract):
     hard_max_attempts: int = Field(alias="hardMaxAttempts", ge=1)
     max_consecutive_semantic_no_progress: int = Field(
@@ -516,9 +527,13 @@ def materialize_attempt_nodes(
         }
     )
     compiled_remediation_inputs.setdefault(
-        "selectedSkill", spec.remediation_tool.name
+        "selectedSkill",
+        tool_descriptor_selected_skill(spec.remediation_tool),
     )
-    verifier_inputs.setdefault("selectedSkill", spec.verification_tool.name)
+    verifier_inputs.setdefault(
+        "selectedSkill",
+        tool_descriptor_selected_skill(spec.verification_tool),
+    )
     compiled_remediation_inputs.setdefault("repositoryOperation", "write")
     verifier_inputs.setdefault("repositoryOperation", "read")
     compiled_remediation_inputs["runtime"] = dict(runtime_block)

--- a/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "every agent Skill reachable from the admitted workflow is frozen into the immutable run snapshot before execution",
+  "resolvedSkillNames": [
+    "moonspec-verify",
+    "remediate-issue"
+  ]
+}

--- a/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/manifest.json
@@ -1,0 +1,41 @@
+{
+  "incidentWorkflowId": "mm:88694a58-7938-4a87-9381-39b92cb498d5",
+  "failureShapeId": "omnigent-remediation-skill-snapshot",
+  "boundary": "workflow admission to immutable resolved Skill snapshot",
+  "escapedFailure": {
+    "message": "selected skill 'remediate-issue' was not resolved into the agent skill snapshot",
+    "cause": "admission collected direct workflow and step Skills but omitted the nested remediationTool selectedSkill that the controller materialized after verification"
+  },
+  "initialParameters": {
+    "workflow": {
+      "steps": [
+        {
+          "skill": {
+            "id": "moonspec-verify"
+          }
+        },
+        {
+          "annotations": {
+            "remediationLoop": {
+              "kind": "remediation_loop",
+              "remediationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "remediate-issue"
+                }
+              },
+              "verificationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "moonspec-verify"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-remediation-skill-snapshot/manifest.json
@@ -11,7 +11,12 @@
       "steps": [
         {
           "skill": {
-            "id": "moonspec-verify"
+            "id": "moonspec-verify",
+            "args": {
+              "payloadTemplate": {
+                "selectedSkill": "not-current-run-intent"
+              }
+            }
           }
         },
         {
@@ -19,11 +24,9 @@
             "remediationLoop": {
               "kind": "remediation_loop",
               "remediationTool": {
-                "type": "agent_runtime",
-                "name": "auto",
-                "inputs": {
-                  "selectedSkill": "remediate-issue"
-                }
+                "type": "skill",
+                "name": "remediate-issue",
+                "inputs": {}
               },
               "verificationTool": {
                 "type": "agent_runtime",

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -33,6 +33,7 @@ from api_service.db.models import (
     RecurringWorkflowScheduleType,
     RecurringWorkflowScopeType,
 )
+from api_service.services import omnigent_execution_plan_service
 from api_service.services.omnigent_policies import (
     bootstrap_document,
     seed_bootstrap_policies,
@@ -5202,6 +5203,22 @@ async def test_remediation_attempt_receives_authoritative_verifier_evidence(
     )
     assert request.parameters["gateResultRef"] == expected["gateResultRef"]
     assert request.parameters["remainingWorkRef"] == expected["remainingWorkRef"]
+
+
+async def test_omnigent_admission_snapshot_includes_dynamic_remediation_skill() -> None:
+    """Replay mm:88694a58 at workflow admission before remediation launch."""
+
+    replay_id = "omnigent-remediation-skill-snapshot"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    selector = omnigent_execution_plan_service._skill_selector(
+        manifest["initialParameters"]
+    )
+
+    assert [entry.name for entry in selector.include] == expected[
+        "resolvedSkillNames"
+    ]
 
 
 async def test_checkpointless_remediation_keeps_the_verified_repository_branch(

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -72,6 +72,88 @@ class _PlanStore:
         return envelope
 
 
+def test_skill_selector_includes_nested_dynamic_execution_skills() -> None:
+    selector = service._skill_selector(
+        {
+            "workflow": {
+                "steps": [
+                    {"skill": {"id": "moonspec-verify"}},
+                    {
+                        "annotations": {
+                            "remediationLoop": {
+                                "kind": "remediation_loop",
+                                "remediationTool": {
+                                    "type": "agent_runtime",
+                                    "inputs": {
+                                        "selectedSkill": "remediate-issue"
+                                    },
+                                },
+                                "verificationTool": {
+                                    "type": "agent_runtime",
+                                    "inputs": {
+                                        "selectedSkill": "moonspec-verify"
+                                    },
+                                },
+                            }
+                        }
+                    },
+                ]
+            }
+        }
+    )
+
+    assert [entry.name for entry in selector.include] == [
+        "moonspec-verify",
+        "remediate-issue",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_admission_persists_nested_dynamic_execution_skills() -> None:
+    artifacts = _ArtifactService()
+
+    resolved, manifest_ref, _manifest_digest, content_refs = (
+        await service._resolve_and_persist_skills(
+            session_factory=object(),
+            artifact_service=artifacts,
+            principal="user-1",
+            workflow_id="mm:remediation-skill-snapshot",
+            task_input_snapshot_digest="sha256:" + "1" * 64,
+            initial_parameters={
+                "workflow": {
+                    "steps": [
+                        {"skill": {"id": "moonspec-verify"}},
+                        {
+                            "annotations": {
+                                "remediationLoop": {
+                                    "kind": "remediation_loop",
+                                    "remediationTool": {
+                                        "type": "agent_runtime",
+                                        "inputs": {
+                                            "selectedSkill": "remediate-issue"
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    ]
+                }
+            },
+        )
+    )
+
+    assert [entry.skill_name for entry in resolved.skills] == [
+        "moonspec-verify",
+        "remediate-issue",
+    ]
+    manifest = json.loads(artifacts.payloads[manifest_ref])
+    assert [entry["skill_name"] for entry in manifest["skills"]] == [
+        "moonspec-verify",
+        "remediate-issue",
+    ]
+    assert len(content_refs) == 2
+
+
 def _snapshot(*, harness: str, policy: str, provider_id: str) -> dict:
     return {
         "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -77,19 +77,28 @@ def test_skill_selector_includes_nested_dynamic_execution_skills() -> None:
         {
             "workflow": {
                 "steps": [
-                    {"skill": {"id": "moonspec-verify"}},
+                    {
+                        "skill": {
+                            "id": "moonspec-verify",
+                            "args": {
+                                "payloadTemplate": {
+                                    "selectedSkill": "not-current-run-intent"
+                                }
+                            },
+                        }
+                    },
                     {
                         "annotations": {
                             "remediationLoop": {
                                 "kind": "remediation_loop",
                                 "remediationTool": {
-                                    "type": "agent_runtime",
-                                    "inputs": {
-                                        "selectedSkill": "remediate-issue"
-                                    },
+                                    "type": "skill",
+                                    "name": "remediate-issue",
+                                    "inputs": {},
                                 },
                                 "verificationTool": {
                                     "type": "agent_runtime",
+                                    "name": "auto",
                                     "inputs": {
                                         "selectedSkill": "moonspec-verify"
                                     },
@@ -122,15 +131,30 @@ async def test_admission_persists_nested_dynamic_execution_skills() -> None:
             initial_parameters={
                 "workflow": {
                     "steps": [
-                        {"skill": {"id": "moonspec-verify"}},
+                        {
+                            "skill": {
+                                "id": "moonspec-verify",
+                                "args": {
+                                    "payloadTemplate": {
+                                        "selectedSkill": "not-current-run-intent"
+                                    }
+                                },
+                            }
+                        },
                         {
                             "annotations": {
                                 "remediationLoop": {
                                     "kind": "remediation_loop",
                                     "remediationTool": {
+                                        "type": "skill",
+                                        "name": "remediate-issue",
+                                        "inputs": {},
+                                    },
+                                    "verificationTool": {
                                         "type": "agent_runtime",
+                                        "name": "auto",
                                         "inputs": {
-                                            "selectedSkill": "remediate-issue"
+                                            "selectedSkill": "moonspec-verify"
                                         },
                                     },
                                 }

--- a/tests/unit/workflows/temporal/test_remediation_loop.py
+++ b/tests/unit/workflows/temporal/test_remediation_loop.py
@@ -11,6 +11,7 @@ from moonmind.workflows.temporal.remediation_loop import (
     capture_remediation_candidate,
     decide_remediation_continuation,
     materialize_attempt_nodes,
+    tool_descriptor_selected_skill,
     project_remediation_loop,
     record_semantic_progress,
     record_verification_evidence,
@@ -77,6 +78,27 @@ def _state(*, attempts: int = 0, evidence_retries: int = 0) -> RemediationLoopSt
             attempts=attempts, evidenceRetries=evidence_retries
         ),
     )
+
+
+def test_tool_descriptor_selected_skill_matches_materialization_contract() -> None:
+    inherited = _spec().remediation_tool
+    explicit = inherited.model_copy(
+        update={
+            "name": "remediate-issue",
+            "inputs": {
+                "instructions": "Fix the remaining verified gaps.",
+                "selectedSkill": "bounded-remediator",
+            },
+        }
+    )
+    named = explicit.model_copy(
+        update={
+            "inputs": {"instructions": "Fix the remaining verified gaps."}
+        }
+    )
+
+    assert tool_descriptor_selected_skill(explicit) == "bounded-remediator"
+    assert tool_descriptor_selected_skill(named) == "remediate-issue"
 
 
 @pytest.mark.parametrize("maximum", [1, 2, 6])


### PR DESCRIPTION
## Summary

- include nested dynamic selectedSkill declarations in Omnigent admission snapshots
- preserve immutable runtime snapshot enforcement without step-time re-resolution
- add a minimized replay for workflow mm:88694a58-7938-4a87-9381-39b92cb498d5

## Tests

- ./tools/test_unit.sh --python-only tests/unit/services/test_omnigent_execution_plan_service.py
- pytest -q tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_admission_snapshot_includes_dynamic_remediation_skill --tb=short