### PR TITLE
Since the Batch GitHub Workflows preset still has an instructions box, I don't think it also needs to expose an input for "Extra instructions / constr

### DIFF
--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -43,8 +43,9 @@ Progress" with a single batch run.
   `preset:github-issue-orchestrate` through the same helper.
 - `max_workflows` (number, optional): hard cap on queued children. Default `25`.
 - `constraints` (string, optional): shared input copied to every child. The
-  Jira preset exposes this input; the GitHub preset relies on its step
-  instructions instead.
+  Jira preset exposes this input; the GitHub preset has no constraints input and
+  instead forwards operator guidance written into its step Instructions box
+  through `--constraints-file artifacts/batch-workflows-constraints.txt`.
 - `run_verify` (boolean, optional): shared verification toggle copied to child
   implement presets. Default `true`.
 - `additional_jql` (string, optional): advanced JQL AND-clause appended to the

--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -42,7 +42,9 @@ Progress" with a single batch run.
   preset supports `preset:github-issue-implement` and
   `preset:github-issue-orchestrate` through the same helper.
 - `max_workflows` (number, optional): hard cap on queued children. Default `25`.
-- `constraints` (string, optional): shared input copied to every child.
+- `constraints` (string, optional): shared input copied to every child. The
+  Jira preset exposes this input; the GitHub preset relies on its step
+  instructions instead.
 - `run_verify` (boolean, optional): shared verification toggle copied to child
   implement presets. Default `true`.
 - `additional_jql` (string, optional): advanced JQL AND-clause appended to the

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -26,12 +26,10 @@ annotations:
     preset:github-issue-implement:
       github_issue: '{{ target.githubIssue }}'
       github_issue_ref: '{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}'
-      constraints: '{{ shared.constraints }}'
       run_verify: '{{ shared.run_verify }}'
     preset:github-issue-orchestrate:
       github_issue: '{{ target.githubIssue }}'
       github_issue_ref: '{{ target.githubIssue.repository }}#{{ target.githubIssue.number }}'
-      constraints: '{{ shared.constraints }}'
       run_verify: '{{ shared.run_verify }}'
   inputSchema:
     type: object
@@ -58,9 +56,6 @@ annotations:
       max_workflows:
         type: string
         title: Max workflows
-      constraints:
-        type: string
-        title: Extra instructions / constraints
       run_verify:
         type: boolean
         title: Run verification
@@ -77,9 +72,6 @@ annotations:
     run_ref:
       widget: select
     repository:
-      advanced: true
-    constraints:
-      widget: textarea
       advanced: true
     run_verify:
       widget: checkbox
@@ -115,11 +107,6 @@ inputs:
   type: text
   required: false
   default: '25'
-- name: constraints
-  label: Extra Instructions / Constraints
-  type: textarea
-  required: false
-  default: ''
 - name: run_verify
   label: Run Verification
   type: boolean
@@ -162,8 +149,7 @@ steps:
     --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \
-    {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %} \
-    --constraints "{{ inputs.constraints }}"
+    {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %}
 
     The helper writes artifacts/batch-workflows-result.json. Report its queued,
     skipped, and error counts honestly and link every queued child workflow.
@@ -176,7 +162,6 @@ steps:
     target:
       runRef: '{{ inputs.run_ref }}'
     sharedInputs:
-      constraints: '{{ inputs.constraints }}'
       run_verify: '{{ inputs.run_verify }}'
     publish:
       mode: '{{ inputs.publish_mode }}'

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -136,6 +136,14 @@ steps:
     context. Do not re-select provider, model, or effort: every child inherits the
     parent runtime via runtimeInheritance="caller".
 
+    This preset has no separate constraints input: this Instructions box is the
+    only batch-level guidance surface. Before invoking the helper, create the
+    artifacts directory and copy any operator-authored guidance added to this box
+    verbatim into artifacts/batch-workflows-constraints.txt so every child
+    workflow receives it as its constraints input. Copy only that added guidance,
+    never this template text. When the operator added none, leave the file absent
+    and the helper sends empty constraints.
+
     Resolve the range and queue each matched issue with "{{ inputs.run_ref }}" and
     publish override "{{ inputs.publish_mode }}" using one helper invocation. The
     portable helper performs the trusted GitHub query, excludes closed issues,
@@ -149,7 +157,8 @@ steps:
     --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \
-    {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %}
+    {% if inputs.run_verify %}--run-verify{% else %}--no-run-verify{% endif %} \
+    --constraints-file artifacts/batch-workflows-constraints.txt
 
     The helper writes artifacts/batch-workflows-result.json. Report its queued,
     skipped, and error counts honestly and link every queued child workflow.

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -59,7 +59,6 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
                     "repository": "MoonLadderStudios/MoonMind",
                     "publish_mode": "pr_with_merge_automation",
                     "max_workflows": "10",
-                    "constraints": "Keep changes focused",
                     "run_verify": True,
                 },
             )
@@ -93,6 +92,48 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
         "--targets artifacts/batch-workflows-targets.json"
         not in step["instructions"]
     )
+    assert "--constraints" not in step["instructions"]
+    assert "constraints" not in orchestration["sharedInputs"]
+    assert "constraints" not in expanded["appliedTemplate"]["inputs"]
+
+
+async def test_batch_github_workflows_drops_constraints_input(tmp_path):
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+            template = await service.get_template(
+                slug="batch-github-workflows",
+                scope="global",
+                scope_ref=None,
+            )
+
+            expanded = await service.expand_template(
+                slug="batch-github-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "issue_range": "3142-3150",
+                    "run_ref": "preset:github-issue-implement",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "constraints": "Stale client value",
+                },
+            )
+
+    assert "constraints" not in template["inputSchema"]["properties"]
+    assert "constraints" not in template["uiSchema"]
+    assert "constraints" not in template["defaults"]
+    assert all(
+        definition["name"] != "constraints" for definition in template["inputs"]
+    )
+    for binding in template["annotations"]["bindings"].values():
+        assert "constraints" not in binding
+
+    assert "constraints" not in expanded["appliedTemplate"]["inputs"]
+    step = expanded["steps"][0]
+    assert "--constraints" not in step["instructions"]
+    assert "Stale client value" not in step["instructions"]
+    assert "constraints" not in step["batchOrchestration"]["sharedInputs"]
 
 
 async def test_batch_github_workflows_uses_repository_context(tmp_path):

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -92,7 +92,11 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
         "--targets artifacts/batch-workflows-targets.json"
         not in step["instructions"]
     )
-    assert "--constraints" not in step["instructions"]
+    assert '--constraints "' not in step["instructions"]
+    assert (
+        "--constraints-file artifacts/batch-workflows-constraints.txt"
+        in step["instructions"]
+    )
     assert "constraints" not in orchestration["sharedInputs"]
     assert "constraints" not in expanded["appliedTemplate"]["inputs"]
 
@@ -131,9 +135,37 @@ async def test_batch_github_workflows_drops_constraints_input(tmp_path):
 
     assert "constraints" not in expanded["appliedTemplate"]["inputs"]
     step = expanded["steps"][0]
-    assert "--constraints" not in step["instructions"]
+    assert '--constraints "' not in step["instructions"]
     assert "Stale client value" not in step["instructions"]
     assert "constraints" not in step["batchOrchestration"]["sharedInputs"]
+
+
+async def test_batch_github_workflows_forwards_step_instruction_constraints(
+    tmp_path,
+):
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="batch-github-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "issue_range": "3142-3150",
+                    "run_ref": "preset:github-issue-implement",
+                    "repository": "MoonLadderStudios/MoonMind",
+                },
+            )
+
+    instructions = expanded["steps"][0]["instructions"]
+    assert (
+        "--constraints-file artifacts/batch-workflows-constraints.txt"
+        in instructions
+    )
+    assert "artifacts/batch-workflows-constraints.txt" in instructions
+    assert "this Instructions box is the" in instructions
 
 
 async def test_batch_github_workflows_uses_repository_context(tmp_path):


### PR DESCRIPTION
Since the Batch GitHub Workflows preset still has an instructions box, I don't think it also needs to expose an input for "Extra instructions / constraints". This can be removed.