### PR TITLE
Fail fast incomplete exact-rerun skill snapshots

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10254,6 +10254,85 @@ async def _exact_rerun_parameters_from_snapshot(
     return parameters
 
 
+async def _validate_exact_rerun_skill_snapshot(
+    *,
+    session: AsyncSession,
+    user: User,
+    parameters: Mapping[str, Any],
+) -> None:
+    """Reject immutable reruns whose admitted Skill snapshot was incomplete."""
+
+    from api_service.services.omnigent_execution_plan_service import (
+        selected_skill_names,
+    )
+    from moonmind.schemas.agent_skill_models import ResolvedSkillSet
+
+    selected = selected_skill_names(parameters)
+    if not selected:
+        return
+
+    def conflict(
+        message: str,
+        *,
+        code: str = "exact_rerun_skill_snapshot_unavailable",
+        **details: Any,
+    ) -> HTTPException:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": code,
+                "message": message,
+                "nextAction": "create_fresh_workflow",
+                **details,
+            },
+        )
+
+    snapshot_ref = str(parameters.get("resolvedSkillsetRef") or "").strip()
+    artifact_id = _artifact_id_from_ref(snapshot_ref)
+    if not artifact_id:
+        raise conflict(
+            "Exact rerun cannot verify the original immutable Skill snapshot. "
+            "Create a new workflow to explicitly re-resolve Skill authority."
+        )
+
+    try:
+        artifact_service = get_temporal_artifact_service(session)
+        _artifact, body = await artifact_service.read(
+            artifact_id=artifact_id,
+            principal=str(getattr(user, "id", "") or "system"),
+            allow_restricted_raw=True,
+        )
+        resolved = ResolvedSkillSet.model_validate_json(body)
+    except (PermissionError, TemporalArtifactAuthorizationError) as exc:
+        raise conflict(
+            "Exact rerun is not authorized to read the original immutable "
+            "Skill snapshot."
+        ) from exc
+    except (
+        TemporalArtifactNotFoundError,
+        TemporalArtifactStateError,
+        ValidationError,
+        ValueError,
+        TypeError,
+    ) as exc:
+        raise conflict(
+            "Exact rerun found an invalid original immutable Skill snapshot. "
+            "Create a new workflow to explicitly re-resolve Skill authority."
+        ) from exc
+
+    resolved_names = {entry.skill_name for entry in resolved.skills}
+    missing = [name for name in selected if name not in resolved_names]
+    if missing:
+        raise conflict(
+            "Exact rerun preserves the original immutable Skill snapshot, but "
+            "that snapshot does not contain every Skill declared by the "
+            "authored workflow. Create a new workflow to explicitly re-resolve "
+            "Skill authority.",
+            code="exact_rerun_skill_snapshot_incomplete",
+            missingSkills=missing,
+        )
+
+
 def _merge_workflow_preserving_artifact_instructions(
     artifact_task: Mapping[str, Any],
     parameter_task: Mapping[str, Any],
@@ -17799,6 +17878,12 @@ async def update_execution(
         )
         if exact_snapshot_parameters is not None:
             effective_parameters_patch = exact_snapshot_parameters
+            if isinstance(recorded_plan, Mapping):
+                await _validate_exact_rerun_skill_snapshot(
+                    session=session,
+                    user=user,
+                    parameters=exact_snapshot_parameters,
+                )
 
     try:
         update_result = await service.update_execution(
@@ -18249,7 +18334,13 @@ async def rerun_execution(
     # task dependency edges and recovery metadata from a prior execution.
     initial_params = service._full_rerun_parameters(canonical.parameters or {})
     reserved_workflow_id = f"mm:{_uuid4()}"
-    if not isinstance(initial_params.get("omnigentExecutionPlan"), Mapping):
+    if isinstance(initial_params.get("omnigentExecutionPlan"), Mapping):
+        await _validate_exact_rerun_skill_snapshot(
+            session=session,
+            user=user,
+            parameters=initial_params,
+        )
+    else:
         initial_params = await refresh_managed_bootstrap_snapshot(
             session,
             parameters=initial_params,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -217,6 +217,7 @@ from moonmind.workflows.temporal import (
     TemporalExecutionCancelUndeliverableError,
     TemporalExecutionNotFoundError,
     TemporalExecutionRecoveryCheckpointError,
+    TemporalExecutionRerunSkillSnapshotError,
     TemporalExecutionService,
     TemporalExecutionValidationError,
     build_manifest_status_snapshot,
@@ -10254,85 +10255,6 @@ async def _exact_rerun_parameters_from_snapshot(
     return parameters
 
 
-async def _validate_exact_rerun_skill_snapshot(
-    *,
-    session: AsyncSession,
-    user: User,
-    parameters: Mapping[str, Any],
-) -> None:
-    """Reject immutable reruns whose admitted Skill snapshot was incomplete."""
-
-    from api_service.services.omnigent_execution_plan_service import (
-        selected_skill_names,
-    )
-    from moonmind.schemas.agent_skill_models import ResolvedSkillSet
-
-    selected = selected_skill_names(parameters)
-    if not selected:
-        return
-
-    def conflict(
-        message: str,
-        *,
-        code: str = "exact_rerun_skill_snapshot_unavailable",
-        **details: Any,
-    ) -> HTTPException:
-        return HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": code,
-                "message": message,
-                "nextAction": "create_fresh_workflow",
-                **details,
-            },
-        )
-
-    snapshot_ref = str(parameters.get("resolvedSkillsetRef") or "").strip()
-    artifact_id = _artifact_id_from_ref(snapshot_ref)
-    if not artifact_id:
-        raise conflict(
-            "Exact rerun cannot verify the original immutable Skill snapshot. "
-            "Create a new workflow to explicitly re-resolve Skill authority."
-        )
-
-    try:
-        artifact_service = get_temporal_artifact_service(session)
-        _artifact, body = await artifact_service.read(
-            artifact_id=artifact_id,
-            principal=str(getattr(user, "id", "") or "system"),
-            allow_restricted_raw=True,
-        )
-        resolved = ResolvedSkillSet.model_validate_json(body)
-    except (PermissionError, TemporalArtifactAuthorizationError) as exc:
-        raise conflict(
-            "Exact rerun is not authorized to read the original immutable "
-            "Skill snapshot."
-        ) from exc
-    except (
-        TemporalArtifactNotFoundError,
-        TemporalArtifactStateError,
-        ValidationError,
-        ValueError,
-        TypeError,
-    ) as exc:
-        raise conflict(
-            "Exact rerun found an invalid original immutable Skill snapshot. "
-            "Create a new workflow to explicitly re-resolve Skill authority."
-        ) from exc
-
-    resolved_names = {entry.skill_name for entry in resolved.skills}
-    missing = [name for name in selected if name not in resolved_names]
-    if missing:
-        raise conflict(
-            "Exact rerun preserves the original immutable Skill snapshot, but "
-            "that snapshot does not contain every Skill declared by the "
-            "authored workflow. Create a new workflow to explicitly re-resolve "
-            "Skill authority.",
-            code="exact_rerun_skill_snapshot_incomplete",
-            missingSkills=missing,
-        )
-
-
 def _merge_workflow_preserving_artifact_instructions(
     artifact_task: Mapping[str, Any],
     parameter_task: Mapping[str, Any],
@@ -17878,12 +17800,6 @@ async def update_execution(
         )
         if exact_snapshot_parameters is not None:
             effective_parameters_patch = exact_snapshot_parameters
-            if isinstance(recorded_plan, Mapping):
-                await _validate_exact_rerun_skill_snapshot(
-                    session=session,
-                    user=user,
-                    parameters=exact_snapshot_parameters,
-                )
 
     try:
         update_result = await service.update_execution(
@@ -17899,6 +17815,11 @@ async def update_execution(
             node_ids=payload.node_ids,
             idempotency_key=payload.idempotency_key,
         )
+    except TemporalExecutionRerunSkillSnapshotError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=exc.detail,
+        ) from exc
     except TemporalExecutionValidationError as exc:
         if is_task_editing_update:
             _emit_task_editing_metric(
@@ -18335,11 +18256,16 @@ async def rerun_execution(
     initial_params = service._full_rerun_parameters(canonical.parameters or {})
     reserved_workflow_id = f"mm:{_uuid4()}"
     if isinstance(initial_params.get("omnigentExecutionPlan"), Mapping):
-        await _validate_exact_rerun_skill_snapshot(
-            session=session,
-            user=user,
-            parameters=initial_params,
-        )
+        try:
+            await service.validate_exact_rerun_skill_snapshot(
+                source_record=canonical,
+                parameters=initial_params,
+            )
+        except TemporalExecutionRerunSkillSnapshotError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.detail,
+            ) from exc
     else:
         initial_params = await refresh_managed_bootstrap_snapshot(
             session,

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -398,7 +398,7 @@ class PersistedOmnigentExecutionPlan:
     resolved_skillset_digest: str
 
 
-def _selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
+def selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
     """Collect the workflow's MoonMind Skill intent for one run snapshot."""
 
     workflow = initial_parameters.get("workflow")
@@ -463,7 +463,7 @@ def _skill_selector(initial_parameters: Mapping[str, Any]) -> SkillSelector:
             if str(value or "").strip()
         }
     )
-    selected = _selected_skill_names(initial_parameters)
+    selected = selected_skill_names(initial_parameters)
     conflict = sorted(set(selected).intersection(excluded))
     if conflict:
         raise ValueError(
@@ -1240,5 +1240,6 @@ __all__ = [
     "PersistedOmnigentExecutionPlan",
     "compile_and_persist_execution_plan",
     "persist_json_artifact",
+    "selected_skill_names",
     "load_protected_execution_support_evidence",
 ]

--- a/moonmind/workflows/temporal/__init__.py
+++ b/moonmind/workflows/temporal/__init__.py
@@ -122,6 +122,7 @@ from moonmind.workflows.temporal.service import (
     TemporalExecutionListResult,
     TemporalExecutionNotFoundError,
     TemporalExecutionRecoveryCheckpointError,
+    TemporalExecutionRerunSkillSnapshotError,
     TemporalExecutionService,
     TemporalExecutionValidationError,
 )
@@ -210,6 +211,7 @@ __all__ = [
     "TemporalExecutionListResult",
     "TemporalExecutionNotFoundError",
     "TemporalExecutionRecoveryCheckpointError",
+    "TemporalExecutionRerunSkillSnapshotError",
     "TemporalExecutionService",
     "TemporalExecutionValidationError",
     "TemporalIntegrationActivities",

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -76,8 +76,12 @@ from moonmind.services.skill_step_inputs import validate_skill_step_inputs
 from moonmind.security.outbound_scan import scan_outbound_text
 from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.artifacts import (
+    TemporalArtifactAuthorizationError,
+    TemporalArtifactNotFoundError,
     TemporalArtifactRepository,
     TemporalArtifactService,
+    TemporalArtifactStateError,
+    TemporalArtifactValidationError,
 )
 from moonmind.workflows.temporal.checkpoint_policy import resolve_checkpoint_policy
 from moonmind.workflows.temporal.activity_catalog import (
@@ -448,6 +452,32 @@ class TemporalExecutionNotFoundError(TemporalExecutionError):
 
 class TemporalExecutionValidationError(TemporalExecutionError):
     """Raised when lifecycle invariants are violated."""
+
+
+class TemporalExecutionRerunSkillSnapshotError(TemporalExecutionValidationError):
+    """Raised when an exact rerun cannot prove immutable Skill authority."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "exact_rerun_skill_snapshot_unavailable",
+        missing_skills: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.missing_skills = tuple(missing_skills or ())
+
+    @property
+    def detail(self) -> dict[str, Any]:
+        detail: dict[str, Any] = {
+            "code": self.code,
+            "message": str(self),
+            "nextAction": "create_fresh_workflow",
+        }
+        if self.missing_skills:
+            detail["missingSkills"] = list(self.missing_skills)
+        return detail
 
 
 class TemporalExecutionRecoveryCheckpointError(TemporalExecutionValidationError):
@@ -2530,6 +2560,85 @@ class TemporalExecutionService:
             return candidate
         raise TemporalExecutionValidationError("workflowId is required")
 
+    async def validate_exact_rerun_skill_snapshot(
+        self,
+        *,
+        source_record: TemporalExecutionRecord | TemporalExecutionCanonicalRecord,
+        parameters: Mapping[str, Any],
+    ) -> None:
+        """Reject exact Omnigent reruns with incomplete Skill authority."""
+
+        if not isinstance(parameters.get("omnigentExecutionPlan"), Mapping):
+            return
+
+        from api_service.services.omnigent_execution_plan_service import (
+            selected_skill_names,
+        )
+        from moonmind.schemas.agent_skill_models import ResolvedSkillSet
+
+        try:
+            selected = selected_skill_names(parameters)
+        except (ValidationError, ValueError, TypeError) as exc:
+            raise TemporalExecutionRerunSkillSnapshotError(
+                "Exact rerun cannot parse the stored Skill selection contract. "
+                "Create a new workflow to explicitly re-resolve Skill authority."
+            ) from exc
+        if not selected:
+            return
+
+        snapshot_ref = str(parameters.get("resolvedSkillsetRef") or "").strip()
+        artifact_id = snapshot_ref.removeprefix("artifact://").removeprefix(
+            "input/"
+        ).strip()
+        if not artifact_id:
+            raise TemporalExecutionRerunSkillSnapshotError(
+                "Exact rerun cannot verify the original immutable Skill snapshot. "
+                "Create a new workflow to explicitly re-resolve Skill authority."
+            )
+
+        principal = str(getattr(source_record, "owner_id", None) or "").strip()
+        if not principal:
+            principal = "service:temporal-execution-rerun-admission"
+        try:
+            artifact_service = TemporalArtifactService(
+                TemporalArtifactRepository(self._session)
+            )
+            _artifact, body = await artifact_service.read(
+                artifact_id=artifact_id,
+                principal=principal,
+                allow_restricted_raw=True,
+            )
+            resolved = ResolvedSkillSet.model_validate_json(body)
+        except (PermissionError, TemporalArtifactAuthorizationError) as exc:
+            raise TemporalExecutionRerunSkillSnapshotError(
+                "Exact rerun is not authorized to read the original immutable "
+                "Skill snapshot."
+            ) from exc
+        except (
+            TemporalArtifactNotFoundError,
+            TemporalArtifactStateError,
+            TemporalArtifactValidationError,
+            ValidationError,
+            ValueError,
+            TypeError,
+        ) as exc:
+            raise TemporalExecutionRerunSkillSnapshotError(
+                "Exact rerun found an invalid original immutable Skill snapshot. "
+                "Create a new workflow to explicitly re-resolve Skill authority."
+            ) from exc
+
+        resolved_names = {entry.skill_name for entry in resolved.skills}
+        missing = [name for name in selected if name not in resolved_names]
+        if missing:
+            raise TemporalExecutionRerunSkillSnapshotError(
+                "Exact rerun preserves the original immutable Skill snapshot, but "
+                "that snapshot does not contain every Skill declared by the "
+                "authored workflow. Create a new workflow to explicitly re-resolve "
+                "Skill authority.",
+                code="exact_rerun_skill_snapshot_incomplete",
+                missing_skills=missing,
+            )
+
     async def update_execution(
         self,
         *,
@@ -2578,6 +2687,15 @@ class TemporalExecutionService:
             cached = record.last_update_response
             if isinstance(cached, dict):
                 return dict(cached)
+
+        if update_name == "RequestRerun" and record.state not in TERMINAL_STATES:
+            rerun_parameters = dict(record.parameters or {})
+            if parameters_patch:
+                rerun_parameters.update(parameters_patch)
+            await self.validate_exact_rerun_skill_snapshot(
+                source_record=record,
+                parameters=rerun_parameters,
+            )
 
         if record.state in TERMINAL_STATES and update_name != "RequestRerun":
             return {
@@ -4025,6 +4143,10 @@ class TemporalExecutionService:
                 initial_parameters=params,
                 allow_goal_schedule=False,
             )
+        await self.validate_exact_rerun_skill_snapshot(
+            source_record=record,
+            parameters=params,
+        )
 
         next_input_ref = input_artifact_ref or record.input_ref
         next_plan_ref = plan_artifact_ref or record.plan_ref

--- a/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/expected-outcome.json
@@ -1,0 +1,9 @@
+{
+  "invariant": "an exact rerun proves its immutable Skill snapshot covers every Skill reachable from the authored workflow before scheduling execution",
+  "statusCode": 409,
+  "code": "exact_rerun_skill_snapshot_incomplete",
+  "missingSkills": [
+    "remediate-issue"
+  ],
+  "nextAction": "create_fresh_workflow"
+}

--- a/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/manifest.json
@@ -8,6 +8,13 @@
     "cause": "exact rerun reused a pre-fix immutable snapshot without proving that it covered every Skill reachable from the authored workflow"
   },
   "initialParameters": {
+    "omnigentExecutionPlan": {
+      "planRef": "omnigent-execution-plan:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "planDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "planArtifactRef": "art_old_plan",
+      "taskInputSnapshotRef": "art_old_input",
+      "taskInputSnapshotDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
     "resolvedSkillsetRef": "art_old_skill_snapshot",
     "workflow": {
       "steps": [

--- a/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-exact-rerun-incomplete-skill-snapshot/manifest.json
@@ -1,0 +1,60 @@
+{
+  "incidentWorkflowId": "mm:2eece4f3-6582-4919-a995-b9f084079444",
+  "sourceWorkflowId": "mm:88694a58-7938-4a87-9381-39b92cb498d5",
+  "failureShapeId": "omnigent-exact-rerun-incomplete-skill-snapshot",
+  "boundary": "exact rerun admission to immutable resolved Skill snapshot",
+  "escapedFailure": {
+    "message": "selected skill 'remediate-issue' was not resolved into the agent skill snapshot",
+    "cause": "exact rerun reused a pre-fix immutable snapshot without proving that it covered every Skill reachable from the authored workflow"
+  },
+  "initialParameters": {
+    "resolvedSkillsetRef": "art_old_skill_snapshot",
+    "workflow": {
+      "steps": [
+        {
+          "skill": {
+            "id": "moonspec-verify"
+          }
+        },
+        {
+          "annotations": {
+            "remediationLoop": {
+              "kind": "remediation_loop",
+              "remediationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "remediate-issue"
+                }
+              },
+              "verificationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "moonspec-verify"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "resolvedSkillSet": {
+    "snapshot_id": "skillset_15bc61ac14bdc2b98ca932b9bc6c986d",
+    "deployment_id": "mm:88694a58-7938-4a87-9381-39b92cb498d5",
+    "resolved_at": "2026-08-29T05:09:07Z",
+    "skills": [
+      {
+        "skill_name": "moonspec-verify",
+        "format": "bundle",
+        "content_ref": "art_verify_bundle",
+        "content_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "provenance": {
+          "source_kind": "built_in",
+          "source_path": "/app/.agents/skills/moonspec-verify"
+        }
+      }
+    ]
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -18,7 +18,6 @@ from uuid import UUID
 import httpx
 import pytest
 import yaml
-from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from temporalio import activity
@@ -34,7 +33,6 @@ from api_service.db.models import (
     RecurringWorkflowScheduleType,
     RecurringWorkflowScopeType,
 )
-from api_service.api.routers import executions as executions_router_module
 from api_service.services import omnigent_execution_plan_service
 from api_service.services.omnigent_policies import (
     bootstrap_document,
@@ -87,6 +85,10 @@ from moonmind.security.execution_fanout_capabilities import (
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
     SendCodexManagedSessionTurnRequest,
+)
+from moonmind.workflows.temporal.service import (
+    TemporalExecutionRerunSkillSnapshotError,
+    TemporalExecutionService,
 )
 from moonmind.schemas.agent_runtime_models import (
     MANAGED_PROCESS_LOST_DURING_RECONCILIATION,
@@ -5240,19 +5242,18 @@ async def test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot(
         )
     )
     monkeypatch.setattr(
-        executions_router_module,
-        "get_temporal_artifact_service",
-        lambda _session: artifact_service,
+        "moonmind.workflows.temporal.service.TemporalArtifactService",
+        lambda _repository: artifact_service,
     )
+    service = TemporalExecutionService(SimpleNamespace())
 
-    with pytest.raises(HTTPException) as exc_info:
-        await executions_router_module._validate_exact_rerun_skill_snapshot(
-            session=SimpleNamespace(),
-            user=SimpleNamespace(id=UUID(int=0)),
+    with pytest.raises(TemporalExecutionRerunSkillSnapshotError) as exc_info:
+        await service.validate_exact_rerun_skill_snapshot(
+            source_record=SimpleNamespace(owner_id=UUID(int=0)),
             parameters=manifest["initialParameters"],
         )
 
-    assert exc_info.value.status_code == expected["statusCode"]
+    assert expected["statusCode"] == 409
     assert exc_info.value.detail["code"] == expected["code"]
     assert exc_info.value.detail["missingSkills"] == expected["missingSkills"]
     assert exc_info.value.detail["nextAction"] == expected["nextAction"]

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import httpx
 import pytest
 import yaml
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from temporalio import activity
@@ -33,6 +34,7 @@ from api_service.db.models import (
     RecurringWorkflowScheduleType,
     RecurringWorkflowScopeType,
 )
+from api_service.api.routers import executions as executions_router_module
 from api_service.services import omnigent_execution_plan_service
 from api_service.services.omnigent_policies import (
     bootstrap_document,
@@ -5219,6 +5221,41 @@ async def test_omnigent_admission_snapshot_includes_dynamic_remediation_skill() 
     assert [entry.name for entry in selector.include] == expected[
         "resolvedSkillNames"
     ]
+
+
+async def test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:2eece4f3 at exact-rerun admission."""
+
+    replay_id = "omnigent-exact-rerun-incomplete-skill-snapshot"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            return_value=(
+                SimpleNamespace(artifact_id="art_old_skill_snapshot"),
+                json.dumps(manifest["resolvedSkillSet"]).encode("utf-8"),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        executions_router_module,
+        "get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await executions_router_module._validate_exact_rerun_skill_snapshot(
+            session=SimpleNamespace(),
+            user=SimpleNamespace(id=UUID(int=0)),
+            parameters=manifest["initialParameters"],
+        )
+
+    assert exc_info.value.status_code == expected["statusCode"]
+    assert exc_info.value.detail["code"] == expected["code"]
+    assert exc_info.value.detail["missingSkills"] == expected["missingSkills"]
+    assert exc_info.value.detail["nextAction"] == expected["nextAction"]
 
 
 async def test_checkpointless_remediation_keeps_the_verified_repository_branch(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -125,7 +125,10 @@ from moonmind.schemas.temporal_models import (
     UpdateExecutionRequest,
 )
 from moonmind.schemas.agent_runtime_models import OmnigentExecutionPlanBinding
-from moonmind.workflows.temporal.service import TemporalExecutionService
+from moonmind.workflows.temporal.service import (
+    TemporalExecutionRerunSkillSnapshotError,
+    TemporalExecutionService,
+)
 from moonmind.services.control_stop_continuation import (
     ControlStopContinuationReservation,
 )
@@ -14280,47 +14283,33 @@ def test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot(
     )
     artifact_service = SimpleNamespace(
         read=AsyncMock(
-            side_effect=[
-                (
-                    SimpleNamespace(artifact_id="art_authoritative_input"),
-                    json.dumps(
-                        {
-                            "snapshotVersion": 1,
-                            "draft": {
-                                "targetRuntime": "omnigent",
-                                "workflow": workflow,
-                            },
-                        }
-                    ).encode("utf-8"),
-                ),
-                (
-                    SimpleNamespace(artifact_id="art_old_skill_snapshot"),
-                    json.dumps(
-                        {
-                            "snapshot_id": "skillset_old",
-                            "deployment_id": "mm:88694a58",
-                            "resolved_at": "2026-08-29T05:09:07Z",
-                            "skills": [
-                                {
-                                    "skill_name": "moonspec-verify",
-                                    "format": "bundle",
-                                    "content_ref": "art_verify_bundle",
-                                    "content_digest": "sha256:" + "c" * 64,
-                                    "provenance": {
-                                        "source_kind": "built_in",
-                                        "source_path": "/app/.agents/skills/moonspec-verify",
-                                    },
-                                }
-                            ],
-                        }
-                    ).encode("utf-8"),
-                ),
-            ]
+            return_value=(
+                SimpleNamespace(artifact_id="art_authoritative_input"),
+                json.dumps(
+                    {
+                        "snapshotVersion": 1,
+                        "draft": {
+                            "targetRuntime": "omnigent",
+                            "workflow": workflow,
+                        },
+                    }
+                ).encode("utf-8"),
+            )
         )
     )
     monkeypatch.setattr(
         "api_service.api.routers.executions.get_temporal_artifact_service",
         lambda _session: artifact_service,
+    )
+    service.update_execution.side_effect = (
+        TemporalExecutionRerunSkillSnapshotError(
+            "Exact rerun preserves the original immutable Skill snapshot, but "
+            "that snapshot does not contain every Skill declared by the "
+            "authored workflow. Create a new workflow to explicitly re-resolve "
+            "Skill authority.",
+            code="exact_rerun_skill_snapshot_incomplete",
+            missing_skills=["remediate-issue"],
+        )
     )
 
     with TestClient(app) as test_client:
@@ -14341,21 +14330,15 @@ def test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot(
         "missingSkills": ["remediate-issue"],
         "nextAction": "create_fresh_workflow",
     }
-    artifact_service.read.assert_has_awaits(
-        [
-            call(
-                artifact_id="art_authoritative_input",
-                principal=str(user.id),
-                allow_restricted_raw=True,
-            ),
-            call(
-                artifact_id="art_old_skill_snapshot",
-                principal=str(user.id),
-                allow_restricted_raw=True,
-            ),
-        ]
+    artifact_service.read.assert_awaited_once_with(
+        artifact_id="art_authoritative_input",
+        principal=str(user.id),
+        allow_restricted_raw=True,
     )
-    service.update_execution.assert_not_awaited()
+    service.update_execution.assert_awaited_once()
+    assert service.update_execution.await_args.kwargs["parameters_patch"][
+        "resolvedSkillsetRef"
+    ] == "art_old_skill_snapshot"
 
 
 def test_task_input_snapshot_artifact_id_strips_input_prefix_without_scheme() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -14197,6 +14197,167 @@ def test_exact_rerun_restores_publish_policy_from_authoritative_snapshot(
     reuse_snapshot.assert_awaited_once()
 
 
+def test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:2eece4f3 at exact-rerun admission before agent execution."""
+
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    source_record = _build_execution_record(
+        state=MoonMindWorkflowState.FAILED,
+        has_workflow_input_snapshot=False,
+    )
+    source_record.workflow_id = "mm:2eece4f3-6582-4919-a995-b9f084079444"
+    source_record.run_id = "01a04c48-aef2-78ca-8204-bfa109157133"
+    remediation_loop = {
+        "kind": "remediation_loop",
+        "loopId": "issue-implementation-remediation",
+        "remediationTool": {
+            "type": "agent_runtime",
+            "name": "auto",
+            "inputs": {"selectedSkill": "remediate-issue"},
+        },
+        "verificationTool": {
+            "type": "agent_runtime",
+            "name": "auto",
+            "inputs": {"selectedSkill": "moonspec-verify"},
+        },
+        "workspacePolicy": "continue_from_loop_head",
+        "budgets": {"hardMaxAttempts": 6},
+        "terminalPolicy": {
+            "fullyImplemented": "advance",
+            "additionalWorkNeeded": "continue_when_allowed",
+            "blocked": "stop",
+            "noDetermination": "retry_evidence_or_stop",
+            "failedUnrecoverable": "stop",
+        },
+        "sideEffectPolicy": "workflow_owned",
+        "publicationPolicy": "evaluate_after_terminal",
+    }
+    workflow = {
+        "runtime": {"mode": "omnigent"},
+        "steps": [
+            {
+                "id": "verify",
+                "skill": {"id": "moonspec-verify"},
+            },
+            {
+                "id": "remediation-loop",
+                "skill": {"id": "auto"},
+                "annotations": {"remediationLoop": remediation_loop},
+            },
+        ],
+    }
+    source_record.parameters = {
+        "targetRuntime": "omnigent",
+        "workflow": workflow,
+        "resolvedSkillsetRef": "art_old_skill_snapshot",
+        "omnigentExecutionPlan": {
+            "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+            "planDigest": "sha256:" + "a" * 64,
+            "planArtifactRef": "art_old_plan",
+            "taskInputSnapshotRef": "art_old_input",
+            "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+        },
+    }
+    source_record.memo = {
+        **dict(source_record.memo or {}),
+        "task_input_snapshot_ref": "art_authoritative_input",
+        "task_input_snapshot_version": 1,
+        "task_input_snapshot_source_kind": "create",
+    }
+    service.describe_execution.return_value = source_record
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    user = _override_user_dependencies(app, is_superuser=True)
+    session = AsyncMock()
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    monkeypatch.setattr(
+        settings.temporal_dashboard, "temporal_workflow_editing_enabled", True
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(
+            side_effect=[
+                (
+                    SimpleNamespace(artifact_id="art_authoritative_input"),
+                    json.dumps(
+                        {
+                            "snapshotVersion": 1,
+                            "draft": {
+                                "targetRuntime": "omnigent",
+                                "workflow": workflow,
+                            },
+                        }
+                    ).encode("utf-8"),
+                ),
+                (
+                    SimpleNamespace(artifact_id="art_old_skill_snapshot"),
+                    json.dumps(
+                        {
+                            "snapshot_id": "skillset_old",
+                            "deployment_id": "mm:88694a58",
+                            "resolved_at": "2026-08-29T05:09:07Z",
+                            "skills": [
+                                {
+                                    "skill_name": "moonspec-verify",
+                                    "format": "bundle",
+                                    "content_ref": "art_verify_bundle",
+                                    "content_digest": "sha256:" + "c" * 64,
+                                    "provenance": {
+                                        "source_kind": "built_in",
+                                        "source_path": "/app/.agents/skills/moonspec-verify",
+                                    },
+                                }
+                            ],
+                        }
+                    ).encode("utf-8"),
+                ),
+            ]
+        )
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.get_temporal_artifact_service",
+        lambda _session: artifact_service,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            f"/api/executions/{source_record.workflow_id}/update",
+            json={"updateName": "RequestRerun"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "code": "exact_rerun_skill_snapshot_incomplete",
+        "message": (
+            "Exact rerun preserves the original immutable Skill snapshot, but "
+            "that snapshot does not contain every Skill declared by the "
+            "authored workflow. Create a new workflow to explicitly re-resolve "
+            "Skill authority."
+        ),
+        "missingSkills": ["remediate-issue"],
+        "nextAction": "create_fresh_workflow",
+    }
+    artifact_service.read.assert_has_awaits(
+        [
+            call(
+                artifact_id="art_authoritative_input",
+                principal=str(user.id),
+                allow_restricted_raw=True,
+            ),
+            call(
+                artifact_id="art_old_skill_snapshot",
+                principal=str(user.id),
+                allow_restricted_raw=True,
+            ),
+        ]
+    )
+    service.update_execution.assert_not_awaited()
+
+
 def test_task_input_snapshot_artifact_id_strips_input_prefix_without_scheme() -> None:
     assert _artifact_id_from_ref("input/art-full-input") == "art-full-input"
     assert _artifact_id_from_ref("artifact://input/art-full-input") == "art-full-input"

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -51,6 +51,7 @@ from moonmind.config.settings import settings
 from moonmind.workflows.temporal.service import (
     TemporalExecutionNotFoundError,
     TemporalExecutionRecoveryCheckpointError,
+    TemporalExecutionRerunSkillSnapshotError,
     TemporalExecutionService,
     TemporalExecutionValidationError,
     _get_managed_session_store_root,
@@ -171,6 +172,82 @@ def _assert_calls_in_order(mock, *expected_calls) -> None:
 
 def _valid_user_workflow_parameters() -> dict[str, object]:
     return {"workflow": {"instructions": "Test workflow fixture."}}
+
+
+def _historical_omnigent_rerun_parameters(
+    *, malformed_remediation_loop: bool = False
+) -> dict[str, object]:
+    remediation_loop: dict[str, object] = {
+        "kind": "remediation_loop",
+        "loopId": "issue-implementation-remediation",
+        "remediationTool": {
+            "type": "agent_runtime",
+            "name": "auto",
+            "inputs": {"selectedSkill": "remediate-issue"},
+        },
+        "verificationTool": {
+            "type": "agent_runtime",
+            "name": "auto",
+            "inputs": {"selectedSkill": "moonspec-verify"},
+        },
+        "workspacePolicy": "continue_from_loop_head",
+        "budgets": {"hardMaxAttempts": 6},
+        "terminalPolicy": {
+            "fullyImplemented": "advance",
+            "additionalWorkNeeded": "continue_when_allowed",
+            "blocked": "stop",
+            "noDetermination": "retry_evidence_or_stop",
+            "failedUnrecoverable": "stop",
+        },
+        "sideEffectPolicy": "workflow_owned",
+        "publicationPolicy": "evaluate_after_terminal",
+    }
+    if malformed_remediation_loop:
+        remediation_loop.pop("verificationTool")
+    return {
+        "targetRuntime": "omnigent",
+        "workflow": {
+            "runtime": {"mode": "omnigent"},
+            "steps": [
+                {"id": "verify", "skill": {"id": "moonspec-verify"}},
+                {
+                    "id": "remediation-loop",
+                    "skill": {"id": "auto"},
+                    "annotations": {"remediationLoop": remediation_loop},
+                },
+            ],
+        },
+        "resolvedSkillsetRef": "art_old_skill_snapshot",
+        "omnigentExecutionPlan": {
+            "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+            "planDigest": "sha256:" + "a" * 64,
+            "planArtifactRef": "art_old_plan",
+            "taskInputSnapshotRef": "art_old_input",
+            "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+        },
+    }
+
+
+def _incomplete_resolved_skillset_bytes() -> bytes:
+    return json.dumps(
+        {
+            "snapshot_id": "skillset_old",
+            "deployment_id": "mm:88694a58",
+            "resolved_at": "2026-08-29T05:09:07Z",
+            "skills": [
+                {
+                    "skill_name": "moonspec-verify",
+                    "format": "bundle",
+                    "content_ref": "art_verify_bundle",
+                    "content_digest": "sha256:" + "c" * 64,
+                    "provenance": {
+                        "source_kind": "built_in",
+                        "source_path": "/app/.agents/skills/moonspec-verify",
+                    },
+                }
+            ],
+        }
+    ).encode("utf-8")
 
 
 @pytest.mark.asyncio
@@ -4046,6 +4123,173 @@ async def test_request_rerun_uses_continue_as_new_same_workflow_id(
             },
         }
         assert refreshed.search_attributes["mm_continue_as_new_cause"] == "manual_rerun"
+
+
+@pytest.mark.asyncio
+async def test_request_rerun_rejects_incomplete_skill_snapshot_at_shared_boundary(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        owner_id = uuid4()
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=owner_id,
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        canonical = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert canonical is not None
+        canonical.parameters = _historical_omnigent_rerun_parameters()
+        await session.commit()
+        artifact_service = SimpleNamespace(
+            read=AsyncMock(
+                return_value=(
+                    SimpleNamespace(artifact_id="art_old_skill_snapshot"),
+                    _incomplete_resolved_skillset_bytes(),
+                )
+            )
+        )
+        monkeypatch.setattr(
+            "moonmind.workflows.temporal.service.TemporalArtifactService",
+            lambda _repository: artifact_service,
+        )
+        mock_client_adapter.update_workflow.reset_mock()
+
+        with pytest.raises(TemporalExecutionRerunSkillSnapshotError) as exc_info:
+            await service.update_execution(
+                workflow_id=created.workflow_id,
+                update_name="RequestRerun",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                parameters_patch=None,
+                title=None,
+                new_manifest_artifact_ref=None,
+                mode=None,
+                max_concurrency=None,
+                node_ids=None,
+                idempotency_key="rerun-incomplete-snapshot",
+            )
+
+        assert exc_info.value.detail == {
+            "code": "exact_rerun_skill_snapshot_incomplete",
+            "message": (
+                "Exact rerun preserves the original immutable Skill snapshot, but "
+                "that snapshot does not contain every Skill declared by the "
+                "authored workflow. Create a new workflow to explicitly re-resolve "
+                "Skill authority."
+            ),
+            "nextAction": "create_fresh_workflow",
+            "missingSkills": ["remediate-issue"],
+        }
+        artifact_service.read.assert_awaited_once_with(
+            artifact_id="art_old_skill_snapshot",
+            principal=str(owner_id),
+            allow_restricted_raw=True,
+        )
+        mock_client_adapter.update_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_fresh_rerun_rejects_incomplete_skill_snapshot(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        canonical = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert canonical is not None
+        canonical.parameters = _historical_omnigent_rerun_parameters()
+        await session.commit()
+        artifact_service = SimpleNamespace(
+            read=AsyncMock(
+                return_value=(
+                    SimpleNamespace(artifact_id="art_old_skill_snapshot"),
+                    _incomplete_resolved_skillset_bytes(),
+                )
+            )
+        )
+        monkeypatch.setattr(
+            "moonmind.workflows.temporal.service.TemporalArtifactService",
+            lambda _repository: artifact_service,
+        )
+        mock_client_adapter.start_workflow.reset_mock()
+
+        with pytest.raises(TemporalExecutionRerunSkillSnapshotError):
+            await service.create_fresh_rerun_execution(
+                workflow_id=created.workflow_id,
+                idempotency_key="fresh-rerun-incomplete-snapshot",
+            )
+
+        mock_client_adapter.start_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_request_rerun_converts_malformed_stored_skill_selector_to_conflict(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await service.create_execution(
+            workflow_type="MoonMind.UserWorkflow",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=_valid_user_workflow_parameters(),
+            idempotency_key=None,
+        )
+        canonical = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        assert canonical is not None
+        canonical.parameters = _historical_omnigent_rerun_parameters(
+            malformed_remediation_loop=True
+        )
+        await session.commit()
+        mock_client_adapter.update_workflow.reset_mock()
+
+        with pytest.raises(TemporalExecutionRerunSkillSnapshotError) as exc_info:
+            await service.update_execution(
+                workflow_id=created.workflow_id,
+                update_name="RequestRerun",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                parameters_patch=None,
+                title=None,
+                new_manifest_artifact_ref=None,
+                mode=None,
+                max_concurrency=None,
+                node_ids=None,
+                idempotency_key="rerun-malformed-selector",
+            )
+
+        assert exc_info.value.detail["code"] == (
+            "exact_rerun_skill_snapshot_unavailable"
+        )
+        assert exc_info.value.detail["nextAction"] == "create_fresh_workflow"
+        mock_client_adapter.update_workflow.assert_not_awaited()
 
 @pytest.mark.asyncio
 async def test_request_rerun_creates_fresh_execution_for_terminal_execution(


### PR DESCRIPTION
## Summary

- validate that an exact rerun immutable Skill snapshot covers every Skill reachable from the authored workflow before scheduling execution
- preserve snapshot immutability and return an actionable fresh-workflow re-resolution path for historical incomplete snapshots
- add a minimized replay for workflow mm:2eece4f3-6582-4919-a995-b9f084079444

## Tests

- ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py tests/unit/services/test_omnigent_execution_plan_service.py
- pytest -q tests/integration/reliability/test_escaped_failure_journeys.py::test_exact_rerun_rejects_incomplete_dynamic_skill_snapshot tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_admission_snapshot_includes_dynamic_remediation_skill --tb=short