### PR TITLE
Accept verified no-commit publication in the generic Omnigent host

### DIFF
--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -630,18 +630,26 @@ class GenericOmnigentHostRealizer:
             current_step_execution_id=step_execution_id,
         )
         push_status = str(publication.get("push_status") or "").strip().lower()
-        if push_status != "pushed":
+        # ``no_commits`` is a canonical terminal publication outcome, not a
+        # dispatch failure. The publisher already proved the workspace head is
+        # exactly the remote base head, so no repository work was lost, and the
+        # durable workflow owns whether a step without commits satisfies its
+        # publish contract -- exactly as it does for the managed-runtime push
+        # boundary. Failing here instead strands workflow-owned side effects
+        # (issue transitions, agent-created pull requests) behind an
+        # unretryable provider error.
+        if push_status not in {"pushed", "no_commits"}:
             raise HarnessPlatformError(
                 "generic Omnigent execution produced no publishable repository output",
                 code="OMNIGENT_REPOSITORY_OUTPUT_MISSING",
             )
         evidence = AcceptedRepositoryEvidence(
-            pushStatus="pushed",
+            pushStatus=push_status,
             branch=publication.get("push_branch"),
             baseBranch=publication.get("push_base_branch"),
             headSha=publication.get("push_head_sha"),
             commitsAheadOfBase=publication.get("push_commit_count"),
-            repositoryChanged=True,
+            repositoryChanged=push_status == "pushed",
             remoteVerified=publication.get("remote_verified"),
             authority="omnigent.generic_host_execution",
         )

--- a/tests/integration/reliability/replays/omnigent-generic-host-verified-no-commit-publication/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-generic-host-verified-no-commit-publication/expected-outcome.json
@@ -1,0 +1,18 @@
+{
+  "invariant": "a remotely verified no-commit publication is canonical terminal repository evidence that continues into the durable workflow publish handoff, and is never reported as a generic dispatch failure",
+  "acceptedRepositoryEvidence": {
+    "schemaVersion": "accepted-repository-evidence/v1",
+    "pushStatus": "no_commits",
+    "commitsAheadOfBase": 0,
+    "repositoryChanged": false,
+    "publicationAuthorized": true,
+    "candidateContaminated": false,
+    "remoteVerified": true,
+    "authority": "omnigent.generic_host_execution"
+  },
+  "resultFailureClass": null,
+  "publicationFeasibilityReason": "no_candidate_change",
+  "publicationFeasible": false,
+  "workflowPublishStatus": "skipped",
+  "staleRemoteEvidenceFailureCode": "OMNIGENT_REPOSITORY_PUBLICATION_UNVERIFIED"
+}

--- a/tests/integration/reliability/replays/omnigent-generic-host-verified-no-commit-publication/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-generic-host-verified-no-commit-publication/manifest.json
@@ -1,0 +1,22 @@
+{
+  "incidentWorkflowId": "mm:1b45c82b-275f-4e4d-ae1a-1bba30e218ff",
+  "failureShapeId": "omnigent-generic-host-verified-no-commit-publication",
+  "boundary": "generic Omnigent host repository publication to durable workflow publish handoff",
+  "escapedFailure": {
+    "message": "generic Omnigent execution produced no publishable repository output",
+    "providerErrorCode": "OMNIGENT_GENERIC_DISPATCH_FAILED",
+    "retryRecommendation": "contact_administrator",
+    "cause": "the generic host realizer required push_status 'pushed' and rejected the canonical remotely verified 'no_commits' publication, so a pull-request handoff step whose implementation commits were already pushed by earlier steps failed the run instead of continuing into the durable workflow publish handoff"
+  },
+  "failedLogicalStepId": "tpl:github-issue-implement:08:a328c02c",
+  "stepRole": "pull-request-handoff",
+  "repository": "MoonLadderStudios/MoonMind",
+  "startingBranch": "moonmind-job-28556e59",
+  "publishMode": "pr",
+  "workspaceRelativePath": "repo",
+  "correlationId": "mm-replay-1b45c82b-generic-no-commit",
+  "sideEffectsStrandedByFailure": [
+    "pull request created by the step agent",
+    "issue transition left in progress by the skipped finalize step"
+  ]
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -61,6 +61,7 @@ from moonmind.omnigent.execute import (
     run_omnigent_execution,
 )
 from moonmind.omnigent.execution_profiles import compile_effective_launch
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from moonmind.omnigent.oauth_host_janitor import OmnigentOAuthHostJanitor
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.oauth_hosts import (
@@ -70,6 +71,10 @@ from moonmind.omnigent.oauth_hosts import (
 from moonmind.omnigent.profile_bound_execution import (
     OmnigentProfileBoundExecutionCoordinator,
     _bind_exact_host,
+)
+from moonmind.omnigent.realizers.generic_host import GenericOmnigentHostRealizer
+from moonmind.omnigent.workspace_publication import (
+    OmnigentWorkspacePublicationService,
 )
 from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
 from moonmind.security.egress import (
@@ -6108,3 +6113,222 @@ async def test_checkpoint_branch_turn_restart_matrix_preserves_exact_once_author
         if event_type == "terminal"
     )
     assert last_host_cleanup < last_profile_release < last_terminal
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run one real git command inside the replayed sandbox workspace."""
+
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _seed_no_commit_publication_repo(
+    *,
+    workspace_root: Path,
+    workspace_id: str,
+    relative_path: str,
+    starting_branch: str,
+) -> tuple[Path, Path]:
+    """Build a real origin/work pair whose head already equals the remote base."""
+
+    origin = workspace_root / "origin.git"
+    origin.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(origin)],
+        capture_output=True,
+        check=True,
+    )
+    repo = workspace_root / "temporal_sandbox" / workspace_id / relative_path
+    repo.mkdir(parents=True)
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        capture_output=True,
+        check=True,
+    )
+    _git(repo, "config", "user.name", "MoonMind Replay")
+    _git(repo, "config", "user.email", "replay@moonmind.local")
+    (repo / "implemented.txt").write_text("work from earlier steps\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "Earlier steps already implemented and pushed this work")
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "origin", "main")
+    # The pull-request handoff step starts on the branch earlier steps published.
+    _git(repo, "checkout", "-B", starting_branch)
+    _git(repo, "push", "origin", starting_branch)
+    _git(repo, "fetch", "origin", "--prune")
+    return repo, origin
+
+
+def _no_commit_publication_request(
+    *,
+    manifest: dict,
+    workspace_id: str,
+) -> AgentExecutionRequest:
+    """Build the exact authored shape the failed handoff step dispatched."""
+
+    correlation_id = manifest["correlationId"]
+    return AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=correlation_id,
+        idempotencyKey=f"{correlation_id}:publication",
+        workspaceSpec={
+            "repository": manifest["repository"],
+            "startingBranch": manifest["startingBranch"],
+            "targetBranch": manifest["startingBranch"],
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": manifest["workspaceRelativePath"],
+            },
+        },
+        parameters={
+            "publishMode": manifest["publishMode"],
+            "repository": manifest["repository"],
+            "repositoryOperation": "write",
+        },
+    )
+
+
+def _no_commit_publication_realizer(
+    workspace_root: Path,
+) -> GenericOmnigentHostRealizer:
+    """Wire the production publisher into the production generic realizer.
+
+    Only the lifecycle collaborators the publication boundary never touches are
+    sentinels; the publisher and the realizer publish decision are real.
+    """
+
+    async def _unused_resolver(_plan: object) -> tuple[object, object]:
+        raise AssertionError("host resolution is outside the publication boundary")
+
+    async def _unused_session_driver(
+        *_args: object, **_kwargs: object
+    ) -> AgentRunResult:
+        raise AssertionError("session driving is outside the publication boundary")
+
+    return GenericOmnigentHostRealizer(
+        runtime_binding_store=SimpleNamespace(),
+        provider_lease_coordinator=SimpleNamespace(),
+        credential_provisioning_service=SimpleNamespace(),
+        host_lease_repository=SimpleNamespace(),
+        host_runtime=SimpleNamespace(),
+        planned_host_resolver=_unused_resolver,
+        session_driver=_unused_session_driver,
+        session_cleanup_service=SimpleNamespace(),
+        workspace_publisher=OmnigentWorkspacePublicationService(
+            workspace_root=workspace_root
+        ),
+    )
+
+
+async def test_verified_no_commit_publication_reaches_the_workflow_publish_handoff(
+    tmp_path: Path,
+) -> None:
+    """Replay mm:1b45c82b across publisher, generic realizer, and workflow.
+
+    The escaped failure was a pull-request handoff step whose implementation
+    commits were already pushed by earlier steps. The publisher proved the
+    workspace head was exactly the remote base head and returned the canonical
+    ``no_commits`` outcome; the generic realizer rejected it and failed the run
+    with ``OMNIGENT_GENERIC_DISPATCH_FAILED``, stranding the pull request the
+    step had already created.
+
+    This replay drives the real publisher against a real git remote so the
+    exact remote-head proof stays load-bearing, then carries the accepted
+    evidence into the durable workflow publish handoff.
+    """
+
+    replay_id = "omnigent-generic-host-verified-no-commit-publication"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_root.mkdir()
+    correlation_id = manifest["correlationId"]
+    workspace_id = hashlib.sha256(
+        f"{correlation_id}:{correlation_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    starting_branch = manifest["startingBranch"]
+    repo, origin = _seed_no_commit_publication_repo(
+        workspace_root=workspace_root,
+        workspace_id=workspace_id,
+        relative_path=manifest["workspaceRelativePath"],
+        starting_branch=starting_branch,
+    )
+    SandboxWorkspaceRecordStore(workspace_root).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id=correlation_id,
+            step_execution_id=correlation_id,
+            relative_path=manifest["workspaceRelativePath"],
+        )
+    )
+
+    request = _no_commit_publication_request(
+        manifest=manifest, workspace_id=workspace_id
+    )
+    realizer = _no_commit_publication_realizer(workspace_root)
+    # The handoff agent created the pull request and produced no new commits.
+    published = await realizer._publish_repository(
+        request,
+        AgentRunResult(summary="Created the pull request for the pushed work."),
+    )
+
+    assert published.failure_class is expected["resultFailureClass"]
+    assert published.provider_error_code is None
+    assert published.metadata["push_status"] == "no_commits"
+    evidence = published.metadata["acceptedRepositoryEvidence"]
+    for key, value in expected["acceptedRepositoryEvidence"].items():
+        assert evidence[key] == value, key
+    # The recorded head must be the live remote head, not an assumed local one.
+    remote_head = _git(
+        repo, "ls-remote", "origin", f"refs/heads/{starting_branch}"
+    ).split()[0]
+    assert evidence["headSha"] == remote_head == _git(repo, "rev-parse", "HEAD")
+    assert evidence["branch"] == starting_branch
+    assert evidence["baseBranch"] == starting_branch
+
+    # Workflow handoff: the accepted outcome must classify and continue, never
+    # fail the run, so later steps such as the finalize transition still run.
+    parent = MoonMindRunWorkflow()
+    parent._owner_type = "user"
+    parent._owner_id = "generic-no-commit-replay"
+    outputs = dict(published.metadata)
+    feasibility = parent._step_publication_feasibility(SimpleNamespace(outputs=outputs))
+    assert feasibility["feasible"] is expected["publicationFeasible"]
+    assert feasibility["reason"] == expected["publicationFeasibilityReason"]
+    parent._record_publish_result(
+        parameters={"publishMode": manifest["publishMode"]},
+        execution_result=SimpleNamespace(outputs=outputs),
+    )
+    assert parent._publish_status == expected["workflowPublishStatus"]
+
+    # Losing the exact remote-head proof must stay fatal: advance the remote
+    # branch behind the workspace's back so the stale local ref still reports
+    # zero commits ahead while the live remote head no longer matches.
+    bystander = tmp_path / "bystander"
+    subprocess.run(
+        ["git", "clone", str(origin), str(bystander)], capture_output=True, check=True
+    )
+    _git(bystander, "config", "user.name", "MoonMind Replay")
+    _git(bystander, "config", "user.email", "replay@moonmind.local")
+    _git(bystander, "checkout", starting_branch)
+    (bystander / "concurrent.txt").write_text(
+        "moved by another actor\n", encoding="utf-8"
+    )
+    _git(bystander, "add", "-A")
+    _git(bystander, "commit", "-m", "Advance the remote base behind the workspace")
+    _git(bystander, "push", "origin", starting_branch)
+
+    with pytest.raises(HarnessPlatformError) as unverified:
+        await realizer._publish_repository(
+            request,
+            AgentRunResult(summary="Created the pull request for the pushed work."),
+        )
+    assert unverified.value.code == expected["staleRemoteEvidenceFailureCode"]

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -1397,8 +1397,11 @@ async def test_host_cleanup_claim_fences_a_stale_activity() -> None:
     )
 
 
-@pytest.mark.asyncio
-async def test_generic_realizer_persists_authority_and_releases_provider_last() -> None:
+async def _generic_publication_harness(
+    publication: dict[str, object],
+) -> SimpleNamespace:
+    """Build the real generic-host realizer around one publication outcome."""
+
     events: list[str] = []
 
     class CountingRuntimeBindings(InMemoryStableRuntimeBindingStore):
@@ -1590,14 +1593,7 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
     class WorkspacePublisher:
         async def publish_request_workspace(self, **_kwargs):
             events.append("workspace-published")
-            return {
-                "push_status": "pushed",
-                "push_branch": "moonmind-job-test",
-                "push_base_branch": "main",
-                "push_head_sha": "a" * 40,
-                "push_commit_count": 1,
-                "remote_verified": True,
-            }
+            return dict(publication)
 
     class TurnCommands:
         async def claim(self, **kwargs):
@@ -1640,6 +1636,45 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
             },
         }
     )
+    return SimpleNamespace(
+        realizer=realizer,
+        publish_request=publish_request,
+        events=events,
+        runtime_store=runtime_store,
+        host_leases=host_leases,
+    )
+
+
+_PUSHED_PUBLICATION: dict[str, object] = {
+    "push_status": "pushed",
+    "push_branch": "moonmind-job-test",
+    "push_base_branch": "main",
+    "push_head_sha": "a" * 40,
+    "push_commit_count": 1,
+    "remote_verified": True,
+}
+
+# The publisher already proved the workspace head is exactly the remote base
+# head, so a step that legitimately adds no commits lost no repository work.
+_NO_COMMIT_PUBLICATION: dict[str, object] = {
+    "push_status": "no_commits",
+    "push_branch": "moonmind-job-test",
+    "push_base_branch": "moonmind-job-test",
+    "push_head_sha": "b" * 40,
+    "push_commit_count": 0,
+    "remote_verified": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_persists_authority_and_releases_provider_last() -> None:
+    harness = await _generic_publication_harness(_PUSHED_PUBLICATION)
+    realizer = harness.realizer
+    publish_request = harness.publish_request
+    events = harness.events
+    runtime_store = harness.runtime_store
+    host_leases = harness.host_leases
+
     result = await realizer.execute(publish_request, _plan("opencode-go/model"))
 
     assert result.summary == "done"
@@ -1660,11 +1695,81 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
     assert host_leases.heartbeat_count >= 1
     assert runtime_store.heartbeat_count >= 1
 
+    assert result.metadata["push_status"] == "pushed"
+    assert result.metadata["acceptedRepositoryEvidence"] == {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "pushed",
+        "branch": "moonmind-job-test",
+        "baseBranch": "main",
+        "headSha": "a" * 40,
+        "commitsAheadOfBase": 1,
+        "repositoryChanged": True,
+        "publicationAuthorized": True,
+        "candidateContaminated": False,
+        "remoteVerified": True,
+        "authority": "omnigent.generic_host_execution",
+    }
+
     first_execution_events = tuple(events)
     replay = await realizer.execute(publish_request, _plan("opencode-go/model"))
 
     assert replay.summary == "done"
     assert events[len(first_execution_events) :] == []
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_accepts_remotely_verified_no_commit_publication() -> (
+    None
+):
+    """A verified no-commit step is a terminal outcome, not a dispatch failure.
+
+    Publication steps such as a pull-request handoff legitimately add no
+    commits because earlier steps already pushed the work. The durable
+    workflow -- not this realizer -- owns whether that satisfies the step's
+    publish contract.
+    """
+
+    harness = await _generic_publication_harness(_NO_COMMIT_PUBLICATION)
+
+    result = await harness.realizer.execute(
+        harness.publish_request, _plan("opencode-go/model")
+    )
+
+    assert result.failure_class is None
+    assert result.provider_error_code is None
+    assert result.metadata["push_status"] == "no_commits"
+    assert result.metadata["acceptedRepositoryEvidence"] == {
+        "schemaVersion": "accepted-repository-evidence/v1",
+        "pushStatus": "no_commits",
+        "branch": "moonmind-job-test",
+        "baseBranch": "moonmind-job-test",
+        "headSha": "b" * 40,
+        "commitsAheadOfBase": 0,
+        "repositoryChanged": False,
+        "publicationAuthorized": True,
+        "candidateContaminated": False,
+        "remoteVerified": True,
+        "authority": "omnigent.generic_host_execution",
+    }
+    # Terminal success must still release every fenced authority in order.
+    assert harness.events[-1] == "command-settled:applied"
+    assert harness.events.index("workspace-published") < harness.events.index(
+        "host-cleaned"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_rejects_unverified_repository_publication() -> None:
+    """Only remotely verified publication outcomes may release the workspace."""
+
+    harness = await _generic_publication_harness({"push_status": "skipped"})
+
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        await harness.realizer.execute(
+            harness.publish_request, _plan("opencode-go/model")
+        )
+
+    assert excinfo.value.code == "OMNIGENT_REPOSITORY_OUTPUT_MISSING"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — diagnosed from failed workflow run `mm:1b45c82b-275f-4e4d-ae1a-1bba30e218ff`.

## Summary

- The generic Omnigent host realizer required `push_status == "pushed"` before releasing the authoritative workspace. A step that legitimately added **no commits** was turned into `HarnessPlatformError(OMNIGENT_REPOSITORY_OUTPUT_MISSING)`, which the activity's broad dispatch handler flattened into `OMNIGENT_GENERIC_DISPATCH_FAILED` / `retryRecommendation: contact_administrator`, failing the entire run.
- `no_commits` is a canonical terminal publication outcome everywhere else in MoonMind. The generic host was the only publication boundary rejecting it:
  - `AcceptedRepositoryEvidence.pushStatus` is typed `Literal["pushed", "no_commits"]`
  - `activity_runtime._accepted_repository_evidence` (managed-runtime push boundary) accepts both
  - `profile_bound_execution` accepts it under `repositoryOutcomePolicy`
  - `run.py` has full workflow-level handling (`_record_publish_result`, `_step_publication_feasibility`, native-PR skip, publish repair)
  - `docs/Workflows/WorkflowFinishSummarySystem.md` declares `NO_COMMIT` a first-class outcome *precisely because* a run may still perform non-repository side effects
- Accept both statuses and emit canonical accepted repository evidence with `repositoryChanged` derived from the status. Any other status still fails — the workspace is released only once publication is remotely verified.

### What actually happened

Workflow `mm:1b45c82b-275f-4e4d-ae1a-1bba30e218ff` (preset `github-issue-implement`, runtime `omnigent`) failed on step 08, the **pull-request handoff**:

1. Steps 01–06 committed and pushed the implementation to `moonmind-job-28556e59` (remote head `33e267cd`).
2. Step 08's agent did its job correctly — it created a non-draft PR (#3837) — and added no new commits.
3. `publish_workspace` ran `git ls-remote`, proved local `HEAD` was **exactly** the remote base head, and returned the canonical `{"push_status": "no_commits", "remote_verified": true}`.
4. `_publish_repository` rejected it. Run failed `FAIL_FAST` with `contact_administrator`.

Step 09 (finalize) never ran, so the created pull request was stranded and issue #3635 was left at `status: in-progress`.

```
agent turn OK ──► publish_workspace ──► no_commits (remote-verified: HEAD == remote base)
                                             │
                    before: ─────────────────┴──► OMNIGENT_REPOSITORY_OUTPUT_MISSING
                                                    └─► OMNIGENT_GENERIC_DISPATCH_FAILED
                                                          └─► run FAILED (contact_administrator)
                    after:  ─────────────────┴──► AcceptedRepositoryEvidence(no_commits,
                                                    repositoryChanged=false)
                                                    └─► durable workflow decides
```

ELI5: the step's job was "create the pull request", not "write more code". MoonMind checked whether new code had been pushed, found none, and declared the whole run broken — even though it had just proved nothing was lost and the PR existed.

## Test Plan

```bash
# 3 targeted tests at the realizer boundary (pushed / no_commits / unverified)
docker run --rm -v "$PWD:/app" -w /app -e PYTHONPATH=/app --user root \
  moonmind-python-tests:local \
  python -m pytest tests/unit/omnigent/test_generic_platform_production_services.py -q
```

- Modified file: **34 passed**.
- Full `tests/unit/omnigent`: **34 failed, 1756 passed, 2 skipped**.
- Unmodified `origin/main` (pristine worktree, same base commit `848b0a63f`): **34 failed, 1754 passed, 2 skipped**.
- The two failure sets are **byte-identical** (`diff` of sorted `^FAILED` node IDs is empty). The 34 are pre-existing environment failures in this checkout (pinned stock Omnigent protocol/host-auth fixtures unavailable); the `+2 passed` delta is exactly the two new tests.

## Demo

N/A — no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

New tests run through the real `GenericOmnigentHostRealizer.execute(...)` production journey, not the private publish helper. The existing full-lifecycle test's fake harness was extracted into `_generic_publication_harness(publication)` so all three publication outcomes exercise the identical authority handoff (claim → provider lease → credentials → host → session → publish → cleanup → settle); the existing test keeps every one of its ordering and replay assertions and now also pins its accepted-evidence payload.

- `..._persists_authority_and_releases_provider_last` — `pushed` (unchanged behavior, evidence now asserted)
- `..._accepts_remotely_verified_no_commit_publication` — the regression: terminal success, `repositoryChanged: false`, fenced authorities still released in order
- `..._rejects_unverified_repository_publication` — `skipped` still raises `OMNIGENT_REPOSITORY_OUTPUT_MISSING`

## Risk notes

- **Publish path.** This widens what the generic host accepts as terminal publication evidence. The safety property is preserved upstream: `push_status: "no_commits"` is only ever produced by `_verified_no_commit_publication`, which raises `OMNIGENT_REPOSITORY_PUBLICATION_UNVERIFIED` unless `git ls-remote` proves the local head is exactly the remote base head. Unverified and `skipped` outcomes still hard-fail before cleanup releases the workspace, so no path can silently discard unpublished work.
- **No Temporal contract change.** No workflow, activity, signal, or update signature changes, and no persisted payload shape changes. `run.py` already handles `push_status: "no_commits"` and `AcceptedRepositoryEvidence` already types it, so in-flight runs need no cutover — the realizer now emits a shape the workflow could already consume.
- No credential, provider-profile, billing, or source-authority behavior is touched.

## Coverage notes

N/A — automated tests cover the change.

## Changelog

Omnigent runs no longer fail when a step legitimately produces no repository commits, such as a pull-request handoff whose work was already pushed by earlier steps.
