### PR TITLE
Restore defensive tier fallback coverage (MoonLadderStudios/MoonMind#3794)

### DIFF
--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -414,6 +414,8 @@ def _resolve_effective_tier(
 
     if fallback_reason and tier_fallback == _FALLBACK_STRICT:
         raise ValueError("requested_model_tier_unavailable")
+    if fallback_reason is None and requested_tier is None:
+        fallback_reason = _MODEL_SOURCE_PROFILE_DEFAULT_TIER
 
     return max(1, min(raw_tier, tier_count)), fallback_reason, source
 

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -248,6 +248,9 @@ def resolve_model_effort(
             advisory_preview,
         )
 
+    if requested_tier is not None and requested_tier < 1:
+        raise ValueError("modelTier must be an integer greater than or equal to 1")
+
     runtime_model, runtime_effort = _runtime_defaults(
         runtime_id,
         workflow_settings=workflow_settings,

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -382,9 +382,7 @@ def _normalize_requested_tier(value: int | None) -> int | None:
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError("modelTier must be an integer greater than or equal to 1")
-    if value < 1:
-        raise ValueError("modelTier must be an integer greater than or equal to 1")
+        raise ValueError("modelTier must be an integer")
     return value
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7826,6 +7826,33 @@ def test_mm1171_create_execution_rejects_invalid_runtime_tier_intent(
     assert "hardOverrideAudit" in response.json()["detail"]["message"]
 
 
+def test_mm1171_create_execution_rejects_below_range_runtime_tier_intent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+    test_client.app.dependency_overrides[get_async_session] = lambda: None
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Reject below-range tier",
+                    "instructions": "Run a workflow.",
+                    "runtime": {"modelTier": 0},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "greater than or equal to 1" in response.json()["detail"]["message"]
+
+
 def test_create_task_shaped_execution_preserves_preset_schedule_provenance(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1199,6 +1199,58 @@ def test_apply_resolved_tier_policy_preserves_original_tier_intent():
     assert resolution["effectiveModelTier"] == 1
 
 
+@pytest.mark.parametrize(
+    ("parameters", "expected_requested_tier", "expected_fallback_reason"),
+    [
+        ({}, None, "profile_default_tier"),
+        ({"modelTier": 2}, 2, None),
+    ],
+)
+def test_apply_resolved_tier_policy_shapes_omitted_and_explicit_default_tiers(
+    parameters,
+    expected_requested_tier,
+    expected_fallback_reason,
+):
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        enabled=True,
+        authState="connected",
+        disabledReason=None,
+        model_tiers=[
+            {
+                "label": "Standard",
+                "model": "tier-1-model",
+                "effort": "medium",
+                "parameters": {"output_format": "text"},
+            },
+            {
+                "label": "Implementation",
+                "model": "tier-2-model",
+                "effort": "high",
+                "parameters": {"output_format": "strict_json"},
+            },
+        ],
+        default_model_tier=2,
+    )
+    request = _make_request(parameters=parameters)
+
+    ManagedRuntimeLauncher._apply_resolved_tier_policy(
+        request=request,
+        profile=profile,
+        strategy=None,
+    )
+
+    assert request.parameters["model"] == "tier-2-model"
+    assert request.parameters["effort"] == "high"
+    assert request.parameters["output_format"] == "strict_json"
+    resolution = request.parameters["metadata"]["moonmind"]["modelEffortResolution"]
+    assert resolution["requestedModelTier"] == expected_requested_tier
+    assert resolution["effectiveModelTier"] == 2
+    assert resolution["fallbackReason"] == expected_fallback_reason
+    assert resolution["resolvedModel"] == "tier-2-model"
+    assert resolution["resolvedEffort"] == "high"
+
+
 def test_apply_resolved_tier_policy_initializes_missing_parameters():
     profile = _make_profile(
         runtime_id="codex_cli",

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -312,6 +312,7 @@ class TestResolveModelEffortTiers:
         assert resolved.effort == "high"
         assert resolved.model_source == "profile_default_tier"
         assert resolved.effort_source == "profile_default_tier"
+        assert resolved.fallback_reason == "profile_default_tier"
 
     def test_requested_tier_below_configured_range_clamps_by_default(self):
         resolved = resolve_model_effort(
@@ -377,6 +378,17 @@ class TestResolveModelEffortTiers:
                 tier_fallback="strict",
                 env={},
             )
+
+    def test_strict_tier_fallback_accepts_in_range_profile_default_tier(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile(default_model_tier=2),
+            tier_fallback="strict",
+            env={},
+        )
+
+        assert resolved.effective_model_tier == 2
+        assert resolved.fallback_reason == "profile_default_tier"
 
     def test_explicit_model_and_effort_bypass_tier_policy(self):
         resolved = resolve_model_effort(

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -327,6 +327,19 @@ class TestResolveModelEffortTiers:
         assert resolved.model == "tier-1-model"
         assert resolved.fallback_reason == "requested_tier_below_configured_range"
 
+    @pytest.mark.parametrize("tier_fallback", ["clamp", "strict"])
+    def test_requested_tier_below_range_without_tiers_is_rejected(
+        self, tier_fallback
+    ):
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            resolve_model_effort(
+                runtime_id="codex_cli",
+                profile=self._profile(model_tiers=[]),
+                requested_model_tier=0,
+                tier_fallback=tier_fallback,
+                env={},
+            )
+
     def test_requested_tier_above_configured_range_clamps_by_default(self):
         resolved = resolve_model_effort(
             runtime_id="codex_cli",

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -299,6 +299,33 @@ class TestResolveModelEffortTiers:
         assert resolved.effective_model_tier == 2
         assert resolved.model == "tier-2-model"
 
+    def test_omitted_requested_tier_uses_profile_default_tier(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile(default_model_tier=2),
+            env={},
+        )
+
+        assert resolved.requested_model_tier is None
+        assert resolved.effective_model_tier == 2
+        assert resolved.model == "tier-2-model"
+        assert resolved.effort == "high"
+        assert resolved.model_source == "profile_default_tier"
+        assert resolved.effort_source == "profile_default_tier"
+
+    def test_requested_tier_below_configured_range_clamps_by_default(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile(),
+            requested_model_tier=0,
+            env={},
+        )
+
+        assert resolved.requested_model_tier == 0
+        assert resolved.effective_model_tier == 1
+        assert resolved.model == "tier-1-model"
+        assert resolved.fallback_reason == "requested_tier_below_configured_range"
+
     def test_requested_tier_above_configured_range_clamps_by_default(self):
         resolved = resolve_model_effort(
             runtime_id="codex_cli",
@@ -403,8 +430,8 @@ class TestResolveModelEffortTiers:
         assert resolved.effort_source == "task_override"
         assert resolved.fallback_reason is None
 
-    @pytest.mark.parametrize("bad_tier", [0, -1, 1.5, "2", True])
-    def test_model_tier_must_be_integer_greater_than_or_equal_to_1(self, bad_tier):
+    @pytest.mark.parametrize("bad_tier", [1.5, "2", True])
+    def test_model_tier_must_be_integer(self, bad_tier):
         with pytest.raises(ValueError, match="modelTier"):
             resolve_model_effort(
                 runtime_id="codex_cli",


### PR DESCRIPTION
Issue reference: MoonLadderStudios/MoonMind#3794

Closes MoonLadderStudios/MoonMind#3794

## Summary

- allow the canonical model/effort resolver to defensively clamp below-range integer tiers to Tier 1
- attribute omitted requested tiers to the configured profile default tier, including strict-mode behavior
- add resolver and API regression coverage while preserving submission-time rejection of modelTier values below 1

## Tests run

- `moonmind container python-tests tests/unit/workflows/executions/test_model_resolver.py tests/unit/api/routers/test_executions.py` — 493 passed, 42 warnings

## Remaining risks

- The integration suite was not run because this change is isolated to resolver fallback behavior and does not alter Temporal payloads, persistence, external-service boundaries, or deployment paths. No known in-scope functional risks remain.