### PR TITLE
Make strict tier rejection actionable — MoonLadderStudios/MoonMind#3795

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -237,6 +237,7 @@ from moonmind.workflows.temporal.hard_switch_cutover import (
     resolve_user_workflow_start_contract,
 )
 from moonmind.workflows.executions.model_resolver import (
+    RequestedModelTierUnavailableError,
     ResolvedModelEffort,
     resolve_effective_model,
     resolve_model_effort,
@@ -7801,6 +7802,16 @@ def _resolve_runtime_model_effort(
                 advisory_preview=advisory_preview,
                 workflow_settings=settings.workflow,
             )
+        except RequestedModelTierUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail={
+                    "code": exc.code,
+                    "message": str(exc),
+                    "requestedModelTier": exc.requested_model_tier,
+                    "configuredTierCount": exc.configured_tier_count,
+                },
+            ) from exc
         except ValueError as exc:
             raise _invalid_workflow_request(str(exc)) from exc
         return (

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -51,7 +51,10 @@ from moonmind.utils.logging import (
     redact_profile_file_templates,
     redact_sensitive_payload,
 )
-from moonmind.workflows.executions.model_resolver import resolve_model_effort
+from moonmind.workflows.executions.model_resolver import (
+    RequestedModelTierUnavailableError,
+    resolve_model_effort,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -925,6 +928,16 @@ async def preview_model_tiers(
                 tier_fallback=step.tier_fallback or "clamp",
                 require_launch_ready=False,
             )
+        except RequestedModelTierUnavailableError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": exc.code,
+                    "message": str(exc),
+                    "requestedModelTier": exc.requested_model_tier,
+                    "configuredTierCount": exc.configured_tier_count,
+                },
+            ) from exc
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         items.append(

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -30,7 +30,12 @@ from moonmind.workflows.executions.runtime_defaults import (
     resolve_runtime_defaults,
 )
 
-__all__ = ["ResolvedModelEffort", "resolve_effective_model", "resolve_model_effort"]
+__all__ = [
+    "RequestedModelTierUnavailableError",
+    "ResolvedModelEffort",
+    "resolve_effective_model",
+    "resolve_model_effort",
+]
 
 # legacy_run contract — the model_source value "task_override" is persisted in
 # execution parameters/diagnostics; the value renames at the
@@ -46,6 +51,26 @@ _FALLBACK_STRICT = "strict"
 _EFFORT_APPLICATION_UNKNOWN = "unknown"
 _FALLBACK_REQUESTED_TIER_BELOW_RANGE = "requested_tier_below_configured_range"
 _FALLBACK_REQUESTED_TIER_ABOVE_RANGE = "requested_tier_above_configured_range"
+
+
+class RequestedModelTierUnavailableError(ValueError):
+    """A strict tier request cannot be satisfied by the selected profile."""
+
+    code = "requested_model_tier_unavailable"
+
+    def __init__(
+        self,
+        *,
+        requested_model_tier: int,
+        configured_tier_count: int,
+    ) -> None:
+        self.requested_model_tier = requested_model_tier
+        self.configured_tier_count = configured_tier_count
+        tier_label = "tier" if configured_tier_count == 1 else "tiers"
+        super().__init__(
+            f"Requested model tier {requested_model_tier} is unavailable; "
+            f"the selected profile defines {configured_tier_count} {tier_label}."
+        )
 
 
 @dataclass(frozen=True)
@@ -415,7 +440,10 @@ def _resolve_effective_tier(
         fallback_reason = _FALLBACK_REQUESTED_TIER_ABOVE_RANGE
 
     if fallback_reason and tier_fallback == _FALLBACK_STRICT:
-        raise ValueError("requested_model_tier_unavailable")
+        raise RequestedModelTierUnavailableError(
+            requested_model_tier=raw_tier,
+            configured_tier_count=tier_count,
+        )
 
     return max(1, min(raw_tier, tier_count)), fallback_reason, source
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -60,6 +60,7 @@ from api_service.api.routers.executions import (
     update_execution as update_execution_route,
 )
 from api_service.api.routers import executions as executions_module
+from api_service.api.schemas import CreateJobRequest
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from moonmind.omnigent.bridge_store import (
@@ -70,6 +71,8 @@ from api_service.db.models import (
     Base,
     ManagedAgentProviderProfile,
     MoonMindWorkflowState,
+    ProviderProfileAuthState,
+    ProviderProfileSlotLease,
     TemporalExecutionCloseStatus,
     TemporalArtifact,
     TemporalArtifactEncryption,
@@ -7200,9 +7203,142 @@ def test_create_task_shaped_execution_rejects_strict_unavailable_model_tier() ->
         )
 
     assert response.status_code == 422
-    assert response.json()["detail"]["message"] == "requested_model_tier_unavailable"
+    assert response.json()["detail"] == {
+        "code": "requested_model_tier_unavailable",
+        "message": (
+            "Requested model tier 3 is unavailable; "
+            "the selected profile defines 2 tiers."
+        ),
+        "requestedModelTier": 3,
+        "configuredTierCount": 2,
+    }
     mock_service.create_execution.assert_not_awaited()
     app.dependency_overrides.clear()
+
+
+# MoonLadderStudios/MoonMind#3795 — strict tier admission must stop before the
+# durable workflow-start and Provider Profile slot-leasing authority boundaries.
+@pytest.mark.asyncio
+async def test_strict_unavailable_tier_consumes_no_resources_and_default_clamps(
+    tmp_path,
+) -> None:
+    original_backend = settings.workflow.temporal_artifact_backend
+    original_root = settings.workflow.temporal_artifact_root
+    settings.workflow.temporal_artifact_backend = "local_fs"
+    settings.workflow.temporal_artifact_root = str(tmp_path / "artifacts")
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/mm3795_strict_tier.db",
+        future=True,
+    )
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex-provider-profile",
+                    runtime_id="codex_cli",
+                    provider_id="openai",
+                    enabled=True,
+                    auth_state=ProviderProfileAuthState.CONNECTED,
+                    model_tiers=[
+                        {
+                            "label": "Review",
+                            "model": "gpt-5-mini",
+                            "effort": "low",
+                            "parameters": {},
+                            "annotations": {},
+                        },
+                        {
+                            "label": "Implement",
+                            "model": "gpt-5.5",
+                            "effort": "high",
+                            "parameters": {},
+                            "annotations": {},
+                        },
+                    ],
+                    default_model_tier=1,
+                )
+            )
+            await session.commit()
+            service = TemporalExecutionService(session)
+            service._client_adapter.start_workflow = AsyncMock(
+                return_value=SimpleNamespace(run_id="run-mm3795-clamp")
+            )
+            user = SimpleNamespace(
+                id=uuid4(),
+                email="mm3795@example.com",
+                is_active=True,
+                is_superuser=False,
+                roles=[],
+            )
+            request_payload = {
+                "type": "workflow",
+                "payload": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex",
+                    "workflow": {
+                        "instructions": "Implement MoonLadderStudios/MoonMind#3795.",
+                        "runtime": {
+                            "mode": "codex",
+                            "providerProfile": "codex-provider-profile",
+                            "modelTier": 3,
+                            "tierFallback": "strict",
+                        },
+                    },
+                },
+            }
+
+            with pytest.raises(HTTPException) as exc_info:
+                await executions_module._create_execution_from_workflow_request(
+                    request=CreateJobRequest.model_validate(request_payload),
+                    service=service,
+                    user=user,
+                    session=session,
+                    principal_context={},
+                )
+
+            assert exc_info.value.status_code == 422
+            service._client_adapter.start_workflow.assert_not_awaited()
+            execution_rows = (
+                await session.execute(select(TemporalExecutionCanonicalRecord))
+            ).scalars().all()
+            slot_leases = (
+                await session.execute(select(ProviderProfileSlotLease))
+            ).scalars().all()
+            assert execution_rows == []
+            assert slot_leases == []
+
+            del request_payload["payload"]["workflow"]["runtime"]["tierFallback"]
+            clamped = await executions_module._create_execution_from_workflow_request(
+                request=CreateJobRequest.model_validate(request_payload),
+                service=service,
+                user=user,
+                session=session,
+                principal_context={},
+            )
+
+            assert clamped.model == "gpt-5.5"
+            assert clamped.input_parameters["modelTierResolution"] == {
+                "requestedModelTier": 3,
+                "effectiveModelTier": 2,
+                "tierLabel": "Implement",
+                "fallbackReason": "requested_tier_above_configured_range",
+                "resolvedModel": "gpt-5.5",
+                "resolvedEffort": "high",
+                "modelSource": "requested_tier",
+                "effortSource": "requested_tier",
+                "effortApplicationStatus": "unknown",
+                "previewMismatch": False,
+                "providerProfileId": "codex-provider-profile",
+            }
+            service._client_adapter.start_workflow.assert_awaited_once()
+    finally:
+        await engine.dispose()
+        settings.workflow.temporal_artifact_backend = original_backend
+        settings.workflow.temporal_artifact_root = original_root
 
 
 def test_create_task_shaped_execution_preserves_task_title_and_publish_overrides(

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -928,6 +928,48 @@ async def test_provider_profile_model_tier_preview_returns_advisory_resolution(
 
 
 @pytest.mark.asyncio
+async def test_provider_profile_model_tier_preview_preserves_strict_error_code(
+    client_app: AsyncClient, _module_db
+) -> None:
+    profile_id = "tier_preview_strict_error_code"
+    payload = {
+        "profile_id": profile_id,
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "credential_source": "none",
+        "runtime_materialization_mode": "composite",
+        "model_tiers": [
+            {"label": "Plan", "model": "gpt-5-mini", "effort": "low"},
+            {"label": "Implement", "model": "gpt-5.5", "effort": "xhigh"},
+        ],
+        "default_model_tier": 1,
+    }
+
+    async with client_app as client:
+        create_response = await client.post("/api/v1/provider-profiles", json=payload)
+        preview_response = await client.post(
+            f"/api/v1/provider-profiles/{profile_id}/model-tiers:preview",
+            json={
+                "steps": [
+                    {"id": "docs", "modelTier": 3, "tierFallback": "strict"}
+                ]
+            },
+        )
+
+    assert create_response.status_code == 201
+    assert preview_response.status_code == 422
+    assert preview_response.json()["detail"] == {
+        "code": "requested_model_tier_unavailable",
+        "message": (
+            "Requested model tier 3 is unavailable; "
+            "the selected profile defines 2 tiers."
+        ),
+        "requestedModelTier": 3,
+        "configuredTierCount": 2,
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("default_model_tier", [2, True])
 async def test_provider_profile_rejects_invalid_default_model_tier(
     client_app: AsyncClient, _module_db, default_model_tier: object

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from moonmind.workflows.executions.model_resolver import (
+    RequestedModelTierUnavailableError,
     resolve_effective_model,
     resolve_model_effort,
 )
@@ -342,7 +343,7 @@ class TestResolveModelEffortTiers:
         assert resolved.model == "tier-1-model"
 
     def test_strict_tier_fallback_rejects_unavailable_requested_tier(self):
-        with pytest.raises(ValueError, match="requested_model_tier_unavailable"):
+        with pytest.raises(RequestedModelTierUnavailableError) as exc_info:
             resolve_model_effort(
                 runtime_id="codex_cli",
                 profile=self._profile(),
@@ -350,6 +351,10 @@ class TestResolveModelEffortTiers:
                 tier_fallback="strict",
                 env={},
             )
+
+        assert exc_info.value.code == "requested_model_tier_unavailable"
+        assert exc_info.value.requested_model_tier == 3
+        assert exc_info.value.configured_tier_count == 2
 
     def test_explicit_model_and_effort_bypass_tier_policy(self):
         resolved = resolve_model_effort(


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3795

Closes MoonLadderStudios/MoonMind#3795

Summary:
- return a stable requested_model_tier_unavailable error code with the requested tier and configured tier count
- preserve strict rejection before execution creation, workflow start, and Provider Profile slot leasing
- add a SQLite-backed boundary test proving strict rejection consumes no resources while omitted/default clamp resolves to the highest configured tier

Tests run:
- focused unit suite: 7 passed in 45.89s
- focused hermetic integration suite: 1 passed in 25.27s
- git diff --check origin/main...HEAD

Remaining risks:
- verification is focused on the affected resolver and execution-admission boundaries; no full repository test suite was run