### PR TITLE
Source workflow tier previews from backend — MoonLadderStudios/MoonMind#3797

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -108,7 +108,7 @@ describe("deriveExplicitWorkflowTitle", () => {
 });
 
 describe("previewModelTier", () => {
-  it("MM-1173 shows concise fallback copy when requested tier exceeds configured tiers", () => {
+  it("MoonLadderStudios/MoonMind#3797 formats backend-resolved preview values", () => {
     const preview = previewModelTier(
       {
         profile_id: "codex_openai_api",
@@ -117,15 +117,22 @@ describe("previewModelTier", () => {
           { label: "Implement", model: "gpt-5.5", effort: "xhigh" },
         ],
       },
-      "3",
+      {
+        stepId: "workflow",
+        requestedTier: 3,
+        effectiveTier: 2,
+        model: "gpt-backend-preview",
+        effort: "high",
+        fallbackReason: "requested_tier_above_configured_range",
+      },
     );
 
     expect(preview).toMatchObject({
       requestedTier: 3,
       effectiveTier: 2,
       label: "Implement",
-      model: "gpt-5.5",
-      effort: "xhigh",
+      model: "gpt-backend-preview",
+      effort: "high",
       fallbackReason: "requested_tier_above_configured_range",
       warning: "Requested Tier 3, used Tier 2 because the selected profile only defines 2 tiers.",
     });
@@ -21494,8 +21501,40 @@ describe("Task Create runtime switch layout stability", () => {
     resolveClaudeProfiles = null;
     fetchSpy = vi
       .spyOn(window, "fetch")
-      .mockImplementation((input: RequestInfo | URL) => {
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
+        if (
+          url ===
+          "/api/v1/provider-profiles/profile%3Acodex-default/model-tiers:preview"
+        ) {
+          const request = JSON.parse(String(init?.body || "{}")) as {
+            steps?: Array<{
+              id: string;
+              modelTier: number;
+              tierFallback: string;
+            }>;
+          };
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              profileId: "profile:codex-default",
+              advisory: true,
+              items: (request.steps || []).map((step) => ({
+                stepId: step.id,
+                requestedTier: step.modelTier,
+                effectiveTier: step.modelTier > 2 ? 2 : step.modelTier,
+                model: step.id.startsWith("step:")
+                  ? "gpt-step-backend-preview"
+                  : "gpt-backend-preview",
+                effort: step.id.startsWith("step:") ? "medium" : "xhigh",
+                fallbackReason:
+                  step.modelTier > 2
+                    ? "requested_tier_above_configured_range"
+                    : null,
+              })),
+            }),
+          } as Response);
+        }
         if (url.startsWith("/api/v1/provider-profiles")) {
           const runtimeId = new URL(`http://localhost${url}`).searchParams.get(
             "runtime_id",
@@ -21726,6 +21765,95 @@ describe("Task Create runtime switch layout stability", () => {
     expect(request.payload.task.runtime).not.toHaveProperty("tierFallback");
     expect(request.payload.task.runtime).not.toHaveProperty("model");
     expect(request.payload.task.runtime).not.toHaveProperty("effort");
+  });
+
+  it("MoonLadderStudios/MoonMind#3797 previews backend truth and submits tier intent", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+      ).toBe("profile:codex-default");
+    });
+
+    fireEvent.change(screen.getByLabelText("Model tier intent"), {
+      target: { value: "3" },
+    });
+
+    expect(
+      await screen.findByText(
+        "Tier 3 · Default · gpt-backend-preview · xhigh",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Requested Tier 3, used Tier 2 because the selected profile only defines 2 tiers.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+    const primaryStep = screen.getByText("Step 1").closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(
+      within(primaryStep).getByLabelText("Step 1 Model tier intent"),
+      { target: { value: "1" } },
+    );
+    expect(
+      await within(primaryStep).findByText(
+        "Tier 1 · Plan · gpt-step-backend-preview · medium",
+      ),
+    ).toBeTruthy();
+
+    const previewCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) =>
+          String(url) ===
+          "/api/v1/provider-profiles/profile%3Acodex-default/model-tiers:preview",
+      )
+      .at(-1);
+    expect(previewCall).toBeTruthy();
+    expect(JSON.parse(String(previewCall?.[1]?.body || "{}"))).toMatchObject({
+      steps: [
+        { id: "workflow", modelTier: 3, tierFallback: "clamp" },
+        expect.objectContaining({
+          id: expect.stringMatching(/^step:/),
+          modelTier: 1,
+          tierFallback: "clamp",
+        }),
+      ],
+    });
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Launch with backend-previewed tier intent." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+
+    expect(request.payload.task.runtime).toMatchObject({
+      mode: "codex_cli",
+      profileId: "profile:codex-default",
+      modelTier: 3,
+      tierFallback: "clamp",
+    });
+    expect(request.payload.task.runtime).not.toHaveProperty("model");
+    expect(request.payload.task.runtime).not.toHaveProperty("effort");
+    expect(request.payload.task.steps[0].runtime).toMatchObject({
+      modelTier: 1,
+      tierFallback: "clamp",
+    });
+    expect(request.payload.task.steps[0].runtime).not.toHaveProperty("model");
+    expect(request.payload.task.steps[0].runtime).not.toHaveProperty("effort");
   });
 
   it("defaults hard overrides from the selected profile until manually changed", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -21514,6 +21514,23 @@ describe("Task Create runtime switch layout stability", () => {
               tierFallback: string;
             }>;
           };
+          const strictUnavailable = (request.steps || []).find(
+            (step) => step.tierFallback === "strict" && step.modelTier > 2,
+          );
+          if (strictUnavailable) {
+            return Promise.resolve({
+              ok: false,
+              text: async () =>
+                JSON.stringify({
+                  detail: {
+                    code: "requested_model_tier_unavailable",
+                    message: `Requested model tier ${strictUnavailable.modelTier} is unavailable; the selected profile defines 2 tiers.`,
+                    requestedModelTier: strictUnavailable.modelTier,
+                    configuredTierCount: 2,
+                  },
+                }),
+            } as Response);
+          }
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -21854,6 +21871,108 @@ describe("Task Create runtime switch layout stability", () => {
     });
     expect(request.payload.task.steps[0].runtime).not.toHaveProperty("model");
     expect(request.payload.task.steps[0].runtime).not.toHaveProperty("effort");
+  });
+
+  it("surfaces strict-tier preview errors without discarding successful previews", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+      ).toBe("profile:codex-default");
+    });
+
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+    const primaryStep = screen.getByText("Step 1").closest(
+      "section",
+    ) as HTMLElement;
+    fireEvent.change(
+      within(primaryStep).getByLabelText("Step 1 Model tier intent"),
+      { target: { value: "1" } },
+    );
+    fireEvent.change(screen.getByLabelText("Model tier intent"), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByLabelText("Tier fallback"), {
+      target: { value: "strict" },
+    });
+
+    const strictPreviewError = await screen.findByRole("alert", {
+      name: "Workflow model tier preview error",
+    });
+    expect(strictPreviewError.textContent).toContain(
+      "Requested model tier 3 is unavailable; the selected profile defines 2 tiers.",
+    );
+    expect(
+      await within(primaryStep).findByText(
+        "Tier 1 · Plan · gpt-step-backend-preview · medium",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Model tier intent"), {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByLabelText("Tier fallback"), {
+      target: { value: "clamp" },
+    });
+    fireEvent.change(
+      within(primaryStep).getByLabelText("Step 1 Model tier intent"),
+      { target: { value: "3" } },
+    );
+    fireEvent.change(
+      within(primaryStep).getByLabelText("Step 1 Tier fallback"),
+      { target: { value: "strict" } },
+    );
+
+    const stepStrictPreviewError = await within(primaryStep).findByRole(
+      "alert",
+      { name: "Step 1 model tier preview error" },
+    );
+    expect(stepStrictPreviewError.textContent).toContain(
+      "Requested model tier 3 is unavailable; the selected profile defines 2 tiers.",
+    );
+    expect(
+      await screen.findByText(
+        "Tier 1 · Plan · gpt-backend-preview · xhigh",
+      ),
+    ).toBeTruthy();
+
+    const previewRequests = fetchSpy.mock.calls
+      .filter(
+        ([url]) =>
+          String(url) ===
+          "/api/v1/provider-profiles/profile%3Acodex-default/model-tiers:preview",
+      )
+      .map(([, init]) =>
+        JSON.parse(String(init?.body || "{}")) as {
+          steps?: Array<{ id: string; tierFallback: string }>;
+        },
+      );
+    expect(previewRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          steps: [
+            expect.objectContaining({ id: "workflow", tierFallback: "strict" }),
+          ],
+        }),
+        expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              id: expect.stringMatching(/^step:/),
+              tierFallback: "clamp",
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          steps: [
+            expect.objectContaining({
+              id: expect.stringMatching(/^step:/),
+              tierFallback: "strict",
+            }),
+          ],
+        }),
+      ]),
+    );
   });
 
   it("defaults hard overrides from the selected profile until manually changed", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useInRouterContext, useLocation } from "react-router-dom";
 
 import type { BootPayload } from "../boot/parseBootPayload";
+import type { components } from "../generated/openapi";
 import { configQueryDefaults } from "../boot/queryClient";
 import { LoadingPlaceholder } from "../components/dashboard/LoadingPlaceholder";
 import { AttachmentImagePreview } from "../components/AttachmentImagePreview";
@@ -735,6 +736,22 @@ interface ProviderModelEffortTier {
 }
 
 type TierFallbackMode = "clamp" | "strict";
+type ProviderProfileTierPreviewItem =
+  components["schemas"]["ProviderProfileTierPreviewItem"];
+type ProviderProfileTierPreviewResponse =
+  components["schemas"]["ProviderProfileTierPreviewResponse"];
+
+interface ModelTierPreviewSelection {
+  id: string;
+  profileId: string;
+  modelTier: number;
+  tierFallback: TierFallbackMode;
+}
+
+type ProviderProfileTierPreviewLookup = Record<
+  string,
+  ProviderProfileTierPreviewItem
+>;
 
 export interface ModelTierPreview {
   requestedTier: number;
@@ -742,7 +759,7 @@ export interface ModelTierPreview {
   label: string;
   model: string;
   effort: string;
-  fallbackReason: "requested_tier_above_configured_range" | null;
+  fallbackReason: string | null;
   warning: string | null;
 }
 
@@ -778,42 +795,109 @@ function defaultModelTierForProfile(
 
 export function previewModelTier(
   profile: ProviderProfile | undefined,
-  requestedTierValue: string,
+  resolved: ProviderProfileTierPreviewItem | undefined,
 ): ModelTierPreview | null {
-  if (typeof requestedTierValue !== "string") {
+  const requestedTier = resolved?.requestedTier;
+  const effectiveTier = resolved?.effectiveTier;
+  if (
+    !Number.isInteger(requestedTier) ||
+    !Number.isInteger(effectiveTier) ||
+    Number(requestedTier) < 1 ||
+    Number(effectiveTier) < 1
+  ) {
     return null;
   }
-  const requestedTier = Number.parseInt(requestedTierValue.trim(), 10);
-  if (!Number.isInteger(requestedTier) || requestedTier < 1) {
-    return null;
-  }
+  const normalizedRequestedTier = Number(requestedTier);
+  const normalizedEffectiveTier = Number(effectiveTier);
   const tiers = modelTiersForProfile(profile);
-  if (tiers.length === 0) {
-    return {
-      requestedTier,
-      effectiveTier: requestedTier,
-      label: `Tier ${requestedTier}`,
-      model: "backend resolved model",
-      effort: "backend resolved effort",
-      fallbackReason: null,
-      warning: null,
-    };
-  }
-  const effectiveTier = Math.min(requestedTier, tiers.length);
-  const tier = tiers[effectiveTier - 1] || {};
-  const fallbackReason =
-    requestedTier > tiers.length ? "requested_tier_above_configured_range" : null;
+  const tier = tiers[normalizedEffectiveTier - 1] || {};
+  const fallbackReason = resolved?.fallbackReason || null;
+  const configuredTierCount = Array.isArray(profile?.model_tiers) &&
+      profile.model_tiers.length > 0
+    ? profile.model_tiers.length
+    : normalizedEffectiveTier;
   return {
-    requestedTier,
-    effectiveTier,
-    label: tier.label || `Tier ${effectiveTier}`,
-    model: tier.model || "runtime default model",
-    effort: tier.effort || "runtime default effort",
+    requestedTier: normalizedRequestedTier,
+    effectiveTier: normalizedEffectiveTier,
+    label: tier.label || `Tier ${normalizedEffectiveTier}`,
+    model: resolved?.model || "runtime default model",
+    effort: resolved?.effort || "runtime default effort",
     fallbackReason,
     warning: fallbackReason
-      ? `Requested Tier ${requestedTier}, used Tier ${effectiveTier} because the selected profile only defines ${tiers.length} ${tiers.length === 1 ? "tier" : "tiers"}.`
+      ? fallbackReason === "requested_tier_above_configured_range"
+        ? `Requested Tier ${normalizedRequestedTier}, used Tier ${normalizedEffectiveTier} because the selected profile only defines ${configuredTierCount} ${configuredTierCount === 1 ? "tier" : "tiers"}.`
+        : `Requested Tier ${normalizedRequestedTier}, used Tier ${normalizedEffectiveTier} because backend tier policy reported ${fallbackReason}.`
       : null,
   };
+}
+
+function requestedModelTier(value: string): number | null {
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function modelTierPreviewEndpoint(
+  providerProfilesEndpoint: string,
+  profileId: string,
+): string {
+  const queryIndex = providerProfilesEndpoint.search(/[?#]/);
+  const endpointWithoutQuery = queryIndex >= 0
+    ? providerProfilesEndpoint.slice(0, queryIndex)
+    : providerProfilesEndpoint;
+  return `${endpointWithoutQuery.replace(/\/+$/, "")}/${encodeURIComponent(profileId)}/model-tiers:preview`;
+}
+
+async function fetchProviderProfileTierPreviews(
+  providerProfilesEndpoint: string,
+  selections: ModelTierPreviewSelection[],
+): Promise<ProviderProfileTierPreviewLookup> {
+  const selectionsByProfile = new Map<string, ModelTierPreviewSelection[]>();
+  for (const selection of selections) {
+    const existing = selectionsByProfile.get(selection.profileId) || [];
+    existing.push(selection);
+    selectionsByProfile.set(selection.profileId, existing);
+  }
+
+  const responses = await Promise.all(
+    Array.from(selectionsByProfile.entries()).map(
+      async ([profileId, profileSelections]) => {
+        const response = await fetch(
+          modelTierPreviewEndpoint(providerProfilesEndpoint, profileId),
+          {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              steps: profileSelections.map((selection) => ({
+                id: selection.id,
+                modelTier: selection.modelTier,
+                tierFallback: selection.tierFallback,
+              })),
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(
+            await responseErrorMessage(
+              response,
+              "Failed to preview Provider Profile model tiers.",
+            ),
+          );
+        }
+        return (await response.json()) as ProviderProfileTierPreviewResponse;
+      },
+    ),
+  );
+
+  const previews: ProviderProfileTierPreviewLookup = {};
+  for (const response of responses) {
+    for (const item of response.items) {
+      previews[item.stepId] = item;
+    }
+  }
+  return previews;
 }
 
 interface BranchOption {
@@ -6504,6 +6588,59 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       })
     : (providerProfilesQuery.data || []);
 
+  const modelTierPreviewSelections = useMemo<ModelTierPreviewSelection[]>(() => {
+    if (providerProfilesQuery.isPlaceholderData) {
+      return [];
+    }
+    const selections: ModelTierPreviewSelection[] = [];
+    const workflowModelTier = requestedModelTier(modelTier);
+    if (providerProfile && workflowModelTier !== null) {
+      selections.push({
+        id: "workflow",
+        profileId: providerProfile,
+        modelTier: workflowModelTier,
+        tierFallback,
+      });
+    }
+    for (const step of steps) {
+      const stepModelTier = requestedModelTier(step.runtimeModelTier);
+      const stepProfileId =
+        step.runtimeProviderProfile.trim() || providerProfile;
+      if (!stepProfileId || stepModelTier === null) {
+        continue;
+      }
+      selections.push({
+        id: `step:${step.localId}`,
+        profileId: stepProfileId,
+        modelTier: stepModelTier,
+        tierFallback:
+          step.runtimeTierFallback === "strict" ? "strict" : "clamp",
+      });
+    }
+    return selections;
+  }, [
+    modelTier,
+    providerProfile,
+    providerProfilesQuery.isPlaceholderData,
+    steps,
+    tierFallback,
+  ]);
+  const modelTierPreviewsQuery = useQuery({
+    queryKey: [
+      "workflow-start",
+      "provider-profile-model-tier-previews",
+      providerProfilesEndpoint,
+      providerProfilesQuery.dataUpdatedAt,
+      modelTierPreviewSelections,
+    ],
+    enabled: modelTierPreviewSelections.length > 0,
+    queryFn: () =>
+      fetchProviderProfileTierPreviews(
+        providerProfilesEndpoint,
+        modelTierPreviewSelections,
+      ),
+  });
+
   useEffect(() => {
     if (runtime !== "omnigent" || !omnigentCatalogQuery.data) return;
     if (!omnigentExecutionTargetRef) {
@@ -8401,7 +8538,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     );
   const workflowTierPreview = previewModelTier(
     selectedProviderProfileForPreview,
-    modelTier,
+    modelTierPreviewsQuery.data?.workflow,
   );
 
   // MM-936: the primary step always carries the publish-mode capability (gh)
@@ -12777,7 +12914,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   );
               const stepTierPreview = previewModelTier(
                 stepPreviewProfile,
-                step.runtimeModelTier,
+                modelTierPreviewsQuery.data?.[`step:${step.localId}`],
               );
               const jiraTransitionState =
                 jiraTransitionStateByStep[step.localId] || null;

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -753,6 +753,11 @@ type ProviderProfileTierPreviewLookup = Record<
   ProviderProfileTierPreviewItem
 >;
 
+interface ProviderProfileTierPreviewResult {
+  previews: ProviderProfileTierPreviewLookup;
+  errors: Record<string, string>;
+}
+
 export interface ModelTierPreview {
   requestedTier: number;
   effectiveTier: number;
@@ -850,54 +855,92 @@ function modelTierPreviewEndpoint(
 async function fetchProviderProfileTierPreviews(
   providerProfilesEndpoint: string,
   selections: ModelTierPreviewSelection[],
-): Promise<ProviderProfileTierPreviewLookup> {
-  const selectionsByProfile = new Map<string, ModelTierPreviewSelection[]>();
+): Promise<ProviderProfileTierPreviewResult> {
+  const clampSelectionsByProfile = new Map<
+    string,
+    ModelTierPreviewSelection[]
+  >();
+  const requestGroups: Array<{
+    profileId: string;
+    selections: ModelTierPreviewSelection[];
+  }> = [];
   for (const selection of selections) {
-    const existing = selectionsByProfile.get(selection.profileId) || [];
+    if (selection.tierFallback === "strict") {
+      requestGroups.push({
+        profileId: selection.profileId,
+        selections: [selection],
+      });
+      continue;
+    }
+    const existing = clampSelectionsByProfile.get(selection.profileId) || [];
     existing.push(selection);
-    selectionsByProfile.set(selection.profileId, existing);
+    clampSelectionsByProfile.set(selection.profileId, existing);
+  }
+  for (const [profileId, profileSelections] of clampSelectionsByProfile) {
+    requestGroups.push({ profileId, selections: profileSelections });
   }
 
-  const responses = await Promise.all(
-    Array.from(selectionsByProfile.entries()).map(
-      async ([profileId, profileSelections]) => {
-        const response = await fetch(
-          modelTierPreviewEndpoint(providerProfilesEndpoint, profileId),
-          {
-            method: "POST",
-            headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
+  const results = await Promise.all(
+    requestGroups.map(
+      async ({ profileId, selections: profileSelections }) => {
+        const errors: Record<string, string> = {};
+        try {
+          const response = await fetch(
+            modelTierPreviewEndpoint(providerProfilesEndpoint, profileId),
+            {
+              method: "POST",
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                steps: profileSelections.map((selection) => ({
+                  id: selection.id,
+                  modelTier: selection.modelTier,
+                  tierFallback: selection.tierFallback,
+                })),
+              }),
             },
-            body: JSON.stringify({
-              steps: profileSelections.map((selection) => ({
-                id: selection.id,
-                modelTier: selection.modelTier,
-                tierFallback: selection.tierFallback,
-              })),
-            }),
-          },
-        );
-        if (!response.ok) {
-          throw new Error(
-            await responseErrorMessage(
+          );
+          if (!response.ok) {
+            const message = await responseErrorMessage(
               response,
               "Failed to preview Provider Profile model tiers.",
-            ),
-          );
+            );
+            for (const selection of profileSelections) {
+              errors[selection.id] = message;
+            }
+            return { response: null, errors };
+          }
+          return {
+            response:
+              (await response.json()) as ProviderProfileTierPreviewResponse,
+            errors,
+          };
+        } catch (error) {
+          const message = error instanceof Error
+            ? error.message
+            : "Failed to preview Provider Profile model tiers.";
+          for (const selection of profileSelections) {
+            errors[selection.id] = message;
+          }
+          return { response: null, errors };
         }
-        return (await response.json()) as ProviderProfileTierPreviewResponse;
       },
     ),
   );
 
   const previews: ProviderProfileTierPreviewLookup = {};
-  for (const response of responses) {
-    for (const item of response.items) {
-      previews[item.stepId] = item;
+  const errors: Record<string, string> = {};
+  for (const result of results) {
+    Object.assign(errors, result.errors);
+    if (result.response) {
+      for (const item of result.response.items) {
+        previews[item.stepId] = item;
+      }
     }
   }
-  return previews;
+  return { previews, errors };
 }
 
 interface BranchOption {
@@ -8538,8 +8581,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     );
   const workflowTierPreview = previewModelTier(
     selectedProviderProfileForPreview,
-    modelTierPreviewsQuery.data?.workflow,
+    modelTierPreviewsQuery.data?.previews.workflow,
   );
+  const workflowTierPreviewError = modelTierPreviewsQuery.data?.errors.workflow;
 
   // MM-936: the primary step always carries the publish-mode capability (gh)
   // when publishing as a PR, surfaced as a non-removable derived chip.
@@ -12914,8 +12958,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   );
               const stepTierPreview = previewModelTier(
                 stepPreviewProfile,
-                modelTierPreviewsQuery.data?.[`step:${step.localId}`],
+                modelTierPreviewsQuery.data?.previews[`step:${step.localId}`],
               );
+              const stepTierPreviewError =
+                modelTierPreviewsQuery.data?.errors[`step:${step.localId}`];
               const jiraTransitionState =
                 jiraTransitionStateByStep[step.localId] || null;
               const showJiraTransitionOptions =
@@ -13747,6 +13793,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                           ) : null}
                         </div>
                       ) : null}
+                      {stepTierPreviewError ? (
+                        <div
+                          className="notice error small"
+                          role="alert"
+                          aria-label={`Step ${index + 1} model tier preview error`}
+                        >
+                          {stepTierPreviewError}
+                        </div>
+                      ) : null}
                       <label>
                         {`Step ${index + 1} Hard override model`}
                         <input
@@ -14185,6 +14240,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 {workflowTierPreview.warning}
               </span>
             ) : null}
+          </div>
+        ) : null}
+        {workflowTierPreviewError ? (
+          <div
+            className="notice error small"
+            role="alert"
+            aria-label="Workflow model tier preview error"
+          >
+            {workflowTierPreviewError}
           </div>
         ) : null}</>
         ) : null}


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3797

Closes MoonLadderStudios/MoonMind#3797

## Summary
- Request workflow and per-step model-tier previews from the Provider Profile backend preview endpoint.
- Render backend-resolved model, effort, effective tier, and fallback reason instead of resolving tiers in the frontend.
- Preserve modelTier and tierFallback intent in submitted runtime payloads, with positive contract coverage that concrete model/effort values are not substituted.

## Tests run
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-start.test.tsx (153 passed)
- ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/components/settings/ProviderProfilesManager.test.tsx (56 passed)
- moonmind container python-tests tests/unit/api_service/api/routers/test_provider_profiles.py::test_provider_profile_model_tier_preview_returns_advisory_resolution tests/unit/api_service/api/routers/test_provider_profiles.py::test_provider_profile_model_tier_preview_preserves_strict_error_code (2 passed)
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- ./node_modules/.bin/eslint -c frontend/eslint.config.mjs frontend/src/entrypoints/workflow-start.tsx frontend/src/entrypoints/workflow-start.test.tsx

## Remaining risks
- No hermetic integration_ci suite was run because this frontend caller change does not select a listed integration boundary; the HTTP contract is covered by the focused UI mock and backend router tests.
