### PR TITLE
MoonLadderStudios/MoonMind#3798: Detect stale tier preview identity

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -8401,6 +8401,9 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
             for key in ("modelTier", "tierFallback"):
                 if key in validated_runtime:
                     normalized_runtime[key] = validated_runtime[key]
+            tier_preview = validated_runtime.get("tierPreview")
+            if isinstance(tier_preview, Mapping):
+                normalized_runtime["tierPreview"] = dict(tier_preview)
             for key in ("profileSelector", "hardOverrideAudit"):
                 value = validated_runtime.get(key)
                 if isinstance(value, Mapping):
@@ -11303,6 +11306,8 @@ async def _create_execution_from_workflow_request(
         initial_parameters["modelTier"] = runtime_payload.get("modelTier")
     if "tierFallback" in runtime_payload:
         initial_parameters["tierFallback"] = runtime_payload.get("tierFallback")
+    if isinstance(runtime_payload.get("tierPreview"), Mapping):
+        initial_parameters["tierPreview"] = dict(runtime_payload["tierPreview"])
     if isinstance(runtime_payload.get("profileSelector"), Mapping):
         initial_parameters["profileSelector"] = dict(
             runtime_payload["profileSelector"]

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -7778,6 +7778,7 @@ def _resolve_runtime_model_effort(
     profile: Any | None,
     runtime_payload: Mapping[str, Any],
     requested_model: str | None,
+    compare_advisory_preview: bool = True,
 ) -> tuple[str | None, str, str | None, dict[str, Any] | None]:
     requested_tier = _runtime_model_tier(runtime_payload)
     requested_effort = runtime_payload.get("effort")
@@ -7786,7 +7787,8 @@ def _resolve_runtime_model_effort(
     tier_fallback = str(runtime_payload.get("tierFallback") or "clamp")
     advisory_preview = (
         runtime_payload.get("tierPreview")
-        if isinstance(runtime_payload.get("tierPreview"), Mapping)
+        if compare_advisory_preview
+        and isinstance(runtime_payload.get("tierPreview"), Mapping)
         else None
     )
 
@@ -8836,6 +8838,10 @@ async def _resolve_step_runtime_selections(
             profile=provider_profile,
             runtime_payload=runtime_payload,
             requested_model=raw_requested_model,
+            compare_advisory_preview=not (
+                effective_profile_id is None
+                and bool(runtime_payload.get("profileSelector"))
+            ),
         )
 
         resolved_runtime = dict(runtime_payload)
@@ -11266,6 +11272,10 @@ async def _create_execution_from_workflow_request(
         profile=_provider_profile,
         runtime_payload=runtime_payload,
         requested_model=raw_requested_model,
+        compare_advisory_preview=not (
+            raw_profile_id is None
+            and bool(runtime_payload.get("profileSelector"))
+        ),
     )
 
     await _resolve_step_runtime_selections(
@@ -11883,16 +11893,20 @@ async def _resolve_recurring_runtime_metadata(
         field_name="payload.workflow.runtime",
     )
     steps_payload = task_payload.get("steps")
+    normalized_step_tier_previews: dict[int, dict[str, Any]] = {}
     if isinstance(steps_payload, Sequence) and not isinstance(steps_payload, (str, bytes)):
         for index, step_payload in enumerate(steps_payload):
             if not isinstance(step_payload, Mapping):
                 continue
             step_runtime = step_payload.get("runtime")
             if isinstance(step_runtime, Mapping):
-                _validate_runtime_tier_intent_for_submit(
+                validated_step_runtime = _validate_runtime_tier_intent_for_submit(
                     step_runtime,
                     field_name=f"payload.workflow.steps[{index}].runtime",
                 )
+                normalized_preview = validated_step_runtime.get("tierPreview")
+                if isinstance(normalized_preview, Mapping):
+                    normalized_step_tier_previews[index] = dict(normalized_preview)
     authored_runtime = (
         request_payload.get("targetRuntime")
         or parameter_payload.get("targetRuntime")
@@ -11974,6 +11988,10 @@ async def _resolve_recurring_runtime_metadata(
         profile=provider_profile,
         runtime_payload=runtime_payload,
         requested_model=raw_requested_model,
+        compare_advisory_preview=not (
+            raw_profile_id is None
+            and bool(runtime_payload.get("profileSelector"))
+        ),
     )
     metadata: dict[str, Any] = {
         "targetRuntime": canonical_target_runtime,
@@ -11998,6 +12016,11 @@ async def _resolve_recurring_runtime_metadata(
         metadata["tierFallback"] = runtime_payload.get("tierFallback")
     if isinstance(runtime_payload.get("profileSelector"), Mapping):
         metadata["profileSelector"] = dict(runtime_payload["profileSelector"])
+    normalized_preview = runtime_payload.get("tierPreview")
+    if isinstance(normalized_preview, Mapping):
+        metadata["_normalizedTierPreview"] = dict(normalized_preview)
+    if normalized_step_tier_previews:
+        metadata["_normalizedStepTierPreviews"] = normalized_step_tier_previews
     return metadata
 
 
@@ -12061,9 +12084,41 @@ def _stamp_recurring_runtime_metadata(
         runtime_payload["tierFallback"] = runtime_metadata.get("tierFallback")
     if isinstance(runtime_metadata.get("profileSelector"), Mapping):
         runtime_payload["profileSelector"] = dict(runtime_metadata["profileSelector"])
+    if isinstance(runtime_metadata.get("_normalizedTierPreview"), Mapping):
+        runtime_payload["tierPreview"] = dict(
+            runtime_metadata["_normalizedTierPreview"]
+        )
     if runtime_payload:
         task_payload["runtime"] = runtime_payload
-        initial_parameters[task_key] = task_payload
+
+    normalized_step_tier_previews = runtime_metadata.get(
+        "_normalizedStepTierPreviews"
+    )
+    steps_payload = task_payload.get("steps")
+    if isinstance(normalized_step_tier_previews, Mapping) and isinstance(
+        steps_payload, Sequence
+    ) and not isinstance(steps_payload, (str, bytes)):
+        normalized_steps = list(steps_payload)
+        for index, step_payload in enumerate(normalized_steps):
+            preview = normalized_step_tier_previews.get(index)
+            if preview is None:
+                preview = normalized_step_tier_previews.get(str(index))
+            if not isinstance(step_payload, Mapping) or not isinstance(
+                preview, Mapping
+            ):
+                continue
+            normalized_step = dict(step_payload)
+            normalized_step_runtime = (
+                dict(normalized_step.get("runtime"))
+                if isinstance(normalized_step.get("runtime"), Mapping)
+                else {}
+            )
+            normalized_step_runtime["tierPreview"] = dict(preview)
+            normalized_step["runtime"] = normalized_step_runtime
+            normalized_steps[index] = normalized_step
+        task_payload["steps"] = normalized_steps
+
+    initial_parameters[task_key] = task_payload
 
 
 def _build_recurring_target(

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -53,6 +53,7 @@ from moonmind.utils.logging import (
 )
 from moonmind.workflows.executions.model_resolver import (
     RequestedModelTierUnavailableError,
+    provider_profile_version,
     resolve_model_effort,
 )
 
@@ -463,6 +464,7 @@ class ProviderProfileTierPreviewItem(BaseModel):
 
 class ProviderProfileTierPreviewResponse(BaseModel):
     profile_id: str = Field(..., alias="profileId")
+    profile_version: int | str = Field(..., alias="profileVersion")
     advisory: bool = True
     items: list[ProviderProfileTierPreviewItem]
 
@@ -951,7 +953,12 @@ async def preview_model_tiers(
             }
         )
 
-    return {"profileId": profile.profile_id, "advisory": True, "items": items}
+    return {
+        "profileId": profile.profile_id,
+        "profileVersion": provider_profile_version(profile),
+        "advisory": True,
+        "items": items,
+    }
 
 
 @router.post(

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -11320,6 +11320,8 @@ export interface components {
         ProviderProfileTierPreviewResponse: {
             /** Profileid */
             profileId: string;
+            /** Profileversion */
+            profileVersion: number | string;
             /**
              * Advisory
              * @default true

--- a/moonmind/runtime_intent.py
+++ b/moonmind/runtime_intent.py
@@ -5,14 +5,104 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
 MODEL_TIER_KEY = "modelTier"
 TIER_FALLBACK_KEY = "tierFallback"
 HARD_OVERRIDE_AUDIT_KEY = "hardOverrideAudit"
+TIER_PREVIEW_KEY = "tierPreview"
 SUPPORTED_TIER_FALLBACKS = frozenset({"clamp", "strict"})
 
 
 class RuntimeIntentValidationError(ValueError):
     """Raised when authored runtime tier intent is invalid."""
+
+
+class RuntimeTierPreview(BaseModel):
+    """Shape-validated advisory Provider Profile snapshot.
+
+    See MoonLadderStudios/MoonMind#3798.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    profile_id: str = Field(..., alias="profileId")
+    profile_version: int | str = Field(..., alias="profileVersion")
+    model: str | None = Field(..., alias="model")
+    effort: str | None = Field(..., alias="effort")
+    requested_tier: int | None = Field(None, alias="requestedTier")
+    effective_tier: int | None = Field(None, alias="effectiveTier")
+    fallback_reason: str | None = Field(None, alias="fallbackReason")
+
+    @field_validator("profile_id", mode="before")
+    @classmethod
+    def _validate_profile_id(cls, value: object) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("must be a non-empty string")
+        return value.strip()
+
+    @field_validator("profile_version", mode="before")
+    @classmethod
+    def _validate_profile_version(cls, value: object) -> int | str:
+        if isinstance(value, bool) or not isinstance(value, (int, str)):
+            raise ValueError("must be a positive integer or non-empty string")
+        if isinstance(value, int):
+            if value < 1:
+                raise ValueError("must be a positive integer or non-empty string")
+            return value
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("must be a positive integer or non-empty string")
+        return normalized
+
+    @field_validator("model", "effort", mode="before")
+    @classmethod
+    def _validate_optional_resolution_string(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("must be null or a non-empty string")
+        return value.strip()
+
+    @field_validator("requested_tier", "effective_tier", mode="before")
+    @classmethod
+    def _validate_optional_tier(cls, value: object) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError("must be null or an integer greater than or equal to 1")
+        return value
+
+    @field_validator("fallback_reason", mode="before")
+    @classmethod
+    def _validate_optional_fallback_reason(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("must be null or a non-empty string")
+        return value.strip()
+
+
+def _preview_validation_message(
+    *,
+    field_name: str,
+    error: ValidationError,
+) -> str:
+    detail = error.errors(include_url=False)[0]
+    location = ".".join(str(part) for part in detail.get("loc", ()))
+    message = str(detail.get("msg") or "is invalid")
+    if message.startswith("Value error, "):
+        message = message.removeprefix("Value error, ")
+    path = f"{field_name}.{TIER_PREVIEW_KEY}"
+    if location:
+        path = f"{path}.{location}"
+    return f"{path} {message}."
 
 
 def validate_runtime_tier_intent(
@@ -45,6 +135,18 @@ def validate_runtime_tier_intent(
             raise RuntimeIntentValidationError(
                 f"{field_name}.tierFallback must be one of: {supported}."
             )
+    if TIER_PREVIEW_KEY in payload:
+        try:
+            preview = RuntimeTierPreview.model_validate(payload[TIER_PREVIEW_KEY])
+        except ValidationError as exc:
+            raise RuntimeIntentValidationError(
+                _preview_validation_message(field_name=field_name, error=exc)
+            ) from exc
+        payload[TIER_PREVIEW_KEY] = preview.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_unset=True,
+        )
     if HARD_OVERRIDE_AUDIT_KEY in payload:
         hard_override_audit = payload[HARD_OVERRIDE_AUDIT_KEY]
         if not isinstance(hard_override_audit, Mapping) or not hard_override_audit:

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1880,6 +1880,7 @@ class ManagedRuntimeProfile(BaseModel):
 
     runtime_id: str = Field(..., alias="runtimeId", min_length=1)
     profile_id: str | None = Field(None, alias="profileId")
+    profile_version: int | str | None = Field(None, alias="profileVersion")
     provider_id: str | None = Field(None, alias="providerId")
     provider_label: str | None = Field(None, alias="providerLabel")
     auth_mode: str | None = Field(None, alias="authMode")

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -2117,6 +2117,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         )
         return ManagedRuntimeProfile(
             profileId=launch_context.profile_id,
+            profileVersion=profile.get("profile_version"),
             runtimeId=runtime_id,
             providerId=profile.get("provider_id"),
             providerLabel=profile.get("provider_label"),

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -739,6 +739,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 else None
             ),
         )
+        launch_profile = self._profile_for_launch(
+            runtime_id=runtime_id,
+            profile=profile,
+            launch_context=launch_context,
+        )
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -756,11 +761,19 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     principalType="service",
                 )
             ),
-            profile=self._profile_for_launch(
-                runtime_id=runtime_id,
-                profile=profile,
-                launch_context=launch_context,
-            ),
+            profile=launch_profile,
+        )
+        # Managed sessions bypass ManagedRuntimeLauncher.launch(), so apply its
+        # authoritative launch-boundary tier resolution explicitly before the
+        # turn payload is created. The current selected profile, not admission
+        # model/effort snapshots, owns the values sent to Codex.
+        from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+        from moonmind.workflows.temporal.runtime.strategies import get_strategy
+
+        ManagedRuntimeLauncher._apply_resolved_tier_policy(
+            request=request,
+            profile=launch_profile,
+            strategy=get_strategy(runtime_id),
         )
         locator = self._locator_from_state(
             session_state=session_handle.session_state,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -1115,6 +1115,7 @@ class ManagedAgentAdapter:
 
             profile_obj = ManagedRuntimeProfile(
                 profile_id=profile_id,
+                profile_version=profile.get("profile_version"),
                 runtime_id=runtime_id_for_profile,
                 provider_id=profile.get("provider_id"),
                 provider_label=profile.get("provider_label"),

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -19,6 +19,7 @@ from pydantic import (
 )
 
 from moonmind.config.settings import settings
+from moonmind.runtime_intent import RuntimeTierPreview
 from moonmind.services.skill_resolution import (
     extract_publish_metadata_from_skill_markdown,
     extract_required_capabilities_from_skill_markdown,
@@ -1319,6 +1320,7 @@ class WorkflowRuntimeSelection(BaseModel):
     )
     model_tier: int | None = Field(None, alias="modelTier", ge=1)
     tier_fallback: str | None = Field(None, alias="tierFallback")
+    tier_preview: RuntimeTierPreview | None = Field(None, alias="tierPreview")
 
     @field_validator("mode", mode="before")
     @classmethod

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -23,6 +23,7 @@ Usage::
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from datetime import datetime
 from typing import Any, Mapping
 
 from moonmind.workflows.executions.runtime_defaults import (
@@ -33,6 +34,7 @@ from moonmind.workflows.executions.runtime_defaults import (
 __all__ = [
     "RequestedModelTierUnavailableError",
     "ResolvedModelEffort",
+    "provider_profile_version",
     "resolve_effective_model",
     "resolve_model_effort",
 ]
@@ -224,6 +226,7 @@ def resolve_model_effort(
                 tier_parameters={},
             ),
             advisory_preview,
+            profile=profile,
         )
 
     tiers = _profile_model_tiers(profile)
@@ -271,6 +274,7 @@ def resolve_model_effort(
                 tier_parameters=dict(tier_parameters),
             ),
             advisory_preview,
+            profile=profile,
         )
 
     if requested_tier is not None and requested_tier < 1:
@@ -304,6 +308,7 @@ def resolve_model_effort(
             tier_parameters={},
         ),
         advisory_preview,
+        profile=profile,
     )
 
 
@@ -314,10 +319,14 @@ def _clean(value: Any | None) -> str | None:
 def _with_preview_mismatch(
     resolved: ResolvedModelEffort,
     advisory_preview: Mapping[str, Any] | None,
+    *,
+    profile: Any | None,
 ) -> ResolvedModelEffort:
     if not advisory_preview:
         return resolved
     expected = {
+        "profileId": _clean(_profile_value(profile, "profile_id", "profileId")),
+        "profileVersion": provider_profile_version(profile),
         "requestedTier": resolved.requested_model_tier,
         "effectiveTier": resolved.effective_model_tier,
         "model": resolved.model,
@@ -329,6 +338,49 @@ def _with_preview_mismatch(
         for key, value in expected.items()
     )
     return replace(resolved, preview_mismatch=preview_mismatch)
+
+
+def _profile_value(profile: Any | None, *field_names: str) -> Any | None:
+    if profile is None:
+        return None
+    if isinstance(profile, Mapping):
+        for field_name in field_names:
+            if field_name in profile:
+                return profile.get(field_name)
+        return None
+    for field_name in field_names:
+        value = getattr(profile, field_name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def provider_profile_version(profile: Any | None) -> int | str | None:
+    """Return the explicit or update-stamp version for a resolved profile.
+
+    Provider Profile rows already carry an authoritative ``updated_at`` value.
+    Treating that value as an opaque version lets advisory snapshots detect a
+    policy edit without introducing a second mutable revision counter.
+    """
+
+    value = _profile_value(
+        profile,
+        "profile_version",
+        "profileVersion",
+        "version",
+    )
+    if value is None:
+        value = _profile_value(profile, "updated_at", "updatedAt")
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 1 else None
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    return None
 
 
 def _runtime_defaults(

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3656,6 +3656,9 @@ class TemporalArtifactActivities:
         from moonmind.provider_profiles.model_tiers import (
             coerce_model_effort_tier_policy,
         )
+        from moonmind.workflows.executions.model_resolver import (
+            provider_profile_version,
+        )
 
         async with get_async_session_context() as session:
             stmt = select(ManagedAgentProviderProfile).where(
@@ -3720,6 +3723,7 @@ class TemporalArtifactActivities:
             profiles.append(
                 {
                     "profile_id": row.profile_id,
+                    "profile_version": provider_profile_version(row),
                     "runtime_id": row.runtime_id,
                     "is_default": row.is_default,
                     "provider_id": row.provider_id,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -1891,12 +1891,24 @@ class ManagedRuntimeLauncher:
         requested_model = parameters.get("requestedModel")
         if requested_model is None and requested_tier is None:
             requested_model = parameters.get("model")
+        requested_effort = parameters.get("effort")
+        admission_resolution = parameters.get("modelTierResolution")
+        if (
+            requested_tier is not None
+            and isinstance(admission_resolution, Mapping)
+            and admission_resolution.get("effortSource") != "task_override"
+        ):
+            # Admission stores the resolved tier effort in ``effort``. Do not
+            # reinterpret that snapshot as an authored override after the
+            # selected profile changes before launch. Older payloads without
+            # source evidence retain their previous pass-through behavior.
+            requested_effort = None
         resolved = resolve_model_effort(
             runtime_id=profile.runtime_id,
             profile=profile,
             requested_model_tier=requested_tier,
             requested_model=requested_model,
-            requested_effort=parameters.get("effort"),
+            requested_effort=requested_effort,
             tier_fallback=parameters.get("tierFallback", "clamp"),
             advisory_preview=parameters.get("tierPreview"),
         )
@@ -1923,7 +1935,15 @@ class ManagedRuntimeLauncher:
         if not isinstance(moonmind_metadata, dict):
             moonmind_metadata = {}
             metadata["moonmind"] = moonmind_metadata
-        moonmind_metadata["modelEffortResolution"] = resolved.as_metadata()
+        resolution_metadata = resolved.as_metadata()
+        moonmind_metadata["modelEffortResolution"] = resolution_metadata
+        if requested_tier is not None or isinstance(
+            parameters.get("tierPreview"), Mapping
+        ):
+            parameters["modelTierResolution"] = {
+                **resolution_metadata,
+                "providerProfileId": profile.profile_id,
+            }
 
     @staticmethod
     def _assert_profile_launch_ready(profile: ManagedRuntimeProfile) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7163,6 +7163,72 @@ def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
     app.dependency_overrides.clear()
 
 
+def test_create_task_shaped_execution_defers_selector_preview_comparison() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.create_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    default_profile = SimpleNamespace(
+        profile_id="codex-default",
+        profile_version=11,
+        runtime_id="codex_cli",
+        provider_id="openrouter",
+        default_model_tier=1,
+        model_tiers=[
+            {
+                "label": "Default",
+                "model": "default-model",
+                "effort": "medium",
+            }
+        ],
+    )
+    scalar_result = SimpleNamespace(first=lambda: default_profile)
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        execute=AsyncMock(
+            return_value=SimpleNamespace(scalars=lambda: scalar_result)
+        )
+    )
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=False)
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex",
+                    "workflow": {
+                        "instructions": "Use the selector-owned tier preview.",
+                        "runtime": {
+                            "mode": "codex",
+                            "profileSelector": {"providerId": "openai"},
+                            "modelTier": 1,
+                            "tierPreview": {
+                                "profileId": "codex-openai",
+                                "profileVersion": 17,
+                                "model": "selected-model",
+                                "effort": "high",
+                            },
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    initial_parameters = mock_service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["modelTierResolution"]["providerProfileId"] == (
+        "codex-default"
+    )
+    assert initial_parameters["modelTierResolution"]["previewMismatch"] is False
+    app.dependency_overrides.clear()
+
+
 def test_create_task_shaped_execution_rejects_strict_unavailable_model_tier() -> None:
     app = FastAPI()
     app.include_router(router)
@@ -10499,6 +10565,63 @@ def test_recurring_target_preserves_omnigent_selection_in_initial_parameters() -
     assert target["initialParameters"]["workflow"]["runtime"] == {
         "mode": "omnigent",
         "executionProfileRef": "codex-oauth-profile",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recurring_target_persists_normalized_tier_previews() -> None:
+    request_payload = {
+        "targetRuntime": "codex_cli",
+        "workflow": {
+            "instructions": "Run nightly with normalized preview evidence.",
+            "runtime": {
+                "mode": "codex_cli",
+                "modelTier": 1,
+                "tierPreview": {
+                    "profileId": "  codex-default  ",
+                    "profileVersion": "  version-17  ",
+                    "model": "  gpt-current  ",
+                    "effort": "  high  ",
+                },
+            },
+            "steps": [
+                {
+                    "id": "review",
+                    "runtime": {
+                        "modelTier": 2,
+                        "tierPreview": {
+                            "profileId": "  codex-default  ",
+                            "profileVersion": "  version-17  ",
+                            "model": "  gpt-review  ",
+                            "effort": "  xhigh  ",
+                        },
+                    },
+                }
+            ],
+        },
+    }
+
+    runtime_metadata = await _resolve_recurring_runtime_metadata(
+        request_payload,
+        session=None,
+    )
+    target = _build_recurring_target(
+        request_payload,
+        runtime_metadata=runtime_metadata,
+    )
+
+    stored_workflow = target["initialParameters"]["workflow"]
+    assert stored_workflow["runtime"]["tierPreview"] == {
+        "profileId": "codex-default",
+        "profileVersion": "version-17",
+        "model": "gpt-current",
+        "effort": "high",
+    }
+    assert stored_workflow["steps"][0]["runtime"]["tierPreview"] == {
+        "profileId": "codex-default",
+        "profileVersion": "version-17",
+        "model": "gpt-review",
+        "effort": "xhigh",
     }
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7086,6 +7086,7 @@ def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
         get=AsyncMock(
             return_value=SimpleNamespace(
                 profile_id="codex-provider-profile",
+                profile_version=42,
                 runtime_id="codex_cli",
                 default_model="legacy-default",
                 default_model_tier=1,
@@ -7122,11 +7123,10 @@ def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
                             "providerProfile": "codex-provider-profile",
                             "modelTier": 2,
                             "tierPreview": {
-                                "requestedTier": 2,
-                                "effectiveTier": 2,
-                                "model": "codex-implement-stale",
+                                "profileId": "codex-provider-profile",
+                                "profileVersion": 41,
+                                "model": "codex-implement-current",
                                 "effort": "high",
-                                "fallbackReason": None,
                             },
                         },
                     },
@@ -7141,6 +7141,12 @@ def test_create_task_shaped_execution_records_tier_preview_mismatch() -> None:
     assert initial_parameters["model"] == "codex-implement-current"
     assert initial_parameters["effort"] == "high"
     assert initial_parameters["modelSource"] == "requested_tier"
+    assert initial_parameters["tierPreview"] == {
+        "profileId": "codex-provider-profile",
+        "profileVersion": 41,
+        "model": "codex-implement-current",
+        "effort": "high",
+    }
     assert initial_parameters["modelTierResolution"] == {
         "requestedModelTier": 2,
         "effectiveModelTier": 2,
@@ -7847,6 +7853,12 @@ def test_mm1171_create_execution_preserves_runtime_tier_intent(
                         "profileSelector": {"providerId": "openai"},
                         "modelTier": 2,
                         "tierFallback": "clamp",
+                        "tierPreview": {
+                            "profileId": "codex-openai",
+                            "profileVersion": 17,
+                            "model": "gpt-5.5",
+                            "effort": "high",
+                        },
                     },
                     "steps": [
                         {
@@ -7857,6 +7869,12 @@ def test_mm1171_create_execution_preserves_runtime_tier_intent(
                                 "profileSelector": {"providerId": "openai"},
                                 "modelTier": 3,
                                 "tierFallback": "strict",
+                                "tierPreview": {
+                                    "profileId": "codex-openai",
+                                    "profileVersion": 17,
+                                    "model": "gpt-5.5",
+                                    "effort": "xhigh",
+                                },
                             },
                         }
                     ],
@@ -7876,6 +7894,13 @@ def test_mm1171_create_execution_preserves_runtime_tier_intent(
     assert workflow_runtime["profileSelector"] == {"providerId": "openai"}
     assert workflow_runtime["modelTier"] == 2
     assert workflow_runtime["tierFallback"] == "clamp"
+    assert workflow_runtime["tierPreview"] == {
+        "profileId": "codex-openai",
+        "profileVersion": 17,
+        "model": "gpt-5.5",
+        "effort": "high",
+    }
+    assert initial_parameters["tierPreview"] == workflow_runtime["tierPreview"]
     assert "requestedModel" not in workflow_runtime
     assert "model" not in workflow_runtime
 
@@ -7884,6 +7909,12 @@ def test_mm1171_create_execution_preserves_runtime_tier_intent(
     assert step_runtime["profileSelector"] == {"providerId": "openai"}
     assert step_runtime["modelTier"] == 3
     assert step_runtime["tierFallback"] == "strict"
+    assert step_runtime["tierPreview"] == {
+        "profileId": "codex-openai",
+        "profileVersion": 17,
+        "model": "gpt-5.5",
+        "effort": "xhigh",
+    }
     assert "requestedModel" not in step_runtime
 
 
@@ -7960,6 +7991,33 @@ def test_mm1171_create_execution_rejects_invalid_runtime_tier_intent(
 
     assert response.status_code == 422
     assert "hardOverrideAudit" in response.json()["detail"]["message"]
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "workflow": {
+                    "title": "Reject malformed preview",
+                    "instructions": "Run a workflow.",
+                    "runtime": {
+                        "modelTier": 1,
+                        "tierPreview": {
+                            "profileId": "codex-default",
+                            "profileVersion": {"revision": 1},
+                            "model": "gpt-5.5",
+                            "effort": "high",
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "tierPreview.profileVersion" in response.json()["detail"]["message"]
 
 
 def test_mm1171_create_execution_rejects_below_range_runtime_tier_intent(

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -903,8 +903,12 @@ async def test_provider_profile_model_tier_preview_returns_advisory_resolution(
 
     assert create_response.status_code == 201
     assert preview_response.status_code == 200
-    assert preview_response.json() == {
+    preview_payload = preview_response.json()
+    assert isinstance(preview_payload["profileVersion"], str)
+    assert preview_payload["profileVersion"]
+    assert preview_payload == {
         "profileId": profile_id,
+        "profileVersion": preview_payload["profileVersion"],
         "advisory": True,
         "items": [
             {

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1210,6 +1210,59 @@ def test_apply_resolved_tier_policy_preserves_original_tier_intent():
     assert resolution["effectiveModelTier"] == 1
 
 
+def test_apply_resolved_tier_policy_replaces_stale_admission_resolution():
+    profile = _make_profile(
+        profile_id="codex-current",
+        profile_version=22,
+        runtime_id="codex_cli",
+        enabled=True,
+        authState="connected",
+        disabledReason=None,
+        model_tiers=[
+            {
+                "label": "Current",
+                "model": "current-model",
+                "effort": "xhigh",
+            }
+        ],
+        default_model_tier=1,
+    )
+    request = _make_request(
+        parameters={
+            "modelTier": 1,
+            "model": "stale-model",
+            "effort": "low",
+            "tierPreview": {
+                "profileId": "codex-current",
+                "profileVersion": 22,
+                "model": "current-model",
+                "effort": "xhigh",
+            },
+            "modelTierResolution": {
+                "providerProfileId": "codex-old",
+                "resolvedModel": "stale-model",
+                "resolvedEffort": "low",
+                "effortSource": "requested_tier",
+                "previewMismatch": True,
+            },
+        }
+    )
+
+    ManagedRuntimeLauncher._apply_resolved_tier_policy(
+        request=request,
+        profile=profile,
+        strategy=None,
+    )
+
+    assert request.parameters["model"] == "current-model"
+    assert request.parameters["effort"] == "xhigh"
+    assert request.parameters["modelTierResolution"] == {
+        **request.parameters["metadata"]["moonmind"]["modelEffortResolution"],
+        "providerProfileId": "codex-current",
+    }
+    assert request.parameters["modelTierResolution"]["previewMismatch"] is False
+
+
 @pytest.mark.parametrize(
     ("parameters", "expected_requested_tier", "expected_fallback_reason"),
     [

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -804,6 +804,7 @@ async def test_launch_resolves_raw_model_tier_and_emits_after_spool_reset(
                 assert recorded["requestedModelTier"] == 2
                 assert recorded["resolvedModel"] == "gpt-tier-2"
                 assert recorded["effortApplicationStatus"] == "not_supported"
+                assert recorded["previewMismatch"] is True
 
     class _FakeProcess:
         pid = 1175
@@ -834,11 +835,21 @@ async def test_launch_resolves_raw_model_tier_and_emits_after_spool_reset(
         run_id="run-raw-tier",
         request=_make_request(
             instruction_ref="Implement the issue",
-            parameters={"modelTier": 2, "tierFallback": "clamp"},
+            parameters={
+                "modelTier": 2,
+                "tierFallback": "clamp",
+                "tierPreview": {
+                    "profileId": "codex-profile",
+                    "profileVersion": 6,
+                    "model": "gpt-tier-2",
+                    "effort": "xhigh",
+                },
+            },
         ),
         profile=_make_profile(
             runtime_id="codex",
             profile_id="codex-profile",
+            profile_version=7,
             model_tiers=[
                 {"label": "Fast", "model": "gpt-tier-1", "effort": "medium"},
                 {"label": "Deep", "model": "gpt-tier-2", "effort": "xhigh"},

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3921,7 +3921,21 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
 
     adapter = CodexSessionAdapter(
         profile_fetcher=_fake_profiles(
-            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+            [
+                {
+                    "profile_id": "codex-default",
+                    "profile_version": 22,
+                    "credential_source": "secret_ref",
+                    "model_tiers": [
+                        {
+                            "label": "Current",
+                            "model": "gpt-current",
+                            "effort": "xhigh",
+                        }
+                    ],
+                    "default_model_tier": 1,
+                }
+            ]
         ),
         slot_requester=_async_noop,
         slot_releaser=_async_noop,
@@ -3957,8 +3971,26 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
     request.parameters["_moonmindActiveSkillsDir"] = (
         "/work/runtime/skills_active/snapshot-retry"
     )
-    request.parameters["model"] = "gpt-5.3-codex-spark"
-    request.parameters["effort"] = "xhigh"
+    request.parameters.update(
+        {
+            "modelTier": 1,
+            "model": "gpt-stale",
+            "effort": "low",
+            "tierPreview": {
+                "profileId": "codex-default",
+                "profileVersion": 22,
+                "model": "gpt-current",
+                "effort": "xhigh",
+            },
+            "modelTierResolution": {
+                "providerProfileId": "codex-old",
+                "resolvedModel": "gpt-stale",
+                "resolvedEffort": "low",
+                "effortSource": "requested_tier",
+                "previewMismatch": True,
+            },
+        }
+    )
 
     handle = await adapter.start(request)
 
@@ -3972,8 +4004,12 @@ async def test_start_reuses_existing_workflow_scoped_session_without_launching(
             "wf-user-1:run-user-1:queue-github-issues:execution:2"
         ),
     }
-    assert send_turn_calls[0].model == "gpt-5.3-codex-spark"
+    assert send_turn_calls[0].model == "gpt-current"
     assert send_turn_calls[0].effort == "xhigh"
+    assert request.parameters["modelTierResolution"]["providerProfileId"] == (
+        "codex-default"
+    )
+    assert request.parameters["modelTierResolution"]["previewMismatch"] is False
     assert request.parameters["_moonmindActiveSkillsDir"] == (
         "/work/runtime/skills_active/snapshot-retry"
     )

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -928,6 +928,7 @@ async def test_start_passes_rich_provider_profile_fields_to_launcher() -> None:
     profiles = [
         {
             "profile_id": "codex-openrouter",
+            "profile_version": "2026-08-30T10:00:00+00:00",
             "provider_id": "openrouter",
             "provider_label": "OpenRouter",
             "credential_source": "secret_ref",
@@ -990,6 +991,7 @@ async def test_start_passes_rich_provider_profile_fields_to_launcher() -> None:
     await adapter.start(request)
 
     profile_payload = captured_payload.get("profile") or {}
+    assert profile_payload["profileVersion"] == "2026-08-30T10:00:00+00:00"
     assert profile_payload.get("providerId") == "openrouter"
     assert profile_payload.get("providerLabel") == "OpenRouter"
     assert profile_payload.get("credentialSource") == "secret_ref"
@@ -1416,6 +1418,8 @@ async def test_provider_profile_list_returns_enabled_profiles(tmp_path: Path):
         profiles = result["profiles"]
         assert len(profiles) == 1
         assert profiles[0]["profile_id"] == "gprofile-1"
+        assert isinstance(profiles[0]["profile_version"], str)
+        assert profiles[0]["profile_version"]
         assert profiles[0]["credential_source"] == "oauth_volume"
         assert profiles[0]["enabled"] is True
         assert profiles[0]["auth_state"] == "connected"

--- a/tests/unit/workflows/executions/test_execution_contract.py
+++ b/tests/unit/workflows/executions/test_execution_contract.py
@@ -1174,6 +1174,62 @@ def test_task_step_accepts_per_step_runtime_selection() -> None:
     assert spec.runtime.effort == "low"
     assert spec.runtime.provider_profile == "claude-default"
 
+
+def test_task_step_accepts_and_normalizes_tier_preview_snapshot() -> None:
+    spec = WorkflowStepSpec.model_validate(
+        {
+            "id": "review",
+            "instructions": "Review with the previewed profile policy.",
+            "runtime": {
+                "modelTier": 2,
+                "tierPreview": {
+                    "profileId": "codex-default",
+                    "profileVersion": "2026-08-30T10:00:00+00:00",
+                    "model": "gpt-5.5",
+                    "effort": "high",
+                },
+            },
+        }
+    )
+
+    assert spec.runtime is not None
+    dumped = spec.runtime.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["tierPreview"] == {
+        "profileId": "codex-default",
+        "profileVersion": "2026-08-30T10:00:00+00:00",
+        "model": "gpt-5.5",
+        "effort": "high",
+    }
+
+
+@pytest.mark.parametrize(
+    "tier_preview",
+    [
+        {"profileVersion": 1, "model": "gpt-5.5", "effort": "high"},
+        {
+            "profileId": "codex-default",
+            "profileVersion": True,
+            "model": "gpt-5.5",
+            "effort": "high",
+        },
+        {
+            "profileId": "codex-default",
+            "profileVersion": 1,
+            "model": {"name": "gpt-5.5"},
+            "effort": "high",
+        },
+    ],
+)
+def test_task_step_rejects_invalid_tier_preview_snapshot(tier_preview: object) -> None:
+    with pytest.raises(ValidationError, match="tierPreview"):
+        WorkflowStepSpec.model_validate(
+            {
+                "id": "review",
+                "instructions": "Reject an invalid preview.",
+                "runtime": {"modelTier": 2, "tierPreview": tier_preview},
+            }
+        )
+
 def test_mm569_accepts_executable_tool_and_skill_payload_fixtures() -> None:
     result = build_canonical_workflow_view(
         job_type="task",

--- a/tests/unit/workflows/executions/test_model_resolver.py
+++ b/tests/unit/workflows/executions/test_model_resolver.py
@@ -247,6 +247,8 @@ class TestPrecedenceOrder:
 class TestResolveModelEffortTiers:
     def _profile(self, **overrides):
         profile = {
+            "profile_id": "codex-profile",
+            "profile_version": 42,
             "enabled": True,
             "auth_state": "connected",
             "default_model": None,
@@ -360,6 +362,8 @@ class TestResolveModelEffortTiers:
             profile=self._profile(),
             requested_model_tier=2,
             advisory_preview={
+                "profileId": "codex-profile",
+                "profileVersion": 42,
                 "requestedTier": 2,
                 "effectiveTier": 2,
                 "model": "stale-model",
@@ -371,6 +375,47 @@ class TestResolveModelEffortTiers:
 
         assert resolved.preview_mismatch is True
         assert resolved.as_metadata()["previewMismatch"] is True
+
+    def test_matching_advisory_preview_profile_identity_is_not_a_mismatch(self):
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile(),
+            requested_model_tier=2,
+            advisory_preview={
+                "profileId": "codex-profile",
+                "profileVersion": 42,
+                "model": "tier-2-model",
+                "effort": "high",
+            },
+            env={},
+        )
+
+        assert resolved.preview_mismatch is False
+
+    @pytest.mark.parametrize(
+        ("identity_field", "stale_value"),
+        [("profileId", "other-profile"), ("profileVersion", 41)],
+    )
+    def test_advisory_preview_profile_identity_mismatch_is_detected(
+        self, identity_field, stale_value
+    ):
+        advisory_preview = {
+            "profileId": "codex-profile",
+            "profileVersion": 42,
+            "model": "tier-2-model",
+            "effort": "high",
+        }
+        advisory_preview[identity_field] = stale_value
+
+        resolved = resolve_model_effort(
+            runtime_id="codex_cli",
+            profile=self._profile(),
+            requested_model_tier=2,
+            advisory_preview=advisory_preview,
+            env={},
+        )
+
+        assert resolved.preview_mismatch is True
 
     def test_advisory_preview_can_resolve_non_launch_ready_profile(self):
         resolved = resolve_model_effort(


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3798

Closes MoonLadderStudios/MoonMind#3798

## Summary

- Declare and shape-validate the optional runtime.tierPreview advisory snapshot.
- Compare profileId and profileVersion alongside resolved tier, model, and effort metadata without trusting preview launch values.
- Carry tierPreview and the resolved profile version through task normalization, provider preview responses, managed-runtime profiles, and the launch boundary.
- Add focused contract, resolver, API, adapter, and launcher regression coverage.

## Tests run

- moonmind container python-tests tests/unit/workflows/executions/test_model_resolver.py tests/unit/workflows/executions/test_execution_contract.py tests/unit/api/routers/test_executions.py tests/unit/api_service/api/routers/test_provider_profiles.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/adapters/test_managed_agent_adapter.py — 911 passed.
- moonmind container python-tests tests/integration/api/test_execution_contract_normalization.py — 18 passed.
- git diff --check origin/main...HEAD — passed.

## Remaining risks

- The verifier identified possible non-blocking documentation drift: the optional preview endpoint example in docs/Security/ProviderProfileModelEffortTiers.md does not yet show profileVersion.
- Strict 409 stale_profile_tiers rejection remains intentionally deferred and is not part of this change.