### PR TITLE
Complete tier launch-boundary validation for MoonLadderStudios/MoonMind#3799

### DIFF
--- a/moonmind/provider_profiles/model_tiers.py
+++ b/moonmind/provider_profiles/model_tiers.py
@@ -65,8 +65,7 @@ class ProviderModelEffortTier(BaseModel):
     def _reject_raw_credential_keys(
         cls, value: dict[str, Any]
     ) -> dict[str, Any]:
-        if _contains_sensitive_key(value):
-            raise ValueError("tier metadata must not contain raw credential-like keys")
+        ensure_tier_metadata_is_credential_free(value)
         return value
 
 
@@ -210,6 +209,13 @@ def coerce_model_effort_tier_policy(
     if normalized_default < 1 or normalized_default > len(normalized):
         raise ValueError("default_model_tier must be within configured model_tiers")
     return normalized, normalized_default
+
+
+def ensure_tier_metadata_is_credential_free(value: Any) -> None:
+    """Reject credential-like keys or values in tier-controlled metadata."""
+
+    if _contains_sensitive_key(value):
+        raise ValueError("tier metadata must not contain raw credential-like keys")
 
 
 def _contains_sensitive_key(value: Any) -> bool:

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1873,6 +1873,9 @@ class RuntimeFileTemplate(BaseModel):
         self.merge_strategy = normalized_merge
         return self
 
+MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION = 1
+
+
 class ManagedRuntimeProfile(BaseModel):
     """Runtime-specific execution parameters for managed agent launches."""
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -141,6 +141,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunStatus,
     AgentRunResult,
+    MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION,
     ManagedRunRecord,
     ManagedRuntimeProfile,
     extract_durable_retrieval_metadata,
@@ -8169,6 +8170,23 @@ class TemporalAgentRuntimeActivities:
         if not run_id or request_data is None or profile_data is None:
             raise TemporalActivityRuntimeError("Payload must contain 'run_id', 'request', and 'profile'")
 
+        profile_tier_policy_version = payload.get("profile_tier_policy_version")
+        if profile_tier_policy_version is not None and (
+            isinstance(profile_tier_policy_version, bool)
+            or profile_tier_policy_version
+            != MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION
+        ):
+            raise TemporalActivityRuntimeError(
+                "profile_tier_policy_version must be 1 when provided"
+            )
+        # Missing version is reserved for an already-scheduled, pre-cutover
+        # Activity payload. New AgentRun histories always stamp the version
+        # behind a Temporal patch marker before scheduling this Activity.
+        require_model_tiers = (
+            profile_tier_policy_version
+            == MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION
+        )
+
         request = AgentExecutionRequest(**request_data)
         profile = ManagedRuntimeProfile(**profile_data)
         workspace_path = payload.get("workspace_path")
@@ -8216,6 +8234,7 @@ class TemporalAgentRuntimeActivities:
             request=request,
             profile=profile,
             workspace_path=workspace_path,
+            require_model_tiers=require_model_tiers,
         )
 
         if workflow_id:

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -1901,6 +1901,21 @@ class ManagedRuntimeLauncher:
             advisory_preview=parameters.get("tierPreview"),
         )
 
+        from moonmind.provider_profiles.model_tiers import (
+            ensure_tier_metadata_is_credential_free,
+        )
+
+        try:
+            ensure_tier_metadata_is_credential_free(resolved.tier_parameters)
+        except ValueError as exc:
+            profile_ref = str(
+                profile.profile_id or profile.runtime_id or "profile"
+            ).strip()
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: "
+                "resolved tier parameters must not contain raw credentials"
+            ) from exc
+
         # Tier values are defaults. Explicit step parameters retain authority.
         for key, value in resolved.tier_parameters.items():
             parameters.setdefault(key, value)
@@ -1954,6 +1969,11 @@ class ManagedRuntimeLauncher:
             raise RuntimeError(
                 f"Provider profile {profile_ref!r} is not launch-ready: "
                 "launch_ready=False"
+            )
+        if not profile.model_tiers:
+            raise RuntimeError(
+                f"Provider profile {profile_ref!r} is not launch-ready: "
+                "model_tiers must contain at least one tier"
             )
         readiness = profile.command_behavior.get("auth_readiness")
         if isinstance(readiness, Mapping):

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -1961,7 +1961,11 @@ class ManagedRuntimeLauncher:
             }
 
     @staticmethod
-    def _assert_profile_launch_ready(profile: ManagedRuntimeProfile) -> None:
+    def _assert_profile_launch_ready(
+        profile: ManagedRuntimeProfile,
+        *,
+        require_model_tiers: bool = True,
+    ) -> None:
         """Re-check compact Provider Profile readiness at the launch boundary."""
 
         profile_ref = str(profile.profile_id or profile.runtime_id or "profile").strip()
@@ -1990,11 +1994,17 @@ class ManagedRuntimeLauncher:
                 f"Provider profile {profile_ref!r} is not launch-ready: "
                 "launch_ready=False"
             )
-        if not profile.model_tiers:
-            raise RuntimeError(
-                f"Provider profile {profile_ref!r} is not launch-ready: "
-                "model_tiers must contain at least one tier"
-            )
+        if require_model_tiers:
+            if not profile.model_tiers:
+                raise RuntimeError(
+                    f"Provider profile {profile_ref!r} is not launch-ready: "
+                    "model_tiers must contain at least one tier"
+                )
+            if profile.default_model_tier > len(profile.model_tiers):
+                raise RuntimeError(
+                    f"Provider profile {profile_ref!r} is not launch-ready: "
+                    "default_model_tier must be within configured model_tiers"
+                )
         readiness = profile.command_behavior.get("auth_readiness")
         if isinstance(readiness, Mapping):
             launch_ready = readiness.get("launch_ready")
@@ -2103,6 +2113,7 @@ class ManagedRuntimeLauncher:
         request: AgentExecutionRequest,
         profile: ManagedRuntimeProfile,
         workspace_path: str | Path | None = None,
+        require_model_tiers: bool = True,
     ) -> tuple[
         ManagedRunRecord,
         asyncio.subprocess.Process | None,
@@ -2126,7 +2137,10 @@ class ManagedRuntimeLauncher:
 
         from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
         from moonmind.workflows.temporal.runtime.strategies import get_strategy
-        self._assert_profile_launch_ready(profile)
+        self._assert_profile_launch_ready(
+            profile,
+            require_model_tiers=require_model_tiers,
+        )
         strategy = get_strategy(normalize_runtime_id(profile.runtime_id))
         self._apply_resolved_tier_policy(
             request=request,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -27,6 +27,7 @@ with workflow.unsafe.imports_passed_through():
         AgentRunStatus as AgentRunStatusModel,
         ExecutionBudget,
         ExecutionBudgetVerdict,
+        MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION,
         ProfileSelector,
         evaluate_execution_budget,
         resolve_execution_budget,
@@ -111,6 +112,9 @@ TERMINAL_CONTRACT_RUNTIME_FAILURE_AUTHORITY_PATCH_ID = (
 )
 MANAGED_PROCESS_LOSS_RECOVERY_PATCH_ID = (
     "agent-run-managed-process-loss-recovery-v1"
+)
+MANAGED_RUNTIME_PROFILE_TIER_POLICY_PATCH_ID = (
+    "agent-run-managed-runtime-profile-tier-policy-v1"
 )
 CODEX_TURN_RUNTIME_SELECTION_PATCH_ID = (
     "agent-run-codex-turn-runtime-selection-v1"
@@ -5143,12 +5147,19 @@ class MoonMindAgentRun:
                         })
 
                     async def _run_launcher(**kw):
+                        launch_payload = {
+                            **kw.get("payload", {}),
+                            "workflow_id": task_workflow_id,
+                        }
+                        if workflow.patched(
+                            MANAGED_RUNTIME_PROFILE_TIER_POLICY_PATCH_ID
+                        ):
+                            launch_payload["profile_tier_policy_version"] = (
+                                MANAGED_RUNTIME_PROFILE_TIER_POLICY_VERSION
+                            )
                         return await self._execute_routed_activity(
                             "agent_runtime.launch",
-                            {
-                                **kw.get("payload", {}),
-                                "workflow_id": task_workflow_id,
-                            },
+                            launch_payload,
                             cancellation_type=ActivityCancellationType.TRY_CANCEL,
                         )
 

--- a/tests/integration/temporal/test_managed_runtime_live_logs.py
+++ b/tests/integration/temporal/test_managed_runtime_live_logs.py
@@ -405,6 +405,7 @@ async def test_long_running_launch_is_visible_through_observability_routes(
                 "print('omega', flush=True)"
             ),
         ],
+        modelTiers=[{"label": "Runtime default"}],
         workspaceMode="shared",
     )
 

--- a/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
+++ b/tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py
@@ -17,6 +17,7 @@ def _make_profile(**overrides) -> ManagedRuntimeProfile:
         command_template=["codex", "exec"],
         default_model="gpt-5.3-codex",
         default_effort=None,
+        model_tiers=[{"label": "Runtime default"}],
         default_timeout_seconds=3600,
         workspace_mode="tempdir",
         env_overrides={},

--- a/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
+++ b/tests/integration/workflows/temporal/test_managed_session_retrieval_context.py
@@ -20,6 +20,7 @@ def _make_profile(**overrides) -> ManagedRuntimeProfile:
         command_template=["claude"],
         default_model="claude-sonnet-4-6",
         default_effort=None,
+        model_tiers=[{"label": "Runtime default"}],
         default_timeout_seconds=3600,
         workspace_mode="tempdir",
         env_overrides={},

--- a/tests/integration/workflows/temporal/test_managed_session_retrieval_durability.py
+++ b/tests/integration/workflows/temporal/test_managed_session_retrieval_durability.py
@@ -209,6 +209,7 @@ async def test_claude_launcher_uses_shared_durable_retrieval_metadata_contract(
         runtimeId="claude_code",
         commandTemplate=["claude"],
         defaultModel="claude-sonnet-4-6",
+        modelTiers=[{"label": "Runtime default"}],
         defaultTimeoutSeconds=3600,
         workspaceMode="tempdir",
         envOverrides={},

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -42,6 +42,7 @@ def _make_profile(**overrides) -> ManagedRuntimeProfile:
         command_template=["codex", "run"],
         default_model="o4-mini",
         default_effort="medium",
+        model_tiers=[{"label": "Runtime default"}],
         default_timeout_seconds=3600,
         workspace_mode="tempdir",
         env_overrides={},
@@ -3122,6 +3123,89 @@ async def test_launch_rechecks_profile_readiness_before_secret_resolution(
             request=request,
             profile=profile,
         )
+
+
+@pytest.mark.asyncio
+async def test_launch_rejects_persisted_profile_without_model_tiers(
+    tmp_path, monkeypatch
+):
+    """MoonLadderStudios/MoonMind#3799: launch rechecks tier presence."""
+
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path))
+    profile = _make_profile(
+        profile_id="persisted-tierless-profile",
+        enabled=True,
+        auth_state="connected",
+        disabled_reason=None,
+        model_tiers=[],
+    )
+
+    monkeypatch.setattr(
+        launcher,
+        "build_command",
+        lambda *_args, **_kwargs: pytest.fail(
+            "command construction must not run for a tier-less profile"
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await launcher.launch(
+            run_id="run-persisted-tierless-profile",
+            request=_make_request(parameters={"modelTier": 1}),
+            profile=profile,
+        )
+
+    message = str(exc_info.value)
+    assert "persisted-tierless-profile" in message
+    assert "model_tiers must contain at least one tier" in message
+
+
+@pytest.mark.asyncio
+async def test_launch_rejects_persisted_tier_with_raw_credentials(
+    tmp_path, monkeypatch
+):
+    """MoonLadderStudios/MoonMind#3799: launch re-screens resolved params."""
+
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path))
+    profile = _make_profile(
+        profile_id="persisted-unsafe-tier-profile",
+        enabled=True,
+        auth_state="connected",
+        disabled_reason=None,
+        model_tiers=[{"label": "Safe", "model": "gpt-safe"}],
+    ).model_copy(
+        update={
+            # Simulate a migration, seed, or direct database write that bypassed
+            # ProviderModelEffortTier's API-write validation.
+            "model_tiers": [
+                {
+                    "label": "Persisted unsafe tier",
+                    "model": "gpt-unsafe",
+                    "parameters": {"api_key": "raw-secret-value"},
+                }
+            ]
+        }
+    )
+
+    monkeypatch.setattr(
+        launcher,
+        "build_command",
+        lambda *_args, **_kwargs: pytest.fail(
+            "command construction must not run for credential-bearing tier params"
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await launcher.launch(
+            run_id="run-persisted-unsafe-tier-profile",
+            request=_make_request(parameters={"modelTier": 1}),
+            profile=profile,
+        )
+
+    message = str(exc_info.value)
+    assert "persisted-unsafe-tier-profile" in message
+    assert "resolved tier parameters must not contain raw credentials" in message
+
 
 @pytest.mark.asyncio
 async def test_launch_resolves_github_token_from_secret_ref_setting(

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1141,6 +1141,32 @@ def test_assert_profile_launch_ready_accepts_connected_enum_auth_state():
     ManagedRuntimeLauncher._assert_profile_launch_ready(profile)
 
 
+def test_assert_profile_launch_ready_rejects_default_tier_above_range():
+    profile = _make_profile(
+        profile_id="persisted-invalid-default-tier",
+        model_tiers=[{"label": "Only tier"}],
+        default_model_tier=2,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="default_model_tier must be within configured model_tiers",
+    ):
+        ManagedRuntimeLauncher._assert_profile_launch_ready(profile)
+
+
+def test_assert_profile_launch_ready_preserves_tierless_legacy_activity_payload():
+    profile = _make_profile(
+        profile_id="in-flight-tierless-profile",
+        model_tiers=[],
+    )
+
+    ManagedRuntimeLauncher._assert_profile_launch_ready(
+        profile,
+        require_model_tiers=False,
+    )
+
+
 def test_apply_resolved_tier_policy_merges_defaults_and_records_codex_effort_status():
     from moonmind.workflows.temporal.runtime.strategies.codex_cli import CodexCliStrategy
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -78,6 +78,74 @@ def _make_store(tmp_path: Path) -> ManagedRunStore:
     return ManagedRunStore(tmp_path / "run_store")
 
 
+def _tier_policy_launch_payload() -> dict[str, Any]:
+    return {
+        "run_id": "in-flight-tierless-run",
+        "request": {
+            "agentKind": "managed",
+            "agentId": "codex_cli",
+            "correlationId": "tier-policy-compatibility",
+            "idempotencyKey": "in-flight-tierless-run",
+        },
+        "profile": {
+            "runtimeId": "codex_cli",
+            "commandTemplate": ["codex", "run"],
+            "defaultModel": "o4-mini",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("profile_tier_policy_version", "require_model_tiers"),
+    [(None, False), (1, True)],
+)
+async def test_agent_runtime_launch_versions_profile_tier_policy_boundary(
+    profile_tier_policy_version: int | None,
+    require_model_tiers: bool,
+) -> None:
+    record = SimpleNamespace(
+        model_dump=lambda **_kwargs: {
+            "runId": "in-flight-tierless-run",
+            "status": "launching",
+        }
+    )
+    launcher = SimpleNamespace(
+        launch=AsyncMock(return_value=(record, None, [], []))
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_launcher=launcher,
+        run_supervisor=object(),
+    )
+    payload = _tier_policy_launch_payload()
+    if profile_tier_policy_version is not None:
+        payload["profile_tier_policy_version"] = profile_tier_policy_version
+
+    result = await activities.agent_runtime_launch(payload)
+
+    assert result["status"] == "launching"
+    assert launcher.launch.await_args.kwargs["require_model_tiers"] is (
+        require_model_tiers
+    )
+
+
+async def test_agent_runtime_launch_rejects_unknown_profile_tier_policy_version() -> None:
+    launcher = SimpleNamespace(launch=AsyncMock())
+    activities = TemporalAgentRuntimeActivities(
+        run_launcher=launcher,
+        run_supervisor=object(),
+    )
+    payload = _tier_policy_launch_payload()
+    payload["profile_tier_policy_version"] = 2
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="profile_tier_policy_version must be 1",
+    ):
+        await activities.agent_runtime_launch(payload)
+
+    launcher.launch.assert_not_awaited()
+
+
 class _StaticArtifactService:
     def __init__(self, payloads: dict[str, bytes]) -> None:
         self._payloads = payloads

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_managed_binding_patch.py
@@ -1,12 +1,14 @@
 """Replay-safety checks for managed workflow binding in MoonMind.AgentRun."""
 
 import inspect
+import re
 
 import pytest
 
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import (
     AGENT_RUN_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
+    MANAGED_RUNTIME_PROFILE_TIER_POLICY_PATCH_ID,
     MoonMindAgentRun,
 )
 
@@ -18,6 +20,17 @@ def test_managed_launch_binding_uses_temporal_patch_guard() -> None:
     assert "task_workflow_id = parent_info.workflow_id" in source
     assert "task_workflow_id = wf_id" in source
     assert "task_workflow_id=task_workflow_id" in source
+
+
+def test_managed_launch_profile_tier_policy_is_replay_patched() -> None:
+    source = inspect.getsource(MoonMindAgentRun.run)
+
+    assert re.search(
+        r"workflow\.patched\(\s*MANAGED_RUNTIME_PROFILE_TIER_POLICY_PATCH_ID\s*\)",
+        source,
+    )
+    assert 'launch_payload["profile_tier_policy_version"]' in source
+    assert MANAGED_RUNTIME_PROFILE_TIER_POLICY_PATCH_ID.endswith("-v1")
 
 
 def test_auto_runtime_rejection_is_replay_patched_at_dispatch() -> None:


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3799

Closes MoonLadderStudios/MoonMind#3799

## Summary

- reject selected provider profiles with no model tiers at the launch boundary
- reuse the canonical tier credential screen before resolved parameters are merged or command construction begins
- add launch-boundary regression coverage and update managed-runtime fixtures to declare a safe default tier

## Tests run

- `moonmind container python-tests tests/unit/services/temporal/runtime/test_launcher.py tests/unit/provider_profiles/test_model_tiers.py tests/unit/workflows/executions/test_model_resolver.py tests/unit/workflows/temporal/runtime/strategies` — 238 passed
- `moonmind container python-tests tests/integration/temporal/test_managed_runtime_live_logs.py::test_long_running_launch_is_visible_through_observability_routes tests/integration/workflows/temporal/test_managed_session_followup_retrieval.py tests/integration/workflows/temporal/test_managed_session_retrieval_context.py tests/integration/workflows/temporal/test_managed_session_retrieval_durability.py` — 14 passed
- `git diff --check origin/main...HEAD` — passed

## Remaining risks

- Persisted profiles that bypassed write validation and have no tiers or credential-bearing tier parameters will now fail launch with an actionable error; this is the intended security boundary.
- No additional implementation gaps were identified by the controlling FULLY_IMPLEMENTED verifier.