### PR TITLE
MoonLadderStudios/MoonMind#3800: Render persisted tier history in workflow details

### DIFF
--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6243,6 +6243,83 @@ describe('Workflow Detail Entrypoint', () => {
     });
   });
 
+  // MoonLadderStudios/MoonMind#3800 — historical detail must explain the
+  // immutable launch-time tier resolution, not a later Provider Profile state.
+  it('renders persisted model tier resolution and its concise fallback explanation', async () => {
+    window.history.pushState({}, 'Overview Test', '/workflows/test-123/overview?source=temporal');
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      entry: 'user_workflow',
+      targetRuntime: 'codex_cli',
+      profileId: 'codex-provider-profile',
+      model: 'gpt-5.5',
+      effort: 'high',
+      inputParameters: {
+        modelTierResolution: {
+          providerProfileId: 'codex-provider-profile',
+          requestedModelTier: 3,
+          effectiveModelTier: 2,
+          tierLabel: 'Implement',
+          fallbackReason: 'requested_tier_above_configured_range',
+          resolvedModel: 'gpt-5.5',
+          resolvedEffort: 'high',
+          modelSource: 'requested_tier',
+          effortSource: 'requested_tier',
+          effortApplicationStatus: 'applied',
+          previewMismatch: false,
+        },
+      },
+      title: 'Historical tier fallback task',
+      summary: 'Verifies persisted tier resolution is shown',
+      status: 'completed',
+      state: 'succeeded',
+      rawState: 'succeeded',
+      temporalStatus: 'completed',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: { canSetTitle: false, canCancel: false, canRerun: false },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/remediations?direction=')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ direction: 'inbound', items: [] }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Requested Tier').closest('div')?.textContent).toContain('Tier 3');
+      expect(screen.getByText('Effective Tier').closest('div')?.textContent).toContain('Tier 2');
+      expect(screen.getByText('Tier Label').closest('div')?.textContent).toContain('Implement');
+      expect(screen.getByText('Fallback Reason').closest('div')?.textContent).toContain(
+        'Requested Tier 3, used Tier 2 because the selected profile only defines 2 tiers.',
+      );
+      expect(screen.getByText('Model').closest('div')?.textContent).toContain('gpt-5.5');
+      expect(screen.getByText('Effort').closest('div')?.textContent).toContain('high');
+    });
+  });
+
   it('hides the Model fact when no model field is populated', async () => {
     window.history.pushState({}, 'Overview Test', '/workflows/test-123/overview?source=temporal');
     const mockExecution = {

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -6256,22 +6256,23 @@ describe('Workflow Detail Entrypoint', () => {
       source: 'temporal',
       workflowType: 'MoonMind.UserWorkflow',
       entry: 'user_workflow',
+      agentRunId: 'agent-run-tier-history',
       targetRuntime: 'codex_cli',
-      profileId: 'codex-provider-profile',
-      model: 'gpt-5.5',
-      effort: 'high',
+      profileId: 'admission-profile',
+      model: 'gpt-5-mini',
+      effort: 'low',
       inputParameters: {
         modelTierResolution: {
-          providerProfileId: 'codex-provider-profile',
-          requestedModelTier: 3,
-          effectiveModelTier: 2,
-          tierLabel: 'Implement',
-          fallbackReason: 'requested_tier_above_configured_range',
-          resolvedModel: 'gpt-5.5',
-          resolvedEffort: 'high',
+          providerProfileId: 'admission-profile',
+          requestedModelTier: 1,
+          effectiveModelTier: 1,
+          tierLabel: 'Admission',
+          fallbackReason: null,
+          resolvedModel: 'gpt-5-mini',
+          resolvedEffort: 'low',
           modelSource: 'requested_tier',
           effortSource: 'requested_tier',
-          effortApplicationStatus: 'applied',
+          effortApplicationStatus: 'unknown',
           previewMismatch: false,
         },
       },
@@ -6285,9 +6286,44 @@ describe('Workflow Detail Entrypoint', () => {
       updatedAt: '2026-03-28T00:00:02Z',
       actions: { canSetTitle: false, canCancel: false, canRerun: false },
     };
+    const launchResolution = {
+      providerProfileId: 'launch-profile',
+      requestedModelTier: 3,
+      effectiveModelTier: 2,
+      tierLabel: 'Implement',
+      fallbackReason: 'requested_tier_above_configured_range',
+      resolvedModel: 'gpt-5.5',
+      resolvedEffort: 'high',
+      modelSource: 'requested_tier',
+      effortSource: 'requested_tier',
+      effortApplicationStatus: 'applied',
+      previewMismatch: false,
+    };
 
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-03-28T00:00:01Z',
+                stream: 'system',
+                text: 'Launcher: recorded model tier resolution for this run.',
+                kind: 'system_annotation',
+                metadata: {
+                  source: 'launcher',
+                  reason: 'model_tier_resolution',
+                  modelTierResolution: launchResolution,
+                },
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
       if (url.includes('/remediations?direction=')) {
         return Promise.resolve({
           ok: true,
@@ -6317,6 +6353,68 @@ describe('Workflow Detail Entrypoint', () => {
       );
       expect(screen.getByText('Model').closest('div')?.textContent).toContain('gpt-5.5');
       expect(screen.getByText('Effort').closest('div')?.textContent).toContain('high');
+      expect(screen.getByText('Provider Profile').closest('div')?.textContent).toContain('launch-profile');
+      expect(screen.getByText('Effort Application').closest('div')?.textContent).toContain('applied');
+    });
+  });
+
+  it('renders a nullable requested tier as the profile default and surfaces unsupported effort', async () => {
+    window.history.pushState({}, 'Overview Test', '/workflows/test-123/overview?source=temporal');
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.UserWorkflow',
+      entry: 'user_workflow',
+      targetRuntime: 'codex_cli',
+      profileId: 'codex-provider-profile',
+      model: 'gpt-5.5',
+      effort: 'high',
+      inputParameters: {
+        modelTierResolution: {
+          providerProfileId: 'codex-provider-profile',
+          requestedModelTier: null,
+          effectiveModelTier: 2,
+          tierLabel: 'Implement',
+          fallbackReason: 'profile_default_tier',
+          resolvedModel: 'gpt-5.5',
+          resolvedEffort: 'high',
+          modelSource: 'profile_default_tier',
+          effortSource: 'profile_default_tier',
+          effortApplicationStatus: 'not_supported',
+          previewMismatch: false,
+        },
+      },
+      title: 'Profile default tier task',
+      summary: 'Verifies the default-tier history shape',
+      status: 'completed',
+      state: 'succeeded',
+      rawState: 'succeeded',
+      temporalStatus: 'completed',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: { canSetTitle: false, canCancel: false, canRerun: false },
+    };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => mockExecution,
+    } as Response);
+
+    renderWithClient(<WorkflowDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Requested Tier').closest('div')?.textContent).toContain('Profile default');
+      expect(screen.getByText('Effective Tier').closest('div')?.textContent).toContain('Tier 2');
+      expect(screen.getByText('Fallback Reason').closest('div')?.textContent).toContain(
+        'Profile default selected Tier 2.',
+      );
+      expect(screen.getByText('Effort Application').closest('div')?.textContent).toContain(
+        'not supported',
+      );
     });
   });
 

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -865,7 +865,7 @@ const StepExecutionListSchema = z
 const ModelTierResolutionSchema = z
   .object({
     providerProfileId: z.string().nullable(),
-    requestedModelTier: z.number().int().positive(),
+    requestedModelTier: z.number().int().positive().nullable(),
     effectiveModelTier: z.number().int().positive(),
     tierLabel: z.string().nullable(),
     fallbackReason: z.string().nullable(),
@@ -2344,10 +2344,14 @@ function RepositoryFact({ repository }: { repository: string }) {
 
 function renderProviderProfileSummary(
   execution: z.infer<typeof ExecutionDetailSchema>,
+  launchProfileId?: string | null,
 ): ReactNode {
-  const providerLabel = execution.providerLabel?.trim();
-  const providerId = execution.providerId?.trim();
-  const profileId = execution.profileId?.trim();
+  const profileId = launchProfileId?.trim() || execution.profileId?.trim();
+  const launchProfileChanged = Boolean(
+    launchProfileId?.trim() && launchProfileId?.trim() !== execution.profileId?.trim(),
+  );
+  const providerLabel = launchProfileChanged ? undefined : execution.providerLabel?.trim();
+  const providerId = launchProfileChanged ? undefined : execution.providerId?.trim();
   const primary = providerLabel || providerId || profileId;
   if (!primary) return '—';
 
@@ -2370,11 +2374,38 @@ function renderProviderProfileSummary(
 
 function persistedModelTierResolution(
   execution: z.infer<typeof ExecutionDetailSchema>,
+  observability: z.infer<typeof ObservabilityEventsResponseSchema> | null | undefined,
 ): z.infer<typeof ModelTierResolutionSchema> | null {
-  const parsed = ModelTierResolutionSchema.safeParse(
+  const events = observability?.events ?? [];
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+    if (event.kind !== 'system_annotation') continue;
+    const metadata = event.metadata ?? {};
+    if (metadata.source !== 'launcher' || metadata.reason !== 'model_tier_resolution') {
+      continue;
+    }
+    const launchAnnotation = ModelTierResolutionSchema.safeParse(
+      metadata.modelTierResolution,
+    );
+    if (launchAnnotation.success) return launchAnnotation.data;
+  }
+
+  const metadata = detailObjectValue(execution.inputParameters.metadata);
+  const moonmindMetadata = detailObjectValue(metadata.moonmind);
+  const launchMetadata = detailObjectValue(moonmindMetadata.modelEffortResolution);
+  if (Object.keys(launchMetadata).length > 0) {
+    const parsedLaunchMetadata = ModelTierResolutionSchema.safeParse({
+      ...launchMetadata,
+      providerProfileId: launchMetadata.providerProfileId ?? execution.profileId ?? null,
+    });
+    if (parsedLaunchMetadata.success) return parsedLaunchMetadata.data;
+  }
+
+  const admissionResolution = ModelTierResolutionSchema.safeParse(
     execution.inputParameters.modelTierResolution,
   );
-  return parsed.success ? parsed.data : null;
+  return admissionResolution.success ? admissionResolution.data : null;
 }
 
 function modelTierFallbackExplanation(
@@ -2382,6 +2413,9 @@ function modelTierFallbackExplanation(
 ): string | null {
   const fallbackReason = resolution.fallbackReason?.trim();
   if (!fallbackReason) return null;
+  if (fallbackReason === 'profile_default_tier') {
+    return `Profile default selected Tier ${resolution.effectiveModelTier}.`;
+  }
   if (fallbackReason === 'requested_tier_above_configured_range') {
     const configuredTierCount = resolution.effectiveModelTier;
     return (
@@ -2390,8 +2424,11 @@ function modelTierFallbackExplanation(
       `${configuredTierCount === 1 ? 'tier' : 'tiers'}.`
     );
   }
+  const requestedTier = resolution.requestedModelTier === null
+    ? 'Profile default'
+    : `Requested Tier ${resolution.requestedModelTier}`;
   return (
-    `Requested Tier ${resolution.requestedModelTier}, used Tier ${resolution.effectiveModelTier} ` +
+    `${requestedTier}, used Tier ${resolution.effectiveModelTier} ` +
     `because backend tier policy reported ${fallbackReason}.`
   );
 }
@@ -9164,6 +9201,18 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const debugTabActive = detailSubroute === 'debug';
   const shouldFetchStepLedger = (stepsTabActive || artifactsTabActive) && Boolean(execution?.stepsHref);
 
+  const modelTierObservabilityQuery = useQuery({
+    queryKey: ['agent-run-observability-events', resolvedAgentRunId],
+    queryFn: () => fetchObservabilityEvents(
+      payload.apiBase,
+      resolvedAgentRunId,
+      agentRunRoutes.observabilityEvents,
+    ),
+    enabled: overviewTabActive && Boolean(resolvedAgentRunId),
+    staleTime: isTerminalExecution ? Infinity : detailPoll,
+    retry: false,
+  });
+
   const stepsQuery = useQuery({
     queryKey: ['workflow-detail-steps', workflowId, execution?.stepsHref],
     queryFn: () => fetchStepLedger(String(execution?.stepsHref || '')),
@@ -10133,11 +10182,14 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const artifactTabCount = artifactsQuery.data?.artifacts.length ?? null;
   const runTabCount = execution ? (execution.relatedRuns?.length ?? 0) + 1 : null;
   const modelTierResolution = execution
-    ? persistedModelTierResolution(execution)
+    ? persistedModelTierResolution(execution, modelTierObservabilityQuery.data)
     : null;
   const modelTierFallback = modelTierResolution
     ? modelTierFallbackExplanation(modelTierResolution)
     : null;
+  const historicalModel = modelTierResolution?.resolvedModel?.trim() || execution?.model;
+  const historicalEffort = modelTierResolution?.resolvedEffort?.trim() || execution?.effort;
+  const historicalProfileId = modelTierResolution?.providerProfileId?.trim() || execution?.profileId;
   return (
     <div className="stack workflow-detail-page">
       <div className="toolbar">
@@ -10402,25 +10454,32 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
 
               <FactGroup title="Runtime">
                 {execution.targetRuntime ? <Fact label="Runtime">{formatRuntimeLabel(execution.targetRuntime)}</Fact> : null}
-                {execution.model ? (
+                {historicalModel ? (
                   <Fact label="Model">
-                    <code className="text-xs">{execution.model}</code>
+                    <code className="text-xs">{historicalModel}</code>
                   </Fact>
                 ) : null}
-                {execution.profileId ? (
-                  <Fact label="Provider Profile">{renderProviderProfileSummary(execution)}</Fact>
+                {historicalProfileId ? (
+                  <Fact label="Provider Profile">
+                    {renderProviderProfileSummary(execution, historicalProfileId)}
+                  </Fact>
                 ) : null}
-                {execution.effort ? <Fact label="Effort">{execution.effort}</Fact> : null}
+                {historicalEffort ? <Fact label="Effort">{historicalEffort}</Fact> : null}
                 {modelTierResolution ? (
                   <>
                     <Fact label="Requested Tier">
-                      Tier {modelTierResolution.requestedModelTier}
+                      {modelTierResolution.requestedModelTier === null
+                        ? 'Profile default'
+                        : `Tier ${modelTierResolution.requestedModelTier}`}
                     </Fact>
                     <Fact label="Effective Tier">
                       Tier {modelTierResolution.effectiveModelTier}
                     </Fact>
                     <Fact label="Tier Label">{modelTierResolution.tierLabel || '—'}</Fact>
                     <Fact label="Fallback Reason">{modelTierFallback || 'No fallback.'}</Fact>
+                    <Fact label="Effort Application">
+                      {formatStatusLabel(modelTierResolution.effortApplicationStatus)}
+                    </Fact>
                   </>
                 ) : null}
                 {execution.priority !== null && execution.priority !== undefined ? (

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -862,6 +862,22 @@ const StepExecutionListSchema = z
   })
   .passthrough();
 
+const ModelTierResolutionSchema = z
+  .object({
+    providerProfileId: z.string().nullable(),
+    requestedModelTier: z.number().int().positive(),
+    effectiveModelTier: z.number().int().positive(),
+    tierLabel: z.string().nullable(),
+    fallbackReason: z.string().nullable(),
+    resolvedModel: z.string().nullable(),
+    resolvedEffort: z.string().nullable(),
+    modelSource: z.string(),
+    effortSource: z.string(),
+    effortApplicationStatus: z.string(),
+    previewMismatch: z.boolean(),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string().optional(),
@@ -2349,6 +2365,34 @@ function renderProviderProfileSummary(
         </span>
       ) : null}
     </span>
+  );
+}
+
+function persistedModelTierResolution(
+  execution: z.infer<typeof ExecutionDetailSchema>,
+): z.infer<typeof ModelTierResolutionSchema> | null {
+  const parsed = ModelTierResolutionSchema.safeParse(
+    execution.inputParameters.modelTierResolution,
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+function modelTierFallbackExplanation(
+  resolution: z.infer<typeof ModelTierResolutionSchema>,
+): string | null {
+  const fallbackReason = resolution.fallbackReason?.trim();
+  if (!fallbackReason) return null;
+  if (fallbackReason === 'requested_tier_above_configured_range') {
+    const configuredTierCount = resolution.effectiveModelTier;
+    return (
+      `Requested Tier ${resolution.requestedModelTier}, used Tier ${resolution.effectiveModelTier} ` +
+      `because the selected profile only defines ${configuredTierCount} ` +
+      `${configuredTierCount === 1 ? 'tier' : 'tiers'}.`
+    );
+  }
+  return (
+    `Requested Tier ${resolution.requestedModelTier}, used Tier ${resolution.effectiveModelTier} ` +
+    `because backend tier policy reported ${fallbackReason}.`
   );
 }
 
@@ -10088,6 +10132,12 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const stepTabCount = stepsQuery.data?.steps.length ?? null;
   const artifactTabCount = artifactsQuery.data?.artifacts.length ?? null;
   const runTabCount = execution ? (execution.relatedRuns?.length ?? 0) + 1 : null;
+  const modelTierResolution = execution
+    ? persistedModelTierResolution(execution)
+    : null;
+  const modelTierFallback = modelTierResolution
+    ? modelTierFallbackExplanation(modelTierResolution)
+    : null;
   return (
     <div className="stack workflow-detail-page">
       <div className="toolbar">
@@ -10361,6 +10411,18 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                   <Fact label="Provider Profile">{renderProviderProfileSummary(execution)}</Fact>
                 ) : null}
                 {execution.effort ? <Fact label="Effort">{execution.effort}</Fact> : null}
+                {modelTierResolution ? (
+                  <>
+                    <Fact label="Requested Tier">
+                      Tier {modelTierResolution.requestedModelTier}
+                    </Fact>
+                    <Fact label="Effective Tier">
+                      Tier {modelTierResolution.effectiveModelTier}
+                    </Fact>
+                    <Fact label="Tier Label">{modelTierResolution.tierLabel || '—'}</Fact>
+                    <Fact label="Fallback Reason">{modelTierFallback || 'No fallback.'}</Fact>
+                  </>
+                ) : null}
                 {execution.priority !== null && execution.priority !== undefined ? (
                   <Fact label="Priority">{execution.priority}</Fact>
                 ) : null}

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -1952,9 +1952,7 @@ class ManagedRuntimeLauncher:
             metadata["moonmind"] = moonmind_metadata
         resolution_metadata = resolved.as_metadata()
         moonmind_metadata["modelEffortResolution"] = resolution_metadata
-        if requested_tier is not None or isinstance(
-            parameters.get("tierPreview"), Mapping
-        ):
+        if resolved.effective_model_tier is not None:
             parameters["modelTierResolution"] = {
                 **resolution_metadata,
                 "providerProfileId": profile.profile_id,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -7407,6 +7407,59 @@ async def test_strict_unavailable_tier_consumes_no_resources_and_default_clamps(
                 "providerProfileId": "codex-provider-profile",
             }
             service._client_adapter.start_workflow.assert_awaited_once()
+
+            # MoonLadderStudios/MoonMind#3800 — launch-time history remains
+            # authoritative after the selected Provider Profile changes.
+            source_record = await session.get(
+                TemporalExecutionCanonicalRecord,
+                clamped.workflow_id,
+            )
+            assert source_record is not None
+            source_record.state = MoonMindWorkflowState.COMPLETED
+            source_record.close_status = TemporalExecutionCloseStatus.COMPLETED
+            source_record.closed_at = datetime.now(UTC)
+            profile = await session.get(
+                ManagedAgentProviderProfile,
+                "codex-provider-profile",
+            )
+            assert profile is not None
+            profile.model_tiers = [
+                {
+                    "label": "Edited after launch",
+                    "model": "gpt-5-mini-edited",
+                    "effort": "low",
+                    "parameters": {},
+                    "annotations": {},
+                }
+            ]
+            profile.default_model_tier = 1
+            await session.commit()
+            await session.refresh(source_record)
+
+            service._client_adapter.describe_workflow = AsyncMock(
+                side_effect=RuntimeError("Temporal history is unavailable in unit test")
+            )
+            historical_record = await service.describe_execution(
+                clamped.workflow_id
+            )
+            historical = _serialize_execution(historical_record, user=user)
+
+            assert historical.status == "completed"
+            assert historical.model == "gpt-5.5"
+            assert historical.effort == "high"
+            assert historical.input_parameters["modelTierResolution"] == {
+                "requestedModelTier": 3,
+                "effectiveModelTier": 2,
+                "tierLabel": "Implement",
+                "fallbackReason": "requested_tier_above_configured_range",
+                "resolvedModel": "gpt-5.5",
+                "resolvedEffort": "high",
+                "modelSource": "requested_tier",
+                "effortSource": "requested_tier",
+                "effortApplicationStatus": "unknown",
+                "previewMismatch": False,
+                "providerProfileId": "codex-provider-profile",
+            }
     finally:
         await engine.dispose()
         settings.workflow.temporal_artifact_backend = original_backend

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -751,27 +751,36 @@ async def test_launch_records_model_tier_resolution_with_runtime_effort_status(
     )
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    resolution = {
-        "providerProfileId": "codex-profile",
+    admission_resolution = {
+        "providerProfileId": "admission-profile",
         "requestedModelTier": 3,
-        "effectiveModelTier": 2,
-        "tierLabel": "Implementation",
+        "effectiveModelTier": 1,
+        "tierLabel": "Admission",
         "fallbackReason": "requested_tier_above_configured_range",
-        "resolvedModel": "gpt-5.5",
-        "resolvedEffort": "xhigh",
+        "resolvedModel": "stale-model",
+        "resolvedEffort": "low",
         "modelSource": "requested_tier",
         "effortSource": "requested_tier",
         "effortApplicationStatus": "unknown",
         "previewMismatch": False,
     }
+    launch_profile = _make_profile(
+        runtime_id="codex_cli",
+        profile_id="launch-profile",
+        model_tiers=[
+            {"label": "Standard", "model": "gpt-5-mini", "effort": "medium"},
+            {"label": "Implementation", "model": "gpt-5.5", "effort": "high"},
+        ],
+        default_model_tier=2,
+    )
 
     await launcher.launch(
         run_id="run-tier-resolution",
         request=_make_request(
             instruction_ref="Implement the issue",
-            parameters={"modelTierResolution": resolution},
+            parameters={"modelTierResolution": admission_resolution},
         ),
-        profile=_make_profile(runtime_id="codex_cli"),
+        profile=launch_profile,
         workspace_path=str(workspace),
     )
 
@@ -782,10 +791,19 @@ async def test_launch_records_model_tier_resolution_with_runtime_effort_status(
     )
     recorded = emission["metadata"]["modelTierResolution"]
     assert recorded == {
-        **resolution,
+        "providerProfileId": "launch-profile",
+        "requestedModelTier": None,
+        "effectiveModelTier": 2,
+        "tierLabel": "Implementation",
+        "fallbackReason": "profile_default_tier",
+        "resolvedModel": "gpt-5.5",
+        "resolvedEffort": "high",
+        "modelSource": "profile_default_tier",
+        "effortSource": "profile_default_tier",
         "effortApplicationStatus": "not_supported",
+        "previewMismatch": False,
     }
-    assert resolution["effortApplicationStatus"] == "unknown"
+    assert admission_resolution["effortApplicationStatus"] == "unknown"
 
 
 @pytest.mark.asyncio
@@ -1340,6 +1358,10 @@ def test_apply_resolved_tier_policy_shapes_omitted_and_explicit_default_tiers(
     assert resolution["fallbackReason"] == expected_fallback_reason
     assert resolution["resolvedModel"] == "tier-2-model"
     assert resolution["resolvedEffort"] == "high"
+    assert request.parameters["modelTierResolution"] == {
+        **resolution,
+        "providerProfileId": profile.profile_id,
+    }
 
 
 def test_apply_resolved_tier_policy_initializes_missing_parameters():


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3800

Closes MoonLadderStudios/MoonMind#3800

## Summary

- Parse the persisted `modelTierResolution` block in historical workflow detail.
- Show the requested tier, effective tier, tier label, and concise fallback explanation alongside the concrete model and effort.
- Add frontend coverage for the historical detail presentation and a database-backed regression proving later Provider Profile tier edits do not rewrite completed-run history.

## Tests run

- `moonmind container python-tests tests/unit/api/routers/test_executions.py::test_strict_unavailable_tier_consumes_no_resources_and_default_clamps` — passed (1 test).
- Focused managed-container launch metadata and diagnostic-bounds tests — passed (4 tests).
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-detail.test.tsx -t 'renders persisted model tier resolution and its concise fallback explanation'` — passed (1 test; 199 skipped).
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` — passed.
- Focused ESLint for the two workflow-detail frontend files — passed.
- `git diff --check origin/main...HEAD` — passed at verification time.

## Remaining risks

- The full workflow-detail frontend file diagnostic completed 194 tests, including the new coverage, but six unrelated pre-existing sidebar tests timed out at their 5-second limit. The isolated issue-specific test, TypeScript check, ESLint check, API history regression, and launch metadata tests all passed.
