### PR TITLE
Label merge automation resolver attempts in workflow titles

### DIFF
--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -1069,6 +1069,12 @@ The parent workflow detail should show a **Merge Automation** panel with:
 - resolver attempt history
 - child workflow links
 
+Resolver child workflow titles include their one-based attempt ordinal, for
+example `Resolve PR #123 (Attempt 1)` and `Resolve PR #123 (Attempt 2)`. The
+ordinal is the same deterministic cycle value used in the child workflow ID so
+the workflow list distinguishes repeated gate passes without inventing a second
+attempt identity.
+
 ### 20.2 Child artifacts
 
 `MoonMind.MergeAutomation` SHOULD write:

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -86,6 +86,9 @@ MERGE_AUTOMATION_STRICT_CONTINUATION_IDENTITY_PATCH = (
 MERGE_AUTOMATION_CONTINUATION_OBSERVABILITY_PATCH = (
     "merge-automation-continuation-observability-v1"
 )
+MERGE_AUTOMATION_RESOLVER_ATTEMPT_TITLE_PATCH = (
+    "merge-automation-resolver-attempt-title-v1"
+)
 # Request/remediate/request loop for one configured automated review provider.
 # Guarded so histories recorded before the loop existed keep replaying their
 # original gate decisions.
@@ -124,6 +127,7 @@ class MoonMindMergeAutomationWorkflow:
         self._post_merge_github_result: dict[str, Any] | None = None
         self._external_event_count = 0
         self._continuation_observability_enabled = False
+        self._resolver_attempt_titles_enabled = False
         self._continuation_counters: dict[str, int] = {
             "continuation_requested": 0,
             "continuation_accepted": 0,
@@ -235,7 +239,11 @@ class MoonMindMergeAutomationWorkflow:
         return attributes
 
     @staticmethod
-    def _resolver_child_memo(resolver_request: Mapping[str, Any]) -> dict[str, Any]:
+    def _resolver_child_memo(
+        resolver_request: Mapping[str, Any],
+        *,
+        attempt: int | None = None,
+    ) -> dict[str, Any]:
         initial_parameters = resolver_request.get("initial_parameters")
         if not isinstance(initial_parameters, Mapping):
             initial_parameters = {}
@@ -271,10 +279,14 @@ class MoonMindMergeAutomationWorkflow:
             ).strip()[:160]
             or None
         )
+        title = (
+            str(resolver_request.get("title") or "Resolve PR").strip() or "Resolve PR"
+        )
+        if attempt is not None:
+            title = f"{title} (Attempt {attempt})"
         memo: dict[str, Any] = {
             "entry": "user_workflow",
-            "title": str(resolver_request.get("title") or "Resolve PR").strip()
-            or "Resolve PR",
+            "title": title,
             "summary": "Resolver child workflow for merge automation.",
         }
         if target_runtime:
@@ -1146,6 +1158,9 @@ class MoonMindMergeAutomationWorkflow:
         self._continuation_observability_enabled = workflow.patched(
             MERGE_AUTOMATION_CONTINUATION_OBSERVABILITY_PATCH
         )
+        self._resolver_attempt_titles_enabled = workflow.patched(
+            MERGE_AUTOMATION_RESOLVER_ATTEMPT_TITLE_PATCH
+        )
         self._review_loop_enabled = workflow.patched(
             MERGE_AUTOMATION_REVIEW_LOOP_PATCH
         )
@@ -1237,9 +1252,8 @@ class MoonMindMergeAutomationWorkflow:
                     pr_number=self._input.pull_request.number,
                     head_sha=self._input.pull_request.head_sha,
                 )
-                resolver_workflow_id = (
-                    f"{resolver_workflow_id}:{len(self._resolver_child_workflow_ids) + 1}"
-                )
+                resolver_attempt = len(self._resolver_child_workflow_ids) + 1
+                resolver_workflow_id = f"{resolver_workflow_id}:{resolver_attempt}"
                 self._resolver_child_workflow_ids.append(resolver_workflow_id)
                 child_kwargs: dict[str, Any] = {
                     "id": resolver_workflow_id,
@@ -1250,7 +1264,14 @@ class MoonMindMergeAutomationWorkflow:
                     "static_details": f"Resolve {self._input.pull_request.url}",
                 }
                 if workflow.patched("merge-automation-resolver-child-visibility-memo"):
-                    child_kwargs["memo"] = self._resolver_child_memo(resolver_request)
+                    child_kwargs["memo"] = self._resolver_child_memo(
+                        resolver_request,
+                        attempt=(
+                            resolver_attempt
+                            if self._resolver_attempt_titles_enabled
+                            else None
+                        ),
+                    )
                 try:
                     resolver_result = await workflow.execute_child_workflow(
                         "MoonMind.UserWorkflow",

--- a/tests/integration/workflows/temporal/workflows/test_merge_automation_full_topology.py
+++ b/tests/integration/workflows/temporal/workflows/test_merge_automation_full_topology.py
@@ -357,6 +357,14 @@ async def test_real_three_workflow_topology_requests_review_then_merges() -> Non
                     second_messages.append(f"{type(current).__name__}: {current}")
                     current = getattr(current, "cause", None) or current.__cause__
                 second_result = " <- ".join(second_messages)
+            first_description = await env.client.get_workflow_handle(
+                f"{resolver_base}:1"
+            ).describe()
+            second_description = await env.client.get_workflow_handle(
+                f"{resolver_base}:2"
+            ).describe()
+            first_memo = await first_description.memo()
+            second_memo = await second_description.memo()
 
     assert result["status"] == "merged", (
         result.get("summary"),
@@ -367,3 +375,5 @@ async def test_real_three_workflow_topology_requests_review_then_merges() -> Non
     assert result["continuationCounters"]["continuation_cycle_completed"] == 1
     assert result["reviewLoop"]["cycles"] == 1
     assert _terminal_evidence_calls == 2
+    assert first_memo["title"] == "Resolve PR #1209 (Attempt 1)"
+    assert second_memo["title"] == "Resolve PR #1209 (Attempt 2)"

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -10,6 +10,7 @@ from temporalio.workflow import ChildWorkflowCancellationType
 
 from moonmind.workflows.temporal.workflows import merge_automation as merge_automation_module
 from moonmind.workflows.temporal.workflows.merge_automation import (
+    MERGE_AUTOMATION_RESOLVER_ATTEMPT_TITLE_PATCH,
     MERGE_AUTOMATION_RESOLVER_PARENT_GATE_ID_PATCH,
     MERGE_AUTOMATION_STRICT_CONTINUATION_IDENTITY_PATCH,
     MERGE_AUTOMATION_WORKFLOW_CHILD_TASK_QUEUE_V2_PATCH,
@@ -385,6 +386,7 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         },
     ]
     child_workflow_ids: list[str] = []
+    child_memos: list[dict[str, Any]] = []
 
     async def fake_execute_activity(
         activity_type: str,
@@ -418,6 +420,7 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         child_payloads.append(payload)
         child_workflow_id = str(kwargs["id"])
         child_workflow_ids.append(child_workflow_id)
+        child_memos.append(kwargs["memo"])
         if len(child_workflow_ids) == 1:
             return {
                 "status": "success",
@@ -494,6 +497,10 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
     assert child_workflow_ids == [
         f"{first_resolver_id}:1",
         f"{second_resolver_id}:2",
+    ]
+    assert [memo["title"] for memo in child_memos] == [
+        "Resolve PR #350 (Attempt 1)",
+        "Resolve PR #350 (Attempt 2)",
     ]
     assert child_payloads[0]["workflow_type"] == "MoonMind.UserWorkflow"
     assert child_payloads[0]["initial_parameters"]["publishMode"] == "auto"
@@ -618,12 +625,29 @@ async def test_merge_automation_tracks_current_head_when_checks_are_still_runnin
     )
     assert child_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
 
+@pytest.mark.parametrize(
+    ("attempt_titles_enabled", "expected_title"),
+    [
+        (True, "Resolve PR #350 (Attempt 1)"),
+        (False, "Resolve PR #350"),
+    ],
+)
 @pytest.mark.asyncio
 async def test_merge_automation_resolver_child_uses_try_cancel(
     monkeypatch: pytest.MonkeyPatch,
+    attempt_titles_enabled: bool,
+    expected_title: str,
 ) -> None:
     workflow = MoonMindMergeAutomationWorkflow()
     child_kwargs: dict[str, Any] = {}
+
+    if not attempt_titles_enabled:
+        monkeypatch.setattr(
+            merge_automation_module.workflow,
+            "patched",
+            lambda patch_id: patch_id
+            != MERGE_AUTOMATION_RESOLVER_ATTEMPT_TITLE_PATCH,
+        )
 
     async def fake_execute_activity(
         activity_type: str,
@@ -687,7 +711,7 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
     assert search_attributes["mm_repo"] == ["MoonLadderStudios/MoonMind"]
     assert child_kwargs["memo"] == {
         "entry": "user_workflow",
-        "title": "Resolve PR #350",
+        "title": expected_title,
         "summary": "Resolver child workflow for merge automation.",
         "targetRuntime": "codex",
         "targetSkill": "pr-resolver",
@@ -702,10 +726,14 @@ def test_merge_automation_child_memo_truncates_runtime_and_skill_visibility() ->
         },
     }
 
-    memo = MoonMindMergeAutomationWorkflow._resolver_child_memo(resolver_request)
+    memo = MoonMindMergeAutomationWorkflow._resolver_child_memo(
+        resolver_request,
+        attempt=12,
+    )
 
     assert memo["targetRuntime"] == "r" * 80
     assert memo["targetSkill"] == "s" * 160
+    assert memo["title"] == "Resolve PR #350 (Attempt 12)"
 
 @pytest.mark.asyncio
 async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marker(


### PR DESCRIPTION
## Summary

- append the one-based merge-automation attempt ordinal to resolver child workflow titles
- derive the title ordinal from the same deterministic value used in the child workflow ID
- preserve replay compatibility for in-flight Temporal histories
- document the operator-visible title contract

## Verification

- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
  - 43 targeted Python tests passed
  - repository frontend phase: 74 files and 1,274 tests passed
- .venv/bin/pytest tests/integration/workflows/temporal/workflows/test_merge_automation_full_topology.py -q --tb=short
  - 1 passed
- .venv/bin/ruff check on changed Python files