### PR TITLE
MoonLadderStudios/MoonMind#3817: Group Settings navigation under Configuration

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -116,6 +116,7 @@ class DashboardDestination:
     capability_key: str
     endpoint_key: str | None = None
     display_mode: str | None = None
+    menu_group_key: str | None = None
     page: str = "dashboard"
     data_wide_panel: bool = True
 
@@ -134,6 +135,8 @@ class DashboardDestination:
             payload["endpointKey"] = self.endpoint_key
         if self.display_mode is not None:
             payload["displayMode"] = self.display_mode
+        if self.menu_group_key is not None:
+            payload["menuGroupKey"] = self.menu_group_key
         return payload
 
 
@@ -253,15 +256,42 @@ DASHBOARD_DESTINATIONS: tuple[DashboardDestination, ...] = (
         page="artifacts",
     ),
     DashboardDestination(
-        key="settings",
-        label="Settings",
+        key="settings-providers-secrets",
+        label="Providers & Secrets",
         icon_key="settings",
-        canonical_path="/settings",
-        path_patterns=("/settings/*",),
+        canonical_path="/settings/providers-secrets",
+        path_patterns=("/settings/providers-secrets",),
         navigation_group="system",
         page_classification="utility",
-        capability_key="settings",
+        capability_key="settingsProvidersSecrets",
         endpoint_key="settings",
+        menu_group_key="configuration",
+        page="settings",
+    ),
+    DashboardDestination(
+        key="settings-user-workspace",
+        label="User / Workspace",
+        icon_key="settings",
+        canonical_path="/settings/user-workspace",
+        path_patterns=("/settings/user-workspace",),
+        navigation_group="system",
+        page_classification="utility",
+        capability_key="settingsUserWorkspace",
+        endpoint_key="settings",
+        menu_group_key="configuration",
+        page="settings",
+    ),
+    DashboardDestination(
+        key="settings-operations",
+        label="Operations",
+        icon_key="settings",
+        canonical_path="/settings/operations",
+        path_patterns=("/settings/operations",),
+        navigation_group="system",
+        page_classification="utility",
+        capability_key="settingsOperations",
+        endpoint_key="settings",
+        menu_group_key="configuration",
         page="settings",
     ),
 )
@@ -566,6 +596,38 @@ def _dashboard_destination(key: str) -> DashboardDestination:
 
 def _dashboard_destination_info() -> list[dict[str, object]]:
     return [destination.to_ui_info() for destination in DASHBOARD_DESTINATIONS]
+
+
+def _settings_destination_features(permissions: set[str]) -> dict[str, bool]:
+    permission_groups = {
+        "settingsProvidersSecrets": {
+            "provider_profiles.read",
+            "provider_profiles.write",
+            "secrets.metadata.read",
+            "secrets.value.write",
+            "secrets.rotate",
+            "secrets.disable",
+            "secrets.delete",
+        },
+        "settingsUserWorkspace": {
+            "settings.catalog.read",
+            "settings.effective.read",
+            "settings.user.write",
+            "settings.workspace.write",
+            "settings.system.read",
+            "settings.system.write",
+            "settings.audit.read",
+        },
+        "settingsOperations": {
+            "operations.read",
+            "operations.invoke",
+        },
+    }
+    return {
+        capability_key: True
+        for capability_key, required_permissions in permission_groups.items()
+        if permissions & required_permissions
+    }
 
 
 def _is_extensionless_collection_route(request: Request, destination_keys: set[str]) -> bool:
@@ -1376,11 +1438,11 @@ async def task_settings_route(
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
     """Serve the React-powered settings page."""
-    destination = _dashboard_destination("settings")
+    destination = _dashboard_destination("settings-providers-secrets")
     return await _render_react_page(
         request,
         destination.page,
-        destination.canonical_path,
+        request.url.path,
         data_wide_panel=destination.data_wide_panel,
         session=session,
         user=_user,
@@ -1593,7 +1655,7 @@ async def get_dashboard_ui_info(
             "artifacts": True,
             "schedules": True,
             "skills": True,
-            "settings": True,
+            **_settings_destination_features(settings_permissions),
             "manifests": True,
             "oauthTerminal": True,
             "remediationCollection": True,

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -600,34 +600,41 @@ def _dashboard_destination_info() -> list[dict[str, object]]:
 
 def _settings_destination_features(permissions: set[str]) -> dict[str, bool]:
     permission_groups = {
-        "settingsProvidersSecrets": {
-            "provider_profiles.read",
-            "provider_profiles.write",
-            "secrets.metadata.read",
-            "secrets.value.write",
-            "secrets.rotate",
-            "secrets.disable",
-            "secrets.delete",
-        },
-        "settingsUserWorkspace": {
-            "settings.catalog.read",
-            "settings.effective.read",
-            "settings.user.write",
-            "settings.workspace.write",
-            "settings.system.read",
-            "settings.system.write",
-            "settings.audit.read",
-        },
-        "settingsOperations": {
-            "operations.read",
-            "operations.invoke",
-        },
+        "settingsProvidersSecrets": (
+            {"provider_profiles.read", "secrets.metadata.read"},
+            {
+                "provider_profiles.write",
+                "secrets.value.write",
+                "secrets.rotate",
+                "secrets.disable",
+                "secrets.delete",
+            },
+        ),
+        "settingsUserWorkspace": (
+            {
+                "settings.catalog.read",
+                "settings.effective.read",
+                "settings.system.read",
+                "settings.audit.read",
+            },
+            {
+                "settings.user.write",
+                "settings.workspace.write",
+                "settings.system.write",
+            },
+        ),
+        "settingsOperations": (
+            {"operations.read"},
+            {"operations.invoke"},
+        ),
     }
-    return {
-        capability_key: True
-        for capability_key, required_permissions in permission_groups.items()
-        if permissions & required_permissions
-    }
+    features: dict[str, bool] = {}
+    for capability_key, (read_permissions, mutation_permissions) in permission_groups.items():
+        if permissions & read_permissions:
+            features[capability_key] = True
+        elif permissions & mutation_permissions:
+            features[capability_key] = False
+    return features
 
 
 def _is_extensionless_collection_route(request: Request, destination_keys: set[str]) -> bool:
@@ -1259,7 +1266,7 @@ async def secrets_route(
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
     """Redirect the legacy secrets page into unified settings."""
-    return RedirectResponse(url="/settings?section=providers-secrets", status_code=307)
+    return RedirectResponse(url="/settings/providers-secrets", status_code=307)
 
 
 @router.get("/workflows", name="workflow_console_root", response_class=HTMLResponse)
@@ -1428,7 +1435,7 @@ async def task_workers_route(
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
     """Redirect the legacy workers page into unified settings."""
-    return RedirectResponse(url="/settings?section=operations", status_code=307)
+    return RedirectResponse(url="/settings/operations", status_code=307)
 
 
 @router.get("/settings", response_class=HTMLResponse)

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -959,7 +959,7 @@ Deployment update belongs in the **Operations** subsection because it is a syste
 The Settings page should continue to use subsection routing such as:
 
 ```text
-/settings?section=operations
+/settings/operations
 ```
 
 ---

--- a/docs/UI/ProviderProfileModelEffortTierSettings.md
+++ b/docs/UI/ProviderProfileModelEffortTierSettings.md
@@ -192,7 +192,7 @@ The editor must state that saved profile policy affects future resolution. Exist
 The canonical route remains:
 
 ```text
-/settings?section=providers-secrets
+/settings/providers-secrets
 ```
 
 No new top-level Settings section is required.

--- a/docs/UI/WorkflowConsoleArchitecture.md
+++ b/docs/UI/WorkflowConsoleArchitecture.md
@@ -154,7 +154,7 @@ If a React route renders structurally correct HTML but spacing, grids, or layout
 | `/oauth-terminal` | OAuth terminal sessions (xterm.js lives here only) |
 | `/index-health` | Index health page |
 
-Convenience redirects: `/secrets` → `/settings?section=providers-secrets`, `/workers` → `/settings?section=operations`, `/manifests/new` → `/manifests`.
+Convenience redirects: `/secrets` → `/settings/providers-secrets`, `/workers` → `/settings/operations`, `/manifests/new` → `/manifests`.
 
 Rules:
 

--- a/frontend/src/components/DashboardSystemMenu.tsx
+++ b/frontend/src/components/DashboardSystemMenu.tsx
@@ -13,6 +13,7 @@ import {
   type DashboardIconKey,
   type DashboardUiInfo,
 } from '../lib/dashboardRoutes';
+import { requestSettingsRouteChange } from '../lib/settingsRouteGuard';
 
 const ICONS: Partial<Record<DashboardIconKey, typeof Settings>> = {
   archive: Archive,
@@ -44,6 +45,7 @@ function DestinationLink({ destination, state, onSelect, menuItem = true }: {
       <span
         role={menuItem ? 'menuitem' : undefined}
         aria-disabled="true"
+        tabIndex={menuItem ? -1 : undefined}
         className="dashboard-system-destination-unavailable"
       >
         <Icon size={16} className="route-nav-icon" aria-hidden="true" />
@@ -57,7 +59,13 @@ function DestinationLink({ destination, state, onSelect, menuItem = true }: {
       to={destination.canonicalPath}
       role={menuItem ? 'menuitem' : undefined}
       className={({ isActive }) => (isActive ? 'active' : undefined)}
-      onClick={onSelect}
+      onClick={(event) => {
+        if (!requestSettingsRouteChange(destination.canonicalPath)) {
+          event.preventDefault();
+          return;
+        }
+        onSelect();
+      }}
     >
       <Icon size={16} className="route-nav-icon" aria-hidden="true" />
       {destination.label}
@@ -148,7 +156,7 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
   const destinations = exposedSystemDestinations(uiInfo);
   const activeDestination = destinationForPath(location.pathname);
   const activeDestinationGroup = destinationGroupForDestination(activeDestination) ?? (
-    location.pathname.replace(/\/$/, '') === '/settings'
+    location.pathname.replace(/\/$/, '') === '/settings' || location.pathname.startsWith('/settings/')
       ? DASHBOARD_DESTINATION_GROUPS.find(({ key }) => key === 'configuration') ?? null
       : null
   );
@@ -176,7 +184,7 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
 
   const items = () => Array.from(
     rootRef.current?.querySelectorAll<HTMLElement>(
-      '.dashboard-system-popover [role="menuitem"]:not([aria-disabled="true"])',
+      '.dashboard-system-popover [role="menuitem"]',
     ) ?? [],
   );
   const focusAt = (index: number) => items()[index]?.focus();

--- a/frontend/src/components/DashboardSystemMenu.tsx
+++ b/frontend/src/components/DashboardSystemMenu.tsx
@@ -3,9 +3,13 @@ import { Archive, Bot, ChevronDown, Moon, Rows3, Settings, ShieldCheck, Sparkles
 import { NavLink, useLocation } from 'react-router-dom';
 
 import {
+  DASHBOARD_DESTINATION_GROUPS,
+  destinationGroupForDestination,
   destinationForPath,
-  visibleSystemDestinations,
+  destinationState,
+  exposedSystemDestinations,
   type DashboardDestination,
+  type DashboardDestinationState,
   type DashboardIconKey,
   type DashboardUiInfo,
 } from '../lib/dashboardRoutes';
@@ -26,15 +30,28 @@ const SECTION_LABELS: Record<string, string> = {
   manifests: 'Data & evidence',
   'omnigent-agents': 'Omnigent',
   remediation: 'Operations',
-  settings: 'Configuration',
 };
 
-function DestinationLink({ destination, onSelect, menuItem = true }: {
+function DestinationLink({ destination, state, onSelect, menuItem = true }: {
   destination: DashboardDestination;
+  state: DashboardDestinationState;
   onSelect: () => void;
   menuItem?: boolean;
 }) {
   const Icon = ICONS[destination.iconKey] ?? Settings;
+  if (state === 'unavailable') {
+    return (
+      <span
+        role={menuItem ? 'menuitem' : undefined}
+        aria-disabled="true"
+        className="dashboard-system-destination-unavailable"
+      >
+        <Icon size={16} className="route-nav-icon" aria-hidden="true" />
+        {destination.label}
+        <span className="sr-only"> unavailable</span>
+      </span>
+    );
+  }
   return (
     <NavLink
       to={destination.canonicalPath}
@@ -48,19 +65,75 @@ function DestinationLink({ destination, onSelect, menuItem = true }: {
   );
 }
 
-function DestinationSections({ destinations, onSelect, menuItems = true }: {
+function DestinationSection({
+  destinations,
+  label,
+  uiInfo,
+  onSelect,
+  menuItems,
+}: {
   destinations: DashboardDestination[];
+  label?: string | undefined;
+  uiInfo: DashboardUiInfo | null;
+  onSelect: () => void;
+  menuItems: boolean;
+}) {
+  return (
+    <div className="dashboard-system-menu-section">
+      {label ? <div className="dashboard-system-menu-label">{label}</div> : null}
+      {destinations.map((destination) => (
+        <DestinationLink
+          key={destination.key}
+          destination={destination}
+          state={destinationState(destination, uiInfo)}
+          onSelect={onSelect}
+          menuItem={menuItems}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DestinationSections({ destinations, uiInfo, onSelect, menuItems = true }: {
+  destinations: DashboardDestination[];
+  uiInfo: DashboardUiInfo | null;
   onSelect: () => void;
   menuItems?: boolean;
 }) {
-  return destinations.map((destination) => {
+  const destinationByKey = new Map(destinations.map((destination) => [destination.key, destination]));
+  const renderedGroups = new Set<string>();
+  return destinations.flatMap((destination) => {
+    const group = destinationGroupForDestination(destination);
+    if (group) {
+      if (renderedGroups.has(group.key)) return [];
+      renderedGroups.add(group.key);
+      const children = group.destinationKeys.flatMap((key) => {
+        const child = destinationByKey.get(key);
+        return child ? [child] : [];
+      });
+      if (children.length === 0) return [];
+      return [(
+        <DestinationSection
+          key={group.key}
+          destinations={children}
+          label={group.label}
+          uiInfo={uiInfo}
+          onSelect={onSelect}
+          menuItems={menuItems}
+        />
+      )];
+    }
     const sectionLabel = SECTION_LABELS[destination.key];
-    return (
-      <div className="dashboard-system-menu-section" key={destination.key}>
-        {sectionLabel ? <div className="dashboard-system-menu-label">{sectionLabel}</div> : null}
-        <DestinationLink destination={destination} onSelect={onSelect} menuItem={menuItems} />
-      </div>
-    );
+    return [(
+      <DestinationSection
+        key={destination.key}
+        destinations={[destination]}
+        label={sectionLabel}
+        uiInfo={uiInfo}
+        onSelect={onSelect}
+        menuItems={menuItems}
+      />
+    )];
   });
 }
 
@@ -72,13 +145,21 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const location = useLocation();
-  const destinations = visibleSystemDestinations(uiInfo);
+  const destinations = exposedSystemDestinations(uiInfo);
   const activeDestination = destinationForPath(location.pathname);
-  const active = Boolean(activeDestination && activeDestination.navigationGroup !== 'primary');
-  // When a System destination is active, the trigger takes on that selection's
-  // one-word label and icon (e.g. "Skills") instead of the generic "System".
-  const triggerLabel = active && activeDestination ? activeDestination.label : 'System';
-  const TriggerIcon = active && activeDestination ? (ICONS[activeDestination.iconKey] ?? Settings) : Settings;
+  const activeDestinationGroup = destinationGroupForDestination(activeDestination) ?? (
+    location.pathname.replace(/\/$/, '') === '/settings'
+      ? DASHBOARD_DESTINATION_GROUPS.find(({ key }) => key === 'configuration') ?? null
+      : null
+  );
+  const active = Boolean(
+    activeDestinationGroup || (activeDestination && activeDestination.navigationGroup !== 'primary'),
+  );
+  const triggerLabel = activeDestinationGroup?.triggerLabel ?? (
+    active && activeDestination ? activeDestination.label : 'System'
+  );
+  const triggerIconKey = activeDestinationGroup?.triggerIconKey ?? activeDestination?.iconKey;
+  const TriggerIcon = active && triggerIconKey ? (ICONS[triggerIconKey] ?? Settings) : Settings;
 
   useEffect(() => setOpen(false), [location.pathname, location.search]);
 
@@ -94,7 +175,9 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
   if (destinations.length === 0) return null;
 
   const items = () => Array.from(
-    rootRef.current?.querySelectorAll<HTMLAnchorElement>('.dashboard-system-popover [role="menuitem"]') ?? [],
+    rootRef.current?.querySelectorAll<HTMLElement>(
+      '.dashboard-system-popover [role="menuitem"]:not([aria-disabled="true"])',
+    ) ?? [],
   );
   const focusAt = (index: number) => items()[index]?.focus();
   const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -105,7 +188,7 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
   };
   const handleMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const menuItems = items();
-    const current = menuItems.indexOf(document.activeElement as HTMLAnchorElement);
+    const current = menuItems.indexOf(document.activeElement as HTMLElement);
     let next: number | null = null;
     if (event.key === 'Escape') {
       event.preventDefault();
@@ -147,14 +230,19 @@ export function DashboardSystemMenu({ uiInfo, mobileDrawerOpen }: {
         </button>
         {open ? (
           <div className="dashboard-system-popover" role="menu" aria-label="System" onKeyDown={handleMenuKeyDown}>
-            <DestinationSections destinations={destinations} onSelect={() => setOpen(false)} />
+            <DestinationSections destinations={destinations} uiInfo={uiInfo} onSelect={() => setOpen(false)} />
           </div>
         ) : null}
       </div>
       {mobileDrawerOpen ? (
         <div className="dashboard-system-inline" aria-label="System destinations">
           <div className="dashboard-system-inline-heading">System</div>
-          <DestinationSections destinations={destinations} onSelect={() => undefined} menuItems={false} />
+          <DestinationSections
+            destinations={destinations}
+            uiInfo={uiInfo}
+            onSelect={() => undefined}
+            menuItems={false}
+          />
         </div>
       ) : null}
     </>

--- a/frontend/src/components/settings/ConfigurationHealthSummary.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.tsx
@@ -270,6 +270,7 @@ export interface ConfigurationHealthSummaryProps {
   isLoading?: boolean;
   isError?: boolean;
   workerPauseConfig: WorkerPauseConfig | null;
+  includeWorkerState?: boolean;
   canWriteProviderProfiles: boolean;
   canRunGithubTokenProbe: boolean;
 }
@@ -280,10 +281,11 @@ export function ConfigurationHealthSummary({
   isLoading = false,
   isError = false,
   workerPauseConfig,
+  includeWorkerState = true,
   canWriteProviderProfiles,
   canRunGithubTokenProbe,
 }: ConfigurationHealthSummaryProps) {
-  const workerPauseConfigured = workerPauseConfig !== null;
+  const workerPauseConfigured = !includeWorkerState || workerPauseConfig !== null;
 
   const { data: workerState } = useQuery<WorkerStateSnapshot>({
     queryKey: ['workers-snapshot'],
@@ -299,7 +301,7 @@ export function ConfigurationHealthSummary({
       }
       return (await response.json()) as WorkerStateSnapshot;
     },
-    enabled: workerPauseConfigured && Boolean(workerPauseConfig?.get),
+    enabled: includeWorkerState && workerPauseConfigured && Boolean(workerPauseConfig?.get),
   });
 
   if (isLoading) {
@@ -370,7 +372,7 @@ export function ConfigurationHealthSummary({
         </span>
       </div>
 
-      <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className={`mt-5 grid gap-4 sm:grid-cols-2 ${includeWorkerState ? 'lg:grid-cols-4' : 'lg:grid-cols-3'}`}>
         <MetricTile
           label="Provider profiles"
           value={String(summary.providerProfileCount)}
@@ -393,7 +395,7 @@ export function ConfigurationHealthSummary({
           }
           tone={summary.brokenSecretCount > 0 ? 'warning' : 'default'}
         />
-        <MetricTile label="Worker state" value={workerStateLabel} />
+        {includeWorkerState ? <MetricTile label="Worker state" value={workerStateLabel} /> : null}
       </div>
 
       {summary.warnings.length > 0 ? (

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { fireEvent, screen, waitFor, within } from '../../utils/test-utils';
 import { renderWithClient } from '../../utils/test-utils';
+import { requestSettingsRouteChange } from '../../lib/settingsRouteGuard';
 import { GeneratedSettingsSection } from './GeneratedSettingsSection';
 
 const workspaceCatalog = {
@@ -492,5 +493,26 @@ describe('GeneratedSettingsSection', () => {
     expect(screen.getByLabelText('Pending settings preview')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
     expect(screen.queryByLabelText('Pending settings preview')).toBeNull();
+  });
+
+  it('blocks Settings route changes and unload while generated edits are pending', async () => {
+    const confirm = vi.spyOn(window, 'confirm')
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    renderWithClient(<GeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+    fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });
+
+    expect(requestSettingsRouteChange('/settings/operations')).toBe(false);
+    expect(confirm).toHaveBeenNthCalledWith(
+      1,
+      'Discard unsaved Settings changes and leave this page? Select OK to discard and leave, or Cancel to stay.',
+    );
+    expect(window.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false);
+    expect(requestSettingsRouteChange('/settings/operations')).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(window.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(true);
   });
 });

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -1,5 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  SETTINGS_ROUTE_CHANGE_REQUEST_EVENT,
+  type SettingsRouteChangeRequestDetail,
+} from '../../lib/settingsRouteGuard';
 
 type SettingScope = 'workspace' | 'user';
 
@@ -385,6 +389,51 @@ export function GeneratedSettingsSection() {
 
   const pendingChanges = Object.values(pending);
   const hasInvalidChange = pendingChanges.some((change) => !change.valid);
+
+  useEffect(() => {
+    if (pendingChanges.length === 0) {
+      return undefined;
+    }
+    const handleRouteChangeRequest = (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      const detail = event.detail as SettingsRouteChangeRequestDetail | undefined;
+      if (!detail?.href) {
+        return;
+      }
+      const destination = new URL(detail.href, window.location.href);
+      const current = new URL(window.location.href);
+      if (
+        destination.pathname === current.pathname &&
+        destination.search === current.search &&
+        destination.hash === current.hash
+      ) {
+        return;
+      }
+      if (!window.confirm(
+        'Discard unsaved Settings changes and leave this page? Select OK to discard and leave, or Cancel to stay.',
+      )) {
+        event.preventDefault();
+      }
+    };
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener(
+      SETTINGS_ROUTE_CHANGE_REQUEST_EVENT,
+      handleRouteChangeRequest,
+    );
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener(
+        SETTINGS_ROUTE_CHANGE_REQUEST_EVENT,
+        handleRouteChangeRequest,
+      );
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [pendingChanges.length]);
 
   const updatePending = (descriptor: SettingDescriptor, raw: string | boolean) => {
     const next = coerceInputValue(descriptor, raw);

--- a/frontend/src/entrypoints/dashboard-alerts.tsx
+++ b/frontend/src/entrypoints/dashboard-alerts.tsx
@@ -72,7 +72,7 @@ export function DashboardAlerts() {
         Profiles in Settings.
         <div style={{ marginTop: "12px" }}>
           <a
-            href="/settings?section=providers-secrets"
+            href="/settings/providers-secrets"
             className="btn btn-sm btn-outline"
           >
             Open Settings
@@ -104,7 +104,7 @@ export function DashboardAlerts() {
       </ul>
       <div style={{ marginTop: "12px" }}>
         <a
-          href="/settings?section=providers-secrets"
+          href="/settings/providers-secrets"
           className="btn btn-sm btn-outline"
         >
           Open Settings

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -985,7 +985,7 @@ function AppShell({
               Workers: Running
             </span>
             <span className="worker-pause-reason" data-worker-pause-reason />
-            <Link className="worker-pause-manage" to="/settings?section=operations" data-worker-pause-manage>
+            <Link className="worker-pause-manage" to="/settings/operations" data-worker-pause-manage>
               Manage operations
             </Link>
           </p>

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../utils/dashboardPreferences';
 import { DASHBOARD_DESTINATIONS } from '../lib/dashboardRoutes';
 import { SKILLS_CREATE_REQUEST_EVENT } from '../lib/skillsCreateRequest';
+import { SETTINGS_ROUTE_CHANGE_REQUEST_EVENT } from '../lib/settingsRouteGuard';
 
 const animatedNavIconMocks = vi.hoisted(() => ({
   moonStart: vi.fn(),
@@ -499,6 +500,7 @@ describe('Dashboard shared entry', () => {
     ['/settings/providers-secrets', 'Settings'],
     ['/settings/user-workspace', 'Settings'],
     ['/settings/operations', 'Settings'],
+    ['/settings/provider-profiles', 'Settings'],
     ['/schedules', 'Recurring'],
     ['/schedules/nightly-build', 'Recurring'],
     ['/skills', 'Skills'],
@@ -522,7 +524,7 @@ describe('Dashboard shared entry', () => {
     expect(trigger.classList.contains('active')).toBe(true);
     expect(screen.queryByRole('button', { name: 'System' })).toBeNull();
     expect(screen.getByRole('link', { name: 'Workflows' }).classList.contains('active')).toBe(false);
-    if (path.startsWith('/settings/')) {
+    if (path.startsWith('/settings/') && path !== '/settings/provider-profiles') {
       expect(trigger.querySelector('.lucide-settings')).not.toBeNull();
       fireEvent.click(trigger);
       const activeLink = screen.getByRole('menuitem', {
@@ -598,6 +600,30 @@ describe('Dashboard shared entry', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('MoonLadderStudios/MoonMind#3817 cancels menu navigation when a Settings draft guard blocks it', () => {
+    function LocationProbe() {
+      return <output aria-label="Current path">{useLocation().pathname}</output>;
+    }
+    window.addEventListener(
+      SETTINGS_ROUTE_CHANGE_REQUEST_EVENT,
+      (event) => event.preventDefault(),
+      { once: true },
+    );
+    renderWithClient(
+      <MemoryRouter initialEntries={['/settings/providers-secrets']}>
+        <DashboardSystemMenu uiInfo={uiInfo()} mobileDrawerOpen={false} />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Settings' });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'User / Workspace' }));
+
+    expect(screen.getByRole('status', { name: 'Current path' }).textContent).toBe('/settings/providers-secrets');
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
   it('MM-1200 renders enabled System children inline on mobile without a nested popover', () => {
     renderWithClient(
       <MemoryRouter initialEntries={['/settings/operations']}>
@@ -670,6 +696,24 @@ describe('Dashboard shared entry', () => {
     expect(screen.getAllByText('Configuration')).toHaveLength(1);
     const unavailable = screen.getByRole('menuitem', { name: /Operations/ });
     expect(unavailable.tagName).toBe('SPAN');
+    expect(unavailable.getAttribute('aria-disabled')).toBe('true');
+    expect(unavailable.tabIndex).toBe(-1);
+  });
+
+  it('MoonLadderStudios/MoonMind#3817 includes unavailable destinations in keyboard focus movement', async () => {
+    renderWithClient(
+      <MemoryRouter initialEntries={['/workflows']}>
+        <DashboardSystemMenu
+          uiInfo={uiInfo({ features: { settingsOperations: false } })}
+          mobileDrawerOpen={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'System' });
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    const unavailable = await screen.findByRole('menuitem', { name: /Operations/ });
+    await waitFor(() => expect(document.activeElement).toBe(unavailable));
     expect(unavailable.getAttribute('aria-disabled')).toBe('true');
   });
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -298,7 +298,9 @@ function uiInfo(overrides: Record<string, unknown> = {}) {
       artifacts: true,
       schedules: true,
       skills: true,
-      settings: true,
+      settingsProvidersSecrets: true,
+      settingsUserWorkspace: true,
+      settingsOperations: true,
       manifests: true,
       remediationCollection: false,
       omnigentAgents: false,
@@ -428,13 +430,18 @@ describe('Dashboard shared entry', () => {
     expect(screen.getByText('Workflow resources')).toBeTruthy();
     expect(screen.getByRole('menuitem', { name: 'Manifests' })).toBeTruthy();
     expect(screen.getByRole('menuitem', { name: 'Artifacts' })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Settings' })).toBeTruthy();
+    const configuration = screen.getByText('Configuration').closest('.dashboard-system-menu-section');
+    expect(configuration).not.toBeNull();
+    expect(within(configuration as HTMLElement).getAllByRole('menuitem').map((item) => item.textContent?.trim())).toEqual([
+      'Providers & Secrets', 'User / Workspace', 'Operations',
+    ]);
+    expect(screen.getAllByText('Configuration')).toHaveLength(1);
     expect(screen.queryByRole('menuitem', { name: 'Remediation' })).toBeNull();
 
     const first = screen.getByRole('menuitem', { name: 'Recurring' });
     first.focus();
     fireEvent.keyDown(first, { key: 'End' });
-    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Settings' }));
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Operations' }));
     fireEvent.keyDown(document.activeElement as Element, { key: 'Escape' });
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
     expect(document.activeElement).toBe(trigger);
@@ -481,7 +488,7 @@ describe('Dashboard shared entry', () => {
     const trigger = screen.getByRole('button', { name: 'System' });
     fireEvent.click(trigger);
     expect(screen.getByRole('menuitem', { name: 'Skills' })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Settings' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Providers & Secrets' })).toBeTruthy();
   });
 
   it.each([
@@ -489,12 +496,14 @@ describe('Dashboard shared entry', () => {
     ['/artifacts/example', 'Artifacts'],
     ['/observability/example', 'Artifacts'],
     ['/remediations/example', 'Remediation'],
-    ['/settings/providers', 'Settings'],
+    ['/settings/providers-secrets', 'Settings'],
+    ['/settings/user-workspace', 'Settings'],
+    ['/settings/operations', 'Settings'],
     ['/schedules', 'Recurring'],
     ['/schedules/nightly-build', 'Recurring'],
     ['/skills', 'Skills'],
     ['/skills/speckit-orchestrate', 'Skills'],
-  ])('MM-1200 marks the System menu active and relabels it for the child route %s', (path, label) => {
+  ])('MM-1200 marks the System menu active and uses the correct trigger for child route %s', (path, label) => {
     renderWithClient(
       <MemoryRouter initialEntries={[path]}>
         <nav aria-label="Test navigation">
@@ -507,19 +516,32 @@ describe('Dashboard shared entry', () => {
       </MemoryRouter>,
     );
 
-    // The trigger takes on the active selection's one-word label in place of
-    // "System" while carrying the active underline treatment.
+    // Configuration children share one stable Settings trigger; other System
+    // destinations retain their selected labels.
     const trigger = screen.getByRole('button', { name: label });
     expect(trigger.classList.contains('active')).toBe(true);
     expect(screen.queryByRole('button', { name: 'System' })).toBeNull();
     expect(screen.getByRole('link', { name: 'Workflows' }).classList.contains('active')).toBe(false);
+    if (path.startsWith('/settings/')) {
+      expect(trigger.querySelector('.lucide-settings')).not.toBeNull();
+      fireEvent.click(trigger);
+      const activeLink = screen.getByRole('menuitem', {
+        name: path.endsWith('providers-secrets')
+          ? 'Providers & Secrets'
+          : path.endsWith('user-workspace')
+            ? 'User / Workspace'
+            : 'Operations',
+      });
+      expect(activeLink.getAttribute('aria-current')).toBe('page');
+      expect(activeLink.classList.contains('active')).toBe(true);
+    }
   });
 
   it.each([
     ['Enter', 'Recurring'],
     [' ', 'Recurring'],
     ['ArrowDown', 'Recurring'],
-    ['ArrowUp', 'Settings'],
+    ['ArrowUp', 'Operations'],
   ])('MM-1200 opens System with %s and focuses %s', async (key, expectedItem) => {
     renderWithClient(
       <MemoryRouter initialEntries={['/workflows']}>
@@ -541,7 +563,7 @@ describe('Dashboard shared entry', () => {
     const trigger = screen.getByRole('button', { name: 'System' });
     fireEvent.click(trigger);
     const first = screen.getByRole('menuitem', { name: 'Recurring' });
-    const last = screen.getByRole('menuitem', { name: 'Settings' });
+    const last = screen.getByRole('menuitem', { name: 'Operations' });
     first.focus();
     fireEvent.keyDown(first, { key: 'ArrowDown' });
     expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Skills' }));
@@ -567,8 +589,8 @@ describe('Dashboard shared entry', () => {
     );
     const trigger = screen.getByRole('button', { name: 'System' });
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Settings' }));
-    expect(screen.getByRole('status', { name: 'Current path' }).textContent).toBe('/settings');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'User / Workspace' }));
+    expect(screen.getByRole('status', { name: 'Current path' }).textContent).toBe('/settings/user-workspace');
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(trigger);
@@ -578,7 +600,7 @@ describe('Dashboard shared entry', () => {
 
   it('MM-1200 renders enabled System children inline on mobile without a nested popover', () => {
     renderWithClient(
-      <MemoryRouter initialEntries={['/workflows']}>
+      <MemoryRouter initialEntries={['/settings/operations']}>
         <DashboardSystemMenu
           uiInfo={uiInfo({ features: { ...uiInfo().features, manifests: false, artifacts: false } })}
           mobileDrawerOpen
@@ -587,12 +609,68 @@ describe('Dashboard shared entry', () => {
     );
     const inline = screen.getByLabelText('System destinations');
     expect(inline.querySelector('[role="menu"]')).toBeNull();
-    expect(screen.getByRole('link', { name: 'Settings' })).toBeTruthy();
+    const configuration = within(inline).getByText('Configuration').closest('.dashboard-system-menu-section');
+    expect(configuration).not.toBeNull();
+    expect(within(configuration as HTMLElement).getAllByRole('link').map((link) => link.textContent?.trim())).toEqual([
+      'Providers & Secrets', 'User / Workspace', 'Operations',
+    ]);
+    expect(within(configuration as HTMLElement).getByRole('link', { name: 'Operations' }).getAttribute('aria-current')).toBe('page');
     // Recurring and Skills render as normal inline links, not a nested popover.
     expect(within(inline).getByRole('link', { name: 'Recurring' })).toBeTruthy();
     expect(within(inline).getByRole('link', { name: 'Skills' })).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'Manifests' })).toBeNull();
     expect(screen.queryByRole('link', { name: 'Artifacts' })).toBeNull();
+  });
+
+  it('MoonLadderStudios/MoonMind#3817 scopes the Configuration group to exposed children', () => {
+    const features: Record<string, boolean> = { ...uiInfo().features };
+    delete features.settingsProvidersSecrets;
+    delete features.settingsOperations;
+    renderWithClient(
+      <MemoryRouter initialEntries={['/settings/user-workspace']}>
+        <DashboardSystemMenu uiInfo={uiInfo({ features })} mobileDrawerOpen={false} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(screen.getAllByText('Configuration')).toHaveLength(1);
+    expect(screen.queryByRole('menuitem', { name: 'Providers & Secrets' })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: 'User / Workspace' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'Operations' })).toBeNull();
+  });
+
+  it('MoonLadderStudios/MoonMind#3817 omits an unexposed group and disables intentionally unavailable children', () => {
+    const hiddenFeatures: Record<string, boolean> = { ...uiInfo().features };
+    delete hiddenFeatures.settingsProvidersSecrets;
+    delete hiddenFeatures.settingsUserWorkspace;
+    delete hiddenFeatures.settingsOperations;
+    const { unmount } = renderWithClient(
+      <MemoryRouter initialEntries={['/workflows']}>
+        <DashboardSystemMenu uiInfo={uiInfo({ features: hiddenFeatures })} mobileDrawerOpen={false} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'System' }));
+    expect(screen.queryByText('Configuration')).toBeNull();
+    unmount();
+
+    renderWithClient(
+      <MemoryRouter initialEntries={['/workflows']}>
+        <DashboardSystemMenu
+          uiInfo={uiInfo({
+            features: {
+              ...hiddenFeatures,
+              settingsOperations: false,
+            },
+          })}
+          mobileDrawerOpen={false}
+        />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'System' }));
+    expect(screen.getAllByText('Configuration')).toHaveLength(1);
+    const unavailable = screen.getByRole('menuitem', { name: /Operations/ });
+    expect(unavailable.tagName).toBe('SPAN');
+    expect(unavailable.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('MM-1192 traps mobile navigation focus, locks scrolling, and restores focus on Escape', async () => {
@@ -604,7 +682,7 @@ describe('Dashboard shared entry', () => {
     fireEvent.click(trigger);
 
     const workflowsLink = screen.getByRole('link', { name: 'Workflows' });
-    const settingsLink = screen.getByRole('link', { name: 'Settings' });
+    const settingsLink = screen.getByRole('link', { name: 'Operations' });
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByRole('button', { name: 'Close navigation menu' })).toBeTruthy();
     expect(document.body.style.overflow).toBe('hidden');
@@ -1789,7 +1867,7 @@ describe('Dashboard shared entry', () => {
 
     expect(await screen.findByText('Workflow list route loaded')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'System' }));
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Settings' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Providers & Secrets' }));
 
     expect(
       await screen.findByText('Settings permissions: provider_profiles.write,settings.effective.read'),
@@ -2123,7 +2201,7 @@ describe('Dashboard shared entry', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'No list' }));
     expect((await screen.findByRole('status')).textContent).toContain('Opening first workflow...');
     fireEvent.click(screen.getByRole('button', { name: 'System' }));
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Settings' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Providers & Secrets' }));
     expect(await screen.findByText('Settings permissions:')).toBeTruthy();
 
     const completeList = resolveList;
@@ -2136,7 +2214,7 @@ describe('Dashboard shared entry', () => {
     } as Response);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/settings');
+      expect(window.location.pathname).toBe('/settings/providers-secrets');
     });
     expect(window.location.search).toBe('');
     expect(screen.queryByText(/stale-row/i)).toBeNull();
@@ -2840,77 +2918,6 @@ describe('Dashboard shared entry', () => {
     expect(narrowLastScheduledBlock).toContain('display: none');
     expect(mobileTableBlock).toContain('display: none');
     expect(mobileCardListBlock).toContain('display: grid');
-  });
-
-  it('stacks Settings section radio controls on mobile viewports', async () => {
-    const settingsLoudSelector = '.settings-page .segmented-control[data-intensity="loud"]';
-    const settingsLoudItemSelector = `${settingsLoudSelector} .segmented-control-item`;
-    const mobileSettingsNavBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === settingsLoudSelector &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-    const mobileSettingsOptionBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === settingsLoudItemSelector &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-    const mobileFirstSettingsOptionBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === `${settingsLoudItemSelector}:first-of-type` &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-    const mobileLastSettingsOptionBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === `${settingsLoudItemSelector}:last-of-type` &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-    const mobileSettingsLabelBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === `${settingsLoudSelector} .segmented-control-item-label` &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-    const mobileSettingsActiveBlock = cssRuleBlockMatching(dashboardCss, (rule) => {
-      return (
-        normalizeCssSelector(rule.selector) === `${settingsLoudItemSelector}:has(input:checked)` &&
-        rule.parent?.type === 'atrule' &&
-        rule.parent.name === 'media' &&
-        rule.parent.params.includes('max-width: 640px')
-      );
-    });
-
-    expect(mobileSettingsNavBlock).toContain('display: grid');
-    expect(mobileSettingsNavBlock).toContain('grid-template-columns: minmax(0, 1fr)');
-    expect(mobileSettingsNavBlock).toContain('width: 100%');
-    expect(mobileSettingsNavBlock).toContain('padding: 0');
-    expect(mobileSettingsOptionBlock).toContain('justify-content: flex-start');
-    expect(mobileSettingsOptionBlock).toContain('width: 100%');
-    expect(mobileFirstSettingsOptionBlock).toContain('border-top-left-radius: 9px');
-    expect(mobileFirstSettingsOptionBlock).toContain('border-top-right-radius: 9px');
-    expect(mobileLastSettingsOptionBlock).toContain('border-bottom-left-radius: 9px');
-    expect(mobileLastSettingsOptionBlock).toContain('border-bottom-right-radius: 9px');
-    expect(mobileSettingsActiveBlock).toContain('0 0 18px rgb(var(--mm-accent) / 0.55)');
-    expect(mobileSettingsActiveBlock).toContain('0 0 32px rgb(var(--mm-accent-2) / 0.22)');
-    // MM-1138 Q3/B2: the active pill keeps its neon glow but no longer runs the
-    // perpetual shimmer animation, so no reduced-motion override is needed.
-    expect(mobileSettingsActiveBlock).not.toContain('animation');
-    expect(mobileSettingsLabelBlock).toContain('white-space: normal');
-    expect(mobileSettingsLabelBlock).toContain('overflow-wrap: anywhere');
   });
 
   it('keeps liquidGL opt-in and away from default dense surfaces', async () => {

--- a/frontend/src/entrypoints/settings.test.tsx
+++ b/frontend/src/entrypoints/settings.test.tsx
@@ -15,7 +15,7 @@ describe('Settings Entrypoint', () => {
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
-    window.history.pushState({}, 'Settings', '/settings?section=providers-secrets');
+    window.history.pushState({}, 'Settings', '/settings/providers-secrets');
     fetchSpy = vi.spyOn(window, 'fetch').mockReturnValue(new Promise(() => {}) as Promise<Response>);
   });
 
@@ -25,7 +25,7 @@ describe('Settings Entrypoint', () => {
   });
 
   it('MM-1185 resets collection layouts and remembered identities from Settings', () => {
-    window.history.replaceState({}, 'Settings', '/settings?section=user-workspace');
+    window.history.replaceState({}, 'Settings', '/settings/user-workspace');
     updateDashboardPreferences({
       workflowListDisplayMode: 'hidden',
       lastSelectedWorkflowId: 'workflow-one',
@@ -46,11 +46,25 @@ describe('Settings Entrypoint', () => {
   it('renders page-matched scoped placeholders for provider profiles and managed secrets', () => {
     renderWithClient(<SettingsPage payload={mockPayload} />);
 
-    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
-    expect(screen.getByRole('heading', { name: 'Providers & Secrets' })).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 2, name: 'Providers & Secrets' })).toBeTruthy();
     expect(screen.getByText('Settings provider profiles loading placeholder').closest('[role="status"]')).toBeTruthy();
     expect(screen.getByText('Settings managed secrets loading placeholder').closest('[role="status"]')).toBeTruthy();
     expect(screen.getAllByTestId('loading-placeholder-table').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each([
+    ['/settings/providers-secrets', 'Providers & Secrets'],
+    ['/settings/user-workspace', 'User / Workspace'],
+    ['/settings/operations', 'Operations'],
+  ])('MoonLadderStudios/MoonMind#3817 gives %s route-owned identity without local navigation', (path, label) => {
+    window.history.replaceState({}, 'Settings', path);
+    renderWithClient(<SettingsPage payload={mockPayload} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: label })).toBeTruthy();
+    expect(document.title).toBe(`${label} | MoonMind`);
+    expect(screen.queryByRole('radio')).toBeNull();
+    expect(screen.queryByRole('tab')).toBeNull();
+    expect(document.querySelector('.settings-page .segmented-control')).toBeNull();
   });
 });
 
@@ -93,7 +107,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
-    window.history.pushState({}, 'Settings', '/settings?section=providers-secrets');
+    window.history.pushState({}, 'Settings', '/settings/providers-secrets');
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/v1/provider-profiles')) {

--- a/frontend/src/entrypoints/settings.test.tsx
+++ b/frontend/src/entrypoints/settings.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import type { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
@@ -10,6 +10,14 @@ describe('Settings Entrypoint', () => {
   const mockPayload: BootPayload = {
     page: 'settings',
     apiBase: '/api',
+    initialData: {
+      settingsPermissions: [
+        'provider_profiles.read',
+        'secrets.metadata.read',
+        'settings.catalog.read',
+        'operations.read',
+      ],
+    },
   };
 
   let fetchSpy: MockInstance;
@@ -66,6 +74,119 @@ describe('Settings Entrypoint', () => {
     expect(screen.queryByRole('tab')).toBeNull();
     expect(document.querySelector('.settings-page .segmented-control')).toBeNull();
   });
+
+  it('resolves bare Settings to the first readable destination with replacement history', async () => {
+    window.history.replaceState({}, 'Settings', '/settings');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: { settingsPermissions: ['operations.read'] },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Operations' })).toBeTruthy();
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+  });
+
+  it('normalizes an unknown Settings alias through the authorized default destination', async () => {
+    window.history.replaceState({}, 'Settings', '/settings/provider-profiles');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: { settingsPermissions: ['settings.catalog.read'] },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'User / Workspace' })).toBeTruthy();
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/user-workspace'));
+  });
+
+  it('shows direct unauthorized destinations without mounting protected page content', () => {
+    window.history.replaceState({}, 'Settings', '/settings/providers-secrets');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: { settingsPermissions: ['operations.read'] },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Providers & Secrets' })).toBeTruthy();
+    expect(screen.getByRole('status', { name: 'Configuration unavailable' })).toBeTruthy();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/settings/providers-secrets');
+  });
+
+  it('renders the unavailable default state when no Configuration page is readable', () => {
+    window.history.replaceState({}, 'Settings', '/settings');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: { settingsPermissions: ['operations.invoke'] },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Configuration unavailable' })).toBeTruthy();
+    expect(screen.getByRole('status', { name: 'Configuration unavailable' })).toBeTruthy();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/settings');
+  });
+
+  it('does not request provider or secret datasets from another Settings page', () => {
+    window.history.replaceState({}, 'Settings', '/settings/operations');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: { settingsPermissions: ['operations.read'] },
+        }}
+      />,
+    );
+
+    const requestedUrls = fetchSpy.mock.calls.map(([input]) => String(input));
+    expect(requestedUrls).not.toContain('/api/v1/provider-profiles');
+    expect(requestedUrls).not.toContain('/api/v1/secrets');
+    expect(screen.queryByLabelText('Configuration health summary')).toBeNull();
+  });
+
+  it('does not request Operations data from the Providers & Secrets summary', async () => {
+    window.history.replaceState({}, 'Settings', '/settings/providers-secrets');
+    renderWithClient(
+      <SettingsPage
+        payload={{
+          page: 'settings',
+          apiBase: '/api',
+          initialData: {
+            settingsPermissions: ['provider_profiles.read', 'secrets.metadata.read'],
+            workerPause: {
+              get: '/api/system/worker-pause',
+              post: '/api/system/worker-pause',
+              shardHealth: '/api/v1/operations/codex/shards',
+            },
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      const requestedUrls = fetchSpy.mock.calls.map(([input]) => String(input));
+      expect(requestedUrls).toContain('/api/v1/provider-profiles');
+      expect(requestedUrls).toContain('/api/v1/secrets');
+    });
+    expect(fetchSpy.mock.calls.map(([input]) => String(input))).not.toContain('/api/system/worker-pause');
+  });
 });
 
 describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filter', () => {
@@ -93,7 +214,11 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
     page: 'settings',
     apiBase: '/api',
     initialData: {
-      settingsPermissions: ['provider_profiles.write'],
+      settingsPermissions: [
+        'provider_profiles.read',
+        'provider_profiles.write',
+        'secrets.metadata.read',
+      ],
       runtimeConfig: {
         system: {
           // `omnigent` is a facade, never a Provider Profile owner, so it must

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { BootPayload } from '../boot/parseBootPayload';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
@@ -23,62 +23,6 @@ import { resetDashboardPreferences } from '../utils/dashboardPreferences';
 // never offered as a Provider Profile runtime filter.
 const NON_PROFILE_OWNING_RUNTIMES = new Set(['omnigent']);
 
-function ProvidersKeyIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="8" cy="14" r="3.5" />
-      <path d="M10.5 12L20 4" />
-      <path d="M17 7l2 2" />
-      <path d="M14 10l2 2" />
-    </svg>
-  );
-}
-
-function UserWorkspaceIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="8" r="3.5" />
-      <path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6" />
-    </svg>
-  );
-}
-
-function OperationsGearIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" />
-      <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1" />
-    </svg>
-  );
-}
-
 interface ProfileData {
   id?: string | number;
   email?: string;
@@ -101,57 +45,47 @@ interface SecretsListResponse {
   items: SecretMetadata[];
 }
 
-const SETTINGS_SECTIONS: ReadonlyArray<{
+const SETTINGS_PAGES: ReadonlyArray<{
   id: 'providers-secrets' | 'user-workspace' | 'operations';
+  path: string;
   label: string;
   description: string;
-  Icon: () => ReactElement;
 }> = [
   {
     id: 'providers-secrets',
+    path: '/settings/providers-secrets',
     label: 'Providers & Secrets',
     description:
       'Configure provider profiles, managed secrets, and the bindings that make runtimes launchable.',
-    Icon: ProvidersKeyIcon,
   },
   {
     id: 'user-workspace',
+    path: '/settings/user-workspace',
     label: 'User / Workspace',
     description:
       'Hold user-scoped and workspace-scoped settings as the dashboard exposes more of the broader configuration model.',
-    Icon: UserWorkspaceIcon,
   },
   {
     id: 'operations',
+    path: '/settings/operations',
     label: 'Operations',
     description:
       'Keep worker pause, drain, quiesce, and related operational controls under Settings.',
-    Icon: OperationsGearIcon,
   },
 ] as const;
 
-type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]['id'];
-
-function isSettingsSection(value: string | null): value is SettingsSectionId {
-  return SETTINGS_SECTIONS.some((section) => section.id === value);
-}
-
-function readSectionFromLocation(): SettingsSectionId {
-  const params = new URLSearchParams(window.location.search);
-  const section = params.get('section');
-  return isSettingsSection(section) ? section : 'providers-secrets';
-}
-
-function updateSectionInLocation(section: SettingsSectionId): void {
-  const url = new URL(window.location.href);
-  url.searchParams.set('section', section);
-  window.history.pushState({}, '', url.toString());
+function settingsPageForPath(pathname: string): (typeof SETTINGS_PAGES)[number] {
+  const normalized = pathname.length > 1 && pathname.endsWith('/')
+    ? pathname.slice(0, -1)
+    : pathname;
+  return SETTINGS_PAGES.find(({ path }) => path === normalized) ?? SETTINGS_PAGES[0]!;
 }
 
 export function SettingsPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const [notice, setNotice] = useState<Notice | null>(null);
-  const [section, setSection] = useState<SettingsSectionId>(() => readSectionFromLocation());
+  const currentPage = settingsPageForPath(window.location.pathname);
+  const section = currentPage.id;
   // Settings is the administrative exception to runtime-scoped Provider Profile
   // selection: it enters on the All-runtimes view and can narrow the table to a
   // single runtime without narrowing global configuration health.
@@ -181,16 +115,12 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
   const canRunGithubTokenProbe = settingsPermissions.has('settings.effective.read');
 
   useEffect(() => {
-    const handlePopState = () => {
-      setSection(readSectionFromLocation());
-      setNotice(null);
-    };
-
-    window.addEventListener('popstate', handlePopState);
+    const previousTitle = document.title;
+    document.title = `${currentPage.label} | MoonMind`;
     return () => {
-      window.removeEventListener('popstate', handlePopState);
+      document.title = previousTitle;
     };
-  }, []);
+  }, [currentPage.label]);
 
   const { data: profile, isLoading, isError } = useQuery<ProfileData>({
     queryKey: ['profile'],
@@ -270,19 +200,6 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           (profile) => profile.runtime_id === providerProfileRuntimeFilter,
         );
 
-  const fallbackSection = SETTINGS_SECTIONS[0]!;
-  const currentSection =
-    SETTINGS_SECTIONS.find((candidate) => candidate.id === section) ?? fallbackSection;
-
-  const handleSelectSection = (nextSection: SettingsSectionId) => {
-    if (nextSection === section) {
-      return;
-    }
-    updateSectionInLocation(nextSection);
-    setSection(nextSection);
-    setNotice(null);
-  };
-
   return (
     <div className="settings-page mx-auto w-full space-y-6 px-4 py-6 sm:px-6 lg:px-8">
       <header className="rounded-[2rem] border border-mm-border/80 bg-transparent px-6 py-6 shadow-sm">
@@ -290,8 +207,8 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 dark:text-slate-400">
             Dashboard Settings
           </p>
-          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Settings</h2>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">{currentSection.description}</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">{currentPage.label}</h2>
+          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">{currentPage.description}</p>
         </div>
       </header>
 
@@ -304,44 +221,6 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
         canWriteProviderProfiles={canWriteProviderProfiles}
         canRunGithubTokenProbe={canRunGithubTokenProbe}
       />
-
-      <section className="rounded-[2rem] border border-mm-border/80 bg-transparent p-3 shadow-sm">
-        <fieldset className="segmented-control-field">
-          <legend className="sr-only">Settings Section</legend>
-          <div
-            className="segmented-control"
-            data-intensity="loud"
-            style={{
-              '--segmented-control-count': SETTINGS_SECTIONS.length,
-            } as CSSProperties}
-          >
-            {SETTINGS_SECTIONS.map((candidate) => {
-              const Icon = candidate.Icon;
-              return (
-                <label
-                  key={candidate.id}
-                  className="segmented-control-item"
-                  title={candidate.description}
-                >
-                  <input
-                    type="radio"
-                    name="settings-section"
-                    value={candidate.id}
-                    checked={candidate.id === section}
-                    onChange={() => handleSelectSection(candidate.id)}
-                  />
-                  <span className="segmented-control-item-icon">
-                    <Icon />
-                  </span>
-                  <span className="segmented-control-item-label">
-                    {candidate.label}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </fieldset>
-      </section>
 
       {notice ? (
         <div
@@ -360,7 +239,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
               <div className="space-y-2">
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Providers & Secrets</h3>
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Provider profile and secret management</h3>
                 <p className="text-sm text-slate-600 dark:text-slate-400">
                   Provider profiles are the durable runtime and provider launch contract.
                   Managed secrets back those profiles without re-exposing raw credential

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -50,6 +50,7 @@ const SETTINGS_PAGES: ReadonlyArray<{
   path: string;
   label: string;
   description: string;
+  readPermissions: readonly string[];
 }> = [
   {
     id: 'providers-secrets',
@@ -57,6 +58,7 @@ const SETTINGS_PAGES: ReadonlyArray<{
     label: 'Providers & Secrets',
     description:
       'Configure provider profiles, managed secrets, and the bindings that make runtimes launchable.',
+    readPermissions: ['provider_profiles.read', 'secrets.metadata.read'],
   },
   {
     id: 'user-workspace',
@@ -64,6 +66,12 @@ const SETTINGS_PAGES: ReadonlyArray<{
     label: 'User / Workspace',
     description:
       'Hold user-scoped and workspace-scoped settings as the dashboard exposes more of the broader configuration model.',
+    readPermissions: [
+      'settings.catalog.read',
+      'settings.effective.read',
+      'settings.system.read',
+      'settings.audit.read',
+    ],
   },
   {
     id: 'operations',
@@ -71,21 +79,59 @@ const SETTINGS_PAGES: ReadonlyArray<{
     label: 'Operations',
     description:
       'Keep worker pause, drain, quiesce, and related operational controls under Settings.',
+    readPermissions: ['operations.read'],
   },
 ] as const;
 
-function settingsPageForPath(pathname: string): (typeof SETTINGS_PAGES)[number] {
+type SettingsPageDefinition = (typeof SETTINGS_PAGES)[number];
+
+function canReadSettingsPage(
+  page: SettingsPageDefinition,
+  permissions: ReadonlySet<string>,
+): boolean {
+  return page.readPermissions.some((permission) => permissions.has(permission));
+}
+
+function resolveSettingsPage(
+  pathname: string,
+  permissions: ReadonlySet<string>,
+): {
+  page: SettingsPageDefinition | null;
+  accessible: boolean;
+  replacementPath: string | null;
+} {
   const normalized = pathname.length > 1 && pathname.endsWith('/')
     ? pathname.slice(0, -1)
     : pathname;
-  return SETTINGS_PAGES.find(({ path }) => path === normalized) ?? SETTINGS_PAGES[0]!;
+  const exactPage = SETTINGS_PAGES.find(({ path }) => path === normalized) ?? null;
+  if (exactPage) {
+    return {
+      page: exactPage,
+      accessible: canReadSettingsPage(exactPage, permissions),
+      replacementPath: pathname === exactPage.path ? null : exactPage.path,
+    };
+  }
+  const defaultPage = SETTINGS_PAGES.find((page) => canReadSettingsPage(page, permissions)) ?? null;
+  return {
+    page: defaultPage,
+    accessible: defaultPage !== null,
+    replacementPath: defaultPage?.path ?? null,
+  };
 }
 
 export function SettingsPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const [notice, setNotice] = useState<Notice | null>(null);
-  const currentPage = settingsPageForPath(window.location.pathname);
-  const section = currentPage.id;
+  const settingsPermissions = new Set(
+    ((payload.initialData as { settingsPermissions?: string[] } | undefined)
+      ?.settingsPermissions ?? []),
+  );
+  const {
+    page: currentPage,
+    accessible: pageAccessible,
+    replacementPath,
+  } = resolveSettingsPage(window.location.pathname, settingsPermissions);
+  const section = currentPage?.id ?? null;
   // Settings is the administrative exception to runtime-scoped Provider Profile
   // selection: it enters on the All-runtimes view and can narrow the table to a
   // single runtime without narrowing global configuration health.
@@ -107,20 +153,32 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
   const defaultTaskModelByRuntime: Record<string, string> =
     runtimeSystemConfig.defaultTaskModelByRuntime ?? {};
   const supportedRuntimes: string[] = runtimeSystemConfig.supportedRuntimes ?? [];
-  const settingsPermissions = new Set(
-    ((payload.initialData as { settingsPermissions?: string[] } | undefined)
-      ?.settingsPermissions ?? []),
-  );
+  const canReadProviderProfiles = settingsPermissions.has('provider_profiles.read');
+  const canReadSecrets = settingsPermissions.has('secrets.metadata.read');
+  const canReadSettingsCatalog = settingsPermissions.has('settings.catalog.read');
   const canWriteProviderProfiles = settingsPermissions.has('provider_profiles.write');
   const canRunGithubTokenProbe = settingsPermissions.has('settings.effective.read');
 
   useEffect(() => {
+    if (!replacementPath) {
+      return;
+    }
+    const target = `${replacementPath}${window.location.search}${window.location.hash}`;
+    const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (target === current) {
+      return;
+    }
+    window.history.replaceState(window.history.state, '', target);
+    window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }));
+  }, [replacementPath]);
+
+  useEffect(() => {
     const previousTitle = document.title;
-    document.title = `${currentPage.label} | MoonMind`;
+    document.title = `${currentPage?.label ?? 'Configuration unavailable'} | MoonMind`;
     return () => {
       document.title = previousTitle;
     };
-  }, [currentPage.label]);
+  }, [currentPage?.label]);
 
   const { data: profile, isLoading, isError } = useQuery<ProfileData>({
     queryKey: ['profile'],
@@ -136,7 +194,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
-    enabled: section === 'user-workspace',
+    enabled: section === 'user-workspace' && pageAccessible,
   });
 
   const {
@@ -154,6 +212,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
+    enabled: section === 'providers-secrets' && pageAccessible && canReadSecrets,
   });
 
   const {
@@ -171,6 +230,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
+    enabled: section === 'providers-secrets' && pageAccessible && canReadProviderProfiles,
   });
 
   // The complete collection stays the single source for configuration health so
@@ -207,22 +267,26 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 dark:text-slate-400">
             Dashboard Settings
           </p>
-          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">{currentPage.label}</h2>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">{currentPage.description}</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">
+            {currentPage?.label ?? 'Configuration unavailable'}
+          </h2>
+          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
+            {currentPage?.description ?? 'No Configuration destination is available for this account.'}
+          </p>
         </div>
       </header>
 
-      <ConfigurationHealthSummary
-        providerProfiles={allProviderProfiles}
-        secrets={secretsData?.items ?? []}
-        isLoading={areProfilesLoading || areSecretsLoading}
-        isError={areProfilesErrored || areSecretsErrored}
-        workerPauseConfig={workerPauseConfig}
-        canWriteProviderProfiles={canWriteProviderProfiles}
-        canRunGithubTokenProbe={canRunGithubTokenProbe}
-      />
+      {!pageAccessible ? (
+        <section
+          role="status"
+          aria-label="Configuration unavailable"
+          className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+        >
+          This Configuration page is unavailable for your current permissions. No protected page data was requested.
+        </section>
+      ) : null}
 
-      {notice ? (
+      {pageAccessible && notice ? (
         <div
           className={`rounded-3xl border px-5 py-4 text-sm shadow-sm ${
             notice.level === 'error'
@@ -234,8 +298,21 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
         </div>
       ) : null}
 
-      {section === 'providers-secrets' ? (
+      {pageAccessible && section === 'providers-secrets' ? (
         <div className="space-y-6">
+          {canReadProviderProfiles && canReadSecrets ? (
+            <ConfigurationHealthSummary
+              providerProfiles={allProviderProfiles}
+              secrets={secretsData?.items ?? []}
+              isLoading={areProfilesLoading || areSecretsLoading}
+              isError={areProfilesErrored || areSecretsErrored}
+              workerPauseConfig={workerPauseConfig}
+              includeWorkerState={false}
+              canWriteProviderProfiles={canWriteProviderProfiles}
+              canRunGithubTokenProbe={canRunGithubTokenProbe}
+            />
+          ) : null}
+
           <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
             <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
               <div className="space-y-2">
@@ -254,7 +331,11 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
             </div>
           </section>
 
-          {areProfilesLoading ? (
+          {!canReadProviderProfiles ? (
+            <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+              Provider profiles are unavailable for your current permissions.
+            </div>
+          ) : areProfilesLoading ? (
             <LoadingPlaceholder
               surface="settings"
               region="provider profiles"
@@ -286,7 +367,11 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
             />
           )}
 
-          {areSecretsLoading ? (
+          {!canReadSecrets ? (
+            <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+              Managed secrets are unavailable for your current permissions.
+            </div>
+          ) : areSecretsLoading ? (
             <LoadingPlaceholder
               surface="settings"
               region="managed secrets"
@@ -314,9 +399,15 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
         </div>
       ) : null}
 
-      {section === 'user-workspace' ? (
+      {pageAccessible && section === 'user-workspace' ? (
         <div className="space-y-6">
-          <GeneratedSettingsSection />
+          {canReadSettingsCatalog ? (
+            <GeneratedSettingsSection />
+          ) : (
+            <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
+              The settings catalog is unavailable for your current permissions.
+            </section>
+          )}
 
           <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
             <h3 className="text-base font-semibold text-slate-900 dark:text-white">
@@ -374,7 +465,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
         </div>
       ) : null}
 
-      {section === 'operations' ? (
+      {pageAccessible && section === 'operations' ? (
         <OperationsSettingsSection workerPauseConfig={workerPauseConfig} />
       ) : null}
     </div>

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -25,6 +25,7 @@ describe('dashboard route resolution', () => {
       Array.from(new Set([
         ...DASHBOARD_DESTINATIONS.flatMap(({ pathPatterns }) => pathPatterns),
         '/settings',
+        '/settings/*',
       ])),
     );
     expect(DASHBOARD_DESTINATIONS.find(({ key }) => key === 'skills')?.displayMode).toBe('skills-list');
@@ -99,6 +100,14 @@ describe('dashboard route resolution', () => {
     'resolves the extensionless collection deep link %s',
     (path) => expect(resolveDashboardRoute(path)).not.toBeNull(),
   );
+  it('routes extensionless Settings aliases through the Settings page for normalization', () => {
+    expect(DASHBOARD_REACT_ROUTE_PATHS).toContain('/settings/*');
+    expect(resolveDashboardRoute('/settings/provider-profiles')).toEqual({
+      page: 'settings',
+      dataWidePanel: true,
+      currentPath: '/settings/provider-profiles',
+    });
+  });
   it.each(['/omnigent/agents', '/omnigent/policies'])(
     'resolves the %s inventory route independently',
     (path) => {

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DASHBOARD_DESTINATION_GROUPS,
   DASHBOARD_DESTINATIONS,
   DASHBOARD_REACT_ROUTE_PATHS,
   destinationState,
@@ -16,13 +17,28 @@ describe('dashboard route resolution', () => {
   it('keeps one canonical typed inventory for every major destination', () => {
     expect(DASHBOARD_DESTINATIONS.map(({ key }) => key)).toEqual([
       'workflows', 'create', 'recurring', 'skills', 'manifests',
-      'omnigent-agents', 'omnigent-policies', 'remediation', 'artifacts', 'settings',
+      'omnigent-agents', 'omnigent-policies', 'remediation', 'artifacts',
+      'settings-providers-secrets', 'settings-user-workspace', 'settings-operations',
     ]);
-    expect(new Set(DASHBOARD_DESTINATIONS.map(({ canonicalPath }) => canonicalPath)).size).toBe(10);
+    expect(new Set(DASHBOARD_DESTINATIONS.map(({ canonicalPath }) => canonicalPath)).size).toBe(12);
     expect(DASHBOARD_REACT_ROUTE_PATHS).toEqual(
-      Array.from(new Set(DASHBOARD_DESTINATIONS.flatMap(({ pathPatterns }) => pathPatterns))),
+      Array.from(new Set([
+        ...DASHBOARD_DESTINATIONS.flatMap(({ pathPatterns }) => pathPatterns),
+        '/settings',
+      ])),
     );
     expect(DASHBOARD_DESTINATIONS.find(({ key }) => key === 'skills')?.displayMode).toBe('skills-list');
+    expect(DASHBOARD_DESTINATION_GROUPS).toContainEqual({
+      key: 'configuration',
+      label: 'Configuration',
+      triggerLabel: 'Settings',
+      triggerIconKey: 'settings',
+      destinationKeys: [
+        'settings-providers-secrets',
+        'settings-user-workspace',
+        'settings-operations',
+      ],
+    });
   });
 
   it('derives shown, hidden, and unavailable states from capability data', () => {
@@ -40,7 +56,8 @@ describe('dashboard route resolution', () => {
       'workflows', 'create',
     ]);
     expect(visibleSystemDestinations(info).map(({ key }) => key)).toEqual([
-      'recurring', 'skills', 'manifests', 'omnigent-agents', 'remediation', 'artifacts', 'settings',
+      'recurring', 'skills', 'manifests', 'omnigent-agents', 'remediation', 'artifacts',
+      'settings-providers-secrets', 'settings-user-workspace', 'settings-operations',
     ]);
   });
 
@@ -56,7 +73,9 @@ describe('dashboard route resolution', () => {
     ['/artifacts/run/1', 'artifacts'],
     ['/observability/run/1', 'artifacts'],
     ['/remediations/mm:1', 'remediation'],
-    ['/settings/providers', 'settings'],
+    ['/settings/providers-secrets', 'settings-providers-secrets'],
+    ['/settings/user-workspace', 'settings-user-workspace'],
+    ['/settings/operations', 'settings-operations'],
     ['/schedules', 'recurring'],
     ['/schedules/nightly%3Abuild', 'recurring'],
     ['/skills', 'skills'],

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -155,6 +155,7 @@ export const DASHBOARD_REACT_ROUTE_PATHS = Array.from(
   new Set([
     ...DASHBOARD_DESTINATIONS.flatMap((destination) => destination.pathPatterns),
     '/settings',
+    '/settings/*',
   ]),
 );
 

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -54,12 +54,35 @@ export type DashboardDestinationInfo = {
   capabilityKey: string;
   endpointKey?: string;
   displayMode?: DashboardDisplayMode;
+  menuGroupKey?: string;
 };
 
 export type DashboardDestination = DashboardDestinationInfo & {
   page: DashboardPage;
   dataWidePanel: boolean;
 };
+
+export type DashboardDestinationGroup = {
+  key: string;
+  label: string;
+  triggerLabel: string;
+  triggerIconKey: DashboardIconKey;
+  destinationKeys: readonly string[];
+};
+
+export const DASHBOARD_DESTINATION_GROUPS: readonly DashboardDestinationGroup[] = [
+  {
+    key: 'configuration',
+    label: 'Configuration',
+    triggerLabel: 'Settings',
+    triggerIconKey: 'settings',
+    destinationKeys: [
+      'settings-providers-secrets',
+      'settings-user-workspace',
+      'settings-operations',
+    ],
+  },
+];
 
 export const DASHBOARD_DESTINATIONS: readonly DashboardDestination[] = [
   { key: 'workflows', label: 'Workflows', iconKey: 'scroll-text', canonicalPath: '/workflows', pathPatterns: ['/workflows', '/workflows/:workflowId', '/workflows/:workflowId/:detailTab'], navigationGroup: 'primary', pageClassification: 'workspace', capabilityKey: 'workflowList', endpointKey: 'workflows', displayMode: 'workflow-list', page: 'workflows-workspace', dataWidePanel: true },
@@ -71,7 +94,9 @@ export const DASHBOARD_DESTINATIONS: readonly DashboardDestination[] = [
   { key: 'omnigent-policies', label: 'Policies', iconKey: 'shield-check', canonicalPath: '/omnigent/policies', pathPatterns: ['/omnigent/policies/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'omnigentPolicies', endpointKey: 'omnigentPolicies', page: 'omnigent-inventory', dataWidePanel: true },
   { key: 'remediation', label: 'Remediation', iconKey: 'wrench', canonicalPath: '/remediations', pathPatterns: ['/remediations/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'remediationCollection', endpointKey: 'remediations', page: 'remediations', dataWidePanel: true },
   { key: 'artifacts', label: 'Artifacts', iconKey: 'archive', canonicalPath: '/artifacts', pathPatterns: ['/artifacts/*', '/observability/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'artifacts', endpointKey: 'artifacts', page: 'artifacts', dataWidePanel: true },
-  { key: 'settings', label: 'Settings', iconKey: 'settings', canonicalPath: '/settings', pathPatterns: ['/settings/*'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settings', endpointKey: 'settings', page: 'settings', dataWidePanel: true },
+  { key: 'settings-providers-secrets', label: 'Providers & Secrets', iconKey: 'settings', canonicalPath: '/settings/providers-secrets', pathPatterns: ['/settings/providers-secrets'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settingsProvidersSecrets', endpointKey: 'settings', menuGroupKey: 'configuration', page: 'settings', dataWidePanel: true },
+  { key: 'settings-user-workspace', label: 'User / Workspace', iconKey: 'settings', canonicalPath: '/settings/user-workspace', pathPatterns: ['/settings/user-workspace'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settingsUserWorkspace', endpointKey: 'settings', menuGroupKey: 'configuration', page: 'settings', dataWidePanel: true },
+  { key: 'settings-operations', label: 'Operations', iconKey: 'settings', canonicalPath: '/settings/operations', pathPatterns: ['/settings/operations'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settingsOperations', endpointKey: 'settings', menuGroupKey: 'configuration', page: 'settings', dataWidePanel: true },
 ];
 
 export type DashboardDestinationState = 'shown' | 'hidden' | 'unavailable';
@@ -107,8 +132,30 @@ export function visibleSystemDestinations(
   return visibleDashboardDestinations(uiInfo).filter(({ navigationGroup }) => navigationGroup !== 'primary');
 }
 
+export function exposedSystemDestinations(
+  uiInfo: DashboardUiInfo | null | undefined,
+): DashboardDestination[] {
+  return DASHBOARD_DESTINATIONS.filter((destination) => {
+    if (destination.navigationGroup === 'primary') return false;
+    const state = destinationState(destination, uiInfo);
+    return state === 'shown' || (
+      state === 'unavailable' && destination.menuGroupKey === 'configuration'
+    );
+  });
+}
+
+export function destinationGroupForDestination(
+  destination: DashboardDestination | null | undefined,
+): DashboardDestinationGroup | null {
+  if (!destination?.menuGroupKey) return null;
+  return DASHBOARD_DESTINATION_GROUPS.find(({ key }) => key === destination.menuGroupKey) ?? null;
+}
+
 export const DASHBOARD_REACT_ROUTE_PATHS = Array.from(
-  new Set(DASHBOARD_DESTINATIONS.flatMap((destination) => destination.pathPatterns)),
+  new Set([
+    ...DASHBOARD_DESTINATIONS.flatMap((destination) => destination.pathPatterns),
+    '/settings',
+  ]),
 );
 
 export function matchesDashboardDestinationRegistry(
@@ -128,6 +175,7 @@ export function matchesDashboardDestinationRegistry(
       local.capabilityKey === remote.capabilityKey &&
       local.endpointKey === remote.endpointKey &&
       local.displayMode === remote.displayMode &&
+      local.menuGroupKey === remote.menuGroupKey &&
       JSON.stringify(local.pathPatterns) === JSON.stringify(remote.pathPatterns)
     );
   });
@@ -247,6 +295,14 @@ export function destinationForPath(pathname: string): DashboardDestination | nul
   const route = resolveDashboardRoute(pathname);
   if (!route) return null;
   if (pathname === '/workflows/new') return DASHBOARD_DESTINATIONS[1] ?? null;
+  if (route.page === 'settings') {
+    const path = withoutTrailingSlash(pathname);
+    return DASHBOARD_DESTINATIONS.find((destination) => (
+      destination.page === 'settings' && (
+        path === destination.canonicalPath || path.startsWith(`${destination.canonicalPath}/`)
+      )
+    )) ?? null;
+  }
   return DASHBOARD_DESTINATIONS.find((destination) => (
     destination.page === route.page && (
       destination.key !== 'artifacts' || pathname.startsWith('/artifacts') || pathname.startsWith('/observability')

--- a/frontend/src/lib/settingsRouteGuard.ts
+++ b/frontend/src/lib/settingsRouteGuard.ts
@@ -1,0 +1,21 @@
+export const SETTINGS_ROUTE_CHANGE_REQUEST_EVENT =
+  'moonmind:settings-route-change-request';
+
+export type SettingsRouteChangeRequestDetail = {
+  href: string;
+};
+
+export function requestSettingsRouteChange(href: string): boolean {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+  return window.dispatchEvent(
+    new CustomEvent<SettingsRouteChangeRequestDetail>(
+      SETTINGS_ROUTE_CHANGE_REQUEST_EVENT,
+      {
+        cancelable: true,
+        detail: { href },
+      },
+    ),
+  );
+}

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -879,6 +879,22 @@ h1 {
   width: 100%;
 }
 
+.route-nav .dashboard-system-destination-unavailable {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  padding: 0.48rem 0.82rem;
+  color: rgb(var(--mm-muted) / 0.78);
+  font-size: 0.9rem;
+  cursor: not-allowed;
+  user-select: none;
+}
+
+.dashboard-system-popover .dashboard-system-destination-unavailable {
+  width: 100%;
+}
+
 /* The System trigger keeps its purple underline when a System destination is
  * active, but the selected row inside the open popover must not repeat that
  * underline. Suppress the masthead underline on every popover row (it also
@@ -6284,7 +6300,7 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
 
 /* MM-1138 Q3: one canonical segmented-control system with two intensity tiers.
  * `data-intensity="quiet"` is the low-key detail-tab look (subtle accent thumb,
- * navigation links); `data-intensity="loud"` is the high-energy create/settings
+ * navigation links); `data-intensity="loud"` is the high-energy create-flow
  * look (neon gradient thumb and radio group, without perpetual motion). Both tiers
  * share the container chrome, item typography, focus ring and the sliding thumb,
  * which is driven by the shared --segmented-control-count /
@@ -6548,67 +6564,6 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     grid-template-columns: minmax(0, 1fr);
   }
 
-  /* MM-1138 Q3: the Settings section switcher (a loud-tier segmented control)
-   * stacks vertically on narrow viewports. Scoped to `.settings-page` so the
-   * create-page controls keep their inline layout, matching prior behavior. */
-  .settings-page .segmented-control[data-intensity="loud"] {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 0.25rem;
-    width: 100%;
-    padding: 0;
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"]::before {
-    display: none;
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"] .segmented-control-item {
-    justify-content: flex-start;
-    min-height: 2.75rem;
-    width: 100%;
-    padding: 0.7rem 0.85rem;
-    border-radius: 8px;
-    letter-spacing: 0.04em;
-    text-align: left;
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"] .segmented-control-item:first-of-type {
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"] .segmented-control-item:last-of-type {
-    border-bottom-left-radius: 9px;
-    border-bottom-right-radius: 9px;
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"] .segmented-control-item:has(input:checked) {
-    background:
-      linear-gradient(
-          115deg,
-          transparent 35%,
-          rgb(255 255 255 / 0.14) 50%,
-          transparent 65%
-        )
-        0 0 / 220% 100% no-repeat,
-      linear-gradient(
-        135deg,
-        color-mix(in srgb, rgb(var(--mm-accent)) 82%, black) 0%,
-        color-mix(in srgb, rgb(var(--mm-accent-2)) 70%, black) 100%
-    );
-    box-shadow:
-      0 0 0 1px rgb(var(--mm-accent) / 0.55),
-      0 0 18px rgb(var(--mm-accent) / 0.55),
-      0 0 32px rgb(var(--mm-accent-2) / 0.22),
-      inset 0 1px 0 rgb(255 255 255 / 0.22);
-  }
-
-  .settings-page .segmented-control[data-intensity="loud"] .segmented-control-item-label {
-    white-space: normal;
-    overflow-wrap: anywhere;
-    line-height: 1.2;
-  }
 }
 
 .segmented-control-panel {
@@ -8029,6 +7984,15 @@ button:where(:not(.secondary, .queue-action, .queue-submit-primary, .queue-step-
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     transform: none;
+  }
+
+  .route-nav .dashboard-system-destination-unavailable {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-height: 3.25rem;
+    padding: 0 1rem;
+    color: rgb(var(--mm-muted) / 0.78);
   }
 
   /* The collapsed nav renders flat menu rows: drop the desktop liquid-glass

--- a/frontend/src/styles/dashboardBrand.test.ts
+++ b/frontend/src/styles/dashboardBrand.test.ts
@@ -178,6 +178,11 @@ describe('dashboard masthead brand styles', () => {
     expect(cssRuleBlock('.dashboard-system-trigger.active::after')).toContain(
       'background: rgb(var(--mm-accent));',
     );
+    const unavailableDestination = cssRuleBlock(
+      '.route-nav .dashboard-system-destination-unavailable',
+    );
+    expect(unavailableDestination).toContain('color: rgb(var(--mm-muted) / 0.78);');
+    expect(unavailableDestination).toContain('cursor: not-allowed;');
     expect(dashboardCss).toMatch(
       /@media \(max-width: 1180px\)\s*\{[\s\S]*\.dashboard-system-menu\s*\{[^}]*display:\s*none;[\s\S]*\.dashboard-system-inline\s*\{[^}]*display:\s*block;/s,
     );

--- a/tests/e2e/test_dashboard_react_mount_browser.py
+++ b/tests/e2e/test_dashboard_react_mount_browser.py
@@ -60,8 +60,8 @@ def server():
     "path,expected_text",
     [
         ("/workflows", "Workflows"),
-        ("/settings?section=operations", "Operations"),
-        ("/settings?section=providers-secrets", "Provider Profiles"),
+        ("/settings/operations", "Operations"),
+        ("/settings/providers-secrets", "Provider Profiles"),
     ],
 )
 def test_react_page_shows_app_content(server, path: str, expected_text: str) -> None:

--- a/tests/integration/api/test_workflow_console_routes.py
+++ b/tests/integration/api/test_workflow_console_routes.py
@@ -87,7 +87,15 @@ async def async_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Async
         "VITE_MANIFEST_PATH", str(_write_dashboard_test_manifest(tmp_path))
     )
 
-    mock_user = SimpleNamespace(id=uuid4(), email="workflow-routes@example.com")
+    mock_user = SimpleNamespace(
+        id=uuid4(),
+        email="workflow-routes@example.com",
+        settings_permissions={
+            "provider_profiles.read",
+            "settings.catalog.read",
+            "operations.read",
+        },
+    )
     for dependency in _resolve_user_dependency_overrides():
         app.dependency_overrides[dependency] = lambda mock_user=mock_user: mock_user
     app.dependency_overrides[get_async_session] = lambda: None
@@ -140,7 +148,9 @@ async def test_supported_workflow_routes_render_console_shell(
         "/skills",
         "/skills/local/editor",
         "/settings",
-        "/settings/provider-profiles",
+        "/settings/providers-secrets",
+        "/settings/user-workspace",
+        "/settings/operations",
         "/manifests",
         "/manifests/default-workflow",
         "/oauth-terminal",
@@ -171,7 +181,9 @@ async def test_ui_info_endpoint_exposes_spa_capabilities_and_endpoints(
     assert payload["app"] == "moonmind"
     assert payload["apiBase"] == "/api"
     assert payload["features"]["workflowList"] is True
-    assert payload["features"]["settings"] is True
+    assert payload["features"]["settingsProvidersSecrets"] is True
+    assert payload["features"]["settingsUserWorkspace"] is True
+    assert payload["features"]["settingsOperations"] is True
     assert payload["endpoints"]["workflows"] == "/api/executions"
     assert payload["endpoints"]["workflowDetail"] == "/api/executions/{workflowId}"
     assert "dashboardConfig" in payload

--- a/tests/integration/temporal/test_system_operations_api.py
+++ b/tests/integration/temporal/test_system_operations_api.py
@@ -78,7 +78,7 @@ def test_worker_pause_route_matches_settings_runtime_contract(
                 app.dependency_overrides[dependency.call] = _override_user
     try:
         with TestClient(app) as client:
-            settings_page = client.get("/settings?section=operations")
+            settings_page = client.get("/settings/operations")
             snapshot = client.get("/api/system/worker-pause")
             command = client.post(
                 "/api/system/worker-pause",

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -456,6 +456,23 @@ def test_dashboard_ui_info_scopes_configuration_destinations_to_permissions() ->
     assert features["settingsOperations"] is True
 
 
+def test_dashboard_ui_info_marks_mutation_only_configuration_destinations_unavailable() -> None:
+    with _client_with_mock_service(
+        user_settings_permissions={
+            "provider_profiles.write",
+            "settings.workspace.write",
+            "operations.invoke",
+        }
+    ) as (client, _mock_service):
+        response = client.get("/api/ui/info")
+
+    assert response.status_code == 200
+    features = response.json()["features"]
+    assert features["settingsProvidersSecrets"] is False
+    assert features["settingsUserWorkspace"] is False
+    assert features["settingsOperations"] is False
+
+
 def test_index_health_route_uses_index_health_boot_payload(client: TestClient) -> None:
     response = client.get("/index-health")
 
@@ -677,11 +694,11 @@ def test_legacy_settings_subroutes_redirect_to_unified_settings(
 ) -> None:
     workers = client.get("/workers", follow_redirects=False)
     assert workers.status_code == 307
-    assert workers.headers["location"] == "/settings?section=operations"
+    assert workers.headers["location"] == "/settings/operations"
 
     secrets = client.get("/secrets", follow_redirects=False)
     assert secrets.status_code == 307
-    assert secrets.headers["location"] == "/settings?section=providers-secrets"
+    assert secrets.headers["location"] == "/settings/providers-secrets"
 
 
 def test_react_tasks_list_and_detail_boot_exclude_route_specific_config(

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -96,11 +96,16 @@ def _write_dashboard_test_manifest(root: Path) -> Path:
 @contextmanager
 def _client_with_mock_service(
     monkeypatch: pytest.MonkeyPatch | None = None,
+    user_settings_permissions: set[str] | None = None,
 ) -> Iterator[tuple[TestClient, AsyncMock]]:
     app = FastAPI()
     app.include_router(router)
 
-    mock_user = SimpleNamespace(id=uuid4(), email="dashboard@example.com")
+    mock_user = SimpleNamespace(
+        id=uuid4(),
+        email="dashboard@example.com",
+        settings_permissions=user_settings_permissions or set(),
+    )
     mock_service = AsyncMock()
     mock_service.list_jobs_page.return_value = SimpleNamespace(
         items=tuple(),
@@ -213,7 +218,9 @@ def test_dashboard_destination_registry_matches_registered_spa_routes() -> None:
         "/workflows/new",
         "/schedules",
         "/skills",
-        "/settings",
+        "/settings/providers-secrets",
+        "/settings/user-workspace",
+        "/settings/operations",
         "/manifests",
         "/omnigent/agents",
         "/omnigent/policies",
@@ -338,10 +345,25 @@ def test_dashboard_ui_info_endpoint_exposes_spa_boundary(client: TestClient) -> 
         "settings.catalog.read" in payload["settingsPermissions"]
     )
     assert payload["features"]["manifests"] is True
+    assert {
+        "settingsProvidersSecrets",
+        "settingsUserWorkspace",
+        "settingsOperations",
+    }.isdisjoint(payload["features"])
     assert payload["destinations"] == [
         destination.to_ui_info() for destination in DASHBOARD_DESTINATIONS
     ]
-    assert len({item["canonicalPath"] for item in payload["destinations"]}) == 10
+    assert len({item["canonicalPath"] for item in payload["destinations"]}) == 12
+    configuration_destinations = [
+        item
+        for item in payload["destinations"]
+        if item.get("menuGroupKey") == "configuration"
+    ]
+    assert [item["key"] for item in configuration_destinations] == [
+        "settings-providers-secrets",
+        "settings-user-workspace",
+        "settings-operations",
+    ]
     skills_destination = next(
         item for item in payload["destinations"] if item["key"] == "skills"
     )
@@ -419,6 +441,19 @@ def test_dashboard_ui_info_endpoint_exposes_spa_boundary(client: TestClient) -> 
         assert 'id="dashboard-alerts-root"' not in response.text
         assert "marked.min.js" not in response.text
         assert "__moonmind_customElementsDefineGuard" not in response.text
+
+
+def test_dashboard_ui_info_scopes_configuration_destinations_to_permissions() -> None:
+    with _client_with_mock_service(
+        user_settings_permissions={"settings.catalog.read", "operations.read"}
+    ) as (client, _mock_service):
+        response = client.get("/api/ui/info")
+
+    assert response.status_code == 200
+    features = response.json()["features"]
+    assert "settingsProvidersSecrets" not in features
+    assert features["settingsUserWorkspace"] is True
+    assert features["settingsOperations"] is True
 
 
 def test_index_health_route_uses_index_health_boot_payload(client: TestClient) -> None:


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3817

Closes MoonLadderStudios/MoonMind#3817

## Summary

- define an explicit Configuration destination group with Providers & Secrets, User / Workspace, and Operations in canonical order
- keep the Settings trigger and icon stable across all three routes while preserving active route-link and unavailable-state semantics
- share grouped navigation across desktop and mobile, scope child visibility by permissions, and remove the page-local Settings destination switcher
- add focused frontend, backend, API integration, styling, and browser-harness coverage

## Tests run

- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/dashboard.test.tsx frontend/src/lib/dashboardRoutes.test.ts frontend/src/entrypoints/settings.test.tsx frontend/src/styles/dashboardBrand.test.ts` (199 passed)
- `moonmind container python-tests tests/unit/api/routers/test_workflow_console.py tests/integration/api/test_workflow_console_routes.py` (85 passed)
- `node ./node_modules/typescript/bin/tsc --noEmit -p frontend/tsconfig.json`
- targeted ESLint for changed frontend files
- `git diff --check origin/main...HEAD`

## Remaining risks

- browser/deployment E2E was not run; focused component and API integration coverage passed
- the npm typecheck shim cannot resolve paths containing a colon in this managed workspace, so the same repository-local TypeScript compiler was invoked directly and passed