### PR TITLE
[Settings redesign] Route-owned Settings pages (MoonLadderStudios/MoonMind#3818)

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -1196,8 +1196,8 @@ async def secrets_route(
     request: Request,
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
-    """Redirect the legacy secrets page into unified settings."""
-    return RedirectResponse(url="/settings?section=providers-secrets", status_code=307)
+    """Redirect the legacy secrets page to its canonical Settings route."""
+    return RedirectResponse(url="/settings/providers-secrets", status_code=307)
 
 
 @router.get("/workflows", name="workflow_console_root", response_class=HTMLResponse)
@@ -1365,8 +1365,8 @@ async def task_workers_route(
     request: Request,
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
-    """Redirect the legacy workers page into unified settings."""
-    return RedirectResponse(url="/settings?section=operations", status_code=307)
+    """Redirect the legacy workers page to its canonical Settings route."""
+    return RedirectResponse(url="/settings/operations", status_code=307)
 
 
 @router.get("/settings", response_class=HTMLResponse)

--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -598,43 +598,76 @@ def _dashboard_destination_info() -> list[dict[str, object]]:
     return [destination.to_ui_info() for destination in DASHBOARD_DESTINATIONS]
 
 
-def _settings_destination_features(permissions: set[str]) -> dict[str, bool]:
-    permission_groups = {
-        "settingsProvidersSecrets": (
-            {"provider_profiles.read", "secrets.metadata.read"},
+_SETTINGS_DESTINATION_PERMISSIONS: dict[
+    str, tuple[str, frozenset[str], frozenset[str]]
+] = {
+    "settings-providers-secrets": (
+        "settingsProvidersSecrets",
+        frozenset(
+            {
+                "provider_profiles.read",
+                "secrets.metadata.read",
+                "settings.effective.read",
+            }
+        ),
+        frozenset(
             {
                 "provider_profiles.write",
                 "secrets.value.write",
                 "secrets.rotate",
                 "secrets.disable",
                 "secrets.delete",
-            },
+            }
         ),
-        "settingsUserWorkspace": (
-            {
-                "settings.catalog.read",
-                "settings.effective.read",
-                "settings.system.read",
-                "settings.audit.read",
-            },
+    ),
+    "settings-user-workspace": (
+        "settingsUserWorkspace",
+        frozenset({"settings.catalog.read"}),
+        frozenset(
             {
                 "settings.user.write",
                 "settings.workspace.write",
                 "settings.system.write",
-            },
+            }
         ),
-        "settingsOperations": (
-            {"operations.read"},
-            {"operations.invoke"},
-        ),
-    }
+    ),
+    "settings-operations": (
+        "settingsOperations",
+        frozenset({"operations.read"}),
+        frozenset({"operations.invoke"}),
+    ),
+}
+
+
+def _settings_destination_features(permissions: set[str]) -> dict[str, bool]:
     features: dict[str, bool] = {}
-    for capability_key, (read_permissions, mutation_permissions) in permission_groups.items():
+    for (
+        capability_key,
+        read_permissions,
+        mutation_permissions,
+    ) in _SETTINGS_DESTINATION_PERMISSIONS.values():
         if permissions & read_permissions:
             features[capability_key] = True
         elif permissions & mutation_permissions:
             features[capability_key] = False
     return features
+
+
+def _settings_redirect_path(user: User, preferred_destination_key: str) -> str:
+    permissions = settings_permissions_for_user(user)
+    ordered_destination_keys = (
+        preferred_destination_key,
+        *(
+            key
+            for key in _SETTINGS_DESTINATION_PERMISSIONS
+            if key != preferred_destination_key
+        ),
+    )
+    for destination_key in ordered_destination_keys:
+        _, read_permissions, _ = _SETTINGS_DESTINATION_PERMISSIONS[destination_key]
+        if permissions & read_permissions:
+            return _dashboard_destination(destination_key).canonical_path
+    return "/settings"
 
 
 def _is_extensionless_collection_route(request: Request, destination_keys: set[str]) -> bool:
@@ -1266,7 +1299,10 @@ async def secrets_route(
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
     """Redirect the legacy secrets page to its canonical Settings route."""
-    return RedirectResponse(url="/settings/providers-secrets", status_code=307)
+    return RedirectResponse(
+        url=_settings_redirect_path(_user, "settings-providers-secrets"),
+        status_code=307,
+    )
 
 
 @router.get("/workflows", name="workflow_console_root", response_class=HTMLResponse)
@@ -1435,7 +1471,10 @@ async def task_workers_route(
     _user: User = Depends(get_current_user()),
 ) -> RedirectResponse:
     """Redirect the legacy workers page to its canonical Settings route."""
-    return RedirectResponse(url="/settings/operations", status_code=307)
+    return RedirectResponse(
+        url=_settings_redirect_path(_user, "settings-operations"),
+        status_code=307,
+    )
 
 
 @router.get("/settings", response_class=HTMLResponse)

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -952,14 +952,14 @@ Representative operational sequence:
 
 ## 17. Interaction with Settings information architecture
 
-The Settings page remains a single operator-facing location for configuration and administrative controls.
+Settings remains the operator-facing configuration area.
 
-Deployment update belongs in the **Operations** subsection because it is a system-control surface. It should not become a top-level navigation item unless the broader Settings architecture is intentionally revisited.
+Deployment update belongs on the **Operations** page because it is a system-control surface. It should not become a top-level navigation item unless the broader Settings architecture is intentionally revisited.
 
-The Settings page should continue to use subsection routing such as:
+Use the canonical Operations route:
 
 ```text
-/settings?section=operations
+/settings/operations
 ```
 
 ---

--- a/docs/UI/ProviderProfileModelEffortTierSettings.md
+++ b/docs/UI/ProviderProfileModelEffortTierSettings.md
@@ -192,10 +192,10 @@ The editor must state that saved profile policy affects future resolution. Exist
 The canonical route remains:
 
 ```text
-/settings?section=providers-secrets
+/settings/providers-secrets
 ```
 
-No new top-level Settings section is required.
+No new Settings destination is required.
 
 Within the Provider Profile form, the desired section order is:
 

--- a/docs/UI/WorkflowConsoleArchitecture.md
+++ b/docs/UI/WorkflowConsoleArchitecture.md
@@ -154,7 +154,7 @@ If a React route renders structurally correct HTML but spacing, grids, or layout
 | `/oauth-terminal` | OAuth terminal sessions (xterm.js lives here only) |
 | `/index-health` | Index health page |
 
-Convenience redirects: `/secrets` → `/settings?section=providers-secrets`, `/workers` → `/settings?section=operations`, `/manifests/new` → `/manifests`.
+Convenience redirects: `/secrets` → `/settings/providers-secrets`, `/workers` → `/settings/operations`, `/manifests/new` → `/manifests`.
 
 Rules:
 

--- a/frontend/src/components/secrets/SecretManager.tsx
+++ b/frontend/src/components/secrets/SecretManager.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
+import { useSettingsDraftRegistration } from '../settings/SettingsDraftGuard';
 import { formatStatusLabel } from '../../utils/formatters';
 
 interface SecretMetadata {
@@ -71,6 +72,20 @@ export function SecretManager({
   const [usageLoadingSlug, setUsageLoadingSlug] = useState<string | null>(null);
   const [usageErrorBySlug, setUsageErrorBySlug] = useState<Record<string, string>>({});
 
+  const discardSecretDraft = () => {
+    setSlug('');
+    setPlaintext('');
+    setIsEditing(false);
+    setRotatePromptOpen(false);
+    setRotatePromptSlug('');
+    setRotatePromptVal('');
+  };
+  useSettingsDraftRegistration(
+    'managed-secret-editor',
+    Boolean(slug || plaintext || isEditing || rotatePromptOpen || rotatePromptVal),
+    discardSecretDraft,
+  );
+
   const createOp = useMutation({
     mutationFn: async ({
       slug: nextSlug,
@@ -92,9 +107,7 @@ export function SecretManager({
     },
     onSuccess: () => {
       onNotice({ level: 'ok', text: 'Secret saved successfully.' });
-      setSlug('');
-      setPlaintext('');
-      setIsEditing(false);
+      discardSecretDraft();
       queryClient.invalidateQueries({ queryKey: ['secrets'] });
     },
     onError: (error: Error) => onNotice({ level: 'error', text: error.message }),
@@ -121,9 +134,7 @@ export function SecretManager({
     },
     onSuccess: () => {
       onNotice({ level: 'ok', text: 'Secret updated successfully.' });
-      setSlug('');
-      setPlaintext('');
-      setIsEditing(false);
+      discardSecretDraft();
       queryClient.invalidateQueries({ queryKey: ['secrets'] });
     },
     onError: (error: Error) => onNotice({ level: 'error', text: error.message }),
@@ -150,9 +161,7 @@ export function SecretManager({
     },
     onSuccess: () => {
       onNotice({ level: 'ok', text: 'Secret rotated successfully.' });
-      setSlug('');
-      setPlaintext('');
-      setIsEditing(false);
+      discardSecretDraft();
       queryClient.invalidateQueries({ queryKey: ['secrets'] });
     },
     onError: (error: Error) => onNotice({ level: 'error', text: error.message }),
@@ -541,7 +550,6 @@ export function SecretManager({
                     slug: rotatePromptSlug,
                     plaintext: rotatePromptVal,
                   });
-                  setRotatePromptOpen(false);
                 }
               }}
               className="mt-6 space-y-4"
@@ -561,7 +569,11 @@ export function SecretManager({
                 <button
                   type="button"
                   className="btn btn-outline"
-                  onClick={() => setRotatePromptOpen(false)}
+                  onClick={() => {
+                    setRotatePromptOpen(false);
+                    setRotatePromptSlug('');
+                    setRotatePromptVal('');
+                  }}
                 >
                   Cancel
                 </button>

--- a/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -8,7 +8,6 @@ import {
   type ConfigurationHealthSummaryProps,
 } from './ConfigurationHealthSummary';
 import type { ProviderProfile } from './ProviderProfilesManager';
-import type { WorkerPauseConfig } from './OperationsSettingsSection';
 
 function makeProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
   return {
@@ -39,7 +38,6 @@ function renderSummary(props: Partial<ConfigurationHealthSummaryProps> = {}) {
         secrets={props.secrets ?? []}
         isLoading={props.isLoading ?? false}
         isError={props.isError ?? false}
-        workerPauseConfig={props.workerPauseConfig ?? null}
         canWriteProviderProfiles={props.canWriteProviderProfiles ?? true}
         canRunGithubTokenProbe={props.canRunGithubTokenProbe ?? true}
       />
@@ -57,8 +55,6 @@ describe('summarizeConfigurationHealth', () => {
     const summary = summarizeConfigurationHealth({
       providerProfiles: [makeProfile({ is_default: true })],
       secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
-      workerPauseConfigured: true,
-      workersPaused: false,
     });
 
     expect(summary.level).toBe('ready');
@@ -74,7 +70,6 @@ describe('summarizeConfigurationHealth', () => {
     const summary = summarizeConfigurationHealth({
       providerProfiles: [],
       secrets: [],
-      workerPauseConfigured: true,
     });
 
     expect(summary.level).toBe('blocked');
@@ -85,7 +80,6 @@ describe('summarizeConfigurationHealth', () => {
     const summary = summarizeConfigurationHealth({
       providerProfiles: [makeProfile({ is_default: false })],
       secrets: [],
-      workerPauseConfigured: true,
     });
 
     expect(summary.level).toBe('warning');
@@ -105,7 +99,6 @@ describe('summarizeConfigurationHealth', () => {
         { slug: 'OPENAI_API_KEY', status: 'active' },
         { slug: 'GH_TOKEN', status: 'invalid' },
       ],
-      workerPauseConfigured: true,
     });
 
     expect(summary.level).toBe('blocked');
@@ -131,7 +124,6 @@ describe('summarizeConfigurationHealth', () => {
         { slug: 'OPENAI_API_KEY', status: 'active' },
         { slug: 'GH_TOKEN', status: 'invalid' },
       ],
-      workerPauseConfigured: true,
     });
 
     expect(summary.level).toBe('ready');
@@ -140,35 +132,6 @@ describe('summarizeConfigurationHealth', () => {
     expect(summary.warnings.map((w) => w.id)).not.toContain('broken-secret-refs');
   });
 
-  it('warns when workers are paused even if configuration is otherwise ready', () => {
-    const summary = summarizeConfigurationHealth({
-      providerProfiles: [makeProfile({ is_default: true })],
-      secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
-      workerPauseConfigured: true,
-      workersPaused: true,
-      workerMode: 'drain',
-    });
-
-    expect(summary.level).toBe('warning');
-    expect(summary.warnings.map((w) => w.id)).toContain('workers-paused');
-    expect(
-      summary.warnings.find((w) => w.id === 'workers-paused')?.message,
-    ).toMatch(/paused/i);
-  });
-
-  it('describes quiesced workers in the paused warning', () => {
-    const summary = summarizeConfigurationHealth({
-      providerProfiles: [makeProfile({ is_default: true })],
-      secrets: [{ slug: 'OPENAI_API_KEY', status: 'active' }],
-      workerPauseConfigured: true,
-      workersPaused: true,
-      workerMode: 'quiesce',
-    });
-
-    expect(
-      summary.warnings.find((w) => w.id === 'workers-paused')?.message,
-    ).toMatch(/quiesced/i);
-  });
 });
 
 describe('ConfigurationHealthSummary', () => {
@@ -182,7 +145,6 @@ describe('ConfigurationHealthSummary', () => {
         { slug: 'OPENAI_API_KEY', status: 'active' },
         { slug: 'ANTHROPIC_API_KEY', status: 'active' },
       ],
-      workerPauseConfig: null,
     });
 
     expect(
@@ -205,7 +167,6 @@ describe('ConfigurationHealthSummary', () => {
         }),
       ],
       secrets: [{ slug: 'GH_TOKEN', status: 'missing' }],
-      workerPauseConfig: null,
     });
 
     const warnings = screen.getByRole('list', { name: /Configuration warnings/i });
@@ -220,7 +181,6 @@ describe('ConfigurationHealthSummary', () => {
       providerProfiles: [makeProfile({ is_default: true })],
       canWriteProviderProfiles: false,
       canRunGithubTokenProbe: true,
-      workerPauseConfig: null,
     });
 
     expect(screen.getByText(/Provider profile writes disabled/i)).toBeTruthy();
@@ -233,37 +193,10 @@ describe('ConfigurationHealthSummary', () => {
       providerProfiles: [makeProfile({ is_default: true })],
       canWriteProviderProfiles: true,
       canRunGithubTokenProbe: false,
-      workerPauseConfig: null,
     });
 
     expect(screen.getByText(/GitHub token probe unavailable/i)).toBeTruthy();
     expect(screen.getByText(/settings\.effective\.read/i)).toBeTruthy();
-  });
-
-  it('reports the live worker pause state when worker controls are configured', async () => {
-    const workerPauseConfig: WorkerPauseConfig = {
-      get: '/api/v1/operations/workers',
-      post: '/api/v1/operations/workers',
-    };
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ system: { workersPaused: true, mode: 'drain' } }),
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    renderSummary({
-      providerProfiles: [makeProfile({ is_default: true })],
-      workerPauseConfig,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Paused')).toBeTruthy();
-    });
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/operations/workers',
-      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) }),
-    );
   });
 
   it('renders a loading state without querying', () => {

--- a/frontend/src/components/settings/ConfigurationHealthSummary.tsx
+++ b/frontend/src/components/settings/ConfigurationHealthSummary.tsx
@@ -1,7 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { isBrokenReferenceStatus } from '../secrets/SecretManager';
-import type { WorkerPauseConfig } from './OperationsSettingsSection';
 import type { ProviderProfile } from './ProviderProfilesManager';
 
 /**
@@ -10,9 +7,8 @@ import type { ProviderProfile } from './ProviderProfilesManager';
  * Aggregates boot/query data already loaded by the Settings page into a single
  * launch-readiness answer: "Is MoonMind configured well enough to run workflows
  * safely?" It surfaces provider/secret counts, missing or invalid defaults, and
- * permission/read-only states with visible reasons. It deliberately reuses the
- * data the page already fetches and the shared worker snapshot query rather than
- * introducing a dedicated backend health endpoint (out of scope).
+ * permission/read-only states with visible reasons. The summary is deliberately
+ * scoped to Providers & Secrets so this route never loads Operations data.
  */
 
 export interface HealthSecret {
@@ -31,9 +27,6 @@ export interface HealthWarning {
 export interface ConfigurationHealthInput {
   providerProfiles: ProviderProfile[];
   secrets: HealthSecret[];
-  workerPauseConfigured: boolean;
-  workersPaused?: boolean | null;
-  workerMode?: string | null;
 }
 
 export interface ConfigurationHealthSummaryData {
@@ -74,13 +67,7 @@ function secretSlugFromRef(ref: string): string | null {
 export function summarizeConfigurationHealth(
   input: ConfigurationHealthInput,
 ): ConfigurationHealthSummaryData {
-  const {
-    providerProfiles,
-    secrets,
-    workerPauseConfigured,
-    workersPaused,
-    workerMode,
-  } = input;
+  const { providerProfiles, secrets } = input;
 
   const enabledProfiles = providerProfiles.filter((profile) => profile.enabled);
   const defaultProfile =
@@ -159,22 +146,6 @@ export function summarizeConfigurationHealth(
     });
   }
 
-  if (!workerPauseConfigured) {
-    warnings.push({
-      id: 'worker-controls-unavailable',
-      level: 'warning',
-      message:
-        'Worker operations controls are not configured for this deployment, so pause/resume state cannot be confirmed here.',
-    });
-  } else if (workersPaused) {
-    const pausedDescriptor = workerMode === 'quiesce' ? 'quiesced' : 'paused';
-    warnings.push({
-      id: 'workers-paused',
-      level: 'warning',
-      message: `Workers are currently ${pausedDescriptor}, so newly launched workflows will not start until workers resume.`,
-    });
-  }
-
   const hasBlocking = warnings.some((warning) => warning.level === 'blocked');
   const level: HealthLevel = hasBlocking
     ? 'blocked'
@@ -199,13 +170,6 @@ export function summarizeConfigurationHealth(
     managedSecretCount: secrets.length,
     brokenSecretCount: brokenSecrets.length,
     warnings,
-  };
-}
-
-interface WorkerStateSnapshot {
-  system?: {
-    workersPaused?: boolean;
-    mode?: string | null;
   };
 }
 
@@ -269,7 +233,6 @@ export interface ConfigurationHealthSummaryProps {
   secrets: HealthSecret[];
   isLoading?: boolean;
   isError?: boolean;
-  workerPauseConfig: WorkerPauseConfig | null;
   canWriteProviderProfiles: boolean;
   canRunGithubTokenProbe: boolean;
 }
@@ -279,29 +242,9 @@ export function ConfigurationHealthSummary({
   secrets,
   isLoading = false,
   isError = false,
-  workerPauseConfig,
   canWriteProviderProfiles,
   canRunGithubTokenProbe,
 }: ConfigurationHealthSummaryProps) {
-  const workerPauseConfigured = workerPauseConfig !== null;
-
-  const { data: workerState } = useQuery<WorkerStateSnapshot>({
-    queryKey: ['workers-snapshot'],
-    queryFn: async () => {
-      if (!workerPauseConfig?.get) {
-        throw new Error('Worker pause GET endpoint is not configured.');
-      }
-      const response = await fetch(workerPauseConfig.get, {
-        headers: { Accept: 'application/json' },
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch worker status: ${response.statusText}`);
-      }
-      return (await response.json()) as WorkerStateSnapshot;
-    },
-    enabled: workerPauseConfigured && Boolean(workerPauseConfig?.get),
-  });
-
   if (isLoading) {
     return (
       <section
@@ -324,29 +267,12 @@ export function ConfigurationHealthSummary({
     );
   }
 
-  const workersPaused = workerState?.system?.workersPaused ?? null;
-  const workerMode = workerState?.system?.mode ?? null;
-
   const summary = summarizeConfigurationHealth({
     providerProfiles,
     secrets,
-    workerPauseConfigured,
-    workersPaused,
-    workerMode,
   });
 
   const badge = LEVEL_BADGE[summary.level];
-
-  let workerStateLabel: string;
-  if (!workerPauseConfigured) {
-    workerStateLabel = 'Not configured';
-  } else if (workersPaused === null) {
-    workerStateLabel = 'Unknown';
-  } else if (workersPaused) {
-    workerStateLabel = workerMode === 'quiesce' ? 'Quiesced' : 'Paused';
-  } else {
-    workerStateLabel = 'Running';
-  }
 
   return (
     <section
@@ -370,7 +296,7 @@ export function ConfigurationHealthSummary({
         </span>
       </div>
 
-      <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <MetricTile
           label="Provider profiles"
           value={String(summary.providerProfileCount)}
@@ -393,7 +319,6 @@ export function ConfigurationHealthSummary({
           }
           tone={summary.brokenSecretCount > 0 ? 'warning' : 'default'}
         />
-        <MetricTile label="Worker state" value={workerStateLabel} />
       </div>
 
       {summary.warnings.length > 0 ? (

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -1,7 +1,13 @@
+import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { fireEvent, screen, waitFor, within } from '../../utils/test-utils';
 import { renderWithClient } from '../../utils/test-utils';
 import { GeneratedSettingsSection } from './GeneratedSettingsSection';
+
+function ControlledGeneratedSettingsSection() {
+  const [scope, setScope] = useState<'workspace' | 'user'>('workspace');
+  return <GeneratedSettingsSection scope={scope} onScopeChange={setScope} />;
+}
 
 const workspaceCatalog = {
   section: 'user-workspace',
@@ -368,7 +374,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('renders descriptor rows with metadata, badges, diagnostics, and filters', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     expect(await screen.findByText('Default Publish Mode')).toBeTruthy();
     expect(screen.getByText('Config')).toBeTruthy();
@@ -397,7 +403,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('switches scope and fetches scoped descriptors', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     await screen.findByText('Default Publish Mode');
     fireEvent.click(screen.getByRole('button', { name: 'User' }));
@@ -408,7 +414,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('does not offer reset for inherited workspace overrides in user scope', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     await screen.findByText('Default Publish Mode');
     fireEvent.click(screen.getByRole('button', { name: 'User' }));
@@ -418,7 +424,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('edits generated controls and previews only changed keys', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     await screen.findByText('Default Publish Mode');
 
@@ -441,7 +447,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('saves only changed keys with expected versions and refreshes catalog', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     await screen.findByText('Default Publish Mode');
     fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });
@@ -463,7 +469,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('disables read-only descriptors and shows lock reason', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     expect(await screen.findByText('Operator Locked Mode')).toBeTruthy();
     expect(screen.getByText('Operator locked by workspace policy.')).toBeTruthy();
@@ -475,7 +481,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('renders a Broken reference indicator on rows whose secret_ref is unresolved', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     expect(await screen.findByText('Default Publish Mode')).toBeTruthy();
 
@@ -485,7 +491,7 @@ describe('GeneratedSettingsSection', () => {
   });
 
   it('supports discard for pending generated setting changes', async () => {
-    renderWithClient(<GeneratedSettingsSection />);
+    renderWithClient(<ControlledGeneratedSettingsSection />);
 
     await screen.findByText('Default Publish Mode');
     fireEvent.change(screen.getByLabelText('Default Publish Mode'), { target: { value: 'branch' } });

--- a/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.test.tsx
@@ -4,9 +4,15 @@ import { fireEvent, screen, waitFor, within } from '../../utils/test-utils';
 import { renderWithClient } from '../../utils/test-utils';
 import { GeneratedSettingsSection } from './GeneratedSettingsSection';
 
-function ControlledGeneratedSettingsSection() {
+function ControlledGeneratedSettingsSection({ canReadAudit = false }: { canReadAudit?: boolean }) {
   const [scope, setScope] = useState<'workspace' | 'user'>('workspace');
-  return <GeneratedSettingsSection scope={scope} onScopeChange={setScope} />;
+  return (
+    <GeneratedSettingsSection
+      scope={scope}
+      onScopeChange={setScope}
+      canReadAudit={canReadAudit}
+    />
+  );
 }
 
 const workspaceCatalog = {
@@ -356,6 +362,26 @@ describe('GeneratedSettingsSection', () => {
       const url = String(input);
       requests.push({ url, init });
 
+      if (url.startsWith('/api/v1/settings/audit')) {
+        return Promise.resolve(jsonResponse({
+          items: [
+            {
+              id: 'audit-1',
+              event_type: 'settings.override.updated',
+              key: 'integrations.github.token_ref',
+              scope: 'user',
+              actor_user_id: 'user-1',
+              old_value: null,
+              new_value: null,
+              redacted: true,
+              reason: 'Prefer branch publication',
+              validation_outcome: 'accepted',
+              affected_systems: ['publishing'],
+              created_at: '2026-08-30T12:00:00Z',
+            },
+          ],
+        }));
+      }
       if (url.includes('scope=user')) {
         return Promise.resolve(jsonResponse(userCatalog));
       }
@@ -498,5 +524,56 @@ describe('GeneratedSettingsSection', () => {
     expect(screen.getByLabelText('Pending settings preview')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
     expect(screen.queryByLabelText('Pending settings preview')).toBeNull();
+  });
+
+  it('loads row audit on demand with the active scope and setting key when authorized', async () => {
+    renderWithClient(<ControlledGeneratedSettingsSection canReadAudit />);
+
+    await screen.findByText('Default Publish Mode');
+    expect(requests.some((request) => request.url.startsWith('/api/v1/settings/audit'))).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'User' }));
+    await screen.findByDisplayValue('env://WORKSPACE_TOKEN');
+    fireEvent.click(screen.getByRole('button', { name: 'View audit for GitHub Token Reference' }));
+
+    await waitFor(() => {
+      const auditRequest = requests.find((request) => request.url.startsWith('/api/v1/settings/audit'));
+      expect(auditRequest).toBeTruthy();
+      const query = new URL(auditRequest?.url ?? '', window.location.origin).searchParams;
+      expect(query.get('scope')).toBe('user');
+      expect(query.get('key')).toBe('integrations.github.token_ref');
+    });
+    expect(await screen.findByRole('region', { name: 'Audit history for GitHub Token Reference' })).toBeTruthy();
+    expect(await screen.findByText(/Prefer branch publication/)).toBeTruthy();
+  });
+
+  it('hides audit affordances without settings.audit.read permission', async () => {
+    renderWithClient(<ControlledGeneratedSettingsSection />);
+
+    await screen.findByText('Default Publish Mode');
+    expect(screen.queryByRole('button', { name: /View audit for/ })).toBeNull();
+    expect(requests.some((request) => request.url.startsWith('/api/v1/settings/audit'))).toBe(false);
+  });
+
+  it('keeps generated settings usable when an audit request fails', async () => {
+    fetchSpy.mockImplementation((input, init) => {
+      const url = String(input);
+      requests.push({ url, init });
+      if (url.startsWith('/api/v1/settings/audit')) {
+        return Promise.resolve(jsonResponse({}, false, 503));
+      }
+      if (url.includes('/api/v1/settings/catalog')) {
+        return Promise.resolve(jsonResponse(workspaceCatalog));
+      }
+      return Promise.resolve(jsonResponse({ error: 'not_found' }, false, 404));
+    });
+    renderWithClient(<ControlledGeneratedSettingsSection canReadAudit />);
+
+    await screen.findByText('Default Publish Mode');
+    fireEvent.click(screen.getByRole('button', { name: 'View audit for Default Publish Mode' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Failed to fetch settings audit');
+    expect(screen.getByText('Default Publish Mode')).toBeTruthy();
+    expect(screen.getByLabelText('Default Publish Mode')).toBeTruthy();
   });
 });

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -27,6 +27,12 @@ interface SettingDiagnostic {
   severity: 'info' | 'warning' | 'error';
 }
 
+interface SettingAuditPolicy {
+  store_old_value: boolean;
+  store_new_value: boolean;
+  redact: boolean;
+}
+
 interface SettingDescriptor {
   key: string;
   title: string;
@@ -58,6 +64,7 @@ interface SettingDescriptor {
   requires_process_restart: boolean;
   applies_to: string[];
   order: number;
+  audit: SettingAuditPolicy;
   value_version: number;
   diagnostics: SettingDiagnostic[];
 }
@@ -73,6 +80,25 @@ interface PendingChange {
   value: unknown;
   valid: boolean;
   message?: string;
+}
+
+interface SettingsAuditEvent {
+  id: string;
+  event_type: string;
+  key: string;
+  scope: string;
+  actor_user_id?: string | null;
+  old_value?: unknown;
+  new_value?: unknown;
+  redacted: boolean;
+  reason?: string | null;
+  validation_outcome?: string | null;
+  affected_systems: string[];
+  created_at?: string | null;
+}
+
+interface SettingsAuditResponse {
+  items: SettingsAuditEvent[];
 }
 
 const SCOPE_LABELS: Record<SettingScope, string> = {
@@ -327,6 +353,17 @@ async function fetchCatalog(scope: SettingScope): Promise<SettingsCatalogRespons
   return response.json();
 }
 
+async function fetchSettingAudit(scope: SettingScope, key: string): Promise<SettingsAuditResponse> {
+  const query = new URLSearchParams({ scope, key });
+  const response = await fetch(`/api/v1/settings/audit?${query.toString()}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch settings audit: ${response.statusText}`);
+  }
+  return response.json();
+}
+
 function flattenedDescriptors(catalog?: SettingsCatalogResponse): SettingDescriptor[] {
   if (!catalog) {
     return [];
@@ -343,12 +380,36 @@ function sanitizeError(error: unknown): string {
   return 'Settings request failed.';
 }
 
+function formatAuditTimestamp(value?: string | null): string {
+  if (!value) {
+    return 'Time unavailable';
+  }
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? value : timestamp.toLocaleString();
+}
+
+function displayAuditValue(
+  event: SettingsAuditEvent,
+  value: unknown,
+  storedByPolicy: boolean,
+): string {
+  if (event.redacted) {
+    return 'Redacted';
+  }
+  if (!storedByPolicy) {
+    return 'Not recorded by policy';
+  }
+  return displayValue(value);
+}
+
 export function GeneratedSettingsSection({
   scope,
   onScopeChange,
+  canReadAudit,
 }: {
   scope: SettingScope;
   onScopeChange: (scope: SettingScope) => void;
+  canReadAudit: boolean;
 }) {
   const queryClient = useQueryClient();
   const { requestDeparture } = useSettingsDraftGuard();
@@ -358,6 +419,7 @@ export function GeneratedSettingsSection({
   const [readOnlyOnly, setReadOnlyOnly] = useState(false);
   const [pending, setPending] = useState<Record<string, PendingChange>>({});
   const [notice, setNotice] = useState<string | null>(null);
+  const [selectedAuditKey, setSelectedAuditKey] = useState<string | null>(null);
 
   const catalogQuery = useQuery({
     queryKey: ['settings-catalog', scope],
@@ -365,6 +427,14 @@ export function GeneratedSettingsSection({
   });
 
   const descriptors = useMemo(() => flattenedDescriptors(catalogQuery.data), [catalogQuery.data]);
+  const selectedAuditDescriptor = descriptors.find(
+    (descriptor) => descriptor.key === selectedAuditKey,
+  );
+  const auditQuery = useQuery({
+    queryKey: ['settings-audit', scope, selectedAuditKey],
+    queryFn: () => fetchSettingAudit(scope, selectedAuditKey ?? ''),
+    enabled: canReadAudit && selectedAuditKey !== null,
+  });
   const categories = useMemo(
     () => Array.from(new Set(descriptors.map((descriptor) => descriptor.category))).sort(),
     [descriptors],
@@ -427,6 +497,7 @@ export function GeneratedSettingsSection({
     setSearch('');
     setModifiedOnly(false);
     setReadOnlyOnly(false);
+    setSelectedAuditKey(null);
   }, [scope]);
 
   const requestScopeChange = (nextScope: SettingScope) => {
@@ -541,6 +612,88 @@ export function GeneratedSettingsSection({
         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 shadow-sm dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
           {notice}
         </div>
+      ) : null}
+
+      {canReadAudit && selectedAuditDescriptor ? (
+        <section
+          id="settings-audit-panel"
+          aria-label={`Audit history for ${selectedAuditDescriptor.title}`}
+          className="rounded-3xl border border-mm-border/80 bg-transparent p-5 shadow-sm"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h4 className="text-base font-semibold text-slate-900 dark:text-white">
+                Audit history: {selectedAuditDescriptor.title}
+              </h4>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                Recent recorded changes for {SCOPE_LABELS[scope].toLowerCase()} scope.
+              </p>
+              {selectedAuditDescriptor.audit.redact ? (
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-500">
+                  This setting&apos;s audit policy may redact values based on your permissions.
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="rounded-xl border border-slate-300 bg-transparent px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+              onClick={() => setSelectedAuditKey(null)}
+              aria-label={`Close audit history for ${selectedAuditDescriptor.title}`}
+            >
+              Close
+            </button>
+          </div>
+
+          {auditQuery.isLoading ? (
+            <p className="mt-4 text-sm text-slate-500 dark:text-slate-400" role="status">
+              Loading audit history...
+            </p>
+          ) : auditQuery.isError ? (
+            <p className="mt-4 text-sm text-rose-700 dark:text-rose-400" role="alert">
+              {sanitizeError(auditQuery.error)} Generated settings remain available.
+            </p>
+          ) : auditQuery.data?.items.length ? (
+            <ol className="mt-4 space-y-3">
+              {auditQuery.data.items.map((event) => (
+                <li
+                  key={event.id}
+                  className="rounded-2xl border border-slate-200 p-4 text-sm dark:border-slate-800"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-semibold text-slate-900 dark:text-white">
+                      {event.event_type.replaceAll('.', ' ').replaceAll('_', ' ')}
+                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">
+                      {formatAuditTimestamp(event.created_at)}
+                    </span>
+                  </div>
+                  <dl className="mt-3 grid gap-2 text-slate-600 dark:text-slate-300 sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs font-medium text-slate-500 dark:text-slate-400">Previous value</dt>
+                      <dd>{displayAuditValue(event, event.old_value, selectedAuditDescriptor.audit.store_old_value)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-medium text-slate-500 dark:text-slate-400">New value</dt>
+                      <dd>{displayAuditValue(event, event.new_value, selectedAuditDescriptor.audit.store_new_value)}</dd>
+                    </div>
+                  </dl>
+                  {event.reason ? (
+                    <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">Reason: {event.reason}</p>
+                  ) : null}
+                  {event.actor_user_id ? (
+                    <p className="mt-1 font-mono text-xs text-slate-500 dark:text-slate-400">
+                      Actor: {event.actor_user_id}
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+              No audit events were found for this setting and scope.
+            </p>
+          )}
+        </section>
       ) : null}
 
       <div className="rounded-3xl border border-mm-border/80 bg-transparent p-5 shadow-sm">
@@ -720,16 +873,30 @@ export function GeneratedSettingsSection({
                     {renderControl(descriptor, currentValue, updatePending)}
                     <div className="flex items-center justify-between gap-3">
                       <span className="font-mono text-xs text-slate-500 dark:text-slate-500">{descriptor.key}</span>
-                      {canReset(descriptor, scope) ? (
-                        <button
-                          type="button"
-                          className="rounded-xl border border-slate-300 bg-transparent px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
-                          onClick={() => resetOverride(descriptor)}
-                          aria-label={`Reset ${descriptor.title}`}
-                        >
-                          Reset
-                        </button>
-                      ) : null}
+                      <div className="flex flex-wrap justify-end gap-2">
+                        {canReadAudit ? (
+                          <button
+                            type="button"
+                            className="rounded-xl border border-slate-300 bg-transparent px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+                            onClick={() => setSelectedAuditKey(descriptor.key)}
+                            aria-controls="settings-audit-panel"
+                            aria-expanded={selectedAuditKey === descriptor.key}
+                            aria-label={`View audit for ${descriptor.title}`}
+                          >
+                            View audit
+                          </button>
+                        ) : null}
+                        {canReset(descriptor, scope) ? (
+                          <button
+                            type="button"
+                            className="rounded-xl border border-slate-300 bg-transparent px-3 py-2 text-sm font-medium text-slate-700 hover:border-slate-400 hover:text-slate-950 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+                            onClick={() => resetOverride(descriptor)}
+                            aria-label={`Reset ${descriptor.title}`}
+                          >
+                            Reset
+                          </button>
+                        ) : null}
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/settings/GeneratedSettingsSection.tsx
+++ b/frontend/src/components/settings/GeneratedSettingsSection.tsx
@@ -1,7 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-type SettingScope = 'workspace' | 'user';
+import {
+  useSettingsDraftGuard,
+  useSettingsDraftRegistration,
+} from './SettingsDraftGuard';
+
+export type SettingScope = 'workspace' | 'user';
 
 interface SettingOption {
   value: string;
@@ -338,9 +343,15 @@ function sanitizeError(error: unknown): string {
   return 'Settings request failed.';
 }
 
-export function GeneratedSettingsSection() {
+export function GeneratedSettingsSection({
+  scope,
+  onScopeChange,
+}: {
+  scope: SettingScope;
+  onScopeChange: (scope: SettingScope) => void;
+}) {
   const queryClient = useQueryClient();
-  const [scope, setScope] = useState<SettingScope>('workspace');
+  const { requestDeparture } = useSettingsDraftGuard();
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('all');
   const [modifiedOnly, setModifiedOnly] = useState(false);
@@ -399,14 +410,33 @@ export function GeneratedSettingsSection() {
     });
   };
 
-  const resetLocalStateForScope = (nextScope: SettingScope) => {
-    setScope(nextScope);
+  const discardPending = useCallback(() => {
+    setPending({});
+  }, []);
+
+  useSettingsDraftRegistration(
+    `generated-settings:${scope}`,
+    pendingChanges.length > 0,
+    discardPending,
+  );
+
+  useEffect(() => {
     setPending({});
     setNotice(null);
     setCategory('all');
     setSearch('');
     setModifiedOnly(false);
     setReadOnlyOnly(false);
+  }, [scope]);
+
+  const requestScopeChange = (nextScope: SettingScope) => {
+    if (nextScope === scope) {
+      return;
+    }
+    requestDeparture(
+      () => onScopeChange(nextScope),
+      `Change to ${SCOPE_LABELS[nextScope]} scope? Your unsaved settings draft will be discarded.`,
+    );
   };
 
   const saveChanges = async () => {
@@ -483,7 +513,7 @@ export function GeneratedSettingsSection() {
       <div className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">User / Workspace</h3>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Generated settings</h3>
             <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
               Configure eligible settings from backend-owned descriptors. Validation, sensitivity, and authorization remain server-side.
             </p>
@@ -498,7 +528,7 @@ export function GeneratedSettingsSection() {
                     ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
                     : 'bg-transparent text-slate-600 hover:text-slate-950 dark:text-slate-400 dark:hover:text-white'
                 }`}
-                onClick={() => resetLocalStateForScope(candidate)}
+                onClick={() => requestScopeChange(candidate)}
               >
                 {SCOPE_LABELS[candidate]}
               </button>

--- a/frontend/src/components/settings/OperationsSettingsSection.test.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.test.tsx
@@ -261,6 +261,7 @@ describe('OperationsSettingsSection deployment update card', () => {
     const { includeShardHealth = true } = options;
     renderWithClient(
       <OperationsSettingsSection
+        canInvokeOperations
         workerPauseConfig={{
           get: '/api/workers',
           post: '/api/worker-action',

--- a/frontend/src/components/settings/OperationsSettingsSection.tsx
+++ b/frontend/src/components/settings/OperationsSettingsSection.tsx
@@ -311,8 +311,10 @@ function workerDisplayName(shard: WorkerShard): string {
 
 export function OperationsSettingsSection({
   workerPauseConfig,
+  canInvokeOperations,
 }: {
   workerPauseConfig: WorkerPauseConfig | null;
+  canInvokeOperations: boolean;
 }) {
   const queryClient = useQueryClient();
   const [notice, setNotice] = useState<{ level: 'ok' | 'error'; text: string } | null>(
@@ -790,15 +792,12 @@ export function OperationsSettingsSection({
 
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
-        <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Operations</h3>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
-            Worker pause, drain, quiesce, and recent operational audit actions live
-            here under Settings.
-          </p>
-        </div>
-      </section>
+      {!canInvokeOperations ? (
+        <section className="rounded-3xl border border-slate-200 bg-slate-50 p-5 text-sm text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-400">
+          Operational state is available for inspection. Commands are read-only because{' '}
+          <code>operations.invoke</code> is not granted.
+        </section>
+      ) : null}
 
       <section
         className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm"
@@ -884,7 +883,7 @@ export function OperationsSettingsSection({
 
               <button
                 type="submit"
-                disabled={deploymentMutation.isPending}
+                disabled={deploymentMutation.isPending || !canInvokeOperations}
                 className="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
               >
                 Update MoonMind
@@ -969,6 +968,7 @@ export function OperationsSettingsSection({
                             <button
                               type="button"
                               className="text-sm font-medium text-sky-700 hover:text-sky-600 dark:text-sky-400"
+                              disabled={!canInvokeOperations || rollbackMutation.isPending}
                               onClick={() => rollbackMutation.mutate(action)}
                             >
                               Roll back to {action.rollbackEligibility.targetImage.reference}
@@ -1287,7 +1287,7 @@ export function OperationsSettingsSection({
                 </p>
 
                 <form className="mt-5 space-y-4" onSubmit={handlePause}>
-                  <fieldset className="space-y-3" disabled={actionMutation.isPending}>
+                  <fieldset className="space-y-3" disabled={actionMutation.isPending || !canInvokeOperations}>
                     <legend className="text-sm font-medium text-slate-700 dark:text-300">
                       Pause workers
                     </legend>
@@ -1325,7 +1325,7 @@ export function OperationsSettingsSection({
                 <div className="my-6 border-t border-slate-200 dark:border-slate-800" />
 
                 <form className="space-y-4" onSubmit={handleResume}>
-                  <fieldset className="space-y-3" disabled={actionMutation.isPending}>
+                  <fieldset className="space-y-3" disabled={actionMutation.isPending || !canInvokeOperations}>
                     <legend className="text-sm font-medium text-slate-700 dark:text-slate-300">
                       Resume workers
                     </legend>

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
 import { formatRuntimeLabel, formatStatusLabel } from '../../utils/formatters';
+import { useSettingsDraftRegistration } from './SettingsDraftGuard';
 
 export interface ProviderProfile {
   profile_id: string;
@@ -723,6 +724,9 @@ export function ProviderProfilesManager({
   const [form, setForm] = useState<ProviderProfileFormState>(() =>
     defaultFormState(createFormRuntimeSeed),
   );
+  const [formBaseline, setFormBaseline] = useState<ProviderProfileFormState>(() =>
+    defaultFormState(createFormRuntimeSeed),
+  );
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
   const createFormRuntimeSeedRef = useRef(createFormRuntimeSeed);
   const [oauthSessions, setOauthSessions] = useState<Record<string, OAuthSessionState>>({});
@@ -812,6 +816,11 @@ export function ProviderProfilesManager({
         ? { ...current, runtimeId: createFormRuntimeSeed }
         : current,
     );
+    setFormBaseline((current) =>
+      current.runtimeId === '' || current.runtimeId === previousSeed
+        ? { ...current, runtimeId: createFormRuntimeSeed }
+        : current,
+    );
   }, [createFormRuntimeSeed, editingProfileId]);
 
   // A single-runtime view cannot show the row being edited when that row
@@ -825,7 +834,9 @@ export function ProviderProfilesManager({
       return;
     }
     setEditingProfileId(null);
-    setForm(defaultFormState(selectedRuntimeId));
+    const nextForm = defaultFormState(selectedRuntimeId);
+    setForm(nextForm);
+    setFormBaseline(nextForm);
   }, [editingProfileId, form.runtimeId, selectedRuntimeId]);
 
   useEffect(() => {
@@ -843,9 +854,17 @@ export function ProviderProfilesManager({
 
   const resetForm = () => {
     setEditingProfileId(null);
-    setForm(defaultFormState(createFormRuntimeSeed));
+    const nextForm = defaultFormState(createFormRuntimeSeed);
+    setForm(nextForm);
+    setFormBaseline(nextForm);
     onNotice(null);
   };
+
+  useSettingsDraftRegistration(
+    'provider-profile',
+    canWriteProviderProfiles && JSON.stringify(form) !== JSON.stringify(formBaseline),
+    resetForm,
+  );
 
   const closeClaudeEnrollment = () => {
     claudeEnrollmentProfileIdRef.current = null;
@@ -1176,7 +1195,9 @@ export function ProviderProfilesManager({
           : `Provider profile "${submittedForm.profileId.trim()}" created.`,
       });
       setEditingProfileId(null);
-      setForm(defaultFormState(createFormRuntimeSeed));
+      const nextForm = defaultFormState(createFormRuntimeSeed);
+      setForm(nextForm);
+      setFormBaseline(nextForm);
       queryClient.setQueryData<ProviderProfile[]>(
         PROVIDER_PROFILE_QUERY_KEY,
         (currentProfiles = []) => {
@@ -1227,7 +1248,9 @@ export function ProviderProfilesManager({
       onNotice({ level: 'ok', text: `Provider profile "${profileId}" deleted.` });
       if (editingProfileId === profileId) {
         setEditingProfileId(null);
-        setForm(defaultFormState(createFormRuntimeSeed));
+        const nextForm = defaultFormState(createFormRuntimeSeed);
+        setForm(nextForm);
+        setFormBaseline(nextForm);
       }
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
     },
@@ -2058,8 +2081,10 @@ export function ProviderProfilesManager({
                             type="button"
                             className="rounded-full border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 transition hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-900 dark:hover:text-white"
                             onClick={() => {
+                              const nextForm = toFormState(profile);
                               setEditingProfileId(profile.profile_id);
-                              setForm(toFormState(profile));
+                              setForm(nextForm);
+                              setFormBaseline(nextForm);
                               onNotice(null);
                             }}
                           >

--- a/frontend/src/components/settings/SettingsComponentSplit.test.tsx
+++ b/frontend/src/components/settings/SettingsComponentSplit.test.tsx
@@ -4,7 +4,9 @@
  * The Settings System design (`docs/Security/SettingsSystem.md` §26) names a
  * suggested frontend component split:
  *
- *   - SettingsPage
+ *   - ProvidersSecretsSettingsPage
+ *   - UserWorkspaceSettingsPage
+ *   - OperationsSettingsPage
  *   - SettingsCatalogSection (a.k.a. GeneratedSettingsSection)
  *   - SettingControlRenderer (lives inside GeneratedSettingsSection)
  *   - SecretRefPicker (lives inside GeneratedSettingsSection)
@@ -24,11 +26,17 @@ import { GeneratedSettingsSection } from './GeneratedSettingsSection';
 import { OperationsSettingsSection } from './OperationsSettingsSection';
 import { ProviderProfilesManager } from './ProviderProfilesManager';
 import { SecretManager } from '../secrets/SecretManager';
-import SettingsPage from '../../entrypoints/settings';
+import {
+  OperationsSettingsPage,
+  ProvidersSecretsSettingsPage,
+  UserWorkspaceSettingsPage,
+} from '../../entrypoints/settings';
 
 describe('Settings System §26 component split', () => {
-  it('exposes a SettingsPage that owns top-level section navigation', () => {
-    expect(typeof SettingsPage).toBe('function');
+  it('exposes three route-owned Settings pages without a shared page selector', () => {
+    expect(typeof ProvidersSecretsSettingsPage).toBe('function');
+    expect(typeof UserWorkspaceSettingsPage).toBe('function');
+    expect(typeof OperationsSettingsPage).toBe('function');
   });
 
   it('exposes GeneratedSettingsSection as the catalog-driven section renderer', () => {

--- a/frontend/src/components/settings/SettingsDraftGuard.tsx
+++ b/frontend/src/components/settings/SettingsDraftGuard.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -17,6 +18,11 @@ interface DraftRegistration {
 
 interface PendingDeparture {
   action: () => void;
+  description: string;
+}
+
+interface PendingHistoryDeparture {
+  restoreDelta: number;
   description: string;
 }
 
@@ -37,6 +43,14 @@ const SettingsDraftGuardContext = createContext<SettingsDraftGuardValue>(immedia
 
 function currentBrowserPath(): string {
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function historyIndex(state: unknown = window.history.state): number | null {
+  if (!state || typeof state !== 'object' || !('idx' in state)) {
+    return null;
+  }
+  const index = (state as { idx?: unknown }).idx;
+  return typeof index === 'number' && Number.isInteger(index) ? index : null;
 }
 
 function isPlainInternalNavigation(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
@@ -61,6 +75,12 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
   const location = useLocation();
   const registrationsRef = useRef(new Map<string, DraftRegistration>());
   const currentPathRef = useRef(currentBrowserPath());
+  const currentHistoryIndexRef = useRef(historyIndex());
+  const restoringPopStateRef = useRef(false);
+  const pendingHistoryDepartureRef = useRef<PendingHistoryDeparture | null>(null);
+  const stayButtonRef = useRef<HTMLButtonElement | null>(null);
+  const discardButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const [pendingDeparture, setPendingDeparture] = useState<PendingDeparture | null>(null);
 
   const hasDirtyDraft = useCallback(
@@ -93,6 +113,7 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
 
   useEffect(() => {
     currentPathRef.current = `${location.pathname}${location.search}${location.hash}`;
+    currentHistoryIndexRef.current = historyIndex();
   }, [location.hash, location.pathname, location.search]);
 
   useEffect(() => {
@@ -120,22 +141,41 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
     };
 
     const handlePopState = (event: PopStateEvent) => {
+      if (restoringPopStateRef.current) {
+        restoringPopStateRef.current = false;
+        const pendingHistoryDeparture = pendingHistoryDepartureRef.current;
+        pendingHistoryDepartureRef.current = null;
+        if (pendingHistoryDeparture) {
+          requestDeparture(
+            () => window.history.go(-pendingHistoryDeparture.restoreDelta),
+            pendingHistoryDeparture.description,
+          );
+        }
+        return;
+      }
       const targetPath = currentBrowserPath();
       const activePath = currentPathRef.current;
       if (targetPath === activePath || !hasDirtyDraft()) {
         return;
       }
 
-      // Browser history has already moved when popstate fires. Restore the
-      // authoritative dirty route immediately, then replay the requested
-      // destination only after the user confirms discard.
+      const activeIndex = currentHistoryIndexRef.current;
+      const targetIndex = historyIndex(event.state);
+      const restoreDelta =
+        activeIndex !== null && targetIndex !== null && activeIndex !== targetIndex
+          ? activeIndex - targetIndex
+          : 1;
+
+      // popstate fires after the browser has moved. Replay the inverse traversal
+      // to restore the dirty route without appending history entries, then replay
+      // the original traversal only after the user confirms discard.
       event.stopImmediatePropagation();
-      window.history.pushState({ moonmindSettingsDraftRestore: true }, '', activePath);
-      navigate(activePath, { replace: true });
-      requestDeparture(
-        () => navigate(targetPath),
-        'Leave this Settings page? Your unsaved draft will be discarded.',
-      );
+      restoringPopStateRef.current = true;
+      pendingHistoryDepartureRef.current = {
+        restoreDelta,
+        description: 'Leave this Settings page? Your unsaved draft will be discarded.',
+      };
+      window.history.go(restoreDelta);
     };
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -177,6 +217,41 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
     departure.action();
   };
 
+  const departurePending = pendingDeparture !== null;
+  useEffect(() => {
+    if (!departurePending) {
+      return undefined;
+    }
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    stayButtonRef.current?.focus();
+    return () => {
+      const previous = previouslyFocusedRef.current;
+      previouslyFocusedRef.current = null;
+      if (previous?.isConnected) {
+        previous.focus();
+      }
+    };
+  }, [departurePending]);
+
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      stay();
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    if (event.shiftKey && document.activeElement === stayButtonRef.current) {
+      event.preventDefault();
+      discardButtonRef.current?.focus();
+    } else if (!event.shiftKey && document.activeElement === discardButtonRef.current) {
+      event.preventDefault();
+      stayButtonRef.current?.focus();
+    }
+  };
+
   return (
     <SettingsDraftGuardContext.Provider value={value}>
       {children}
@@ -190,6 +265,7 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
             aria-labelledby="settings-unsaved-title"
             aria-modal="true"
             className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+            onKeyDown={handleDialogKeyDown}
             role="dialog"
           >
             <h2 id="settings-unsaved-title" className="text-lg font-semibold text-slate-950 dark:text-white">
@@ -203,6 +279,7 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
                 type="button"
                 className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 dark:border-slate-700 dark:text-slate-200"
                 onClick={stay}
+                ref={stayButtonRef}
               >
                 Stay
               </button>
@@ -210,6 +287,7 @@ export function SettingsDraftGuardProvider({ children }: { children: ReactNode }
                 type="button"
                 className="rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-500"
                 onClick={discardAndLeave}
+                ref={discardButtonRef}
               >
                 Discard and leave
               </button>

--- a/frontend/src/components/settings/SettingsDraftGuard.tsx
+++ b/frontend/src/components/settings/SettingsDraftGuard.tsx
@@ -1,0 +1,245 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+interface DraftRegistration {
+  dirty: boolean;
+  discard: () => void;
+}
+
+interface PendingDeparture {
+  action: () => void;
+  description: string;
+}
+
+interface SettingsDraftGuardValue {
+  registerDraft: (draftId: string, registration: DraftRegistration | null) => void;
+  requestDeparture: (action: () => void, description?: string) => boolean;
+}
+
+const immediateGuard: SettingsDraftGuardValue = {
+  registerDraft: () => undefined,
+  requestDeparture: (action) => {
+    action();
+    return true;
+  },
+};
+
+const SettingsDraftGuardContext = createContext<SettingsDraftGuardValue>(immediateGuard);
+
+function currentBrowserPath(): string {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function isPlainInternalNavigation(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    anchor.target ||
+    anchor.hasAttribute('download')
+  ) {
+    return false;
+  }
+  const rawHref = (anchor.getAttribute('href') ?? '').trimStart();
+  return Boolean(rawHref && !rawHref.startsWith('#'));
+}
+
+export function SettingsDraftGuardProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const registrationsRef = useRef(new Map<string, DraftRegistration>());
+  const currentPathRef = useRef(currentBrowserPath());
+  const [pendingDeparture, setPendingDeparture] = useState<PendingDeparture | null>(null);
+
+  const hasDirtyDraft = useCallback(
+    () => Array.from(registrationsRef.current.values()).some((draft) => draft.dirty),
+    [],
+  );
+
+  const registerDraft = useCallback(
+    (draftId: string, registration: DraftRegistration | null) => {
+      if (registration) {
+        registrationsRef.current.set(draftId, registration);
+      } else {
+        registrationsRef.current.delete(draftId);
+      }
+    },
+    [],
+  );
+
+  const requestDeparture = useCallback(
+    (action: () => void, description = 'Leave this page?') => {
+      if (!hasDirtyDraft()) {
+        action();
+        return true;
+      }
+      setPendingDeparture({ action, description });
+      return false;
+    },
+    [hasDirtyDraft],
+  );
+
+  useEffect(() => {
+    currentPathRef.current = `${location.pathname}${location.search}${location.hash}`;
+  }, [location.hash, location.pathname, location.search]);
+
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent) => {
+      const target = event.target;
+      const anchor = target instanceof Element ? target.closest<HTMLAnchorElement>('a[href]') : null;
+      if (!anchor || !isPlainInternalNavigation(event, anchor)) {
+        return;
+      }
+      const destination = new URL(anchor.href, window.location.href);
+      if (destination.origin !== window.location.origin) {
+        return;
+      }
+      const targetPath = `${destination.pathname}${destination.search}${destination.hash}`;
+      if (targetPath === currentPathRef.current || !hasDirtyDraft()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      requestDeparture(
+        () => navigate(targetPath),
+        'Leave this Settings page? Your unsaved draft will be discarded.',
+      );
+    };
+
+    const handlePopState = (event: PopStateEvent) => {
+      const targetPath = currentBrowserPath();
+      const activePath = currentPathRef.current;
+      if (targetPath === activePath || !hasDirtyDraft()) {
+        return;
+      }
+
+      // Browser history has already moved when popstate fires. Restore the
+      // authoritative dirty route immediately, then replay the requested
+      // destination only after the user confirms discard.
+      event.stopImmediatePropagation();
+      window.history.pushState({ moonmindSettingsDraftRestore: true }, '', activePath);
+      navigate(activePath, { replace: true });
+      requestDeparture(
+        () => navigate(targetPath),
+        'Leave this Settings page? Your unsaved draft will be discarded.',
+      );
+    };
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!hasDirtyDraft()) {
+        return;
+      }
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    document.addEventListener('click', handleDocumentClick, true);
+    window.addEventListener('popstate', handlePopState);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      document.removeEventListener('click', handleDocumentClick, true);
+      window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [hasDirtyDraft, navigate, requestDeparture]);
+
+  const value = useMemo<SettingsDraftGuardValue>(
+    () => ({ registerDraft, requestDeparture }),
+    [registerDraft, requestDeparture],
+  );
+
+  const stay = () => setPendingDeparture(null);
+  const discardAndLeave = () => {
+    const departure = pendingDeparture;
+    if (!departure) {
+      return;
+    }
+    for (const registration of registrationsRef.current.values()) {
+      if (registration.dirty) {
+        registration.discard();
+      }
+    }
+    registrationsRef.current.clear();
+    setPendingDeparture(null);
+    departure.action();
+  };
+
+  return (
+    <SettingsDraftGuardContext.Provider value={value}>
+      {children}
+      {pendingDeparture ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/55 p-4"
+          role="presentation"
+        >
+          <section
+            aria-describedby="settings-unsaved-description"
+            aria-labelledby="settings-unsaved-title"
+            aria-modal="true"
+            className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+            role="dialog"
+          >
+            <h2 id="settings-unsaved-title" className="text-lg font-semibold text-slate-950 dark:text-white">
+              Unsaved changes
+            </h2>
+            <p id="settings-unsaved-description" className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              {pendingDeparture.description}
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 dark:border-slate-700 dark:text-slate-200"
+                onClick={stay}
+              >
+                Stay
+              </button>
+              <button
+                type="button"
+                className="rounded-xl bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-500"
+                onClick={discardAndLeave}
+              >
+                Discard and leave
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </SettingsDraftGuardContext.Provider>
+  );
+}
+
+export function useSettingsDraftGuard(): Pick<SettingsDraftGuardValue, 'requestDeparture'> {
+  const { requestDeparture } = useContext(SettingsDraftGuardContext);
+  return { requestDeparture };
+}
+
+export function useSettingsDraftRegistration(
+  draftId: string,
+  dirty: boolean,
+  discard: () => void,
+): void {
+  const { registerDraft } = useContext(SettingsDraftGuardContext);
+  const discardRef = useRef(discard);
+  discardRef.current = discard;
+
+  useEffect(() => {
+    registerDraft(draftId, {
+      dirty,
+      discard: () => discardRef.current(),
+    });
+    return () => registerDraft(draftId, null);
+  }, [dirty, draftId, registerDraft]);
+}

--- a/frontend/src/entrypoints/dashboard-alerts.tsx
+++ b/frontend/src/entrypoints/dashboard-alerts.tsx
@@ -72,7 +72,7 @@ export function DashboardAlerts() {
         Profiles in Settings.
         <div style={{ marginTop: "12px" }}>
           <a
-            href="/settings?section=providers-secrets"
+            href="/settings/providers-secrets"
             className="btn btn-sm btn-outline"
           >
             Open Settings
@@ -104,7 +104,7 @@ export function DashboardAlerts() {
       </ul>
       <div style={{ marginTop: "12px" }}>
         <a
-          href="/settings?section=providers-secrets"
+          href="/settings/providers-secrets"
           className="btn btn-sm btn-outline"
         >
           Open Settings

--- a/frontend/src/entrypoints/dashboard-app.tsx
+++ b/frontend/src/entrypoints/dashboard-app.tsx
@@ -79,7 +79,18 @@ const PAGE_IMPORTS = {
   'oauth-terminal': () => import('./oauth-terminal'),
   remediations: () => import('./remediations'),
   schedules: () => import('./schedules'),
-  settings: () => import('./settings'),
+  'settings-entry': async () => ({
+    default: (await import('./settings')).SettingsEntryPage,
+  }),
+  'settings-operations': async () => ({
+    default: (await import('./settings')).OperationsSettingsPage,
+  }),
+  'settings-providers-secrets': async () => ({
+    default: (await import('./settings')).ProvidersSecretsSettingsPage,
+  }),
+  'settings-user-workspace': async () => ({
+    default: (await import('./settings')).UserWorkspaceSettingsPage,
+  }),
   skills: () => import('./skills'),
   'workflow-start': () => import('./workflow-start'),
   'workflows-workspace': () => import('./workflows-workspace'),
@@ -985,7 +996,7 @@ function AppShell({
               Workers: Running
             </span>
             <span className="worker-pause-reason" data-worker-pause-reason />
-            <Link className="worker-pause-manage" to="/settings?section=operations" data-worker-pause-manage>
+            <Link className="worker-pause-manage" to="/settings/operations" data-worker-pause-manage>
               Manage operations
             </Link>
           </p>
@@ -1435,7 +1446,11 @@ function RoutedDashboardPage({
 
   if (
     isUiInfoPending &&
-    (route.page === 'workflow-start' || route.currentPath === '/workflows/new')
+    (
+      route.page === 'workflow-start' ||
+      route.currentPath === '/workflows/new' ||
+      route.page.startsWith('settings-')
+    )
   ) {
     return (
       <AppShell
@@ -1488,7 +1503,9 @@ function RoutedDashboardPage({
     ? 'workflows-workspace'
     : route.page === 'skills'
       ? 'skills'
-      : `${route.page}:${route.currentPath}${location.search}${location.hash}`;
+      : route.page.startsWith('settings-')
+        ? `${route.page}:${route.currentPath}`
+        : `${route.page}:${route.currentPath}${location.search}${location.hash}`;
 
   return (
     <AppShell

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -279,12 +279,18 @@ vi.mock('./workflow-start', () => ({
   },
 }));
 
-vi.mock('./settings', () => ({
-  default: ({ payload }: { payload: BootPayload }) => {
+vi.mock('./settings', () => {
+  const MockSettingsPage = ({ payload }: { payload: BootPayload }) => {
     const initialData = payload.initialData as { settingsPermissions?: string[] } | undefined;
     return <div>Settings permissions: {(initialData?.settingsPermissions ?? []).join(',')}</div>;
-  },
-}));
+  };
+  return {
+    SettingsEntryPage: MockSettingsPage,
+    OperationsSettingsPage: MockSettingsPage,
+    ProvidersSecretsSettingsPage: MockSettingsPage,
+    UserWorkspaceSettingsPage: MockSettingsPage,
+  };
+});
 
 function uiInfo(overrides: Record<string, unknown> = {}) {
   return {
@@ -489,7 +495,7 @@ describe('Dashboard shared entry', () => {
     ['/artifacts/example', 'Artifacts'],
     ['/observability/example', 'Artifacts'],
     ['/remediations/example', 'Remediation'],
-    ['/settings/providers', 'Settings'],
+    ['/settings/providers-secrets', 'Settings'],
     ['/schedules', 'Recurring'],
     ['/schedules/nightly-build', 'Recurring'],
     ['/skills', 'Skills'],

--- a/frontend/src/entrypoints/settings.test.tsx
+++ b/frontend/src/entrypoints/settings.test.tsx
@@ -1,21 +1,37 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { fireEvent, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 
 import type { BootPayload } from '../boot/parseBootPayload';
 import { renderWithClient } from '../utils/test-utils';
-import { SettingsPage } from './settings';
+import { ProvidersSecretsSettingsPage, UserWorkspaceSettingsPage } from './settings';
 import { readDashboardPreferences, updateDashboardPreferences } from '../utils/dashboardPreferences';
+
+const renderProvidersPage = (payload: BootPayload) => renderWithClient(
+  <BrowserRouter><ProvidersSecretsSettingsPage payload={payload} /></BrowserRouter>,
+);
+
+const renderUserWorkspacePage = (payload: BootPayload) => renderWithClient(
+  <BrowserRouter><UserWorkspaceSettingsPage payload={payload} /></BrowserRouter>,
+);
 
 describe('Settings Entrypoint', () => {
   const mockPayload: BootPayload = {
-    page: 'settings',
+    page: 'settings-providers-secrets',
     apiBase: '/api',
+    initialData: {
+      settingsPermissions: [
+        'provider_profiles.read',
+        'secrets.metadata.read',
+        'settings.catalog.read',
+      ],
+    },
   };
 
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
-    window.history.pushState({}, 'Settings', '/settings?section=providers-secrets');
+    window.history.pushState({}, 'Settings', '/settings/providers-secrets');
     fetchSpy = vi.spyOn(window, 'fetch').mockReturnValue(new Promise(() => {}) as Promise<Response>);
   });
 
@@ -25,14 +41,14 @@ describe('Settings Entrypoint', () => {
   });
 
   it('MM-1185 resets collection layouts and remembered identities from Settings', () => {
-    window.history.replaceState({}, 'Settings', '/settings?section=user-workspace');
+    window.history.replaceState({}, 'Settings', '/settings/user-workspace?scope=workspace');
     updateDashboardPreferences({
       workflowListDisplayMode: 'hidden',
       lastSelectedWorkflowId: 'workflow-one',
       recurringListDisplayMode: 'hidden',
       lastSelectedDefinitionId: 'schedule-one',
     });
-    renderWithClient(<SettingsPage payload={mockPayload} />);
+    renderUserWorkspacePage(mockPayload);
 
     fireEvent.click(screen.getByRole('button', { name: 'Reset dashboard preferences' }));
 
@@ -44,9 +60,8 @@ describe('Settings Entrypoint', () => {
   });
 
   it('renders page-matched scoped placeholders for provider profiles and managed secrets', () => {
-    renderWithClient(<SettingsPage payload={mockPayload} />);
+    renderProvidersPage(mockPayload);
 
-    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Providers & Secrets' })).toBeTruthy();
     expect(screen.getByText('Settings provider profiles loading placeholder').closest('[role="status"]')).toBeTruthy();
     expect(screen.getByText('Settings managed secrets loading placeholder').closest('[role="status"]')).toBeTruthy();
@@ -76,10 +91,14 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   };
 
   const payloadWithRuntimes: BootPayload = {
-    page: 'settings',
+    page: 'settings-providers-secrets',
     apiBase: '/api',
     initialData: {
-      settingsPermissions: ['provider_profiles.write'],
+      settingsPermissions: [
+        'provider_profiles.read',
+        'provider_profiles.write',
+        'secrets.metadata.read',
+      ],
       runtimeConfig: {
         system: {
           // `omnigent` is a facade, never a Provider Profile owner, so it must
@@ -93,7 +112,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
-    window.history.pushState({}, 'Settings', '/settings?section=providers-secrets');
+    window.history.pushState({}, 'Settings', '/settings/providers-secrets');
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/v1/provider-profiles')) {
@@ -134,7 +153,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   }
 
   it('fetches the complete Provider Profile collection and defaults to All runtimes', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
 
@@ -152,7 +171,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   });
 
   it('offers one option per available runtime using canonical IDs and formatted labels', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
 
@@ -174,7 +193,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   });
 
   it('shows only matching rows while the global health summary keeps every loaded profile', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
 
@@ -201,7 +220,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   });
 
   it('prefills the create form runtime from the active filter without touching an existing runtime', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
 
@@ -221,7 +240,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   });
 
   it('names the active runtime in the empty state instead of the global message', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
     expect(screen.queryByText('No provider profiles configured yet.')).toBeNull();
@@ -235,7 +254,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   });
 
   it('keeps runtime_id immutable while editing an existing profile', async () => {
-    renderWithClient(<SettingsPage payload={payloadWithRuntimes} />);
+    renderProvidersPage(payloadWithRuntimes);
 
     await screen.findByRole('heading', { name: 'Provider Profiles' });
 

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -391,7 +391,11 @@ function UserWorkspaceSettingsContent({ payload }: { payload: BootPayload }) {
       </section>
 
       <NoticeBanner notice={notice} />
-      <GeneratedSettingsSection scope={scope} onScopeChange={changeScope} />
+      <GeneratedSettingsSection
+        scope={scope}
+        onScopeChange={changeScope}
+        canReadAudit={permissions.has('settings.audit.read')}
+      />
 
       <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
         <h3 className="text-base font-semibold text-slate-900 dark:text-white">

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { BootPayload } from '../boot/parseBootPayload';
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+import type { BootPayload } from '../boot/parseBootPayload';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
 import { SecretManager } from '../components/secrets/SecretManager';
 import { ConfigurationHealthSummary } from '../components/settings/ConfigurationHealthSummary';
-import { GeneratedSettingsSection } from '../components/settings/GeneratedSettingsSection';
+import {
+  GeneratedSettingsSection,
+  type SettingScope,
+} from '../components/settings/GeneratedSettingsSection';
 import { GithubTokenProbePanel } from '../components/settings/GithubTokenProbePanel';
 import {
   OperationsSettingsSection,
@@ -16,68 +21,13 @@ import {
   ProviderProfilesManager,
   type ProviderProfile,
 } from '../components/settings/ProviderProfilesManager';
+import {
+  SettingsDraftGuardProvider,
+  useSettingsDraftGuard,
+} from '../components/settings/SettingsDraftGuard';
 import { resetDashboardPreferences } from '../utils/dashboardPreferences';
 
-// `omnigent` is an execution facade, not a Provider Profile owner: every
-// profile it launches is owned by the underlying managed runtime, so it is
-// never offered as a Provider Profile runtime filter.
 const NON_PROFILE_OWNING_RUNTIMES = new Set(['omnigent']);
-
-function ProvidersKeyIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="8" cy="14" r="3.5" />
-      <path d="M10.5 12L20 4" />
-      <path d="M17 7l2 2" />
-      <path d="M14 10l2 2" />
-    </svg>
-  );
-}
-
-function UserWorkspaceIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="8" r="3.5" />
-      <path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6" />
-    </svg>
-  );
-}
-
-function OperationsGearIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      focusable="false"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" />
-      <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1" />
-    </svg>
-  );
-}
 
 interface ProfileData {
   id?: string | number;
@@ -101,136 +51,138 @@ interface SecretsListResponse {
   items: SecretMetadata[];
 }
 
-const SETTINGS_SECTIONS: ReadonlyArray<{
-  id: 'providers-secrets' | 'user-workspace' | 'operations';
-  label: string;
+interface SettingsInitialData {
+  settingsPermissions?: string[];
+  workerPause?: WorkerPauseConfig | null;
+  runtimeConfig?: {
+    system?: {
+      defaultTaskModelByRuntime?: Record<string, string>;
+      supportedRuntimes?: string[];
+    };
+  };
+}
+
+function settingsInitialData(payload: BootPayload): SettingsInitialData {
+  return (payload.initialData as SettingsInitialData | undefined) ?? {};
+}
+
+function settingsPermissions(payload: BootPayload): Set<string> {
+  return new Set(settingsInitialData(payload).settingsPermissions ?? []);
+}
+
+function SettingsPageFrame({
+  title,
+  description,
+  children,
+}: {
+  title: string;
   description: string;
-  Icon: () => ReactElement;
-}> = [
-  {
-    id: 'providers-secrets',
-    label: 'Providers & Secrets',
-    description:
-      'Configure provider profiles, managed secrets, and the bindings that make runtimes launchable.',
-    Icon: ProvidersKeyIcon,
-  },
-  {
-    id: 'user-workspace',
-    label: 'User / Workspace',
-    description:
-      'Hold user-scoped and workspace-scoped settings as the dashboard exposes more of the broader configuration model.',
-    Icon: UserWorkspaceIcon,
-  },
-  {
-    id: 'operations',
-    label: 'Operations',
-    description:
-      'Keep worker pause, drain, quiesce, and related operational controls under Settings.',
-    Icon: OperationsGearIcon,
-  },
-] as const;
-
-type SettingsSectionId = (typeof SETTINGS_SECTIONS)[number]['id'];
-
-function isSettingsSection(value: string | null): value is SettingsSectionId {
-  return SETTINGS_SECTIONS.some((section) => section.id === value);
-}
-
-function readSectionFromLocation(): SettingsSectionId {
-  const params = new URLSearchParams(window.location.search);
-  const section = params.get('section');
-  return isSettingsSection(section) ? section : 'providers-secrets';
-}
-
-function updateSectionInLocation(section: SettingsSectionId): void {
-  const url = new URL(window.location.href);
-  url.searchParams.set('section', section);
-  window.history.pushState({}, '', url.toString());
-}
-
-export function SettingsPage({ payload }: { payload: BootPayload }) {
-  const queryClient = useQueryClient();
-  const [notice, setNotice] = useState<Notice | null>(null);
-  const [section, setSection] = useState<SettingsSectionId>(() => readSectionFromLocation());
-  // Settings is the administrative exception to runtime-scoped Provider Profile
-  // selection: it enters on the All-runtimes view and can narrow the table to a
-  // single runtime without narrowing global configuration health.
-  const [providerProfileRuntimeFilter, setProviderProfileRuntimeFilter] = useState<string>(
-    ALL_RUNTIMES_FILTER_VALUE,
-  );
-  const workerPauseConfig =
-    (payload.initialData as { workerPause?: WorkerPauseConfig } | undefined)?.workerPause ??
-    null;
-  const runtimeSystemConfig =
-    (payload.initialData as {
-      runtimeConfig?: {
-        system?: {
-          defaultTaskModelByRuntime?: Record<string, string>;
-          supportedRuntimes?: string[];
-        };
-      };
-    } | undefined)?.runtimeConfig?.system ?? {};
-  const defaultTaskModelByRuntime: Record<string, string> =
-    runtimeSystemConfig.defaultTaskModelByRuntime ?? {};
-  const supportedRuntimes: string[] = runtimeSystemConfig.supportedRuntimes ?? [];
-  const settingsPermissions = new Set(
-    ((payload.initialData as { settingsPermissions?: string[] } | undefined)
-      ?.settingsPermissions ?? []),
-  );
-  const canWriteProviderProfiles = settingsPermissions.has('provider_profiles.write');
-  const canRunGithubTokenProbe = settingsPermissions.has('settings.effective.read');
-
+  children: ReactNode;
+}) {
   useEffect(() => {
-    const handlePopState = () => {
-      setSection(readSectionFromLocation());
-      setNotice(null);
-    };
+    document.title = `${title} | MoonMind`;
+  }, [title]);
 
-    window.addEventListener('popstate', handlePopState);
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, []);
+  return (
+    <div className="settings-page mx-auto w-full space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+      <header className="rounded-[2rem] border border-mm-border/80 bg-transparent px-6 py-6 shadow-sm">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 dark:text-slate-400">
+            Configuration
+          </p>
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">
+            {title}
+          </h2>
+          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
+            {description}
+          </p>
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+}
 
-  const { data: profile, isLoading, isError } = useQuery<ProfileData>({
-    queryKey: ['profile'],
-    queryFn: async () => {
-      const response = await fetch('/me', {
-        credentials: 'include',
-        headers: {
-          Accept: 'application/json',
-        },
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch profile: ${response.statusText}`);
-      }
-      return response.json();
-    },
-    enabled: section === 'user-workspace',
-  });
+function SettingsUnavailableState({
+  title,
+  permissions,
+}: {
+  title: string;
+  permissions: string[];
+}) {
+  return (
+    <section
+      aria-label={`${title} unavailable`}
+      className="rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm dark:border-amber-900/50 dark:bg-amber-900/20"
+    >
+      <h3 className="text-lg font-semibold text-amber-950 dark:text-amber-100">
+        This configuration page is unavailable
+      </h3>
+      <p className="mt-2 text-sm text-amber-800 dark:text-amber-200">
+        Your account cannot inspect this destination. Direct navigation remains on this route so
+        the authorization boundary is explicit.
+      </p>
+      <p className="mt-3 text-xs text-amber-700 dark:text-amber-300">
+        Required inspection permission: {permissions.map((permission) => (
+          <code key={permission} className="ml-1">{permission}</code>
+        ))}
+      </p>
+    </section>
+  );
+}
 
-  const {
-    data: secretsData,
-    isLoading: areSecretsLoading,
-    isError: areSecretsErrored,
-  } = useQuery<SecretsListResponse>({
+function RegionUnavailable({ children }: { children: ReactNode }) {
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-400">
+      {children}
+    </section>
+  );
+}
+
+function NoticeBanner({ notice }: { notice: Notice | null }) {
+  if (!notice) return null;
+  return (
+    <div
+      className={`rounded-3xl border px-5 py-4 text-sm shadow-sm ${
+        notice.level === 'error'
+          ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400'
+          : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-900/20 dark:text-emerald-400'
+      }`}
+    >
+      {notice.text}
+    </div>
+  );
+}
+
+function ProvidersSecretsSettingsContent({ payload }: { payload: BootPayload }) {
+  const queryClient = useQueryClient();
+  const { requestDeparture } = useSettingsDraftGuard();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const permissions = settingsPermissions(payload);
+  const canReadProviderProfiles = permissions.has('provider_profiles.read');
+  const canWriteProviderProfiles = permissions.has('provider_profiles.write');
+  const canReadSecretMetadata = permissions.has('secrets.metadata.read');
+  const canRunGithubTokenProbe = permissions.has('settings.effective.read');
+  const runtimeSystemConfig = settingsInitialData(payload).runtimeConfig?.system ?? {};
+  const defaultTaskModelByRuntime = runtimeSystemConfig.defaultTaskModelByRuntime ?? {};
+  const supportedRuntimes = runtimeSystemConfig.supportedRuntimes ?? [];
+  const providerProfileRuntimeFilter =
+    searchParams.get('runtime')?.trim() || ALL_RUNTIMES_FILTER_VALUE;
+
+  const secretsQuery = useQuery<SecretsListResponse>({
     queryKey: ['secrets'],
     queryFn: async () => {
       const response = await fetch('/api/v1/secrets', {
         headers: { Accept: 'application/json' },
       });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch secrets: ${response.statusText}`);
-      }
+      if (!response.ok) throw new Error(`Failed to fetch secrets: ${response.statusText}`);
       return response.json();
     },
+    enabled: canReadSecretMetadata,
   });
 
-  const {
-    data: providerProfiles,
-    isLoading: areProfilesLoading,
-    isError: areProfilesErrored,
-  } = useQuery<ProviderProfile[]>({
+  const providerProfilesQuery = useQuery<ProviderProfile[]>({
     queryKey: PROVIDER_PROFILE_QUERY_KEY,
     queryFn: async () => {
       const response = await fetch('/api/v1/provider-profiles', {
@@ -241,11 +193,10 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
       return response.json();
     },
+    enabled: canReadProviderProfiles,
   });
 
-  // The complete collection stays the single source for configuration health so
-  // global counts and diagnostics never follow the table filter.
-  const allProviderProfiles = providerProfiles ?? [];
+  const allProviderProfiles = providerProfilesQuery.data ?? [];
   const providerProfileRuntimeOptions = useMemo(() => {
     const runtimeIds: string[] = [];
     for (const runtimeId of [
@@ -262,7 +213,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
       }
     }
     return runtimeIds;
-  }, [supportedRuntimes, allProviderProfiles]);
+  }, [allProviderProfiles, supportedRuntimes]);
   const visibleProviderProfiles =
     providerProfileRuntimeFilter === ALL_RUNTIMES_FILTER_VALUE
       ? allProviderProfiles
@@ -270,235 +221,286 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
           (profile) => profile.runtime_id === providerProfileRuntimeFilter,
         );
 
-  const fallbackSection = SETTINGS_SECTIONS[0]!;
-  const currentSection =
-    SETTINGS_SECTIONS.find((candidate) => candidate.id === section) ?? fallbackSection;
-
-  const handleSelectSection = (nextSection: SettingsSectionId) => {
-    if (nextSection === section) {
-      return;
-    }
-    updateSectionInLocation(nextSection);
-    setSection(nextSection);
-    setNotice(null);
+  const selectRuntime = (runtimeId: string | undefined) => {
+    const nextRuntime = runtimeId ?? ALL_RUNTIMES_FILTER_VALUE;
+    if (nextRuntime === providerProfileRuntimeFilter) return;
+    requestDeparture(() => {
+      setSearchParams((current) => {
+        const next = new URLSearchParams(current);
+        if (nextRuntime === ALL_RUNTIMES_FILTER_VALUE) next.delete('runtime');
+        else next.set('runtime', nextRuntime);
+        return next;
+      });
+      setNotice(null);
+    }, 'Change the runtime filter? Your unsaved Provider Profile draft will be discarded.');
   };
 
   return (
-    <div className="settings-page mx-auto w-full space-y-6 px-4 py-6 sm:px-6 lg:px-8">
-      <header className="rounded-[2rem] border border-mm-border/80 bg-transparent px-6 py-6 shadow-sm">
-        <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500 dark:text-slate-400">
-            Dashboard Settings
-          </p>
-          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">Settings</h2>
-          <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">{currentSection.description}</p>
-        </div>
-      </header>
+    <SettingsPageFrame
+      title="Providers & Secrets"
+      description="Manage launch-ready Provider Profiles, credential references, OAuth lifecycle, and managed secret metadata."
+    >
+      {canReadProviderProfiles && canReadSecretMetadata ? (
+        <ConfigurationHealthSummary
+          providerProfiles={allProviderProfiles}
+          secrets={secretsQuery.data?.items ?? []}
+          isLoading={providerProfilesQuery.isLoading || secretsQuery.isLoading}
+          isError={providerProfilesQuery.isError || secretsQuery.isError}
+          canWriteProviderProfiles={canWriteProviderProfiles}
+          canRunGithubTokenProbe={canRunGithubTokenProbe}
+        />
+      ) : (
+        <RegionUnavailable>
+          The complete launch-readiness summary requires both <code>provider_profiles.read</code>{' '}
+          and <code>secrets.metadata.read</code>. Accessible regions remain available below.
+        </RegionUnavailable>
+      )}
 
-      <ConfigurationHealthSummary
-        providerProfiles={allProviderProfiles}
-        secrets={secretsData?.items ?? []}
-        isLoading={areProfilesLoading || areSecretsLoading}
-        isError={areProfilesErrored || areSecretsErrored}
-        workerPauseConfig={workerPauseConfig}
-        canWriteProviderProfiles={canWriteProviderProfiles}
-        canRunGithubTokenProbe={canRunGithubTokenProbe}
-      />
+      <NoticeBanner notice={notice} />
 
-      <section className="rounded-[2rem] border border-mm-border/80 bg-transparent p-3 shadow-sm">
-        <fieldset className="segmented-control-field">
-          <legend className="sr-only">Settings Section</legend>
-          <div
-            className="segmented-control"
-            data-intensity="loud"
-            style={{
-              '--segmented-control-count': SETTINGS_SECTIONS.length,
-            } as CSSProperties}
-          >
-            {SETTINGS_SECTIONS.map((candidate) => {
-              const Icon = candidate.Icon;
-              return (
-                <label
-                  key={candidate.id}
-                  className="segmented-control-item"
-                  title={candidate.description}
-                >
-                  <input
-                    type="radio"
-                    name="settings-section"
-                    value={candidate.id}
-                    checked={candidate.id === section}
-                    onChange={() => handleSelectSection(candidate.id)}
-                  />
-                  <span className="segmented-control-item-icon">
-                    <Icon />
-                  </span>
-                  <span className="segmented-control-item-label">
-                    {candidate.label}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </fieldset>
+      <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Provider Profiles keep launch metadata and SecretRefs. Managed Secrets keep encrypted
+          values or external references; profiles never expose those values after creation.
+        </p>
       </section>
 
-      {notice ? (
-        <div
-          className={`rounded-3xl border px-5 py-4 text-sm shadow-sm ${
-            notice.level === 'error'
-              ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400'
-              : 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-900/20 dark:text-emerald-400'
-          }`}
-        >
-          {notice.text}
-        </div>
-      ) : null}
-
-      {section === 'providers-secrets' ? (
-        <div className="space-y-6">
-          <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
-              <div className="space-y-2">
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Providers & Secrets</h3>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
-                  Provider profiles are the durable runtime and provider launch contract.
-                  Managed secrets back those profiles without re-exposing raw credential
-                  values after creation.
-                </p>
-              </div>
-              <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/50 p-4 text-sm text-slate-600 dark:text-slate-400">
-                Use secret refs such as <code>db://OPENAI_API_KEY</code> inside provider
-                profiles. Secrets stay in the managed secret store; profiles only keep the
-                refs and launch metadata.
-              </div>
-            </div>
-          </section>
-
-          {areProfilesLoading ? (
-            <LoadingPlaceholder
-              surface="settings"
-              region="provider profiles"
-              variant="table"
-              density="compact"
-              preserveContext
-            />
-          ) : areProfilesErrored ? (
-            <div className="rounded-3xl border border-rose-200 dark:border-rose-900/50 bg-rose-50 dark:bg-rose-900/20 p-6 text-sm text-rose-700 dark:text-rose-400 shadow-sm">
-              Failed to load provider profiles.
-            </div>
-          ) : (
-            <ProviderProfilesManager
-              profiles={visibleProviderProfiles}
-              secretSlugs={(secretsData?.items ?? []).map((secret) => secret.slug)}
-              onNotice={setNotice}
-              queryClient={queryClient}
-              defaultTaskModelByRuntime={defaultTaskModelByRuntime}
-              canWriteProviderProfiles={canWriteProviderProfiles}
-              selectedRuntimeId={
-                providerProfileRuntimeFilter === ALL_RUNTIMES_FILTER_VALUE
-                  ? undefined
-                  : providerProfileRuntimeFilter
-              }
-              runtimeFilterOptions={providerProfileRuntimeOptions}
-              onSelectRuntimeId={(runtimeId) =>
-                setProviderProfileRuntimeFilter(runtimeId ?? ALL_RUNTIMES_FILTER_VALUE)
-              }
-            />
-          )}
-
-          {areSecretsLoading ? (
-            <LoadingPlaceholder
-              surface="settings"
-              region="managed secrets"
-              variant="table"
-              density="compact"
-              preserveContext
-            />
-          ) : areSecretsErrored ? (
-            <div className="rounded-3xl border border-rose-200 dark:border-rose-900/50 bg-rose-50 dark:bg-rose-900/20 p-6 text-sm text-rose-700 dark:text-rose-400 shadow-sm">
-              Failed to load managed secrets.
-            </div>
-          ) : (
-            <SecretManager
-              secrets={secretsData?.items ?? []}
-              onNotice={setNotice}
-              queryClient={queryClient}
-              permissions={settingsPermissions}
-            />
-          )}
-
-          <GithubTokenProbePanel
-            canRunProbe={canRunGithubTokenProbe}
+      {canReadProviderProfiles ? (
+        providerProfilesQuery.isLoading ? (
+          <LoadingPlaceholder surface="settings" region="provider profiles" variant="table" density="compact" preserveContext />
+        ) : providerProfilesQuery.isError ? (
+          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400">
+            Failed to load provider profiles.
+          </div>
+        ) : (
+          <ProviderProfilesManager
+            profiles={visibleProviderProfiles}
+            secretSlugs={(secretsQuery.data?.items ?? []).map((secret) => secret.slug)}
             onNotice={setNotice}
+            queryClient={queryClient}
+            defaultTaskModelByRuntime={defaultTaskModelByRuntime}
+            canWriteProviderProfiles={canWriteProviderProfiles}
+            selectedRuntimeId={providerProfileRuntimeFilter === ALL_RUNTIMES_FILTER_VALUE ? undefined : providerProfileRuntimeFilter}
+            runtimeFilterOptions={providerProfileRuntimeOptions}
+            onSelectRuntimeId={selectRuntime}
           />
-        </div>
-      ) : null}
+        )
+      ) : (
+        <RegionUnavailable>
+          Provider Profiles are unavailable because <code>provider_profiles.read</code> is not granted.
+        </RegionUnavailable>
+      )}
 
-      {section === 'user-workspace' ? (
-        <div className="space-y-6">
-          <GeneratedSettingsSection />
+      {canReadSecretMetadata ? (
+        secretsQuery.isLoading ? (
+          <LoadingPlaceholder surface="settings" region="managed secrets" variant="table" density="compact" preserveContext />
+        ) : secretsQuery.isError ? (
+          <div className="rounded-3xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-700 shadow-sm dark:border-rose-900/50 dark:bg-rose-900/20 dark:text-rose-400">
+            Failed to load managed secrets.
+          </div>
+        ) : (
+          <SecretManager
+            secrets={secretsQuery.data?.items ?? []}
+            onNotice={setNotice}
+            queryClient={queryClient}
+            permissions={permissions}
+          />
+        )
+      ) : (
+        <RegionUnavailable>
+          Managed Secret metadata is unavailable because <code>secrets.metadata.read</code> is not granted.
+        </RegionUnavailable>
+      )}
 
-          <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
-            <h3 className="text-base font-semibold text-slate-900 dark:text-white">
-              Dashboard preferences
-            </h3>
-            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-              Clear saved list layouts, selected workflows and recurring schedules, and other
-              browser-local dashboard choices.
-            </p>
-            <button
-              type="button"
-              className="mt-4 rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mm-accent dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-              onClick={() => {
-                resetDashboardPreferences();
-                setNotice({ level: 'ok', text: 'Dashboard preferences reset.' });
-              }}
-            >
-              Reset dashboard preferences
-            </button>
-          </section>
-
-          <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
-            {isLoading ? (
-              <LoadingPlaceholder
-                surface="settings"
-                region="current user"
-                variant="settings"
-                density="normal"
-                preserveContext
-              />
-            ) : isError ? (
-              <p className="text-sm text-rose-700 dark:text-rose-400">Failed to load profile data.</p>
-            ) : (
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/50 p-5">
-                  <div className="text-sm font-medium text-slate-500 dark:text-slate-400">Signed-in user</div>
-                  <div className="mt-2 text-base font-semibold text-slate-900 dark:text-white">
-                    {profile?.email || 'Unknown user'}
-                  </div>
-                  {profile?.id ? (
-                    <div className="mt-1 font-mono text-xs text-slate-500 dark:text-slate-400">
-                      {profile.id}
-                    </div>
-                  ) : null}
-                </div>
-                <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/50 p-5 text-sm text-slate-600 dark:text-slate-400">
-                  Future user and workspace settings should land here instead of adding
-                  more top-level tabs. This keeps the main product surface centered on
-                  tasks while still leaving room for the project&apos;s wider configuration
-                  model.
-                </div>
-              </div>
-            )}
-          </section>
-        </div>
-      ) : null}
-
-      {section === 'operations' ? (
-        <OperationsSettingsSection workerPauseConfig={workerPauseConfig} />
-      ) : null}
-    </div>
+      <GithubTokenProbePanel canRunProbe={canRunGithubTokenProbe} onNotice={setNotice} />
+    </SettingsPageFrame>
   );
 }
-export default SettingsPage;
+
+export function ProvidersSecretsSettingsPage({ payload }: { payload: BootPayload }) {
+  const permissions = settingsPermissions(payload);
+  const canInspect =
+    permissions.has('provider_profiles.read') ||
+    permissions.has('secrets.metadata.read') ||
+    permissions.has('settings.effective.read');
+
+  return (
+    <SettingsDraftGuardProvider>
+      {canInspect ? (
+        <ProvidersSecretsSettingsContent payload={payload} />
+      ) : (
+        <SettingsPageFrame
+          title="Providers & Secrets"
+          description="Manage launch-ready Provider Profiles, credential references, OAuth lifecycle, and managed secret metadata."
+        >
+          <SettingsUnavailableState title="Providers & Secrets" permissions={['provider_profiles.read', 'secrets.metadata.read']} />
+        </SettingsPageFrame>
+      )}
+    </SettingsDraftGuardProvider>
+  );
+}
+
+function UserWorkspaceSettingsContent({ payload }: { payload: BootPayload }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const permissions = settingsPermissions(payload);
+  const scope: SettingScope = searchParams.get('scope') === 'user' ? 'user' : 'workspace';
+  const canWriteScope = permissions.has(`settings.${scope}.write`);
+
+  const profileQuery = useQuery<ProfileData>({
+    queryKey: ['profile'],
+    queryFn: async () => {
+      const response = await fetch('/me', {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) throw new Error(`Failed to fetch profile: ${response.statusText}`);
+      return response.json();
+    },
+  });
+
+  const changeScope = (nextScope: SettingScope) => {
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      next.set('scope', nextScope);
+      return next;
+    });
+  };
+
+  return (
+    <SettingsPageFrame
+      title="User / Workspace"
+      description="Review descriptor-driven preferences and defaults at user or workspace scope, including validation and application diagnostics."
+    >
+      <section aria-label="User and workspace settings summary" className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+              {scope === 'user' ? 'User scope' : 'Workspace scope'}
+            </h3>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+              {canWriteScope
+                ? 'Overrides can be reviewed and saved at this scope.'
+                : 'Safe inspection is available; changes at this scope are read-only.'}
+            </p>
+          </div>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+            {canWriteScope ? 'Writable' : 'Read-only'}
+          </span>
+        </div>
+      </section>
+
+      <NoticeBanner notice={notice} />
+      <GeneratedSettingsSection scope={scope} onScopeChange={changeScope} />
+
+      <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
+        <h3 className="text-base font-semibold text-slate-900 dark:text-white">
+          Dashboard preferences
+        </h3>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          Clear browser-local list layouts, selected workflows and recurring schedules, and other dashboard choices.
+        </p>
+        <button
+          type="button"
+          className="mt-4 rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+          onClick={() => {
+            resetDashboardPreferences();
+            setNotice({ level: 'ok', text: 'Dashboard preferences reset.' });
+          }}
+        >
+          Reset dashboard preferences
+        </button>
+      </section>
+
+      <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
+        {profileQuery.isLoading ? (
+          <LoadingPlaceholder surface="settings" region="current user" variant="settings" density="normal" preserveContext />
+        ) : profileQuery.isError ? (
+          <p className="text-sm text-rose-700 dark:text-rose-400">Failed to load profile data.</p>
+        ) : (
+          <div>
+            <div className="text-sm font-medium text-slate-500 dark:text-slate-400">Signed-in user</div>
+            <div className="mt-2 text-base font-semibold text-slate-900 dark:text-white">
+              {profileQuery.data?.email || 'Unknown user'}
+            </div>
+            {profileQuery.data?.id ? (
+              <div className="mt-1 font-mono text-xs text-slate-500 dark:text-slate-400">
+                {profileQuery.data.id}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </section>
+    </SettingsPageFrame>
+  );
+}
+
+export function UserWorkspaceSettingsPage({ payload }: { payload: BootPayload }) {
+  const canInspect = settingsPermissions(payload).has('settings.catalog.read');
+  return (
+    <SettingsDraftGuardProvider>
+      {canInspect ? (
+        <UserWorkspaceSettingsContent payload={payload} />
+      ) : (
+        <SettingsPageFrame
+          title="User / Workspace"
+          description="Review descriptor-driven preferences and defaults at user or workspace scope, including validation and application diagnostics."
+        >
+          <SettingsUnavailableState title="User / Workspace" permissions={['settings.catalog.read']} />
+        </SettingsPageFrame>
+      )}
+    </SettingsDraftGuardProvider>
+  );
+}
+
+export function OperationsSettingsPage({ payload }: { payload: BootPayload }) {
+  const permissions = settingsPermissions(payload);
+  const canInspect = permissions.has('operations.read');
+  const workerPauseConfig = settingsInitialData(payload).workerPause ?? null;
+
+  return (
+    <SettingsDraftGuardProvider>
+      <SettingsPageFrame
+        title="Operations"
+        description="Inspect worker, queue, runtime, deployment, and maintenance state and run authorized operational commands."
+      >
+        {canInspect ? (
+          <OperationsSettingsSection
+            workerPauseConfig={workerPauseConfig}
+            canInvokeOperations={permissions.has('operations.invoke')}
+          />
+        ) : (
+          <SettingsUnavailableState title="Operations" permissions={['operations.read']} />
+        )}
+      </SettingsPageFrame>
+    </SettingsDraftGuardProvider>
+  );
+}
+
+export function SettingsEntryPage({ payload }: { payload: BootPayload }) {
+  const permissions = settingsPermissions(payload);
+  if (
+    permissions.has('provider_profiles.read') ||
+    permissions.has('secrets.metadata.read') ||
+    permissions.has('settings.effective.read')
+  ) {
+    return <Navigate to="/settings/providers-secrets" replace />;
+  }
+  if (permissions.has('settings.catalog.read')) {
+    return <Navigate to="/settings/user-workspace" replace />;
+  }
+  if (permissions.has('operations.read')) {
+    return <Navigate to="/settings/operations" replace />;
+  }
+  return (
+    <SettingsPageFrame
+      title="Configuration"
+      description="No configuration destination is available for this account."
+    >
+      <SettingsUnavailableState
+        title="Configuration"
+        permissions={['provider_profiles.read', 'settings.catalog.read', 'operations.read']}
+      />
+    </SettingsPageFrame>
+  );
+}

--- a/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
+++ b/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
@@ -1,0 +1,267 @@
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { act, fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
+import { ProvidersSecretsSettingsPage, UserWorkspaceSettingsPage } from './settings';
+
+const generatedDescriptor = {
+  key: 'workflow.default_publish_mode',
+  title: 'Default Publish Mode',
+  description: 'Default publication behavior.',
+  category: 'Workflow',
+  section: 'user-workspace',
+  type: 'enum',
+  ui: 'select',
+  scopes: ['workspace', 'user'],
+  default_value: 'pr',
+  effective_value: 'pr',
+  override_value: null,
+  source: 'default',
+  source_explanation: 'Default value.',
+  apply_mode: 'next_request',
+  activation_state: 'active',
+  active: true,
+  options: [
+    { value: 'pr', label: 'Pull request' },
+    { value: 'branch', label: 'Branch' },
+  ],
+  constraints: null,
+  sensitive: false,
+  read_only: false,
+  requires_reload: false,
+  requires_worker_restart: false,
+  requires_process_restart: false,
+  applies_to: ['workflows'],
+  order: 1,
+  value_version: 1,
+  diagnostics: [],
+};
+
+function ok(body: unknown): Response {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as Response;
+}
+
+function destinationLink(path: string): HTMLAnchorElement {
+  const link = document.createElement('a');
+  link.href = path;
+  link.textContent = 'Destination';
+  document.body.appendChild(link);
+  return link;
+}
+
+describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      if (url === '/me') return Promise.resolve(ok({ id: 'user-1', email: 'user@example.com' }));
+      if (url.startsWith('/api/v1/settings/catalog')) {
+        return Promise.resolve(ok({
+          section: 'user-workspace',
+          scope: url.includes('scope=user') ? 'user' : 'workspace',
+          categories: { Workflow: [generatedDescriptor] },
+        }));
+      }
+      if (url === '/api/v1/provider-profiles') return Promise.resolve(ok([]));
+      if (url === '/api/v1/secrets') return Promise.resolve(ok({ items: [] }));
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    document.querySelectorAll('a[href="/settings/operations"]').forEach((node) => node.remove());
+  });
+
+  it('keeps a generated-settings draft on Stay and discards it before route navigation', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderWithClient(
+      <BrowserRouter>
+        <UserWorkspaceSettingsPage
+          payload={{
+            page: 'settings-user-workspace',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: ['settings.catalog.read', 'settings.workspace.write'],
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    const control = await screen.findByLabelText('Default Publish Mode') as HTMLSelectElement;
+    fireEvent.change(control, { target: { value: 'branch' } });
+    expect(window.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false);
+
+    const link = destinationLink('/settings/operations');
+    fireEvent.click(link);
+    expect(screen.getByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+    expect(window.location.pathname).toBe('/settings/user-workspace');
+    expect((screen.getByLabelText('Default Publish Mode') as HTMLSelectElement).value).toBe('branch');
+
+    fireEvent.click(link);
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+    expect((screen.getByLabelText('Default Publish Mode') as HTMLSelectElement).value).toBe('pr');
+  });
+
+  it('guards generated-settings scope changes and stores the confirmed scope in history', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderWithClient(
+      <BrowserRouter>
+        <UserWorkspaceSettingsPage
+          payload={{
+            page: 'settings-user-workspace',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: [
+                'settings.catalog.read',
+                'settings.workspace.write',
+                'settings.user.write',
+              ],
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.change(await screen.findByLabelText('Default Publish Mode'), {
+      target: { value: 'branch' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'User' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+    expect(window.location.search).toBe('?scope=workspace');
+
+    fireEvent.click(screen.getByRole('button', { name: 'User' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+    await waitFor(() => expect(window.location.search).toBe('?scope=user'));
+    expect(await screen.findByRole('heading', { name: 'User scope' })).toBeTruthy();
+  });
+
+  it('protects a dirty Provider Profile form before changing routes or runtime filters', async () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderWithClient(
+      <BrowserRouter>
+        <ProvidersSecretsSettingsPage
+          payload={{
+            page: 'settings-providers-secrets',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: [
+                'provider_profiles.read',
+                'provider_profiles.write',
+                'secrets.metadata.read',
+              ],
+              runtimeConfig: { system: { supportedRuntimes: ['codex_cli', 'claude_code'] } },
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    const profileId = await screen.findByLabelText(/Profile ID/) as HTMLInputElement;
+    fireEvent.change(profileId, { target: { value: 'draft-profile' } });
+    fireEvent.change(screen.getByLabelText('Provider Profile runtime filter'), {
+      target: { value: 'codex_cli' },
+    });
+    expect(screen.getByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+    expect(profileId.value).toBe('draft-profile');
+    expect(window.location.search).toBe('');
+
+    const link = destinationLink('/settings/operations');
+    fireEvent.click(link);
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+  });
+
+  it('restores page-local scope across Back and Forward navigation', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderWithClient(
+      <BrowserRouter>
+        <UserWorkspaceSettingsPage
+          payload={{
+            page: 'settings-user-workspace',
+            apiBase: '/api',
+            initialData: { settingsPermissions: ['settings.catalog.read'] },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'Workspace scope' });
+    fireEvent.click(await screen.findByRole('button', { name: 'User' }));
+    expect(await screen.findByRole('heading', { name: 'User scope' })).toBeTruthy();
+
+    act(() => window.history.back());
+    expect(await screen.findByRole('heading', { name: 'Workspace scope' })).toBeTruthy();
+    act(() => window.history.forward());
+    expect(await screen.findByRole('heading', { name: 'User scope' })).toBeTruthy();
+  });
+
+  it('guards browser Back navigation and preserves the active draft when the user stays', async () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    window.history.pushState({}, '', '/settings/user-workspace?scope=workspace');
+    renderWithClient(
+      <BrowserRouter>
+        <UserWorkspaceSettingsPage
+          payload={{
+            page: 'settings-user-workspace',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: ['settings.catalog.read', 'settings.workspace.write'],
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    const control = await screen.findByLabelText('Default Publish Mode') as HTMLSelectElement;
+    fireEvent.change(control, { target: { value: 'branch' } });
+    act(() => window.history.back());
+    expect(await screen.findByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+    expect(window.location.pathname).toBe('/settings/user-workspace');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+    expect(control.value).toBe('branch');
+    expect(window.location.pathname).toBe('/settings/user-workspace');
+
+    act(() => window.history.back());
+    expect(await screen.findByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/providers-secrets'));
+  });
+
+  it('restores the Provider Profile runtime filter across Back and Forward navigation', async () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderWithClient(
+      <BrowserRouter>
+        <ProvidersSecretsSettingsPage
+          payload={{
+            page: 'settings-providers-secrets',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: ['provider_profiles.read', 'secrets.metadata.read'],
+              runtimeConfig: { system: { supportedRuntimes: ['codex_cli', 'claude_code'] } },
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    const filter = await screen.findByLabelText('Provider Profile runtime filter') as HTMLSelectElement;
+    fireEvent.change(filter, { target: { value: 'codex_cli' } });
+    await waitFor(() => expect(window.location.search).toBe('?runtime=codex_cli'));
+    fireEvent.change(filter, { target: { value: 'claude_code' } });
+    await waitFor(() => expect(window.location.search).toBe('?runtime=claude_code'));
+
+    act(() => window.history.back());
+    await waitFor(() => expect(filter.value).toBe('codex_cli'));
+    act(() => window.history.forward());
+    await waitFor(() => expect(filter.value).toBe('claude_code'));
+  });
+});

--- a/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
+++ b/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
@@ -179,6 +179,77 @@ describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', ()
     await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
   });
 
+  it('protects and discards a Managed Secret draft before route navigation', async () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderWithClient(
+      <BrowserRouter>
+        <ProvidersSecretsSettingsPage
+          payload={{
+            page: 'settings-providers-secrets',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: ['provider_profiles.read', 'secrets.metadata.read'],
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    const slug = await screen.findByLabelText('Secret slug') as HTMLInputElement;
+    fireEvent.change(slug, { target: { value: 'draft-secret' } });
+
+    const link = destinationLink('/settings/operations');
+    fireEvent.click(link);
+    expect(screen.getByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+    expect(slug.value).toBe('draft-secret');
+
+    fireEvent.click(link);
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+    expect(slug.value).toBe('');
+  });
+
+  it('keeps the unsaved-changes dialog keyboard-modal and restores focus on Escape', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderWithClient(
+      <BrowserRouter>
+        <UserWorkspaceSettingsPage
+          payload={{
+            page: 'settings-user-workspace',
+            apiBase: '/api',
+            initialData: {
+              settingsPermissions: ['settings.catalog.read', 'settings.workspace.write'],
+            },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    fireEvent.change(await screen.findByLabelText('Default Publish Mode'), {
+      target: { value: 'branch' },
+    });
+    const link = destinationLink('/settings/operations');
+    link.focus();
+    fireEvent.click(link);
+
+    const dialog = screen.getByRole('dialog', { name: 'Unsaved changes' });
+    const stay = screen.getByRole('button', { name: 'Stay' });
+    const discard = screen.getByRole('button', { name: 'Discard and leave' });
+    await waitFor(() => expect(document.activeElement).toBe(stay));
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(discard);
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    expect(document.activeElement).toBe(stay);
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Unsaved changes' })).toBeNull());
+    expect(document.activeElement).toBe(link);
+    expect(window.location.pathname).toBe('/settings/user-workspace');
+  });
+
   it('restores page-local scope across Back and Forward navigation', async () => {
     window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
     renderWithClient(
@@ -234,6 +305,9 @@ describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', ()
     expect(await screen.findByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
     await waitFor(() => expect(window.location.pathname).toBe('/settings/providers-secrets'));
+
+    act(() => window.history.forward());
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/user-workspace'));
   });
 
   it('restores the Provider Profile runtime filter across Back and Forward navigation', async () => {

--- a/frontend/src/entrypoints/settingsRoutes.test.tsx
+++ b/frontend/src/entrypoints/settingsRoutes.test.tsx
@@ -1,0 +1,227 @@
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { renderWithClient, screen, waitFor } from '../utils/test-utils';
+import {
+  OperationsSettingsPage,
+  ProvidersSecretsSettingsPage,
+  SettingsEntryPage,
+  UserWorkspaceSettingsPage,
+} from './settings';
+
+function renderRoute(Page: typeof ProvidersSecretsSettingsPage, payload: BootPayload) {
+  return renderWithClient(
+    <BrowserRouter>
+      <Page payload={payload} />
+    </BrowserRouter>,
+  );
+}
+
+function response(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response;
+}
+
+describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
+  let fetchSpy: MockInstance;
+  const requestedUrls: string[] = [];
+
+  beforeEach(() => {
+    requestedUrls.length = 0;
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === '/api/v1/provider-profiles') return Promise.resolve(response([]));
+      if (url === '/api/v1/secrets') return Promise.resolve(response({ items: [] }));
+      if (url === '/me') return Promise.resolve(response({ id: 'user-1', email: 'user@example.com' }));
+      if (url.startsWith('/api/v1/settings/catalog')) {
+        const scope = url.includes('scope=user') ? 'user' : 'workspace';
+        return Promise.resolve(response({ section: 'user-workspace', scope, categories: {} }));
+      }
+      if (url === '/api/system/worker-pause') {
+        return Promise.resolve(response({ system: { workersPaused: false }, metrics: {}, commands: [] }));
+      }
+      if (url === '/api/v1/operations/codex/shards') return Promise.resolve(response({ shards: [] }));
+      if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+        return Promise.resolve(response({
+          stack: 'moonmind',
+          projectName: 'moonmind',
+          currentImage: { evidence: 'available' },
+          recentActions: [],
+          policy: {
+            repository: 'moonmind',
+            allowedReferences: [],
+            recentTags: [],
+            mutableReferences: [],
+            allowedModes: [],
+          },
+        }));
+      }
+      if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+        return Promise.resolve(response({ stack: 'moonmind', repositories: [] }));
+      }
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) } as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('mounts only Providers & Secrets primary data and managers', async () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderRoute(ProvidersSecretsSettingsPage, {
+      page: 'settings-providers-secrets',
+      apiBase: '/api',
+      initialData: {
+        settingsPermissions: [
+          'provider_profiles.read',
+          'provider_profiles.write',
+          'secrets.metadata.read',
+          'settings.effective.read',
+        ],
+      },
+    } as BootPayload);
+
+    expect(await screen.findByRole('heading', { name: 'Providers & Secrets' })).toBeTruthy();
+    await waitFor(() => expect(requestedUrls).toContain('/api/v1/provider-profiles'));
+    expect(requestedUrls).toContain('/api/v1/secrets');
+    expect(requestedUrls.some((url) => url.startsWith('/api/v1/settings/catalog'))).toBe(false);
+    expect(requestedUrls).not.toContain('/me');
+    expect(requestedUrls).not.toContain('/api/system/worker-pause');
+    expect(screen.queryByLabelText('Generated user and workspace settings')).toBeNull();
+    expect(screen.queryByLabelText('Worker Operations')).toBeNull();
+    expect(screen.queryByRole('radio')).toBeNull();
+  });
+
+  it('mounts only User / Workspace primary data', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderRoute(UserWorkspaceSettingsPage, {
+      page: 'settings-user-workspace',
+      apiBase: '/api',
+      initialData: { settingsPermissions: ['settings.catalog.read'] },
+    } as BootPayload);
+
+    expect(await screen.findByRole('heading', { name: 'User / Workspace' })).toBeTruthy();
+    await waitFor(() => {
+      expect(requestedUrls).toContain(
+        '/api/v1/settings/catalog?section=user-workspace&scope=workspace',
+      );
+    });
+    expect(requestedUrls).toContain('/me');
+    expect(requestedUrls).not.toContain('/api/v1/provider-profiles');
+    expect(requestedUrls).not.toContain('/api/v1/secrets');
+    expect(requestedUrls).not.toContain('/api/system/worker-pause');
+    expect(screen.queryByRole('heading', { name: 'Provider Profiles' })).toBeNull();
+    expect(screen.queryByLabelText('Worker Operations')).toBeNull();
+  });
+
+  it('mounts only Operations primary data', async () => {
+    window.history.replaceState({}, '', '/settings/operations');
+    renderRoute(OperationsSettingsPage, {
+      page: 'settings-operations',
+      apiBase: '/api',
+      initialData: {
+        settingsPermissions: ['operations.read', 'operations.invoke'],
+        workerPause: {
+          get: '/api/system/worker-pause',
+          post: '/api/system/worker-pause',
+          shardHealth: '/api/v1/operations/codex/shards',
+        },
+      },
+    } as BootPayload);
+
+    expect(await screen.findByRole('heading', { name: 'Operations' })).toBeTruthy();
+    await waitFor(() => expect(requestedUrls).toContain('/api/system/worker-pause'));
+    expect(requestedUrls).not.toContain('/api/v1/provider-profiles');
+    expect(requestedUrls).not.toContain('/api/v1/secrets');
+    expect(requestedUrls.some((url) => url.startsWith('/api/v1/settings/catalog'))).toBe(false);
+    expect(screen.queryByRole('heading', { name: 'Provider Profiles' })).toBeNull();
+    expect(screen.queryByLabelText('Generated user and workspace settings')).toBeNull();
+  });
+
+  it('shows an intentional unavailable state for a direct unauthorized route without fetching', () => {
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderRoute(ProvidersSecretsSettingsPage, {
+      page: 'settings-providers-secrets',
+      apiBase: '/api',
+      initialData: { settingsPermissions: [] },
+    } as BootPayload);
+
+    expect(screen.getByRole('heading', { name: 'Providers & Secrets' })).toBeTruthy();
+    expect(screen.getByRole('region', { name: 'Providers & Secrets unavailable' })).toBeTruthy();
+    expect(requestedUrls).toEqual([]);
+    expect(window.location.pathname).toBe('/settings/providers-secrets');
+  });
+
+  it('preserves an accessible region when a sibling query on the same page fails', async () => {
+    fetchSpy.mockImplementation((input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === '/api/v1/provider-profiles') {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: 'Unavailable',
+          json: async () => ({}),
+        } as Response);
+      }
+      if (url === '/api/v1/secrets') return Promise.resolve(response({ items: [] }));
+      return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) } as Response);
+    });
+    window.history.replaceState({}, '', '/settings/providers-secrets');
+    renderRoute(ProvidersSecretsSettingsPage, {
+      page: 'settings-providers-secrets',
+      apiBase: '/api',
+      initialData: {
+        settingsPermissions: ['provider_profiles.read', 'secrets.metadata.read'],
+      },
+    } as BootPayload);
+
+    expect(await screen.findByText('Failed to load provider profiles.')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Managed Secrets' })).toBeTruthy();
+  });
+
+  it('keeps Operations inspection available while disabling commands for read-only users', async () => {
+    window.history.replaceState({}, '', '/settings/operations');
+    renderRoute(OperationsSettingsPage, {
+      page: 'settings-operations',
+      apiBase: '/api',
+      initialData: {
+        settingsPermissions: ['operations.read'],
+        workerPause: {
+          get: '/api/system/worker-pause',
+          post: '/api/system/worker-pause',
+          shardHealth: '/api/v1/operations/codex/shards',
+        },
+      },
+    } as BootPayload);
+
+    expect(await screen.findByText(/commands are read-only/i)).toBeTruthy();
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: 'Update MoonMind' }) as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+
+  it('resolves the bare Settings entry to the first destination the user can inspect', async () => {
+    window.history.replaceState({}, '', '/settings');
+    renderWithClient(
+      <BrowserRouter>
+        <SettingsEntryPage
+          payload={{
+            page: 'settings-entry',
+            apiBase: '/api',
+            initialData: { settingsPermissions: ['operations.read'] },
+          } as BootPayload}
+        />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+  });
+});

--- a/frontend/src/entrypoints/settingsRoutes.test.tsx
+++ b/frontend/src/entrypoints/settingsRoutes.test.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 
 import type { BootPayload } from '../boot/parseBootPayload';
-import { renderWithClient, screen, waitFor } from '../utils/test-utils';
+import { fireEvent, renderWithClient, screen, waitFor } from '../utils/test-utils';
 import {
   OperationsSettingsPage,
   ProvidersSecretsSettingsPage,
@@ -27,6 +27,51 @@ function response(body: unknown): Response {
   } as Response;
 }
 
+const userWorkspaceCatalog = {
+  section: 'user-workspace',
+  scope: 'workspace',
+  categories: {
+    Workflow: [
+      {
+        key: 'workflow.default_publish_mode',
+        title: 'Default Publish Mode',
+        description: 'Fallback publish mode used when tasks omit publish mode.',
+        category: 'Workflow',
+        section: 'user-workspace',
+        type: 'string',
+        ui: 'readonly',
+        scopes: ['workspace'],
+        default_value: 'pr',
+        effective_value: 'pr',
+        override_value: null,
+        source: 'default',
+        source_explanation: 'Resolved from default.',
+        apply_mode: 'next_task',
+        activation_state: 'active',
+        active: true,
+        pending_value: null,
+        affected_process_or_worker: 'publishing',
+        completion_guidance: null,
+        options: null,
+        constraints: null,
+        sensitive: false,
+        secret_role: null,
+        read_only: true,
+        read_only_reason: 'Read-only test descriptor.',
+        requires_reload: false,
+        requires_worker_restart: false,
+        requires_process_restart: false,
+        applies_to: ['publishing'],
+        depends_on: [],
+        order: 10,
+        audit: { store_old_value: true, store_new_value: true, redact: false },
+        value_version: 1,
+        diagnostics: [],
+      },
+    ],
+  },
+};
+
 describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
   let fetchSpy: MockInstance;
   const requestedUrls: string[] = [];
@@ -39,9 +84,12 @@ describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
       if (url === '/api/v1/provider-profiles') return Promise.resolve(response([]));
       if (url === '/api/v1/secrets') return Promise.resolve(response({ items: [] }));
       if (url === '/me') return Promise.resolve(response({ id: 'user-1', email: 'user@example.com' }));
+      if (url.startsWith('/api/v1/settings/audit')) {
+        return Promise.resolve(response({ items: [] }));
+      }
       if (url.startsWith('/api/v1/settings/catalog')) {
         const scope = url.includes('scope=user') ? 'user' : 'workspace';
-        return Promise.resolve(response({ section: 'user-workspace', scope, categories: {} }));
+        return Promise.resolve(response({ ...userWorkspaceCatalog, scope }));
       }
       if (url === '/api/system/worker-pause') {
         return Promise.resolve(response({ system: { workersPaused: false }, metrics: {}, commands: [] }));
@@ -119,6 +167,32 @@ describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
     expect(requestedUrls).not.toContain('/api/system/worker-pause');
     expect(screen.queryByRole('heading', { name: 'Provider Profiles' })).toBeNull();
     expect(screen.queryByLabelText('Worker Operations')).toBeNull();
+    expect(screen.queryByRole('button', { name: /View audit for/ })).toBeNull();
+  });
+
+  it('maps settings.audit.read to an on-demand User / Workspace audit request', async () => {
+    window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+    renderRoute(UserWorkspaceSettingsPage, {
+      page: 'settings-user-workspace',
+      apiBase: '/api',
+      initialData: {
+        settingsPermissions: ['settings.catalog.read', 'settings.audit.read'],
+      },
+    } as BootPayload);
+
+    const auditButton = await screen.findByRole('button', {
+      name: 'View audit for Default Publish Mode',
+    });
+    expect(requestedUrls.some((url) => url.startsWith('/api/v1/settings/audit'))).toBe(false);
+    fireEvent.click(auditButton);
+
+    await waitFor(() => {
+      const auditUrl = requestedUrls.find((url) => url.startsWith('/api/v1/settings/audit'));
+      expect(auditUrl).toBeTruthy();
+      const query = new URL(auditUrl ?? '', window.location.origin).searchParams;
+      expect(query.get('scope')).toBe('workspace');
+      expect(query.get('key')).toBe('workflow.default_publish_mode');
+    });
   });
 
   it('mounts only Operations primary data', async () => {

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4049,7 +4049,7 @@ export interface paths {
         };
         /**
          * Secrets Route
-         * @description Redirect the legacy secrets page into unified settings.
+         * @description Redirect the legacy secrets page to its canonical Settings route.
          */
         get: operations["secrets_route_secrets_get"];
         put?: never;
@@ -4269,7 +4269,7 @@ export interface paths {
         };
         /**
          * Task Workers Route
-         * @description Redirect the legacy workers page into unified settings.
+         * @description Redirect the legacy workers page to its canonical Settings route.
          */
         get: operations["task_workers_route_workers_get"];
         put?: never;

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -56,7 +56,7 @@ describe('dashboard route resolution', () => {
     ['/artifacts/run/1', 'artifacts'],
     ['/observability/run/1', 'artifacts'],
     ['/remediations/mm:1', 'remediation'],
-    ['/settings/providers', 'settings'],
+    ['/settings/providers-secrets', 'settings'],
     ['/schedules', 'recurring'],
     ['/schedules/nightly%3Abuild', 'recurring'],
     ['/skills', 'skills'],
@@ -90,6 +90,18 @@ describe('dashboard route resolution', () => {
       });
     },
   );
+  it.each([
+    ['/settings', 'settings-entry'],
+    ['/settings/providers-secrets', 'settings-providers-secrets'],
+    ['/settings/user-workspace', 'settings-user-workspace'],
+    ['/settings/operations', 'settings-operations'],
+  ])('resolves the canonical Settings route %s to %s', (path, page) => {
+    expect(resolveDashboardRoute(path)).toEqual({
+      page,
+      dataWidePanel: true,
+      currentPath: path,
+    });
+  });
   it.each(['/artifacts', '/observability'])('resolves the %s evidence collection route', (path) => {
     expect(resolveDashboardRoute(path)).toEqual({
       page: 'artifacts',

--- a/frontend/src/lib/dashboardRoutes.ts
+++ b/frontend/src/lib/dashboardRoutes.ts
@@ -9,7 +9,10 @@ export type DashboardPage =
   | 'oauth-terminal'
   | 'remediations'
   | 'schedules'
-  | 'settings'
+  | 'settings-entry'
+  | 'settings-operations'
+  | 'settings-providers-secrets'
+  | 'settings-user-workspace'
   | 'skills'
   | 'workflow-start'
   | 'workflows-workspace'
@@ -71,7 +74,7 @@ export const DASHBOARD_DESTINATIONS: readonly DashboardDestination[] = [
   { key: 'omnigent-policies', label: 'Policies', iconKey: 'shield-check', canonicalPath: '/omnigent/policies', pathPatterns: ['/omnigent/policies/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'omnigentPolicies', endpointKey: 'omnigentPolicies', page: 'omnigent-inventory', dataWidePanel: true },
   { key: 'remediation', label: 'Remediation', iconKey: 'wrench', canonicalPath: '/remediations', pathPatterns: ['/remediations/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'remediationCollection', endpointKey: 'remediations', page: 'remediations', dataWidePanel: true },
   { key: 'artifacts', label: 'Artifacts', iconKey: 'archive', canonicalPath: '/artifacts', pathPatterns: ['/artifacts/*', '/observability/*'], navigationGroup: 'operations', pageClassification: 'collection', capabilityKey: 'artifacts', endpointKey: 'artifacts', page: 'artifacts', dataWidePanel: true },
-  { key: 'settings', label: 'Settings', iconKey: 'settings', canonicalPath: '/settings', pathPatterns: ['/settings/*'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settings', endpointKey: 'settings', page: 'settings', dataWidePanel: true },
+  { key: 'settings', label: 'Settings', iconKey: 'settings', canonicalPath: '/settings', pathPatterns: ['/settings/*'], navigationGroup: 'system', pageClassification: 'utility', capabilityKey: 'settings', endpointKey: 'settings', page: 'settings-entry', dataWidePanel: true },
 ];
 
 export type DashboardDestinationState = 'shown' | 'hidden' | 'unavailable';
@@ -216,8 +219,17 @@ export function resolveDashboardRoute(pathname: string): DashboardRoute | null {
   if (isWorkflowDetailPath(path) && path !== '/workflows/new') {
     return { page: 'workflows-workspace', dataWidePanel: true, currentPath: path };
   }
-  if (path === '/settings' || path.startsWith('/settings/')) {
-    return { page: 'settings', dataWidePanel: true, currentPath: path };
+  if (path === '/settings') {
+    return { page: 'settings-entry', dataWidePanel: true, currentPath: path };
+  }
+  if (path === '/settings/providers-secrets') {
+    return { page: 'settings-providers-secrets', dataWidePanel: true, currentPath: path };
+  }
+  if (path === '/settings/user-workspace') {
+    return { page: 'settings-user-workspace', dataWidePanel: true, currentPath: path };
+  }
+  if (path === '/settings/operations') {
+    return { page: 'settings-operations', dataWidePanel: true, currentPath: path };
   }
   if (path === '/skills' || path.startsWith('/skills/')) {
     return { page: 'skills', dataWidePanel: true, currentPath: path };
@@ -247,6 +259,9 @@ export function destinationForPath(pathname: string): DashboardDestination | nul
   const route = resolveDashboardRoute(pathname);
   if (!route) return null;
   if (pathname === '/workflows/new') return DASHBOARD_DESTINATIONS[1] ?? null;
+  if (pathname === '/settings' || pathname.startsWith('/settings/')) {
+    return DASHBOARD_DESTINATIONS.find((destination) => destination.key === 'settings') ?? null;
+  }
   return DASHBOARD_DESTINATIONS.find((destination) => (
     destination.page === route.page && (
       destination.key !== 'artifacts' || pathname.startsWith('/artifacts') || pathname.startsWith('/observability')
@@ -303,7 +318,7 @@ export function payloadForDashboardRoute(
   initialData.layout = layout;
   initialData.uiEndpoints = objectValue(uiInfo?.endpoints) ?? {};
 
-  if (route.page === 'settings') {
+  if (route.page.startsWith('settings-')) {
     initialData.workerPause = objectValue(uiInfo?.workerPause) ?? initialData.workerPause ?? {
       get: '/api/system/worker-pause',
       post: '/api/system/worker-pause',

--- a/tests/e2e/test_dashboard_react_mount_browser.py
+++ b/tests/e2e/test_dashboard_react_mount_browser.py
@@ -60,8 +60,8 @@ def server():
     "path,expected_text",
     [
         ("/workflows", "Workflows"),
-        ("/settings?section=operations", "Operations"),
-        ("/settings?section=providers-secrets", "Provider Profiles"),
+        ("/settings/operations", "Operations"),
+        ("/settings/providers-secrets", "Provider Profiles"),
     ],
 )
 def test_react_page_shows_app_content(server, path: str, expected_text: str) -> None:

--- a/tests/integration/temporal/test_system_operations_api.py
+++ b/tests/integration/temporal/test_system_operations_api.py
@@ -78,7 +78,7 @@ def test_worker_pause_route_matches_settings_runtime_contract(
                 app.dependency_overrides[dependency.call] = _override_user
     try:
         with TestClient(app) as client:
-            settings_page = client.get("/settings?section=operations")
+            settings_page = client.get("/settings/operations")
             snapshot = client.get("/api/system/worker-pause")
             command = client.post(
                 "/api/system/worker-pause",

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -690,15 +690,41 @@ def test_proposal_review_routes_are_not_dashboard_surfaces(client: TestClient) -
 
 
 def test_legacy_settings_subroutes_redirect_to_canonical_routes(
-    client: TestClient,
 ) -> None:
-    workers = client.get("/workers", follow_redirects=False)
+    with _client_with_mock_service(
+        user_settings_permissions={"provider_profiles.read", "operations.read"}
+    ) as (client, _mock_service):
+        workers = client.get("/workers", follow_redirects=False)
+        secrets = client.get("/secrets", follow_redirects=False)
+
     assert workers.status_code == 307
     assert workers.headers["location"] == "/settings/operations"
-
-    secrets = client.get("/secrets", follow_redirects=False)
     assert secrets.status_code == 307
     assert secrets.headers["location"] == "/settings/providers-secrets"
+
+
+def test_legacy_settings_subroutes_fall_back_to_first_authorized_destination() -> None:
+    with _client_with_mock_service(
+        user_settings_permissions={"settings.catalog.read"}
+    ) as (client, _mock_service):
+        workers = client.get("/workers", follow_redirects=False)
+        secrets = client.get("/secrets", follow_redirects=False)
+
+    assert workers.status_code == 307
+    assert workers.headers["location"] == "/settings/user-workspace"
+    assert secrets.status_code == 307
+    assert secrets.headers["location"] == "/settings/user-workspace"
+
+
+def test_legacy_settings_subroutes_fall_back_to_bare_entry_without_permissions() -> None:
+    with _client_with_mock_service() as (client, _mock_service):
+        workers = client.get("/workers", follow_redirects=False)
+        secrets = client.get("/secrets", follow_redirects=False)
+
+    assert workers.status_code == 307
+    assert workers.headers["location"] == "/settings"
+    assert secrets.status_code == 307
+    assert secrets.headers["location"] == "/settings"
 
 
 def test_react_tasks_list_and_detail_boot_exclude_route_specific_config(

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -637,16 +637,16 @@ def test_proposal_review_routes_are_not_dashboard_surfaces(client: TestClient) -
         assert response.status_code == 404
 
 
-def test_legacy_settings_subroutes_redirect_to_unified_settings(
+def test_legacy_settings_subroutes_redirect_to_canonical_routes(
     client: TestClient,
 ) -> None:
     workers = client.get("/workers", follow_redirects=False)
     assert workers.status_code == 307
-    assert workers.headers["location"] == "/settings?section=operations"
+    assert workers.headers["location"] == "/settings/operations"
 
     secrets = client.get("/secrets", follow_redirects=False)
     assert secrets.status_code == 307
-    assert secrets.headers["location"] == "/settings?section=providers-secrets"
+    assert secrets.headers["location"] == "/settings/providers-secrets"
 
 
 def test_react_tasks_list_and_detail_boot_exclude_route_specific_config(


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#3818

Closes MoonLadderStudios/MoonMind#3818

## Summary
- Split Settings into Providers & Secrets, User / Workspace, and Operations route-owned pages with independent data, permission, loading, and failure boundaries.
- Replaced page-local destination state with canonical routes and updated legacy redirects, links, tests, and documentation.
- Added reusable dirty-draft navigation protection and page-local history state for provider filters and user/workspace scope.
- Added authorized, lazy-loaded, scope-aware settings audit history with redaction and failure containment.

## Tests run
- Focused Settings frontend unit suite: 10 files, 290 tests passed.
- Frontend TypeScript typecheck passed.
- Focused remediation ESLint passed.
- Frontend production build passed.
- Settings audit backend unit boundary: 3 tests passed through the durable container backend.
- Retained prior verification: workflow-console unit boundary (59 passed) and system-operations integration boundary (2 passed).

## Remaining risks
- Browser smoke was not rerun because RUN_E2E_TESTS=1 was unavailable in the verification environment; focused route, navigation, and production-build coverage passed.
- The production build retained only existing non-blocking chunk-size and stale caniuse-lite advisories.