### PR TITLE
MoonLadderStudios/MoonMind#3819: Add backend provider profile creation presets

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -29,6 +29,12 @@ from api_service.db.models import (
     SecretStatus,
     User,
 )
+from api_service.services.provider_profile_creation_presets import (
+    CreationPresetError,
+    ProviderProfileAuthenticationMethod,
+    apply_provider_profile_creation_preset,
+    get_provider_profile_creation_preset,
+)
 from api_service.services.settings_catalog import has_settings_permission
 from moonmind.auth.secret_refs import (
     ParsedSecretRef,
@@ -207,9 +213,14 @@ class ProviderProfileCreate(BaseModel):
     default_model_tier: Optional[int] = Field(default=None, ge=1)
     model_overrides: Optional[dict[str, str]] = None
 
-    credential_source: str = Field(..., pattern="^(oauth_volume|secret_ref|none)$")
-    runtime_materialization_mode: str = Field(
-        ..., pattern="^(oauth_home|api_key_env|env_bundle|config_bundle|composite)$"
+    authentication_method: Optional[ProviderProfileAuthenticationMethod] = None
+    preset_version: Optional[str] = Field(default=None, max_length=128)
+    credential_source: Optional[str] = Field(
+        default=None, pattern="^(oauth_volume|secret_ref|none)$"
+    )
+    runtime_materialization_mode: Optional[str] = Field(
+        default=None,
+        pattern="^(oauth_home|api_key_env|env_bundle|config_bundle|composite)$",
     )
 
     volume_ref: Optional[str] = None
@@ -217,7 +228,7 @@ class ProviderProfileCreate(BaseModel):
     account_label: Optional[str] = None
 
     tags: Optional[list[str]] = None
-    priority: int = Field(default=100)
+    priority: Optional[int] = None
 
     secret_refs: Optional[dict[str, str]] = None
     clear_env_keys: Optional[list[str]] = None
@@ -226,20 +237,20 @@ class ProviderProfileCreate(BaseModel):
     home_path_overrides: Optional[dict[str, str]] = None
     command_behavior: Optional[dict[str, Any]] = None
 
-    max_parallel_runs: int = Field(default=1, ge=1)
-    cooldown_after_429_seconds: int = Field(default=900, ge=0)
-    rate_limit_policy: str = Field(
-        default="backoff", pattern="^(backoff|queue|fail_fast)$"
+    max_parallel_runs: Optional[int] = Field(default=None, ge=1)
+    cooldown_after_429_seconds: Optional[int] = Field(default=None, ge=0)
+    rate_limit_policy: Optional[str] = Field(
+        default=None, pattern="^(backoff|queue|fail_fast)$"
     )
-    enabled: bool = False
-    is_default: bool = False
-    max_lease_duration_seconds: int = Field(default=7200, ge=60)
-    auth_state: str = Field(
-        default="not_configured",
+    enabled: Optional[bool] = None
+    is_default: Optional[bool] = None
+    max_lease_duration_seconds: Optional[int] = Field(default=None, ge=60)
+    auth_state: Optional[str] = Field(
+        default=None,
         pattern="^(not_configured|oauth_pending|api_key_pending|connected|validation_failed|disconnected)$",
     )
     disabled_reason: Optional[str] = Field(
-        default="missing_credentials",
+        default=None,
         pattern="^(missing_credentials|auth_invalid|user_disabled|policy_disabled|disconnected)$",
     )
     first_authenticated_at: Optional[datetime] = None
@@ -288,16 +299,28 @@ class ProviderProfileCreate(BaseModel):
             raise ValueError("enabled profiles require auth_state=connected")
         if self.enabled:
             self.disabled_reason = None
-        validate_codex_oauth_profile_refs(
-            runtime_id=self.runtime_id,
-            credential_source=self.credential_source,
-            runtime_materialization_mode=self.runtime_materialization_mode,
-            volume_ref=self.volume_ref,
-            volume_mount_path=self.volume_mount_path,
-            max_parallel_runs=self.max_parallel_runs,
-            volume_ref_field_name="volume_ref",
-            volume_mount_path_field_name="volume_mount_path",
+        incomplete_guided_oauth = (
+            self.authentication_method == ProviderProfileAuthenticationMethod.OAUTH
+            and not self.enabled
+            and self.auth_state != ProviderProfileAuthState.CONNECTED.value
+            and self.volume_ref is None
+            and self.volume_mount_path is None
         )
+        if (
+            not incomplete_guided_oauth
+            and self.credential_source is not None
+            and self.runtime_materialization_mode is not None
+        ):
+            validate_codex_oauth_profile_refs(
+                runtime_id=self.runtime_id,
+                credential_source=self.credential_source,
+                runtime_materialization_mode=self.runtime_materialization_mode,
+                volume_ref=self.volume_ref,
+                volume_mount_path=self.volume_mount_path,
+                max_parallel_runs=self.max_parallel_runs,
+                volume_ref_field_name="volume_ref",
+                volume_mount_path_field_name="volume_mount_path",
+            )
         return self
 
 
@@ -435,6 +458,34 @@ class ProviderProfileResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class ProviderProfileCreationPresetField(BaseModel):
+    value: Any
+    source: str
+    editable: bool
+    required: bool
+    lock_reason: Optional[str] = None
+
+
+class ProviderProfileCreationPresetDiagnostic(BaseModel):
+    code: str
+    severity: str = Field(..., pattern="^(info|warning|error)$")
+    message: str
+    field: Optional[str] = None
+    action: Optional[str] = None
+
+
+class ProviderProfileCreationPresetResponse(BaseModel):
+    version: str
+    supported: bool
+    runtime_id: str
+    provider_id: str
+    authentication_method: ProviderProfileAuthenticationMethod
+    fields: dict[str, ProviderProfileCreationPresetField]
+    diagnostics: list[ProviderProfileCreationPresetDiagnostic]
+    manual_creation_allowed: bool = False
+    required_manual_fields: list[str] = Field(default_factory=list)
+
+
 class ProviderProfileTierPreviewStep(BaseModel):
     step_id: str = Field(..., alias="id")
     model_tier: Optional[int] = Field(default=None, ge=1, alias="modelTier")
@@ -533,6 +584,73 @@ def _get_session() -> Any:
     return get_async_session
 
 
+def _normalized_create_values(body: ProviderProfileCreate) -> dict[str, Any]:
+    values = body.model_dump(
+        exclude={"authentication_method", "preset_version"},
+        mode="json",
+    )
+    supplied_fields = set(body.model_fields_set)
+    supplied_fields.difference_update({"authentication_method", "preset_version"})
+
+    if body.authentication_method is not None:
+        preset = get_provider_profile_creation_preset(
+            runtime_id=body.runtime_id,
+            provider_id=body.provider_id,
+            authentication_method=body.authentication_method,
+        )
+        try:
+            return apply_provider_profile_creation_preset(
+                preset=preset,
+                requested_version=body.preset_version,
+                values=values,
+                supplied_fields=supplied_fields,
+            )
+        except CreationPresetError as exc:
+            status_code = (
+                409
+                if exc.code
+                == "provider_profile_creation_preset_version_mismatch"
+                else 422
+            )
+            raise HTTPException(status_code=status_code, detail=exc.as_detail()) from exc
+
+    missing_manual_fields = [
+        field_name
+        for field_name in ("credential_source", "runtime_materialization_mode")
+        if values.get(field_name) is None
+    ]
+    if missing_manual_fields:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "provider_profile_manual_fields_required",
+                "message": (
+                    "Manual Provider Profile creation requires explicit launch-policy fields."
+                ),
+                "required_fields": missing_manual_fields,
+            },
+        )
+
+    manual_defaults: dict[str, Any] = {
+        "priority": 100,
+        "max_parallel_runs": 1,
+        "cooldown_after_429_seconds": 900,
+        "rate_limit_policy": "backoff",
+        "enabled": False,
+        "is_default": False,
+        "max_lease_duration_seconds": 7200,
+        "auth_state": "not_configured",
+    }
+    for field_name, default_value in manual_defaults.items():
+        if field_name not in supplied_fields:
+            values[field_name] = default_value
+    if "disabled_reason" not in supplied_fields:
+        values["disabled_reason"] = (
+            None if values["enabled"] else "missing_credentials"
+        )
+    return values
+
+
 async def _credential_validation_guard(
     profile_id: str,
     request: Request,
@@ -608,6 +726,26 @@ async def list_profiles(
     ]
 
 
+@router.get(
+    "/creation-preset",
+    response_model=ProviderProfileCreationPresetResponse,
+)
+async def get_creation_preset(
+    runtime_id: str,
+    provider_id: str,
+    authentication_method: ProviderProfileAuthenticationMethod,
+    current_user: User = Depends(get_current_user()),
+) -> dict[str, Any]:
+    """Preview the versioned backend policy used by standard profile creation."""
+
+    _require_provider_profile_permission(current_user, "provider_profiles.read")
+    return get_provider_profile_creation_preset(
+        runtime_id=runtime_id,
+        provider_id=provider_id,
+        authentication_method=authentication_method,
+    ).as_dict()
+
+
 @router.get("/{profile_id}", response_model=ProviderProfileResponse)
 async def get_profile(
     profile_id: str,
@@ -646,6 +784,7 @@ async def create_profile(
     existing = await session.get(ManagedAgentProviderProfile, body.profile_id)
     if existing:
         raise HTTPException(status_code=409, detail="Profile already exists")
+    values = _normalized_create_values(body)
     try:
         model_tiers, default_model_tier = coerce_model_effort_tier_policy(
             model_tiers=(
@@ -670,44 +809,52 @@ async def create_profile(
         model_tiers=model_tiers,
         default_model_tier=default_model_tier,
         model_overrides=body.model_overrides,
-        credential_source=ProviderCredentialSource(body.credential_source),
+        credential_source=ProviderCredentialSource(values["credential_source"]),
         runtime_materialization_mode=RuntimeMaterializationMode(
-            body.runtime_materialization_mode
+            values["runtime_materialization_mode"]
         ),
-        volume_ref=body.volume_ref,
-        volume_mount_path=body.volume_mount_path,
+        volume_ref=values["volume_ref"],
+        volume_mount_path=values["volume_mount_path"],
         account_label=body.account_label,
-        tags=body.tags,
-        priority=body.priority,
-        secret_refs=body.secret_refs,
-        clear_env_keys=body.clear_env_keys,
-        env_template=body.env_template,
-        file_templates=body.file_templates,
-        home_path_overrides=body.home_path_overrides,
-        command_behavior=body.command_behavior,
+        tags=values["tags"],
+        priority=values["priority"],
+        secret_refs=values["secret_refs"],
+        clear_env_keys=values["clear_env_keys"],
+        env_template=values["env_template"],
+        file_templates=values["file_templates"],
+        home_path_overrides=values["home_path_overrides"],
+        command_behavior=values["command_behavior"],
         owner_user_id=getattr(current_user, "id", None),
-        max_parallel_runs=body.max_parallel_runs,
-        cooldown_after_429_seconds=body.cooldown_after_429_seconds,
-        rate_limit_policy=ManagedAgentRateLimitPolicy(body.rate_limit_policy),
-        enabled=body.enabled,
+        max_parallel_runs=values["max_parallel_runs"],
+        cooldown_after_429_seconds=values["cooldown_after_429_seconds"],
+        rate_limit_policy=ManagedAgentRateLimitPolicy(values["rate_limit_policy"]),
+        enabled=values["enabled"],
         is_default=False,
-        max_lease_duration_seconds=body.max_lease_duration_seconds,
-        auth_state=ProviderProfileAuthState(body.auth_state),
+        max_lease_duration_seconds=values["max_lease_duration_seconds"],
+        auth_state=ProviderProfileAuthState(values["auth_state"]),
         disabled_reason=(
-            ProviderProfileDisabledReason(body.disabled_reason)
-            if body.disabled_reason is not None
+            ProviderProfileDisabledReason(values["disabled_reason"])
+            if values["disabled_reason"] is not None
             else None
         ),
         first_authenticated_at=body.first_authenticated_at,
         last_validated_at=body.last_validated_at,
         last_auth_method=(
-            ProviderProfileAuthMethod(body.last_auth_method)
-            if body.last_auth_method is not None
+            ProviderProfileAuthMethod(values["last_auth_method"])
+            if values["last_auth_method"] is not None
             else None
         ),
     )
     _validate_profile_tier_policy(profile)
-    _validate_codex_oauth_profile_row(profile)
+    incomplete_preset_oauth = (
+        body.authentication_method == ProviderProfileAuthenticationMethod.OAUTH
+        and not profile.enabled
+        and profile.auth_state != ProviderProfileAuthState.CONNECTED
+        and profile.volume_ref is None
+        and profile.volume_mount_path is None
+    )
+    if not incomplete_preset_oauth:
+        _validate_codex_oauth_profile_row(profile)
     session.add(profile)
     await session.flush()
     if profile.enabled:
@@ -725,7 +872,9 @@ async def create_profile(
     await normalize_runtime_default_profile(
         session=session,
         runtime_id=body.runtime_id,
-        preferred_profile_id=profile.profile_id if body.is_default else None,
+        preferred_profile_id=(
+            profile.profile_id if values["is_default"] else None
+        ),
     )
     await session.commit()
     await session.refresh(profile)

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -587,7 +587,7 @@ def _get_session() -> Any:
 def _normalized_create_values(body: ProviderProfileCreate) -> dict[str, Any]:
     values = body.model_dump(
         exclude={"authentication_method", "preset_version"},
-        mode="json",
+        mode="python",
     )
     supplied_fields = set(body.model_fields_set)
     supplied_fields.difference_update({"authentication_method", "preset_version"})
@@ -801,8 +801,8 @@ async def create_profile(
 
     profile = ManagedAgentProviderProfile(
         profile_id=body.profile_id,
-        runtime_id=body.runtime_id,
-        provider_id=body.provider_id,
+        runtime_id=values["runtime_id"],
+        provider_id=values["provider_id"],
         provider_label=body.provider_label,
         default_model=body.default_model,
         default_effort=body.default_effort,
@@ -837,8 +837,8 @@ async def create_profile(
             if values["disabled_reason"] is not None
             else None
         ),
-        first_authenticated_at=body.first_authenticated_at,
-        last_validated_at=body.last_validated_at,
+        first_authenticated_at=values["first_authenticated_at"],
+        last_validated_at=values["last_validated_at"],
         last_auth_method=(
             ProviderProfileAuthMethod(values["last_auth_method"])
             if values["last_auth_method"] is not None
@@ -871,7 +871,7 @@ async def create_profile(
         )
     await normalize_runtime_default_profile(
         session=session,
-        runtime_id=body.runtime_id,
+        runtime_id=profile.runtime_id,
         preferred_profile_id=(
             profile.profile_id if values["is_default"] else None
         ),
@@ -879,7 +879,7 @@ async def create_profile(
     await session.commit()
     await session.refresh(profile)
 
-    await sync_provider_profile_manager(session=session, runtime_id=body.runtime_id)
+    await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
 
     secret_ref_results = _secret_ref_results_for_rows([profile])
     secret_statuses = await _managed_secret_statuses_for_rows(

--- a/api_service/services/provider_profile_creation_presets.py
+++ b/api_service/services/provider_profile_creation_presets.py
@@ -1,0 +1,707 @@
+"""Backend-owned Provider Profile creation presets.
+
+The preset catalog is the create-time policy authority for guided Provider
+Profile creation.  It deliberately contains no persistence or HTTP behavior so
+the same immutable definition drives both preview and atomic create
+normalization.
+
+MoonLadderStudios/MoonMind#3819
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ProviderProfileAuthenticationMethod(str, Enum):
+    OAUTH = "oauth"
+    API_KEY = "api_key"
+    NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class CreationPresetField:
+    value: Any
+    source: str
+    editable: bool
+    required: bool = False
+    lock_reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "value": copy.deepcopy(self.value),
+            "source": self.source,
+            "editable": self.editable,
+            "required": self.required,
+            "lock_reason": self.lock_reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CreationPresetDiagnostic:
+    code: str
+    severity: str
+    message: str
+    field: str | None = None
+    action: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "field": self.field,
+            "action": self.action,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderProfileCreationPreset:
+    runtime_id: str
+    provider_id: str
+    authentication_method: ProviderProfileAuthenticationMethod
+    supported: bool
+    fields: Mapping[str, CreationPresetField]
+    diagnostics: tuple[CreationPresetDiagnostic, ...] = ()
+    manual_creation_allowed: bool = False
+    required_manual_fields: tuple[str, ...] = ()
+
+    @property
+    def version(self) -> str:
+        canonical = {
+            "runtime_id": self.runtime_id,
+            "provider_id": self.provider_id,
+            "authentication_method": self.authentication_method.value,
+            "supported": self.supported,
+            "fields": {
+                name: field.as_dict() for name, field in sorted(self.fields.items())
+            },
+            "diagnostics": [item.as_dict() for item in self.diagnostics],
+            "manual_creation_allowed": self.manual_creation_allowed,
+            "required_manual_fields": list(self.required_manual_fields),
+        }
+        digest = hashlib.sha256(
+            json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+        return f"provider-profile-create-v1-{digest[:20]}"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "supported": self.supported,
+            "runtime_id": self.runtime_id,
+            "provider_id": self.provider_id,
+            "authentication_method": self.authentication_method.value,
+            "fields": {
+                name: field.as_dict() for name, field in self.fields.items()
+            },
+            "diagnostics": [item.as_dict() for item in self.diagnostics],
+            "manual_creation_allowed": self.manual_creation_allowed,
+            "required_manual_fields": list(self.required_manual_fields),
+        }
+
+
+class CreationPresetError(ValueError):
+    """Base error for deterministic creation-preset conflicts."""
+
+    code = "provider_profile_creation_preset_error"
+
+    def __init__(self, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details
+
+    def as_detail(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, **self.details}
+
+
+class UnsupportedCreationPresetError(CreationPresetError):
+    code = "provider_profile_creation_preset_unsupported"
+
+
+class CreationPresetVersionRequiredError(CreationPresetError):
+    code = "provider_profile_creation_preset_version_required"
+
+
+class CreationPresetVersionMismatchError(CreationPresetError):
+    code = "provider_profile_creation_preset_version_mismatch"
+
+
+class CreationPresetFieldLockedError(CreationPresetError):
+    code = "provider_profile_creation_preset_field_locked"
+
+
+_PERSISTED_PRESET_FIELDS = frozenset(
+    {
+        "credential_source",
+        "runtime_materialization_mode",
+        "volume_ref",
+        "volume_mount_path",
+        "tags",
+        "priority",
+        "secret_refs",
+        "clear_env_keys",
+        "env_template",
+        "file_templates",
+        "home_path_overrides",
+        "command_behavior",
+        "max_parallel_runs",
+        "cooldown_after_429_seconds",
+        "rate_limit_policy",
+        "enabled",
+        "is_default",
+        "max_lease_duration_seconds",
+        "auth_state",
+        "disabled_reason",
+        "last_auth_method",
+    }
+)
+
+
+def _field(
+    value: Any,
+    source: str,
+    *,
+    editable: bool,
+    required: bool = False,
+    lock_reason: str | None = None,
+) -> CreationPresetField:
+    if not editable and lock_reason is None:
+        lock_reason = "This value is controlled by the runtime/provider strategy."
+    return CreationPresetField(
+        value=value,
+        source=source,
+        editable=editable,
+        required=required,
+        lock_reason=lock_reason,
+    )
+
+
+def _missing_credentials_diagnostic(
+    authentication_method: ProviderProfileAuthenticationMethod,
+) -> CreationPresetDiagnostic:
+    label = (
+        "OAuth"
+        if authentication_method == ProviderProfileAuthenticationMethod.OAUTH
+        else "API-key"
+    )
+    return CreationPresetDiagnostic(
+        code="credential_setup_required",
+        severity="warning",
+        message=(
+            f"The profile will remain disabled and non-launch-ready until {label} "
+            "credential setup succeeds."
+        ),
+        field="authentication_method",
+        action=(
+            "connect_oauth"
+            if authentication_method == ProviderProfileAuthenticationMethod.OAUTH
+            else "add_api_key"
+        ),
+    )
+
+
+def _common_fields(
+    *,
+    authentication_method: ProviderProfileAuthenticationMethod,
+    credential_source: str,
+    runtime_materialization_mode: str,
+    system_tags: list[str],
+    secret_ref_roles: list[str],
+    clear_env_keys: list[str],
+    env_template: dict[str, Any] | None = None,
+    command_behavior: dict[str, Any] | None = None,
+    max_parallel_runs: int = 1,
+    max_parallel_runs_editable: bool = True,
+    volume_mount_path_after_setup: str | None = None,
+) -> dict[str, CreationPresetField]:
+    credential_lock_reason = (
+        "Credential source follows the selected authentication method and changes "
+        "only after validated credential setup."
+    )
+    materialization_lock_reason = (
+        "Materialization is fixed by the selected "
+        "runtime/provider/authentication strategy."
+    )
+    fields = {
+        "credential_source": _field(
+            credential_source,
+            "runtime_provider_authentication_strategy",
+            editable=False,
+            required=True,
+            lock_reason=credential_lock_reason,
+        ),
+        "runtime_materialization_mode": _field(
+            runtime_materialization_mode,
+            "runtime_provider_authentication_strategy",
+            editable=False,
+            required=True,
+            lock_reason=materialization_lock_reason,
+        ),
+        "max_parallel_runs": _field(
+            max_parallel_runs,
+            (
+                "exclusive_credential_identity"
+                if not max_parallel_runs_editable
+                else "runtime_capacity_baseline"
+            ),
+            editable=max_parallel_runs_editable,
+            required=True,
+            lock_reason=(
+                "This OAuth home is an exclusive mutable identity and supports "
+                "one run at a time."
+                if not max_parallel_runs_editable
+                else None
+            ),
+        ),
+        "cooldown_after_429_seconds": _field(
+            300, "provider_rate_limit_default", editable=True, required=True
+        ),
+        "rate_limit_policy": _field(
+            "backoff", "provider_rate_limit_default", editable=True, required=True
+        ),
+        "priority": _field(100, "provider_profile_default", editable=True),
+        "user_tags": _field([], "user_input", editable=True),
+        "system_tags": _field(
+            system_tags,
+            "runtime_provider_authentication_strategy",
+            editable=False,
+            lock_reason="System tags describe the selected backend strategy.",
+        ),
+        "tags": _field(
+            system_tags,
+            "system_tags_plus_user_tags",
+            editable=True,
+        ),
+        "volume_ref": _field(
+            None,
+            "credential_enrollment",
+            editable=False,
+            required=authentication_method == ProviderProfileAuthenticationMethod.OAUTH,
+            lock_reason=(
+                "OAuth enrollment creates and owns the credential volume reference."
+            ),
+        ),
+        "volume_mount_path": _field(
+            None,
+            "credential_enrollment",
+            editable=False,
+            required=authentication_method == ProviderProfileAuthenticationMethod.OAUTH,
+            lock_reason=(
+                "OAuth enrollment applies the runtime-owned credential mount path."
+            ),
+        ),
+        "volume_mount_path_after_setup": _field(
+            volume_mount_path_after_setup,
+            "runtime_provider_authentication_strategy",
+            editable=False,
+        ),
+        "secret_refs": _field(
+            {},
+            "credential_enrollment",
+            editable=(
+                authentication_method == ProviderProfileAuthenticationMethod.API_KEY
+            ),
+            required=bool(secret_ref_roles),
+            lock_reason=(
+                None
+                if authentication_method == ProviderProfileAuthenticationMethod.API_KEY
+                else (
+                    "The selected authentication strategy does not accept manual "
+                    "SecretRef bindings."
+                )
+            ),
+        ),
+        "secret_ref_roles": _field(
+            secret_ref_roles,
+            "runtime_provider_authentication_strategy",
+            editable=False,
+            required=bool(secret_ref_roles),
+            lock_reason="SecretRef roles are named by the runtime/provider strategy.",
+        ),
+        "clear_env_keys": _field(
+            clear_env_keys,
+            "runtime_provider_isolation_policy",
+            editable=False,
+            required=True,
+            lock_reason="Environment clearing is backend-owned launch security policy.",
+        ),
+        "clear_env_keys_strategy": _field(
+            "runtime_provider_isolation_policy",
+            "runtime_provider_isolation_policy",
+            editable=False,
+        ),
+        "env_template": _field(
+            env_template or {},
+            "runtime_provider_authentication_strategy",
+            editable=False,
+        ),
+        "file_templates": _field(
+            [], "runtime_provider_authentication_strategy", editable=False
+        ),
+        "home_path_overrides": _field(
+            {}, "runtime_provider_authentication_strategy", editable=False
+        ),
+        "command_behavior": _field(
+            command_behavior or {},
+            "runtime_provider_authentication_strategy",
+            editable=False,
+        ),
+        "enabled": _field(
+            False,
+            "credential_activation_policy",
+            editable=False,
+            required=True,
+            lock_reason=(
+                "Creation cannot enable a profile before credential validation "
+                "succeeds."
+            ),
+        ),
+        "auth_state": _field(
+            "not_configured",
+            "credential_activation_policy",
+            editable=False,
+            required=True,
+        ),
+        "disabled_reason": _field(
+            "missing_credentials",
+            "credential_activation_policy",
+            editable=False,
+            required=True,
+        ),
+        "last_auth_method": _field(
+            None, "credential_activation_policy", editable=False
+        ),
+        "is_default": _field(False, "user_intent_after_readiness", editable=True),
+        "may_become_runtime_default": _field(
+            True,
+            "runtime_default_readiness_policy",
+            editable=False,
+            lock_reason=(
+                "Default assignment is applied only after launch readiness succeeds."
+            ),
+        ),
+        "max_lease_duration_seconds": _field(
+            7200, "runtime_lease_default", editable=True, required=True
+        ),
+    }
+    return fields
+
+
+def _oauth_preset(
+    *, runtime_id: str, provider_id: str, mount_path: str, clear_env_keys: list[str]
+) -> ProviderProfileCreationPreset:
+    command_behavior = {
+        "supported_auth_methods": ["oauth_volume"],
+        "auth_actions": ["connect_oauth"],
+        "auth_strategy": "oauth_volume",
+        "auth_state": "not_configured",
+        "auth_status_label": "Not connected",
+        "auth_readiness": {
+            "connected": False,
+            "backing_secret_exists": False,
+            "launch_ready": False,
+            "failure_reason": "OAuth setup has not completed.",
+        },
+    }
+    return ProviderProfileCreationPreset(
+        runtime_id=runtime_id,
+        provider_id=provider_id,
+        authentication_method=ProviderProfileAuthenticationMethod.OAUTH,
+        supported=True,
+        fields=_common_fields(
+            authentication_method=ProviderProfileAuthenticationMethod.OAUTH,
+            credential_source="oauth_volume",
+            runtime_materialization_mode="oauth_home",
+            system_tags=["oauth", "first-party"],
+            secret_ref_roles=[],
+            clear_env_keys=clear_env_keys,
+            command_behavior=command_behavior,
+            max_parallel_runs=1,
+            max_parallel_runs_editable=False,
+            volume_mount_path_after_setup=mount_path,
+        ),
+        diagnostics=(
+            _missing_credentials_diagnostic(
+                ProviderProfileAuthenticationMethod.OAUTH
+            ),
+        ),
+    )
+
+
+def _api_key_preset(
+    *,
+    runtime_id: str,
+    provider_id: str,
+    materialization_mode: str,
+    secret_role: str,
+    clear_env_keys: list[str],
+    env_template: dict[str, Any],
+    auth_strategy: str,
+    system_tags: list[str] | None = None,
+) -> ProviderProfileCreationPreset:
+    command_behavior = {
+        "supported_auth_methods": ["secret_ref"],
+        "auth_actions": ["use_api_key"],
+        "auth_strategy": auth_strategy,
+        "auth_state": "not_configured",
+        "auth_status_label": "Not connected",
+        "auth_readiness": {
+            "connected": False,
+            "backing_secret_exists": False,
+            "launch_ready": False,
+            "failure_reason": "API-key setup has not completed.",
+        },
+    }
+    return ProviderProfileCreationPreset(
+        runtime_id=runtime_id,
+        provider_id=provider_id,
+        authentication_method=ProviderProfileAuthenticationMethod.API_KEY,
+        supported=True,
+        fields=_common_fields(
+            authentication_method=ProviderProfileAuthenticationMethod.API_KEY,
+            credential_source="secret_ref",
+            runtime_materialization_mode=materialization_mode,
+            system_tags=system_tags or ["api-key", "first-party"],
+            secret_ref_roles=[secret_role],
+            clear_env_keys=clear_env_keys,
+            env_template=env_template,
+            command_behavior=command_behavior,
+        ),
+        diagnostics=(
+            _missing_credentials_diagnostic(
+                ProviderProfileAuthenticationMethod.API_KEY
+            ),
+        ),
+    )
+
+
+def _supported_presets() -> dict[
+    tuple[str, str, ProviderProfileAuthenticationMethod],
+    ProviderProfileCreationPreset,
+]:
+    presets = [
+        _oauth_preset(
+            runtime_id="codex_cli",
+            provider_id="openai",
+            mount_path="/home/app/.codex",
+            clear_env_keys=[
+                "OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
+                "OPENAI_ORG_ID",
+                "OPENAI_PROJECT",
+                "MINIMAX_API_KEY",
+            ],
+        ),
+        _oauth_preset(
+            runtime_id="claude_code",
+            provider_id="anthropic",
+            mount_path="/home/app/.claude",
+            clear_env_keys=[
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+                "ANTHROPIC_BASE_URL",
+                "CLAUDE_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+        ),
+        _api_key_preset(
+            runtime_id="codex_cli",
+            provider_id="openai",
+            materialization_mode="api_key_env",
+            secret_role="openai_api_key",
+            clear_env_keys=[
+                "OPENAI_BASE_URL",
+                "OPENAI_ORG_ID",
+                "OPENAI_PROJECT",
+                "MINIMAX_API_KEY",
+            ],
+            env_template={
+                "OPENAI_API_KEY": {"from_secret_ref": "openai_api_key"}
+            },
+            auth_strategy="api_key_env",
+        ),
+        _api_key_preset(
+            runtime_id="claude_code",
+            provider_id="anthropic",
+            materialization_mode="api_key_env",
+            secret_role="anthropic_api_key",
+            clear_env_keys=[
+                "ANTHROPIC_AUTH_TOKEN",
+                "ANTHROPIC_BASE_URL",
+                "CLAUDE_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+            env_template={
+                "ANTHROPIC_API_KEY": {"from_secret_ref": "anthropic_api_key"}
+            },
+            auth_strategy="api_key_env",
+        ),
+        _api_key_preset(
+            runtime_id="opencode",
+            provider_id="opencode",
+            materialization_mode="composite",
+            secret_role="opencode_api_key",
+            clear_env_keys=[
+                "OPENCODE_AUTH_CONTENT",
+                "OPENCODE_CONFIG",
+                "OPENCODE_CONFIG_CONTENT",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ],
+            env_template={},
+            auth_strategy="opencode_auth_json",
+            system_tags=["api-key", "opencode", "zen"],
+        ),
+        _api_key_preset(
+            runtime_id="opencode",
+            provider_id="opencode-go",
+            materialization_mode="composite",
+            secret_role="opencode_api_key",
+            clear_env_keys=[
+                "OPENCODE_AUTH_CONTENT",
+                "OPENCODE_CONFIG",
+                "OPENCODE_CONFIG_CONTENT",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ],
+            env_template={},
+            auth_strategy="opencode_auth_json",
+            system_tags=["api-key", "opencode", "go"],
+        ),
+    ]
+    return {
+        (preset.runtime_id, preset.provider_id, preset.authentication_method): preset
+        for preset in presets
+    }
+
+
+_SUPPORTED_PRESETS = _supported_presets()
+
+
+def get_provider_profile_creation_preset(
+    *,
+    runtime_id: str,
+    provider_id: str,
+    authentication_method: ProviderProfileAuthenticationMethod | str,
+) -> ProviderProfileCreationPreset:
+    normalized_runtime_id = str(runtime_id or "").strip()
+    normalized_provider_id = str(provider_id or "").strip()
+    method = ProviderProfileAuthenticationMethod(authentication_method)
+    preset = _SUPPORTED_PRESETS.get(
+        (normalized_runtime_id, normalized_provider_id, method)
+    )
+    if preset is not None:
+        return preset
+
+    return ProviderProfileCreationPreset(
+        runtime_id=normalized_runtime_id,
+        provider_id=normalized_provider_id,
+        authentication_method=method,
+        supported=False,
+        fields={},
+        diagnostics=(
+            CreationPresetDiagnostic(
+                code="no_safe_standard_creation_preset",
+                severity="error",
+                message=(
+                    "No validated standard creation preset exists for this runtime, "
+                    "provider, and authentication method. Use the authorized manual "
+                    "profile path and supply every required launch field."
+                ),
+                action="open_manual_profile",
+            ),
+        ),
+        manual_creation_allowed=True,
+        required_manual_fields=(
+            "credential_source",
+            "runtime_materialization_mode",
+            "clear_env_keys",
+            "command_behavior",
+        ),
+    )
+
+
+def apply_provider_profile_creation_preset(
+    *,
+    preset: ProviderProfileCreationPreset,
+    requested_version: str | None,
+    values: Mapping[str, Any],
+    supplied_fields: set[str],
+) -> dict[str, Any]:
+    """Apply one preset and explicit supported overrides to create values.
+
+    Validation completes before a SQLAlchemy row is constructed, which keeps
+    stale, unsupported, and locked-field requests outside the persistence
+    transaction.
+    """
+
+    if not preset.supported:
+        raise UnsupportedCreationPresetError(
+            "No safe standard creation preset exists for this combination.",
+            runtime_id=preset.runtime_id,
+            provider_id=preset.provider_id,
+            authentication_method=preset.authentication_method.value,
+            diagnostics=[item.as_dict() for item in preset.diagnostics],
+            manual_creation_allowed=preset.manual_creation_allowed,
+            required_manual_fields=list(preset.required_manual_fields),
+        )
+    if not requested_version:
+        raise CreationPresetVersionRequiredError(
+            "preset_version is required for standard Provider Profile creation.",
+            current_version=preset.version,
+        )
+    if requested_version != preset.version:
+        raise CreationPresetVersionMismatchError(
+            "The Provider Profile creation preset changed; reload and review the "
+            "current policy.",
+            requested_version=requested_version,
+            current_version=preset.version,
+        )
+
+    normalized = dict(values)
+    for field_name in _PERSISTED_PRESET_FIELDS:
+        field = preset.fields.get(field_name)
+        if field is None:
+            continue
+        if field_name in supplied_fields:
+            requested_value = values.get(field_name)
+            if not field.editable and requested_value != field.value:
+                raise CreationPresetFieldLockedError(
+                    f"{field_name} is locked by the selected creation preset.",
+                    field=field_name,
+                    lock_reason=field.lock_reason,
+                    expected_value=copy.deepcopy(field.value),
+                )
+            normalized[field_name] = copy.deepcopy(requested_value)
+        else:
+            normalized[field_name] = copy.deepcopy(field.value)
+
+    # ``tags`` is the persisted union of backend-owned system tags and optional
+    # user tags.  Explicit user input cannot erase strategy identity.
+    system_tags = list(preset.fields["system_tags"].value)
+    requested_tags = values.get("tags") if "tags" in supplied_fields else []
+    normalized["tags"] = list(
+        dict.fromkeys([*system_tags, *(requested_tags or [])])
+    )
+    return normalized
+
+
+__all__ = [
+    "CreationPresetError",
+    "CreationPresetFieldLockedError",
+    "CreationPresetVersionMismatchError",
+    "CreationPresetVersionRequiredError",
+    "ProviderProfileAuthenticationMethod",
+    "ProviderProfileCreationPreset",
+    "UnsupportedCreationPresetError",
+    "apply_provider_profile_creation_preset",
+    "get_provider_profile_creation_preset",
+]

--- a/api_service/services/provider_profile_creation_presets.py
+++ b/api_service/services/provider_profile_creation_presets.py
@@ -160,6 +160,8 @@ _PERSISTED_PRESET_FIELDS = frozenset(
         "max_lease_duration_seconds",
         "auth_state",
         "disabled_reason",
+        "first_authenticated_at",
+        "last_validated_at",
         "last_auth_method",
     }
 )
@@ -211,7 +213,6 @@ def _missing_credentials_diagnostic(
 def _common_fields(
     *,
     authentication_method: ProviderProfileAuthenticationMethod,
-    credential_source: str,
     runtime_materialization_mode: str,
     system_tags: list[str],
     secret_ref_roles: list[str],
@@ -223,8 +224,8 @@ def _common_fields(
     volume_mount_path_after_setup: str | None = None,
 ) -> dict[str, CreationPresetField]:
     credential_lock_reason = (
-        "Credential source follows the selected authentication method and changes "
-        "only after validated credential setup."
+        "Credential source remains none until validated credential setup installs "
+        "the source selected by the authentication method."
     )
     materialization_lock_reason = (
         "Materialization is fixed by the selected "
@@ -232,8 +233,8 @@ def _common_fields(
     )
     fields = {
         "credential_source": _field(
-            credential_source,
-            "runtime_provider_authentication_strategy",
+            "none",
+            "credential_activation_policy",
             editable=False,
             required=True,
             lock_reason=credential_lock_reason,
@@ -379,6 +380,24 @@ def _common_fields(
         "last_auth_method": _field(
             None, "credential_activation_policy", editable=False
         ),
+        "first_authenticated_at": _field(
+            None,
+            "credential_activation_policy",
+            editable=False,
+            lock_reason=(
+                "Authentication history is recorded only after validated "
+                "credential setup."
+            ),
+        ),
+        "last_validated_at": _field(
+            None,
+            "credential_activation_policy",
+            editable=False,
+            lock_reason=(
+                "Credential validation history is recorded only by a validation "
+                "or finalization endpoint."
+            ),
+        ),
         "is_default": _field(False, "user_intent_after_readiness", editable=True),
         "may_become_runtime_default": _field(
             True,
@@ -418,7 +437,6 @@ def _oauth_preset(
         supported=True,
         fields=_common_fields(
             authentication_method=ProviderProfileAuthenticationMethod.OAUTH,
-            credential_source="oauth_volume",
             runtime_materialization_mode="oauth_home",
             system_tags=["oauth", "first-party"],
             secret_ref_roles=[],
@@ -467,7 +485,6 @@ def _api_key_preset(
         supported=True,
         fields=_common_fields(
             authentication_method=ProviderProfileAuthenticationMethod.API_KEY,
-            credential_source="secret_ref",
             runtime_materialization_mode=materialization_mode,
             system_tags=system_tags or ["api-key", "first-party"],
             secret_ref_roles=[secret_role],
@@ -667,6 +684,11 @@ def apply_provider_profile_creation_preset(
         )
 
     normalized = dict(values)
+    # Persist the exact canonical identity that selected this preset.  Requests
+    # with surrounding whitespace must not validate against one tuple and then
+    # create an unroutable profile under a different identity.
+    normalized["runtime_id"] = preset.runtime_id
+    normalized["provider_id"] = preset.provider_id
     for field_name in _PERSISTED_PRESET_FIELDS:
         field = preset.fields.get(field_name)
         if field is None:

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -118,16 +118,151 @@ describe('defaultFormState', () => {
     expect(state.isDefault).toBe(false);
   });
 
-  it('includes all legacy fields', () => {
+  it('does not guess backend-owned creation policy', () => {
     const state = defaultFormState();
 
     expect(state.profileId).toBe('');
     expect(state.runtimeId).toBe('');
     expect(state.providerId).toBe('');
-    expect(state.credentialSource).toBe('secret_ref');
-    expect(state.rateLimitPolicy).toBe('backoff');
-    expect(state.enabled).toBe(true);
+    expect(state.authenticationMethod).toBe('');
+    expect(state.credentialSource).toBe('');
+    expect(state.runtimeMaterializationMode).toBe('');
+    expect(state.maxParallelRuns).toBe('');
+    expect(state.cooldownAfter429Seconds).toBe('');
+    expect(state.rateLimitPolicy).toBe('');
+    expect(state.enabled).toBe(false);
     expect(state.isDefault).toBe(false);
+  });
+});
+
+describe('backend creation presets', () => {
+  it('uses the generated preset contract and omits untouched advanced values', async () => {
+    const field = (
+      value: unknown,
+      editable = true,
+      source = 'test_policy',
+    ) => ({
+      value,
+      source,
+      editable,
+      required: false,
+      lock_reason: editable ? null : 'Backend controlled.',
+    });
+    const preset = {
+      version: 'provider-profile-create-v1-test',
+      supported: true,
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      authentication_method: 'api_key',
+      fields: {
+        credential_source: field('secret_ref', false),
+        runtime_materialization_mode: field('api_key_env', false),
+        secret_refs: field({}),
+        volume_ref: field(null, false),
+        volume_mount_path: field(null, false),
+        max_parallel_runs: field(1),
+        cooldown_after_429_seconds: field(300),
+        rate_limit_policy: field('backoff'),
+        enabled: field(false, false),
+        is_default: field(false),
+        command_behavior: field({ auth_strategy: 'api_key_env' }, false),
+        user_tags: field([]),
+        priority: field(100),
+        clear_env_keys: field(['MINIMAX_API_KEY'], false),
+      },
+      diagnostics: [],
+      manual_creation_allowed: false,
+      required_manual_fields: [],
+    };
+    const savedProfile: ProviderProfile = {
+      profile_id: 'preset-profile',
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'api_key_env',
+      secret_refs: {},
+      max_parallel_runs: 1,
+      cooldown_after_429_seconds: 300,
+      rate_limit_policy: 'backoff',
+      enabled: false,
+      is_default: false,
+    };
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+      async (input, init) => {
+        const url = String(input);
+        if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+          return {
+            ok: true,
+            json: async () => preset,
+          } as Response;
+        }
+        if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => savedProfile,
+          } as Response;
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      },
+    );
+
+    renderProviderProfilesManager();
+    fireEvent.change(screen.getByLabelText(/Profile ID/), {
+      target: { value: 'preset-profile' },
+    });
+    fireEvent.change(screen.getByLabelText(/Runtime ID/), {
+      target: { value: 'codex_cli' },
+    });
+    fireEvent.change(screen.getByLabelText(/Provider ID/), {
+      target: { value: 'openai' },
+    });
+    fireEvent.change(screen.getByLabelText(/Authentication method/), {
+      target: { value: 'api_key' },
+    });
+
+    await screen.findByText(/Backend preset provider-profile-create-v1-test loaded/);
+    expect((screen.getByLabelText(/Credential source/) as HTMLSelectElement).value).toBe(
+      'secret_ref',
+    );
+    expect(
+      (screen.getByLabelText(/Materialization mode/) as HTMLSelectElement).value,
+    ).toBe('api_key_env');
+    expect(screen.queryByLabelText('Enabled')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([, init]) => init?.method === 'POST'),
+      ).toBe(true);
+    });
+    const postCall = fetchSpy.mock.calls.find(([, init]) => init?.method === 'POST');
+    const payload = JSON.parse(String((postCall?.[1] as RequestInit).body));
+    expect(payload).toMatchObject({
+      profile_id: 'preset-profile',
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      authentication_method: 'api_key',
+      preset_version: 'provider-profile-create-v1-test',
+    });
+    for (const omittedField of [
+      'credential_source',
+      'runtime_materialization_mode',
+      'secret_refs',
+      'volume_ref',
+      'volume_mount_path',
+      'max_parallel_runs',
+      'cooldown_after_429_seconds',
+      'rate_limit_policy',
+      'enabled',
+      'is_default',
+      'command_behavior',
+      'tags',
+      'priority',
+      'clear_env_keys',
+    ]) {
+      expect(payload).not.toHaveProperty(omittedField);
+    }
   });
 });
 

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -155,7 +155,7 @@ describe('backend creation presets', () => {
       provider_id: 'openai',
       authentication_method: 'api_key',
       fields: {
-        credential_source: field('secret_ref', false),
+        credential_source: field('none', false),
         runtime_materialization_mode: field('api_key_env', false),
         secret_refs: field({}),
         volume_ref: field(null, false),
@@ -178,7 +178,7 @@ describe('backend creation presets', () => {
       profile_id: 'preset-profile',
       runtime_id: 'codex_cli',
       provider_id: 'openai',
-      credential_source: 'secret_ref',
+      credential_source: 'none',
       runtime_materialization_mode: 'api_key_env',
       secret_refs: {},
       max_parallel_runs: 1,
@@ -221,8 +221,11 @@ describe('backend creation presets', () => {
     });
 
     await screen.findByText(/Backend preset provider-profile-create-v1-test loaded/);
+    expect(screen.queryByLabelText(/Credential source/)).toBeNull();
+    expect(screen.queryByLabelText('Runtime default')).toBeNull();
+    fireEvent.click(screen.getByLabelText(/Show advanced options/));
     expect((screen.getByLabelText(/Credential source/) as HTMLSelectElement).value).toBe(
-      'secret_ref',
+      'none',
     );
     expect(
       (screen.getByLabelText(/Materialization mode/) as HTMLSelectElement).value,
@@ -263,6 +266,200 @@ describe('backend creation presets', () => {
     ]) {
       expect(payload).not.toHaveProperty(omittedField);
     }
+  });
+
+  it('routes unsupported guided combinations through manual creation', async () => {
+    const unsupportedPreset = {
+      version: 'provider-profile-create-v1-unsupported',
+      supported: false,
+      runtime_id: 'codex_cli',
+      provider_id: 'openrouter',
+      authentication_method: 'api_key',
+      fields: {},
+      diagnostics: [
+        {
+          code: 'no_safe_standard_creation_preset',
+          severity: 'error',
+          message: 'Use the authorized manual profile path.',
+          field: null,
+          action: 'open_manual_profile',
+        },
+      ],
+      manual_creation_allowed: true,
+      required_manual_fields: [
+        'credential_source',
+        'runtime_materialization_mode',
+        'clear_env_keys',
+        'command_behavior',
+      ],
+    };
+    const savedProfile: ProviderProfile = {
+      profile_id: 'manual-openrouter',
+      runtime_id: 'codex_cli',
+      provider_id: 'openrouter',
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'api_key_env',
+      secret_refs: {},
+      max_parallel_runs: 1,
+      cooldown_after_429_seconds: 900,
+      rate_limit_policy: 'backoff',
+      enabled: false,
+    };
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+      async (input, init) => {
+        const url = String(input);
+        if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+          return {
+            ok: true,
+            json: async () => unsupportedPreset,
+          } as Response;
+        }
+        if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+          return {
+            ok: true,
+            json: async () => savedProfile,
+          } as Response;
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      },
+    );
+
+    renderProviderProfilesManager();
+    fireEvent.change(screen.getByLabelText(/Profile ID/), {
+      target: { value: 'manual-openrouter' },
+    });
+    fireEvent.change(screen.getByLabelText(/Runtime ID/), {
+      target: { value: 'codex_cli' },
+    });
+    fireEvent.change(screen.getByLabelText(/Provider ID/), {
+      target: { value: 'openrouter' },
+    });
+    fireEvent.change(screen.getByLabelText(/Authentication method/), {
+      target: { value: 'api_key' },
+    });
+
+    await screen.findByText('Use the authorized manual profile path.');
+    expect((screen.getByLabelText(/Show advanced options/) as HTMLInputElement).checked).toBe(true);
+    fireEvent.change(screen.getByLabelText(/Credential source/), {
+      target: { value: 'secret_ref' },
+    });
+    fireEvent.change(screen.getByLabelText(/Materialization mode/), {
+      target: { value: 'api_key_env' },
+    });
+    fireEvent.change(screen.getByLabelText(/Clear env keys/), {
+      target: { value: 'OPENAI_API_KEY' },
+    });
+    fireEvent.change(screen.getByLabelText('Command behavior'), {
+      target: { value: '{"auth_strategy":"manual"}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true);
+    });
+    const postCall = fetchSpy.mock.calls.find(([, init]) => init?.method === 'POST');
+    const payload = JSON.parse(String((postCall?.[1] as RequestInit).body));
+    expect(payload).toMatchObject({
+      profile_id: 'manual-openrouter',
+      runtime_id: 'codex_cli',
+      provider_id: 'openrouter',
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'api_key_env',
+      clear_env_keys: ['OPENAI_API_KEY'],
+      command_behavior: { auth_strategy: 'manual' },
+    });
+    expect(payload).not.toHaveProperty('authentication_method');
+    expect(payload).not.toHaveProperty('preset_version');
+  });
+
+  it('reloads the active preset after a version mismatch', async () => {
+    const field = (value: unknown, editable = true) => ({
+      value,
+      source: 'test_policy',
+      editable,
+      required: false,
+      lock_reason: editable ? null : 'Backend controlled.',
+    });
+    const makePreset = (version: string, cooldown: number) => ({
+      version,
+      supported: true,
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      authentication_method: 'api_key',
+      fields: {
+        credential_source: field('none', false),
+        runtime_materialization_mode: field('api_key_env', false),
+        secret_refs: field({}),
+        volume_ref: field(null, false),
+        volume_mount_path: field(null, false),
+        max_parallel_runs: field(1),
+        cooldown_after_429_seconds: field(cooldown),
+        rate_limit_policy: field('backoff'),
+        enabled: field(false, false),
+        is_default: field(false),
+        command_behavior: field({ auth_strategy: 'api_key_env' }, false),
+        user_tags: field([]),
+        priority: field(100),
+        clear_env_keys: field(['MINIMAX_API_KEY'], false),
+      },
+      diagnostics: [],
+      manual_creation_allowed: false,
+      required_manual_fields: [],
+    });
+    let presetRequests = 0;
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(
+      async (input, init) => {
+        const url = String(input);
+        if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+          presetRequests += 1;
+          return {
+            ok: true,
+            json: async () =>
+              presetRequests === 1
+                ? makePreset('provider-profile-create-v1-old', 300)
+                : makePreset('provider-profile-create-v1-current', 600),
+          } as Response;
+        }
+        if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+          return {
+            ok: false,
+            json: async () => ({
+              detail: {
+                code: 'provider_profile_creation_preset_version_mismatch',
+                message: 'The preset changed.',
+              },
+            }),
+          } as Response;
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      },
+    );
+    const { onNotice } = renderProviderProfilesManager();
+    fireEvent.change(screen.getByLabelText(/Profile ID/), {
+      target: { value: 'stale-preset-profile' },
+    });
+    fireEvent.change(screen.getByLabelText(/Runtime ID/), {
+      target: { value: 'codex_cli' },
+    });
+    fireEvent.change(screen.getByLabelText(/Provider ID/), {
+      target: { value: 'openai' },
+    });
+    fireEvent.change(screen.getByLabelText(/Authentication method/), {
+      target: { value: 'api_key' },
+    });
+
+    await screen.findByText(/provider-profile-create-v1-old loaded/);
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await screen.findByText(/provider-profile-create-v1-current loaded/);
+    expect(presetRequests).toBe(2);
+    expect(onNotice).toHaveBeenCalledWith({
+      level: 'error',
+      text: 'The creation policy changed. Reloading the current preset for review.',
+    });
+    expect((screen.getByLabelText(/Show advanced options/) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText(/Cooldown after 429/) as HTMLInputElement).value).toBe('600');
+    expect(fetchSpy.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1);
   });
 });
 
@@ -507,6 +704,24 @@ describe('ProviderProfilesManager form controls', () => {
     account_label: 'Codex account',
   };
 
+  const codexApiKeySetupProfile: ProviderProfile = {
+    ...profile,
+    profile_id: 'codex-openai-api-key',
+    credential_source: 'none',
+    runtime_materialization_mode: 'api_key_env',
+    secret_refs: {},
+    enabled: false,
+    is_default: false,
+    auth_state: 'not_configured',
+    disabled_reason: 'missing_credentials',
+    command_behavior: {
+      auth_strategy: 'api_key_env',
+      auth_state: 'not_configured',
+      auth_actions: ['use_api_key'],
+      auth_status_label: 'OpenAI credentials not connected',
+    },
+  };
+
   const claudeCredentialProfile: ProviderProfile = {
     ...profile,
     profile_id: 'claude-anthropic',
@@ -597,6 +812,7 @@ describe('ProviderProfilesManager form controls', () => {
   it('labels secret refs and resets create-form values', () => {
     renderProviderProfilesManager();
 
+    fireEvent.click(screen.getByLabelText(/Show advanced options/));
     const secretRefs = screen.getByLabelText('Secret refs (JSON object of string refs)');
     expect(secretRefs.tagName).toBe('TEXTAREA');
 
@@ -753,6 +969,7 @@ describe('ProviderProfilesManager form controls', () => {
     fireEvent.change(screen.getByLabelText(/Provider ID/), {
       target: { value: 'openai' },
     });
+    fireEvent.click(screen.getByLabelText(/Show advanced options/));
     fireEvent.change(screen.getByLabelText('Secret refs (JSON object of string refs)'), {
       target: { value: '[]' },
     });
@@ -1016,6 +1233,53 @@ describe('ProviderProfilesManager form controls', () => {
     expect(screen.getByText('Setup required')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'OAuth codex-openai-oauth' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Enable' })).toHaveProperty('disabled', true);
+  });
+
+  it('enrolls a Codex OpenAI API key through the provider API-key endpoint', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'ready',
+        status_label: 'OpenAI API key ready',
+        readiness: {
+          connected: true,
+          backing_secret_exists: true,
+          launch_ready: true,
+        },
+      }),
+    } as Response);
+
+    renderProviderProfilesManager([codexApiKeySetupProfile]);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Use OpenAI API key codex-openai-api-key',
+      }),
+    );
+    expect(
+      screen.getByRole('dialog', {
+        name: 'OpenAI API key enrollment for codex-openai-api-key',
+      }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to API key paste' }));
+    fireEvent.change(screen.getByLabelText('OpenAI API key'), {
+      target: { value: 'sk-openai-provider-test' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Validate and save OpenAI API key' }),
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/provider-profiles/codex-openai-api-key/credentials/api-key',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ api_key: 'sk-openai-provider-test' }),
+        }),
+      );
+    });
+    expect(
+      fetchSpy.mock.calls.some(([input]) => String(input).includes('/oauth-sessions')),
+    ).toBe(false);
   });
 
   it('shows supported Claude OAuth lifecycle actions for connected claude_anthropic rows', () => {

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -2,6 +2,12 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 
 import { formatRuntimeLabel, formatStatusLabel } from '../../utils/formatters';
+import type { components } from '../../generated/openapi';
+
+type ProviderProfileAuthenticationMethod =
+  components['schemas']['ProviderProfileAuthenticationMethod'];
+type ProviderProfileCreationPreset =
+  components['schemas']['ProviderProfileCreationPresetResponse'];
 
 export interface ProviderProfile {
   profile_id: string;
@@ -94,6 +100,7 @@ interface ProviderProfileFormState {
   providerLabel: string;
   defaultModel: string;
   defaultEffort: string;
+  authenticationMethod: '' | ProviderProfileAuthenticationMethod;
   credentialSource: string;
   runtimeMaterializationMode: string;
   secretRefsText: string;
@@ -111,29 +118,7 @@ interface ProviderProfileFormState {
   accountLabel: string;
 }
 
-interface ProviderProfileSavePayload {
-  profile_id: string;
-  runtime_id: string;
-  provider_id: string;
-  provider_label: string | null;
-  default_model: string | null;
-  default_effort: string | null;
-  credential_source: string;
-  runtime_materialization_mode: string;
-  secret_refs: Record<string, string>;
-  volume_ref: string | null;
-  volume_mount_path: string | null;
-  max_parallel_runs: number;
-  cooldown_after_429_seconds: number;
-  rate_limit_policy: string;
-  enabled: boolean;
-  is_default: boolean;
-  command_behavior: Record<string, unknown> | null;
-  tags: string[] | null;
-  priority: number | null;
-  clear_env_keys: string[] | null;
-  account_label: string | null;
-}
+type ProviderProfileSavePayload = components['schemas']['ProviderProfileCreate'];
 
 type OAuthSessionStatus =
   | 'pending'
@@ -224,15 +209,16 @@ export function defaultFormState(runtimeId = ''): ProviderProfileFormState {
     providerLabel: '',
     defaultModel: '',
     defaultEffort: '',
-    credentialSource: 'secret_ref',
-    runtimeMaterializationMode: 'api_key_env',
+    authenticationMethod: '',
+    credentialSource: '',
+    runtimeMaterializationMode: '',
     secretRefsText: '{}',
     volumeRef: '',
     volumeMountPath: '',
-    maxParallelRuns: '1',
-    cooldownAfter429Seconds: '300',
-    rateLimitPolicy: 'backoff',
-    enabled: true,
+    maxParallelRuns: '',
+    cooldownAfter429Seconds: '',
+    rateLimitPolicy: '',
+    enabled: false,
     isDefault: false,
     commandBehavior: '{}',
     tagsText: '',
@@ -250,6 +236,7 @@ export function toFormState(profile: ProviderProfile): ProviderProfileFormState 
     providerLabel: profile.provider_label ?? '',
     defaultModel: profile.default_model ?? '',
     defaultEffort: profile.default_effort ?? '',
+    authenticationMethod: '',
     credentialSource: profile.credential_source,
     runtimeMaterializationMode: profile.runtime_materialization_mode,
     secretRefsText: JSON.stringify(profile.secret_refs ?? {}, null, 2),
@@ -506,9 +493,12 @@ function redactClaudeSecretText(value: string | null | undefined, submittedToken
   return redacted;
 }
 
-function extractErrorMessage(payload: unknown): string {
+function extractErrorMessage(
+  payload: unknown,
+  fallback = 'Anthropic API key validation failed.',
+): string {
   if (typeof payload === 'string') return payload;
-  if (!payload || typeof payload !== 'object') return 'Anthropic API key validation failed.';
+  if (!payload || typeof payload !== 'object') return fallback;
   const record = payload as Record<string, unknown>;
   if (typeof record.message === 'string') return record.message;
   if (typeof record.detail === 'string') return record.detail;
@@ -518,7 +508,7 @@ function extractErrorMessage(payload: unknown): string {
     if (typeof detail.error === 'string') return detail.error;
   }
   if (typeof record.error === 'string') return record.error;
-  return 'Anthropic API key validation failed.';
+  return fallback;
 }
 
 function isFirstPartyOAuthProfile(profile: ProviderProfile): boolean {
@@ -666,12 +656,54 @@ function canRetryOAuthStatus(status: OAuthSessionStatus): boolean {
   return status === 'failed' || status === 'cancelled' || status === 'expired';
 }
 
-function buildSavePayload(form: ProviderProfileFormState): ProviderProfileSavePayload {
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function applyCreationPresetToForm(
+  form: ProviderProfileFormState,
+  preset: ProviderProfileCreationPreset,
+): ProviderProfileFormState {
+  const value = (fieldName: string): unknown => preset.fields[fieldName]?.value;
+  const stringValue = (fieldName: string): string => {
+    const fieldValue = value(fieldName);
+    return fieldValue == null ? '' : String(fieldValue);
+  };
+  return {
+    ...form,
+    credentialSource: stringValue('credential_source'),
+    runtimeMaterializationMode: stringValue('runtime_materialization_mode'),
+    secretRefsText: JSON.stringify(value('secret_refs') ?? {}, null, 2),
+    volumeRef: stringValue('volume_ref'),
+    volumeMountPath: stringValue('volume_mount_path'),
+    maxParallelRuns: stringValue('max_parallel_runs'),
+    cooldownAfter429Seconds: stringValue('cooldown_after_429_seconds'),
+    rateLimitPolicy: stringValue('rate_limit_policy'),
+    enabled: value('enabled') === true,
+    isDefault: value('is_default') === true,
+    commandBehavior: JSON.stringify(value('command_behavior') ?? {}, null, 2),
+    tagsText: Array.isArray(value('user_tags'))
+      ? (value('user_tags') as string[]).join(', ')
+      : '',
+    priority: stringValue('priority'),
+    clearEnvKeysText: Array.isArray(value('clear_env_keys'))
+      ? (value('clear_env_keys') as string[]).join('\n')
+      : '',
+  };
+}
+
+function buildSavePayload(
+  form: ProviderProfileFormState,
+  options: {
+    isEditing: boolean;
+    creationPreset: ProviderProfileCreationPreset | null;
+  },
+): ProviderProfileSavePayload {
   const isCodexOAuth =
     form.runtimeId.trim() === 'codex_cli' &&
     form.credentialSource === 'oauth_volume' &&
     form.runtimeMaterializationMode === 'oauth_home';
-  const payload = {
+  const payload: ProviderProfileSavePayload = {
     profile_id: form.profileId.trim(),
     runtime_id: form.runtimeId.trim(),
     provider_id: form.providerId.trim(),
@@ -705,6 +737,52 @@ function buildSavePayload(form: ProviderProfileFormState): ProviderProfileSavePa
     throw new Error('Provider ID is required.');
   }
 
+  if (options.isEditing) {
+    return payload;
+  }
+  if (!form.authenticationMethod) {
+    throw new Error('Authentication method is required.');
+  }
+  const preset = options.creationPreset;
+  if (!preset) {
+    throw new Error('Wait for the backend creation preset before creating the profile.');
+  }
+  if (!preset.supported) {
+    throw new Error(
+      preset.diagnostics[0]?.message ??
+        'This runtime, provider, and authentication combination is unsupported.',
+    );
+  }
+  payload.authentication_method = form.authenticationMethod;
+  payload.preset_version = preset.version;
+
+  const omitWhenRecommended = (
+    payloadKey: keyof ProviderProfileSavePayload,
+    fieldName: string,
+  ) => {
+    if (valuesEqual(payload[payloadKey], preset.fields[fieldName]?.value)) {
+      delete payload[payloadKey];
+    }
+  };
+  omitWhenRecommended('credential_source', 'credential_source');
+  omitWhenRecommended('runtime_materialization_mode', 'runtime_materialization_mode');
+  omitWhenRecommended('secret_refs', 'secret_refs');
+  omitWhenRecommended('volume_ref', 'volume_ref');
+  omitWhenRecommended('volume_mount_path', 'volume_mount_path');
+  omitWhenRecommended('max_parallel_runs', 'max_parallel_runs');
+  omitWhenRecommended('cooldown_after_429_seconds', 'cooldown_after_429_seconds');
+  omitWhenRecommended('rate_limit_policy', 'rate_limit_policy');
+  omitWhenRecommended('enabled', 'enabled');
+  omitWhenRecommended('is_default', 'is_default');
+  omitWhenRecommended('command_behavior', 'command_behavior');
+  if (
+    valuesEqual(payload.tags ?? [], preset.fields.user_tags?.value ?? [])
+  ) {
+    delete payload.tags;
+  }
+  omitWhenRecommended('priority', 'priority');
+  omitWhenRecommended('clear_env_keys', 'clear_env_keys');
+
   return payload;
 }
 
@@ -723,6 +801,10 @@ export function ProviderProfilesManager({
   const [form, setForm] = useState<ProviderProfileFormState>(() =>
     defaultFormState(createFormRuntimeSeed),
   );
+  const [creationPreset, setCreationPreset] =
+    useState<ProviderProfileCreationPreset | null>(null);
+  const [creationPresetLoading, setCreationPresetLoading] = useState(false);
+  const [creationPresetError, setCreationPresetError] = useState<string | null>(null);
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
   const createFormRuntimeSeedRef = useRef(createFormRuntimeSeed);
   const [oauthSessions, setOauthSessions] = useState<Record<string, OAuthSessionState>>({});
@@ -758,7 +840,7 @@ export function ProviderProfilesManager({
     form.runtimeId.trim() === 'codex_cli' &&
     form.credentialSource === 'oauth_volume' &&
     form.runtimeMaterializationMode === 'oauth_home';
-  const defaultFormValues = defaultFormState();
+  const presetField = (fieldName: string) => creationPreset?.fields[fieldName];
 
   const updateClaudeEnrollmentForProfile = (
     profileId: string,
@@ -813,6 +895,84 @@ export function ProviderProfilesManager({
         : current,
     );
   }, [createFormRuntimeSeed, editingProfileId]);
+
+  useEffect(() => {
+    if (editingProfileId !== null) {
+      setCreationPreset(null);
+      setCreationPresetLoading(false);
+      setCreationPresetError(null);
+      return;
+    }
+
+    const runtimeId = form.runtimeId.trim();
+    const providerId = form.providerId.trim();
+    const authenticationMethod = form.authenticationMethod;
+    if (!runtimeId || !providerId || !authenticationMethod) {
+      setCreationPreset(null);
+      setCreationPresetLoading(false);
+      setCreationPresetError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const params = new URLSearchParams({
+      runtime_id: runtimeId,
+      provider_id: providerId,
+      authentication_method: authenticationMethod,
+    });
+    setCreationPreset(null);
+    setCreationPresetLoading(true);
+    setCreationPresetError(null);
+
+    void fetch(`/api/v1/provider-profiles/creation-preset?${params.toString()}`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const payload: unknown = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(
+            extractErrorMessage(
+              payload,
+              'Failed to load the Provider Profile creation preset.',
+            ),
+          );
+        }
+        return payload as ProviderProfileCreationPreset;
+      })
+      .then((preset) => {
+        setCreationPreset(preset);
+        setForm((current) =>
+          current.runtimeId.trim() === preset.runtime_id &&
+          current.providerId.trim() === preset.provider_id &&
+          current.authenticationMethod === preset.authentication_method
+            ? applyCreationPresetToForm(current, preset)
+            : current,
+        );
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        setCreationPresetError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to load the Provider Profile creation preset.',
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setCreationPresetLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [
+    editingProfileId,
+    form.runtimeId,
+    form.providerId,
+    form.authenticationMethod,
+  ]);
 
   // A single-runtime view cannot show the row being edited when that row
   // belongs to another runtime, so close the editor instead of leaving it
@@ -1146,7 +1306,7 @@ export function ProviderProfilesManager({
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
-      const payload = buildSavePayload(formState);
+      const payload = buildSavePayload(formState, { isEditing, creationPreset });
       const endpoint = isEditing
         ? `/api/v1/provider-profiles/${encodeURIComponent(payload.profile_id)}`
         : '/api/v1/provider-profiles';
@@ -1160,10 +1320,10 @@ export function ProviderProfilesManager({
       });
       if (!response.ok) {
         const errorPayload = await response.json().catch(() => ({}));
-        const detail =
-          typeof errorPayload.detail === 'string'
-            ? errorPayload.detail
-            : `Failed to ${isEditing ? 'update' : 'create'} provider profile.`;
+        const detail = extractErrorMessage(
+          errorPayload,
+          `Failed to ${isEditing ? 'update' : 'create'} provider profile.`,
+        );
         throw new Error(detail);
       }
       return response.json() as Promise<ProviderProfile>;
@@ -2508,6 +2668,28 @@ export function ProviderProfilesManager({
             </div>
           </fieldset>
 
+          {!isEditing ? (
+            <div
+              className={`rounded-xl border p-4 text-sm ${
+                creationPreset?.supported === false || creationPresetError
+                  ? 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-300'
+                  : 'border-sky-200 bg-sky-50 text-sky-800 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-300'
+              }`}
+              aria-live="polite"
+            >
+              {creationPresetLoading
+                ? 'Loading backend creation recommendations…'
+                : creationPresetError
+                  ? creationPresetError
+                  : creationPreset
+                    ? creationPreset.supported
+                      ? `Backend preset ${creationPreset.version} loaded. Untouched advanced values will be omitted and normalized by the server.`
+                      : creationPreset.diagnostics[0]?.message ??
+                        'This combination does not have a safe standard creation preset.'
+                    : 'Choose runtime, provider, and authentication method to load backend creation recommendations.'}
+            </div>
+          ) : null}
+
           {/* ── Provider Settings (have smart defaults) ── */}
           <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
             <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
@@ -2526,11 +2708,37 @@ export function ProviderProfilesManager({
                 />
                 <p className="text-xs text-slate-400 dark:text-slate-500">Optional display name</p>
               </label>
+              {!isEditing ? (
+                <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <span>Authentication method <span className="text-amber-600 dark:text-amber-400">*</span></span>
+                  <select
+                    className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
+                    value={form.authenticationMethod}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        authenticationMethod: event.target.value as
+                          | ''
+                          | ProviderProfileAuthenticationMethod,
+                      }))
+                    }
+                  >
+                    <option value="">Choose authentication…</option>
+                    <option value="oauth">OAuth</option>
+                    <option value="api_key">API key</option>
+                    <option value="none">No credentials</option>
+                  </select>
+                  <p className="text-xs text-slate-400 dark:text-slate-500">
+                    Selects the backend-owned credential and launch strategy.
+                  </p>
+                </label>
+              ) : null}
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                 <span>Credential source</span>
                 <select
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                   value={form.credentialSource}
+                  disabled={!isEditing && !presetField('credential_source')?.editable}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
@@ -2538,12 +2746,16 @@ export function ProviderProfilesManager({
                     }))
                   }
                 >
+                  <option value="">Backend-derived</option>
                   <option value="secret_ref">secret_ref</option>
                   <option value="oauth_volume">oauth_volume</option>
                   <option value="none">none</option>
                 </select>
                 <p className="text-xs text-slate-400 dark:text-slate-500">
-                  Default: {defaultFormValues.credentialSource}
+                  {isEditing
+                    ? 'Saved launch-contract value.'
+                    : presetField('credential_source')?.lock_reason ??
+                      'Choose an authentication method to derive this value.'}
                 </p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2551,6 +2763,7 @@ export function ProviderProfilesManager({
                 <select
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                   value={form.runtimeMaterializationMode}
+                  disabled={!isEditing && !presetField('runtime_materialization_mode')?.editable}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
@@ -2558,6 +2771,7 @@ export function ProviderProfilesManager({
                     }))
                   }
                 >
+                  <option value="">Backend-derived</option>
                   <option value="api_key_env">api_key_env</option>
                   <option value="env_bundle">env_bundle</option>
                   <option value="config_bundle">config_bundle</option>
@@ -2565,7 +2779,10 @@ export function ProviderProfilesManager({
                   <option value="oauth_home">oauth_home</option>
                 </select>
                 <p className="text-xs text-slate-400 dark:text-slate-500">
-                  Default: {defaultFormValues.runtimeMaterializationMode}
+                  {isEditing
+                    ? 'Saved launch-contract value.'
+                    : presetField('runtime_materialization_mode')?.lock_reason ??
+                      'Choose an authentication method to derive this value.'}
                 </p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2605,16 +2822,18 @@ export function ProviderProfilesManager({
                 </p>
               </label>
               <div className="flex gap-4 items-start xl:col-span-1">
-                <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
-                  <input
-                    type="checkbox"
-                    checked={form.enabled}
-                    onChange={(event) =>
-                      setForm((current) => ({ ...current, enabled: event.target.checked }))
-                    }
-                  />
-                  Enabled
-                </label>
+                {isEditing ? (
+                  <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
+                    <input
+                      type="checkbox"
+                      checked={form.enabled}
+                      onChange={(event) =>
+                        setForm((current) => ({ ...current, enabled: event.target.checked }))
+                      }
+                    />
+                    Enabled
+                  </label>
+                ) : null}
                 <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
                   <input
                     type="checkbox"
@@ -2640,7 +2859,10 @@ export function ProviderProfilesManager({
                 <input
                   type="number"
                   min="1"
-                  disabled={isCodexOAuthForm}
+                  disabled={
+                    isCodexOAuthForm ||
+                    (!isEditing && presetField('max_parallel_runs')?.editable === false)
+                  }
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                   value={isCodexOAuthForm ? '1' : form.maxParallelRuns}
                   onChange={(event) =>
@@ -2653,7 +2875,11 @@ export function ProviderProfilesManager({
                 <p className="text-xs text-slate-400 dark:text-slate-500">
                   {isCodexOAuthForm
                     ? 'Fixed at 1 because the Codex OAuth home is an exclusive mutable identity.'
-                    : `Default: ${defaultFormValues.maxParallelRuns}`}
+                    : isEditing
+                      ? 'Saved capacity value.'
+                      : presetField('max_parallel_runs')
+                        ? `Recommended by ${presetField('max_parallel_runs')?.source}.`
+                        : 'Loaded from the backend creation preset.'}
                 </p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2671,7 +2897,11 @@ export function ProviderProfilesManager({
                   }
                 />
                 <p className="text-xs text-slate-400 dark:text-slate-500">
-                  Default: {defaultFormValues.cooldownAfter429Seconds}
+                  {isEditing
+                    ? 'Saved rate-limit value.'
+                    : presetField('cooldown_after_429_seconds')
+                      ? `Recommended by ${presetField('cooldown_after_429_seconds')?.source}.`
+                      : 'Loaded from the backend creation preset.'}
                 </p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2686,12 +2916,17 @@ export function ProviderProfilesManager({
                     }))
                   }
                 >
+                  <option value="">Backend recommendation</option>
                   <option value="backoff">backoff</option>
                   <option value="queue">queue</option>
                   <option value="fail_fast">fail_fast</option>
                 </select>
                 <p className="text-xs text-slate-400 dark:text-slate-500">
-                  Default: {defaultFormValues.rateLimitPolicy}
+                  {isEditing
+                    ? 'Saved rate-limit policy.'
+                    : presetField('rate_limit_policy')
+                      ? `Recommended by ${presetField('rate_limit_policy')?.source}.`
+                      : 'Loaded from the backend creation preset.'}
                 </p>
               </label>
             </div>
@@ -2712,6 +2947,7 @@ export function ProviderProfilesManager({
                   rows={6}
                   className="w-full rounded-2xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-sm text-slate-900 dark:text-white shadow-sm"
                   value={form.secretRefsText}
+                  disabled={!isEditing && presetField('secret_refs')?.editable === false}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
@@ -2743,6 +2979,7 @@ export function ProviderProfilesManager({
                   <input
                     className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                     value={form.volumeRef}
+                    disabled={!isEditing && presetField('volume_ref')?.editable === false}
                     onChange={(event) =>
                       setForm((current) => ({ ...current, volumeRef: event.target.value }))
                     }
@@ -2754,6 +2991,7 @@ export function ProviderProfilesManager({
                   <input
                     className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                     value={form.volumeMountPath}
+                    disabled={!isEditing && presetField('volume_mount_path')?.editable === false}
                     onChange={(event) =>
                       setForm((current) => ({
                         ...current,
@@ -2779,6 +3017,7 @@ export function ProviderProfilesManager({
                   rows={4}
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-sm text-slate-900 dark:text-white shadow-sm"
                   value={form.commandBehavior}
+                  disabled={!isEditing && presetField('command_behavior')?.editable === false}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
@@ -2840,6 +3079,7 @@ export function ProviderProfilesManager({
                 rows={3}
                 className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-sm text-slate-900 dark:text-white shadow-sm"
                 value={form.clearEnvKeysText}
+                disabled={!isEditing && presetField('clear_env_keys')?.editable === false}
                 onChange={(event) =>
                   setForm((current) => ({
                     ...current,
@@ -2856,7 +3096,12 @@ export function ProviderProfilesManager({
             <button
               type="submit"
               className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-5 py-2.5 text-sm font-semibold text-white dark:text-slate-900 transition hover:bg-slate-800 dark:hover:bg-slate-200"
-              disabled={saveMutation.isPending}
+              disabled={
+                saveMutation.isPending ||
+                (!isEditing &&
+                  Boolean(form.authenticationMethod) &&
+                  (creationPresetLoading || !creationPreset?.supported))
+              }
             >
               {saveMutation.isPending
                 ? 'Saving...'

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -329,6 +329,7 @@ function visibleReadinessChecks(readiness?: ProviderProfileReadiness | null): Pr
 type ProviderAuthActionLabel =
   | 'OAuth'
   | 'Use Anthropic API key'
+  | 'Use OpenAI API key'
   | 'Use OpenCode API key'
   | 'Validate OAuth'
   | 'Disconnect OAuth';
@@ -338,7 +339,7 @@ interface ClaudeAuthAction {
   label: ProviderAuthActionLabel;
 }
 
-type OpencodeAuthAction = ClaudeAuthAction;
+type ProviderApiKeyAuthAction = ClaudeAuthAction;
 
 type ClaudeEnrollmentStep =
   | 'not_connected'
@@ -367,9 +368,10 @@ type ProviderAuthModel =
       readiness: ClaudeReadinessMetadata | null;
     }
   | {
-      kind: 'opencode_credentials';
+      kind: 'api_key_credentials';
+      providerLabel: string;
       statusLabel: string | null;
-      actions: OpencodeAuthAction[];
+      actions: ProviderApiKeyAuthAction[];
       readiness: ClaudeReadinessMetadata | null;
     }
   | { kind: 'none' };
@@ -397,10 +399,6 @@ const CLAUDE_AUTH_ACTION_LABELS: Record<string, ProviderAuthActionLabel> = {
   use_api_key: 'Use Anthropic API key',
   validate_oauth: 'Validate OAuth',
   disconnect_oauth: 'Disconnect OAuth',
-};
-
-const OPENCODE_AUTH_ACTION_LABELS: Record<string, ProviderAuthActionLabel> = {
-  use_api_key: 'Use OpenCode API key',
 };
 
 const CLAUDE_ENROLLMENT_STEPS: ClaudeEnrollmentStep[] = [
@@ -511,6 +509,27 @@ function extractErrorMessage(
   return fallback;
 }
 
+function extractErrorCode(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.code === 'string') return record.code;
+  if (record.detail && typeof record.detail === 'object') {
+    const detail = record.detail as Record<string, unknown>;
+    return typeof detail.code === 'string' ? detail.code : null;
+  }
+  return null;
+}
+
+class ProviderProfileRequestError extends Error {
+  readonly code: string | null;
+
+  constructor(message: string, code: string | null = null) {
+    super(message);
+    this.name = 'ProviderProfileRequestError';
+    this.code = code;
+  }
+}
+
 function isFirstPartyOAuthProfile(profile: ProviderProfile): boolean {
   const authActions = commandBehaviorStringArray(profile, 'auth_actions') ?? [];
   return (
@@ -563,30 +582,29 @@ function claudeCredentialActions(profile: ProviderProfile): ClaudeAuthAction[] {
     .filter((action): action is ClaudeAuthAction => action !== null);
 }
 
-function isOpencodeGoProfile(profile: ProviderProfile): boolean {
-  return profile.runtime_id === 'opencode' && profile.provider_id === 'opencode-go';
+function isProviderApiKeyCredentialProfile(profile: ProviderProfile): boolean {
+  return (
+    (profile.runtime_id === 'codex_cli' && profile.provider_id === 'openai') ||
+    (profile.runtime_id === 'opencode' &&
+      (profile.provider_id === 'opencode-go' || profile.provider_id === 'opencode'))
+  );
 }
 
-function isOpencodeCredentialMethodProfile(profile: ProviderProfile): boolean {
-  return profile.runtime_id === 'opencode' && (profile.provider_id === 'opencode-go' || profile.provider_id === 'opencode');
+function providerApiKeyLabel(profile: ProviderProfile): string {
+  if (profile.runtime_id === 'codex_cli') return 'OpenAI';
+  return 'OpenCode';
 }
 
-function defaultOpencodeCredentialActions(profile: ProviderProfile): string[] {
-  if (!isOpencodeGoProfile(profile)) {
-    return [];
-  }
-  return ['use_api_key'];
-}
-
-function opencodeCredentialActions(profile: ProviderProfile): OpencodeAuthAction[] {
+function providerApiKeyCredentialActions(profile: ProviderProfile): ProviderApiKeyAuthAction[] {
   const actionIds = commandBehaviorStringArray(profile, 'auth_actions');
-  const resolvedActionIds = actionIds ?? defaultOpencodeCredentialActions(profile);
+  const resolvedActionIds = actionIds ?? ['use_api_key'];
+  const label: ProviderAuthActionLabel =
+    profile.runtime_id === 'codex_cli'
+      ? 'Use OpenAI API key'
+      : 'Use OpenCode API key';
   return resolvedActionIds
-    .map((actionId) => {
-      const label = OPENCODE_AUTH_ACTION_LABELS[actionId];
-      return label ? { id: actionId, label } : null;
-    })
-    .filter((action): action is OpencodeAuthAction => action !== null);
+    .filter((actionId) => actionId === 'use_api_key')
+    .map((actionId) => ({ id: actionId, label }));
 }
 
 function providerAuthModel(profile: ProviderProfile): ProviderAuthModel {
@@ -594,11 +612,12 @@ function providerAuthModel(profile: ProviderProfile): ProviderAuthModel {
     return { kind: 'codex_oauth' };
   }
 
-  if (isOpencodeCredentialMethodProfile(profile)) {
+  if (isProviderApiKeyCredentialProfile(profile)) {
     return {
-      kind: 'opencode_credentials',
+      kind: 'api_key_credentials',
+      providerLabel: providerApiKeyLabel(profile),
       statusLabel: formatStatusLabel(commandBehaviorString(profile, 'auth_status_label'), ''),
-      actions: opencodeCredentialActions(profile),
+      actions: providerApiKeyCredentialActions(profile),
       readiness: normalizeReadinessMetadata(commandBehaviorValue(profile, 'auth_readiness')),
     };
   }
@@ -701,8 +720,10 @@ function buildSavePayload(
 ): ProviderProfileSavePayload {
   const isCodexOAuth =
     form.runtimeId.trim() === 'codex_cli' &&
-    form.credentialSource === 'oauth_volume' &&
-    form.runtimeMaterializationMode === 'oauth_home';
+    ((options.isEditing &&
+      form.credentialSource === 'oauth_volume' &&
+      form.runtimeMaterializationMode === 'oauth_home') ||
+      (!options.isEditing && form.authenticationMethod === 'oauth'));
   const payload: ProviderProfileSavePayload = {
     profile_id: form.profileId.trim(),
     runtime_id: form.runtimeId.trim(),
@@ -740,10 +761,27 @@ function buildSavePayload(
   if (options.isEditing) {
     return payload;
   }
-  if (!form.authenticationMethod) {
-    throw new Error('Authentication method is required.');
+
+  if (!form.maxParallelRuns.trim()) delete payload.max_parallel_runs;
+  if (!form.cooldownAfter429Seconds.trim()) {
+    delete payload.cooldown_after_429_seconds;
   }
+  if (!form.rateLimitPolicy) delete payload.rate_limit_policy;
+  if (!form.priority.trim()) delete payload.priority;
+
   const preset = options.creationPreset;
+  const authenticationMethod = form.authenticationMethod;
+  const usesManualCreation =
+    !authenticationMethod ||
+    (preset?.supported === false && preset.manual_creation_allowed);
+  if (usesManualCreation) {
+    if (!payload.credential_source || !payload.runtime_materialization_mode) {
+      throw new Error(
+        'Manual creation requires credential source and materialization mode.',
+      );
+    }
+    return payload;
+  }
   if (!preset) {
     throw new Error('Wait for the backend creation preset before creating the profile.');
   }
@@ -753,7 +791,7 @@ function buildSavePayload(
         'This runtime, provider, and authentication combination is unsupported.',
     );
   }
-  payload.authentication_method = form.authenticationMethod;
+  payload.authentication_method = authenticationMethod;
   payload.preset_version = preset.version;
 
   const omitWhenRecommended = (
@@ -805,6 +843,8 @@ export function ProviderProfilesManager({
     useState<ProviderProfileCreationPreset | null>(null);
   const [creationPresetLoading, setCreationPresetLoading] = useState(false);
   const [creationPresetError, setCreationPresetError] = useState<string | null>(null);
+  const [creationPresetRefreshKey, setCreationPresetRefreshKey] = useState(0);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
   const createFormRuntimeSeedRef = useRef(createFormRuntimeSeed);
   const [oauthSessions, setOauthSessions] = useState<Record<string, OAuthSessionState>>({});
@@ -838,8 +878,14 @@ export function ProviderProfilesManager({
   const isEditing = editingProfileId !== null;
   const isCodexOAuthForm =
     form.runtimeId.trim() === 'codex_cli' &&
-    form.credentialSource === 'oauth_volume' &&
-    form.runtimeMaterializationMode === 'oauth_home';
+    ((isEditing &&
+      form.credentialSource === 'oauth_volume' &&
+      form.runtimeMaterializationMode === 'oauth_home') ||
+      (!isEditing && form.authenticationMethod === 'oauth'));
+  const manualCreationAllowed =
+    !isEditing &&
+    creationPreset?.supported === false &&
+    creationPreset.manual_creation_allowed;
   const presetField = (fieldName: string) => creationPreset?.fields[fieldName];
 
   const updateClaudeEnrollmentForProfile = (
@@ -942,13 +988,17 @@ export function ProviderProfilesManager({
       })
       .then((preset) => {
         setCreationPreset(preset);
-        setForm((current) =>
-          current.runtimeId.trim() === preset.runtime_id &&
-          current.providerId.trim() === preset.provider_id &&
-          current.authenticationMethod === preset.authentication_method
-            ? applyCreationPresetToForm(current, preset)
-            : current,
-        );
+        if (preset.supported) {
+          setForm((current) =>
+            current.runtimeId.trim() === preset.runtime_id &&
+            current.providerId.trim() === preset.provider_id &&
+            current.authenticationMethod === preset.authentication_method
+              ? applyCreationPresetToForm(current, preset)
+              : current,
+          );
+        } else if (preset.manual_creation_allowed) {
+          setShowAdvancedOptions(true);
+        }
       })
       .catch((error: unknown) => {
         if (error instanceof DOMException && error.name === 'AbortError') {
@@ -972,6 +1022,7 @@ export function ProviderProfilesManager({
     form.runtimeId,
     form.providerId,
     form.authenticationMethod,
+    creationPresetRefreshKey,
   ]);
 
   // A single-runtime view cannot show the row being edited when that row
@@ -986,6 +1037,7 @@ export function ProviderProfilesManager({
     }
     setEditingProfileId(null);
     setForm(defaultFormState(selectedRuntimeId));
+    setShowAdvancedOptions(false);
   }, [editingProfileId, form.runtimeId, selectedRuntimeId]);
 
   useEffect(() => {
@@ -1004,6 +1056,7 @@ export function ProviderProfilesManager({
   const resetForm = () => {
     setEditingProfileId(null);
     setForm(defaultFormState(createFormRuntimeSeed));
+    setShowAdvancedOptions(false);
     onNotice(null);
   };
 
@@ -1145,16 +1198,16 @@ export function ProviderProfilesManager({
     };
   }, [claudeEnrollment]);
 
-  // ── OpenCode API-key enrollment (mirrors Claude flow but uses /credentials/api-key) ──
-  const [opencodeEnrollment, setOpencodeEnrollment] = useState<ClaudeEnrollmentState | null>(null);
-  const opencodeEnrollmentDrawerRef = useRef<HTMLDivElement | null>(null);
-  const opencodeEnrollmentProfileIdRef = useRef<string | null>(null);
+  // ── Provider API-key enrollment through /credentials/api-key ──
+  const [apiKeyEnrollment, setApiKeyEnrollment] = useState<ClaudeEnrollmentState | null>(null);
+  const apiKeyEnrollmentDrawerRef = useRef<HTMLDivElement | null>(null);
+  const apiKeyEnrollmentProfileIdRef = useRef<string | null>(null);
 
-  const updateOpencodeEnrollmentForProfile = (
+  const updateApiKeyEnrollmentForProfile = (
     profileId: string,
     updater: (current: ClaudeEnrollmentState) => ClaudeEnrollmentState,
   ) => {
-    setOpencodeEnrollment((current) => {
+    setApiKeyEnrollment((current) => {
       if (!current || current.profile.profile_id !== profileId) {
         return current;
       }
@@ -1162,36 +1215,36 @@ export function ProviderProfilesManager({
     });
   };
 
-  const closeOpencodeEnrollment = () => {
-    opencodeEnrollmentProfileIdRef.current = null;
-    setOpencodeEnrollment(null);
+  const closeApiKeyEnrollment = () => {
+    apiKeyEnrollmentProfileIdRef.current = null;
+    setApiKeyEnrollment(null);
   };
 
-  const openOpencodeEnrollment = (profile: ProviderProfile) => {
+  const openApiKeyEnrollment = (profile: ProviderProfile) => {
     const authModel = providerAuthModel(profile);
-    opencodeEnrollmentProfileIdRef.current = profile.profile_id;
-    setOpencodeEnrollment({
+    apiKeyEnrollmentProfileIdRef.current = profile.profile_id;
+    setApiKeyEnrollment({
       profile,
       step: 'not_connected',
       token: '',
       failureReason: null,
-      statusLabel: authModel.kind === 'opencode_credentials' ? authModel.statusLabel : null,
-      readiness: authModel.kind === 'opencode_credentials' ? authModel.readiness : null,
+      statusLabel: authModel.kind === 'api_key_credentials' ? authModel.statusLabel : null,
+      readiness: authModel.kind === 'api_key_credentials' ? authModel.readiness : null,
     });
     onNotice(null);
   };
 
-  const updateOpencodeEnrollmentToken = (token: string) => {
-    setOpencodeEnrollment((current) => (current ? { ...current, token } : current));
+  const updateApiKeyEnrollmentToken = (token: string) => {
+    setApiKeyEnrollment((current) => (current ? { ...current, token } : current));
   };
 
-  const continueOpencodeEnrollment = () => {
-    setOpencodeEnrollment((current) =>
+  const continueApiKeyEnrollment = () => {
+    setApiKeyEnrollment((current) =>
       current ? { ...current, step: 'awaiting_token_paste', failureReason: null } : current,
     );
   };
 
-  const opencodeEnrollmentMutation = useMutation({
+  const apiKeyEnrollmentMutation = useMutation({
     mutationFn: async ({
       profileId,
       submittedToken,
@@ -1210,13 +1263,13 @@ export function ProviderProfilesManager({
       const payload: unknown = await response.json().catch(() => ({}));
 
       if (!response.ok) {
-        throw new Error(redactClaudeSecretText(extractErrorMessage(payload), submittedToken) ?? 'OpenCode API key validation failed.');
+        throw new Error(redactClaudeSecretText(extractErrorMessage(payload), submittedToken) ?? 'Provider API key validation failed.');
       }
 
       return payload as ClaudeManualAuthResult;
     },
     onMutate: ({ profileId }) => {
-      updateOpencodeEnrollmentForProfile(profileId, (current) => ({
+      updateApiKeyEnrollmentForProfile(profileId, (current) => ({
         ...current,
         step: 'validating_token',
         token: '',
@@ -1224,22 +1277,22 @@ export function ProviderProfilesManager({
       }));
     },
     onSuccess: async (result, { profileId }) => {
-      updateOpencodeEnrollmentForProfile(profileId, (current) => ({
+      updateApiKeyEnrollmentForProfile(profileId, (current) => ({
         ...current,
         step: 'saving_secret',
         token: '',
       }));
       await delay(CLAUDE_ENROLLMENT_PROGRESS_DELAY_MS);
-      updateOpencodeEnrollmentForProfile(profileId, (current) => ({
+      updateApiKeyEnrollmentForProfile(profileId, (current) => ({
         ...current,
         step: 'updating_profile',
         token: '',
       }));
       await delay(CLAUDE_ENROLLMENT_PROGRESS_DELAY_MS);
-      if (opencodeEnrollmentProfileIdRef.current !== profileId) {
+      if (apiKeyEnrollmentProfileIdRef.current !== profileId) {
         return;
       }
-      updateOpencodeEnrollmentForProfile(profileId, (current) => ({
+      updateApiKeyEnrollmentForProfile(profileId, (current) => ({
         ...current,
         step: 'ready',
         token: '',
@@ -1250,59 +1303,62 @@ export function ProviderProfilesManager({
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
       onNotice({
         level: 'ok',
-        text: `OpenCode API key enrollment completed for "${profileId}".`,
+        text: `Provider API key enrollment completed for "${profileId}".`,
       });
     },
     onError: (error, { profileId, submittedToken }) => {
-      if (opencodeEnrollmentProfileIdRef.current !== profileId) {
+      if (apiKeyEnrollmentProfileIdRef.current !== profileId) {
         return;
       }
       const failureReason =
         error instanceof Error
           ? redactClaudeSecretText(error.message, submittedToken)
-          : 'OpenCode API key validation failed.';
-      updateOpencodeEnrollmentForProfile(profileId, (current) => ({
+          : 'Provider API key validation failed.';
+      updateApiKeyEnrollmentForProfile(profileId, (current) => ({
         ...current,
         step: 'failed',
         token: '',
-        failureReason: failureReason ?? 'OpenCode API key validation failed.',
+        failureReason: failureReason ?? 'Provider API key validation failed.',
       }));
     },
   });
 
-  const submitOpencodeEnrollment = () => {
-    if (!opencodeEnrollment) return;
-    const profileId = opencodeEnrollment.profile.profile_id;
-    const submittedToken = opencodeEnrollment.token.trim();
+  const submitApiKeyEnrollment = () => {
+    if (!apiKeyEnrollment) return;
+    const profileId = apiKeyEnrollment.profile.profile_id;
+    const submittedToken = apiKeyEnrollment.token.trim();
     if (!submittedToken) {
-      onNotice({ level: 'error', text: 'OpenCode API key is required.' });
+      onNotice({
+        level: 'error',
+        text: `${providerApiKeyLabel(apiKeyEnrollment.profile)} API key is required.`,
+      });
       return;
     }
 
-    opencodeEnrollmentMutation.mutate({ profileId, submittedToken });
+    apiKeyEnrollmentMutation.mutate({ profileId, submittedToken });
   };
 
   useEffect(() => {
-    if (!opencodeEnrollment) return;
-    opencodeEnrollmentDrawerRef.current?.focus();
-  }, [opencodeEnrollment?.profile.profile_id]);
+    if (!apiKeyEnrollment) return;
+    apiKeyEnrollmentDrawerRef.current?.focus();
+  }, [apiKeyEnrollment?.profile.profile_id]);
 
   useEffect(() => {
-    opencodeEnrollmentProfileIdRef.current = opencodeEnrollment?.profile.profile_id ?? null;
-  }, [opencodeEnrollment?.profile.profile_id]);
+    apiKeyEnrollmentProfileIdRef.current = apiKeyEnrollment?.profile.profile_id ?? null;
+  }, [apiKeyEnrollment?.profile.profile_id]);
 
   useEffect(() => {
-    if (!opencodeEnrollment) return;
+    if (!apiKeyEnrollment) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        closeOpencodeEnrollment();
+        closeApiKeyEnrollment();
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [opencodeEnrollment]);
+  }, [apiKeyEnrollment]);
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
@@ -1324,7 +1380,7 @@ export function ProviderProfilesManager({
           errorPayload,
           `Failed to ${isEditing ? 'update' : 'create'} provider profile.`,
         );
-        throw new Error(detail);
+        throw new ProviderProfileRequestError(detail, extractErrorCode(errorPayload));
       }
       return response.json() as Promise<ProviderProfile>;
     },
@@ -1337,6 +1393,7 @@ export function ProviderProfilesManager({
       });
       setEditingProfileId(null);
       setForm(defaultFormState(createFormRuntimeSeed));
+      setShowAdvancedOptions(false);
       queryClient.setQueryData<ProviderProfile[]>(
         PROVIDER_PROFILE_QUERY_KEY,
         (currentProfiles = []) => {
@@ -1364,6 +1421,19 @@ export function ProviderProfilesManager({
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
     },
     onError: (error: Error) => {
+      setShowAdvancedOptions(true);
+      if (
+        !isEditing &&
+        error instanceof ProviderProfileRequestError &&
+        error.code === 'provider_profile_creation_preset_version_mismatch'
+      ) {
+        setCreationPresetRefreshKey((current) => current + 1);
+        onNotice({
+          level: 'error',
+          text: 'The creation policy changed. Reloading the current preset for review.',
+        });
+        return;
+      }
       onNotice({ level: 'error', text: error.message });
     },
   });
@@ -1804,8 +1874,8 @@ export function ProviderProfilesManager({
                 const enableAllowed = mayEnableFromSettings(profile);
                 const claudeReadiness =
                   authModel.kind === 'claude_credentials' ? authModel.readiness : undefined;
-                const opencodeReadiness =
-                  authModel.kind === 'opencode_credentials' ? authModel.readiness : undefined;
+                const apiKeyReadiness =
+                  authModel.kind === 'api_key_credentials' ? authModel.readiness : undefined;
                 const hasStatusDetails = Boolean(
                   (activationLabel && activationLabel !== 'Connected') ||
                     profile.disabled_reason ||
@@ -1816,11 +1886,11 @@ export function ProviderProfilesManager({
                     claudeReadiness?.backingSecretExists !== undefined ||
                     claudeReadiness?.launchReady !== undefined ||
                     claudeReadiness?.failureReason ||
-                    opencodeReadiness?.connected !== undefined ||
-                    opencodeReadiness?.lastValidatedAt ||
-                    opencodeReadiness?.backingSecretExists !== undefined ||
-                    opencodeReadiness?.launchReady !== undefined ||
-                    opencodeReadiness?.failureReason,
+                    apiKeyReadiness?.connected !== undefined ||
+                    apiKeyReadiness?.lastValidatedAt ||
+                    apiKeyReadiness?.backingSecretExists !== undefined ||
+                    apiKeyReadiness?.launchReady !== undefined ||
+                    apiKeyReadiness?.failureReason,
                 );
                 return (
                 <tr key={profile.profile_id} role="row">
@@ -1988,7 +2058,7 @@ export function ProviderProfilesManager({
                           {authModel.statusLabel}
                         </div>
                       ) : null}
-                      {authModel.kind === 'opencode_credentials' && authModel.statusLabel ? (
+                      {authModel.kind === 'api_key_credentials' && authModel.statusLabel ? (
                         <div className="text-xs font-medium text-slate-600 dark:text-slate-400">
                           {authModel.statusLabel}
                         </div>
@@ -2068,27 +2138,27 @@ export function ProviderProfilesManager({
                                 Failure: {redactClaudeSecretText(authModel.readiness.failureReason)}
                               </div>
                             ) : null}
-                            {authModel.kind === 'opencode_credentials' && authModel.readiness?.connected !== undefined ? (
+                            {authModel.kind === 'api_key_credentials' && authModel.readiness?.connected !== undefined ? (
                               <div className="text-xs text-slate-500 dark:text-slate-400">
-                                OpenCode connection: {authModel.readiness.connected ? 'Connected' : 'Not connected'}
+                                {authModel.providerLabel} connection: {authModel.readiness.connected ? 'Connected' : 'Not connected'}
                               </div>
                             ) : null}
-                            {authModel.kind === 'opencode_credentials' && authModel.readiness?.lastValidatedAt ? (
+                            {authModel.kind === 'api_key_credentials' && authModel.readiness?.lastValidatedAt ? (
                               <div className="text-xs text-slate-500 dark:text-slate-400">
                                 Last validated: {authModel.readiness.lastValidatedAt}
                               </div>
                             ) : null}
-                            {authModel.kind === 'opencode_credentials' && authModel.readiness?.backingSecretExists !== undefined ? (
+                            {authModel.kind === 'api_key_credentials' && authModel.readiness?.backingSecretExists !== undefined ? (
                               <div className="text-xs text-slate-500 dark:text-slate-400">
                                 Backing secret: {authModel.readiness.backingSecretExists ? 'Present' : 'Missing'}
                               </div>
                             ) : null}
-                            {authModel.kind === 'opencode_credentials' && authModel.readiness?.launchReady !== undefined ? (
+                            {authModel.kind === 'api_key_credentials' && authModel.readiness?.launchReady !== undefined ? (
                               <div className="text-xs text-slate-500 dark:text-slate-400">
                                 Launch readiness: {authModel.readiness.launchReady ? 'Ready' : 'Not ready'}
                               </div>
                             ) : null}
-                            {authModel.kind === 'opencode_credentials' && authModel.readiness?.failureReason ? (
+                            {authModel.kind === 'api_key_credentials' && authModel.readiness?.failureReason ? (
                               <div className="text-xs text-rose-600 dark:text-rose-400">
                                 Failure: {redactClaudeSecretText(authModel.readiness.failureReason)}
                               </div>
@@ -2145,7 +2215,7 @@ export function ProviderProfilesManager({
                             </button>
                           ))
                         : null}
-                      {canWriteProviderProfiles && authModel.kind === 'opencode_credentials'
+                      {canWriteProviderProfiles && authModel.kind === 'api_key_credentials'
                         ? authModel.actions.map((action) => (
                             <button
                               key={action.id}
@@ -2153,11 +2223,11 @@ export function ProviderProfilesManager({
                               className="rounded-full border border-emerald-300 dark:border-emerald-700 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 transition hover:border-emerald-500 dark:hover:border-emerald-500"
                               onClick={() => {
                                 if (action.id === 'use_api_key') {
-                                  openOpencodeEnrollment(profile);
+                                  openApiKeyEnrollment(profile);
                                   return;
                                 }
                               }}
-                              disabled={opencodeEnrollmentMutation.isPending}
+                              disabled={apiKeyEnrollmentMutation.isPending}
                               aria-label={`${action.label} ${profile.profile_id}`}
                             >
                               {action.label}
@@ -2220,6 +2290,7 @@ export function ProviderProfilesManager({
                             onClick={() => {
                               setEditingProfileId(profile.profile_id);
                               setForm(toFormState(profile));
+                              setShowAdvancedOptions(true);
                               onNotice(null);
                             }}
                           >
@@ -2480,17 +2551,17 @@ export function ProviderProfilesManager({
         </div>
       ) : null}
 
-      {opencodeEnrollment ? (
+      {apiKeyEnrollment ? (
         <div
           className="fixed inset-0 z-50 flex justify-end bg-slate-950/40"
           onMouseDown={(event) => {
             if (event.target === event.currentTarget) {
-              closeOpencodeEnrollment();
+              closeApiKeyEnrollment();
             }
           }}
         >
           <div
-            ref={opencodeEnrollmentDrawerRef}
+            ref={apiKeyEnrollmentDrawerRef}
             role="dialog"
             aria-modal="true"
             aria-labelledby="opencode-enrollment-title"
@@ -2503,27 +2574,27 @@ export function ProviderProfilesManager({
                 id="opencode-enrollment-title"
                 className="text-base font-semibold text-slate-900 dark:text-white"
               >
-                OpenCode API key enrollment for {opencodeEnrollment.profile.profile_id}
+                {providerApiKeyLabel(apiKeyEnrollment.profile)} API key enrollment for {apiKeyEnrollment.profile.profile_id}
               </h4>
               <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
-                Use an OpenCode Go API key for OpenCode launches. Paste the key here, then validate and save it as a managed provider credential.
+                Use a {providerApiKeyLabel(apiKeyEnrollment.profile)} API key for {formatRuntimeLabel(apiKeyEnrollment.profile.runtime_id)} launches. Paste the key here, then validate and save it as a managed provider credential.
               </p>
             </div>
             <button
               type="button"
               className="inline-flex items-center justify-center rounded-lg border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-300 transition hover:border-slate-400 dark:hover:border-slate-500"
-              onClick={closeOpencodeEnrollment}
+              onClick={closeApiKeyEnrollment}
             >
               Cancel API key enrollment
             </button>
           </div>
 
-          <div className="mt-4 flex flex-wrap gap-2" aria-label="OpenCode enrollment lifecycle states">
+          <div className="mt-4 flex flex-wrap gap-2" aria-label={`${providerApiKeyLabel(apiKeyEnrollment.profile)} enrollment lifecycle states`}>
             {CLAUDE_ENROLLMENT_STEPS.map((step) => (
               <span
                 key={step}
                 className={`rounded-full px-2.5 py-1 font-mono text-xs ${
-                  step === opencodeEnrollment.step
+                  step === apiKeyEnrollment.step
                     ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
                     : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
                 }`}
@@ -2533,64 +2604,64 @@ export function ProviderProfilesManager({
             ))}
           </div>
 
-          {opencodeEnrollment.step === 'not_connected' ? (
+          {apiKeyEnrollment.step === 'not_connected' ? (
             <div className="mt-5 space-y-4">
               <div className="rounded-xl border border-slate-200 dark:border-slate-800 p-4 text-sm text-slate-700 dark:text-slate-300">
-                Continue when you are ready to paste the OpenCode API key. This path stores the key in Managed Secrets and does not create an OAuth terminal session.
+                Continue when you are ready to paste the {providerApiKeyLabel(apiKeyEnrollment.profile)} API key. This path stores the key in Managed Secrets and does not create an OAuth terminal session.
               </div>
               <button
                 type="button"
                 className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 transition hover:bg-slate-800 dark:hover:bg-slate-200"
-                onClick={continueOpencodeEnrollment}
+                onClick={continueApiKeyEnrollment}
               >
                 Continue to API key paste
               </button>
             </div>
           ) : null}
 
-          {opencodeEnrollment.step === 'awaiting_token_paste' ? (
+          {apiKeyEnrollment.step === 'awaiting_token_paste' ? (
             <div className="mt-5 space-y-4">
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>OpenCode API key</span>
+                <span>{providerApiKeyLabel(apiKeyEnrollment.profile)} API key</span>
                 <input
                   type="password"
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={opencodeEnrollment.token}
-                  onChange={(event) => updateOpencodeEnrollmentToken(event.target.value)}
+                  value={apiKeyEnrollment.token}
+                  onChange={(event) => updateApiKeyEnrollmentToken(event.target.value)}
                   autoComplete="off"
                 />
               </label>
               <button
                 type="button"
                 className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900 transition hover:bg-slate-800 dark:hover:bg-slate-200"
-                onClick={() => void submitOpencodeEnrollment()}
+                onClick={() => void submitApiKeyEnrollment()}
               >
-                Validate and save OpenCode API key
+                Validate and save {providerApiKeyLabel(apiKeyEnrollment.profile)} API key
               </button>
             </div>
           ) : null}
 
-          {['validating_token', 'saving_secret', 'updating_profile'].includes(opencodeEnrollment.step) ? (
+          {['validating_token', 'saving_secret', 'updating_profile'].includes(apiKeyEnrollment.step) ? (
             <div className="mt-5 rounded-xl border border-sky-200 dark:border-sky-900/60 bg-sky-50 dark:bg-sky-950/30 p-4 text-sm font-medium text-sky-800 dark:text-sky-300">
-              Processing OpenCode API key enrollment: {formatStatusLabel(opencodeEnrollment.step)}
+              Processing {providerApiKeyLabel(apiKeyEnrollment.profile)} API key enrollment: {formatStatusLabel(apiKeyEnrollment.step)}
             </div>
           ) : null}
 
-          {opencodeEnrollment.step === 'ready' ? (
+          {apiKeyEnrollment.step === 'ready' ? (
             <div className="mt-5 rounded-xl border border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-950/30 p-4 text-sm font-medium text-emerald-800 dark:text-emerald-300">
-              {formatStatusLabel(opencodeEnrollment.statusLabel ?? 'OpenCode API key ready')}
+              {formatStatusLabel(apiKeyEnrollment.statusLabel ?? `${providerApiKeyLabel(apiKeyEnrollment.profile)} API key ready`)}
             </div>
           ) : null}
 
-          {opencodeEnrollment.step === 'failed' ? (
+          {apiKeyEnrollment.step === 'failed' ? (
             <div className="mt-5 space-y-4">
               <div className="rounded-xl border border-rose-200 dark:border-rose-900/60 bg-rose-50 dark:bg-rose-950/30 p-4 text-sm font-medium text-rose-700 dark:text-rose-300">
-                {opencodeEnrollment.failureReason ?? 'OpenCode API key validation failed.'}
+                {apiKeyEnrollment.failureReason ?? `${providerApiKeyLabel(apiKeyEnrollment.profile)} API key validation failed.`}
               </div>
               <button
                 type="button"
                 className="inline-flex items-center justify-center rounded-lg border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 transition hover:border-slate-400 dark:hover:border-slate-500"
-                onClick={continueOpencodeEnrollment}
+                onClick={continueApiKeyEnrollment}
               >
                 Return to API key paste
               </button>
@@ -2710,7 +2781,7 @@ export function ProviderProfilesManager({
               </label>
               {!isEditing ? (
                 <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                  <span>Authentication method <span className="text-amber-600 dark:text-amber-400">*</span></span>
+                  <span>Authentication method</span>
                   <select
                     className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
                     value={form.authenticationMethod}
@@ -2729,61 +2800,24 @@ export function ProviderProfilesManager({
                     <option value="none">No credentials</option>
                   </select>
                   <p className="text-xs text-slate-400 dark:text-slate-500">
-                    Selects the backend-owned credential and launch strategy.
+                    Choose a guided setup method, or leave blank to create an expert manual profile.
                   </p>
                 </label>
               ) : null}
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Credential source</span>
-                <select
+                <span>Account label</span>
+                <input
                   className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={form.credentialSource}
-                  disabled={!isEditing && !presetField('credential_source')?.editable}
+                  value={form.accountLabel}
                   onChange={(event) =>
                     setForm((current) => ({
                       ...current,
-                      credentialSource: event.target.value,
+                      accountLabel: event.target.value,
                     }))
                   }
-                >
-                  <option value="">Backend-derived</option>
-                  <option value="secret_ref">secret_ref</option>
-                  <option value="oauth_volume">oauth_volume</option>
-                  <option value="none">none</option>
-                </select>
-                <p className="text-xs text-slate-400 dark:text-slate-500">
-                  {isEditing
-                    ? 'Saved launch-contract value.'
-                    : presetField('credential_source')?.lock_reason ??
-                      'Choose an authentication method to derive this value.'}
-                </p>
-              </label>
-              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Materialization mode</span>
-                <select
-                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={form.runtimeMaterializationMode}
-                  disabled={!isEditing && !presetField('runtime_materialization_mode')?.editable}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      runtimeMaterializationMode: event.target.value,
-                    }))
-                  }
-                >
-                  <option value="">Backend-derived</option>
-                  <option value="api_key_env">api_key_env</option>
-                  <option value="env_bundle">env_bundle</option>
-                  <option value="config_bundle">config_bundle</option>
-                  <option value="composite">composite</option>
-                  <option value="oauth_home">oauth_home</option>
-                </select>
-                <p className="text-xs text-slate-400 dark:text-slate-500">
-                  {isEditing
-                    ? 'Saved launch-contract value.'
-                    : presetField('runtime_materialization_mode')?.lock_reason ??
-                      'Choose an authentication method to derive this value.'}
-                </p>
+                  placeholder="team-default"
+                />
+                <p className="text-xs text-slate-400 dark:text-slate-500">Optional friendly account name</p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                 <span>Default model</span>
@@ -2823,6 +2857,7 @@ export function ProviderProfilesManager({
               </label>
               <div className="flex gap-4 items-start xl:col-span-1">
                 {isEditing ? (
+                  <>
                   <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
                     <input
                       type="checkbox"
@@ -2833,25 +2868,26 @@ export function ProviderProfilesManager({
                     />
                     Enabled
                   </label>
+                  <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
+                    <input
+                      type="checkbox"
+                      checked={form.isDefault}
+                      onChange={(event) =>
+                        setForm((current) => ({ ...current, isDefault: event.target.checked }))
+                      }
+                    />
+                    Runtime default
+                  </label>
+                  </>
                 ) : null}
-                <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 flex-1">
-                  <input
-                    type="checkbox"
-                    checked={form.isDefault}
-                    onChange={(event) =>
-                      setForm((current) => ({ ...current, isDefault: event.target.checked }))
-                    }
-                  />
-                  Runtime default
-                </label>
               </div>
             </div>
           </fieldset>
 
-          {/* ── Runtime Limits (have smart defaults) ── */}
+          {/* ── Standard runtime capacity ── */}
           <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
             <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
-              Runtime Limits <span className="font-normal text-slate-500 dark:text-slate-400">&mdash; defaults provided</span>
+              Runtime capacity <span className="font-normal text-slate-500 dark:text-slate-400">&mdash; defaults provided</span>
             </legend>
             <div className="grid gap-4 md:grid-cols-3">
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2882,6 +2918,116 @@ export function ProviderProfilesManager({
                         : 'Loaded from the backend creation preset.'}
                 </p>
               </label>
+            </div>
+          </fieldset>
+
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-4">
+            <label className="flex items-start gap-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={showAdvancedOptions}
+                aria-controls="provider-profile-advanced-options"
+                aria-expanded={showAdvancedOptions}
+                onChange={(event) => setShowAdvancedOptions(event.target.checked)}
+              />
+              <span>
+                Show advanced options
+                <span className="mt-1 block text-xs font-normal text-slate-500 dark:text-slate-400">
+                  Credential bindings, volumes, rate limits, routing, and launch shaping
+                </span>
+                {!showAdvancedOptions ? (
+                  <span className="mt-1 block text-xs font-normal text-slate-500 dark:text-slate-400">
+                    {creationPreset?.supported
+                      ? 'Using backend-recommended launch settings.'
+                      : 'Advanced draft values are preserved while collapsed.'}
+                  </span>
+                ) : null}
+              </span>
+            </label>
+          </div>
+
+          {showAdvancedOptions ? (
+          <div id="provider-profile-advanced-options" className="space-y-6">
+          {/* ── Backend launch strategy ── */}
+          <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
+            <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Launch strategy <span className="font-normal text-slate-500 dark:text-slate-400">&mdash; expert controls</span>
+            </legend>
+            {manualCreationAllowed ? (
+              <p className="text-sm text-amber-700 dark:text-amber-300">
+                This combination has no standard preset. Supply the required manual launch fields before creating the profile.
+              </p>
+            ) : null}
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Credential source</span>
+                <select
+                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
+                  value={form.credentialSource}
+                  disabled={
+                    !isEditing &&
+                    creationPreset?.supported === true &&
+                    presetField('credential_source')?.editable === false
+                  }
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      credentialSource: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="">Backend-derived</option>
+                  <option value="secret_ref">secret_ref</option>
+                  <option value="oauth_volume">oauth_volume</option>
+                  <option value="none">none</option>
+                </select>
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  {isEditing || manualCreationAllowed || !form.authenticationMethod
+                    ? 'Explicit manual launch-contract value.'
+                    : presetField('credential_source')?.lock_reason ??
+                      'Choose an authentication method to derive this value.'}
+                </p>
+              </label>
+              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                <span>Materialization mode</span>
+                <select
+                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
+                  value={form.runtimeMaterializationMode}
+                  disabled={
+                    !isEditing &&
+                    creationPreset?.supported === true &&
+                    presetField('runtime_materialization_mode')?.editable === false
+                  }
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      runtimeMaterializationMode: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="">Backend-derived</option>
+                  <option value="api_key_env">api_key_env</option>
+                  <option value="env_bundle">env_bundle</option>
+                  <option value="config_bundle">config_bundle</option>
+                  <option value="composite">composite</option>
+                  <option value="oauth_home">oauth_home</option>
+                </select>
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  {isEditing || manualCreationAllowed || !form.authenticationMethod
+                    ? 'Explicit manual launch-contract value.'
+                    : presetField('runtime_materialization_mode')?.lock_reason ??
+                      'Choose an authentication method to derive this value.'}
+                </p>
+              </label>
+            </div>
+          </fieldset>
+
+          {/* ── Advanced rate-limit policy ── */}
+          <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
+            <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Rate limits <span className="font-normal text-slate-500 dark:text-slate-400">&mdash; defaults provided</span>
+            </legend>
+            <div className="grid gap-4 md:grid-cols-2">
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                 <span>Cooldown after 429 (seconds)</span>
                 <input
@@ -2901,7 +3047,7 @@ export function ProviderProfilesManager({
                     ? 'Saved rate-limit value.'
                     : presetField('cooldown_after_429_seconds')
                       ? `Recommended by ${presetField('cooldown_after_429_seconds')?.source}.`
-                      : 'Loaded from the backend creation preset.'}
+                      : 'Optional manual override.'}
                 </p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -2926,7 +3072,7 @@ export function ProviderProfilesManager({
                     ? 'Saved rate-limit policy.'
                     : presetField('rate_limit_policy')
                       ? `Recommended by ${presetField('rate_limit_policy')?.source}.`
-                      : 'Loaded from the backend creation preset.'}
+                      : 'Optional manual override.'}
                 </p>
               </label>
             </div>
@@ -3058,20 +3204,6 @@ export function ProviderProfilesManager({
                   placeholder="100"
                 />
               </label>
-              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Account label</span>
-                <input
-                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={form.accountLabel}
-                  onChange={(event) =>
-                    setForm((current) => ({
-                      ...current,
-                      accountLabel: event.target.value,
-                    }))
-                  }
-                  placeholder="team-default"
-                />
-              </label>
             </div>
             <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
               <span>Clear env keys</span>
@@ -3091,6 +3223,8 @@ export function ProviderProfilesManager({
               <p className="text-xs text-slate-400 dark:text-slate-500">One key per line</p>
             </label>
           </fieldset>
+          </div>
+          ) : null}
 
           <div className="flex flex-wrap gap-3">
             <button
@@ -3100,7 +3234,8 @@ export function ProviderProfilesManager({
                 saveMutation.isPending ||
                 (!isEditing &&
                   Boolean(form.authenticationMethod) &&
-                  (creationPresetLoading || !creationPreset?.supported))
+                  (creationPresetLoading ||
+                    (!creationPreset?.supported && !manualCreationAllowed)))
               }
             >
               {saveMutation.isPending

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -824,6 +824,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/provider-profiles/creation-preset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Creation Preset
+         * @description Preview the versioned backend policy used by standard profile creation.
+         */
+        get: operations["get_creation_preset_api_v1_provider_profiles_creation_preset_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/provider-profiles/{profile_id}": {
         parameters: {
             query?: never;
@@ -11042,6 +11062,11 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /**
+         * ProviderProfileAuthenticationMethod
+         * @enum {string}
+         */
+        ProviderProfileAuthenticationMethod: "oauth" | "api_key" | "none";
         /** ProviderProfileCreate */
         ProviderProfileCreate: {
             /** Profile Id */
@@ -11067,10 +11092,13 @@ export interface components {
             model_overrides?: {
                 [key: string]: string;
             } | null;
+            authentication_method?: components["schemas"]["ProviderProfileAuthenticationMethod"] | null;
+            /** Preset Version */
+            preset_version?: string | null;
             /** Credential Source */
-            credential_source: string;
+            credential_source?: string | null;
             /** Runtime Materialization Mode */
-            runtime_materialization_mode: string;
+            runtime_materialization_mode?: string | null;
             /** Volume Ref */
             volume_ref?: string | null;
             /** Volume Mount Path */
@@ -11079,11 +11107,8 @@ export interface components {
             account_label?: string | null;
             /** Tags */
             tags?: string[] | null;
-            /**
-             * Priority
-             * @default 100
-             */
-            priority: number;
+            /** Priority */
+            priority?: number | null;
             /** Secret Refs */
             secret_refs?: {
                 [key: string]: string;
@@ -11106,52 +11131,79 @@ export interface components {
             command_behavior?: {
                 [key: string]: unknown;
             } | null;
-            /**
-             * Max Parallel Runs
-             * @default 1
-             */
-            max_parallel_runs: number;
-            /**
-             * Cooldown After 429 Seconds
-             * @default 900
-             */
-            cooldown_after_429_seconds: number;
-            /**
-             * Rate Limit Policy
-             * @default backoff
-             */
-            rate_limit_policy: string;
-            /**
-             * Enabled
-             * @default false
-             */
-            enabled: boolean;
-            /**
-             * Is Default
-             * @default false
-             */
-            is_default: boolean;
-            /**
-             * Max Lease Duration Seconds
-             * @default 7200
-             */
-            max_lease_duration_seconds: number;
-            /**
-             * Auth State
-             * @default not_configured
-             */
-            auth_state: string;
-            /**
-             * Disabled Reason
-             * @default missing_credentials
-             */
-            disabled_reason: string | null;
+            /** Max Parallel Runs */
+            max_parallel_runs?: number | null;
+            /** Cooldown After 429 Seconds */
+            cooldown_after_429_seconds?: number | null;
+            /** Rate Limit Policy */
+            rate_limit_policy?: string | null;
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Is Default */
+            is_default?: boolean | null;
+            /** Max Lease Duration Seconds */
+            max_lease_duration_seconds?: number | null;
+            /** Auth State */
+            auth_state?: string | null;
+            /** Disabled Reason */
+            disabled_reason?: string | null;
             /** First Authenticated At */
             first_authenticated_at?: string | null;
             /** Last Validated At */
             last_validated_at?: string | null;
             /** Last Auth Method */
             last_auth_method?: string | null;
+        };
+        /** ProviderProfileCreationPresetDiagnostic */
+        ProviderProfileCreationPresetDiagnostic: {
+            /** Code */
+            code: string;
+            /** Severity */
+            severity: string;
+            /** Message */
+            message: string;
+            /** Field */
+            field?: string | null;
+            /** Action */
+            action?: string | null;
+        };
+        /** ProviderProfileCreationPresetField */
+        ProviderProfileCreationPresetField: {
+            /** Value */
+            value: unknown;
+            /** Source */
+            source: string;
+            /** Editable */
+            editable: boolean;
+            /** Required */
+            required: boolean;
+            /** Lock Reason */
+            lock_reason?: string | null;
+        };
+        /** ProviderProfileCreationPresetResponse */
+        ProviderProfileCreationPresetResponse: {
+            /** Version */
+            version: string;
+            /** Supported */
+            supported: boolean;
+            /** Runtime Id */
+            runtime_id: string;
+            /** Provider Id */
+            provider_id: string;
+            authentication_method: components["schemas"]["ProviderProfileAuthenticationMethod"];
+            /** Fields */
+            fields: {
+                [key: string]: components["schemas"]["ProviderProfileCreationPresetField"];
+            };
+            /** Diagnostics */
+            diagnostics: components["schemas"]["ProviderProfileCreationPresetDiagnostic"][];
+            /**
+             * Manual Creation Allowed
+             * @default false
+             */
+            manual_creation_allowed: boolean;
+            /** Required Manual Fields */
+            required_manual_fields?: string[];
         };
         /** ProviderProfilePolicy */
         ProviderProfilePolicy: {
@@ -16063,6 +16115,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProviderProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_creation_preset_api_v1_provider_profiles_creation_preset_get: {
+        parameters: {
+            query: {
+                runtime_id: string;
+                provider_id: string;
+                authentication_method: components["schemas"]["ProviderProfileAuthenticationMethod"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderProfileCreationPresetResponse"];
                 };
             };
             /** @description Validation Error */

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -673,17 +673,17 @@ async def test_create_codex_oauth_profile_requires_volume_ref_and_mount_path(
         "materialization_mode",
     ),
     [
-        ("codex_cli", "openai", "oauth", "oauth_volume", "oauth_home"),
-        ("codex_cli", "openai", "api_key", "secret_ref", "api_key_env"),
-        ("claude_code", "anthropic", "oauth", "oauth_volume", "oauth_home"),
+        ("codex_cli", "openai", "oauth", "none", "oauth_home"),
+        ("codex_cli", "openai", "api_key", "none", "api_key_env"),
+        ("claude_code", "anthropic", "oauth", "none", "oauth_home"),
         (
             "claude_code",
             "anthropic",
             "api_key",
-            "secret_ref",
+            "none",
             "api_key_env",
         ),
-        ("opencode", "opencode", "api_key", "secret_ref", "composite"),
+        ("opencode", "opencode", "api_key", "none", "composite"),
     ],
 )
 async def test_creation_preset_conformance_matrix(
@@ -734,6 +734,8 @@ async def test_creation_preset_conformance_matrix(
         "clear_env_keys",
         "enabled",
         "auth_state",
+        "first_authenticated_at",
+        "last_validated_at",
         "may_become_runtime_default",
     ):
         assert required_metadata == set(payload["fields"][field_name])
@@ -811,7 +813,7 @@ async def test_create_applies_preset_to_omitted_advanced_fields_atomically(
 
     assert response.status_code == 201
     payload = response.json()
-    assert payload["credential_source"] == "secret_ref"
+    assert payload["credential_source"] == "none"
     assert payload["runtime_materialization_mode"] == "api_key_env"
     assert payload["max_parallel_runs"] == 1
     assert payload["cooldown_after_429_seconds"] == 300
@@ -896,7 +898,7 @@ async def test_create_rejects_locked_preset_override_before_persistence(
                 "provider_id": "openai",
                 "authentication_method": "api_key",
                 "preset_version": preset["version"],
-                "credential_source": "none",
+                "credential_source": "secret_ref",
             },
         )
 
@@ -904,8 +906,8 @@ async def test_create_rejects_locked_preset_override_before_persistence(
     detail = response.json()["detail"]
     assert detail["code"] == "provider_profile_creation_preset_field_locked"
     assert detail["field"] == "credential_source"
-    assert detail["expected_value"] == "secret_ref"
-    assert "selected authentication method" in detail["lock_reason"]
+    assert detail["expected_value"] == "none"
+    assert "validated credential setup" in detail["lock_reason"]
     async with db_base.async_session_maker() as session:
         assert await session.get(ManagedAgentProviderProfile, profile_id) is None
 
@@ -935,6 +937,88 @@ async def test_create_rejects_stale_preset_before_persistence(
     assert detail["current_version"].startswith("provider-profile-create-v1-")
     async with db_base.async_session_maker() as session:
         assert await session.get(ManagedAgentProviderProfile, profile_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timestamp_field",
+    ["first_authenticated_at", "last_validated_at"],
+)
+async def test_create_rejects_guided_authentication_history_override(
+    client_app: AsyncClient,
+    _module_db,
+    timestamp_field: str,
+) -> None:
+    profile_id = f"preset-auth-history-{timestamp_field}-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "codex_cli",
+                    "provider_id": "openai",
+                    "authentication_method": "api_key",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+                timestamp_field: "2026-08-30T20:00:00Z",
+            },
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_creation_preset_field_locked"
+    assert detail["field"] == timestamp_field
+    assert detail["expected_value"] is None
+    async with db_base.async_session_maker() as session:
+        assert await session.get(ManagedAgentProviderProfile, profile_id) is None
+
+
+@pytest.mark.asyncio
+async def test_create_guided_profile_persists_preset_normalized_identity(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"preset-normalized-identity-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "codex_cli",
+                    "provider_id": "openai",
+                    "authentication_method": "api_key",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": " codex_cli ",
+                "provider_id": " openai ",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["runtime_id"] == "codex_cli"
+    assert payload["provider_id"] == "openai"
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert row is not None
+        assert row.runtime_id == "codex_cli"
+        assert row.provider_id == "openai"
 
 
 @pytest.mark.asyncio
@@ -1005,7 +1089,7 @@ async def test_create_guided_oauth_profile_is_disabled_until_enrollment(
 
     assert response.status_code == 201
     payload = response.json()
-    assert payload["credential_source"] == "oauth_volume"
+    assert payload["credential_source"] == "none"
     assert payload["runtime_materialization_mode"] == "oauth_home"
     assert payload["volume_ref"] is None
     assert payload["volume_mount_path"] is None

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -662,6 +662,358 @@ async def test_create_codex_oauth_profile_requires_volume_ref_and_mount_path(
     assert "volume_ref is required" in response.text
     assert "volume_mount_path is required" in response.text
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "runtime_id",
+        "provider_id",
+        "authentication_method",
+        "credential_source",
+        "materialization_mode",
+    ),
+    [
+        ("codex_cli", "openai", "oauth", "oauth_volume", "oauth_home"),
+        ("codex_cli", "openai", "api_key", "secret_ref", "api_key_env"),
+        ("claude_code", "anthropic", "oauth", "oauth_volume", "oauth_home"),
+        (
+            "claude_code",
+            "anthropic",
+            "api_key",
+            "secret_ref",
+            "api_key_env",
+        ),
+        ("opencode", "opencode", "api_key", "secret_ref", "composite"),
+    ],
+)
+async def test_creation_preset_conformance_matrix(
+    client_app: AsyncClient,
+    _module_db,
+    runtime_id: str,
+    provider_id: str,
+    authentication_method: str,
+    credential_source: str,
+    materialization_mode: str,
+) -> None:
+    async with client_app as client:
+        response = await client.get(
+            "/api/v1/provider-profiles/creation-preset",
+            params={
+                "runtime_id": runtime_id,
+                "provider_id": provider_id,
+                "authentication_method": authentication_method,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["supported"] is True
+    assert payload["version"].startswith("provider-profile-create-v1-")
+    assert payload["runtime_id"] == runtime_id
+    assert payload["provider_id"] == provider_id
+    assert payload["authentication_method"] == authentication_method
+    assert payload["fields"]["credential_source"]["value"] == credential_source
+    assert (
+        payload["fields"]["runtime_materialization_mode"]["value"]
+        == materialization_mode
+    )
+    required_metadata = {"value", "source", "editable", "required", "lock_reason"}
+    for field_name in (
+        "credential_source",
+        "runtime_materialization_mode",
+        "max_parallel_runs",
+        "cooldown_after_429_seconds",
+        "rate_limit_policy",
+        "priority",
+        "user_tags",
+        "system_tags",
+        "volume_ref",
+        "volume_mount_path",
+        "secret_ref_roles",
+        "command_behavior",
+        "clear_env_keys",
+        "enabled",
+        "auth_state",
+        "may_become_runtime_default",
+    ):
+        assert required_metadata == set(payload["fields"][field_name])
+    assert payload["fields"]["enabled"]["value"] is False
+    assert payload["fields"]["enabled"]["editable"] is False
+    assert payload["diagnostics"][0]["code"] == "credential_setup_required"
+
+
+@pytest.mark.asyncio
+async def test_creation_preset_reports_actionable_unsupported_combination(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    async with client_app as client:
+        response = await client.get(
+            "/api/v1/provider-profiles/creation-preset",
+            params={
+                "runtime_id": "custom_runtime",
+                "provider_id": "custom_provider",
+                "authentication_method": "api_key",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["supported"] is False
+    assert payload["manual_creation_allowed"] is True
+    assert payload["required_manual_fields"] == [
+        "credential_source",
+        "runtime_materialization_mode",
+        "clear_env_keys",
+        "command_behavior",
+    ]
+    assert payload["diagnostics"] == [
+        {
+            "code": "no_safe_standard_creation_preset",
+            "severity": "error",
+            "message": (
+                "No validated standard creation preset exists for this runtime, "
+                "provider, and authentication method. Use the authorized manual "
+                "profile path and supply every required launch field."
+            ),
+            "field": None,
+            "action": "open_manual_profile",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_applies_preset_to_omitted_advanced_fields_atomically(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"preset-omission-{uuid4().hex}"
+    async with client_app as client:
+        preset_response = await client.get(
+            "/api/v1/provider-profiles/creation-preset",
+            params={
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "api_key",
+            },
+        )
+        preset = preset_response.json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["credential_source"] == "secret_ref"
+    assert payload["runtime_materialization_mode"] == "api_key_env"
+    assert payload["max_parallel_runs"] == 1
+    assert payload["cooldown_after_429_seconds"] == 300
+    assert payload["rate_limit_policy"] == "backoff"
+    assert payload["priority"] == 100
+    assert payload["tags"] == ["api-key", "first-party"]
+    assert payload["secret_refs"] == {}
+    assert payload["env_template"] == {
+        "OPENAI_API_KEY": {"from_secret_ref": "openai_api_key"}
+    }
+    assert "MINIMAX_API_KEY" in payload["clear_env_keys"]
+    assert payload["command_behavior"]["auth_strategy"] == "api_key_env"
+    assert payload["enabled"] is False
+    assert payload["auth_state"] == "not_configured"
+    assert payload["disabled_reason"] == "missing_credentials"
+    assert payload["launch_ready"] is False
+    assert payload["is_default"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_editable_preset_override_and_preserves_system_tags(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"preset-override-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "claude_code",
+                    "provider_id": "anthropic",
+                    "authentication_method": "api_key",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "claude_code",
+                "provider_id": "anthropic",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+                "max_parallel_runs": 3,
+                "cooldown_after_429_seconds": 42,
+                "rate_limit_policy": "queue",
+                "tags": ["team-a"],
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["max_parallel_runs"] == 3
+    assert payload["cooldown_after_429_seconds"] == 42
+    assert payload["rate_limit_policy"] == "queue"
+    assert payload["tags"] == ["api-key", "first-party", "team-a"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_locked_preset_override_before_persistence(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"locked-preset-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "codex_cli",
+                    "provider_id": "openai",
+                    "authentication_method": "api_key",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+                "credential_source": "none",
+            },
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_creation_preset_field_locked"
+    assert detail["field"] == "credential_source"
+    assert detail["expected_value"] == "secret_ref"
+    assert "selected authentication method" in detail["lock_reason"]
+    async with db_base.async_session_maker() as session:
+        assert await session.get(ManagedAgentProviderProfile, profile_id) is None
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_stale_preset_before_persistence(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"stale-preset-{uuid4().hex}"
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "api_key",
+                "preset_version": "stale-browser-version",
+            },
+        )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_creation_preset_version_mismatch"
+    assert detail["requested_version"] == "stale-browser-version"
+    assert detail["current_version"].startswith("provider-profile-create-v1-")
+    async with db_base.async_session_maker() as session:
+        assert await session.get(ManagedAgentProviderProfile, profile_id) is None
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unsupported_standard_combination_before_persistence(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"unsupported-preset-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "custom_runtime",
+                    "provider_id": "custom_provider",
+                    "authentication_method": "api_key",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "custom_runtime",
+                "provider_id": "custom_provider",
+                "authentication_method": "api_key",
+                "preset_version": preset["version"],
+            },
+        )
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["code"] == "provider_profile_creation_preset_unsupported"
+    assert detail["manual_creation_allowed"] is True
+    assert detail["required_manual_fields"]
+    async with db_base.async_session_maker() as session:
+        assert await session.get(ManagedAgentProviderProfile, profile_id) is None
+
+
+@pytest.mark.asyncio
+async def test_create_guided_oauth_profile_is_disabled_until_enrollment(
+    client_app: AsyncClient,
+    _module_db,
+) -> None:
+    profile_id = f"oauth-preset-{uuid4().hex}"
+    async with client_app as client:
+        preset = (
+            await client.get(
+                "/api/v1/provider-profiles/creation-preset",
+                params={
+                    "runtime_id": "codex_cli",
+                    "provider_id": "openai",
+                    "authentication_method": "oauth",
+                },
+            )
+        ).json()
+        response = await client.post(
+            "/api/v1/provider-profiles",
+            json={
+                "profile_id": profile_id,
+                "runtime_id": "codex_cli",
+                "provider_id": "openai",
+                "authentication_method": "oauth",
+                "preset_version": preset["version"],
+                "is_default": True,
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["credential_source"] == "oauth_volume"
+    assert payload["runtime_materialization_mode"] == "oauth_home"
+    assert payload["volume_ref"] is None
+    assert payload["volume_mount_path"] is None
+    assert payload["max_parallel_runs"] == 1
+    assert payload["enabled"] is False
+    assert payload["launch_ready"] is False
+    assert payload["is_default"] is False
+
 @pytest.mark.asyncio
 async def test_provider_profile_update_rejects_non_owner(
     client_app: AsyncClient, _module_db


### PR DESCRIPTION
Issue reference: MoonLadderStudios/MoonMind#3819

Closes MoonLadderStudios/MoonMind#3819

## Summary

- Add a typed, versioned backend creation-preset contract for runtime, provider, and authentication combinations.
- Apply preset-owned values atomically when advanced create fields are omitted, with stale-version, locked-field, unsupported-combination, readiness, activation, and runtime-default safeguards.
- Update the Provider Profile UI to consume generated OpenAPI types and backend-derived preset values, including advanced summaries and reset behavior.
- Add backend and frontend coverage for supported presets, omission, explicit overrides, stale identities, unsupported combinations, and credential readiness.

## Tests run

- Backend unit and focused hermetic integration: 89 passed.
- ProviderProfilesManager frontend unit suite: 57 passed.
- Frontend TypeScript typecheck: passed.
- Focused frontend ESLint: passed.
- Fresh OpenAPI generation comparison: passed.
- Repository diff and workspace hygiene checks: passed.

## Remaining risks

- The preset catalog is intentionally explicit for currently supported runtime/provider/authentication combinations; future integrations must add catalog policy and conformance coverage before standard creation is enabled.
- Verification was focused on the affected backend, integration, frontend, lint, type, and generated-contract surfaces rather than the full repository suite.