### PR TITLE
Fix Omnigent qualification drift

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -597,7 +597,7 @@ async def _reconcile_omnigent_bootstrap_once(
     )
     qualification_ready = (
         await _sync_omnigent_deployment_qualification()
-        if images_ready and catalog_ready and provider_ready
+        if images_ready and catalog_ready
         else False
     )
     return OmnigentBootstrapReadiness(
@@ -1412,12 +1412,12 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 "provider_id": "opencode",
                 "provider_label": "OpenCode Zen",
                 "default_model": "opencode/muse-spark-1.2-contributor-free",
-                "default_effort": None,
+                "default_effort": "xhigh",
                 "model_tiers": [
                     {
                         "label": "Muse Spark 1.2 Contributor Free",
                         "model": "opencode/muse-spark-1.2-contributor-free",
-                        "effort": None,
+                        "effort": "xhigh",
                         "parameters": {},
                         "annotations": {},
                     }
@@ -1454,12 +1454,12 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 "provider_id": "opencode",
                 "provider_label": "OpenCode Zen",
                 "default_model": "opencode/muse-spark-1.2-contributor-free",
-                "default_effort": None,
+                "default_effort": "xhigh",
                 "model_tiers": [
                     {
                         "label": "Muse Spark 1.2 Contributor Free",
                         "model": "opencode/muse-spark-1.2-contributor-free",
-                        "effort": None,
+                        "effort": "xhigh",
                         "parameters": {},
                         "annotations": {},
                     }

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -157,6 +157,7 @@ class BootstrapController:
         revalidation = await reconcile_opencode_provider_readiness(
             session_factory=self._session_factory,
             allow_enrollment=False,
+            profile_ids=(provider_profile_ref,),
         )
         if not revalidation.ready:
             raise ValueError(

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -293,6 +293,7 @@ async def reconcile_opencode_provider_readiness(
     *,
     session_factory: Any,
     allow_enrollment: bool = True,
+    profile_ids: Collection[str] | None = None,
     env: Mapping[str, Any] | None = None,
     controller: Any | None = None,
 ) -> ProviderReconcileOutcome:
@@ -311,6 +312,15 @@ async def reconcile_opencode_provider_readiness(
 
     image_ref = _pinned_image_ref()
     profiles = await _opencode_profiles(session_factory)
+    if profile_ids is not None:
+        selected_ids = {
+            str(profile_id).strip()
+            for profile_id in profile_ids
+            if str(profile_id).strip()
+        }
+        profiles = [
+            profile for profile in profiles if profile.profile_id in selected_ids
+        ]
     enrolled = [profile for profile in profiles if _has_enrolled_credential(profile)]
     # A disabled profile cannot launch, and re-validating it would neither help
     # nor honor the operator. Its credential still counts as enrolled above, so

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -600,3 +600,44 @@ async def test_provider_readiness_is_skipped_without_resolved_images(
     assert called is False
     assert outcome.provider_ready is False
     assert outcome.ready is False
+
+
+@pytest.mark.asyncio
+async def test_default_qualification_runs_when_an_unrelated_provider_is_unready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-default profile must not strand the default support combination."""
+
+    calls: list[str] = []
+
+    async def ready(*args, **kwargs) -> bool:
+        del args, kwargs
+        return True
+
+    async def provider(*, allow_enrollment: bool) -> bool:
+        assert allow_enrollment is True
+        calls.append("provider")
+        return False
+
+    async def qualification() -> bool:
+        calls.append("qualification")
+        return True
+
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_images", ready)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_policies", ready)
+    monkeypatch.setattr(api_main, "_sync_omnigent_bootstrap_agent_profile", ready)
+    monkeypatch.setattr(api_main, "_sync_omnigent_harness_catalog", ready)
+    monkeypatch.setattr(
+        api_main, "_sync_managed_bootstrap_recurring_schedules", ready
+    )
+    monkeypatch.setattr(api_main, "_sync_omnigent_provider_readiness", provider)
+    monkeypatch.setattr(
+        api_main, "_sync_omnigent_deployment_qualification", qualification
+    )
+
+    outcome = await api_main._reconcile_omnigent_bootstrap_once(refresh_images=False)
+
+    assert calls == ["provider", "qualification"]
+    assert outcome.provider_ready is False
+    assert outcome.qualification_ready is True
+    assert outcome.ready is False

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -192,12 +192,12 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
 
     zen_profile = next(p for p in profiles if p.profile_id == "opencode-zen-free")
     assert zen_profile.default_model == "opencode/muse-spark-1.2-contributor-free"
-    assert zen_profile.default_effort is None
+    assert zen_profile.default_effort == "xhigh"
     assert zen_profile.model_tiers == [
         {
             "label": "Muse Spark 1.2 Contributor Free",
             "model": "opencode/muse-spark-1.2-contributor-free",
-            "effort": None,
+            "effort": "xhigh",
             "parameters": {},
             "annotations": {},
         }
@@ -225,8 +225,8 @@ async def test_auto_seed_keeps_configured_zen_credential_validation_pending(
     assert profile.enabled is True
     assert profile.auth_state == ProviderProfileAuthState.API_KEY_PENDING
     assert profile.disabled_reason is None
-    assert profile.default_effort is None
-    assert profile.model_tiers[0]["effort"] is None
+    assert profile.default_effort == "xhigh"
+    assert profile.model_tiers[0]["effort"] == "xhigh"
     assert profile.model_catalog_evidence_json is None
     readiness = profile.command_behavior["auth_readiness"]
     assert readiness["connected"] is False

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -422,6 +422,7 @@ async def test_requalification_uses_the_current_provider_profile_model(
     revalidate.assert_awaited_once_with(
         session_factory=controller._session_factory,
         allow_enrollment=False,
+        profile_ids=("opencode-go-default",),
     )
 
 

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -469,6 +469,31 @@ async def test_current_evidence_is_left_untouched(
 
 
 @pytest.mark.asyncio
+async def test_targeted_revalidation_ignores_an_unrelated_stale_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default qualification must not inherit another profile's failure."""
+
+    _install_stubs(monkeypatch)
+    selected = _profile(
+        profile_id="opencode-zen-free",
+        evidence_image=CURRENT_IMAGE,
+    )
+    unrelated = _profile(
+        profile_id="opencode-go-default",
+        evidence_image=PREVIOUS_IMAGE,
+    )
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory([selected, unrelated]),
+        profile_ids=(selected.profile_id,),
+        controller=_Controller(),
+    )
+
+    assert outcome == ProviderReconcileOutcome(ready=True, checked=1)
+
+
+@pytest.mark.asyncio
 async def test_stale_host_image_evidence_is_revalidated_and_refreshed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Summary: Scope OpenCode readiness revalidation to the selected provider profile, allow default deployment qualification to proceed when an unrelated provider is unready, and persist the Zen contributor-free model with xhigh effort across startup seeding. Testing: six focused unit regressions passed; git diff --check passed.