### PR TITLE
Fix OpenCode Zen materializer qualification

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -516,12 +516,13 @@ async def _sync_omnigent_provider_readiness(*, allow_enrollment: bool) -> bool:
 
 
 async def _sync_omnigent_deployment_qualification() -> bool:
-    """Refresh signed execution evidence after managed default drift.
+    """Refresh signed execution evidence after managed authority drift.
 
     The built-in OpenCode Agent Profile is compiled from authenticated catalog
     inventory and can legitimately advance after a deployment refresh. Keep the
-    qualification bound to that new immutable profile instead of requiring an
-    operator to repeat a bootstrap action for an already-enrolled API key.
+    qualification entries bound to that new immutable profile for every
+    launch-ready materializer class instead of requiring an operator to change
+    the runtime default or repeat bootstrap for an already-enrolled API key.
     """
 
     try:

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -262,6 +262,13 @@ model against the exact pinned host and publishes the same deployment evidence
 required by key-backed profiles. An existing explicit operator disable remains
 authoritative.
 
+Deployment qualification is independent of runtime-default selection. MoonMind
+publishes one exact signed entry for each launch-ready OpenCode materializer
+class, so an explicitly selected Zen profile retains `none@1` evidence while an
+OpenCode Go default retains separate `opencode-auth-json@1` evidence. Changing
+the default does not invalidate another launch-ready class or transfer its
+credential authority.
+
 An optional OpenCode Go Provider Profile has the following effective shape:
 
 ```yaml
@@ -482,7 +489,10 @@ The default local deployment-qualification path instead binds the immutable
 runtime substrate and credential compatibility class. Per-run model/options
 and Required Capabilities are admitted independently through class admission,
 provider/runtime validation, and exact-host model attestation, so selecting a
-valid default Provider Profile does not require manual requalification.
+valid launch-ready Provider Profile does not require changing the runtime
+default or manual requalification. The deployment evidence publication retains
+one independently signed entry per launchable materializer class; entries are
+replaced only by a newly qualified entry for the same deployment-scoped class.
 
 ## 16. Migration and rollback
 

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -32,6 +32,21 @@ from moonmind.omnigent.harness_platform.support import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_profile_model_effort(profile: Any) -> tuple[str, str]:
+    """Resolve one Provider Profile through the canonical launch authority."""
+
+    from moonmind.workflows.executions.model_resolver import resolve_model_effort
+
+    resolved = resolve_model_effort(
+        runtime_id=str(getattr(profile, "runtime_id", None) or "opencode"),
+        profile=profile,
+        require_launch_ready=False,
+    )
+    model = str(resolved.model or "").strip()
+    effort = validate_effort(str(resolved.effort or "xhigh").strip())
+    return model, effort
+
+
 class BootstrapController:
     """Idempotent controller driven by desired state."""
 
@@ -179,12 +194,11 @@ class BootstrapController:
         if provider_profile is None:
             raise ValueError("the persisted OpenCode Provider Profile no longer exists")
         desired_updates: dict[str, Any] = {}
-        current_model = str(provider_profile.default_model or "").strip()
+        current_model, current_effort = _resolve_profile_model_effort(provider_profile)
         if current_model:
             desired_updates["model_display_name"] = current_model
-        current_effort = str(provider_profile.default_effort or "").strip()
         if current_effort:
-            desired_updates["effort"] = validate_effort(current_effort)
+            desired_updates["effort"] = current_effort
         record = record.model_copy(
             update={
                 "state": BootstrapState.resolving_images,
@@ -226,42 +240,64 @@ class BootstrapController:
             )
 
             async with self._session_factory() as session:
-                default_profile = await session.scalar(
+                result = await session.execute(
                     select(ManagedAgentProviderProfile)
                     .where(
                         ManagedAgentProviderProfile.runtime_id == "opencode",
                         ManagedAgentProviderProfile.enabled.is_(True),
-                        ManagedAgentProviderProfile.is_default.is_(True),
                     )
                     .order_by(
+                        ManagedAgentProviderProfile.is_default.desc(),
                         ManagedAgentProviderProfile.priority.desc(),
                         ManagedAgentProviderProfile.profile_id.asc(),
                     )
-                    .limit(1)
                 )
-                if default_profile is None:
+                profiles = list(result.scalars().all())
+                if not profiles:
                     return True
                 secret_statuses = await _managed_secret_statuses_for_profiles(
                     session=session,
-                    rows=[default_profile],
+                    rows=profiles,
                 )
-                if not provider_profile_launch_ready(
-                    default_profile,
-                    managed_secret_statuses=secret_statuses,
-                ):
+                launch_ready_profiles = [
+                    profile
+                    for profile in profiles
+                    if provider_profile_launch_ready(
+                        profile,
+                        managed_secret_statuses=secret_statuses,
+                    )
+                ]
+                if not launch_ready_profiles:
                     return True
-            default_model = str(default_profile.default_model or "").strip()
+            representative = launch_ready_profiles[0]
+            try:
+                default_model, default_effort = _resolve_profile_model_effort(
+                    representative
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s model authority is invalid: %s",
+                    representative.profile_id,
+                    exc,
+                )
+                return False
             if not default_model:
-                return True
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s has no resolvable default model",
+                    representative.profile_id,
+                )
+                return False
             record = BootstrapRecord(
                 state=BootstrapState.resolving_images,
                 desired=BootstrapDesired(
-                    provider=str(default_profile.provider_id or ""),
+                    provider=str(representative.provider_id or ""),
                     modelDisplayName=default_model,
-                    effort=str(default_profile.default_effort or "xhigh"),
+                    effort=default_effort,
                     acceptContributorDataUse=True,
                 ),
-                providerProfileRef=str(default_profile.profile_id),
+                providerProfileRef=str(representative.profile_id),
             )
             save_bootstrap_record(record)
             initialized = await self._reconcile(
@@ -269,8 +305,6 @@ class BootstrapController:
                 api_key=None,
                 principal=None,
             )
-            if initialized.state != BootstrapState.ready:
-                return False
             return await self._ensure_launchable_materializer_qualifications(
                 initialized
             )
@@ -337,8 +371,9 @@ class BootstrapController:
                 drift.append("omnigent_build_digest")
 
         if provider_profile is not None:
-            current_model = str(provider_profile.default_model or "").strip()
-            current_effort = str(provider_profile.default_effort or "").strip()
+            current_model, current_effort = _resolve_profile_model_effort(
+                provider_profile
+            )
             if current_model and record.resolved.qualified_model_id != current_model:
                 drift.append("model")
             if current_effort and record.desired.effort != current_effort:
@@ -364,28 +399,37 @@ class BootstrapController:
             ) != int(provider_profile.credential_generation):
                 drift.append("evidence_credential_generation")
             if provider_profile is not None:
-                if (
-                    evidence.model.get("qualifiedId")
-                    != str(provider_profile.default_model or "").strip()
-                ):
+                if evidence.model.get("qualifiedId") != current_model:
                     drift.append("evidence_model")
-                if (
-                    evidence.model.get("effort")
-                    != str(provider_profile.default_effort or "").strip()
-                ):
+                if evidence.model.get("effort") != current_effort:
                     drift.append("evidence_effort")
+
+        # Materializer qualification is independent of whether the default
+        # bootstrap record remains current. In particular, a launch-ready Zen
+        # profile must not lose ``none@1`` evidence because a disabled or
+        # drifted OpenCode Go default cannot be requalified.
+        materializers_ready = await self._ensure_launchable_materializer_qualifications(
+            record
+        )
 
         if record.state != BootstrapState.ready:
             drift.append("bootstrap_state")
         if not drift:
-            return await self._ensure_launchable_materializer_qualifications(record)
+            return materializers_ready
 
         logger.info(
             "Refreshing OpenCode deployment qualification after managed "
             "default drift: fields=%s",
             ",".join(sorted(set(drift))),
         )
-        refreshed = await self.requalify()
+        try:
+            refreshed = await self.requalify()
+        except ValueError as exc:
+            logger.warning(
+                "OpenCode default deployment qualification refresh deferred: %s",
+                exc,
+            )
+            return materializers_ready
         if refreshed.state == BootstrapState.ready:
             logger.info(
                 "OpenCode deployment qualification now matches Agent Profile %s",
@@ -397,7 +441,7 @@ class BootstrapController:
             "OpenCode deployment qualification refresh deferred: code=%s",
             failure_code,
         )
-        return False
+        return materializers_ready
 
     async def _ensure_launchable_materializer_qualifications(
         self,
@@ -442,12 +486,15 @@ class BootstrapController:
         if resolved is None:
             return False
         try:
+            published = list(load_deployment_evidence_entries())
+        except ValueError:
+            published = []
+        try:
             primary_evidence = load_deployment_evidence_for_support_combination(
                 str(record.last_evidence_ref or "")
             )
-            published = list(load_deployment_evidence_entries())
         except ValueError:
-            return False
+            primary_evidence = None
 
         async with self._session_factory() as session:
             result = await session.execute(
@@ -496,17 +543,30 @@ class BootstrapController:
                 if key not in shared_exclusions
             }
 
-        primary_shared_identity = _shared_identity(primary_evidence)
+        primary_shared_identity = (
+            _shared_identity(primary_evidence) if primary_evidence is not None else None
+        )
+        all_materializers_ready = True
         for materializer_ref, profile in representatives.items():
             profile_ref = str(profile.profile_id)
-            qualified_model = str(profile.default_model or "").strip()
-            effort = str(profile.default_effort or "xhigh").strip()
+            try:
+                qualified_model, effort = _resolve_profile_model_effort(profile)
+            except ValueError as exc:
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s model authority is invalid: %s",
+                    profile_ref,
+                    exc,
+                )
+                all_materializers_ready = False
+                continue
             credential_generation = int(profile.credential_generation)
             current = next(
                 (
                     evidence
                     for evidence in published
                     if evidence.support_identity.materializerRefs == (materializer_ref,)
+                    and primary_shared_identity is not None
                     and _shared_identity(evidence) == primary_shared_identity
                     and evidence.host_image_ref == resolved.opencode_host_image_ref
                     and evidence.provider.get("profileRef") == profile_ref
@@ -525,7 +585,8 @@ class BootstrapController:
                     "%s has no default model",
                     profile_ref,
                 )
-                return False
+                all_materializers_ready = False
+                continue
 
             revalidation = await reconcile_opencode_provider_readiness(
                 session_factory=self._session_factory,
@@ -538,31 +599,67 @@ class BootstrapController:
                     "%s could not be revalidated",
                     profile_ref,
                 )
-                return False
+                all_materializers_ready = False
+                continue
             async with self._session_factory() as session:
                 refreshed = await session.get(
                     ManagedAgentProviderProfile,
                     profile_ref,
                 )
             if refreshed is None:
-                return False
-            qualified_model = str(refreshed.default_model or "").strip()
-            effort = validate_effort(str(refreshed.default_effort or "xhigh").strip())
-            evidence_payload = await self._qualify_and_publish(
-                provider_profile_ref=profile_ref,
-                qualified_model=qualified_model,
-                effort=effort,
-                resolved=resolved,
-                record=record,
-            )
-            published.append(validate_deployment_evidence(evidence_payload))
+                all_materializers_ready = False
+                continue
+            try:
+                qualified_model, effort = _resolve_profile_model_effort(refreshed)
+            except ValueError as exc:
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s refreshed model authority is invalid: %s",
+                    profile_ref,
+                    exc,
+                )
+                all_materializers_ready = False
+                continue
+            try:
+                evidence_payload = await self._qualify_and_publish(
+                    provider_profile_ref=profile_ref,
+                    qualified_model=qualified_model,
+                    effort=effort,
+                    resolved=resolved,
+                    record=record,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "OpenCode deployment qualification deferred for materializer "
+                    "%s using Provider Profile %s: %s",
+                    materializer_ref,
+                    profile_ref,
+                    exc,
+                )
+                all_materializers_ready = False
+                continue
+            try:
+                validated_evidence = validate_deployment_evidence(evidence_payload)
+            except ValueError as exc:
+                logger.warning(
+                    "OpenCode deployment qualification produced invalid evidence "
+                    "for materializer %s using Provider Profile %s: %s",
+                    materializer_ref,
+                    profile_ref,
+                    exc,
+                )
+                all_materializers_ready = False
+                continue
+            published.append(validated_evidence)
+            if primary_shared_identity is None:
+                primary_shared_identity = _shared_identity(validated_evidence)
             logger.info(
                 "Published OpenCode deployment qualification for materializer %s "
                 "using Provider Profile %s",
                 materializer_ref,
                 profile_ref,
             )
-        return True
+        return all_materializers_ready
 
     async def _reconcile(
         self,
@@ -862,9 +959,7 @@ class BootstrapController:
                         cand = str(_persisted.opencode_host_image_ref).strip()
                         if "@sha256:" in cand:
                             image_ref = cand
-                except (
-                    Exception
-                ):  # best-effort fallback to passed resolved if persisted state unavailable
+                except Exception:  # best-effort fallback to passed resolved if persisted state unavailable
                     pass
 
             def _is_substrate_unavailable(exc: Exception) -> bool:

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -269,7 +269,11 @@ class BootstrapController:
                 api_key=None,
                 principal=None,
             )
-            return initialized.state == BootstrapState.ready
+            if initialized.state != BootstrapState.ready:
+                return False
+            return await self._ensure_launchable_materializer_qualifications(
+                initialized
+            )
 
         from sqlalchemy import select
 
@@ -374,7 +378,7 @@ class BootstrapController:
         if record.state != BootstrapState.ready:
             drift.append("bootstrap_state")
         if not drift:
-            return True
+            return await self._ensure_launchable_materializer_qualifications(record)
 
         logger.info(
             "Refreshing OpenCode deployment qualification after managed "
@@ -387,13 +391,178 @@ class BootstrapController:
                 "OpenCode deployment qualification now matches Agent Profile %s",
                 refreshed.agent_profile_ref,
             )
-            return True
+            return await self._ensure_launchable_materializer_qualifications(refreshed)
         failure_code = str((refreshed.failure or {}).get("code") or "unknown")
         logger.warning(
             "OpenCode deployment qualification refresh deferred: code=%s",
             failure_code,
         )
         return False
+
+    async def _ensure_launchable_materializer_qualifications(
+        self,
+        record: BootstrapRecord,
+    ) -> bool:
+        """Publish exact evidence for every launchable materializer class.
+
+        Provider Profile default selection chooses the representative used for
+        the primary bootstrap record. It must not make another explicitly
+        selected, launch-ready credential class unusable. One validated
+        representative per materializer is sufficient because profile and
+        model readiness remain independently enforced during plan compilation
+        and launch.
+        """
+
+        from sqlalchemy import select
+
+        from api_service.db.models import ManagedAgentProviderProfile
+        from api_service.services.provider_profile_readiness import (
+            provider_profile_launch_ready,
+        )
+        from api_service.services.provider_profile_service import (
+            _managed_secret_statuses_for_profiles,
+        )
+        from moonmind.omnigent.bootstrap.provider_revalidation import (
+            reconcile_opencode_provider_readiness,
+        )
+        from moonmind.omnigent.bootstrap.store import load_resolved_state
+        from moonmind.omnigent.deployment_evidence import (
+            load_deployment_evidence_entries,
+            load_deployment_evidence_for_support_combination,
+            validate_deployment_evidence,
+        )
+        from moonmind.omnigent.harness_platform.materializers import (
+            materializer_ref_for_provider,
+        )
+        from moonmind.omnigent.harness_platform.support import (
+            DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS,
+        )
+
+        resolved = load_resolved_state()
+        if resolved is None:
+            return False
+        try:
+            primary_evidence = load_deployment_evidence_for_support_combination(
+                str(record.last_evidence_ref or "")
+            )
+            published = list(load_deployment_evidence_entries())
+        except ValueError:
+            return False
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ManagedAgentProviderProfile)
+                .where(
+                    ManagedAgentProviderProfile.runtime_id == "opencode",
+                    ManagedAgentProviderProfile.enabled.is_(True),
+                )
+                .order_by(
+                    ManagedAgentProviderProfile.is_default.desc(),
+                    ManagedAgentProviderProfile.priority.desc(),
+                    ManagedAgentProviderProfile.profile_id.asc(),
+                )
+            )
+            profiles = list(result.scalars().all())
+            secret_statuses = await _managed_secret_statuses_for_profiles(
+                session=session,
+                rows=profiles,
+            )
+            profiles = [
+                profile
+                for profile in profiles
+                if provider_profile_launch_ready(
+                    profile,
+                    managed_secret_statuses=secret_statuses,
+                )
+            ]
+
+        representatives: dict[str, Any] = {}
+        for profile in profiles:
+            materializer_ref = materializer_ref_for_provider(
+                str(profile.runtime_id or ""),
+                str(profile.provider_id or ""),
+            )
+            representatives.setdefault(materializer_ref, profile)
+
+        shared_exclusions = DEPLOYMENT_QUALIFICATION_EXCLUDED_FIELDS | {
+            "materializerRefs"
+        }
+
+        def _shared_identity(evidence: Any) -> dict[str, Any]:
+            identity = evidence.support_identity.model_dump(mode="json", by_alias=True)
+            return {
+                key: value
+                for key, value in identity.items()
+                if key not in shared_exclusions
+            }
+
+        primary_shared_identity = _shared_identity(primary_evidence)
+        for materializer_ref, profile in representatives.items():
+            profile_ref = str(profile.profile_id)
+            qualified_model = str(profile.default_model or "").strip()
+            effort = str(profile.default_effort or "xhigh").strip()
+            credential_generation = int(profile.credential_generation)
+            current = next(
+                (
+                    evidence
+                    for evidence in published
+                    if evidence.support_identity.materializerRefs == (materializer_ref,)
+                    and _shared_identity(evidence) == primary_shared_identity
+                    and evidence.host_image_ref == resolved.opencode_host_image_ref
+                    and evidence.provider.get("profileRef") == profile_ref
+                    and evidence.provider.get("credentialGeneration")
+                    == credential_generation
+                    and evidence.model.get("qualifiedId") == qualified_model
+                    and evidence.model.get("effort") == effort
+                ),
+                None,
+            )
+            if current is not None:
+                continue
+            if not qualified_model:
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s has no default model",
+                    profile_ref,
+                )
+                return False
+
+            revalidation = await reconcile_opencode_provider_readiness(
+                session_factory=self._session_factory,
+                allow_enrollment=False,
+                profile_ids=(profile_ref,),
+            )
+            if not revalidation.ready:
+                logger.warning(
+                    "OpenCode deployment qualification deferred: Provider Profile "
+                    "%s could not be revalidated",
+                    profile_ref,
+                )
+                return False
+            async with self._session_factory() as session:
+                refreshed = await session.get(
+                    ManagedAgentProviderProfile,
+                    profile_ref,
+                )
+            if refreshed is None:
+                return False
+            qualified_model = str(refreshed.default_model or "").strip()
+            effort = validate_effort(str(refreshed.default_effort or "xhigh").strip())
+            evidence_payload = await self._qualify_and_publish(
+                provider_profile_ref=profile_ref,
+                qualified_model=qualified_model,
+                effort=effort,
+                resolved=resolved,
+                record=record,
+            )
+            published.append(validate_deployment_evidence(evidence_payload))
+            logger.info(
+                "Published OpenCode deployment qualification for materializer %s "
+                "using Provider Profile %s",
+                materializer_ref,
+                profile_ref,
+            )
+        return True
 
     async def _reconcile(
         self,

--- a/moonmind/omnigent/bootstrap/evidence.py
+++ b/moonmind/omnigent/bootstrap/evidence.py
@@ -14,8 +14,12 @@ from moonmind.omnigent.deployment_evidence import (
     DEPLOYMENT_EVIDENCE_ISSUER,
     DEPLOYMENT_EVIDENCE_VERSION,
     sign_deployment_evidence,
+    validate_deployment_evidence,
 )
-from moonmind.omnigent.harness_platform.support import SupportKeyPayload
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_deployment_qualification_key,
+)
 
 
 def build_deployment_evidence(
@@ -75,24 +79,72 @@ def build_deployment_evidence(
     return signed
 
 
-def write_deployment_evidence(evidence: dict[str, Any], path: Path | None = None) -> Path:
+def write_deployment_evidence(
+    evidence: dict[str, Any], path: Path | None = None
+) -> Path:
+    """Upsert one signed qualification without discarding other materializers.
+
+    A deployment can expose multiple launch-ready credential classes for the
+    same harness. Each class requires exact materializer evidence, while the
+    evidence file remains one deployment-owned publication. Preserve valid
+    entries for other deployment qualification keys and replace only the
+    incoming key.
+    """
+
     dest = path or Path(
         os.getenv(
             "MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE",
             "var/omnigent-evidence/deployment-execution-evidence.json",
         )
     )
-    # Also handle compose mount
-    compose_dest = Path("/workspace/omnigent-evidence/deployment-execution-evidence.json")
-    # Ensure parent
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    incoming = validate_deployment_evidence(evidence)
+    incoming_key = compute_deployment_qualification_key(incoming.support_identity)
+    retained: list[dict[str, Any]] = []
     try:
-        compose_dest.parent.mkdir(parents=True, exist_ok=True)
-        compose_dest.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    except OSError:
-        # Best-effort: compose volume may be unavailable in hermetic tests
-        pass
-    # If evidence is single entry, also support entries array form for loader compatibility
-    # The loader handles both raw and entries list, so single object is fine
+        existing = json.loads(dest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        existing = None
+    if isinstance(existing, dict):
+        raw_entries = existing.get("entries")
+        candidates = raw_entries if isinstance(raw_entries, list) else [existing]
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            try:
+                parsed = validate_deployment_evidence(candidate)
+            except ValueError:
+                continue
+            if (
+                compute_deployment_qualification_key(parsed.support_identity)
+                == incoming_key
+            ):
+                continue
+            retained.append(parsed.model_dump(mode="json", by_alias=True))
+
+    entries = [
+        *retained,
+        incoming.model_dump(mode="json", by_alias=True),
+    ]
+    entries.sort(key=lambda item: str(item["supportCombinationKey"]))
+    payload = {"entries": entries}
+
+    def _write(destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        tmp = destination.with_suffix(destination.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        tmp.replace(destination)
+
+    _write(dest)
+    compose_dest = Path(
+        "/workspace/omnigent-evidence/deployment-execution-evidence.json"
+    )
+    if compose_dest != dest:
+        try:
+            _write(compose_dest)
+        except OSError:
+            # Best-effort: compose volume may be unavailable in hermetic tests.
+            pass
     return dest

--- a/moonmind/omnigent/deployment_evidence.py
+++ b/moonmind/omnigent/deployment_evidence.py
@@ -358,10 +358,57 @@ def _unqualified_combination_message(
     return (
         "this deployment is not qualified for the requested execution "
         f"combination {plan_payload.supportCombinationKey} ({detail}). "
-        "Qualification follows the current Provider and Agent Profile defaults; "
-        "align those defaults with the requested host and launch policy before "
-        "qualifying the deployment."
+        "Qualification follows the current launch-ready Provider Profile "
+        "materializer classes and Agent Profile launch policy; revalidate the "
+        "requested profile and retry deployment qualification."
     )
+
+
+def _load_deployment_evidence_candidates(
+    path: str | Path | None,
+) -> list[Any]:
+    configured = str(
+        path
+        or os.getenv(
+            _DEPLOYMENT_EVIDENCE_ENV,
+            "/workspace/omnigent-evidence/deployment-execution-evidence.json",
+        )
+    ).strip()
+    if not configured:
+        raise ValueError("deployment execution evidence is not configured")
+    try:
+        raw = json.loads(Path(configured).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("deployment execution evidence is unavailable") from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError("deployment evidence must be an object")
+    entries = raw.get("entries")
+    return list(entries) if isinstance(entries, list) else [raw]
+
+
+def load_deployment_evidence_entries(
+    *,
+    path: str | Path | None = None,
+    now: datetime | None = None,
+) -> tuple[DeploymentExecutionEvidence, ...]:
+    """Load every independently valid local qualification entry.
+
+    Invalid unrelated entries do not make a valid exact combination
+    inadmissible. Callers receive only HMAC-verified, current evidence and can
+    decide which deployment qualification class they own.
+    """
+
+    validated: list[DeploymentExecutionEvidence] = []
+    for candidate in _load_deployment_evidence_candidates(path):
+        if not isinstance(candidate, Mapping):
+            continue
+        try:
+            validated.append(validate_deployment_evidence(candidate, now=now))
+        except ValueError:
+            continue
+    if not validated:
+        raise ValueError("deployment execution evidence is unavailable")
+    return tuple(validated)
 
 
 def load_deployment_evidence_for_support_combination(
@@ -381,23 +428,7 @@ def load_deployment_evidence_for_support_combination(
     expected_key = str(support_combination_key or "").strip()
     if not expected_key.startswith("omnigent-support:sha256:"):
         raise ValueError("deployment support combination key is unavailable")
-    configured = str(
-        path
-        or os.getenv(
-            _DEPLOYMENT_EVIDENCE_ENV,
-            "/workspace/omnigent-evidence/deployment-execution-evidence.json",
-        )
-    ).strip()
-    if not configured:
-        raise ValueError("deployment execution evidence is not configured")
-    try:
-        raw = json.loads(Path(configured).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError("deployment execution evidence is unavailable") from exc
-    if not isinstance(raw, Mapping):
-        raise ValueError("deployment evidence must be an object")
-    entries = raw.get("entries")
-    candidates = list(entries) if isinstance(entries, list) else [raw]
+    candidates = _load_deployment_evidence_candidates(path)
     matching = [
         value
         for value in candidates
@@ -418,22 +449,7 @@ def load_deployment_evidence(
     path: str | Path | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    configured = str(
-        path or os.getenv(_DEPLOYMENT_EVIDENCE_ENV, "/workspace/omnigent-evidence/deployment-execution-evidence.json")
-    ).strip()
-    # Also try alternative env MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE
-    if not configured:
-        configured = str(os.getenv("MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE", "")).strip()
-    if not configured:
-        raise ValueError("deployment execution evidence is not configured")
-    try:
-        raw = json.loads(Path(configured).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError("deployment execution evidence is unavailable") from exc
-    if not isinstance(raw, Mapping):
-        raise ValueError("deployment evidence must be an object")
-    entries = raw.get("entries")
-    candidates = list(entries) if isinstance(entries, list) else [raw]
+    candidates = _load_deployment_evidence_candidates(path)
     requested_qualification_key = compute_deployment_qualification_key(
         plan_payload.supportIdentity
     )
@@ -460,6 +476,7 @@ __all__ = [
     "assert_deployment_evidence_matches_plan",
     "get_or_create_signing_key",
     "load_deployment_evidence",
+    "load_deployment_evidence_entries",
     "load_deployment_evidence_for_support_combination",
     "sign_deployment_evidence",
     "validate_deployment_evidence",

--- a/tests/integration/reliability/replays/opencode-selected-materializer-evidence-admission/expected-outcome.json
+++ b/tests/integration/reliability/replays/opencode-selected-materializer-evidence-admission/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "invariant": "each launchable OpenCode credential materializer class retains independent exact deployment qualification evidence",
+  "supportTier": "deployment_qualified",
+  "selectedMaterializerRef": "none@1"
+}

--- a/tests/integration/reliability/replays/opencode-selected-materializer-evidence-admission/manifest.json
+++ b/tests/integration/reliability/replays/opencode-selected-materializer-evidence-admission/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentReference": "user-report-2026-08-31-opencode-zen-materializer-evidence",
+  "terminalFailureCode": "OMNIGENT_EXECUTION_EVIDENCE_UNAVAILABLE",
+  "failureShape": "an upgraded deployment retained OpenCode Go as the runtime default, so its sole qualification used opencode-auth-json@1 and rejected an explicitly selected OpenCode Zen plan requiring none@1",
+  "targetRuntime": "omnigent",
+  "evidencePolicy": "either",
+  "defaultProviderId": "opencode-go",
+  "selectedProviderId": "opencode"
+}

--- a/tests/integration/reliability/test_omnigent_plan_admission_replays.py
+++ b/tests/integration/reliability/test_omnigent_plan_admission_replays.py
@@ -122,3 +122,54 @@ async def test_default_evidence_admits_opencode_zen_model(
         payload.supportIdentity.modelConfigDigest
         != qualified_plan.supportIdentity.modelConfigDigest
     ) is expected["modelConfigDigestMayVary"]
+
+
+async def test_selected_zen_materializer_has_independent_deployment_evidence(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replay_id = "opencode-selected-materializer-evidence-admission"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EVIDENCE_POLICY", manifest["evidencePolicy"])
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    launch_policy_ref = default_launch_policy_ref(_OPENCODE_ALLOWED_LAUNCH_POLICIES)
+
+    go_plan = await _capture_plan_payload(
+        launch_policy_ref=launch_policy_ref,
+        provider_id=manifest["defaultProviderId"],
+    )
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=go_plan,
+        launch_policy_ref=launch_policy_ref,
+    )
+    zen_plan = await _capture_plan_payload(
+        launch_policy_ref=launch_policy_ref,
+        provider_id=manifest["selectedProviderId"],
+    )
+    _write_deployment_evidence(
+        tmp_path,
+        monkeypatch,
+        plan_payload=zen_plan,
+        launch_policy_ref=launch_policy_ref,
+    )
+
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=_ArtifactService(),
+        launch_policy_ref=launch_policy_ref,
+        plan_store=_PlanStore(None),
+        provider_id=manifest["selectedProviderId"],
+    )
+
+    payload = result.envelope.payload
+    assert payload.admissionAuthority.supportTier == expected["supportTier"]
+    assert (
+        payload.credentialBindings["primary-model"].materializerRef
+        == expected["selectedMaterializerRef"]
+    )

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -786,9 +786,16 @@ async def test_credentialless_default_initializes_deployment_qualification(
         return record.model_copy(update={"state": BootstrapState.ready})
 
     monkeypatch.setattr(controller, "_reconcile", _reconcile)
+    ensure_materializers = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        controller,
+        "_ensure_launchable_materializer_qualifications",
+        ensure_materializers,
+    )
 
     assert await controller.reconcile_deployment_qualification()
     assert saved[-1].provider_profile_ref == "opencode-zen-free"
+    ensure_materializers.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -856,6 +863,11 @@ async def test_managed_agent_profile_advance_requalifies_default_deployment(
     )
     requalify = AsyncMock(return_value=refreshed)
     monkeypatch.setattr(controller, "requalify", requalify)
+    monkeypatch.setattr(
+        controller,
+        "_ensure_launchable_materializer_qualifications",
+        AsyncMock(return_value=True),
+    )
 
     assert await controller.reconcile_deployment_qualification()
     requalify.assert_awaited_once_with()
@@ -922,6 +934,157 @@ async def test_current_default_qualification_avoids_repeating_live_workload(
     )
     requalify = AsyncMock()
     monkeypatch.setattr(controller, "requalify", requalify)
+    ensure_materializers = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        controller,
+        "_ensure_launchable_materializer_qualifications",
+        ensure_materializers,
+    )
 
     assert await controller.reconcile_deployment_qualification()
     requalify.assert_not_awaited()
+    ensure_materializers.assert_awaited_once_with(current)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("zen_already_published", "expected_qualification_count"),
+    [(False, 1), (True, 0)],
+)
+async def test_launchable_materializer_classes_are_qualified_once(
+    monkeypatch,
+    zen_already_published: bool,
+    expected_qualification_count: int,
+) -> None:
+    """A non-default Zen profile must retain exact ``none@1`` evidence."""
+
+    from moonmind.omnigent.bootstrap.provider_revalidation import (
+        ProviderReconcileOutcome,
+    )
+    from moonmind.omnigent.harness_platform.support import SupportKeyPayload
+
+    def _support_identity(materializer_ref: str) -> SupportKeyPayload:
+        return SupportKeyPayload(
+            omnigentServerBuildRef="sha256:" + "a" * 64,
+            omnigentHostBuildRef="sha256:" + "a" * 64,
+            harnessImplementationRef=(
+                "omnigent-harness-implementation:sha256:" + "c" * 64
+            ),
+            vendorRuntimeRefs=["opencode@1.18.11#sha256:" + "d" * 64],
+            agentSourceRef="agent-source:sha256:" + "e" * 64,
+            materializerRefs=[materializer_ref],
+            providerCompatibilityClass="opencode-native.primary-model",
+            hostClassRef="omnigent-opencode@1",
+            architecture="linux/amd64",
+            launchPolicyRef="omnigent-on-demand@1",
+            modelConfigDigest="sha256:" + "f" * 64,
+            executionRealizerRef="generic-omnigent-host@1",
+            requiredCapabilitiesDigest="sha256:" + "1" * 64,
+        )
+
+    def _evidence(profile, materializer_ref: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            support_identity=_support_identity(materializer_ref),
+            host_image_ref=_HOST_IMAGE_REF,
+            provider={
+                "profileRef": profile.profile_id,
+                "credentialGeneration": profile.credential_generation,
+            },
+            model={
+                "qualifiedId": profile.default_model,
+                "effort": profile.default_effort,
+            },
+        )
+
+    shared = {
+        "runtime_id": "opencode",
+        "enabled": True,
+        "priority": 100,
+        "credential_generation": 1,
+    }
+    go_profile = SimpleNamespace(
+        **shared,
+        profile_id="opencode-go-default",
+        provider_id="opencode-go",
+        is_default=True,
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        default_effort="xhigh",
+    )
+    zen_profile = SimpleNamespace(
+        **shared,
+        profile_id="opencode-zen-free",
+        provider_id="opencode",
+        is_default=False,
+        default_model="opencode/muse-spark-1.2-contributor-free",
+        default_effort="xhigh",
+    )
+    profiles = [go_profile, zen_profile]
+
+    class _QualificationSession:
+        async def execute(self, _statement):
+            return SimpleNamespace(
+                scalars=lambda: SimpleNamespace(all=lambda: profiles)
+            )
+
+        async def get(self, _model, identity):
+            return {profile.profile_id: profile for profile in profiles}.get(identity)
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield _QualificationSession()
+
+    current_images = ResolvedOmnigentDeploymentState(
+        serverImageRef=_SERVER_IMAGE_REF,
+        opencodeHostImageRef=_HOST_IMAGE_REF,
+        omnigentBuildDigest="sha256:" + "a" * 64,
+        architecture="linux/amd64",
+    )
+    go_evidence = _evidence(go_profile, "opencode-auth-json@1")
+    zen_evidence = _evidence(zen_profile, "none@1")
+    published = [go_evidence]
+    if zen_already_published:
+        published.append(zen_evidence)
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.store.load_resolved_state",
+        lambda: current_images,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.load_deployment_evidence_for_support_combination",
+        lambda _key: go_evidence,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.load_deployment_evidence_entries",
+        lambda: tuple(published),
+    )
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_service._managed_secret_statuses_for_profiles",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_readiness.provider_profile_launch_ready",
+        lambda *_args, **_kwargs: True,
+    )
+    revalidate = AsyncMock(return_value=ProviderReconcileOutcome(ready=True))
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.provider_revalidation.reconcile_opencode_provider_readiness",
+        revalidate,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.validate_deployment_evidence",
+        lambda _payload: zen_evidence,
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    qualify = AsyncMock(return_value={})
+    monkeypatch.setattr(controller, "_qualify_and_publish", qualify)
+
+    record = _ready_bootstrap_record(agent_profile_ref="omnigent-opencode-default@8")
+    assert await controller._ensure_launchable_materializer_qualifications(record)
+    assert qualify.await_count == expected_qualification_count
+    assert revalidate.await_count == expected_qualification_count
+    if expected_qualification_count:
+        assert qualify.await_args.kwargs["provider_profile_ref"] == (
+            "opencode-zen-free"
+        )

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -756,8 +756,10 @@ async def test_credentialless_default_initializes_deployment_qualification(
     )
 
     class _QualificationSession:
-        async def scalar(self, _statement):
-            return profile
+        async def execute(self, _statement):
+            return SimpleNamespace(
+                scalars=lambda: SimpleNamespace(all=lambda: [profile])
+            )
 
     @asynccontextmanager
     async def _session_scope():
@@ -795,6 +797,91 @@ async def test_credentialless_default_initializes_deployment_qualification(
 
     assert await controller.reconcile_deployment_qualification()
     assert saved[-1].provider_profile_ref == "opencode-zen-free"
+    ensure_materializers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_default_materializer_initializes_when_default_is_not_launch_ready(
+    monkeypatch,
+) -> None:
+    """A broken runtime default must not prevent credentialless Zen evidence."""
+
+    disabled_default = SimpleNamespace(
+        profile_id="opencode-go-default",
+        runtime_id="opencode",
+        provider_id="opencode-go",
+        is_default=True,
+        enabled=True,
+        priority=200,
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        default_effort="xhigh",
+    )
+    zen_profile = SimpleNamespace(
+        profile_id="opencode-zen-free",
+        runtime_id="opencode",
+        provider_id="opencode",
+        is_default=False,
+        enabled=True,
+        priority=100,
+        default_model=None,
+        default_effort=None,
+        model_tiers=[
+            {
+                "label": "Zen free",
+                "model": "opencode/muse-spark-1.2-contributor-free",
+                "effort": "high",
+            }
+        ],
+        default_model_tier=1,
+    )
+    profiles = [disabled_default, zen_profile]
+
+    class _QualificationSession:
+        async def execute(self, _statement):
+            return SimpleNamespace(
+                scalars=lambda: SimpleNamespace(all=lambda: profiles)
+            )
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield _QualificationSession()
+
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: None)
+    monkeypatch.setattr(
+        controller_module, "save_bootstrap_record", lambda _record: None
+    )
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_service._managed_secret_statuses_for_profiles",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        "api_service.services.provider_profile_readiness.provider_profile_launch_ready",
+        lambda profile, **_kwargs: profile.profile_id == "opencode-zen-free",
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+
+    async def _reconcile(*, record, api_key, principal):
+        assert api_key is None
+        assert principal is None
+        assert record.provider_profile_ref == "opencode-zen-free"
+        assert (
+            record.desired.model_display_name
+            == "opencode/muse-spark-1.2-contributor-free"
+        )
+        assert record.desired.effort == "high"
+        return record.model_copy(update={"state": BootstrapState.ready})
+
+    monkeypatch.setattr(controller, "_reconcile", _reconcile)
+    ensure_materializers = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        controller,
+        "_ensure_launchable_materializer_qualifications",
+        ensure_materializers,
+    )
+
+    assert await controller.reconcile_deployment_qualification()
     ensure_materializers.assert_awaited_once()
 
 
@@ -874,6 +961,82 @@ async def test_managed_agent_profile_advance_requalifies_default_deployment(
 
 
 @pytest.mark.asyncio
+async def test_secondary_qualification_survives_default_requalification_failure(
+    monkeypatch,
+) -> None:
+    """A drifted default cannot overwrite successful secondary evidence."""
+
+    provider_profile = SimpleNamespace(
+        profile_id="opencode-go-default",
+        runtime_id="opencode",
+        is_default=True,
+        default_model="opencode-go/muse-spark-1.2-contributor",
+        default_effort="xhigh",
+        credential_generation=1,
+    )
+    agent_profile = SimpleNamespace(
+        profile_id="omnigent-opencode-default",
+        active_version=8,
+    )
+
+    class _QualificationSession:
+        async def get(self, model, _identity):
+            return {
+                "ManagedAgentProviderProfile": provider_profile,
+                "OmnigentAgentProfile": agent_profile,
+            }.get(model.__name__)
+
+        async def scalar(self, _statement):
+            return SimpleNamespace(version=8)
+
+    @asynccontextmanager
+    async def _session_scope():
+        yield _QualificationSession()
+
+    current = _ready_bootstrap_record(agent_profile_ref="omnigent-opencode-default@7")
+    current_images = ResolvedOmnigentDeploymentState(
+        serverImageRef=_SERVER_IMAGE_REF,
+        opencodeHostImageRef=_HOST_IMAGE_REF,
+        omnigentBuildDigest="sha256:" + "a" * 64,
+        architecture="linux/amd64",
+    )
+    evidence = SimpleNamespace(
+        host_image_ref=_HOST_IMAGE_REF,
+        provider={"profileRef": "opencode-go-default", "credentialGeneration": 1},
+        model={
+            "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
+            "effort": "xhigh",
+        },
+    )
+    monkeypatch.setattr(controller_module, "load_bootstrap_record", lambda: current)
+    monkeypatch.setattr(
+        "moonmind.omnigent.bootstrap.store.load_resolved_state",
+        lambda: current_images,
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_evidence.load_deployment_evidence_for_support_combination",
+        lambda _key: evidence,
+    )
+    controller = controller_module.BootstrapController(
+        session_factory=lambda: _session_scope()
+    )
+    ensure_materializers = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        controller,
+        "_ensure_launchable_materializer_qualifications",
+        ensure_materializers,
+    )
+    monkeypatch.setattr(
+        controller,
+        "requalify",
+        AsyncMock(side_effect=ValueError("default profile is not launch ready")),
+    )
+
+    assert await controller.reconcile_deployment_qualification()
+    ensure_materializers.assert_awaited_once_with(current)
+
+
+@pytest.mark.asyncio
 async def test_current_default_qualification_avoids_repeating_live_workload(
     monkeypatch,
 ) -> None:
@@ -948,13 +1111,31 @@ async def test_current_default_qualification_avoids_repeating_live_workload(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("zen_already_published", "expected_qualification_count"),
-    [(False, 1), (True, 0)],
+    (
+        "zen_already_published",
+        "zen_uses_tiers",
+        "primary_evidence_available",
+        "default_revalidation_ready",
+        "expected_qualification_count",
+        "expected_revalidation_count",
+        "expected_ready",
+    ),
+    [
+        (False, False, True, True, 1, 1, True),
+        (True, False, True, True, 0, 0, True),
+        (False, True, True, True, 1, 1, True),
+        (False, False, False, False, 1, 2, False),
+    ],
 )
 async def test_launchable_materializer_classes_are_qualified_once(
     monkeypatch,
     zen_already_published: bool,
+    zen_uses_tiers: bool,
+    primary_evidence_available: bool,
+    default_revalidation_ready: bool,
     expected_qualification_count: int,
+    expected_revalidation_count: int,
+    expected_ready: bool,
 ) -> None:
     """A non-default Zen profile must retain exact ``none@1`` evidence."""
 
@@ -982,7 +1163,13 @@ async def test_launchable_materializer_classes_are_qualified_once(
             requiredCapabilitiesDigest="sha256:" + "1" * 64,
         )
 
-    def _evidence(profile, materializer_ref: str) -> SimpleNamespace:
+    def _evidence(
+        profile,
+        materializer_ref: str,
+        *,
+        model: str,
+        effort: str,
+    ) -> SimpleNamespace:
         return SimpleNamespace(
             support_identity=_support_identity(materializer_ref),
             host_image_ref=_HOST_IMAGE_REF,
@@ -991,8 +1178,8 @@ async def test_launchable_materializer_classes_are_qualified_once(
                 "credentialGeneration": profile.credential_generation,
             },
             model={
-                "qualifiedId": profile.default_model,
-                "effort": profile.default_effort,
+                "qualifiedId": model,
+                "effort": effort,
             },
         )
 
@@ -1015,8 +1202,22 @@ async def test_launchable_materializer_classes_are_qualified_once(
         profile_id="opencode-zen-free",
         provider_id="opencode",
         is_default=False,
-        default_model="opencode/muse-spark-1.2-contributor-free",
-        default_effort="xhigh",
+        default_model=(
+            None if zen_uses_tiers else "opencode/muse-spark-1.2-contributor-free"
+        ),
+        default_effort=None if zen_uses_tiers else "xhigh",
+        model_tiers=(
+            [
+                {
+                    "label": "Zen free",
+                    "model": "opencode/muse-spark-1.2-contributor-free",
+                    "effort": "high",
+                }
+            ]
+            if zen_uses_tiers
+            else []
+        ),
+        default_model_tier=1,
     )
     profiles = [go_profile, zen_profile]
 
@@ -1039,8 +1240,18 @@ async def test_launchable_materializer_classes_are_qualified_once(
         omnigentBuildDigest="sha256:" + "a" * 64,
         architecture="linux/amd64",
     )
-    go_evidence = _evidence(go_profile, "opencode-auth-json@1")
-    zen_evidence = _evidence(zen_profile, "none@1")
+    go_evidence = _evidence(
+        go_profile,
+        "opencode-auth-json@1",
+        model="opencode-go/muse-spark-1.2-contributor",
+        effort="xhigh",
+    )
+    zen_evidence = _evidence(
+        zen_profile,
+        "none@1",
+        model="opencode/muse-spark-1.2-contributor-free",
+        effort="high" if zen_uses_tiers else "xhigh",
+    )
     published = [go_evidence]
     if zen_already_published:
         published.append(zen_evidence)
@@ -1049,9 +1260,15 @@ async def test_launchable_materializer_classes_are_qualified_once(
         "moonmind.omnigent.bootstrap.store.load_resolved_state",
         lambda: current_images,
     )
+
+    def _load_primary(_key):
+        if not primary_evidence_available:
+            raise ValueError("primary evidence unavailable")
+        return go_evidence
+
     monkeypatch.setattr(
         "moonmind.omnigent.deployment_evidence.load_deployment_evidence_for_support_combination",
-        lambda _key: go_evidence,
+        _load_primary,
     )
     monkeypatch.setattr(
         "moonmind.omnigent.deployment_evidence.load_deployment_evidence_entries",
@@ -1065,7 +1282,18 @@ async def test_launchable_materializer_classes_are_qualified_once(
         "api_service.services.provider_profile_readiness.provider_profile_launch_ready",
         lambda *_args, **_kwargs: True,
     )
-    revalidate = AsyncMock(return_value=ProviderReconcileOutcome(ready=True))
+
+    async def _revalidate(*, profile_ids, **_kwargs):
+        profile_ref = profile_ids[0]
+        return ProviderReconcileOutcome(
+            ready=(
+                default_revalidation_ready
+                if profile_ref == "opencode-go-default"
+                else True
+            )
+        )
+
+    revalidate = AsyncMock(side_effect=_revalidate)
     monkeypatch.setattr(
         "moonmind.omnigent.bootstrap.provider_revalidation.reconcile_opencode_provider_readiness",
         revalidate,
@@ -1081,10 +1309,19 @@ async def test_launchable_materializer_classes_are_qualified_once(
     monkeypatch.setattr(controller, "_qualify_and_publish", qualify)
 
     record = _ready_bootstrap_record(agent_profile_ref="omnigent-opencode-default@8")
-    assert await controller._ensure_launchable_materializer_qualifications(record)
+    assert (
+        await controller._ensure_launchable_materializer_qualifications(record)
+        is expected_ready
+    )
     assert qualify.await_count == expected_qualification_count
-    assert revalidate.await_count == expected_qualification_count
+    assert revalidate.await_count == expected_revalidation_count
     if expected_qualification_count:
         assert qualify.await_args.kwargs["provider_profile_ref"] == (
             "opencode-zen-free"
+        )
+        assert qualify.await_args.kwargs["qualified_model"] == (
+            "opencode/muse-spark-1.2-contributor-free"
+        )
+        assert qualify.await_args.kwargs["effort"] == (
+            "high" if zen_uses_tiers else "xhigh"
         )

--- a/tests/unit/omnigent/test_deployment_evidence_publishing.py
+++ b/tests/unit/omnigent/test_deployment_evidence_publishing.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+from moonmind.omnigent.bootstrap.evidence import (
+    build_deployment_evidence,
+    write_deployment_evidence,
+)
+from moonmind.omnigent.deployment_evidence import (
+    load_deployment_evidence_entries,
+)
+from moonmind.omnigent.harness_platform.support import (
+    SupportKeyPayload,
+    compute_support_combination_key,
+)
+
+
+def _identity(
+    materializer_ref: str,
+    *,
+    model_digest: str = "sha256:" + "1" * 64,
+) -> SupportKeyPayload:
+    return SupportKeyPayload(
+        omnigentServerBuildRef="sha256:" + "2" * 64,
+        omnigentHostBuildRef="sha256:" + "3" * 64,
+        harnessImplementationRef=("omnigent-harness-implementation:sha256:" + "4" * 64),
+        vendorRuntimeRefs=["opencode@1.18.11#sha256:" + "5" * 64],
+        agentSourceRef="agent-source:sha256:" + "6" * 64,
+        materializerRefs=[materializer_ref],
+        providerCompatibilityClass="opencode-native.primary-model",
+        hostClassRef="omnigent-opencode@1",
+        architecture="linux/amd64",
+        launchPolicyRef="omnigent-on-demand@1",
+        modelConfigDigest=model_digest,
+        executionRealizerRef="generic-omnigent-host@1",
+        requiredCapabilitiesDigest="sha256:" + "7" * 64,
+    )
+
+
+def _evidence(
+    materializer_ref: str,
+    *,
+    profile_ref: str,
+    model_digest: str = "sha256:" + "1" * 64,
+) -> dict:
+    identity = _identity(materializer_ref, model_digest=model_digest)
+    return build_deployment_evidence(
+        support_identity=identity,
+        support_combination_key=compute_support_combination_key(identity),
+        host_image_ref="ghcr.io/example/opencode@sha256:" + "8" * 64,
+        policy_snapshot_digest="sha256:" + "9" * 64,
+        effective_launch_snapshot_digest="sha256:" + "a" * 64,
+        provider_profile_ref=profile_ref,
+        credential_generation=1,
+        qualified_model_id="opencode/example",
+        effort="xhigh",
+        results={"readQualification": "passed"},
+        evidence_refs={"readRun": "artifact:read-run"},
+        resolved_state=None,
+    )
+
+
+def test_publisher_preserves_independent_materializer_qualifications(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "MOONMIND_DEPLOYMENT_EVIDENCE_KEY_PATH",
+        str(tmp_path / "deployment_evidence_key"),
+    )
+    path = tmp_path / "deployment-execution-evidence.json"
+    go_evidence = _evidence(
+        "opencode-auth-json@1",
+        profile_ref="opencode-go-default",
+    )
+    zen_evidence = _evidence(
+        "none@1",
+        profile_ref="opencode-zen-free",
+    )
+
+    write_deployment_evidence(go_evidence, path=path)
+    write_deployment_evidence(zen_evidence, path=path)
+
+    loaded = load_deployment_evidence_entries(path=path)
+    assert {entry.support_identity.materializerRefs for entry in loaded} == {
+        ("opencode-auth-json@1",),
+        ("none@1",),
+    }
+    assert len(json.loads(path.read_text(encoding="utf-8"))["entries"]) == 2
+
+    replacement = _evidence(
+        "opencode-auth-json@1",
+        profile_ref="opencode-go-default",
+        model_digest="sha256:" + "b" * 64,
+    )
+    write_deployment_evidence(replacement, path=path)
+
+    replaced = load_deployment_evidence_entries(path=path)
+    assert len(replaced) == 2
+    go_entry = next(
+        entry
+        for entry in replaced
+        if entry.support_identity.materializerRefs == ("opencode-auth-json@1",)
+    )
+    assert go_entry.support_identity.modelConfigDigest == "sha256:" + "b" * 64

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -684,7 +684,11 @@ async def test_resolved_fanout_is_admitted_as_platform_owned_capability(
     assert result.envelope.payload.resolvedTools["tools"] == []
 
 
-async def _capture_plan_payload(*, launch_policy_ref: str):
+async def _capture_plan_payload(
+    *,
+    launch_policy_ref: str,
+    provider_id: str = "opencode-go",
+):
     """Return the compiled plan payload deployment qualification must match.
 
     Bootstrap qualification compiles the same plan to learn the exact support
@@ -704,6 +708,7 @@ async def _capture_plan_payload(*, launch_policy_ref: str):
                 patch,
                 artifacts=_ArtifactService(),
                 launch_policy_ref=launch_policy_ref,
+                provider_id=provider_id,
             )
     return captured["payload"]
 
@@ -713,7 +718,10 @@ def _write_deployment_evidence(
 ) -> None:
     """Sign and publish deployment evidence for one exact combination."""
 
-    from moonmind.omnigent.bootstrap.evidence import build_deployment_evidence
+    from moonmind.omnigent.bootstrap.evidence import (
+        build_deployment_evidence,
+        write_deployment_evidence,
+    )
     from moonmind.omnigent.harness_platform.support import (
         compute_support_combination_key,
     )
@@ -736,7 +744,7 @@ def _write_deployment_evidence(
         resolved_state=None,
     )
     destination = tmp_path / "deployment-execution-evidence.json"
-    destination.write_text(json.dumps(evidence), encoding="utf-8")
+    write_deployment_evidence(evidence, path=destination)
     monkeypatch.setenv("MOONMIND_OMNIGENT_DEPLOYMENT_EVIDENCE", str(destination))
 
 


### PR DESCRIPTION
## Related issue

Follow-up to #3869.

## Summary

- Preserve exact materializer policy while publishing independent signed deployment evidence for every launch-ready OpenCode materializer class.
- Keep OpenCode Go as the operator-selected runtime default without preventing an explicitly selected credentialless OpenCode Zen run from using `none@1`.
- Add a production replay for the escaped upgrade case and document the multi-entry evidence contract.

ELI5: MoonMind previously kept one signed qualification ticket for whichever OpenCode profile was the default. It now keeps a separate ticket for each usable credential path, so the Go and Zen paths no longer overwrite or block one another.

## Test Plan

```bash
./tools/test_unit.sh --python-only tests/unit/omnigent/test_deployment_evidence_publishing.py tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/services/test_omnigent_execution_plan_service.py::test_deployment_evidence_admits_the_launch_policy_admission_selects tests/unit/services/test_omnigent_execution_plan_service.py::test_deployment_evidence_for_another_launch_policy_is_inadmissible tests/unit/services/test_omnigent_execution_plan_service.py::test_deployment_evidence_admits_a_plan_that_requests_capabilities tests/unit/services/test_omnigent_execution_plan_service.py::test_default_evidence_policy_admits_a_selected_profile_model tests/unit/services/test_omnigent_execution_plan_service.py::test_untrusted_evidence_values_are_redacted_from_admission_errors tests/integration/reliability/test_omnigent_plan_admission_replays.py
# 27 passed

MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-opencode-evidence ./tools/test_integration.sh
# 618 passed, 1 skipped

.venv/bin/ruff check moonmind/omnigent/bootstrap/evidence.py moonmind/omnigent/deployment_evidence.py moonmind/omnigent/bootstrap/controller.py api_service/main.py tests/unit/omnigent/test_deployment_evidence_publishing.py tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/services/test_omnigent_execution_plan_service.py tests/integration/reliability/test_omnigent_plan_admission_replays.py
# passed
```

The broader impacted unit selector passed 2,417 tests with 1 skip. Its three failures are existing macOS permission failures in `test_tool_bundle_initializer.py`; the prior product-boundary run also reproduced the existing ARM64-versus-amd64 assertion documented in #3869.

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Deployment evidence publication changes from a single evidence object to the already-supported `entries` collection. Existing single-object evidence remains readable and is converted on the next qualification write. Exact materializer matching is not relaxed: each entry is independently HMAC-validated, stale or invalid entries are excluded, and credential-bearing Go evidence cannot authorize the credentialless Zen materializer (or vice versa). No Temporal payload shape, credential source, or secret material changes.

## Coverage notes

Manual diagnosis confirmed the escaped state on an upgraded deployment: `opencode-go-default` remained the runtime default and the sole signed entry contained `opencode-auth-json@1`, while the explicitly selected Zen plan required `none@1`. The replay fixture preserves that exact authority mismatch.

## Changelog

Fix OpenCode Zen launches when another OpenCode Provider Profile remains the runtime default.
