### PR TITLE
Fix Omnigent batch fanout recovery

### DIFF
--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -84,8 +84,11 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      require the canonical `workflowId` in the response, and verify that ID via
      `GET /api/executions/{workflowId}` before counting it as queued;
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
-     When MoonMind supplies `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN`, forward it
-     as the execution-scoped bearer and mark both calls as fan-out v1.
+     When MoonMind supplies `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE`
+     (preferred) or `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN`, read and forward
+     the execution-scoped bearer and mark both calls as fan-out v1. A declared
+     token file that is missing or empty is a hard failure; do not fall back to
+     the ambient value.
 4. Write one summary artifact at `batch_pr_resolver_result.json` under the managed session artifact spool path when available, otherwise under the configured `--artifacts-dir`.
 5. On any submission or verification error, write `skill_outcome.json` with a
    `failed` or `partial` status so the managed runtime cannot report the batch

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -631,6 +631,19 @@ def _read_worker_token() -> str | None:
     return None
 
 def _read_execution_fanout_token() -> str | None:
+    token_file = str(
+        os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE", "")
+    ).strip()
+    if token_file:
+        path = Path(token_file)
+        if not path.is_file():
+            raise RuntimeError(
+                "execution fan-out capability file is unavailable: " + token_file
+            )
+        token = path.read_text(encoding="utf-8").strip()
+        if not token:
+            raise RuntimeError("execution fan-out capability file is empty")
+        return token
     token = str(
         os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", "")
     ).strip()

--- a/.agents/skills/batch-workflows/SKILL.md
+++ b/.agents/skills/batch-workflows/SKILL.md
@@ -131,9 +131,11 @@ Progress" with a single batch run.
      duplicate child workflows.
    - Submits via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
-   - When MoonMind supplies `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN`, forwards
-     it as the execution-scoped bearer and marks create and describe calls as
-     fan-out v1.
+   - When MoonMind supplies `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE`
+     (preferred) or `MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN`, reads and forwards
+     the execution-scoped bearer and marks create and describe calls as fan-out
+     v1. A declared token file that is missing or empty is a hard failure; the
+     helper must not fall back to the ambient value.
 
    If provider-specific input validation fails before a trustworthy target list
    can be written, still invoke the same helper exactly once with

--- a/.agents/skills/batch-workflows/bin/batch_workflows.py
+++ b/.agents/skills/batch-workflows/bin/batch_workflows.py
@@ -885,6 +885,19 @@ def _read_worker_token() -> str | None:
 
 
 def _read_execution_fanout_token() -> str | None:
+    token_file = _text(
+        os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE")
+    )
+    if token_file:
+        path = Path(token_file)
+        if not path.is_file():
+            raise RuntimeError(
+                "execution fan-out capability file is unavailable: " + token_file
+            )
+        token = path.read_text(encoding="utf-8").strip()
+        if not token:
+            raise RuntimeError("execution fan-out capability file is empty")
+        return token
     return _text(os.getenv("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN")) or None
 
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11485,13 +11485,14 @@ async def _create_execution_from_workflow_request(
             initial_parameters,
             snapshot=profile_snapshot,
         )
-        # The profile model and effort are defaults for omitted runtime fields.
-        # Preserve explicit authored selections that were already resolved above
-        # so the immutable execution plan and Temporal parameters carry the same
-        # authority.
-        if model_source == "task_override":
+        # The Agent Profile model and effort are defaults only when provider
+        # selection did not already resolve a more specific model authority.
+        # Preserve both explicit task overrides and the selected Provider
+        # Profile's default/tier so the immutable plan cannot pair one profile's
+        # credential class with another profile's model.
+        if model_source == "task_override" or _provider_profile is not None:
             initial_parameters["model"] = resolved_model
-        if "effort" in runtime_payload:
+        if "effort" in runtime_payload or _provider_profile is not None:
             initial_parameters["effort"] = resolved_effort
         selected_provider_profile = await session.get(
             ManagedAgentProviderProfile,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11490,9 +11490,25 @@ async def _create_execution_from_workflow_request(
         # Preserve both explicit task overrides and the selected Provider
         # Profile's default/tier so the immutable plan cannot pair one profile's
         # credential class with another profile's model.
-        if model_source == "task_override" or _provider_profile is not None:
+        provider_authority_sources = {
+            "provider_profile_default",
+            "requested_tier",
+            "profile_default_tier",
+        }
+        if (
+            model_source == "task_override"
+            or model_source in provider_authority_sources
+        ):
             initial_parameters["model"] = resolved_model
-        if "effort" in runtime_payload or _provider_profile is not None:
+        effort_source = (
+            str(model_tier_resolution.get("effortSource") or "")
+            if isinstance(model_tier_resolution, Mapping)
+            else ""
+        )
+        if (
+            "effort" in runtime_payload
+            or effort_source in provider_authority_sources
+        ):
             initial_parameters["effort"] = resolved_effort
         selected_provider_profile = await session.get(
             ManagedAgentProviderProfile,

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -390,6 +390,20 @@ def compile_execution_plan(
     agent_source_ref = (
         "agent-source:sha256:" + _hashlib.sha256(agent_source_ref.encode()).hexdigest()
     )
+    support_architecture = (
+        host_architecture
+        or (
+            selected_host_class.architectures[0]
+            if selected_host_class.architectures
+            else "linux/amd64"
+        )
+    )
+    if support_architecture not in selected_host_class.architectures:
+        raise HarnessPlatformError(
+            f"selected Host Class {selected_host_class.ref} does not support "
+            f"architecture {support_architecture}",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_CLASS_UNAVAILABLE,
+        )
 
     support_payload = SupportKeyPayload.model_validate(
         {
@@ -401,11 +415,7 @@ def compile_execution_plan(
             "materializerRefs": sorted(materializer_refs),
             "providerCompatibilityClass": credential_binding_set.bindingSetId,
             "hostClassRef": selected_host_class.ref,
-            "architecture": (
-                selected_host_class.architectures[0]
-                if selected_host_class.architectures
-                else "linux/amd64"
-            ),
+            "architecture": support_architecture,
             "launchPolicyRef": launch_policy.ref,
             "modelConfigDigest": model_digest,
             "executionRealizerRef": realizer,

--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -168,6 +168,7 @@ class OmnigentHostLauncherPort(Protocol):
         host_class: HostClass,
         launch_policy: LaunchPolicy,
         credential_handles: list[dict[str, Any]],
+        runtime_environment: Mapping[str, str] | None = None,
     ) -> dict[str, Any]: ...
 
 
@@ -176,7 +177,11 @@ class OmnigentHostRegistrationPort(Protocol):
     """Wait for the launched host to register its harness with the endpoint."""
 
     async def wait_for_registration(
-        self, *, correlation_name: str, harness_id: str
+        self,
+        *,
+        correlation_name: str,
+        harness_id: str,
+        credentialless: bool = False,
     ) -> dict[str, Any]: ...
 
 

--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -173,6 +173,20 @@ class OmnigentHostLauncherPort(Protocol):
 
 
 @runtime_checkable
+class OmnigentRuntimeEnvironmentPort(Protocol):
+    """Build lease-scoped runtime capabilities at the infrastructure boundary."""
+
+    def build(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        host_lease_ref: str,
+        launch_policy: LaunchPolicy,
+    ) -> Mapping[str, str]: ...
+
+
+@runtime_checkable
 class OmnigentHostRegistrationPort(Protocol):
     """Wait for the launched host to register its harness with the endpoint."""
 

--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -183,7 +183,8 @@ class OmnigentRuntimeEnvironmentPort(Protocol):
         plan: OmnigentExecutionPlanEnvelope,
         host_lease_ref: str,
         launch_policy: LaunchPolicy,
-    ) -> Mapping[str, str]: ...
+    ) -> Mapping[str, str]:
+        raise NotImplementedError
 
 
 @runtime_checkable

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -12,6 +12,8 @@ composition root (:mod:`moonmind.omnigent.production`).
 from __future__ import annotations
 
 import hashlib
+import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -35,6 +37,13 @@ from moonmind.omnigent.host_ports import (
     OmnigentSkillDeliveryPort,
     OmnigentWorkspaceMaterializationPort,
     host_correlation_identity,
+)
+from moonmind.omnigent.workspace_intent import authored_required_capabilities
+from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
+    ExecutionFanoutCapabilityError,
+    mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -104,6 +113,87 @@ class GenericOmnigentHostRuntime:
         self._registration = registration_waiter
         self._attestor = host_attestor
         self._cleanup = cleanup_service
+
+    @staticmethod
+    def _execution_fanout_authorization(
+        request: AgentExecutionRequest,
+    ) -> Mapping[str, Any] | None:
+        step_execution = request.step_execution
+        if step_execution is None:
+            return None
+        policy = step_execution.skill_source_policy
+        if "executionFanout" not in policy:
+            return None
+        evidence = policy.get("executionFanout")
+        if not isinstance(evidence, Mapping):
+            raise HarnessPlatformError(
+                "execution fan-out authorization evidence is malformed",
+                code="authorization_denied",
+            )
+        return evidence
+
+    @classmethod
+    def _runtime_environment(
+        cls,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        host_lease_ref: str,
+        launch_policy: LaunchPolicy,
+    ) -> dict[str, str]:
+        """Mint only the execution capabilities authorized for this host lease."""
+
+        required_capabilities = authored_required_capabilities(request)
+        if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required_capabilities:
+            return {}
+        try:
+            require_execution_fanout_authorization(
+                required_capabilities,
+                cls._execution_fanout_authorization(request),
+            )
+        except ExecutionFanoutCapabilityError as exc:
+            raise HarnessPlatformError(str(exc), code="authorization_denied") from exc
+        step_execution = request.step_execution
+        workflow_id = (
+            str(step_execution.workflow_id or "").strip()
+            if step_execution is not None
+            else str(request.correlation_id or "").strip()
+        )
+        step_execution_id = (
+            str(step_execution.step_execution_id or "").strip()
+            if step_execution is not None
+            else str(request.correlation_id or "").strip()
+        )
+        runtime_id = str(plan.payload.harnessId or "").strip()
+        moonmind_url = str(
+            os.environ.get("MOONMIND_URL") or "http://api:8000"
+        ).strip()
+        if not workflow_id or not step_execution_id or not runtime_id or not moonmind_url:
+            raise HarnessPlatformError(
+                "execution fan-out runtime identity is incomplete",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        from moonmind.config.settings import settings
+
+        return {
+            "MOONMIND_URL": moonmind_url,
+            "MOONMIND_AGENT_RUN_ID": step_execution_id,
+            "MOONMIND_TASK_WORKFLOW_ID": workflow_id,
+            "MOONMIND_STEP_ID": step_execution_id,
+            "MOONMIND_RUNTIME_ID": runtime_id,
+            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": (
+                mint_execution_fanout_capability(
+                    secret=str(settings.security.JWT_SECRET_KEY or ""),
+                    parent_workflow_id=workflow_id,
+                    agent_run_id=step_execution_id,
+                    step_id=step_execution_id,
+                    session_id=host_lease_ref,
+                    runtime_id=runtime_id,
+                    source_kind="omnigent",
+                    lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
+                )
+            ),
+        }
 
     async def prepare(
         self,
@@ -236,6 +326,12 @@ class GenericOmnigentHostRuntime:
                 prepared.egress_attestation["appliedRuleDigest"]
             ),
         }
+        runtime_environment = self._runtime_environment(
+            request=request,
+            plan=plan,
+            host_lease_ref=host_lease_ref,
+            launch_policy=launch_policy,
+        )
         spec = HostLaunchSpec.model_validate(
             {
                 "executionPlanRef": plan.planRef,
@@ -263,7 +359,10 @@ class GenericOmnigentHostRuntime:
                 ),
                 "credentialAttachments": list(credential_attachments),
                 "controlAttachment": (
-                    self._launcher.control_attachment(host_lease_ref)
+                    self._launcher.control_attachment(
+                        host_lease_ref,
+                        require_capability_mount=bool(runtime_environment),
+                    )
                     if hasattr(self._launcher, "control_attachment")
                     else None
                 ),
@@ -299,11 +398,19 @@ class GenericOmnigentHostRuntime:
             host_class=host_class,
             launch_policy=launch_policy,
             credential_handles=credential_handles,
+            runtime_environment=runtime_environment,
         )
         try:
             registration = await self._registration.wait_for_registration(
                 correlation_name=correlation,
                 harness_id=plan.payload.harnessId,
+                credentialless=(
+                    bool(credential_handles)
+                    and all(
+                        str(handle.get("materializerRef") or "") == "none@1"
+                        for handle in credential_handles
+                    )
+                ),
             )
             attestations = await self._attestor.attest(
                 request=request,

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -12,8 +12,6 @@ composition root (:mod:`moonmind.omnigent.production`).
 from __future__ import annotations
 
 import hashlib
-import os
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -34,16 +32,10 @@ from moonmind.omnigent.host_ports import (
     OmnigentHostLauncherPort,
     OmnigentHostRegistrationPort,
     OmnigentMountedToolPort,
+    OmnigentRuntimeEnvironmentPort,
     OmnigentSkillDeliveryPort,
     OmnigentWorkspaceMaterializationPort,
     host_correlation_identity,
-)
-from moonmind.omnigent.workspace_intent import authored_required_capabilities
-from moonmind.security.execution_fanout_capabilities import (
-    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
-    ExecutionFanoutCapabilityError,
-    mint_execution_fanout_capability,
-    require_execution_fanout_authorization,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -84,6 +76,7 @@ class GenericOmnigentHostRuntime:
         tool_service: OmnigentMountedToolPort,
         github_credential_service: OmnigentGithubCredentialPort,
         egress_service: OmnigentEgressAttestationPort,
+        runtime_environment_service: OmnigentRuntimeEnvironmentPort,
         registration_waiter: OmnigentHostRegistrationPort,
         host_attestor: OmnigentHostAttestationPort,
         cleanup_service: OmnigentHostCleanupPort,
@@ -95,6 +88,7 @@ class GenericOmnigentHostRuntime:
             tool_service,
             github_credential_service,
             egress_service,
+            runtime_environment_service,
             registration_waiter,
             host_attestor,
             cleanup_service,
@@ -110,90 +104,10 @@ class GenericOmnigentHostRuntime:
         self._tools = tool_service
         self._github_credentials = github_credential_service
         self._egress = egress_service
+        self._runtime_environment = runtime_environment_service
         self._registration = registration_waiter
         self._attestor = host_attestor
         self._cleanup = cleanup_service
-
-    @staticmethod
-    def _execution_fanout_authorization(
-        request: AgentExecutionRequest,
-    ) -> Mapping[str, Any] | None:
-        step_execution = request.step_execution
-        if step_execution is None:
-            return None
-        policy = step_execution.skill_source_policy
-        if "executionFanout" not in policy:
-            return None
-        evidence = policy.get("executionFanout")
-        if not isinstance(evidence, Mapping):
-            raise HarnessPlatformError(
-                "execution fan-out authorization evidence is malformed",
-                code="authorization_denied",
-            )
-        return evidence
-
-    @classmethod
-    def _runtime_environment(
-        cls,
-        *,
-        request: AgentExecutionRequest,
-        plan: OmnigentExecutionPlanEnvelope,
-        host_lease_ref: str,
-        launch_policy: LaunchPolicy,
-    ) -> dict[str, str]:
-        """Mint only the execution capabilities authorized for this host lease."""
-
-        required_capabilities = authored_required_capabilities(request)
-        if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required_capabilities:
-            return {}
-        try:
-            require_execution_fanout_authorization(
-                required_capabilities,
-                cls._execution_fanout_authorization(request),
-            )
-        except ExecutionFanoutCapabilityError as exc:
-            raise HarnessPlatformError(str(exc), code="authorization_denied") from exc
-        step_execution = request.step_execution
-        workflow_id = (
-            str(step_execution.workflow_id or "").strip()
-            if step_execution is not None
-            else str(request.correlation_id or "").strip()
-        )
-        step_execution_id = (
-            str(step_execution.step_execution_id or "").strip()
-            if step_execution is not None
-            else str(request.correlation_id or "").strip()
-        )
-        runtime_id = str(plan.payload.harnessId or "").strip()
-        moonmind_url = str(
-            os.environ.get("MOONMIND_URL") or "http://api:8000"
-        ).strip()
-        if not workflow_id or not step_execution_id or not runtime_id or not moonmind_url:
-            raise HarnessPlatformError(
-                "execution fan-out runtime identity is incomplete",
-                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-            )
-        from moonmind.config.settings import settings
-
-        return {
-            "MOONMIND_URL": moonmind_url,
-            "MOONMIND_AGENT_RUN_ID": step_execution_id,
-            "MOONMIND_TASK_WORKFLOW_ID": workflow_id,
-            "MOONMIND_STEP_ID": step_execution_id,
-            "MOONMIND_RUNTIME_ID": runtime_id,
-            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": (
-                mint_execution_fanout_capability(
-                    secret=str(settings.security.JWT_SECRET_KEY or ""),
-                    parent_workflow_id=workflow_id,
-                    agent_run_id=step_execution_id,
-                    step_id=step_execution_id,
-                    session_id=host_lease_ref,
-                    runtime_id=runtime_id,
-                    source_kind="omnigent",
-                    lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
-                )
-            ),
-        }
 
     async def prepare(
         self,
@@ -326,11 +240,13 @@ class GenericOmnigentHostRuntime:
                 prepared.egress_attestation["appliedRuleDigest"]
             ),
         }
-        runtime_environment = self._runtime_environment(
-            request=request,
-            plan=plan,
-            host_lease_ref=host_lease_ref,
-            launch_policy=launch_policy,
+        runtime_environment = dict(
+            self._runtime_environment.build(
+                request=request,
+                plan=plan,
+                host_lease_ref=host_lease_ref,
+                launch_policy=launch_policy,
+            )
         )
         spec = HostLaunchSpec.model_validate(
             {

--- a/moonmind/omnigent/host_services/__init__.py
+++ b/moonmind/omnigent/host_services/__init__.py
@@ -13,6 +13,9 @@ from moonmind.omnigent.host_services.legacy_host_containers import (
 )
 from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
 from moonmind.omnigent.host_services.registration import OmnigentHostRegistrationService
+from moonmind.omnigent.host_services.runtime_environment import (
+    OmnigentRuntimeEnvironmentService,
+)
 from moonmind.omnigent.host_services.runtime_scripts import OmnigentRuntimeScriptService
 from moonmind.omnigent.host_services.skills import OmnigentSkillDeliveryService
 from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
@@ -27,6 +30,7 @@ __all__ = [
     "OmnigentGithubCredentialService",
     "OmnigentHostRegistrationService",
     "OmnigentMountedToolService",
+    "OmnigentRuntimeEnvironmentService",
     "OmnigentRuntimeScriptService",
     "OmnigentSkillDeliveryService",
     "OmnigentWorkspaceMaterializer",

--- a/moonmind/omnigent/host_services/launcher.py
+++ b/moonmind/omnigent/host_services/launcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -56,8 +57,13 @@ class DockerOmnigentHostLauncher:
     def server_url(self) -> str:
         return self._server_url
 
-    def control_attachment(self, host_lease_ref: str) -> dict[str, Any] | None:
-        if not self._host_api_token:
+    def control_attachment(
+        self,
+        host_lease_ref: str,
+        *,
+        require_capability_mount: bool = False,
+    ) -> dict[str, Any] | None:
+        if not self._host_api_token and not require_capability_mount:
             return None
         digest = hashlib.sha256(host_lease_ref.encode("utf-8")).hexdigest()[:32]
         return {
@@ -74,6 +80,7 @@ class DockerOmnigentHostLauncher:
         host_class: HostClass,
         launch_policy: LaunchPolicy,
         credential_handles: list[dict[str, Any]],
+        runtime_environment: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         if spec.serverUrl != self._server_url:
             raise HarnessPlatformError(
@@ -87,6 +94,30 @@ class DockerOmnigentHostLauncher:
             if spec.controlAttachment is not None
             else ""
         )
+        supplied_runtime_environment = dict(runtime_environment or {})
+        fanout_bearer = str(
+            supplied_runtime_environment.pop(
+                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", ""
+            )
+            or ""
+        ).strip()
+        allowed_runtime_environment = {
+            "MOONMIND_URL",
+            "MOONMIND_AGENT_RUN_ID",
+            "MOONMIND_TASK_WORKFLOW_ID",
+            "MOONMIND_STEP_ID",
+            "MOONMIND_RUNTIME_ID",
+        }
+        if set(supplied_runtime_environment) - allowed_runtime_environment:
+            raise HarnessPlatformError(
+                "generic host received unsupported runtime environment names",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        if fanout_bearer and not control_volume:
+            raise HarnessPlatformError(
+                "execution fan-out requires a lease-owned capability mount",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
         await self._backend.run(
             [
                 "docker",
@@ -117,26 +148,48 @@ class DockerOmnigentHostLauncher:
                         control_volume,
                     ]
                 )
-                await self._backend.run(
-                    [
-                        "docker",
-                        "run",
-                        "--rm",
-                        "-i",
-                        "--user",
-                        "0:0",
-                        "--network",
-                        "none",
-                        "--mount",
-                        f"type=volume,src={control_volume},dst=/control",
-                        "--entrypoint",
-                        "/bin/sh",
-                        host_class.imageRef,
-                        "-ceu",
-                        "umask 077; cat > /control/api-token; chown 1000:1000 /control/api-token; chmod 0400 /control/api-token",
-                    ],
-                    input_bytes=self._host_api_token.encode("utf-8"),
-                )
+                if self._host_api_token:
+                    await self._backend.run(
+                        [
+                            "docker",
+                            "run",
+                            "--rm",
+                            "-i",
+                            "--user",
+                            "0:0",
+                            "--network",
+                            "none",
+                            "--mount",
+                            f"type=volume,src={control_volume},dst=/control",
+                            "--entrypoint",
+                            "/bin/sh",
+                            host_class.imageRef,
+                            "-ceu",
+                            "umask 077; cat > /control/api-token; chown 1000:1000 /control/api-token; chmod 0400 /control/api-token",
+                        ],
+                        input_bytes=self._host_api_token.encode("utf-8"),
+                    )
+                if fanout_bearer:
+                    await self._backend.run(
+                        [
+                            "docker",
+                            "run",
+                            "--rm",
+                            "-i",
+                            "--user",
+                            "0:0",
+                            "--network",
+                            "none",
+                            "--mount",
+                            f"type=volume,src={control_volume},dst=/control",
+                            "--entrypoint",
+                            "/bin/sh",
+                            host_class.imageRef,
+                            "-ceu",
+                            "umask 077; cat > /control/execution-fanout; chown 1000:1000 /control/execution-fanout; chmod 0400 /control/execution-fanout",
+                        ],
+                        input_bytes=fanout_bearer.encode("utf-8"),
+                    )
             # Initialize the writable host-state volume before a read-only-root launch.
             await self._backend.run(
                 [
@@ -165,6 +218,10 @@ class DockerOmnigentHostLauncher:
                 ["docker", "volume", "rm", state_volume], check=False
             )
             raise
+        if fanout_bearer:
+            supplied_runtime_environment[
+                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE"
+            ] = "/run/moonmind-host-auth/execution-fanout"
         script, runtime_environment = self._scripts.build_entrypoint(
             credential_handles=credential_handles,
             skill_attachment=spec.skillAttachment,
@@ -172,10 +229,12 @@ class DockerOmnigentHostLauncher:
             tool_attachments=spec.toolAttachments,
             github_credential_attachment=spec.githubCredentialAttachment,
             control_attachment=spec.controlAttachment,
+            control_credential_available=bool(self._host_api_token),
             enable_opencode_runtime=any(
                 item.harnessId == "opencode-native"
                 for item in host_class.declaredHarnessImplementations
             ),
+            runtime_environment=supplied_runtime_environment,
         )
         command = [
             "docker",

--- a/moonmind/omnigent/host_services/registration.py
+++ b/moonmind/omnigent/host_services/registration.py
@@ -12,21 +12,46 @@ from moonmind.omnigent.harness_platform.failures import (
 )
 
 
-def _harness_ready(host: dict[str, Any], harness_id: str) -> bool:
+# Stock Omnigent first publishes an offline catalog row, then replaces it with
+# the live host identity after the runner tunnel and harness discovery are
+# ready. Cold startup on the supported local Compose path can exceed one
+# minute, including the bounded direct-spawn fallback when the optional runner
+# zygote is unavailable. Keep one shared, bounded registration policy for both
+# host lifecycle implementations.
+HOST_REGISTRATION_ATTEMPTS = 91
+HOST_REGISTRATION_INTERVAL_SECONDS = 2.0
+
+
+def _harness_readiness(host: dict[str, Any], harness_id: str) -> Any:
     readiness = host.get("configured_harnesses") or host.get("harnesses") or {}
     if isinstance(readiness, dict):
-        value = readiness.get(harness_id)
-        return value is True or str(value).lower() in {
+        return readiness.get(harness_id)
+    return harness_id in {str(item) for item in readiness} if isinstance(
+        readiness, list
+    ) else False
+
+
+def _harness_ready(
+    host: dict[str, Any],
+    harness_id: str,
+    *,
+    credentialless: bool,
+) -> bool:
+    value = _harness_readiness(host, harness_id)
+    if value is True or str(value).lower() in {
             "ready",
             "available",
             "authenticated",
             "true",
-        }
-    return (
-        harness_id in {str(item) for item in readiness}
-        if isinstance(readiness, list)
-        else False
-    )
+    }:
+        return True
+    # A credentialless provider route deliberately has no host auth material.
+    # Stock Omnigent therefore reports the installed OpenCode harness as
+    # ``needs-auth`` even though the selected provider/model is usable. Exact
+    # host attestation immediately follows registration and proves the selected
+    # model through that host, so admit this structural readiness only when the
+    # immutable plan selected the credentialless materializer.
+    return credentialless and str(value).lower() == "needs-auth"
 
 
 class OmnigentHostRegistrationService:
@@ -35,8 +60,8 @@ class OmnigentHostRegistrationService:
         *,
         client: Any,
         expected_owner: str,
-        attempts: int = 30,
-        interval_seconds: float = 2.0,
+        attempts: int = HOST_REGISTRATION_ATTEMPTS,
+        interval_seconds: float = HOST_REGISTRATION_INTERVAL_SECONDS,
     ) -> None:
         self._client = client
         self._owner = expected_owner.strip()
@@ -53,6 +78,7 @@ class OmnigentHostRegistrationService:
         *,
         correlation_name: str,
         harness_id: str,
+        credentialless: bool = False,
     ) -> dict[str, Any]:
         for attempt in range(self._attempts):
             observed_at = datetime.now(UTC)
@@ -65,7 +91,12 @@ class OmnigentHostRegistrationService:
                 and str(item.get("owner") or "") == self._owner
                 and str(item.get("status") or "").lower() == "online"
             ]
-            if len(matches) == 1 and _harness_ready(matches[0], harness_id):
+            if len(matches) == 1 and _harness_ready(
+                matches[0],
+                harness_id,
+                credentialless=credentialless,
+            ):
+                readiness = _harness_readiness(matches[0], harness_id)
                 return {
                     "host": matches[0],
                     "omnigentHostId": str(
@@ -73,6 +104,8 @@ class OmnigentHostRegistrationService:
                     ),
                     "observedAt": observed_at.isoformat(),
                     "harnessReady": True,
+                    "observedHarnessReadiness": readiness,
+                    "credentialless": credentialless,
                 }
             if len(matches) > 1:
                 raise HarnessPlatformError(
@@ -87,4 +120,8 @@ class OmnigentHostRegistrationService:
         )
 
 
-__all__ = ["OmnigentHostRegistrationService"]
+__all__ = [
+    "HOST_REGISTRATION_ATTEMPTS",
+    "HOST_REGISTRATION_INTERVAL_SECONDS",
+    "OmnigentHostRegistrationService",
+]

--- a/moonmind/omnigent/host_services/runtime_environment.py
+++ b/moonmind/omnigent/host_services/runtime_environment.py
@@ -1,0 +1,112 @@
+"""Lease-scoped capability construction for generic Omnigent hosts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from moonmind.omnigent.harness_platform.execution_plan import (
+    OmnigentExecutionPlanEnvelope,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import LaunchPolicy
+from moonmind.omnigent.workspace_intent import authored_required_capabilities
+from moonmind.security.execution_fanout_capabilities import (
+    EXECUTION_FANOUT_REQUIRED_CAPABILITY,
+    ExecutionFanoutCapabilityError,
+    mint_execution_fanout_capability,
+    require_execution_fanout_authorization,
+)
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+
+class OmnigentRuntimeEnvironmentService:
+    """Mint only capabilities authorized for one immutable host lease."""
+
+    def __init__(self, *, moonmind_url: str, signing_secret: str) -> None:
+        self._moonmind_url = moonmind_url.strip()
+        self._signing_secret = signing_secret
+
+    @staticmethod
+    def _execution_fanout_authorization(
+        request: AgentExecutionRequest,
+    ) -> Mapping[str, Any] | None:
+        step_execution = request.step_execution
+        if step_execution is None:
+            return None
+        policy = step_execution.skill_source_policy
+        if "executionFanout" not in policy:
+            return None
+        evidence = policy.get("executionFanout")
+        if not isinstance(evidence, Mapping):
+            raise HarnessPlatformError(
+                "execution fan-out authorization evidence is malformed",
+                code="authorization_denied",
+            )
+        return evidence
+
+    def build(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        plan: OmnigentExecutionPlanEnvelope,
+        host_lease_ref: str,
+        launch_policy: LaunchPolicy,
+    ) -> Mapping[str, str]:
+        required_capabilities = authored_required_capabilities(request)
+        if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required_capabilities:
+            return {}
+        try:
+            require_execution_fanout_authorization(
+                required_capabilities,
+                self._execution_fanout_authorization(request),
+            )
+        except ExecutionFanoutCapabilityError as exc:
+            raise HarnessPlatformError(str(exc), code="authorization_denied") from exc
+        step_execution = request.step_execution
+        workflow_id = (
+            str(step_execution.workflow_id or "").strip()
+            if step_execution is not None
+            else str(request.correlation_id or "").strip()
+        )
+        step_execution_id = (
+            str(step_execution.step_execution_id or "").strip()
+            if step_execution is not None
+            else str(request.correlation_id or "").strip()
+        )
+        runtime_id = str(plan.payload.harnessId or "").strip()
+        if (
+            not workflow_id
+            or not step_execution_id
+            or not runtime_id
+            or not self._moonmind_url
+        ):
+            raise HarnessPlatformError(
+                "execution fan-out runtime identity is incomplete",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        return {
+            "MOONMIND_URL": self._moonmind_url,
+            "MOONMIND_AGENT_RUN_ID": step_execution_id,
+            "MOONMIND_TASK_WORKFLOW_ID": workflow_id,
+            "MOONMIND_STEP_ID": step_execution_id,
+            "MOONMIND_RUNTIME_ID": runtime_id,
+            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": (
+                mint_execution_fanout_capability(
+                    secret=self._signing_secret,
+                    parent_workflow_id=workflow_id,
+                    agent_run_id=step_execution_id,
+                    step_id=step_execution_id,
+                    session_id=host_lease_ref,
+                    runtime_id=runtime_id,
+                    source_kind="omnigent",
+                    lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
+                )
+            ),
+        }
+
+
+__all__ = ["OmnigentRuntimeEnvironmentService"]

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -45,6 +45,14 @@ _GITHUB_RUNTIME_ENV = {
     "GH_NO_UPDATE_NOTIFIER": "1",
     "GH_NO_EXTENSION_UPDATE_NOTIFIER": "1",
 }
+_MOONMIND_RUNTIME_ENV_FILES = {
+    "MOONMIND_URL": "moonmind-url",
+    "MOONMIND_AGENT_RUN_ID": "agent-run-id",
+    "MOONMIND_TASK_WORKFLOW_ID": "task-workflow-id",
+    "MOONMIND_STEP_ID": "step-id",
+    "MOONMIND_RUNTIME_ID": "runtime-id",
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "execution-fanout-file",
+}
 
 
 class OmnigentRuntimeScriptService:
@@ -57,7 +65,9 @@ class OmnigentRuntimeScriptService:
         tool_attachments: tuple[dict[str, Any], ...] = (),
         github_credential_attachment: dict[str, Any] | None = None,
         control_attachment: dict[str, Any] | None = None,
+        control_credential_available: bool = True,
         enable_opencode_runtime: bool = False,
+        runtime_environment: dict[str, str] | None = None,
     ) -> tuple[str, dict[str, str]]:
         generation_checks: list[str] = []
         for handle in credential_handles:
@@ -73,6 +83,16 @@ class OmnigentRuntimeScriptService:
             "MOONMIND_ACTIVE_SKILLS_DIR": str(skill_attachment["targetPath"]),
             "MOONMIND_STEP_EXECUTION_ID": step_execution_id,
         }
+        supplied_runtime_environment = dict(runtime_environment or {})
+        if set(supplied_runtime_environment) - set(_MOONMIND_RUNTIME_ENV_FILES):
+            raise ValueError("unsupported MoonMind runtime environment")
+        for key, value in supplied_runtime_environment.items():
+            normalized = str(value or "").strip()
+            if not normalized or any(
+                character in normalized for character in ("\0", "\r", "\n")
+            ):
+                raise ValueError(f"invalid MoonMind runtime environment {key}")
+            environment[key] = normalized
         staging_dir = "/run/mm-credentials/opencode"
         opencode_data = "/home/app/.local/share/opencode"
         has_opencode_materializer = any(
@@ -110,7 +130,7 @@ class OmnigentRuntimeScriptService:
                 environment[key] = str(value)
         control_path = (
             f"{control_attachment['targetPath']}/api-token"
-            if control_attachment is not None
+            if control_attachment is not None and control_credential_available
             else ""
         )
         environment["MOONMIND_OMNIGENT_CONTROL_CREDENTIAL_FILE"] = control_path
@@ -136,11 +156,22 @@ class OmnigentRuntimeScriptService:
             *(_OPENCODE_RUNTIME_ENV if opencode_runtime else {}),
             *(_OPENCODE_PROXY_ENV_NAMES if opencode_runtime else {}),
             *(_GITHUB_RUNTIME_ENV if github_credential_attachment is not None else {}),
+            *supplied_runtime_environment,
         }
         if passthrough_names:
             environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(
                 sorted(passthrough_names)
             )
+        runtime_context_writes = "".join(
+            f'printf \'%s\\n\' "${key}" > {runtime_context_dir}/{filename}; '
+            for key, filename in _MOONMIND_RUNTIME_ENV_FILES.items()
+            if key in supplied_runtime_environment
+        )
+        runtime_context_exports = "".join(
+            f"'export {key}=$(cat {runtime_context_dir}/{filename})' "
+            for key, filename in _MOONMIND_RUNTIME_ENV_FILES.items()
+            if key in supplied_runtime_environment
+        )
         script = (
             "set -eu; "
             "unset OPENAI_API_KEY ANTHROPIC_API_KEY OPENCODE_AUTH_CONTENT "
@@ -170,7 +201,8 @@ class OmnigentRuntimeScriptService:
             "printf '%s\\n' \"$MOONMIND_STEP_EXECUTION_ID\" > "
             + runtime_context_dir
             + "/step-execution-id; "
-            "chmod 0600 " + runtime_context_dir + "/*; "
+            + runtime_context_writes
+            + "chmod 0600 " + runtime_context_dir + "/*; "
             "printf '%s\\n' '#!/bin/sh' "
             "'export MOONMIND_ACTIVE_SKILLS_DIR=$(cat "
             + runtime_context_dir
@@ -178,7 +210,8 @@ class OmnigentRuntimeScriptService:
             "'export MOONMIND_STEP_EXECUTION_ID=$(cat "
             + runtime_context_dir
             + "/step-execution-id)' "
-            "'if [ -r /home/app/.config/gh/hosts.yml ]; then' "
+            + runtime_context_exports
+            + "'if [ -r /home/app/.config/gh/hosts.yml ]; then' "
             "'  export GH_CONFIG_DIR=/home/app/.config/gh' "
             "'  export GH_PROMPT_DISABLED=1' "
             "'  export GH_NO_UPDATE_NOTIFIER=1' "

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -27,6 +27,10 @@ from moonmind.omnigent.host_failures import OmnigentOAuthHostError
 from moonmind.omnigent.host_services.legacy_host_containers import (
     LegacyOmnigentHostContainerService,
 )
+from moonmind.omnigent.host_services.registration import (
+    HOST_REGISTRATION_ATTEMPTS,
+    HOST_REGISTRATION_INTERVAL_SECONDS,
+)
 from moonmind.omnigent.oauth_hosts import (
     HostPreflightFailure,
     deterministic_host_container_name,
@@ -229,12 +233,6 @@ _SAFE_STEP_EXECUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,510}[A-Za-z
 _MAX_RESTORE_INPUT_REFS = 64
 _MAX_RESTORE_INPUT_BYTES = 64 * 1024 * 1024
 _MAX_RESTORE_TOTAL_BYTES = 256 * 1024 * 1024
-# Stock Omnigent first publishes an offline catalog row, then replaces it with
-# the live host identity after the runner tunnel is ready. Cold image and
-# catalog startup has exceeded one minute on the supported local Compose path;
-# keep the wait bounded but large enough for that authoritative online edge.
-_HOST_REGISTRATION_ATTEMPTS = 91
-_HOST_REGISTRATION_INTERVAL_SECONDS = 2
 _HOST_EXEC_PREFLIGHT_ATTEMPTS = 11
 _HOST_EXEC_PREFLIGHT_INTERVAL_SECONDS = 1
 # Restore payloads are read through the durable artifact contract as raw bytes,
@@ -3646,7 +3644,7 @@ class OmnigentOAuthHostRuntime:
             host_lease.lease_id
         )
         adapter = self._runtime_adapter(binding)
-        for attempt in range(_HOST_REGISTRATION_ATTEMPTS):
+        for attempt in range(HOST_REGISTRATION_ATTEMPTS):
             hosts = await self._client.list_hosts()
             if expected_id:
                 matches = [
@@ -3671,8 +3669,8 @@ class OmnigentOAuthHostRuntime:
                 return dict(online[0])
             if len(online) > 1:
                 break
-            if attempt + 1 < _HOST_REGISTRATION_ATTEMPTS:
-                await asyncio.sleep(_HOST_REGISTRATION_INTERVAL_SECONDS)
+            if attempt + 1 < HOST_REGISTRATION_ATTEMPTS:
+                await asyncio.sleep(HOST_REGISTRATION_INTERVAL_SECONDS)
         raise OmnigentOAuthHostError(
             "expected exactly one compatible online host after bounded registration wait",
             code=HostPreflightFailure.HOST_NOT_REGISTERED.value,

--- a/moonmind/omnigent/production.py
+++ b/moonmind/omnigent/production.py
@@ -14,6 +14,7 @@ from moonmind.auth.resolvers import (
     RootSecretResolver,
 )
 from moonmind.auth.secret_refs import SecretBackend
+from moonmind.config.settings import settings
 from moonmind.omnigent.bridge_artifacts import TemporalOmnigentArtifactGateway
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.credential_materializers import (
@@ -55,6 +56,7 @@ from moonmind.omnigent.host_services import (
     OmnigentGithubCredentialService,
     OmnigentHostRegistrationService,
     OmnigentMountedToolService,
+    OmnigentRuntimeEnvironmentService,
     OmnigentRuntimeScriptService,
     OmnigentSkillDeliveryService,
     OmnigentWorkspaceMaterializer,
@@ -249,6 +251,10 @@ def build_generic_omnigent_execution_services(
         tool_service=OmnigentMountedToolService(backend=docker),
         github_credential_service=OmnigentGithubCredentialService(docker),
         egress_service=OmnigentEgressService(backend=docker, artifacts=artifacts),
+        runtime_environment_service=OmnigentRuntimeEnvironmentService(
+            moonmind_url=str(os.getenv("MOONMIND_URL") or "http://api:8000"),
+            signing_secret=str(settings.security.JWT_SECRET_KEY or ""),
+        ),
         registration_waiter=OmnigentHostRegistrationService(
             client=client, expected_owner=expected_owner
         ),

--- a/moonmind/workflows/executions/runtime_inheritance.py
+++ b/moonmind/workflows/executions/runtime_inheritance.py
@@ -75,6 +75,7 @@ class InheritedRuntime:
     effort: Optional[str] = None
     profile_id: Optional[str] = None
     execution_profile_ref: Optional[str] = None
+    agent_profile: Optional[dict[str, Any]] = None
     omnigent: Optional[dict[str, Any]] = None
     source_workflow_id: Optional[str] = None
 
@@ -258,6 +259,33 @@ def _extract_parent_runtime_fields(record: Any) -> InheritedRuntime:
     execution_profile_ref = (
         _coerce_str(workflow_runtime.get("executionProfileRef")) or profile_id
     )
+    raw_agent_profile = (
+        workflow_runtime.get("agentProfile")
+        if isinstance(workflow_runtime.get("agentProfile"), Mapping)
+        else parameters.get("agentProfile")
+    )
+    raw_agent_profile_snapshot = parameters.get("agentProfileSnapshot")
+    agent_profile_snapshot = (
+        raw_agent_profile_snapshot
+        if isinstance(raw_agent_profile_snapshot, Mapping)
+        else {}
+    )
+    agent_profile = (
+        dict(raw_agent_profile) if isinstance(raw_agent_profile, Mapping) else {}
+    )
+    # Persisted ``agentProfile`` is intentionally a compact immutable identity,
+    # while admission also requires the selected Provider Profile authority.
+    # Reconstruct the authorable exact selector from the full immutable
+    # snapshot; never copy the snapshot document itself into a child request.
+    for key in ("profileId", "version", "digest", "providerProfileRef"):
+        if agent_profile.get(key) in (None, "") and agent_profile_snapshot.get(
+            key
+        ) not in (None, ""):
+            agent_profile[key] = agent_profile_snapshot[key]
+    if not _coerce_str(agent_profile.get("providerProfileRef")) and profile_id:
+        agent_profile["providerProfileRef"] = profile_id
+    if not agent_profile:
+        agent_profile = None
     raw_omnigent = (
         workflow_runtime.get("omnigent")
         if isinstance(workflow_runtime.get("omnigent"), Mapping)
@@ -273,6 +301,7 @@ def _extract_parent_runtime_fields(record: Any) -> InheritedRuntime:
         effort=effort,
         profile_id=profile_id,
         execution_profile_ref=execution_profile_ref,
+        agent_profile=agent_profile,
         omnigent=omnigent,
         source_workflow_id=workflow_id,
     )
@@ -468,14 +497,18 @@ def apply_inherited_runtime_to_payload(
         runtime_block["executionProfileRef"] = inherited.execution_profile_ref
     if inherited.profile_id and not explicit_profile_id:
         runtime_block["profileId"] = inherited.profile_id
-    if inherited.omnigent:
-        explicit_omnigent = (
-            runtime_block.get("omnigent")
-            if isinstance(runtime_block.get("omnigent"), Mapping)
-            else payload.get("omnigent")
-        )
-        if not isinstance(explicit_omnigent, Mapping):
-            runtime_block["omnigent"] = dict(inherited.omnigent)
+    if inherited.agent_profile:
+        explicit_agent_profile = payload.get("agentProfile")
+        if not isinstance(explicit_agent_profile, Mapping):
+            explicit_agent_profile = runtime_block.get("agentProfile")
+        if not isinstance(explicit_agent_profile, Mapping):
+            runtime_block["agentProfile"] = dict(inherited.agent_profile)
+    if inherited.omnigent and not isinstance(payload.get("omnigent"), Mapping):
+        # Omnigent launch and execution-target selectors are request-level
+        # fields.  The create router deliberately does not consume
+        # workflow.runtime.omnigent, so nesting inherited selectors there
+        # silently discards the parent's effective execution target.
+        payload["omnigent"] = dict(inherited.omnigent)
 
     if runtime_block:
         task_payload["runtime"] = runtime_block

--- a/moonmind/workflows/executions/runtime_inheritance.py
+++ b/moonmind/workflows/executions/runtime_inheritance.py
@@ -282,7 +282,11 @@ def _extract_parent_runtime_fields(record: Any) -> InheritedRuntime:
             key
         ) not in (None, ""):
             agent_profile[key] = agent_profile_snapshot[key]
-    if not _coerce_str(agent_profile.get("providerProfileRef")) and profile_id:
+    if (
+        agent_profile
+        and not _coerce_str(agent_profile.get("providerProfileRef"))
+        and profile_id
+    ):
         agent_profile["providerProfileRef"] = profile_id
     if not agent_profile:
         agent_profile = None
@@ -501,7 +505,10 @@ def apply_inherited_runtime_to_payload(
         explicit_agent_profile = payload.get("agentProfile")
         if not isinstance(explicit_agent_profile, Mapping):
             explicit_agent_profile = runtime_block.get("agentProfile")
-        if not isinstance(explicit_agent_profile, Mapping):
+        if (
+            not isinstance(explicit_agent_profile, Mapping)
+            and not explicit_profile_id
+        ):
             runtime_block["agentProfile"] = dict(inherited.agent_profile)
     if inherited.omnigent and not isinstance(payload.get("omnigent"), Mapping):
         # Omnigent launch and execution-target selectors are request-level

--- a/tests/integration/reliability/replays/omnigent-fanout-runtime-inheritance/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-fanout-runtime-inheritance/expected-outcome.json
@@ -1,0 +1,19 @@
+{
+  "invariant": "caller inheritance preserves the parent's exact immutable Agent Profile and keeps Omnigent execution-target and launch-policy selectors at the API request level consumed by admission",
+  "providerProfileRef": "opencode-zen-free",
+  "agentProfile": {
+    "profileId": "omnigent-opencode-default",
+    "version": 11,
+    "digest": "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91",
+    "providerProfileRef": "opencode-zen-free"
+  },
+  "omnigent": {
+    "agentProfileRef": {
+      "profileId": "omnigent-opencode-default",
+      "version": 11,
+      "digest": "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91"
+    },
+    "launchPolicyRef": "omnigent-on-demand@1",
+    "executionTargetRef": "omnigent-opencode@1"
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-fanout-runtime-inheritance/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-fanout-runtime-inheritance/manifest.json
@@ -1,0 +1,45 @@
+{
+  "incidentWorkflowId": "mm:4b70984f-1b70-452a-9a4c-528357740faf",
+  "sourceWorkflowId": "mm:171981b9-8988-40e5-ab5c-e3b66d6dee61",
+  "terminalFailureCode": "CHILD_WORKFLOW_QUEUE_FAILED",
+  "matchedPrs": 7,
+  "queuedWorkflows": 0,
+  "failureShape": "the execution-scoped fan-out transport reached POST /api/executions, but caller inheritance discarded the exact Agent Profile and nested Omnigent launch selectors under workflow.runtime, so every child was rejected with an incompatible Provider Profile conflict",
+  "parentEffectiveParameters": {
+    "targetRuntime": "omnigent",
+    "model": "opencode/muse-spark-1.2-contributor-free",
+    "effort": "xhigh",
+    "profileId": "opencode-zen-free",
+    "agentProfile": {
+      "profileId": "omnigent-opencode-default",
+      "version": 11,
+      "digest": "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91"
+    },
+    "agentProfileSnapshot": {
+      "profileId": "omnigent-opencode-default",
+      "version": 11,
+      "digest": "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91",
+      "providerProfileRef": "opencode-zen-free",
+      "executionProfileRef": "omnigent-opencode@1",
+      "launchPolicyRef": "omnigent-on-demand@1"
+    },
+    "omnigent": {
+      "agentProfileRef": {
+        "profileId": "omnigent-opencode-default",
+        "version": 11,
+        "digest": "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91"
+      },
+      "launchPolicyRef": "omnigent-on-demand@1",
+      "executionTargetRef": "omnigent-opencode@1"
+    },
+    "workflow": {
+      "runtime": {
+        "mode": "omnigent",
+        "model": "opencode/muse-spark-1.2-contributor-free",
+        "effort": "xhigh",
+        "profileId": "opencode-zen-free",
+        "executionProfileRef": "opencode-zen-free"
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-generic-fanout-env-handoff/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-generic-fanout-env-handoff/expected-outcome.json
@@ -1,0 +1,15 @@
+{
+  "invariant": "trusted execution.fanout authorization is minted for the exact generic host lease, transported only through a read-only capability file, and restored with MoonMind execution identity in the OpenCode tool shell",
+  "visibleEnvironmentNames": [
+    "MOONMIND_URL",
+    "MOONMIND_AGENT_RUN_ID",
+    "MOONMIND_TASK_WORKFLOW_ID",
+    "MOONMIND_STEP_ID",
+    "MOONMIND_RUNTIME_ID",
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE"
+  ],
+  "excludedEnvironmentNames": [
+    "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"
+  ],
+  "capabilityFile": "/run/moonmind-host-auth/execution-fanout"
+}

--- a/tests/integration/reliability/replays/omnigent-generic-fanout-env-handoff/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-generic-fanout-env-handoff/manifest.json
@@ -1,0 +1,11 @@
+{
+  "incidentWorkflowId": "mm:eb37130f-2bf0-480d-bb01-1569581cd944",
+  "sourceWorkflowId": "mm:171981b9-8988-40e5-ab5c-e3b66d6dee61",
+  "stepExecutionId": "mm:eb37130f-2bf0-480d-bb01-1569581cd944:01a0599e-16c5-7b0f-aeca-abb203facc47:node-1:execution:1",
+  "moonmindUrl": "http://api:8000",
+  "requiredCapabilities": ["gh", "execution.fanout"],
+  "terminalFailureCode": "CHILD_WORKFLOW_QUEUE_FAILED",
+  "matchedPrs": 7,
+  "queuedWorkflows": 0,
+  "failureShape": "the generic Omnigent host received GitHub credentials and completed its provider turn, but it omitted MOONMIND_URL and the execution-scoped fan-out capability file from the runner and OpenCode tool-shell environment"
+}

--- a/tests/integration/reliability/replays/omnigent-generic-host-readiness-long-tail/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-generic-host-readiness-long-tail/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "the generic exact-host lifecycle covers supported cold-start tails and admits needs-auth only for a credentialless plan whose exact selected model is attested next",
+  "hostId": "host-generic-long-readiness-replay",
+  "catalogReadCount": 41,
+  "sleepCount": 40,
+  "sleepSeconds": 2.0
+}

--- a/tests/integration/reliability/replays/omnigent-generic-host-readiness-long-tail/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-generic-host-readiness-long-tail/manifest.json
@@ -1,0 +1,9 @@
+{
+  "incidentWorkflowId": "mm:ed856a13-58ef-42ae-9763-f673198c0e9a",
+  "failureShape": "the exact ARM64 host registered with credentialless OpenCode reported as needs-auth, which the generic realizer rejected until its one-minute registration window expired",
+  "boundary": "exact generic host launch to harness-ready catalog publication",
+  "emptyCatalogReads": 40,
+  "containerName": "mm-host-a76b18a1c964dddd3ebdc59a",
+  "expectedOwner": "moonmind",
+  "harnessId": "opencode-native"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -62,6 +62,12 @@ from moonmind.omnigent.execute import (
 )
 from moonmind.omnigent.execution_profiles import compile_effective_launch
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.host_services.registration import (
+    OmnigentHostRegistrationService,
+)
+from moonmind.omnigent.host_services.runtime_scripts import (
+    OmnigentRuntimeScriptService,
+)
 from moonmind.omnigent.oauth_host_janitor import OmnigentOAuthHostJanitor
 from moonmind.omnigent.oauth_host_runtime import OmnigentOAuthHostRuntime
 from moonmind.omnigent.host_failures import OmnigentOAuthHostError
@@ -124,6 +130,13 @@ from moonmind.workflows.executions.repository_contract import (
 )
 from moonmind.workflows.executions.runtime_capabilities import (
     resolve_runtime_execution_capabilities,
+)
+from moonmind.workflows.executions.runtime_inheritance import (
+    SCOPE_CREATE_CHILD,
+    SCOPE_INHERIT_RUNTIME,
+    ExecutionPrincipal,
+    apply_inherited_runtime_to_payload,
+    resolve_child_runtime_inheritance,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
 from moonmind.workflows.provider_failures import (
@@ -3196,6 +3209,76 @@ async def test_omnigent_host_registration_covers_observed_long_tail(
     sleep.assert_awaited_with(expected["sleepSeconds"])
 
 
+async def test_generic_host_registration_covers_direct_spawn_readiness_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:ed856a13 after generic-host readiness exceeded one minute."""
+
+    replay_id = "omnigent-generic-host-readiness-long-tail"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    ready_host = {
+        "host_id": expected["hostId"],
+        "name": manifest["containerName"],
+        "owner": manifest["expectedOwner"],
+        "status": "online",
+        "configured_harnesses": {manifest["harnessId"]: "needs-auth"},
+    }
+    client = SimpleNamespace(
+        list_hosts=AsyncMock(
+            side_effect=[
+                *([[]] * manifest["emptyCatalogReads"]),
+                [ready_host],
+            ]
+        )
+    )
+    waiter = OmnigentHostRegistrationService(
+        client=client,
+        expected_owner=manifest["expectedOwner"],
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(
+        "moonmind.omnigent.host_services.registration.asyncio.sleep",
+        sleep,
+    )
+
+    registration = await waiter.wait_for_registration(
+        correlation_name=manifest["containerName"],
+        harness_id=manifest["harnessId"],
+        credentialless=True,
+    )
+
+    assert registration["omnigentHostId"] == expected["hostId"]
+    assert registration["harnessReady"] is True
+    assert client.list_hosts.await_count == expected["catalogReadCount"]
+    assert sleep.await_count == expected["sleepCount"]
+    sleep.assert_awaited_with(expected["sleepSeconds"])
+
+
+async def test_generic_host_registration_rejects_needs_auth_for_credentialed_plan(
+) -> None:
+    host = {
+        "host_id": "host-needs-auth",
+        "name": "mm-host-credentialed",
+        "owner": "moonmind",
+        "status": "online",
+        "configured_harnesses": {"opencode-native": "needs-auth"},
+    }
+    waiter = OmnigentHostRegistrationService(
+        client=SimpleNamespace(list_hosts=AsyncMock(return_value=[host])),
+        expected_owner="moonmind",
+        attempts=1,
+        interval_seconds=0.001,
+    )
+
+    with pytest.raises(HarnessPlatformError):
+        await waiter.wait_for_registration(
+            correlation_name="mm-host-credentialed",
+            harness_id="opencode-native",
+            credentialless=False,
+        )
+
+
 async def test_tool_output_only_omnigent_turn_continues_before_publication(
     tmp_path: Path,
 ) -> None:
@@ -3958,6 +4041,98 @@ async def test_omnigent_codex_tool_shell_receives_moonmind_execution_environment
         runtime_environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"]
     )
     assert "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN" not in runtime_environment
+
+
+async def test_generic_omnigent_fanout_crosses_runner_and_opencode_shell() -> None:
+    """Replay mm:eb37130f after the original mm:171981b9 admission fix."""
+
+    replay_id = "omnigent-generic-fanout-env-handoff"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    runtime_environment = {
+        "MOONMIND_URL": manifest["moonmindUrl"],
+        "MOONMIND_AGENT_RUN_ID": manifest["stepExecutionId"],
+        "MOONMIND_TASK_WORKFLOW_ID": manifest["incidentWorkflowId"],
+        "MOONMIND_STEP_ID": manifest["stepExecutionId"],
+        "MOONMIND_RUNTIME_ID": "opencode-native",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": expected[
+            "capabilityFile"
+        ],
+    }
+
+    script, environment = OmnigentRuntimeScriptService().build_entrypoint(
+        credential_handles=[],
+        skill_attachment={"targetPath": "/opt/moonmind-skills"},
+        step_execution_id=manifest["stepExecutionId"],
+        control_attachment={"targetPath": "/run/moonmind-host-auth"},
+        enable_opencode_runtime=True,
+        runtime_environment=runtime_environment,
+    )
+
+    assert manifest["sourceWorkflowId"] == "mm:171981b9-8988-40e5-ab5c-e3b66d6dee61"
+    assert manifest["matchedPrs"] == 7
+    assert manifest["queuedWorkflows"] == 0
+    passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
+    for name in expected["visibleEnvironmentNames"]:
+        assert environment[name] == runtime_environment[name]
+        assert name in passthrough
+        assert f"export {name}=$(cat " in script
+    for name in expected["excludedEnvironmentNames"]:
+        assert name not in environment
+        assert f"export {name}=" not in script
+    syntax = subprocess.run(
+        ["/bin/sh", "-n"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+async def test_generic_omnigent_fanout_preserves_exact_caller_runtime() -> None:
+    """Replay mm:4b70984f at the API runtime-inheritance boundary."""
+
+    replay_id = "omnigent-fanout-runtime-inheritance"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = SimpleNamespace(
+        workflow_id=manifest["incidentWorkflowId"],
+        owner_id="replay-owner",
+        parameters=manifest["parentEffectiveParameters"],
+        memo={},
+        search_attributes={},
+    )
+    service = SimpleNamespace(describe_execution=AsyncMock(return_value=parent))
+    principal = ExecutionPrincipal(
+        user_id="replay-owner",
+        workflow_id=manifest["incidentWorkflowId"],
+        scopes=frozenset({SCOPE_CREATE_CHILD, SCOPE_INHERIT_RUNTIME}),
+    )
+    payload = {
+        "runtimeInheritance": "caller",
+        "workflow": {"instructions": "Resolve the selected pull request."},
+    }
+
+    inherited = await resolve_child_runtime_inheritance(
+        request_payload=payload,
+        task_payload=payload["workflow"],
+        principal=principal,
+        service=service,
+    )
+    assert inherited is not None
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=payload["workflow"],
+        inherited=inherited,
+    )
+
+    runtime = payload["workflow"]["runtime"]
+    assert runtime["mode"] == "omnigent"
+    assert runtime["profileId"] == expected["providerProfileRef"]
+    assert runtime["agentProfile"] == expected["agentProfile"]
+    assert payload["omnigent"] == expected["omnigent"]
+    assert "omnigent" not in runtime
 
 
 async def test_omnigent_batch_fanout_crosses_only_scoped_execution_proxy_routes(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4934,6 +4934,143 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
     )
 
 
+def test_api_execution_keeps_selected_provider_profile_model_in_opencode_plan(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """Replay mm:171981b9 at the Provider Profile -> plan authority handoff."""
+
+    test_client, temporal_service, _user = client
+    temporal_service.create_execution.return_value = _build_execution_record()
+    provider_profile = SimpleNamespace(
+        profile_id="opencode-zen-free",
+        runtime_id="opencode",
+        provider_id="opencode",
+        default_model="opencode/muse-spark-1.2-contributor-free",
+        default_effort="xhigh",
+        model_tiers=[
+            {
+                "label": "Muse Spark 1.2 Contributor Free",
+                "model": "opencode/muse-spark-1.2-contributor-free",
+                "effort": "xhigh",
+                "parameters": {},
+                "annotations": {},
+            }
+        ],
+        default_model_tier=1,
+        enabled=True,
+        auth_state="connected",
+        disabled_reason=None,
+    )
+    db_session = SimpleNamespace(
+        get=AsyncMock(
+            side_effect=[provider_profile, provider_profile, None]
+        ),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    test_client.app.dependency_overrides[get_async_session] = lambda: db_session
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        "profileId": "omnigent-opencode-default",
+        "version": 11,
+        "digest": "sha256:" + "a" * 64,
+        "providerProfileRef": "opencode-zen-free",
+        "executionProfileRef": "generic-omnigent-host@1",
+        "allowedLaunchPolicyRefs": ["omnigent-on-demand@1"],
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "agentId": "opencode-native-ui",
+        "document": {
+            # The upstream Agent Profile has a different default; the selected
+            # Provider Profile remains authoritative for this run's model.
+            "model": {
+                "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
+                "effort": "xhigh",
+                "settings": {},
+            },
+            "rag": {},
+            "capture": {"stream": True},
+            "workspace": {"mutation": "allowed"},
+            "harness": {"id": "opencode-native"},
+            "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+        },
+    }
+    plan_binding = OmnigentExecutionPlanBinding(
+        planRef="omnigent-execution-plan:sha256:" + "b" * 64,
+        planDigest="sha256:" + "b" * 64,
+        planArtifactRef="art_zen_plan",
+        taskInputSnapshotRef="art_zen_task",
+        taskInputSnapshotDigest="sha256:" + "c" * 64,
+    )
+    compiled_parameters: dict[str, object] = {}
+
+    async def compile_plan(**kwargs):
+        compiled_parameters.update(kwargs["initial_parameters"])
+        return SimpleNamespace(
+            binding=plan_binding,
+            artifact_refs=("art_profile", "art_skills", "art_zen_plan"),
+            resolved_skillset_ref="art_skills",
+        )
+
+    with (
+        patch(
+            "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+            new=AsyncMock(return_value=snapshot),
+        ),
+        patch(
+            "api_service.services.omnigent_execution_plan_service.persist_json_artifact",
+            new=AsyncMock(return_value=("art_zen_task", "sha256:" + "c" * 64)),
+        ),
+        patch(
+            "api_service.services.omnigent_execution_plan_service.compile_and_persist_execution_plan",
+            new=compile_plan,
+        ),
+        patch(
+            "api_service.api.routers.executions.get_temporal_artifact_service",
+            return_value=SimpleNamespace(),
+        ),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "workflow",
+                "payload": {
+                    "targetRuntime": "omnigent",
+                    "agentProfile": {
+                        "profileId": "omnigent-opencode-default",
+                        "providerProfileRef": "opencode-zen-free",
+                    },
+                    "omnigent": {
+                        "executionTargetRef": "omnigent-opencode-default@11",
+                        "launchPolicyRef": "omnigent-on-demand@1",
+                    },
+                    "workflow": {
+                        "instructions": "Run credentialless OpenCode.",
+                        "runtime": {
+                            "mode": "omnigent",
+                            "profileId": "opencode-zen-free",
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.text
+    assert compiled_parameters["model"] == (
+        "opencode/muse-spark-1.2-contributor-free"
+    )
+    assert compiled_parameters["effort"] == "xhigh"
+    assert compiled_parameters["modelSource"] == "profile_default_tier"
+    initial_parameters = temporal_service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["model"] == (
+        "opencode/muse-spark-1.2-contributor-free"
+    )
+    assert initial_parameters["modelTierResolution"]["resolvedModel"] == (
+        "opencode/muse-spark-1.2-contributor-free"
+    )
+
+
 def test_api_idempotent_omnigent_retry_reuses_recorded_plan_before_resolution(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
@@ -9039,6 +9176,172 @@ def test_create_task_shaped_execution_accepts_scoped_fanout_bearer(
     assert initial_parameters["parentWorkflowId"] == "mm:parent-task"
     assert initial_parameters["targetRuntime"] == "codex_cli"
     assert service.create_execution.await_args.kwargs["owner_id"] == user.id
+
+
+def test_execution_fanout_inherits_exact_omnigent_agent_profile(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """Replay mm:4b70984f through fan-out admission and plan compilation."""
+
+    test_client, service, user = client
+    for dependency in tuple(test_client.app.dependency_overrides):
+        if getattr(dependency, "__name__", "") == "_current_user_fallback":
+            test_client.app.dependency_overrides[dependency] = lambda: None
+    service.create_execution.return_value = _build_execution_record(owner_id=str(user.id))
+    digest = "sha256:a40d86b5a425308cebc144392c0ef9d69733a37f7abe005ee0cf0439767e6e91"
+    agent_profile = {
+        "profileId": "omnigent-opencode-default",
+        "version": 11,
+        "digest": digest,
+    }
+    omnigent_selection = {
+        "agentProfileRef": agent_profile,
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "executionTargetRef": "omnigent-opencode@1",
+    }
+    service.describe_execution.return_value = SimpleNamespace(
+        workflow_id="mm:parent-task",
+        owner_id=user.id,
+        owner_type="user",
+        parameters={
+            "targetRuntime": "omnigent",
+            "model": "opencode/muse-spark-1.2-contributor-free",
+            "effort": "xhigh",
+            "profileId": "opencode-zen-free",
+            "agentProfile": agent_profile,
+            "agentProfileSnapshot": {
+                **agent_profile,
+                "providerProfileRef": "opencode-zen-free",
+            },
+            "omnigent": omnigent_selection,
+            "workflow": {
+                "runtime": {
+                    "mode": "omnigent",
+                    "model": "opencode/muse-spark-1.2-contributor-free",
+                    "effort": "xhigh",
+                    "profileId": "opencode-zen-free",
+                    "executionProfileRef": "opencode-zen-free",
+                }
+            },
+        },
+        memo={},
+        search_attributes={},
+    )
+    provider_profile = SimpleNamespace(
+        profile_id="opencode-zen-free",
+        runtime_id="opencode",
+        provider_id="opencode",
+        default_model="opencode/muse-spark-1.2-contributor-free",
+        default_effort="xhigh",
+        model_tiers=[],
+        default_model_tier=None,
+        enabled=True,
+        auth_state="connected",
+        disabled_reason=None,
+    )
+    db_session = SimpleNamespace(
+        get=AsyncMock(
+            side_effect=[provider_profile, None, provider_profile, None]
+        ),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    test_client.app.dependency_overrides[get_async_session] = lambda: db_session
+    snapshot = {
+        "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
+        **agent_profile,
+        "providerProfileRef": "opencode-zen-free",
+        "executionProfileRef": "omnigent-opencode@1",
+        "allowedLaunchPolicyRefs": [
+            "omnigent-on-demand@1",
+            "opencode-on-demand@1",
+        ],
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "agentId": "opencode-native-ui",
+        "document": {
+            "model": {"settings": {}},
+            "rag": {},
+            "capture": {"stream": True},
+            "workspace": {"mutation": "allowed"},
+            "harness": {"id": "opencode-native"},
+            "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+        },
+    }
+    plan_binding = OmnigentExecutionPlanBinding(
+        planRef="omnigent-execution-plan:sha256:" + "b" * 64,
+        planDigest="sha256:" + "b" * 64,
+        planArtifactRef="art_inherited_plan",
+        taskInputSnapshotRef="art_inherited_task",
+        taskInputSnapshotDigest="sha256:" + "c" * 64,
+    )
+    profile_resolver = AsyncMock(return_value=snapshot)
+    compile_plan = AsyncMock(
+        return_value=SimpleNamespace(
+            binding=plan_binding,
+            artifact_refs=("art_profile", "art_skills", "art_inherited_plan"),
+            resolved_skillset_ref="art_skills",
+        )
+    )
+
+    with (
+        patch(
+            "api_service.api.routers.executions.resolve_agent_profile_snapshot",
+            new=profile_resolver,
+        ),
+        patch(
+            "api_service.services.omnigent_execution_plan_service.persist_json_artifact",
+            new=AsyncMock(
+                return_value=("art_inherited_task", "sha256:" + "c" * 64)
+            ),
+        ),
+        patch(
+            "api_service.services.omnigent_execution_plan_service.compile_and_persist_execution_plan",
+            new=compile_plan,
+        ),
+        patch(
+            "api_service.api.routers.executions.get_temporal_artifact_service",
+            return_value=SimpleNamespace(),
+        ),
+    ):
+        response = test_client.post(
+            "/api/executions",
+            headers={
+                "Authorization": f"Bearer {_execution_fanout_token()}",
+                "X-MoonMind-Execution-Fanout": "v1",
+            },
+            json={
+                "type": "workflow",
+                "payload": {
+                    "runtimeInheritance": "caller",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "workflow": {
+                        "instructions": "Resolve PR #3861.",
+                        "idempotencyKey": "parent:pr:3861",
+                        "skill": {"name": "pr-resolver"},
+                        "inputs": {
+                            "repo": "MoonLadderStudios/MoonMind",
+                            "pr": "3861",
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201, response.text
+    assert profile_resolver.await_args.kwargs["selection"] == {
+        **agent_profile,
+        "providerProfileRef": "opencode-zen-free",
+        "launchPolicyRef": "omnigent-on-demand@1",
+    }
+    compile_parameters = compile_plan.await_args.kwargs["initial_parameters"]
+    assert compile_parameters["profileId"] == "opencode-zen-free"
+    assert compile_parameters["model"] == (
+        "opencode/muse-spark-1.2-contributor-free"
+    )
+    assert compile_parameters["omnigent"]["executionTargetRef"] == (
+        "omnigent-opencode@1"
+    )
+    assert compile_parameters["parentWorkflowId"] == "mm:parent-task"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4934,10 +4934,48 @@ def test_api_execution_compiles_opencode_plan_before_temporal_schedule(
     )
 
 
-def test_api_execution_keeps_selected_provider_profile_model_in_opencode_plan(
+@pytest.mark.parametrize(
+    (
+        "provider_default_model",
+        "provider_model_tiers",
+        "provider_default_tier",
+        "expected_model",
+        "expected_model_source",
+    ),
+    [
+        (
+            "opencode/muse-spark-1.2-contributor-free",
+            [
+                {
+                    "label": "Muse Spark 1.2 Contributor Free",
+                    "model": "opencode/muse-spark-1.2-contributor-free",
+                    "effort": "xhigh",
+                    "parameters": {},
+                    "annotations": {},
+                }
+            ],
+            1,
+            "opencode/muse-spark-1.2-contributor-free",
+            "profile_default_tier",
+        ),
+        (
+            None,
+            [],
+            None,
+            "opencode-go/muse-spark-1.2-contributor",
+            "none",
+        ),
+    ],
+)
+def test_api_execution_keeps_authoritative_model_in_opencode_plan(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    provider_default_model: str | None,
+    provider_model_tiers: list[dict[str, object]],
+    provider_default_tier: int | None,
+    expected_model: str,
+    expected_model_source: str,
 ) -> None:
-    """Replay mm:171981b9 at the Provider Profile -> plan authority handoff."""
+    """Replay Provider Profile and Agent Profile model authority handoffs."""
 
     test_client, temporal_service, _user = client
     temporal_service.create_execution.return_value = _build_execution_record()
@@ -4945,18 +4983,10 @@ def test_api_execution_keeps_selected_provider_profile_model_in_opencode_plan(
         profile_id="opencode-zen-free",
         runtime_id="opencode",
         provider_id="opencode",
-        default_model="opencode/muse-spark-1.2-contributor-free",
+        default_model=provider_default_model,
         default_effort="xhigh",
-        model_tiers=[
-            {
-                "label": "Muse Spark 1.2 Contributor Free",
-                "model": "opencode/muse-spark-1.2-contributor-free",
-                "effort": "xhigh",
-                "parameters": {},
-                "annotations": {},
-            }
-        ],
-        default_model_tier=1,
+        model_tiers=provider_model_tiers,
+        default_model_tier=provider_default_tier,
         enabled=True,
         auth_state="connected",
         disabled_reason=None,
@@ -4980,8 +5010,8 @@ def test_api_execution_keeps_selected_provider_profile_model_in_opencode_plan(
         "launchPolicyRef": "omnigent-on-demand@1",
         "agentId": "opencode-native-ui",
         "document": {
-            # The upstream Agent Profile has a different default; the selected
-            # Provider Profile remains authoritative for this run's model.
+            # The Agent Profile remains authoritative unless Provider Profile
+            # resolution establishes a more specific model source.
             "model": {
                 "qualifiedId": "opencode-go/muse-spark-1.2-contributor",
                 "effort": "xhigh",
@@ -5055,20 +5085,19 @@ def test_api_execution_keeps_selected_provider_profile_model_in_opencode_plan(
         )
 
     assert response.status_code == 201, response.text
-    assert compiled_parameters["model"] == (
-        "opencode/muse-spark-1.2-contributor-free"
-    )
+    assert compiled_parameters["model"] == expected_model
     assert compiled_parameters["effort"] == "xhigh"
-    assert compiled_parameters["modelSource"] == "profile_default_tier"
+    assert compiled_parameters["modelSource"] == expected_model_source
     initial_parameters = temporal_service.create_execution.await_args.kwargs[
         "initial_parameters"
     ]
-    assert initial_parameters["model"] == (
-        "opencode/muse-spark-1.2-contributor-free"
-    )
-    assert initial_parameters["modelTierResolution"]["resolvedModel"] == (
-        "opencode/muse-spark-1.2-contributor-free"
-    )
+    assert initial_parameters["model"] == expected_model
+    if provider_model_tiers:
+        assert initial_parameters["modelTierResolution"]["resolvedModel"] == (
+            expected_model
+        )
+    else:
+        assert "modelTierResolution" not in initial_parameters
 
 
 def test_api_idempotent_omnigent_retry_reuses_recorded_plan_before_resolution(

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -50,6 +50,7 @@ from moonmind.omnigent.harness_platform.stores import (
     InMemoryExecutionPlanUsageStore,
 )
 from moonmind.omnigent.host_leases import InMemoryOmnigentHostLeaseRepository
+from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
 from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
@@ -84,6 +85,9 @@ from moonmind.omnigent.secret_resolution import (
 from moonmind.provider_profiles.lease_client import (
     CredentialLease,
     CredentialLeasePurpose,
+)
+from moonmind.security.execution_fanout_capabilities import (
+    verify_execution_fanout_capability,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 
@@ -910,7 +914,20 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
 
 
 @pytest.mark.asyncio
-async def test_host_volume_initializers_use_setup_authority() -> None:
+@pytest.mark.parametrize(
+    ("host_api_token", "expected_secret_payloads"),
+    [
+        (
+            "host-control-token",
+            [b"host-control-token", b"scoped-fanout-token"],
+        ),
+        ("", [b"scoped-fanout-token"]),
+    ],
+)
+async def test_host_volume_initializers_use_setup_authority(
+    host_api_token: str,
+    expected_secret_payloads: list[bytes],
+) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
 
     class Backend:
@@ -918,8 +935,11 @@ async def test_host_volume_initializers_use_setup_authority() -> None:
             calls.append((list(argv), dict(kwargs)))
             return (0, "container-id" if argv[1] == "create" else "", "")
 
+    script_inputs = {}
+
     class Scripts:
-        def build_entrypoint(self, **_kwargs):
+        def build_entrypoint(self, **kwargs):
+            script_inputs.update(kwargs)
             return "exec true", {}
 
     backend = Backend()
@@ -927,7 +947,7 @@ async def test_host_volume_initializers_use_setup_authority() -> None:
         backend=backend,
         runtime_scripts=Scripts(),
         server_url="http://omnigent:8000",
-        host_api_token="host-control-token",
+        host_api_token=host_api_token,
     )
     host_class = HostClass.model_validate(
         {
@@ -973,7 +993,10 @@ async def test_host_volume_initializers_use_setup_authority() -> None:
                     "targetPath": "/opt/moonmind-skills",
                     "accessMode": "read-only",
                 },
-                "controlAttachment": launcher.control_attachment(owner_ref),
+                "controlAttachment": launcher.control_attachment(
+                    owner_ref,
+                    require_capability_mount=True,
+                ),
                 "stateAttachment": {
                     "kind": "volume",
                     "sourceRef": "mm-host-state-test",
@@ -986,14 +1009,89 @@ async def test_host_volume_initializers_use_setup_authority() -> None:
         host_class=host_class,
         launch_policy=get_launch_policy("omnigent-on-demand@1"),
         credential_handles=[],
+        runtime_environment={
+            "MOONMIND_URL": "http://api:8000",
+            "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+            "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+            "MOONMIND_STEP_ID": "step-1",
+            "MOONMIND_RUNTIME_ID": "opencode-native",
+            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "scoped-fanout-token",
+        },
     )
 
     setup_runs = [argv for argv, _kwargs in calls if argv[:2] == ["docker", "run"]]
-    assert len(setup_runs) == 2
+    assert len(setup_runs) == len(expected_secret_payloads) + 1
     for argv in setup_runs:
         assert argv[argv.index("--user") + 1] == "0:0"
     workload_create = next(argv for argv, _kwargs in calls if argv[:2] == ["docker", "create"])
     assert workload_create[workload_create.index("--user") + 1] == "1000:1000"
+    assert "scoped-fanout-token" not in json.dumps(
+        [argv for argv, _kwargs in calls]
+    )
+    assert [
+        kwargs["input_bytes"]
+        for _argv, kwargs in calls
+        if kwargs.get("input_bytes")
+    ] == expected_secret_payloads
+    assert script_inputs["runtime_environment"] == {
+        "MOONMIND_URL": "http://api:8000",
+        "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+        "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+        "MOONMIND_STEP_ID": "step-1",
+        "MOONMIND_RUNTIME_ID": "opencode-native",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": (
+            "/run/moonmind-host-auth/execution-fanout"
+        ),
+    }
+    assert script_inputs["control_credential_available"] is bool(host_api_token)
+
+
+def test_generic_host_mints_scoped_fanout_from_step_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "workflow-1",
+            "idempotencyKey": "idem-1",
+            "parameters": {"requiredCapabilities": ["gh", "execution.fanout"]},
+            "stepExecution": {
+                "workflowId": "workflow-1",
+                "runId": "run-1",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 1,
+                "stepExecutionId": "workflow-1:run-1:node-1:execution:1",
+                "runtimeContextPolicy": "fresh_agent_run",
+                "skillSourcePolicy": {
+                    "executionFanout": {
+                        "authorized": True,
+                        "selectedSkill": "batch-dependabot-resolver",
+                        "sourceKind": "built_in",
+                    }
+                },
+            },
+        }
+    )
+
+    environment = GenericOmnigentHostRuntime._runtime_environment(
+        request=request,
+        plan=_plan("opencode/muse-spark-1.2-contributor-free"),
+        host_lease_ref="host-lease-1",
+        launch_policy=get_launch_policy("omnigent-on-demand@1"),
+    )
+    capability = verify_execution_fanout_capability(
+        environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"],
+        secret="test_jwt_secret_key",
+    )
+
+    assert environment["MOONMIND_URL"] == "http://api:8000"
+    assert capability.parent_workflow_id == "workflow-1"
+    assert capability.agent_run_id == "workflow-1:run-1:node-1:execution:1"
+    assert capability.session_id == "host-lease-1"
+    assert capability.runtime_id == "opencode-native"
+    assert capability.source_kind == "omnigent"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -50,7 +50,6 @@ from moonmind.omnigent.harness_platform.stores import (
     InMemoryExecutionPlanUsageStore,
 )
 from moonmind.omnigent.host_leases import InMemoryOmnigentHostLeaseRepository
-from moonmind.omnigent.host_runtime import GenericOmnigentHostRuntime
 from moonmind.omnigent.host_services.attestation import (
     _assert_exact_omnigent_build,
     _attest_workspace_mount,
@@ -67,6 +66,9 @@ from moonmind.omnigent.host_services.launcher import DockerOmnigentHostLauncher
 from moonmind.omnigent.host_services.mounted_tools import (
     OmnigentMountedToolService,
     deployment_mounted_tool_names,
+)
+from moonmind.omnigent.host_services.runtime_environment import (
+    OmnigentRuntimeEnvironmentService,
 )
 from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
 from moonmind.omnigent.provider_leases import (
@@ -1075,7 +1077,10 @@ def test_generic_host_mints_scoped_fanout_from_step_authority(
         }
     )
 
-    environment = GenericOmnigentHostRuntime._runtime_environment(
+    environment = OmnigentRuntimeEnvironmentService(
+        moonmind_url="http://api:8000",
+        signing_secret="test_jwt_secret_key",
+    ).build(
         request=request,
         plan=_plan("opencode/muse-spark-1.2-contributor-free"),
         host_lease_ref="host-lease-1",

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -10,6 +10,7 @@ def _build(
     target_path: str,
     github_attachment=None,
     enable_opencode_runtime: bool = False,
+    runtime_environment=None,
 ):
     return OmnigentRuntimeScriptService().build_entrypoint(
         credential_handles=[
@@ -22,6 +23,7 @@ def _build(
         step_execution_id="workflow:run:node-1:execution:1",
         github_credential_attachment=github_attachment,
         enable_opencode_runtime=enable_opencode_runtime,
+        runtime_environment=runtime_environment,
     )
 
 
@@ -142,3 +144,38 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert "> /home/app/.omnigent/moonmind/bin/gh" in _script
     assert "export GH_CONFIG_DIR=/home/app/.config/gh" in _script
     assert "GIT_CONFIG_VALUE_0" in _script
+
+
+def test_opencode_projection_restores_scoped_fanout_file_selector() -> None:
+    runtime_environment = {
+        "MOONMIND_URL": "http://api:8000",
+        "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+        "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+        "MOONMIND_STEP_ID": "step-1",
+        "MOONMIND_RUNTIME_ID": "opencode-native",
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": (
+            "/run/moonmind-host-auth/execution-fanout"
+        ),
+    }
+    script, environment = _build(
+        target_path="",
+        enable_opencode_runtime=True,
+        runtime_environment=runtime_environment,
+    )
+
+    passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
+    assert set(runtime_environment) <= passthrough
+    assert {
+        key: environment[key] for key in runtime_environment
+    } == runtime_environment
+    for key in runtime_environment:
+        assert f"export {key}=$(cat " in script
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=" not in script
+    syntax = subprocess.run(
+        ["/bin/sh", "-n"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -225,7 +225,11 @@ def _snapshot(*, harness: str, policy: str, provider_id: str) -> dict:
 
 
 def _policy_snapshot(
-    *, harness: str, policy: str, host_image_ref: str | None = None
+    *,
+    harness: str,
+    policy: str,
+    host_image_ref: str | None = None,
+    architecture: str | None = None,
 ) -> dict:
     profile_ref = f"omnigent-{harness.removesuffix('-native')}@1"
     host_image_digest = "7" if harness == "opencode-native" else "f"
@@ -243,6 +247,8 @@ def _policy_snapshot(
     document["providerProfile"]["compatibleProviders"] = [
         "opencode" if harness == "opencode-native" else "codex"
     ]
+    if architecture is not None:
+        document["host"]["architectures"] = [architecture]
     policy_id, _, version = policy.rpartition("@")
     return compile_policy_snapshot(
         policy_id=policy_id,
@@ -349,7 +355,15 @@ async def test_product_boundary_persists_secret_free_plan_and_exact_realizer(
     assert result.envelope.payload.effectiveLaunchSnapshotRef.startswith("artifact:")
     assert result.envelope.payload.effectiveLaunchSnapshotDigest.startswith("sha256:")
     assert result.envelope.payload.hostImageRef
-    assert result.envelope.payload.hostArchitecture == "linux/amd64"
+    assert result.envelope.payload.hostArchitecture in {
+        "linux/amd64",
+        "linux/arm64",
+    }
+    assert result.envelope.payload.supportIdentity is not None
+    assert (
+        result.envelope.payload.supportIdentity.architecture
+        == result.envelope.payload.hostArchitecture
+    )
     assert result.envelope.payload.authority is not None
     assert result.envelope.payload.authority.taskInputSnapshotRef == "art_request_1"
     admission = result.envelope.payload.admissionAuthority
@@ -379,6 +393,74 @@ async def test_product_boundary_persists_secret_free_plan_and_exact_realizer(
         "secretBody",
     ):
         assert forbidden not in serialized
+
+
+@pytest.mark.asyncio
+async def test_product_boundary_uses_exact_arm64_architecture_for_support_identity(
+    monkeypatch,
+) -> None:
+    """A multi-architecture Host Class must bind support to the selected host."""
+
+    monkeypatch.setattr(service, "DbExecutionPlanStore", _PlanStore)
+    monkeypatch.setattr(
+        service,
+        "resolve_execution_evidence",
+        lambda plan_payload, **_kwargs: (
+            _protected_support_evidence(plan_payload),
+            "supported",
+        ),
+    )
+
+    async def resolve_policy(**_kwargs):
+        return _policy_snapshot(
+            harness="opencode-native",
+            policy="opencode-on-demand@1",
+            architecture="arm64",
+        )
+
+    monkeypatch.setattr(service, "_resolve_runtime_policy_snapshot", resolve_policy)
+    monkeypatch.setenv(
+        "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        "ghcr.io/example/omnigent-host@sha256:" + "7" * 64,
+    )
+    artifacts = _ArtifactService()
+    result = await service.compile_and_persist_execution_plan(
+        session_factory=object(),
+        artifact_service=artifacts,
+        principal="user-1",
+        workflow_id="mm:test-arm64-support-identity",
+        agent_profile_snapshot=_snapshot(
+            harness="opencode-native",
+            policy="opencode-on-demand@1",
+            provider_id="provider-opencode-native",
+        ),
+        provider_profile=SimpleNamespace(
+            profile_id="provider-opencode-native",
+            runtime_id="opencode",
+            provider_id="opencode-go",
+        ),
+        initial_parameters={
+            "model": "example/model",
+            "targetRuntime": "omnigent",
+            "publishMode": "none",
+            "maxAttempts": 2,
+            "workflow": {"instructions": "Use the selected ARM64 host."},
+        },
+        authored_request_ref="art_request_arm64",
+        authored_request_digest="sha256:" + "1" * 64,
+        task_input_snapshot_ref="art_request_arm64",
+        task_input_snapshot_digest="sha256:" + "1" * 64,
+    )
+
+    assert result.envelope.payload.hostArchitecture == "linux/arm64"
+    assert result.envelope.payload.supportIdentity is not None
+    assert result.envelope.payload.supportIdentity.architecture == "linux/arm64"
+
+    from moonmind.workflows.temporal.activities.omnigent_session_activities import (
+        _validate_plan_support_authority,
+    )
+
+    _validate_plan_support_authority(result.envelope)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 def _load_module() -> dict[str, Any]:
     repo_root = Path(__file__).resolve().parents[2]
     return runpy.run_path(
@@ -772,6 +774,35 @@ def test_read_worker_token_prefers_env_over_file(
     monkeypatch.setenv("MOONMIND_WORKER_TOKEN_FILE", str(token_file))
 
     assert read_worker_token() == "env-token"
+
+
+def test_execution_fanout_token_prefers_lease_owned_file(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    module = _load_module()
+    token_file = tmp_path / "execution-fanout"
+    token_file.write_text("file-capability\n", encoding="utf-8")
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE", str(token_file)
+    )
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", "ambient-capability"
+    )
+
+    assert module["_read_execution_fanout_token"]() == "file-capability"
+
+
+def test_execution_fanout_token_file_fails_closed_when_missing(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    module = _load_module()
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        str(tmp_path / "missing-capability"),
+    )
+
+    with pytest.raises(RuntimeError, match="capability file is unavailable"):
+        module["_read_execution_fanout_token"]()
 
 # ---------------------------------------------------------------------------
 # SkillInvocation payload contract tests

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -117,6 +117,37 @@ def test_http_submission_forwards_scoped_execution_fanout_bearer(
     assert captured_headers["X-moonmind-execution-fanout"] == "v1"
 
 
+def test_execution_fanout_token_prefers_lease_owned_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    token_file = tmp_path / "execution-fanout"
+    token_file.write_text("file-capability\n", encoding="utf-8")
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE", str(token_file)
+    )
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", "ambient-capability"
+    )
+
+    assert module["_read_execution_fanout_token"]() == "file-capability"
+
+
+def test_execution_fanout_token_file_fails_closed_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    monkeypatch.setenv(
+        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE",
+        str(tmp_path / "missing-capability"),
+    )
+
+    with pytest.raises(RuntimeError, match="capability file is unavailable"):
+        module["_read_execution_fanout_token"]()
+
+
 _JIRA_TARGET: dict[str, Any] = {
     "provider": "jira",
     "ref": "THOR-123",

--- a/tests/unit/workflows/executions/test_runtime_inheritance.py
+++ b/tests/unit/workflows/executions/test_runtime_inheritance.py
@@ -109,6 +109,8 @@ def _parent_record(
     effort: str | None = "high",
     profile_id: str | None = "codex_default",
     execution_profile_ref: str | None = "codex_default",
+    agent_profile: dict[str, Any] | None = None,
+    agent_profile_snapshot: dict[str, Any] | None = None,
     omnigent: dict[str, Any] | None = None,
 ) -> SimpleNamespace:
     parameters: dict[str, Any] = {}
@@ -125,10 +127,14 @@ def _parent_record(
         workflow_runtime["mode"] = target_runtime
     if execution_profile_ref is not None:
         workflow_runtime["executionProfileRef"] = execution_profile_ref
+    if agent_profile is not None:
+        workflow_runtime["agentProfile"] = agent_profile
     if workflow_runtime:
         parameters["workflow"] = {"runtime": workflow_runtime}
     if omnigent is not None:
         parameters["omnigent"] = omnigent
+    if agent_profile_snapshot is not None:
+        parameters["agentProfileSnapshot"] = agent_profile_snapshot
     return SimpleNamespace(
         workflow_id=workflow_id,
         owner_id=owner_id,
@@ -415,15 +421,27 @@ def test_apply_inherited_runtime_writes_target_and_task_runtime_fields() -> None
 
 @pytest.mark.asyncio
 async def test_github_3453_child_inherits_complete_omnigent_selection() -> None:
+    agent_profile = {
+        "profileId": "omnigent-opencode-default",
+        "version": 11,
+        "digest": "sha256:" + "a" * 64,
+    }
+    expected_agent_profile = {
+        **agent_profile,
+        "providerProfileRef": "opencode-zen-free",
+    }
     selection = {
-        "executionTargetRef": "omnigent-codex@1",
-        "launchPolicyRef": "codex-on-demand@1",
-        "agent": {"harnessOverride": "codex-native"},
+        "executionTargetRef": "omnigent-opencode@1",
+        "launchPolicyRef": "omnigent-on-demand@1",
     }
     parent = _parent_record(
         target_runtime="omnigent",
-        profile_id=None,
-        execution_profile_ref="codex-oauth-profile",
+        model="opencode/muse-spark-1.2-contributor-free",
+        effort="xhigh",
+        profile_id="opencode-zen-free",
+        execution_profile_ref="opencode-zen-free",
+        agent_profile=agent_profile,
+        agent_profile_snapshot=expected_agent_profile,
         omnigent=selection,
     )
     service = _FakeService({"mm:parent": parent})
@@ -450,11 +468,14 @@ async def test_github_3453_child_inherits_complete_omnigent_selection() -> None:
     assert payload["targetRuntime"] == "omnigent"
     assert payload["task"]["runtime"] == {
         "mode": "omnigent",
-        "model": "gpt-5.4",
-        "effort": "high",
-        "executionProfileRef": "codex-oauth-profile",
-        "omnigent": selection,
+        "model": "opencode/muse-spark-1.2-contributor-free",
+        "effort": "xhigh",
+        "executionProfileRef": "opencode-zen-free",
+        "profileId": "opencode-zen-free",
+        "agentProfile": expected_agent_profile,
     }
+    assert payload["omnigent"] == selection
+    assert "omnigent" not in payload["task"]["runtime"]
 
 
 def test_github_3453_explicit_child_omnigent_selection_wins_inheritance() -> None:
@@ -472,11 +493,12 @@ def test_github_3453_explicit_child_omnigent_selection_wins_inheritance() -> Non
     }
     payload: dict[str, Any] = {
         "targetRuntime": "omnigent",
+        "omnigent": child_selection,
+        "agentProfile": {"profileId": "child-agent", "version": 2},
         "task": {
             "runtime": {
                 "mode": "omnigent",
                 "executionProfileRef": "child-profile",
-                "omnigent": child_selection,
             }
         },
     }
@@ -488,7 +510,9 @@ def test_github_3453_explicit_child_omnigent_selection_wins_inheritance() -> Non
     )
 
     assert payload["task"]["runtime"]["executionProfileRef"] == "child-profile"
-    assert payload["task"]["runtime"]["omnigent"] == child_selection
+    assert payload["omnigent"] == child_selection
+    assert payload["agentProfile"] == {"profileId": "child-agent", "version": 2}
+    assert "agentProfile" not in payload["task"]["runtime"]
 
 
 def test_apply_inherited_runtime_does_not_overwrite_existing_runtime_fields() -> None:

--- a/tests/unit/workflows/executions/test_runtime_inheritance.py
+++ b/tests/unit/workflows/executions/test_runtime_inheritance.py
@@ -478,6 +478,38 @@ async def test_github_3453_child_inherits_complete_omnigent_selection() -> None:
     assert "omnigent" not in payload["task"]["runtime"]
 
 
+@pytest.mark.asyncio
+async def test_non_omnigent_parent_does_not_synthesize_agent_profile() -> None:
+    parent = _parent_record(
+        target_runtime="codex_cli",
+        profile_id="codex-default",
+        execution_profile_ref="codex-default",
+    )
+    service = _FakeService({"mm:parent": parent})
+    principal = ExecutionPrincipal(
+        user_id="user-1",
+        workflow_id="mm:parent",
+        scopes=frozenset({SCOPE_CREATE_CHILD, SCOPE_INHERIT_RUNTIME}),
+    )
+    payload: dict[str, Any] = {"runtimeInheritance": "caller", "task": {}}
+
+    inherited = await resolve_child_runtime_inheritance(
+        request_payload=payload,
+        task_payload=payload["task"],
+        principal=principal,
+        service=service,
+    )
+
+    assert inherited is not None
+    assert inherited.agent_profile is None
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=payload["task"],
+        inherited=inherited,
+    )
+    assert "agentProfile" not in payload["task"]["runtime"]
+
+
 def test_github_3453_explicit_child_omnigent_selection_wins_inheritance() -> None:
     inherited = InheritedRuntime(
         target_runtime="omnigent",
@@ -615,6 +647,34 @@ def test_apply_inherited_runtime_preserves_explicit_provider_profile_ref() -> No
     assert task_payload["runtime"]["providerProfileRef"] == "child-explicit"
     assert "executionProfileRef" not in task_payload["runtime"]
     assert "profileId" not in task_payload["runtime"]
+
+
+def test_explicit_child_provider_skips_parent_agent_profile() -> None:
+    payload: dict[str, Any] = {
+        "targetRuntime": "omnigent",
+        "task": {"runtime": {"providerProfileRef": "child-explicit"}},
+    }
+    task_payload = payload["task"]
+    inherited = InheritedRuntime(
+        target_runtime="omnigent",
+        profile_id="parent-provider",
+        execution_profile_ref="parent-provider",
+        agent_profile={
+            "profileId": "parent-agent",
+            "version": 2,
+            "digest": "sha256:" + "a" * 64,
+            "providerProfileRef": "parent-provider",
+        },
+    )
+
+    apply_inherited_runtime_to_payload(
+        payload=payload,
+        task_payload=task_payload,
+        inherited=inherited,
+    )
+
+    assert task_payload["runtime"]["providerProfileRef"] == "child-explicit"
+    assert "agentProfile" not in task_payload["runtime"]
 
 
 def test_apply_inherited_runtime_skips_profile_backfill_when_child_sets_execution_profile_ref() -> None:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -6801,7 +6801,9 @@ async def test_cancel_execution_dispatches_temporal_cancel_before_session_cleanu
             service.cancel_execution(
                 workflow_id=created.workflow_id, reason="stop", graceful=True
             ),
-            timeout=0.2,
+            # This is a deadlock guard, not a database performance assertion.
+            # The mocked cleanup still has the 0.01s production timeout above.
+            timeout=2.0,
         )
 
         assert cancel_dispatched.is_set()


### PR DESCRIPTION
## Summary

- align persisted support identity with the selected generic host architecture
- carry execution-scoped fanout authority through a read-only capability file and tolerate credentialless `needs-auth` readiness
- preserve the exact Agent Profile, provider profile, and Omnigent launch selectors when fanout creates child executions
- add escaped-failure replay fixtures for the production regressions

## Validation

- `./tools/test_unit.sh --python-only <10 changed regression node IDs>` — 11 passed
- live recovery workflow `mm:d2be3eed-157e-42ed-a725-cc62755ce490` — completed with 7 matched, 7 created, 7 queued, 0 queue errors

## Incident

Fixes the failure path observed in workflow `mm:171981b9-8988-40e5-ab5c-e3b66d6dee61`.