### PR TITLE
Fix remediation assessment artifact contract

### DIFF
--- a/api_service/data/presets/issue-implement-work-pr.yaml
+++ b/api_service/data/presets/issue-implement-work-pr.yaml
@@ -199,7 +199,6 @@ steps:
           issue_provider: '{{ inputs.issue_provider }}'
           issue_ref: '{{ inputs.issue_ref }}'
           brief_artifact_path: '{{ inputs.brief_artifact_path }}'
-          assessment_artifact_path: '{{ inputs.assessment_artifact_path }}'
           verify_artifact_path: '{{ inputs.verify_artifact_path }}'
           instructions: 'Run the selected remediate-issue Skill. Before editing,
             read the complete latest authoritative verifier evidence materialized by

--- a/tests/integration/reliability/replays/remediation-assessment-output-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/remediation-assessment-output-contract/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "remediationAssessmentOutputDeclared": false,
+  "verificationAssessmentInputRetained": true,
+  "publisherBehaviorWithoutDeclaredAssessmentOutput": "skip_assessment_publication"
+}

--- a/tests/integration/reliability/replays/remediation-assessment-output-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/remediation-assessment-output-contract/expected-outcome.json
@@ -1,5 +1,6 @@
 {
   "remediationAssessmentOutputDeclared": false,
   "verificationAssessmentInputRetained": true,
-  "publisherBehaviorWithoutDeclaredAssessmentOutput": "skip_assessment_publication"
+  "publisherCompleted": true,
+  "assessmentArtifactPublished": false
 }

--- a/tests/integration/reliability/replays/remediation-assessment-output-contract/manifest.json
+++ b/tests/integration/reliability/replays/remediation-assessment-output-contract/manifest.json
@@ -1,0 +1,18 @@
+{
+  "incidentWorkflowId": "mm:14460d13-a81d-49b8-a83e-11010801dc90",
+  "failureShapeId": "remediation-assessment-output-contract",
+  "boundary": "issue implementation preset to dynamic remediation AgentRun artifact publication",
+  "escapedFailure": {
+    "message": "Declared assessment verdict artifact was not produced: artifacts/github-issue-implement-assessment.json",
+    "cause": "The remediation tool inherited an assessment producer path even though only the initial assessment step owns that output."
+  },
+  "escapedRemediationInputs": {
+    "selectedSkill": "remediate-issue",
+    "repositoryOperation": "write",
+    "assessment_artifact_path": "artifacts/github-issue-implement-assessment.json"
+  },
+  "verificationInputs": {
+    "selectedSkill": "moonspec-verify",
+    "assessment_artifact_path": "artifacts/github-issue-implement-assessment.json"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -148,6 +148,11 @@ from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
     TemporalSandboxActivities,
 )
+from moonmind.workflows.temporal.artifacts import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 from moonmind.workflows.temporal.remediation_loop import (
@@ -5637,8 +5642,11 @@ async def test_instructionless_remediation_verifier_is_rejected_before_dispatch(
         )
 
 
-async def test_remediation_does_not_declare_initial_assessment_output() -> None:
-    """Replay mm:14460d13 at preset compilation before AgentRun dispatch."""
+async def test_remediation_does_not_declare_initial_assessment_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:14460d13 through request construction and publication."""
 
     replay_id = "remediation-assessment-output-contract"
     manifest = load_replay(replay_id, "manifest.json")
@@ -5665,6 +5673,69 @@ async def test_remediation_does_not_declare_initial_assessment_output() -> None:
         workspace_head_ref=None,
         runtime={"mode": "omnigent"},
     )
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id="incident-replay",
+        task_queue="mm.workflow.default",
+        search_attributes={},
+        start_time=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+    parent = MoonMindRunWorkflow()
+    request = parent._build_agent_execution_request(
+        node_inputs=remediation["inputs"],
+        node_id=remediation["id"],
+        tool_name=remediation["tool"]["name"],
+    )
+    agent_run_info = SimpleNamespace(
+        workflow_id=f"{manifest['incidentWorkflowId']}:agent:remediation-1",
+        run_id="incident-agent-replay",
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", lambda: agent_run_info)
+    enriched = MoonMindAgentRun()._enrich_result_metadata(
+        request=request,
+        result=AgentRunResult(summary="Remediation completed."),
+        include_parent_execution=True,
+    )
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/remediation-publication.db"
+    )
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        session_maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_maker() as session:
+            artifact_service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=artifact_service
+            )
+
+            async def _skip_notify(
+                *_args: object, **_kwargs: object
+            ) -> dict[str, str]:
+                return {"status": "skipped"}
+
+            monkeypatch.setattr(
+                activities, "execution_notify_completion", _skip_notify
+            )
+            monkeypatch.setattr(
+                activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id=agent_run_info.workflow_id,
+                    workflow_run_id=agent_run_info.run_id,
+                ),
+            )
+            published = await activities.agent_runtime_publish_artifacts(enriched)
+    finally:
+        await engine.dispose()
 
     assert manifest["incidentWorkflowId"] == (
         "mm:14460d13-a81d-49b8-a83e-11010801dc90"
@@ -5681,9 +5752,15 @@ async def test_remediation_does_not_declare_initial_assessment_output() -> None:
     assert "assessment_artifact_path" in verification_inputs
     assert "assessment_artifact_path" not in remediation["inputs"]
     assert "assessment_artifact_path" in verification["inputs"]
-    assert expected["publisherBehaviorWithoutDeclaredAssessmentOutput"] == (
-        "skip_assessment_publication"
-    )
+    assert "assessment_artifact_path" not in request.parameters
+    assert enriched is not None
+    assert "assessment_artifact_path" not in enriched.metadata
+    assert isinstance(published, AgentRunResult)
+    assert published.diagnostics_ref is not None
+    assert (
+        "assessmentArtifactRef" in published.metadata
+    ) is expected["assessmentArtifactPublished"]
+    assert expected["publisherCompleted"] is True
 
 
 async def test_instructionless_inflight_remediation_loop_remains_replayable(

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -150,6 +150,10 @@ from moonmind.workflows.temporal.activity_runtime import (
 )
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
+from moonmind.workflows.temporal.remediation_loop import (
+    RemediationLoopSpec,
+    materialize_attempt_nodes,
+)
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
@@ -5631,6 +5635,55 @@ async def test_instructionless_remediation_verifier_is_rejected_before_dispatch(
         parent._initialize_remediation_loop_controller(
             ordered_nodes=[manifest["controllerPlanNode"]]
         )
+
+
+async def test_remediation_does_not_declare_initial_assessment_output() -> None:
+    """Replay mm:14460d13 at preset compilation before AgentRun dispatch."""
+
+    replay_id = "remediation-assessment-output-contract"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    preset = yaml.safe_load(
+        (REPO_ROOT / "api_service/data/presets/issue-implement-work-pr.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    controller = next(
+        step
+        for step in preset["steps"]
+        if step["title"] == "Remediation loop controller"
+    )
+    loop = controller["annotations"]["remediationLoop"]
+    remediation_inputs = loop["remediationTool"]["inputs"]
+    verification_inputs = loop["verificationTool"]["inputs"]
+    loop["budgets"]["hardMaxAttempts"] = 6
+    remediation, verification = materialize_attempt_nodes(
+        spec=RemediationLoopSpec.model_validate(loop),
+        workflow_id=manifest["incidentWorkflowId"],
+        run_id="incident-replay",
+        ordinal=1,
+        workspace_head_ref=None,
+        runtime={"mode": "omnigent"},
+    )
+
+    assert manifest["incidentWorkflowId"] == (
+        "mm:14460d13-a81d-49b8-a83e-11010801dc90"
+    )
+    assert manifest["escapedRemediationInputs"]["assessment_artifact_path"] == (
+        "artifacts/github-issue-implement-assessment.json"
+    )
+    assert (
+        "assessment_artifact_path" in manifest["verificationInputs"]
+    ) is expected["verificationAssessmentInputRetained"]
+    assert (
+        "assessment_artifact_path" in remediation_inputs
+    ) is expected["remediationAssessmentOutputDeclared"]
+    assert "assessment_artifact_path" in verification_inputs
+    assert "assessment_artifact_path" not in remediation["inputs"]
+    assert "assessment_artifact_path" in verification["inputs"]
+    assert expected["publisherBehaviorWithoutDeclaredAssessmentOutput"] == (
+        "skip_assessment_publication"
+    )
 
 
 async def test_instructionless_inflight_remediation_loop_remains_replayable(

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -491,9 +491,16 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert remediation_loop["kind"] == "remediation_loop"
         assert remediation_loop["budgets"]["hardMaxAttempts"] == "6"
         assert remediation_loop["workspacePolicy"] == "continue_from_loop_head"
+        assert (
+            "assessment_artifact_path"
+            not in remediation_loop["remediationTool"]["inputs"]
+        )
         assert remediation_loop["verificationTool"]["inputs"][
             "verify_artifact_path"
         ] == "artifacts/jira-implement-verify.json"
+        assert remediation_loop["verificationTool"]["inputs"][
+            "assessment_artifact_path"
+        ] == "artifacts/jira-implement-assessment.json"
         assert "Run the selected moonspec-verify Skill" in (
             remediation_loop["verificationTool"]["inputs"]["instructions"]
         )

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3644,6 +3644,7 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     assert loop["remediationTool"]["inputs"]["selectedSkill"] == (
         "remediate-issue"
     )
+    assert "assessment_artifact_path" not in loop["remediationTool"]["inputs"]
     assert "authoritative verifier evidence materialized by MoonMind" in (
         loop["remediationTool"]["inputs"]["instructions"]
     )
@@ -3655,6 +3656,9 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
     )
     assert loop["verificationTool"]["name"] == "auto"
     assert loop["verificationTool"]["inputs"]["selectedSkill"] == "moonspec-verify"
+    assert loop["verificationTool"]["inputs"]["assessment_artifact_path"] == (
+        "artifacts/github-issue-implement-assessment.json"
+    )
     assert "Run the selected moonspec-verify Skill" in (
         loop["verificationTool"]["inputs"]["instructions"]
     )


### PR DESCRIPTION
## Related issue

N/A — incident workflow `mm:14460d13-a81d-49b8-a83e-11010801dc90`

## Summary

- Remove the initial-assessment output path from dynamically materialized remediation steps.
- Keep the assessment artifact as a read-only verifier input and durable attachment.
- Add a minimized incident replay plus GitHub/Jira preset expansion coverage.

ELI5: the repair step was mistakenly told to create the assessment file that belongs to an earlier step, so strict artifact publication rejected an otherwise successful repair. The preset now assigns that output only to its actual producer.

## Test Plan

```bash
./tools/test_unit.sh --python-only tests/unit/api/test_presets_service.py
MOONMIND_FORCE_LOCAL_TESTS=1 bash ./tools/run_repo_python.sh -m pytest tests/integration/test_startup_preset_seeding.py::test_startup_seeds_default_task_templates -q --tb=short
MOONMIND_FORCE_LOCAL_TESTS=1 bash ./tools/run_repo_python.sh -m pytest tests/integration/reliability/test_escaped_failure_journeys.py::test_remediation_does_not_declare_initial_assessment_output -q --tb=short
bash ./tools/run_repo_python.sh tools/verify_test_shard_ownership.py
```

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Risk notes

This changes future preset expansion only. It does not mutate Temporal payload schemas or rewrite already-expanded in-flight histories. Existing failed executions retain their original plan and require a new run after deployment. Strict publisher validation remains unchanged.

## Coverage notes

Manual verification traced the parent workflow, all child workflows, and the failing `agent_runtime.publish_artifacts` activity input. The activity received `assessment_artifact_path` from the remediation tool even though the remediator produced a remotely verified commit instead of a new assessment.

## Changelog

Fix issue-remediation workflows failing publication on an unrelated assessment artifact contract.