### PR TITLE
Bump Claude Code CLI to 2.1.257

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -7,7 +7,7 @@ ARG CODEX_CLI_VERSION=latest
 # which does not exist). npm then omits the unresolvable optional dependency and
 # the launcher aborts with "claude native binary not installed", breaking every
 # image build until upstream catches up. Bump this deliberately.
-ARG CLAUDE_CLI_VERSION=2.1.236
+ARG CLAUDE_CLI_VERSION=2.1.257
 # Build the shared runtime image with Codex/Claude CLIs by default so the API
 # and Temporal workers can run from the same image tag. Disable selectively in
 # test-only or constrained builds.


### PR DESCRIPTION
## Summary

- bump the pinned Claude Code CLI from 2.1.236 to 2.1.257
- restore support for models that require Claude Code 2.1.251 or newer

## Validation

- built the Docker tooling-builder stage with Claude Code 2.1.257
- verified the built image reports Claude Code 2.1.257
- ran ./tools/test_unit.sh --python-only tests/unit/test_docker_publish_workflow.py (10 passed)