### PR TITLE
Fix OpenCode provider auto-enrollment

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1138,6 +1138,83 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     });
   });
 
+  it("names the selected generic Omnigent agent when no provider profile is ready", async () => {
+    const digest = `sha256:${"e".repeat(64)}`;
+    const genericProfiles = [{
+      profileId: "omnigent-opencode-default",
+      displayName: "OpenCode via Omnigent",
+      state: "active",
+      activeVersion: 1,
+      defaultForRuntime: true,
+      versions: [{
+        version: 1,
+        digest,
+        // Production-authored v2 profiles do not carry the legacy execution
+        // profile metadata that previously made the empty-state label fall
+        // back to Codex CLI.
+        document: {
+          schemaVersion: "moonmind.omnigent-agent-profile.v2",
+          harness: { id: "opencode-native" },
+        },
+        validationResult: { ready: true },
+      }],
+    }];
+    const genericReadiness = {
+      schemaVersion: "moonmind.omnigent-execution-readiness.v3",
+      runtimeId: "omnigent",
+      displayName: "Omnigent",
+      executionTargets: [{
+        ref: "omnigent-opencode-default@1",
+        harnessId: "opencode-native",
+        agentProfileRef: {
+          profileId: "omnigent-opencode-default",
+          version: 1,
+          digest,
+        },
+        available: false,
+        supportTier: "experimental",
+        compatibleProviderProfiles: [],
+        compatibleHostClasses: [],
+        policies: ["omnigent-on-demand@1"],
+        models: [],
+        gateReasons: [{
+          code: "compatible_provider_profile_unavailable",
+          message: "Connect and validate a compatible Provider Profile.",
+        }],
+      }],
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => readyOmnigentCatalog } as Response);
+      }
+      if (url === "/api/omnigent/execution-readiness") {
+        return Promise.resolve({ ok: true, json: async () => genericReadiness } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => genericProfiles } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), {
+      target: { value: "omnigent" },
+    });
+
+    expect(await screen.findByText(
+      "No launch-ready Provider Profiles are configured for OpenCode via Omnigent. Configure one in Settings before starting this workflow.",
+    )).toBeTruthy();
+    expect(screen.queryByText(/configured for Codex CLI/)).toBeNull();
+  });
+
   it("synchronizes the execution target when the Agent Profile changes", async () => {
     const payload = omnigentPayload();
     const initialData = payload.initialData as {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -8463,6 +8463,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           : profile.account_label || profile.profile_id,
       isDefault: Boolean(profile.is_default),
     }));
+  const providerProfileScopeLabel =
+    runtime === "omnigent" && selectedProfileIsGenericV2
+      ? selectedOmnigentAgentProfile?.displayName ||
+        omnigentExecutionReadinessQuery.data?.displayName ||
+        "Omnigent"
+      : formatRuntimeLabel(providerProfileRuntime);
   const selectedOmnigentReadiness = (omnigentCatalogQuery.data?.executionProfiles || []).find(
     (profile) => profile.ref === omnigentExecutionTargetRef,
   );
@@ -14121,7 +14127,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               ) : (
                 <p className="small" role="alert" id="queue-provider-profile-empty">
                   No launch-ready Provider Profiles are configured for{" "}
-                  {formatRuntimeLabel(providerProfileRuntime)}. Configure one in
+                  {providerProfileScopeLabel}. Configure one in
                   Settings before starting this workflow.
                 </p>
               )}

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -889,7 +889,13 @@ class BootstrapController:
                     rate_limit_policy=ManagedAgentRateLimitPolicy.QUEUE,
                     default_model=qualified_model,
                     default_effort=effort,
-                    is_default=True,
+                    # Default authority belongs only to a launch-ready profile.
+                    # The credentialless Zen seed may already be the runtime
+                    # default, and the database enforces that invariant with a
+                    # partial unique index. Keep this candidate non-default
+                    # until exact-host validation and credential persistence
+                    # both succeed, then switch defaults atomically below.
+                    is_default=False,
                     owner_user_id=owner_id,
                 )
                 session.add(profile)
@@ -959,7 +965,9 @@ class BootstrapController:
                         cand = str(_persisted.opencode_host_image_ref).strip()
                         if "@sha256:" in cand:
                             image_ref = cand
-                except Exception:  # best-effort fallback to passed resolved if persisted state unavailable
+                except (
+                    Exception
+                ):  # best-effort fallback to passed resolved if persisted state unavailable
                     pass
 
             def _is_substrate_unavailable(exc: Exception) -> bool:
@@ -1047,6 +1055,9 @@ class BootstrapController:
                 _provider_api_key_secret_slug,
                 _upsert_managed_secret,
             )
+            from api_service.services.provider_profile_service import (
+                normalize_runtime_default_profile,
+            )
 
             async with asm() as session:
                 prof = await session.get(ManagedAgentProviderProfile, profile_id)
@@ -1089,6 +1100,16 @@ class BootstrapController:
                 # that would turn an unverified selection into readiness
                 # evidence and defer the rejection until exact-host launch.
                 prof.model_catalog_evidence_json = validation_evidence
+                # Clear the previous runtime default before promoting the
+                # validated profile. The helper flushes those changes in the
+                # order required by ux_provider_profiles_runtime_default, so a
+                # seeded Zen default and a newly enrolled Go profile never
+                # overlap as defaults, even transiently.
+                await normalize_runtime_default_profile(
+                    session=session,
+                    runtime_id=prof.runtime_id,
+                    preferred_profile_id=profile_id,
+                )
                 await session.commit()
                 return profile_id
         finally:

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -1057,6 +1057,7 @@ class BootstrapController:
             )
             from api_service.services.provider_profile_service import (
                 normalize_runtime_default_profile,
+                sync_provider_profile_manager,
             )
 
             async with asm() as session:
@@ -1111,6 +1112,10 @@ class BootstrapController:
                     preferred_profile_id=profile_id,
                 )
                 await session.commit()
+                await sync_provider_profile_manager(
+                    session=session,
+                    runtime_id=prof.runtime_id,
+                )
                 return profile_id
         finally:
             if guard is not None:

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -1,7 +1,9 @@
 """Unit tests for _auto_seed_provider_profiles startup function."""
 
 import asyncio
+from datetime import UTC, datetime
 from enum import Enum
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import select, text
@@ -243,6 +245,123 @@ async def test_auto_seed_never_attaches_the_deployment_key_to_zen(
     assert readiness["connected"] is True
     assert readiness["backing_secret_exists"] is False
     assert readiness["launch_ready"] is True
+
+
+async def _enroll_opencode_go_with_pinned_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    validation_error: Exception | None = None,
+) -> None:
+    """Exercise the real bootstrap profile transaction with hermetic edges."""
+
+    from moonmind.omnigent.bootstrap.controller import BootstrapController
+    from moonmind.omnigent.harness_platform import host_classes
+    from moonmind.omnigent import opencode_runtime_validation, production
+    from moonmind.provider_profiles import maintenance
+
+    image_ref = "ghcr.io/example/opencode@sha256:" + "a" * 64
+    qualified_model = "opencode-go/muse-spark-1.2-contributor"
+
+    class Guard:
+        lease = SimpleNamespace(lease_id="lease-opencode-go-default")
+
+        async def release(self) -> None:
+            return None
+
+    async def acquire_guard(**_kwargs):
+        return Guard()
+
+    class RuntimeValidation:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def validate(self, **_kwargs):
+            if validation_error is not None:
+                raise validation_error
+            return {
+                "credentialGeneration": 1,
+                "imageRef": image_ref,
+                "materializerRef": "opencode-auth-json@1",
+                "runtimeVersions": {"opencode": "1.18.11"},
+                "validatedAt": datetime.now(UTC).isoformat(),
+                "models": [{"qualifiedId": qualified_model}],
+            }
+
+    monkeypatch.setattr(
+        maintenance, "acquire_credential_maintenance_guard", acquire_guard
+    )
+    monkeypatch.setattr(host_classes, "get_opencode_host_image_ref", lambda: image_ref)
+    monkeypatch.setattr(
+        opencode_runtime_validation,
+        "OpenCodeProviderRuntimeValidationService",
+        RuntimeValidation,
+    )
+    monkeypatch.setattr(production, "build_omnigent_secret_resolver", object)
+
+    await BootstrapController(
+        session_factory=db_base.async_session_maker
+    )._ensure_provider_profile(
+        api_key="sk-opencode-test-key",
+        qualified_model=qualified_model,
+        effort="xhigh",
+        resolved=SimpleNamespace(opencode_host_image_ref=image_ref),
+    )
+
+
+@pytest.mark.asyncio
+async def test_opencode_go_enrollment_atomically_replaces_seeded_zen_default(
+    _module_db, monkeypatch
+):
+    """A configured key must coexist with the launch-ready Zen seed."""
+
+    from api_service.main import _auto_seed_provider_profiles
+
+    await _auto_seed_provider_profiles()
+    await _enroll_opencode_go_with_pinned_runtime(monkeypatch)
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.runtime_id == "opencode"
+            )
+        )
+        profiles = {profile.profile_id: profile for profile in result.scalars()}
+
+    assert set(profiles) == {"opencode-zen-free", "opencode-go-default"}
+    assert profiles["opencode-zen-free"].enabled is True
+    assert profiles["opencode-zen-free"].is_default is False
+    assert profiles["opencode-go-default"].enabled is True
+    assert profiles["opencode-go-default"].is_default is True
+    assert sum(profile.is_default for profile in profiles.values()) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_opencode_go_validation_preserves_seeded_zen_default(
+    _module_db, monkeypatch
+):
+    """A rejected candidate never receives runtime-default authority."""
+
+    from api_service.main import _auto_seed_provider_profiles
+
+    await _auto_seed_provider_profiles()
+    with pytest.raises(ValueError, match="credential rejected"):
+        await _enroll_opencode_go_with_pinned_runtime(
+            monkeypatch,
+            validation_error=ValueError("credential rejected"),
+        )
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(ManagedAgentProviderProfile).where(
+                ManagedAgentProviderProfile.runtime_id == "opencode"
+            )
+        )
+        profiles = {profile.profile_id: profile for profile in result.scalars()}
+
+    assert profiles["opencode-zen-free"].enabled is True
+    assert profiles["opencode-zen-free"].is_default is True
+    assert profiles["opencode-go-default"].enabled is False
+    assert profiles["opencode-go-default"].is_default is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -251,16 +251,18 @@ async def _enroll_opencode_go_with_pinned_runtime(
     monkeypatch: pytest.MonkeyPatch,
     *,
     validation_error: Exception | None = None,
-) -> None:
+) -> list[tuple[str, dict]]:
     """Exercise the real bootstrap profile transaction with hermetic edges."""
 
     from moonmind.omnigent.bootstrap.controller import BootstrapController
     from moonmind.omnigent.harness_platform import host_classes
     from moonmind.omnigent import opencode_runtime_validation, production
     from moonmind.provider_profiles import maintenance
+    from moonmind.workflows.temporal import client as temporal_client
 
     image_ref = "ghcr.io/example/opencode@sha256:" + "a" * 64
     qualified_model = "opencode-go/muse-spark-1.2-contributor"
+    manager_sync_signals: list[tuple[str, dict]] = []
 
     class Guard:
         lease = SimpleNamespace(lease_id="lease-opencode-go-default")
@@ -287,6 +289,21 @@ async def _enroll_opencode_go_with_pinned_runtime(
                 "models": [{"qualifiedId": qualified_model}],
             }
 
+    class TemporalHandle:
+        async def signal(self, signal_name: str, payload: dict) -> None:
+            manager_sync_signals.append((signal_name, payload))
+
+    class TemporalClient:
+        async def start_workflow(self, *_args, **_kwargs) -> None:
+            return None
+
+        def get_workflow_handle(self, _workflow_id: str) -> TemporalHandle:
+            return TemporalHandle()
+
+    class TemporalAdapter:
+        async def get_client(self) -> TemporalClient:
+            return TemporalClient()
+
     monkeypatch.setattr(
         maintenance, "acquire_credential_maintenance_guard", acquire_guard
     )
@@ -297,6 +314,7 @@ async def _enroll_opencode_go_with_pinned_runtime(
         RuntimeValidation,
     )
     monkeypatch.setattr(production, "build_omnigent_secret_resolver", object)
+    monkeypatch.setattr(temporal_client, "TemporalClientAdapter", TemporalAdapter)
 
     await BootstrapController(
         session_factory=db_base.async_session_maker
@@ -306,6 +324,7 @@ async def _enroll_opencode_go_with_pinned_runtime(
         effort="xhigh",
         resolved=SimpleNamespace(opencode_host_image_ref=image_ref),
     )
+    return manager_sync_signals
 
 
 @pytest.mark.asyncio
@@ -317,7 +336,7 @@ async def test_opencode_go_enrollment_atomically_replaces_seeded_zen_default(
     from api_service.main import _auto_seed_provider_profiles
 
     await _auto_seed_provider_profiles()
-    await _enroll_opencode_go_with_pinned_runtime(monkeypatch)
+    manager_sync_signals = await _enroll_opencode_go_with_pinned_runtime(monkeypatch)
 
     async with db_base.async_session_maker() as session:
         result = await session.execute(
@@ -333,6 +352,17 @@ async def test_opencode_go_enrollment_atomically_replaces_seeded_zen_default(
     assert profiles["opencode-go-default"].enabled is True
     assert profiles["opencode-go-default"].is_default is True
     assert sum(profile.is_default for profile in profiles.values()) == 1
+
+    assert len(manager_sync_signals) == 1
+    signal_name, signal_payload = manager_sync_signals[0]
+    assert signal_name == "sync_profiles"
+    manager_profiles = signal_payload["profiles"]
+    assert [profile["profile_id"] for profile in manager_profiles] == [
+        "opencode-go-default",
+        "opencode-zen-free",
+    ]
+    assert manager_profiles[0]["is_default"] is True
+    assert manager_profiles[0]["launch_ready"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- keep a new OpenCode Go Provider Profile non-default until exact-host credential validation succeeds
- atomically promote the validated Go profile through the canonical runtime-default normalizer, preserving the Zen default when validation fails
- label generic Omnigent provider-profile gaps with the selected Agent Profile instead of the legacy Codex CLI fallback
- add production-shaped backend and frontend regressions

## Verification

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api_service/test_provider_profile_auto_seed.py tests/unit/omnigent/test_provider_revalidation.py tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/api/routers/test_omnigent_bootstrap.py` (84 passed)
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-start.test.tsx` (155 passed)
- `npm run ui:typecheck`
- `npm run ui:lint`
- `./tools/test_integration.sh` (618 passed, 1 skipped)