### PR TITLE
Speed up required CI shards

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
       integration_ci: ${{ steps.select.outputs.integration_ci }}
       reliability_journey: ${{ steps.select.outputs.reliability_journey }}
       exact_artifact: ${{ steps.select.outputs.exact_artifact }}
+      omnigent_conformance: ${{ steps.select.outputs.omnigent_conformance }}
       full_backend: ${{ steps.select.outputs.full_backend }}
       frontend_static: ${{ steps.select.outputs.frontend_static }}
       frontend_browser_chromium: ${{ steps.select.outputs.frontend_browser_chromium }}
@@ -156,6 +157,11 @@ jobs:
           if-no-files-found: ignore
 
   omnigent-deterministic-conformance:
+    # Republishes the deterministic Omnigent evidence bundle from layers that
+    # the exclusive shards already execute, so it runs only for Omnigent-owned
+    # changes and full-verification events instead of on every pull request.
+    needs: select-test-suites
+    if: needs.select-test-suites.outputs.omnigent_conformance == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -243,7 +249,7 @@ jobs:
             --ignore=tests/unit/api \
             --ignore=tests/unit/api_service \
             -m "unit_fast and not provider_verification and not requires_credentials" \
-            -q -n auto --dist loadfile --durations=25 \
+            -q -n auto --dist loadfile --durations=25 --timeout 600 \
             --junitxml=artifacts/pytest-unit-fast.xml
       - name: Upload generated fault-lab diagnostics
         if: failure()
@@ -340,7 +346,7 @@ jobs:
           set -euo pipefail
           python -m pytest tests/unit/api tests/unit/api_service tests/component/api \
             -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-            -q -n auto --dist loadfile --durations=25 \
+            -q -n auto --dist load --durations=25 --timeout 600 \
             --junitxml=artifacts/pytest-api-component.xml
 
   temporal-boundary:
@@ -368,7 +374,7 @@ jobs:
           set -euo pipefail
           python -m pytest tests/unit/workflows/temporal \
             -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-            -q --durations=25 \
+            -q -n auto --dist loadfile --durations=25 --timeout 600 \
             --junitxml=artifacts/pytest-temporal-boundary.xml
 
   integration-ci:
@@ -385,9 +391,28 @@ jobs:
           fetch-depth: 1
       - name: Initialize pinned Omnigent verifier source
         run: git submodule update --init --depth 1 -- omnigent
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build the pytest image with a shared layer cache
+        # The compose ``pytest`` service otherwise rebuilds the dependency
+        # layers from scratch on every run. The GitHub Actions cache keeps
+        # them across runs; only the layers behind changed inputs rebuild.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: api_service/Dockerfile
+          target: test-runtime
+          build-args: |
+            INSTALL_CODEX_CLI=false
+            INSTALL_TEST_DEPS=true
+          load: true
+          tags: moonmind-python-tests:ci
+          cache-from: type=gha,scope=integration-ci-test-runtime
+          cache-to: type=gha,scope=integration-ci-test-runtime,mode=max
       - name: Run hermetic integration CI suite
         env:
           MOONMIND_FORCE_LOCAL_TESTS: "1"
+          MOONMIND_PYTHON_TEST_IMAGE: moonmind-python-tests:ci
         run: |
           set -euo pipefail
           ./tools/test_integration.sh
@@ -561,7 +586,10 @@ jobs:
           load: true
           tags: moonmind-exact-artifact:candidate
           # A local single-arch image so its digest is the immutable artifact
-          # under test.
+          # under test. The layer cache only skips rebuilding unchanged layers;
+          # the resulting image digest is still computed from this checkout.
+          cache-from: type=gha,scope=exact-artifact-api-runtime
+          cache-to: type=gha,scope=exact-artifact-api-runtime,mode=max
       - name: Resolve the immutable image identity
         id: digest
         shell: bash

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -810,6 +810,7 @@ jobs:
       - integration-ci
       - reliability-journey-checkpoint-resume
       - omnigent-exact-artifact
+      - omnigent-deterministic-conformance
       - verify-test-shard-ownership
     if: always()
     runs-on: ubuntu-latest
@@ -882,6 +883,9 @@ jobs:
           require_selected "omnigent-exact-artifact" \
             "${{ needs.select-test-suites.outputs.exact_artifact }}" \
             "${{ needs.omnigent-exact-artifact.result }}"
+          require_selected "omnigent-deterministic-conformance" \
+            "${{ needs.select-test-suites.outputs.omnigent_conformance }}" \
+            "${{ needs.omnigent-deterministic-conformance.result }}"
           require_selected "verify-test-shard-ownership" \
             "${{ needs.select-test-suites.outputs.full_backend }}" \
             "${{ needs.verify-test-shard-ownership.result }}"

--- a/docs/Development/BackendTestSelection.md
+++ b/docs/Development/BackendTestSelection.md
@@ -143,8 +143,10 @@ overrides the default worker count.
 ### Omnigent Conformance Selection
 
 The selector enables `omnigent_conformance=true` for Omnigent-owned paths (the
-same inventory that elevates the complete Omnigent contract gate) and for every
-full-verification event. The deterministic conformance runner republishes the
+same inventory that elevates the complete Omnigent contract gate), for the
+runner's own evidence inputs listed in `OMNIGENT_CONFORMANCE_INPUT_EXACT` (its
+pytest layers, frontend test, profile fixture, and report builder), and for every
+full-verification event. `ci-required` aggregates the selected job's result. The deterministic conformance runner republishes the
 Omnigent evidence bundle from layers the exclusive shards already execute, so an
 unrelated change does not pay for it.
 
@@ -181,7 +183,7 @@ Conditional GitHub Actions jobs are not suitable as individual branch-protection
 - `select-test-suites` computes backend suite outputs from a shallow, submodule-free checkout.
 - `preflight-policy` runs the static repository policy checks in parallel with test selection.
 - `moonspec-projection` verifies the vendored MoonSpec projection.
-- `unit-fast`, `unit-slow`, `api-component`, `temporal-boundary`, `integration-ci`, and `reliability-journey-checkpoint-resume` run only when selected.
+- `unit-fast`, `unit-slow`, `api-component`, `temporal-boundary`, `integration-ci`, `reliability-journey-checkpoint-resume`, `omnigent-exact-artifact`, and `omnigent-deterministic-conformance` run only when selected.
 - `ci-required` always runs and fails if any always-required or selected backend job did not complete successfully.
 
 `ci-required` is a pure result aggregator: it performs no repository operations (no checkout, no submodules, no Python/Node setup, no repository command) and has a short timeout. It evaluates every dependency and emits one annotation per failed, cancelled, timed-out, or unexpectedly skipped selected job before exiting, rather than stopping at the first failure. This keeps repository, submodule, and policy work off the serial tail of required CI.

--- a/docs/Development/BackendTestSelection.md
+++ b/docs/Development/BackendTestSelection.md
@@ -41,6 +41,8 @@ api_component=true|false
 temporal_boundary=true|false
 integration_ci=true|false
 reliability_journey=true|false
+exact_artifact=true|false
+omnigent_conformance=true|false
 full_backend=true|false
 frontend_static=true|false
 frontend_browser_chromium=true|false
@@ -131,6 +133,21 @@ This suite validates compose-backed local infrastructure seams and must remain f
 Tests under `tests/integration/reliability/` are explicitly excluded because
 the reliability journey shard owns them.
 
+`tools/test_integration.sh` builds the compose `pytest` image unless
+`MOONMIND_PYTHON_TEST_IMAGE` names a caller-supplied image, in which case the
+image must already be loadable locally. CI prebuilds that image with a GitHub
+Actions layer cache so dependency layers are not rebuilt on every run. The suite
+runs under xdist with per-file distribution; `MOONMIND_INTEGRATION_WORKERS`
+overrides the default worker count.
+
+### Omnigent Conformance Selection
+
+The selector enables `omnigent_conformance=true` for Omnigent-owned paths (the
+same inventory that elevates the complete Omnigent contract gate) and for every
+full-verification event. The deterministic conformance runner republishes the
+Omnigent evidence bundle from layers the exclusive shards already execute, so an
+unrelated change does not pay for it.
+
 ## Full Backend Path
 
 The selector enables `full_backend=true` and selects all backend suites when any of the following is true:
@@ -213,15 +230,21 @@ Run component coverage:
 ```bash
 pytest tests/unit/api tests/unit/api_service tests/component/api \
   -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-  -q -n auto --dist loadfile --durations=25
+  -q -n auto --dist load --durations=25
 ```
+
+Component tests distribute per test rather than per file because a few router
+modules hold several hundred tests each. `tests/unit/api/conftest.py` fails
+Compose-only hostname lookups immediately (the settings-backed S3 artifact store
+and the API Postgres engine) so un-overridden request dependencies do not spend
+seconds per request in DNS and client retry backoff.
 
 Run Temporal boundary coverage:
 
 ```bash
 pytest tests/unit/workflows/temporal \
   -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-  -q --durations=25
+  -q -n auto --dist loadfile --durations=25
 ```
 
 Run slow unit coverage without xdist:

--- a/docs/Development/PreCommitWorkflow.md
+++ b/docs/Development/PreCommitWorkflow.md
@@ -124,11 +124,11 @@ python -m pytest tests/unit \
 
 python -m pytest tests/unit/api tests/unit/api_service tests/component/api \
   -m "component and not temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-  -q -n auto --dist loadfile --durations=25
+  -q -n auto --dist load --durations=25
 
 python -m pytest tests/unit/workflows/temporal \
   -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" \
-  -q --durations=25
+  -q -n auto --dist loadfile --durations=25
 
 python -m pytest tests/unit \
   -m "slow and not provider_verification and not requires_credentials and not integration" \

--- a/tests/integration/temporal/test_remediation_action_contracts.py
+++ b/tests/integration/temporal/test_remediation_action_contracts.py
@@ -31,6 +31,7 @@ from tests.unit.workflows.temporal.test_remediation_context import (
     _admin_permissions,
     _admin_profile,
     _create_target_and_remediation,
+    _fast_verification_phase,
     _read_artifact_json,
     mock_client_adapter,
     temporal_db,
@@ -87,6 +88,7 @@ async def test_remediation_action_contract_publishes_request_result_and_verifica
             session=session,
             artifact_service=artifact_service,
             action_executor=RecordingActionExecutor(),
+            verification_phase=_fast_verification_phase(session),
         )
 
         result = await tools.execute_action(
@@ -247,6 +249,7 @@ async def test_remediation_lifecycle_repair_prevention_summary_artifacts(
             session=session,
             artifact_service=artifact_service,
             action_executor=RecordingActionExecutor(),
+            verification_phase=_fast_verification_phase(session),
         )
 
         result = await tools.execute_action(

--- a/tests/support/network_guards.py
+++ b/tests/support/network_guards.py
@@ -50,21 +50,31 @@ def install_settings_backed_artifact_store_guard(monkeypatch) -> None:
     )
 
 
+def _is_loopback_target(host) -> bool:
+    if host in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(str(host)).is_loopback
+    except ValueError:
+        return False
+
+
 def install_dns_guard(monkeypatch) -> None:
-    """Fail DNS resolution for any non-loopback hostname immediately."""
+    """Fail address resolution for any non-loopback target immediately.
+
+    Hostnames and numeric addresses alike are refused unless they are loopback,
+    so a unit test cannot reach the network through either path.
+    """
 
     real_getaddrinfo = socket.getaddrinfo
 
     def _guarded_getaddrinfo(host, *args, **kwargs):
-        if host not in _LOOPBACK_HOSTS:
-            try:
-                ipaddress.ip_address(str(host))
-            except ValueError:
-                raise socket.gaierror(
-                    socket.EAI_NONAME,
-                    f"Refusing DNS lookup for {host!r} inside unit tests; "
-                    "override the dependency that opens this connection.",
-                ) from None
+        if not _is_loopback_target(host):
+            raise socket.gaierror(
+                socket.EAI_NONAME,
+                f"Refusing address resolution for {host!r} inside unit tests; "
+                "override the dependency that opens this connection.",
+            )
         return real_getaddrinfo(host, *args, **kwargs)
 
     monkeypatch.setattr(socket, "getaddrinfo", _guarded_getaddrinfo)

--- a/tests/support/network_guards.py
+++ b/tests/support/network_guards.py
@@ -1,0 +1,70 @@
+"""Fail-fast guards that keep hermetic unit tests off the network.
+
+API unit tests build a FastAPI app and override the service, user, and
+Temporal-client dependencies. Anything they leave un-overridden still resolves
+the Compose-only hostnames from ``moonmind.config.settings`` (the artifact
+MinIO endpoint and the API Postgres host). Those lookups fail, and the failure
+is swallowed, so the tests pass, but only after DNS and client retry backoff:
+about 8 to 30 seconds per request depending on the resolver. These guards make
+the same failures immediate so the tests keep their current behaviour without
+the wait.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+_LOOPBACK_HOSTS = frozenset({None, "", "localhost"})
+
+
+def install_settings_backed_artifact_store_guard(monkeypatch) -> None:
+    """Refuse to build a network-backed artifact store from settings.
+
+    Tests that need a real store either inject one or switch the settings
+    backend to ``local_fs``; both keep working. Only the S3 branch, which
+    opens a connection in its constructor, is refused.
+    """
+
+    from moonmind.workflows.temporal.artifacts import (
+        TemporalArtifactService,
+        TemporalArtifactValidationError,
+    )
+
+    original = TemporalArtifactService._build_store_from_settings
+
+    def _guarded_build_store_from_settings():
+        from moonmind.config.settings import settings
+
+        if settings.workflow.temporal_artifact_backend == "s3":
+            raise TemporalArtifactValidationError(
+                "Refusing to open a network-backed artifact store from settings "
+                "inside unit tests. Inject a store or use the local_fs backend."
+            )
+        return original()
+
+    monkeypatch.setattr(
+        TemporalArtifactService,
+        "_build_store_from_settings",
+        staticmethod(_guarded_build_store_from_settings),
+    )
+
+
+def install_dns_guard(monkeypatch) -> None:
+    """Fail DNS resolution for any non-loopback hostname immediately."""
+
+    real_getaddrinfo = socket.getaddrinfo
+
+    def _guarded_getaddrinfo(host, *args, **kwargs):
+        if host not in _LOOPBACK_HOSTS:
+            try:
+                ipaddress.ip_address(str(host))
+            except ValueError:
+                raise socket.gaierror(
+                    socket.EAI_NONAME,
+                    f"Refusing DNS lookup for {host!r} inside unit tests; "
+                    "override the dependency that opens this connection.",
+                ) from None
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", _guarded_getaddrinfo)

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -6,6 +6,10 @@ from importlib import import_module
 
 import pytest
 
+from tests.support.network_guards import (
+    install_dns_guard,
+    install_settings_backed_artifact_store_guard,
+)
 from tests.support.temporal_guards import install_temporal_client_adapter_guard
 
 
@@ -17,3 +21,16 @@ def prevent_live_temporal_lifecycle_calls(monkeypatch):
     """Keep API unit tests from starting/signaling/canceling real workflows."""
 
     install_temporal_client_adapter_guard(monkeypatch)
+
+
+@pytest.fixture(autouse=True)
+def prevent_network_waits(monkeypatch):
+    """Fail Compose-only hostname lookups immediately instead of after backoff.
+
+    Un-overridden request dependencies (the settings-backed S3 artifact store
+    and the API Postgres engine) otherwise spend 8 to 30 seconds per request
+    failing to reach hosts that only exist in Docker Compose.
+    """
+
+    install_settings_backed_artifact_store_guard(monkeypatch)
+    install_dns_guard(monkeypatch)

--- a/tests/unit/test_pytest_unit_workflow.py
+++ b/tests/unit/test_pytest_unit_workflow.py
@@ -415,6 +415,8 @@ def test_ci_required_is_pure_result_aggregator() -> None:
         "temporal-boundary",
         "integration-ci",
         "reliability-journey-checkpoint-resume",
+        "omnigent-exact-artifact",
+        "omnigent-deterministic-conformance",
         "verify-test-shard-ownership",
     ):
         assert dependency in job["needs"]
@@ -443,6 +445,8 @@ def test_ci_required_reports_all_failures_before_exiting() -> None:
         "temporal-boundary",
         "integration-ci",
         "reliability-journey-checkpoint-resume",
+        "omnigent-exact-artifact",
+        "omnigent-deterministic-conformance",
         "verify-test-shard-ownership",
     ):
         assert name in script

--- a/tests/unit/test_pytest_unit_workflow.py
+++ b/tests/unit/test_pytest_unit_workflow.py
@@ -275,6 +275,61 @@ def test_unit_workflow_keeps_api_and_temporal_ownership() -> None:
     assert "--junitxml=artifacts/pytest-temporal-boundary.xml" in temporal_command
 
 
+def test_parallel_shards_bound_hung_tests_and_spread_large_modules() -> None:
+    unit_fast = _run_command("unit-fast", "Run selected unit suite")
+    api_command = _run_command("api-component", "Run API/component suite")
+    temporal_command = _run_command("temporal-boundary", "Run Temporal boundary suite")
+
+    for command in (unit_fast, api_command, temporal_command):
+        assert "-n auto" in command
+        # A hung test must fail its own shard instead of running to the job
+        # timeout; faulthandler alone only dumps stacks.
+        assert "--timeout 600" in command
+    # The API shard's 400-test router modules dominate a per-file distribution,
+    # so component tests are distributed per test.
+    assert "--dist load " in api_command or api_command.rstrip().endswith("--dist load")
+    assert "--dist loadfile" not in api_command
+    assert "--dist loadfile" in temporal_command
+
+
+def test_deterministic_conformance_is_selection_gated() -> None:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["omnigent-deterministic-conformance"]
+
+    assert job["needs"] == "select-test-suites"
+    assert (
+        job["if"]
+        == "needs.select-test-suites.outputs.omnigent_conformance == 'true'"
+    )
+    assert "omnigent_conformance" in workflow["jobs"]["select-test-suites"]["outputs"]
+
+
+def test_image_building_jobs_share_a_layer_cache() -> None:
+    workflow = _load_workflow()
+    integration_steps = workflow["jobs"]["integration-ci"]["steps"]
+    build = next(
+        step
+        for step in integration_steps
+        if (step.get("uses") or "").startswith("docker/build-push-action@")
+    )
+    assert build["with"]["target"] == "test-runtime"
+    assert build["with"]["load"] is True
+    assert build["with"]["cache-from"].startswith("type=gha,")
+    assert build["with"]["cache-to"].startswith("type=gha,")
+    run_step = next(
+        step for step in integration_steps if step.get("name") == "Run hermetic integration CI suite"
+    )
+    assert run_step["env"]["MOONMIND_PYTHON_TEST_IMAGE"] == build["with"]["tags"]
+
+    exact_build = next(
+        step
+        for step in workflow["jobs"]["omnigent-exact-artifact"]["steps"]
+        if (step.get("uses") or "").startswith("docker/build-push-action@")
+    )
+    assert exact_build["with"]["cache-from"].startswith("type=gha,")
+    assert exact_build["with"]["cache-to"].startswith("type=gha,")
+
+
 def test_unit_slow_has_separate_non_parallel_job_and_required_contract() -> None:
     workflow = _load_workflow()
     job = workflow["jobs"]["unit-slow"]

--- a/tests/unit/tools/test_select_test_suites.py
+++ b/tests/unit/tools/test_select_test_suites.py
@@ -6,8 +6,10 @@ import pytest
 
 from tools import select_test_suites
 from tools.select_test_suites import (
+    OMNIGENT_CONFORMANCE_INPUT_EXACT,
     OMNIGENT_CONTRACT_GATE_KEYS,
     is_exact_artifact_owned,
+    is_omnigent_conformance_input,
     is_omnigent_contract_owned,
     select_suites,
 )
@@ -498,3 +500,38 @@ def test_full_verification_events_select_deterministic_conformance() -> None:
 
     assert outputs["omnigent_conformance"] == "true"
     assert "omnigent_conformance" in OMNIGENT_CONTRACT_GATE_KEYS
+
+
+def test_conformance_runner_inputs_select_deterministic_conformance_only() -> None:
+    for path in sorted(OMNIGENT_CONFORMANCE_INPUT_EXACT):
+        outputs = _outputs([path])
+        assert outputs["omnigent_conformance"] == "true", path
+        assert outputs["full_backend"] == "false", path
+        # An evidence input outside the owned inventory does not elevate the
+        # complete Omnigent contract gate; its owning shard still runs it.
+        if not is_omnigent_contract_owned(path):
+            assert outputs["exact_artifact"] == "false", path
+
+
+def test_conformance_input_inventory_matches_the_runner() -> None:
+    from tools import run_omnigent_conformance as runner
+
+    executed = {
+        argument
+        for command in runner.COMMANDS
+        for argument in command
+        if isinstance(argument, str)
+        and argument.startswith(("tests/", "frontend/"))
+        and not argument.startswith("--")
+    }
+    evidence = {path for paths in runner.EVIDENCE_GROUPS.values() for path in paths}
+    profile = str(runner.PROFILE.relative_to(REPO_ROOT)).replace("\\", "/")
+    report_builder = "tools/build_omnigent_conformance_report.py"
+
+    for path in executed | evidence | {profile, report_builder}:
+        # Directory arguments select through their prefix rule; probe a file
+        # inside them so the check matches the way changed paths arrive.
+        candidate = f"{path}/probe.py" if (REPO_ROOT / path).is_dir() else path
+        assert is_omnigent_conformance_input(candidate), path
+    for path in OMNIGENT_CONFORMANCE_INPUT_EXACT:
+        assert (REPO_ROOT / path).exists(), path

--- a/tests/unit/tools/test_select_test_suites.py
+++ b/tests/unit/tools/test_select_test_suites.py
@@ -36,6 +36,7 @@ def test_docs_only_change_does_not_select_heavy_backend_suites(
         "integration_ci": "false",
         "reliability_journey": "false",
         "exact_artifact": "false",
+        "omnigent_conformance": "false",
         "full_backend": "false",
         "frontend_static": "false",
         "frontend_browser_chromium": "false",
@@ -467,3 +468,33 @@ def test_non_deployable_backend_change_does_not_select_exact_artifact() -> None:
 def test_docs_only_change_does_not_select_exact_artifact() -> None:
     assert _outputs(["docs/Omnigent/Overview.md"])["exact_artifact"] == "false"
     assert not is_exact_artifact_owned("docs/Omnigent/Overview.md")
+
+
+def test_omnigent_owned_change_selects_deterministic_conformance() -> None:
+    outputs = _outputs(["moonmind/omnigent/native_ui.py"])
+
+    assert outputs["omnigent_conformance"] == "true"
+
+
+@pytest.mark.parametrize(
+    "changed_path",
+    [
+        "api_service/api/routers/executions.py",
+        "moonmind/workflows/temporal/workflows/run.py",
+        "tests/integration/temporal/test_compose_foundation.py",
+        "docs/Omnigent/Overview.md",
+    ],
+)
+def test_non_omnigent_change_skips_deterministic_conformance(changed_path: str) -> None:
+    assert _outputs([changed_path])["omnigent_conformance"] == "false", changed_path
+
+
+def test_full_verification_events_select_deterministic_conformance() -> None:
+    outputs = select_suites(
+        ["docs/Development/PreCommitWorkflow.md"],
+        event_name="push",
+        ref_name="main",
+    ).as_outputs()
+
+    assert outputs["omnigent_conformance"] == "true"
+    assert "omnigent_conformance" in OMNIGENT_CONTRACT_GATE_KEYS

--- a/tests/unit/workflows/temporal/test_remediation_context.py
+++ b/tests/unit/workflows/temporal/test_remediation_context.py
@@ -148,6 +148,7 @@ from moonmind.workflows.temporal.remediation_tools import (
     RemediationLogReadResult,
 )
 from moonmind.workflows.temporal.remediation_verification import (
+    CanonicalRecordEvidenceReader,
     RemediationVerificationPhase,
     TargetEvidenceSnapshot,
 )
@@ -2401,6 +2402,7 @@ async def test_remediation_execute_action_delegates_and_publishes_lifecycle_arti
             session=session,
             artifact_service=artifact_service,
             action_executor=executor,
+            verification_phase=_fast_verification_phase(session),
         )
 
         result = await tools.execute_action(
@@ -2513,6 +2515,7 @@ async def test_execute_action_preserves_approval_lifecycle_artifact_refs(
             session=session,
             artifact_service=artifact_service,
             action_executor=RecordingActionExecutor(),
+            verification_phase=_fast_verification_phase(session),
         )
         with patch.object(
             tools,
@@ -2639,6 +2642,7 @@ async def test_remediation_execute_action_reuses_retry_artifacts(
             session=session,
             artifact_service=artifact_service,
             action_executor=RecordingActionExecutor(),
+            verification_phase=_fast_verification_phase(session),
         )
 
         first = await tools.execute_action(
@@ -2734,6 +2738,7 @@ async def test_remediation_execute_action_publishes_v1_request_and_result_artifa
             session=session,
             artifact_service=artifact_service,
             action_executor=SensitiveHintActionExecutor(),
+            verification_phase=_fast_verification_phase(session),
         )
 
         result = await tools.execute_action(
@@ -3995,6 +4000,18 @@ class _ScriptedVerificationReader:
 async def _noop_verification_sleep(_seconds):
     return None
 
+
+def _fast_verification_phase(session) -> RemediationVerificationPhase:
+    """Production verification against the canonical record, minus the real sleeps.
+
+    The execution.* verification contracts stabilize for 30 seconds in 5-second
+    polls; the phase already accepts an injected sleep so tests never wait.
+    """
+
+    return RemediationVerificationPhase(
+        reader=CanonicalRecordEvidenceReader(session),
+        sleep=_noop_verification_sleep,
+    )
 
 def _verification_snapshot(stage, *, state, close_status=None, run_id="target-run", paused=None):
     return TargetEvidenceSnapshot(

--- a/tests/unit/workloads/test_docker_workload_launcher.py
+++ b/tests/unit/workloads/test_docker_workload_launcher.py
@@ -230,6 +230,11 @@ class _Process:
         self.returncode = -9
         self._closed.set()
 
+    def container_exited(self, returncode: int = 137) -> None:
+        """Model ``docker run`` returning once its container was stopped or killed."""
+        self.returncode = returncode
+        self._closed.set()
+
 class _Pipe:
     def __init__(self, process: _Process, data: bytes) -> None:
         self._process = process
@@ -361,10 +366,17 @@ async def test_unrestricted_launcher_timeout_stops_and_kills_without_remove_on_e
 ) -> None:
     created: list[list[str]] = []
 
+    workload: list[_Process] = []
+
     async def _fake_create_subprocess_exec(*args: str, **_kwargs: Any) -> _Process:
         created.append(list(args))
         if args[1] == "ps":
-            return _Process(never_complete=True)
+            workload.append(_Process(never_complete=True))
+            return workload[-1]
+        if args[1] in {"stop", "kill"}:
+            # The real ``docker run`` exits once its container is stopped.
+            for process in workload:
+                process.container_exited()
         return _Process(returncode=0)
 
     monkeypatch.setattr(

--- a/tests/unit/workloads/test_gpu_container_qualification.py
+++ b/tests/unit/workloads/test_gpu_container_qualification.py
@@ -105,11 +105,21 @@ def _fake_docker(
     recorded: list[list[str]],
     *,
     run_process: Any = None,
+    stop_ends_run: bool = False,
 ) -> Any:
+    workloads: list[_Process] = []
+
     async def _create(*args: str, **_kwargs: Any) -> _Process:
         recorded.append(list(args))
         if len(args) > 1 and args[1] == "run":
-            return run_process() if callable(run_process) else _Process(returncode=0)
+            process = run_process() if callable(run_process) else _Process(returncode=0)
+            workloads.append(process)
+            return process
+        if stop_ends_run and len(args) > 1 and args[1] in {"stop", "kill"}:
+            # A stopped container ends its ``docker run`` process, so the
+            # launcher does not have to wait out the kill grace period.
+            for process in workloads:
+                process.container_exited()
         return _Process(returncode=0)
 
     return _create
@@ -120,10 +130,11 @@ def _install_fake_docker(
     recorded: list[list[str]],
     *,
     run_process: Any = None,
+    stop_ends_run: bool = False,
 ) -> None:
     monkeypatch.setattr(
         "moonmind.workloads.docker_launcher.asyncio.create_subprocess_exec",
-        _fake_docker(recorded, run_process=run_process),
+        _fake_docker(recorded, run_process=run_process, stop_ends_run=stop_ends_run),
     )
 
 
@@ -432,6 +443,7 @@ async def test_gpu_container_timeout_targets_only_the_run_owned_container(
         monkeypatch,
         recorded,
         run_process=lambda: _Process(never_complete=True),
+        stop_ends_run=True,
     )
 
     result = await DockerWorkloadLauncher().run(
@@ -462,6 +474,7 @@ async def test_gpu_container_timeout_preserves_partial_declared_outputs(
         monkeypatch,
         recorded,
         run_process=lambda: _Process(never_complete=True),
+        stop_ends_run=True,
     )
 
     result = await DockerWorkloadLauncher().run(

--- a/tools/run_omnigent_conformance.py
+++ b/tools/run_omnigent_conformance.py
@@ -101,6 +101,10 @@ EVIDENCE_GROUPS = {
     ),
 }
 PENDING_EVIDENCE_GROUPS = {"cumulativeJourney"}
+# The deterministic layers are ordinary hermetic pytest modules that already run
+# under xdist in the unit shards; spreading them across the runner's cores keeps
+# the evidence bundle identical while the job finishes in a fraction of the time.
+_PYTEST_PARALLEL_ARGS = ("-n", "auto", "--dist", "loadfile")
 COMMANDS = (
     (
         sys.executable,
@@ -115,6 +119,7 @@ COMMANDS = (
         "--ignore=tests/integration/omnigent/test_host_auth_lifecycle.py",
         "-q",
         "--tb=short",
+        *_PYTEST_PARALLEL_ARGS,
     ),
     (
         sys.executable,
@@ -131,6 +136,7 @@ COMMANDS = (
         "tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py",
         "-q",
         "--tb=short",
+        *_PYTEST_PARALLEL_ARGS,
     ),
     (
         "npm",

--- a/tools/select_test_suites.py
+++ b/tools/select_test_suites.py
@@ -22,6 +22,7 @@ OUTPUT_KEYS = (
     "integration_ci",
     "reliability_journey",
     "exact_artifact",
+    "omnigent_conformance",
     "full_backend",
     "frontend_static",
     "frontend_browser_chromium",
@@ -181,6 +182,10 @@ OMNIGENT_CONTRACT_GATE_KEYS = (
     # An Omnigent-owned change ships in the deployable API/worker/UI images, so
     # it must also exercise the Tier-1 exact deployable-artifact gate.
     "exact_artifact",
+    # The deterministic conformance runner republishes the Omnigent evidence
+    # bundle from the same layers; it is part of the owned contract gate rather
+    # than an unconditional job, so unrelated changes do not pay for it.
+    "omnigent_conformance",
 )
 
 OMNIGENT_CONTRACT_EXACT = {
@@ -318,6 +323,7 @@ class SuiteSelection:
     integration_ci: bool = False
     reliability_journey: bool = False
     exact_artifact: bool = False
+    omnigent_conformance: bool = False
     full_backend: bool = False
     frontend_static: bool = False
     frontend_browser_chromium: bool = False
@@ -434,6 +440,7 @@ def _full_backend_selection() -> SuiteSelection:
         integration_ci=True,
         reliability_journey=True,
         exact_artifact=True,
+        omnigent_conformance=True,
         full_backend=True,
     )
 

--- a/tools/select_test_suites.py
+++ b/tools/select_test_suites.py
@@ -220,6 +220,26 @@ OMNIGENT_CONTRACT_GLOBS = (
     "tools/build_omnigent_*",
 )
 
+# Inputs of the deterministic conformance runner that live outside the owned
+# inventory above: the pytest layers and frontend test it executes, its profile,
+# and its report builder. A change to any of them must republish the evidence
+# bundle, but it does not by itself elevate the complete contract gate; the
+# shard that owns the file still runs it. tests/unit/tools cross-checks this set
+# against ``tools/run_omnigent_conformance.py``.
+OMNIGENT_CONFORMANCE_INPUT_EXACT = {
+    "frontend/src/entrypoints/workflow-detail.test.tsx",
+    "tests/fixtures/omnigent/conformance-v4.json",
+    "tests/integration/reliability/test_checkpoint_cold_resume.py",
+    "tests/integration/reliability_journey/"
+    "test_omnigent_cumulative_remediation_journey.py",
+    "tests/unit/tools/test_run_omnigent_live_conformance.py",
+    "tests/unit/workflows/adapters/test_external_adapter_registry.py",
+    "tests/unit/workflows/temporal/test_remediation_workspace_head.py",
+    "tests/unit/workflows/temporal/test_temporal_workers.py",
+    "tests/unit/workflows/temporal/workflows/test_run_bounded_story_loop.py",
+    "tests/unit/workflows/temporal/workflows/test_run_integration.py",
+}
+
 # The subset of owned paths whose change can affect the compiled native UI or
 # facade behavior, which must additionally exercise the compiled production
 # browser suite (issue #3710 required PR gate item 7).
@@ -371,6 +391,7 @@ def _is_non_backend_path(path: str) -> bool:
 def _is_backend_path(path: str) -> bool:
     return (
         path in FORCE_FULL_EXACT
+        or path in OMNIGENT_CONFORMANCE_INPUT_EXACT
         or path in API_COMPONENT_EXACT
         or path in TEMPORAL_BOUNDARY_EXACT
         or path in INTEGRATION_CI_EXACT
@@ -405,6 +426,11 @@ def is_exact_artifact_owned(path: str) -> bool:
         prefixes=EXACT_ARTIFACT_PREFIXES,
         globs=EXACT_ARTIFACT_GLOBS,
     )
+
+
+def is_omnigent_conformance_input(path: str) -> bool:
+    """Return whether a changed path feeds the deterministic conformance runner."""
+    return is_omnigent_contract_owned(path) or path in OMNIGENT_CONFORMANCE_INPUT_EXACT
 
 
 def _is_omnigent_facade_path(path: str) -> bool:
@@ -548,6 +574,7 @@ def select_suites(
         # and frontend Dockerfiles are non-backend but still change the
         # deployable image runtime surface.
         exact_artifact=any(is_exact_artifact_owned(path) for path in paths),
+        omnigent_conformance=any(is_omnigent_conformance_input(path) for path in paths),
         frontend_static=static or chromium,
         frontend_browser_chromium=chromium,
         frontend_browser_firefox=firefox,

--- a/tools/test_integration.sh
+++ b/tools/test_integration.sh
@@ -77,18 +77,35 @@ fi
 
 export MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1
 
-# Build pytest service
-"${COMPOSE_CMD[@]}" --project-name "$TEST_COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" --project-directory "$COMPOSE_PROJECT_DIR" build pytest
+# Build the pytest service image unless the caller supplied one.
+#
+# MOONMIND_PYTHON_TEST_IMAGE names the image the compose ``pytest`` service
+# runs. When it is set, the caller owns that image (CI prebuilds it with a
+# registry-backed layer cache), so it must already be loadable locally; a
+# missing image is an actionable setup error rather than a silent rebuild.
+if [[ -n "${MOONMIND_PYTHON_TEST_IMAGE:-}" ]]; then
+  if ! docker image inspect "$MOONMIND_PYTHON_TEST_IMAGE" >/dev/null 2>&1; then
+    echo "Error: MOONMIND_PYTHON_TEST_IMAGE=$MOONMIND_PYTHON_TEST_IMAGE is set but the image is not available locally; build or pull it first, or unset it to build here." >&2
+    exit 1
+  fi
+  echo "Using prebuilt pytest image $MOONMIND_PYTHON_TEST_IMAGE"
+else
+  "${COMPOSE_CMD[@]}" --project-name "$TEST_COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" --project-directory "$COMPOSE_PROJECT_DIR" build pytest
+fi
 
 # Run integration tests (always cleaned up via trap)
 # --timeout 120: kill any single test that runs longer than 120 seconds
 # --timeout-method=thread: use thread-based timeout (works with async tests)
 # --durations=10: print the 10 slowest tests at the end
+# -n / --dist loadfile: the hermetic suite provisions its own Temporal test
+#   servers, Postgres clusters, and sockets on ephemeral ports, so test files
+#   run on separate workers; MOONMIND_INTEGRATION_WORKERS overrides the count.
+INTEGRATION_WORKERS="${MOONMIND_INTEGRATION_WORKERS:-2}"
 run_tests() {
   "${COMPOSE_CMD[@]}" --project-name "$TEST_COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" --project-directory "$COMPOSE_PROJECT_DIR" run --rm \
     -e MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1 \
     pytest \
-    bash -lc "pytest tests/integration -m 'integration_ci' --tb=short --timeout 120 --timeout-method=thread --durations=10"
+    bash -lc "pytest tests/integration -m 'integration_ci' --tb=short --timeout 120 --timeout-method=thread --durations=10 -n $INTEGRATION_WORKERS --dist loadfile"
 }
 
 run_tests


### PR DESCRIPTION
## Summary

`CI / Test Suite` wall time was set by four jobs at a ~7 minute median with tails to 16-23 minutes (40-run sample). Most of that time was not test work:

- **api-component**: describe-execution unit tests override the service, user, and Temporal-client dependencies but not the DB session or artifact-store factory, so every request did two real network attempts against Compose-only hostnames (MinIO `head_bucket` with botocore retry backoff, Postgres DNS for the async engine). The failures were swallowed, so the tests passed, but at 7-15 s each on CI (30-86 s on a slow runner). With `--dist loadfile` the 419-test `test_executions.py` sat on one xdist worker and was the whole job. Verified with a faulthandler stack dump: 30 s -> 0.1 s per test once both lookups fail fast.
- **temporal-boundary**: ran serially; four remediation tests waited out the real 30 s verification stabilization window (152 s of a 353 s job).
- **integration-ci**: rebuilt the test image cold every run (~1m50s) and repeated the same 30 s sleeps twice.
- **omnigent-deterministic-conformance**: ran unconditionally and serially on every PR, re-executing ~1,900 tests the exclusive shards already run; longest job in 11 of 40 runs.
- **unit-fast**: three workload timeout tests waited out the 30 s docker kill-grace on a fake process.

## Changes

- `tests/unit/api/conftest.py` + `tests/support/network_guards.py`: autouse guards that refuse the settings-backed S3 store and non-loopback DNS lookups immediately (tests that need a store inject one or use `local_fs`; both still work).
- api-component shard uses `--dist load`; unit shards get `--timeout 600` so a hung test fails its shard instead of running to the job timeout.
- Remediation action tests (unit + integration) inject the no-op verification sleep the phase already supports.
- Workload timeout tests model `docker stop` ending the `docker run` process (opt-in per test) instead of waiting out the kill grace.
- temporal-boundary runs under xdist (`tools/test_unit.sh` already runs that tree with xdist locally).
- integration-ci prebuilds the `test-runtime` image via `docker/build-push-action` with a GitHub Actions layer cache; `tools/test_integration.sh` accepts a caller-supplied `MOONMIND_PYTHON_TEST_IMAGE` (fails fast if the image is missing) and runs the suite with two workers (`MOONMIND_INTEGRATION_WORKERS`).
- The deterministic Omnigent conformance job is selection-gated via a new `omnigent_conformance` selector output (Omnigent-owned paths + full-verification events) and its pytest layers run under xdist. The exact-artifact image build reuses a layer cache.
- Docs: `docs/Development/BackendTestSelection.md`, `docs/Development/PreCommitWorkflow.md`.

## Verification

Run in the `moonmind-python-tests:local` image against this branch:

- api-component selection with `--dist load`: 1863 passed, 1 xfailed, 0 failed.
- temporal-boundary selection with `-n 4 --dist loadfile`: 3738 passed; the single failure (`test_agent_session_deployment_safety::..._without_merge_base`) is `git ls-files` exit 128 from running inside a git worktree mount and passes on the primary checkout.
- The four slow remediation tests: 30-60 s -> ~3.5 s each. Workload test files: 135 passed, 30 s waits gone.
- `tools/test_integration.sh` with `-n 2`: 611 passed; the 7 failures were the uninitialized `omnigent` submodule in the local worktree (CI initializes it), and `tests/integration/omnigent/test_embedded_recovery.py` passes with it present (18 passed).
- Selector, conformance-runner, workflow-contract, and taxonomy unit tests pass.

Expected effect: typical run from ~7 min toward ~4 min, with the DNS-driven 16-minute tail removed. The first run on this branch pays the Docker layer-cache warm-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
