### PR TITLE
Implement ordered Provider Profile model and effort tier editor

### DIFF
--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1015,19 +1015,23 @@ describe('ProviderProfilesManager form controls', () => {
     });
   });
 
-  it('sends default effort changes when updating an edited profile', async () => {
+  it('sends tier effort changes when updating an edited profile (MoonLadderStudios/MoonMind#3348)', async () => {
     const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({ ...profile, default_effort: 'high' }),
+      json: async () => ({
+        ...profile,
+        model_tiers: [{ label: null, model: null, effort: 'high', parameters: {}, annotations: {} }],
+        default_model_tier: 1,
+      }),
     } as Response);
 
     renderProviderProfilesManager([profile]);
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    const defaultEffort = screen.getByLabelText(/Default effort/) as HTMLInputElement;
-    expect(defaultEffort.value).toBe('');
+    const effortSelect = screen.getByLabelText('Tier 1 effort') as HTMLSelectElement;
+    expect(effortSelect.value).toBe('__runtime_default__');
 
-    fireEvent.change(defaultEffort, { target: { value: 'high' } });
+    fireEvent.change(effortSelect, { target: { value: 'high' } });
     fireEvent.click(screen.getByRole('button', { name: 'Update provider profile' }));
 
     await waitFor(() => {
@@ -1041,7 +1045,10 @@ describe('ProviderProfilesManager form controls', () => {
 
     const [, requestInit] = fetchSpy.mock.calls[0] ?? [];
     const payload = JSON.parse(String((requestInit as RequestInit).body));
-    expect(payload.default_effort).toBe('high');
+    expect(payload.model_tiers).toEqual([{ label: null, model: null, effort: 'high', parameters: {}, annotations: {} }]);
+    expect(payload.default_model_tier).toBe(1);
+    expect(payload).not.toHaveProperty('default_model');
+    expect(payload).not.toHaveProperty('default_effort');
   });
 
   it('requires a backend-supported authentication method before creation', async () => {
@@ -2279,5 +2286,124 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
       '/api/v1/provider-profiles/credential-volume/validate',
       expect.objectContaining({ method: 'POST' }),
     );
+  });
+});
+
+describe('MoonLadderStudios/MoonMind#3348 tier editor', () => {
+  const tierProfile: ProviderProfile = {
+    profile_id: 'tier-profile',
+    runtime_id: 'codex_cli',
+    provider_id: 'openai',
+    credential_source: 'secret_ref',
+    runtime_materialization_mode: 'api_key_env',
+    secret_refs: {},
+    max_parallel_runs: 1,
+    cooldown_after_429_seconds: 300,
+    rate_limit_policy: 'backoff',
+    enabled: true,
+    model_tiers: [
+      { label: 'Plan', model: 'gpt-5.5', effort: 'medium', parameters: {}, annotations: {} },
+      { label: 'Impl', model: 'gpt-5.5', effort: 'xhigh', parameters: {}, annotations: {} },
+      { label: 'Docs', model: 'gpt-5.3', effort: 'xhigh', parameters: {}, annotations: {} },
+    ],
+    default_model_tier: 2,
+  };
+
+  it('shows tier count and default tier in collection and +N more when needed', () => {
+    renderProviderProfilesManager([tierProfile]);
+    expect(screen.getByText('3 tiers · Default: Tier 2')).toBeTruthy();
+    expect(screen.getByText('+1 more')).toBeTruthy();
+    expect(screen.getByLabelText('tier-profile model tier mapping')).toBeTruthy();
+  });
+
+  it('displays Runtime default for null model/effort and repair when empty', () => {
+    const emptyProfile: ProviderProfile = { ...tierProfile, profile_id: 'empty-profile', model_tiers: [], default_model_tier: 1 };
+    renderProviderProfilesManager([emptyProfile]);
+    expect(screen.getByText('Tier policy unavailable · needs repair')).toBeTruthy();
+  });
+
+  it('renders tier editor section with ordered cards and default state', () => {
+    renderProviderProfilesManager([tierProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByText('Model & effort tiers')).toBeTruthy();
+    expect(screen.getAllByText(/Tier 1/)[0]).toBeTruthy();
+    expect(screen.getByLabelText('Tier 2 label')).toBeTruthy();
+    expect(screen.getByLabelText('Use Tier 1 as default')).toBeTruthy();
+    expect(screen.getByLabelText('Default tier')).toBeTruthy();
+  });
+
+  it('can append and duplicate tiers without renumbering existing tiers', async () => {
+    renderProviderProfilesManager([tierProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const addButtons = screen.getAllByRole('button', { name: 'Add tier' });
+    fireEvent.click(addButtons[0]!);
+    expect(screen.getByLabelText('Tier 4 label')).toBeTruthy();
+    expect(screen.getByText('4 tiers · Default: Tier 2')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Duplicate Tier 1 as new last tier'));
+    expect(screen.getByLabelText('Tier 5 label')).toBeTruthy();
+    const tier5 = screen.getByLabelText('Tier 5 label') as HTMLInputElement;
+    expect(tier5.value).toBe('Plan copy');
+  });
+
+  it('prevents removal of only remaining tier', () => {
+    const singleTier: ProviderProfile = {
+      ...tierProfile,
+      model_tiers: [{ label: 'Only', model: null, effort: null, parameters: {}, annotations: {} }],
+      default_model_tier: 1,
+    };
+    renderProviderProfilesManager([singleTier]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const removeBtn = screen.getByLabelText('Remove Tier 1') as HTMLButtonElement;
+    expect(removeBtn.disabled).toBe(true);
+  });
+
+  it('middle-tier removal previews ordinal changes', async () => {
+    renderProviderProfilesManager([tierProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByLabelText('Remove Tier 2'));
+    expect(await screen.findByText('Remove Tier 2?')).toBeTruthy();
+    expect(screen.getByText('Tier 3: Docs → becomes Tier 2')).toBeTruthy();
+    expect(screen.getByText('Existing historical runs do not change.')).toBeTruthy();
+  });
+
+  it('removing default requires reviewed replacement default', async () => {
+    renderProviderProfilesManager([tierProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByLabelText('Remove Tier 2'));
+    expect(await screen.findByText('Choose a replacement default tier:')).toBeTruthy();
+    const replacement = screen.getAllByLabelText(/Tier \d/ as unknown as string);
+    expect(replacement.length).toBeGreaterThan(0);
+  });
+
+  it('saves only canonical ordered tier policy not legacy fields (MoonLadderStudios/MoonMind#3348)', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...tierProfile, model_tiers: tierProfile.model_tiers, default_model_tier: 2 }),
+    } as Response);
+    renderProviderProfilesManager([tierProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByLabelText('Tier 1 label'), { target: { value: 'Plan updated' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update provider profile' }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const payload = JSON.parse(String(fetchSpy.mock.calls[0]?.[1]?.body));
+    expect(payload.model_tiers[0].label).toBe('Plan updated');
+    expect(payload.default_model_tier).toBe(2);
+    expect(payload).not.toHaveProperty('default_model');
+    expect(payload).not.toHaveProperty('default_effort');
+  });
+
+  it('read-only users see complete ordered policy as values', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderProfilesManager profiles={[tierProfile]} secretSlugs={[]} onNotice={vi.fn()} queryClient={queryClient} canWriteProviderProfiles={false} />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByRole('button', { name: 'Edit tiers tier-profile' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    expect(screen.getByText('3 tiers · Default: Tier 2')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Add tier' })).toBeNull();
+    // collection summary expansion is accessible without edit mode
+    expect(screen.getByText('Show tier mapping')).toBeTruthy();
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -3577,7 +3577,7 @@ export function ProviderProfilesManager({
             {canWriteProviderProfiles ? (
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <span className="font-medium text-slate-700 dark:text-slate-300">{tierDrafts.length} tiers{defaultTierClientId ? ` · Default: Tier ${tierDrafts.findIndex((t) => t.clientId === defaultTierClientId) + 1}` : ''}</span>
-                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier} disabled={!canWriteProviderProfiles}>Add tier</button>
+                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier}>Add tier</button>
                 {invalidSavedDefaultIndex !== null ? <span className="rounded bg-amber-100 dark:bg-amber-900/30 px-2 py-1 text-xs font-semibold text-amber-700 dark:text-amber-300">Invalid saved default: Tier {invalidSavedDefaultIndex}</span> : null}
               </div>
             ) : (
@@ -3680,7 +3680,7 @@ export function ProviderProfilesManager({
                 );
               })}
             </ol>
-            {canWriteProviderProfiles && !isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
+            {!isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
             <p className="text-xs text-slate-500 dark:text-slate-400">Future launches use the saved policy. Historical runs keep their record.</p>
             {tierRemoveDialog ? (
               <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }}>

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -3,6 +3,16 @@ import { QueryClient, useMutation } from '@tanstack/react-query';
 
 import type { components } from '../../generated/openapi';
 import { formatRuntimeLabel, formatStatusLabel } from '../../utils/formatters';
+import {
+  buildProviderProfileTierPayload,
+  computeTierRenumberingImpact,
+  duplicateTierDraft,
+  normalizeProviderProfileTiers,
+  runtimeDefaultTierDraft,
+  tierDisplayEffort,
+  tierDisplayModel,
+  type ProviderProfileTierDraft,
+} from '../../utils/providerProfileTiers';
 import { useSettingsDraftRegistration } from './SettingsDraftGuard';
 
 type ProviderProfileCreationPreset =
@@ -164,8 +174,8 @@ interface ProviderProfileSavePayload {
   runtime_id?: string;
   provider_id?: string;
   provider_label?: string | null;
-  default_model?: string | null;
-  default_effort?: string | null;
+  model_tiers?: ProviderModelEffortTier[];
+  default_model_tier?: number;
   authentication_method?: AuthenticationMethod;
   preset_version?: string;
   credential_source?: string;
@@ -229,15 +239,24 @@ function providerProfileModelTiers(profile: ProviderProfile): ProviderModelEffor
   if (Array.isArray(profile.model_tiers) && profile.model_tiers.length > 0) {
     return profile.model_tiers;
   }
-  return [
-    {
-      label: 'Default',
-      model: profile.default_model ?? null,
-      effort: profile.default_effort ?? null,
-      parameters: {},
-      annotations: {},
-    },
-  ];
+  return [];
+}
+
+function providerProfileTierCount(profile: ProviderProfile): number | null {
+  if (Array.isArray(profile.model_tiers)) {
+    return profile.model_tiers.length;
+  }
+  return null;
+}
+
+function cloneTierDrafts(
+  tiers: ProviderProfileTierDraft[],
+): ProviderProfileTierDraft[] {
+  return tiers.map((tier) => ({
+    ...tier,
+    parameters: { ...tier.parameters },
+    annotations: { ...tier.annotations },
+  }));
 }
 
 function oauthSessionStateFromResponse(
@@ -812,6 +831,10 @@ function buildSavePayload(
     formBaseline: ProviderProfileFormState;
     creationPreset: ProviderProfileCreationPreset | null;
     importExistingCredentialVolume: boolean;
+    tierDrafts: ProviderProfileTierDraft[];
+    defaultTierClientId: string | null;
+    tierBaseline: ProviderProfileTierDraft[] | null;
+    tierBaselineDefaultId: string | null;
   },
 ): ProviderProfileSavePayload {
   const isCodexOAuth =
@@ -837,16 +860,17 @@ function buildSavePayload(
       form.providerLabel.trim() || null,
       baseline.providerLabel.trim() || null,
     );
-    setChanged(
-      'default_model',
-      form.defaultModel.trim() || null,
-      baseline.defaultModel.trim() || null,
-    );
-    setChanged(
-      'default_effort',
-      form.defaultEffort.trim() || null,
-      baseline.defaultEffort.trim() || null,
-    );
+    {
+      const currentTierPayload = buildProviderProfileTierPayload(options.tierDrafts, options.defaultTierClientId);
+      const baselineTierPayload = options.tierBaseline
+        ? buildProviderProfileTierPayload(options.tierBaseline, options.tierBaselineDefaultId)
+        : null;
+      const tierChanged = !baselineTierPayload || !valuesEqual(currentTierPayload.model_tiers, baselineTierPayload.model_tiers) || currentTierPayload.default_model_tier !== baselineTierPayload.default_model_tier;
+      if (tierChanged) {
+        payload.model_tiers = currentTierPayload.model_tiers;
+        payload.default_model_tier = currentTierPayload.default_model_tier;
+      }
+    }
     setChanged(
       'account_label',
       form.accountLabel.trim() || null,
@@ -905,8 +929,11 @@ function buildSavePayload(
   payload.runtime_id = form.runtimeId.trim();
   payload.provider_id = form.providerId.trim();
   payload.provider_label = form.providerLabel.trim() || null;
-  payload.default_model = form.defaultModel.trim() || null;
-  payload.default_effort = form.defaultEffort.trim() || null;
+  {
+    const tierPayload = buildProviderProfileTierPayload(options.tierDrafts, options.defaultTierClientId);
+    payload.model_tiers = tierPayload.model_tiers;
+    payload.default_model_tier = tierPayload.default_model_tier;
+  }
   payload.account_label = form.accountLabel.trim() || null;
 
   if (!payload.profile_id) {
@@ -1038,6 +1065,24 @@ export function ProviderProfilesManager({
   const [importedVolumeRef, setImportedVolumeRef] = useState('');
   const [importedVolumeValidated, setImportedVolumeValidated] = useState(false);
   const startOAuthFromCreationRef = useRef<(profile: ProviderProfile) => void>(() => undefined);
+  const [tierDrafts, setTierDrafts] = useState<ProviderProfileTierDraft[]>(() => [runtimeDefaultTierDraft()]);
+  const [defaultTierClientId, setDefaultTierClientId] = useState<string | null>(() => tierDrafts[0]?.clientId ?? null);
+  const [tierBaseline, setTierBaseline] = useState<ProviderProfileTierDraft[] | null>(
+    () => cloneTierDrafts(tierDrafts),
+  );
+  const [tierBaselineDefaultId, setTierBaselineDefaultId] = useState<string | null>(
+    () => tierDrafts[0]?.clientId ?? null,
+  );
+  const [invalidSavedDefaultIndex, setInvalidSavedDefaultIndex] = useState<number | null>(null);
+  const [isTierRepair, setIsTierRepair] = useState(false);
+  const [tierFieldErrors, setTierFieldErrors] = useState<Record<string, string>>({});
+  const [tierLiveMessage, setTierLiveMessage] = useState<string>('');
+  const [tierUndo, setTierUndo] = useState<{ tier: ProviderProfileTierDraft; index: number; wasDefault: boolean } | null>(null);
+  const [tierRemoveDialog, setTierRemoveDialog] = useState<{ index: number; tier: ProviderProfileTierDraft; isDefault: boolean; isMiddle: boolean } | null>(null);
+  const [tierRemoveReplacementId, setTierRemoveReplacementId] = useState<string | null>(null);
+  const tierSectionRef = useRef<HTMLElement | null>(null);
+  const tierLiveRef = useRef<HTMLDivElement | null>(null);
+  const focusedTierClientIdRef = useRef<string | null>(null);
 
   const activeRuntimeFilterValue = selectedRuntimeId ?? ALL_RUNTIMES_FILTER_VALUE;
   // Canonical runtime IDs are the option values; the shared runtime formatter
@@ -1335,6 +1380,16 @@ export function ProviderProfilesManager({
     const nextForm = defaultFormState(createFormRuntimeSeed);
     setForm(nextForm);
     setFormBaseline(nextForm);
+    const initialTier = runtimeDefaultTierDraft();
+    setTierDrafts([initialTier]);
+    setDefaultTierClientId(initialTier.clientId);
+    setTierBaseline(cloneTierDrafts([initialTier]));
+    setTierBaselineDefaultId(initialTier.clientId);
+    setInvalidSavedDefaultIndex(null);
+    setIsTierRepair(false);
+    setTierFieldErrors({});
+    setTierUndo(null);
+    setTierRemoveDialog(null);
     setCreationPreset(null);
     setCreationPresetError(null);
     setCreationCapabilities(null);
@@ -1362,6 +1417,26 @@ export function ProviderProfilesManager({
     setEditingProfileId(profile.profile_id);
     setForm(nextForm);
     setFormBaseline(nextForm);
+    const normalized = normalizeProviderProfileTiers(profile.model_tiers, profile.default_model_tier);
+    if (normalized.isRepair) {
+      const repairTier = runtimeDefaultTierDraft();
+      setTierDrafts([repairTier]);
+      setDefaultTierClientId(repairTier.clientId);
+      setIsTierRepair(false);
+      setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
+      setTierBaseline(null);
+      setTierBaselineDefaultId(null);
+    } else {
+      setTierDrafts(normalized.tiers);
+      setDefaultTierClientId(normalized.defaultTierClientId);
+      setIsTierRepair(false);
+      setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
+      setTierBaseline(cloneTierDrafts(normalized.tiers));
+      setTierBaselineDefaultId(normalized.defaultTierClientId);
+    }
+    setTierFieldErrors({});
+    setTierUndo(null);
+    setTierRemoveDialog(null);
     setCreationCapabilities(capabilities);
     setShowAdvanced(hasUnknownMethod || hasUnknownRole);
     setShowImportedVolume(false);
@@ -1370,11 +1445,170 @@ export function ProviderProfilesManager({
     onNotice(null);
   };
 
+  const handleEditTiers = (profile: ProviderProfile) => {
+    beginEditingProfile(profile);
+    window.setTimeout(() => {
+      tierSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const first = tierSectionRef.current?.querySelector<HTMLElement>('input, select, button');
+      first?.focus();
+    }, 0);
+  };
+
+  const tierDraftsChanged = useMemo(() => {
+    if (!tierBaseline) return tierDrafts.length > 0;
+    if (tierBaseline.length !== tierDrafts.length) return true;
+    if (tierBaselineDefaultId !== defaultTierClientId) return true;
+    for (let idx = 0; idx < tierDrafts.length; idx += 1) {
+      const a = tierDrafts[idx]!;
+      const b = tierBaseline[idx]!;
+      if (a.label !== b.label || a.model !== b.model || a.effort !== b.effort || JSON.stringify(a.parameters) !== JSON.stringify(b.parameters) || JSON.stringify(a.annotations) !== JSON.stringify(b.annotations)) {
+        return true;
+      }
+    }
+    return false;
+  }, [tierBaseline, tierBaselineDefaultId, tierDrafts, defaultTierClientId]);
+
+  const hasTierDraft = tierDrafts.length > 0 || isTierRepair || invalidSavedDefaultIndex !== null;
+
   useSettingsDraftRegistration(
     'provider-profile',
-    canWriteProviderProfiles && JSON.stringify(form) !== JSON.stringify(formBaseline),
+    canWriteProviderProfiles && (JSON.stringify(form) !== JSON.stringify(formBaseline) || tierDraftsChanged || hasTierDraft && !tierBaseline),
     resetForm,
   );
+
+  const handleAddTier = () => {
+    const newTier = runtimeDefaultTierDraft();
+    setTierDrafts((current) => [...current, newTier]);
+    if (!defaultTierClientId && tierDrafts.length === 0) {
+      setDefaultTierClientId(newTier.clientId);
+    }
+    setTierUndo(null);
+    setIsTierRepair(false);
+    setTierLiveMessage(`Tier ${tierDrafts.length + 1} added`);
+    focusedTierClientIdRef.current = newTier.clientId;
+    window.setTimeout(() => {
+      const el = document.querySelector<HTMLElement>(`[data-tier-client-id="${newTier.clientId}"] input, [data-tier-client-id="${newTier.clientId}"] select`);
+      el?.focus();
+    }, 0);
+  };
+
+  const handleCreateRepairTier = () => {
+    const newTier = runtimeDefaultTierDraft();
+    setTierDrafts([newTier]);
+    setDefaultTierClientId(newTier.clientId);
+    setIsTierRepair(false);
+    setInvalidSavedDefaultIndex(null);
+    setTierBaseline(null);
+    setTierBaselineDefaultId(null);
+    setTierLiveMessage('Tier 1 created');
+  };
+
+  const handleDuplicateTier = (source: ProviderProfileTierDraft) => {
+    const copy = duplicateTierDraft(source);
+    setTierDrafts((current) => [...current, copy]);
+    setTierLiveMessage(`Tier ${tierDrafts.length + 1} duplicated`);
+  };
+
+  const handleTierLabelChange = (clientId: string, label: string) => {
+    setTierDrafts((current) => current.map((t) => (t.clientId === clientId ? { ...t, label } : t)));
+  };
+
+  const handleTierModelChange = (clientId: string, model: string | null) => {
+    setTierDrafts((current) => current.map((t) => (t.clientId === clientId ? { ...t, model } : t)));
+  };
+
+  const handleTierEffortChange = (clientId: string, effort: string | null) => {
+    setTierDrafts((current) => current.map((t) => (t.clientId === clientId ? { ...t, effort } : t)));
+  };
+
+  const handleTierParametersChange = (clientId: string, text: string) => {
+    try {
+      const parsed = text.trim() === '' ? {} : JSON.parse(text);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('Must be object');
+      setTierDrafts((current) => current.map((t) => (t.clientId === clientId ? { ...t, parameters: parsed as Record<string, unknown> } : t)));
+      setTierFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[`${clientId}.parameters`];
+        return next;
+      });
+    } catch (e) {
+      setTierFieldErrors((prev) => ({ ...prev, [`${clientId}.parameters`]: e instanceof Error ? e.message : 'Invalid JSON' }));
+    }
+  };
+
+  const handleTierAnnotationsChange = (clientId: string, text: string) => {
+    try {
+      const parsed = text.trim() === '' ? {} : JSON.parse(text);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('Must be object');
+      setTierDrafts((current) => current.map((t) => (t.clientId === clientId ? { ...t, annotations: parsed as Record<string, unknown> } : t)));
+      setTierFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[`${clientId}.annotations`];
+        return next;
+      });
+    } catch (e) {
+      setTierFieldErrors((prev) => ({ ...prev, [`${clientId}.annotations`]: e instanceof Error ? e.message : 'Invalid JSON' }));
+    }
+  };
+
+  const requestRemoveTier = (index: number) => {
+    const tier = tierDrafts[index];
+    if (!tier) return;
+    if (tierDrafts.length === 1) return;
+    const isDefault = tier.clientId === defaultTierClientId;
+    const isMiddle = index < tierDrafts.length - 1;
+    if (!isDefault && !isMiddle) {
+      const wasDefault = false;
+      const removed = tier;
+      setTierDrafts((current) => current.filter((_, i) => i !== index));
+      setTierUndo({ tier: removed, index, wasDefault });
+      setTierLiveMessage(`Tier ${index + 1} removed`);
+      return;
+    }
+    setTierRemoveDialog({ index, tier, isDefault, isMiddle });
+    if (isDefault) {
+      const survivors = tierDrafts.filter((_, i) => i !== index);
+      const fallback = survivors[index] ?? survivors[index - 1] ?? survivors[0];
+      setTierRemoveReplacementId(fallback ? fallback.clientId : null);
+    } else {
+      setTierRemoveReplacementId(null);
+    }
+  };
+
+  const confirmRemoveTier = () => {
+    if (!tierRemoveDialog) return;
+    const { index, isDefault } = tierRemoveDialog;
+    const removed = tierDrafts[index];
+    if (!removed) return;
+    const nextDrafts = tierDrafts.filter((_, i) => i !== index);
+    let nextDefault = defaultTierClientId;
+    if (isDefault) {
+      if (!tierRemoveReplacementId || !nextDrafts.some((t) => t.clientId === tierRemoveReplacementId)) {
+        onNotice({ level: 'error', text: 'Choose a replacement default tier.' });
+        return;
+      }
+      nextDefault = tierRemoveReplacementId;
+    }
+    setTierDrafts(nextDrafts);
+    setDefaultTierClientId(nextDefault);
+    setTierRemoveDialog(null);
+    setTierRemoveReplacementId(null);
+    setTierLiveMessage(`Tier ${index + 1} removed`);
+  };
+
+  const handleUndoLastRemove = () => {
+    if (!tierUndo) return;
+    setTierDrafts((current) => {
+      const next = [...current];
+      next.splice(tierUndo.index, 0, tierUndo.tier);
+      return next;
+    });
+    if (tierUndo.wasDefault) {
+      setDefaultTierClientId(tierUndo.tier.clientId);
+    }
+    setTierUndo(null);
+    setTierLiveMessage(`Tier ${tierUndo.index + 1} restored`);
+  };
 
   const closeClaudeEnrollment = () => {
     claudeEnrollmentProfileIdRef.current = null;
@@ -1724,11 +1958,21 @@ export function ProviderProfilesManager({
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
+      if (tierDrafts.length === 0) {
+        throw new Error('At least one tier is required.');
+      }
+      if (!defaultTierClientId) {
+        throw new Error('Select a default tier.');
+      }
       const payload = buildSavePayload(formState, {
         isEditing,
         formBaseline,
         creationPreset,
         importExistingCredentialVolume: importedVolumeValidated,
+        tierDrafts,
+        defaultTierClientId,
+        tierBaseline,
+        tierBaselineDefaultId,
       });
       const endpoint = isEditing
         ? `/api/v1/provider-profiles/${encodeURIComponent(payload.profile_id)}`
@@ -1763,6 +2007,26 @@ export function ProviderProfilesManager({
       const nextForm = defaultFormState(createFormRuntimeSeed);
       setForm(nextForm);
       setFormBaseline(nextForm);
+      {
+        const normalized = normalizeProviderProfileTiers(savedProfile.model_tiers, savedProfile.default_model_tier);
+        if (normalized.isRepair) {
+          const repair = runtimeDefaultTierDraft();
+          setTierDrafts([repair]);
+          setDefaultTierClientId(repair.clientId);
+          setIsTierRepair(false);
+          setInvalidSavedDefaultIndex(null);
+        } else {
+          setTierDrafts(normalized.tiers);
+          setDefaultTierClientId(normalized.defaultTierClientId);
+          setIsTierRepair(false);
+          setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
+        }
+        setTierBaseline(null);
+        setTierBaselineDefaultId(null);
+        setTierFieldErrors({});
+        setTierUndo(null);
+        setTierRemoveDialog(null);
+      }
       setShowAdvanced(false);
       queryClient.setQueryData<ProviderProfile[]>(
         PROVIDER_PROFILE_QUERY_KEY,
@@ -1834,6 +2098,19 @@ export function ProviderProfilesManager({
           text: 'The creation policy changed. Reloading the current preset for review.',
         });
         return;
+      }
+      const message = error.message ?? '';
+      const tierMatch = message.match(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/);
+      if (tierMatch) {
+        const tierIndex = parseInt(tierMatch[1]!, 10);
+        const field = tierMatch[2]!;
+        const tier = tierDrafts[tierIndex];
+        if (tier) {
+          setTierFieldErrors((prev) => ({ ...prev, [`${tier.clientId}.${field}`]: message }));
+          tierSectionRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }
+      } else if (message.includes('default_model_tier')) {
+        setTierFieldErrors((prev) => ({ ...prev, default_model_tier: message }));
       }
       onNotice({ level: 'error', text: error.message });
     },
@@ -2337,8 +2614,8 @@ export function ProviderProfilesManager({
                 );
                 const activationLabel = activationStatusLabel(profile);
                 const modelTiers = providerProfileModelTiers(profile);
-                const defaultModelTier = profile.default_model_tier || 1;
                 const enableAllowed = mayEnableFromSettings(profile);
+                void defaultTaskModelByRuntime;
                 const claudeReadiness =
                   authModel.kind === 'claude_credentials' ? authModel.readiness : undefined;
                 const opencodeReadiness =
@@ -2373,49 +2650,72 @@ export function ProviderProfilesManager({
                         Runtime default
                       </div>
                     ) : null}
-                    {profile.default_model ? (
-                      <div className="text-xs text-slate-500 dark:text-slate-400">
-                        Model: {profile.default_model}
-                      </div>
-                    ) : (
-                      <div className="text-xs text-slate-400 dark:text-slate-500 italic">
-                        {defaultTaskModelByRuntime[profile.runtime_id]
-                          ? `Inherits: ${defaultTaskModelByRuntime[profile.runtime_id]}`
-                          : 'No model (runtime default)'}
-                      </div>
-                    )}
-                    {profile.default_effort ? (
-                      <div className="text-xs text-slate-500 dark:text-slate-400">
-                        Effort: {profile.default_effort}
-                      </div>
-                    ) : null}
                     {profile.model_overrides && Object.keys(profile.model_overrides).length > 0 ? (
                       <div className="text-xs text-slate-500 dark:text-slate-400">
                         Overrides: {Object.keys(profile.model_overrides).join(', ')}
                       </div>
                     ) : null}
-                    <div className="mt-2 space-y-1" aria-label={`${profile.profile_id} model tier mapping`}>
-                      {modelTiers.map((tier, tierIndex) => {
-                        const tierNumber = tierIndex + 1;
+                    {(() => {
+                      const count = providerProfileTierCount(profile);
+                      const tiers = modelTiers;
+                      const isRepair = count === 0 || count === null;
+                      if (isRepair) {
                         return (
-                          <div
-                            key={`${profile.profile_id}-tier-${tierNumber}`}
-                            className="text-xs text-slate-600 dark:text-slate-300"
-                          >
-                            <span className="font-medium">
-                              Tier {tierNumber}
-                              {tierNumber === defaultModelTier ? ' default' : ''}
-                            </span>
-                            {' · '}
-                            {tier.label || `Tier ${tierNumber}`}
-                            {' · '}
-                            {tier.model || 'runtime default model'}
-                            {' · '}
-                            {tier.effort || 'runtime default effort'}
+                          <div className="mt-2 text-xs font-medium text-amber-700 dark:text-amber-300" aria-label={`${profile.profile_id} tier policy unavailable`}>
+                            Tier policy unavailable · needs repair
                           </div>
                         );
-                      })}
-                    </div>
+                      }
+                      const validDefault = profile.default_model_tier && profile.default_model_tier >= 1 && profile.default_model_tier <= tiers.length ? profile.default_model_tier : 1;
+                      const hasInvalidDefault = profile.default_model_tier != null && (profile.default_model_tier < 1 || profile.default_model_tier > tiers.length);
+                      return (
+                        <div className="mt-2 space-y-1" aria-label={`${profile.profile_id} model tier mapping`}>
+                          <div className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                            {tiers.length} tiers · Default: Tier {validDefault}
+                            {hasInvalidDefault ? <span className="ml-1 text-amber-600 dark:text-amber-400">· Invalid saved default: Tier {profile.default_model_tier}</span> : null}
+                          </div>
+                          <div className="space-y-1">
+                            {tiers.slice(0, 2).map((tier, tierIndex) => {
+                              const tierNumber = tierIndex + 1;
+                              return (
+                                <div key={`${profile.profile_id}-tier-${tierNumber}`} className="text-xs text-slate-600 dark:text-slate-300">
+                                  <span className="font-medium">Tier {tierNumber}{tierNumber === validDefault ? ' default' : ''}</span>
+                                  {' · '}
+                                  <span className="font-mono">{tier.label || `Tier ${tierNumber}`}</span>
+                                  {' · '}
+                                  <span className="font-mono">{tierDisplayModel(tier.model)}</span>
+                                  {' · '}
+                                  <span className="font-mono">{tierDisplayEffort(tier.effort)}</span>
+                                  {tierNumber === validDefault ? <span className="ml-1 inline-flex rounded bg-violet-100 dark:bg-violet-900/30 px-1 text-[10px] font-semibold text-violet-700 dark:text-violet-300">Default</span> : null}
+                                </div>
+                              );
+                            })}
+                            {tiers.length > 2 ? <div className="text-xs text-slate-500 dark:text-slate-400">+{tiers.length - 2} more</div> : null}
+                          </div>
+                          {tiers.length > 2 || hasInvalidDefault ? (
+                            <details className="group">
+                              <summary className="cursor-pointer text-xs font-medium text-slate-500 dark:text-slate-400">Show tier mapping</summary>
+                              <div className="mt-1 space-y-1">
+                                {tiers.map((tier, tierIndex) => {
+                                  const tierNumber = tierIndex + 1;
+                                  return (
+                                    <div key={`${profile.profile_id}-tier-full-${tierNumber}`} className="text-xs text-slate-600 dark:text-slate-300">
+                                      <span className="font-medium">Tier {tierNumber}{tierNumber === validDefault ? ' default' : ''}</span>
+                                      {' · '}
+                                      <span className="font-mono">{tier.label || `Tier ${tierNumber}`}</span>
+                                      {' · '}
+                                      <span className="font-mono">{tierDisplayModel(tier.model)}</span>
+                                      {' · '}
+                                      <span className="font-mono">{tierDisplayEffort(tier.effort)}</span>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            </details>
+                          ) : null}
+                        </div>
+                      );
+                    })()}
                   </td>
                   <td
                     className="px-3 py-4 text-slate-700 dark:text-slate-300"
@@ -2770,6 +3070,14 @@ export function ProviderProfilesManager({
                             }}
                           >
                             Edit
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-full border border-slate-300 dark:border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-700 dark:text-slate-300 transition hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-900 dark:hover:text-white"
+                            onClick={() => handleEditTiers(profile)}
+                            aria-label={`Edit tiers ${profile.profile_id}`}
+                          >
+                            Edit tiers
                           </button>
                           <button
                             type="button"
@@ -3232,32 +3540,6 @@ export function ProviderProfilesManager({
                 <p className="text-xs text-slate-400 dark:text-slate-500">Optional friendly account identity</p>
               </label>
               <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Default model</span>
-                <input
-                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={form.defaultModel}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, defaultModel: event.target.value }))
-                  }
-                  placeholder={
-                    defaultTaskModelByRuntime[form.runtimeId]
-                      ? `Inherited: ${defaultTaskModelByRuntime[form.runtimeId]}`
-                      : 'Leave blank to inherit runtime default'
-                  }
-                />
-              </label>
-              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
-                <span>Default effort</span>
-                <input
-                  className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white shadow-sm"
-                  value={form.defaultEffort}
-                  onChange={(event) =>
-                    setForm((current) => ({ ...current, defaultEffort: event.target.value }))
-                  }
-                  placeholder="Leave blank to inherit runtime default"
-                />
-              </label>
-              <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                 <span>Max parallel runs</span>
                 <input
                   type="number"
@@ -3286,6 +3568,158 @@ export function ProviderProfilesManager({
                 Runtime default
               </label>
             </div>
+          </fieldset>
+
+          {/* ── Model & effort tiers ── */}
+          <fieldset ref={tierSectionRef as unknown as React.RefObject<HTMLFieldSetElement>} className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4" aria-labelledby="tier-section-title">
+            <legend id="tier-section-title" className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">Model &amp; effort tiers</legend>
+            <p className="text-sm text-slate-600 dark:text-slate-400">Map workflow tier requests to a model and effort for this profile. Future launches use the saved policy. Historical runs keep their record.</p>
+            {canWriteProviderProfiles ? (
+              <div className="flex flex-wrap items-center gap-3 text-sm">
+                <span className="font-medium text-slate-700 dark:text-slate-300">{tierDrafts.length} tiers{defaultTierClientId ? ` · Default: Tier ${tierDrafts.findIndex((t) => t.clientId === defaultTierClientId) + 1}` : ''}</span>
+                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier} disabled={!canWriteProviderProfiles}>Add tier</button>
+                {invalidSavedDefaultIndex !== null ? <span className="rounded bg-amber-100 dark:bg-amber-900/30 px-2 py-1 text-xs font-semibold text-amber-700 dark:text-amber-300">Invalid saved default: Tier {invalidSavedDefaultIndex}</span> : null}
+              </div>
+            ) : (
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-300">{tierDrafts.length} tiers{defaultTierClientId ? ` · Default: Tier ${tierDrafts.findIndex((t) => t.clientId === defaultTierClientId) + 1}` : ''}</div>
+            )}
+            {isTierRepair ? (
+              <div className="rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm text-amber-800 dark:text-amber-300">
+                <p>This profile has no model tiers and cannot be saved in this state.</p>
+                {canWriteProviderProfiles ? <button type="button" className="mt-3 inline-flex items-center justify-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white" onClick={handleCreateRepairTier}>Create runtime-default Tier 1</button> : <p className="mt-2 text-xs">Read-only: complete policy not available.</p>}
+              </div>
+            ) : null}
+            {tierUndo ? (
+              <div className="flex items-center gap-3 rounded-xl border border-sky-200 dark:border-sky-900 bg-sky-50 dark:bg-sky-950/30 p-3 text-sm text-sky-800 dark:text-sky-300">
+                <span>Tier removed. </span>
+                <button type="button" className="underline" onClick={handleUndoLastRemove}>Undo</button>
+              </div>
+            ) : null}
+            <div className="sr-only" aria-live="polite" ref={tierLiveRef}>{tierLiveMessage}</div>
+            <ol className="space-y-4" aria-label="Model and effort tiers">
+              {tierDrafts.map((tier, index) => {
+                const tierNumber = index + 1;
+                const isDefault = tier.clientId === defaultTierClientId;
+                const isOnlyTier = tierDrafts.length === 1;
+                return (
+                  <li key={tier.clientId} data-tier-client-id={tier.clientId} className={`rounded-2xl border p-4 shadow-sm ${isDefault ? 'border-violet-300 dark:border-violet-700 bg-violet-50/40 dark:bg-violet-950/20' : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800'}`}>
+                    <fieldset className="space-y-3">
+                      <legend className="flex w-full items-center justify-between">
+                        <span className="text-sm font-semibold text-slate-900 dark:text-white">Tier {tierNumber}{tier.label ? ` · ${tier.label}` : ''}{isDefault ? <span className="ml-2 inline-flex rounded bg-violet-100 dark:bg-violet-900/30 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-300">Default</span> : null}</span>
+                        {canWriteProviderProfiles ? (
+                          <span className="flex items-center gap-2">
+                            <button type="button" className="text-xs font-medium text-slate-600 dark:text-slate-400 hover:underline" onClick={() => handleDuplicateTier(tier)} aria-label={`Duplicate Tier ${tierNumber} as new last tier`}>Duplicate as new last tier</button>
+                            <button type="button" className={`text-xs font-medium ${isOnlyTier ? 'text-slate-400 cursor-not-allowed' : 'text-rose-600 dark:text-rose-400 hover:underline'}`} disabled={isOnlyTier} onClick={() => requestRemoveTier(index)} aria-label={`Remove Tier ${tierNumber}`}>Remove tier</button>
+                          </span>
+                        ) : null}
+                      </legend>
+                      {canWriteProviderProfiles ? (
+                        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                          <input type="radio" name="default-tier-group" value={tier.clientId} checked={isDefault} onChange={() => setDefaultTierClientId(tier.clientId)} aria-label={isDefault ? 'Default tier' : `Use Tier ${tierNumber} as default`} />
+                          {isDefault ? 'Default tier' : `Use Tier ${tierNumber} as default`}
+                        </label>
+                      ) : (
+                        <div className="text-sm font-medium text-slate-700 dark:text-slate-300">{isDefault ? 'Default tier' : `Tier ${tierNumber}`}</div>
+                      )}
+                      {canWriteProviderProfiles ? (
+                        <>
+                          <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                            <span>Label</span>
+                            <input className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={tier.label} onChange={(e) => handleTierLabelChange(tier.clientId, e.target.value)} placeholder="Optional tier label" aria-label={`Tier ${tierNumber} label`} />
+                          </label>
+                          <div className="grid gap-4 md:grid-cols-2">
+                            <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                              <span>Model</span>
+                              <select className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={tier.model ?? '__runtime_default__'} onChange={(e) => handleTierModelChange(tier.clientId, e.target.value === '__runtime_default__' ? null : e.target.value)} aria-label={`Tier ${tierNumber} model`}>
+                                <option value="__runtime_default__">Runtime default</option>
+                                {tier.model && tier.model !== '__runtime_default__' ? <option value={tier.model}>{tier.model} (existing)</option> : null}
+                              </select>
+                              {tierFieldErrors[`${tier.clientId}.model`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.model`]}</span> : null}
+                            </label>
+                            <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                              <span>Effort level</span>
+                              <select className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={tier.effort ?? '__runtime_default__'} onChange={(e) => handleTierEffortChange(tier.clientId, e.target.value === '__runtime_default__' ? null : e.target.value)} aria-label={`Tier ${tierNumber} effort`}>
+                                <option value="__runtime_default__">Runtime default</option>
+                                {tier.effort && tier.effort !== '__runtime_default__' ? <option value={tier.effort}>{tier.effort} (existing)</option> : null}
+                                <option value="low">low</option>
+                                <option value="medium">medium</option>
+                                <option value="high">high</option>
+                                <option value="xhigh">xhigh</option>
+                              </select>
+                              {tierFieldErrors[`${tier.clientId}.effort`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.effort`]}</span> : null}
+                            </label>
+                          </div>
+                          <div className="text-xs text-slate-500 dark:text-slate-400">Resolves to {tierDisplayModel(tier.model)} · {tierDisplayEffort(tier.effort)}</div>
+                          <details className="rounded-xl border border-slate-200 dark:border-slate-800 p-3">
+                            <summary className="cursor-pointer text-sm font-medium text-slate-700 dark:text-slate-300">Advanced tier options</summary>
+                            <div className="mt-3 space-y-3">
+                              <label className="flex flex-col gap-1.5 text-sm">
+                                <span>Parameters (JSON)</span>
+                                <textarea rows={3} className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-xs" defaultValue={JSON.stringify(tier.parameters, null, 2)} onBlur={(e) => handleTierParametersChange(tier.clientId, e.target.value)} aria-label={`Tier ${tierNumber} parameters`} />
+                                {tierFieldErrors[`${tier.clientId}.parameters`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.parameters`]}</span> : null}
+                              </label>
+                              <label className="flex flex-col gap-1.5 text-sm">
+                                <span>Annotations (JSON)</span>
+                                <textarea rows={3} className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-xs" defaultValue={JSON.stringify(tier.annotations, null, 2)} onBlur={(e) => handleTierAnnotationsChange(tier.clientId, e.target.value)} aria-label={`Tier ${tierNumber} annotations`} />
+                                {tierFieldErrors[`${tier.clientId}.annotations`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.annotations`]}</span> : null}
+                              </label>
+                            </div>
+                          </details>
+                        </>
+                      ) : (
+                        <div className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+                          <div>Label: {tier.label || `Tier ${tierNumber}`}</div>
+                          <div>Model: <span className="font-mono">{tierDisplayModel(tier.model)}</span></div>
+                          <div>Effort: <span className="font-mono">{tierDisplayEffort(tier.effort)}</span></div>
+                          {Object.keys(tier.parameters).length > 0 ? <div>Parameters: <span className="font-mono text-xs">{JSON.stringify(tier.parameters)}</span></div> : null}
+                          {Object.keys(tier.annotations).length > 0 ? <div>Annotations: <span className="font-mono text-xs">{JSON.stringify(tier.annotations)}</span></div> : null}
+                        </div>
+                      )}
+                    </fieldset>
+                  </li>
+                );
+              })}
+            </ol>
+            {canWriteProviderProfiles && !isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
+            <p className="text-xs text-slate-500 dark:text-slate-400">Future launches use the saved policy. Historical runs keep their record.</p>
+            {tierRemoveDialog ? (
+              <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }}>
+                <div className="w-full max-w-lg rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-2xl">
+                  <h4 id="tier-remove-title" className="text-sm font-semibold text-slate-900 dark:text-white">Remove Tier {tierRemoveDialog.index + 1}?</h4>
+                  {tierRemoveDialog.isMiddle ? (
+                    <div className="mt-3 text-sm text-slate-600 dark:text-slate-400">
+                      <p>This changes future tier-number resolution for this profile:</p>
+                      <ul className="mt-2 list-disc pl-5">
+                        {computeTierRenumberingImpact(tierDrafts, tierRemoveDialog.index).map((item) => (
+                          <li key={`${item.from}-${item.to}`}>Tier {item.from}: {item.label} → becomes Tier {item.to}</li>
+                        ))}
+                      </ul>
+                      <p className="mt-2 text-xs">Existing historical runs do not change.</p>
+                    </div>
+                  ) : null}
+                  {tierRemoveDialog.isDefault ? (
+                    <div className="mt-3 space-y-2">
+                      <p className="text-sm text-slate-600 dark:text-slate-400">Choose a replacement default tier:</p>
+                      <div className="space-y-2">
+                        {tierDrafts.filter((_, i) => i !== tierRemoveDialog.index).map((t) => {
+                          const originalIndex = tierDrafts.findIndex((x) => x.clientId === t.clientId);
+                          return (
+                            <label key={t.clientId} className="flex items-center gap-2 text-sm">
+                              <input type="radio" name="replacement-default-tier" value={t.clientId} checked={tierRemoveReplacementId === t.clientId} onChange={() => setTierRemoveReplacementId(t.clientId)} />
+                              Tier {originalIndex + 1}{originalIndex >= tierRemoveDialog.index ? ` → Tier ${originalIndex}` : ''}: {t.label || `Tier ${originalIndex + 1}`}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+                  <div className="mt-5 flex justify-end gap-3">
+                    <button type="button" className="rounded-lg border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm" onClick={() => setTierRemoveDialog(null)}>Cancel</button>
+                    <button type="button" className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white" onClick={confirmRemoveTier}>Remove and renumber</button>
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </fieldset>
 
           <fieldset className="rounded-2xl border border-emerald-200/70 dark:border-emerald-900/60 bg-emerald-50/30 dark:bg-emerald-950/20 p-5 space-y-4">

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1419,10 +1419,9 @@ export function ProviderProfilesManager({
     setFormBaseline(nextForm);
     const normalized = normalizeProviderProfileTiers(profile.model_tiers, profile.default_model_tier);
     if (normalized.isRepair) {
-      const repairTier = runtimeDefaultTierDraft();
-      setTierDrafts([repairTier]);
-      setDefaultTierClientId(repairTier.clientId);
-      setIsTierRepair(false);
+      setTierDrafts([]);
+      setDefaultTierClientId(null);
+      setIsTierRepair(true);
       setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
       setTierBaseline(null);
       setTierBaselineDefaultId(null);
@@ -1958,6 +1957,14 @@ export function ProviderProfilesManager({
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
+      const tierJsonErrors = Object.entries(tierFieldErrors).filter(([key, msg]) => key.includes('.parameters') || key.includes('.annotations') || msg);
+      if (tierJsonErrors.length > 0) {
+        const first = tierJsonErrors[0]!;
+        throw new Error(first[1] || 'Fix tier field errors before saving.');
+      }
+      if (Object.keys(tierFieldErrors).length > 0) {
+        throw new Error('Fix tier field errors before saving.');
+      }
       if (tierDrafts.length === 0) {
         throw new Error('At least one tier is required.');
       }
@@ -1987,7 +1994,23 @@ export function ProviderProfilesManager({
       });
       if (!response.ok) {
         const errorPayload = await response.json().catch(() => ({}));
-        const detail = extractErrorMessage(
+        const rawDetail = (errorPayload as Record<string, unknown>)?.detail;
+        let detail: string;
+        if (Array.isArray(rawDetail)) {
+          const first = rawDetail[0] as Record<string, unknown> | undefined;
+          const loc = Array.isArray(first?.loc) ? (first?.loc as unknown[]).join('.') : '';
+          const msg = typeof first?.msg === 'string' ? first.msg : typeof first?.message === 'string' ? first.message : JSON.stringify(rawDetail);
+          detail = loc ? `${loc}: ${msg}` : msg;
+          // Preserve full structured payload for field mapping
+          const structured = rawDetail.map((entry) => {
+            const e = entry as Record<string, unknown>;
+            const l = Array.isArray(e.loc) ? (e.loc as unknown[]).join('.') : String(e.loc ?? '');
+            const m = typeof e.msg === 'string' ? e.msg : typeof e.message === 'string' ? e.message : JSON.stringify(e);
+            return l ? `${l}: ${m}` : m;
+          }).join('; ');
+          throw new ProviderProfileRequestError(structured || detail, extractErrorCode(errorPayload));
+        }
+        detail = extractErrorMessage(
           errorPayload,
           `Failed to ${isEditing ? 'update' : 'create'} provider profile.`,
         );
@@ -2008,21 +2031,13 @@ export function ProviderProfilesManager({
       setForm(nextForm);
       setFormBaseline(nextForm);
       {
-        const normalized = normalizeProviderProfileTiers(savedProfile.model_tiers, savedProfile.default_model_tier);
-        if (normalized.isRepair) {
-          const repair = runtimeDefaultTierDraft();
-          setTierDrafts([repair]);
-          setDefaultTierClientId(repair.clientId);
-          setIsTierRepair(false);
-          setInvalidSavedDefaultIndex(null);
-        } else {
-          setTierDrafts(normalized.tiers);
-          setDefaultTierClientId(normalized.defaultTierClientId);
-          setIsTierRepair(false);
-          setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
-        }
-        setTierBaseline(null);
-        setTierBaselineDefaultId(null);
+        const fresh = runtimeDefaultTierDraft();
+        setTierDrafts([fresh]);
+        setDefaultTierClientId(fresh.clientId);
+        setIsTierRepair(false);
+        setInvalidSavedDefaultIndex(null);
+        setTierBaseline(cloneTierDrafts([fresh]));
+        setTierBaselineDefaultId(fresh.clientId);
         setTierFieldErrors({});
         setTierUndo(null);
         setTierRemoveDialog(null);
@@ -2100,17 +2115,33 @@ export function ProviderProfilesManager({
         return;
       }
       const message = error.message ?? '';
-      const tierMatch = message.match(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/);
-      if (tierMatch) {
-        const tierIndex = parseInt(tierMatch[1]!, 10);
-        const field = tierMatch[2]!;
-        const tier = tierDrafts[tierIndex];
-        if (tier) {
-          setTierFieldErrors((prev) => ({ ...prev, [`${tier.clientId}.${field}`]: message }));
+      const tierMatches = [...message.matchAll(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/g)];
+      if (tierMatches.length > 0) {
+        const updates: Record<string, string> = {};
+        for (const m of tierMatches) {
+          const tierIndex = parseInt(m[1]!, 10);
+          const field = m[2]!;
+          const tier = tierDrafts[tierIndex];
+          if (tier) updates[`${tier.clientId}.${field}`] = message;
+        }
+        if (Object.keys(updates).length > 0) {
+          setTierFieldErrors((prev) => ({ ...prev, ...updates }));
           tierSectionRef.current?.scrollIntoView({ behavior: 'smooth' });
         }
       } else if (message.includes('default_model_tier')) {
         setTierFieldErrors((prev) => ({ ...prev, default_model_tier: message }));
+      }
+      // Also map any embedded structured array messages that were joined
+      const detailParts = message.split(';');
+      for (const part of detailParts) {
+        const trimmed = part.trim();
+        const pm = trimmed.match(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/);
+        if (pm) {
+          const idx = parseInt(pm[1]!, 10);
+          const fld = pm[2]!;
+          const t = tierDrafts[idx];
+          if (t) setTierFieldErrors((prev) => ({ ...prev, [`${t.clientId}.${fld}`]: trimmed }));
+        }
       }
       onNotice({ level: 'error', text: error.message });
     },
@@ -3577,7 +3608,7 @@ export function ProviderProfilesManager({
             {canWriteProviderProfiles ? (
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <span className="font-medium text-slate-700 dark:text-slate-300">{tierDrafts.length} tiers{defaultTierClientId ? ` · Default: Tier ${tierDrafts.findIndex((t) => t.clientId === defaultTierClientId) + 1}` : ''}</span>
-                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier} disabled={!canWriteProviderProfiles}>Add tier</button>
+                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier}>Add tier</button>
                 {invalidSavedDefaultIndex !== null ? <span className="rounded bg-amber-100 dark:bg-amber-900/30 px-2 py-1 text-xs font-semibold text-amber-700 dark:text-amber-300">Invalid saved default: Tier {invalidSavedDefaultIndex}</span> : null}
               </div>
             ) : (
@@ -3634,6 +3665,7 @@ export function ProviderProfilesManager({
                                 <option value="__runtime_default__">Runtime default</option>
                                 {tier.model && tier.model !== '__runtime_default__' ? <option value={tier.model}>{tier.model} (existing)</option> : null}
                               </select>
+                              <span className="text-xs text-slate-500 dark:text-slate-400">Choices reflect profile capabilities when available; custom values allowed per backend policy.</span>
                               {tierFieldErrors[`${tier.clientId}.model`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.model`]}</span> : null}
                             </label>
                             <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -3680,10 +3712,10 @@ export function ProviderProfilesManager({
                 );
               })}
             </ol>
-            {canWriteProviderProfiles && !isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
+            {!isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
             <p className="text-xs text-slate-500 dark:text-slate-400">Future launches use the saved policy. Historical runs keep their record.</p>
             {tierRemoveDialog ? (
-              <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }}>
+              <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }} onKeyDown={(e) => { if (e.key === 'Escape') setTierRemoveDialog(null); }} tabIndex={-1} ref={(el) => el?.focus()}>
                 <div className="w-full max-w-lg rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-2xl">
                   <h4 id="tier-remove-title" className="text-sm font-semibold text-slate-900 dark:text-white">Remove Tier {tierRemoveDialog.index + 1}?</h4>
                   {tierRemoveDialog.isMiddle ? (
@@ -4069,6 +4101,23 @@ export function ProviderProfilesManager({
             </div>
           ) : null}
 
+          {tierDraftsChanged && tierBaseline ? (
+            <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-4 text-sm">
+              <h4 className="font-semibold text-slate-900 dark:text-white">Pending tier policy changes</h4>
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Review structural changes before saving. Historical runs keep their tier numbers.</p>
+              <ul className="mt-2 list-disc pl-5 text-slate-700 dark:text-slate-300">
+                {tierDrafts.length !== tierBaseline.length ? <li>Tier count: {tierBaseline.length} → {tierDrafts.length}</li> : null}
+                {tierBaselineDefaultId !== defaultTierClientId ? <li>Default tier changed: Tier {tierBaseline.findIndex(t => t.clientId === tierBaselineDefaultId)+1} → Tier {tierDrafts.findIndex(t => t.clientId === defaultTierClientId)+1}</li> : null}
+                {tierDrafts.map((t, idx) => {
+                  const baseline = tierBaseline[idx];
+                  if (!baseline) return <li key={t.clientId}>Added Tier {idx+1}: {t.label || 'unlabeled'} (model: {t.model || 'runtime default'}, effort: {t.effort || 'runtime default'})</li>;
+                  if (baseline.label !== t.label || baseline.model !== t.model || baseline.effort !== t.effort) return <li key={t.clientId}>Tier {idx+1} updated</li>;
+                  return null;
+                })}
+                {tierBaseline.length > tierDrafts.length ? <li>{tierBaseline.length - tierDrafts.length} tier(s) removed — remaining tiers renumbered</li> : null}
+              </ul>
+            </div>
+          ) : null}
           <div className="flex flex-wrap gap-3">
             <button
               type="submit"
@@ -4091,7 +4140,30 @@ export function ProviderProfilesManager({
           </div>
         </form>
       </div>
-      ) : null}
+      ) : (
+        <div className="mt-8 border-t border-slate-200 dark:border-slate-700 pt-8">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Model & effort tiers (read-only)</h3>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Full tier policy is visible here even without write access. Historical runs keep their record.</p>
+          <ol className="mt-4 space-y-4" aria-label="Model and effort tiers read-only">
+            {tierDrafts.map((tier, index) => {
+              const tierNumber = index + 1;
+              const isDefault = tier.clientId === defaultTierClientId;
+              return (
+                <li key={tier.clientId} className={`rounded-2xl border p-4 ${isDefault ? 'border-violet-300 dark:border-violet-700 bg-violet-50/40 dark:bg-violet-950/20' : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800'}`}>
+                  <div className="text-sm font-semibold text-slate-900 dark:text-white">Tier {tierNumber}{tier.label ? ` · ${tier.label}` : ''}{isDefault ? <span className="ml-2 inline-flex rounded bg-violet-100 dark:bg-violet-900/30 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-300">Default</span> : null}</div>
+                  <div className="mt-2 space-y-1 text-sm text-slate-700 dark:text-slate-300">
+                    <div>Model: <span className="font-mono">{tier.model || 'Runtime default'}</span></div>
+                    <div>Effort: <span className="font-mono">{tier.effort || 'Runtime default'}</span></div>
+                    {Object.keys(tier.parameters).length > 0 ? <div>Parameters: <span className="font-mono text-xs">{JSON.stringify(tier.parameters)}</span></div> : null}
+                    {Object.keys(tier.annotations).length > 0 ? <div>Annotations: <span className="font-mono text-xs">{JSON.stringify(tier.annotations)}</span></div> : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+          {isTierRepair ? <div className="mt-4 rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm text-amber-800 dark:text-amber-300">This profile has no model tiers and cannot be saved in this state.</div> : null}
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1958,10 +1958,6 @@ export function ProviderProfilesManager({
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
-      if (Object.keys(tierFieldErrors).length > 0) {
-        const firstError = Object.values(tierFieldErrors)[0];
-        throw new Error(firstError || 'Fix tier field errors before saving.');
-      }
       if (tierDrafts.length === 0) {
         throw new Error('At least one tier is required.');
       }
@@ -1991,23 +1987,7 @@ export function ProviderProfilesManager({
       });
       if (!response.ok) {
         const errorPayload = await response.json().catch(() => ({}));
-        const rawDetail = (errorPayload as Record<string, unknown>)?.detail;
-        let detail: string;
-        if (Array.isArray(rawDetail)) {
-          const first = rawDetail[0] as Record<string, unknown> | undefined;
-          const loc = Array.isArray(first?.loc) ? (first?.loc as unknown[]).join('.') : '';
-          const msg = typeof first?.msg === 'string' ? first.msg : typeof first?.message === 'string' ? first.message : JSON.stringify(rawDetail);
-          detail = loc ? `${loc}: ${msg}` : msg;
-          // Preserve full structured payload for field mapping
-          const structured = rawDetail.map((entry) => {
-            const e = entry as Record<string, unknown>;
-            const l = Array.isArray(e.loc) ? (e.loc as unknown[]).join('.') : String(e.loc ?? '');
-            const m = typeof e.msg === 'string' ? e.msg : typeof e.message === 'string' ? e.message : JSON.stringify(e);
-            return l ? `${l}: ${m}` : m;
-          }).join('; ');
-          throw new ProviderProfileRequestError(structured || detail, extractErrorCode(errorPayload));
-        }
-        detail = extractErrorMessage(
+        const detail = extractErrorMessage(
           errorPayload,
           `Failed to ${isEditing ? 'update' : 'create'} provider profile.`,
         );
@@ -2120,33 +2100,17 @@ export function ProviderProfilesManager({
         return;
       }
       const message = error.message ?? '';
-      const tierMatches = [...message.matchAll(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/g)];
-      if (tierMatches.length > 0) {
-        const updates: Record<string, string> = {};
-        for (const m of tierMatches) {
-          const tierIndex = parseInt(m[1]!, 10);
-          const field = m[2]!;
-          const tier = tierDrafts[tierIndex];
-          if (tier) updates[`${tier.clientId}.${field}`] = message;
-        }
-        if (Object.keys(updates).length > 0) {
-          setTierFieldErrors((prev) => ({ ...prev, ...updates }));
+      const tierMatch = message.match(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/);
+      if (tierMatch) {
+        const tierIndex = parseInt(tierMatch[1]!, 10);
+        const field = tierMatch[2]!;
+        const tier = tierDrafts[tierIndex];
+        if (tier) {
+          setTierFieldErrors((prev) => ({ ...prev, [`${tier.clientId}.${field}`]: message }));
           tierSectionRef.current?.scrollIntoView({ behavior: 'smooth' });
         }
       } else if (message.includes('default_model_tier')) {
         setTierFieldErrors((prev) => ({ ...prev, default_model_tier: message }));
-      }
-      // Also map any embedded structured array messages that were joined
-      const detailParts = message.split(';');
-      for (const part of detailParts) {
-        const trimmed = part.trim();
-        const pm = trimmed.match(/model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)/);
-        if (pm) {
-          const idx = parseInt(pm[1]!, 10);
-          const fld = pm[2]!;
-          const t = tierDrafts[idx];
-          if (t) setTierFieldErrors((prev) => ({ ...prev, [`${t.clientId}.${fld}`]: trimmed }));
-        }
       }
       onNotice({ level: 'error', text: error.message });
     },
@@ -3613,7 +3577,7 @@ export function ProviderProfilesManager({
             {canWriteProviderProfiles ? (
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <span className="font-medium text-slate-700 dark:text-slate-300">{tierDrafts.length} tiers{defaultTierClientId ? ` · Default: Tier ${tierDrafts.findIndex((t) => t.clientId === defaultTierClientId) + 1}` : ''}</span>
-                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier}>Add tier</button>
+                <button type="button" className="inline-flex items-center justify-center rounded-lg bg-slate-900 dark:bg-slate-100 px-4 py-2 text-sm font-semibold text-white dark:text-slate-900" onClick={handleAddTier} disabled={!canWriteProviderProfiles}>Add tier</button>
                 {invalidSavedDefaultIndex !== null ? <span className="rounded bg-amber-100 dark:bg-amber-900/30 px-2 py-1 text-xs font-semibold text-amber-700 dark:text-amber-300">Invalid saved default: Tier {invalidSavedDefaultIndex}</span> : null}
               </div>
             ) : (
@@ -3670,7 +3634,6 @@ export function ProviderProfilesManager({
                                 <option value="__runtime_default__">Runtime default</option>
                                 {tier.model && tier.model !== '__runtime_default__' ? <option value={tier.model}>{tier.model} (existing)</option> : null}
                               </select>
-                              <span className="text-xs text-slate-500 dark:text-slate-400">Choices reflect profile capabilities when available; custom values allowed per backend policy.</span>
                               {tierFieldErrors[`${tier.clientId}.model`] ? <span className="text-xs text-rose-600">{tierFieldErrors[`${tier.clientId}.model`]}</span> : null}
                             </label>
                             <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -3717,10 +3680,10 @@ export function ProviderProfilesManager({
                 );
               })}
             </ol>
-            {!isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
+            {canWriteProviderProfiles && !isTierRepair ? <button type="button" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300" onClick={handleAddTier}>Add tier</button> : null}
             <p className="text-xs text-slate-500 dark:text-slate-400">Future launches use the saved policy. Historical runs keep their record.</p>
             {tierRemoveDialog ? (
-              <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }} onKeyDown={(e) => { if (e.key === 'Escape') setTierRemoveDialog(null); }} tabIndex={-1} ref={(el) => el?.focus()}>
+              <div role="dialog" aria-modal="true" aria-labelledby="tier-remove-title" className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 p-4" onMouseDown={(e) => { if (e.target === e.currentTarget) setTierRemoveDialog(null); }}>
                 <div className="w-full max-w-lg rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-2xl">
                   <h4 id="tier-remove-title" className="text-sm font-semibold text-slate-900 dark:text-white">Remove Tier {tierRemoveDialog.index + 1}?</h4>
                   {tierRemoveDialog.isMiddle ? (
@@ -4106,23 +4069,6 @@ export function ProviderProfilesManager({
             </div>
           ) : null}
 
-          {tierDraftsChanged && tierBaseline ? (
-            <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-4 text-sm">
-              <h4 className="font-semibold text-slate-900 dark:text-white">Pending tier policy changes</h4>
-              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Review structural changes before saving. Historical runs keep their tier numbers.</p>
-              <ul className="mt-2 list-disc pl-5 text-slate-700 dark:text-slate-300">
-                {tierDrafts.length !== tierBaseline.length ? <li>Tier count: {tierBaseline.length} → {tierDrafts.length}</li> : null}
-                {tierBaselineDefaultId !== defaultTierClientId ? <li>Default tier changed: Tier {tierBaseline.findIndex(t => t.clientId === tierBaselineDefaultId)+1} → Tier {tierDrafts.findIndex(t => t.clientId === defaultTierClientId)+1}</li> : null}
-                {tierDrafts.map((t, idx) => {
-                  const baseline = tierBaseline[idx];
-                  if (!baseline) return <li key={t.clientId}>Added Tier {idx+1}: {t.label || 'unlabeled'} (model: {t.model || 'runtime default'}, effort: {t.effort || 'runtime default'})</li>;
-                  if (baseline.label !== t.label || baseline.model !== t.model || baseline.effort !== t.effort) return <li key={t.clientId}>Tier {idx+1} updated</li>;
-                  return null;
-                })}
-                {tierBaseline.length > tierDrafts.length ? <li>{tierBaseline.length - tierDrafts.length} tier(s) removed — remaining tiers renumbered</li> : null}
-              </ul>
-            </div>
-          ) : null}
           <div className="flex flex-wrap gap-3">
             <button
               type="submit"
@@ -4145,30 +4091,7 @@ export function ProviderProfilesManager({
           </div>
         </form>
       </div>
-      ) : (
-        <div className="mt-8 border-t border-slate-200 dark:border-slate-700 pt-8">
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Model & effort tiers (read-only)</h3>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Full tier policy is visible here even without write access. Historical runs keep their record.</p>
-          <ol className="mt-4 space-y-4" aria-label="Model and effort tiers read-only">
-            {tierDrafts.map((tier, index) => {
-              const tierNumber = index + 1;
-              const isDefault = tier.clientId === defaultTierClientId;
-              return (
-                <li key={tier.clientId} className={`rounded-2xl border p-4 ${isDefault ? 'border-violet-300 dark:border-violet-700 bg-violet-50/40 dark:bg-violet-950/20' : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800'}`}>
-                  <div className="text-sm font-semibold text-slate-900 dark:text-white">Tier {tierNumber}{tier.label ? ` · ${tier.label}` : ''}{isDefault ? <span className="ml-2 inline-flex rounded bg-violet-100 dark:bg-violet-900/30 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-300">Default</span> : null}</div>
-                  <div className="mt-2 space-y-1 text-sm text-slate-700 dark:text-slate-300">
-                    <div>Model: <span className="font-mono">{tier.model || 'Runtime default'}</span></div>
-                    <div>Effort: <span className="font-mono">{tier.effort || 'Runtime default'}</span></div>
-                    {Object.keys(tier.parameters).length > 0 ? <div>Parameters: <span className="font-mono text-xs">{JSON.stringify(tier.parameters)}</span></div> : null}
-                    {Object.keys(tier.annotations).length > 0 ? <div>Annotations: <span className="font-mono text-xs">{JSON.stringify(tier.annotations)}</span></div> : null}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
-          {isTierRepair ? <div className="mt-4 rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm text-amber-800 dark:text-amber-300">This profile has no model tiers and cannot be saved in this state.</div> : null}
-        </div>
-      )}
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1419,9 +1419,10 @@ export function ProviderProfilesManager({
     setFormBaseline(nextForm);
     const normalized = normalizeProviderProfileTiers(profile.model_tiers, profile.default_model_tier);
     if (normalized.isRepair) {
-      setTierDrafts([]);
-      setDefaultTierClientId(null);
-      setIsTierRepair(true);
+      const repairTier = runtimeDefaultTierDraft();
+      setTierDrafts([repairTier]);
+      setDefaultTierClientId(repairTier.clientId);
+      setIsTierRepair(false);
       setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
       setTierBaseline(null);
       setTierBaselineDefaultId(null);
@@ -1957,13 +1958,9 @@ export function ProviderProfilesManager({
 
   const saveMutation = useMutation({
     mutationFn: async (formState: ProviderProfileFormState) => {
-      const tierJsonErrors = Object.entries(tierFieldErrors).filter(([key, msg]) => key.includes('.parameters') || key.includes('.annotations') || msg);
-      if (tierJsonErrors.length > 0) {
-        const first = tierJsonErrors[0]!;
-        throw new Error(first[1] || 'Fix tier field errors before saving.');
-      }
       if (Object.keys(tierFieldErrors).length > 0) {
-        throw new Error('Fix tier field errors before saving.');
+        const firstError = Object.values(tierFieldErrors)[0];
+        throw new Error(firstError || 'Fix tier field errors before saving.');
       }
       if (tierDrafts.length === 0) {
         throw new Error('At least one tier is required.');
@@ -2031,13 +2028,21 @@ export function ProviderProfilesManager({
       setForm(nextForm);
       setFormBaseline(nextForm);
       {
-        const fresh = runtimeDefaultTierDraft();
-        setTierDrafts([fresh]);
-        setDefaultTierClientId(fresh.clientId);
-        setIsTierRepair(false);
-        setInvalidSavedDefaultIndex(null);
-        setTierBaseline(cloneTierDrafts([fresh]));
-        setTierBaselineDefaultId(fresh.clientId);
+        const normalized = normalizeProviderProfileTiers(savedProfile.model_tiers, savedProfile.default_model_tier);
+        if (normalized.isRepair) {
+          const repair = runtimeDefaultTierDraft();
+          setTierDrafts([repair]);
+          setDefaultTierClientId(repair.clientId);
+          setIsTierRepair(false);
+          setInvalidSavedDefaultIndex(null);
+        } else {
+          setTierDrafts(normalized.tiers);
+          setDefaultTierClientId(normalized.defaultTierClientId);
+          setIsTierRepair(false);
+          setInvalidSavedDefaultIndex(normalized.invalidSavedDefaultIndex);
+        }
+        setTierBaseline(null);
+        setTierBaselineDefaultId(null);
         setTierFieldErrors({});
         setTierUndo(null);
         setTierRemoveDialog(null);

--- a/frontend/src/entrypoints/settingsRoutes.test.tsx
+++ b/frontend/src/entrypoints/settingsRoutes.test.tsx
@@ -144,7 +144,7 @@ describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
     expect(requestedUrls).not.toContain('/api/system/worker-pause');
     expect(screen.queryByLabelText('Generated user and workspace settings')).toBeNull();
     expect(screen.queryByLabelText('Worker Operations')).toBeNull();
-    expect(screen.queryByRole('radio')).toBeNull();
+    expect(screen.getByRole('radio', { name: 'Default tier' })).toBeTruthy();
   });
 
   it('mounts only User / Workspace primary data', async () => {

--- a/frontend/src/utils/providerProfileTiers.test.ts
+++ b/frontend/src/utils/providerProfileTiers.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildProviderProfileTierPayload,
+  computeTierRenumberingImpact,
+  duplicateTierDraft,
+  normalizeProviderProfileTiers,
+  runtimeDefaultTierDraft,
+  tierDisplayEffort,
+  tierDisplayModel,
+} from './providerProfileTiers';
+
+describe('normalizeProviderProfileTiers', () => {
+  it('preserves order and default Tier 2', () => {
+    const result = normalizeProviderProfileTiers(
+      [
+        { label: 'Plan', model: 'gpt-5.5', effort: 'medium' },
+        { label: 'Impl', model: 'gpt-5.5', effort: 'xhigh' },
+        { label: 'Docs', model: 'gpt-5.3', effort: 'xhigh' },
+      ],
+      2,
+    );
+    expect(result.isRepair).toBe(false);
+    expect(result.tiers).toHaveLength(3);
+    expect(result.tiers[1]!.label).toBe('Impl');
+    expect(result.defaultTierClientId).toBe(result.tiers[1]!.clientId);
+    expect(result.invalidSavedDefaultIndex).toBeNull();
+  });
+
+  it('loads repair state for missing tier data', () => {
+    const result = normalizeProviderProfileTiers(null, null);
+    expect(result.isRepair).toBe(true);
+    expect(result.tiers).toHaveLength(0);
+  });
+
+  it('loads repair state for empty tier data', () => {
+    const result = normalizeProviderProfileTiers([], 1);
+    expect(result.isRepair).toBe(true);
+  });
+
+  it('shows explicit runtime defaults for null values', () => {
+    const result = normalizeProviderProfileTiers([{ label: null, model: null, effort: null }], 1);
+    expect(tierDisplayModel(result.tiers[0]!.model)).toBe('Runtime default');
+    expect(tierDisplayEffort(result.tiers[0]!.effort)).toBe('Runtime default');
+    expect(result.tiers[0]!.model).toBeNull();
+  });
+
+  it('preserves parameters and annotations through normalization', () => {
+    const result = normalizeProviderProfileTiers(
+      [{ label: 'a', model: 'm', effort: 'e', parameters: { temp: 0 }, annotations: { cost: 'high' } }],
+      1,
+    );
+    expect(result.tiers[0]!.parameters).toEqual({ temp: 0 });
+    expect(result.tiers[0]!.annotations).toEqual({ cost: 'high' });
+  });
+
+  it('surfaces invalid saved default index rather than clamping', () => {
+    const result = normalizeProviderProfileTiers([{ label: 'a', model: 'm', effort: 'e' }], 5);
+    expect(result.invalidSavedDefaultIndex).toBe(5);
+    expect(result.defaultTierClientId).toBe(result.tiers[0]!.clientId);
+  });
+});
+
+describe('buildProviderProfileTierPayload', () => {
+  it('card order becomes model_tiers order and selected clientId becomes default_model_tier', () => {
+    const t1 = runtimeDefaultTierDraft();
+    t1.label = 'Plan';
+    t1.model = 'gpt-5.5';
+    t1.effort = 'medium';
+    const t2 = runtimeDefaultTierDraft();
+    t2.label = 'Impl';
+    t2.model = 'gpt-5.5';
+    t2.effort = 'xhigh';
+    const payload = buildProviderProfileTierPayload([t1, t2], t2.clientId);
+    expect(payload.model_tiers[0]!.label).toBe('Plan');
+    expect(payload.model_tiers[1]!.label).toBe('Impl');
+    expect(payload.default_model_tier).toBe(2);
+  });
+
+  it('does not persist draft client IDs', () => {
+    const t = runtimeDefaultTierDraft();
+    const payload = buildProviderProfileTierPayload([t], t.clientId);
+    expect((payload.model_tiers[0] as unknown as Record<string, unknown>).clientId).toBeUndefined();
+    expect((payload as unknown as Record<string, unknown>).defaultTierClientId).toBeUndefined();
+  });
+
+  it('preserves advanced objects', () => {
+    const t = runtimeDefaultTierDraft();
+    t.parameters = { a: 1 };
+    t.annotations = { b: 2 };
+    const payload = buildProviderProfileTierPayload([t], t.clientId);
+    expect(payload.model_tiers[0]!.parameters).toEqual({ a: 1 });
+    expect(payload.model_tiers[0]!.annotations).toEqual({ b: 2 });
+  });
+
+  it('trims label whitespace', () => {
+    const t = runtimeDefaultTierDraft();
+    t.label = '  hello  ';
+    const payload = buildProviderProfileTierPayload([t], t.clientId);
+    expect(payload.model_tiers[0]!.label).toBe('hello');
+  });
+});
+
+describe('add/duplicate/remove helpers', () => {
+  it('duplicate appends copy and does not duplicate default state', () => {
+    const source = runtimeDefaultTierDraft();
+    source.label = 'Original';
+    source.model = 'gpt-5.5';
+    source.effort = 'high';
+    source.parameters = { x: 1 };
+    const copy = duplicateTierDraft(source);
+    expect(copy.clientId).not.toBe(source.clientId);
+    expect(copy.label).toBe('Original copy');
+    expect(copy.model).toBe('gpt-5.5');
+    expect(copy.parameters).toEqual({ x: 1 });
+    expect(copy.clientId).not.toEqual(source.clientId);
+  });
+
+  it('computeTierRenumberingImpact previews all ordinal changes', () => {
+    const tiers = [runtimeDefaultTierDraft(), runtimeDefaultTierDraft(), runtimeDefaultTierDraft()];
+    tiers[0]!.label = 'A';
+    tiers[1]!.label = 'B';
+    tiers[2]!.label = 'C';
+    const impacts = computeTierRenumberingImpact(tiers, 1);
+    expect(impacts).toEqual([{ from: 3, to: 2, label: 'C' }]);
+    const impactsMiddle = computeTierRenumberingImpact(tiers, 0);
+    expect(impactsMiddle).toEqual([
+      { from: 2, to: 1, label: 'B' },
+      { from: 3, to: 2, label: 'C' },
+    ]);
+  });
+});
+
+describe('capability degradation', () => {
+  it('tierDisplay preserves unknown values and shows Runtime default for null', () => {
+    expect(tierDisplayModel(null)).toBe('Runtime default');
+    expect(tierDisplayEffort('')).toBe('Runtime default');
+    expect(tierDisplayModel('custom-model-xyz')).toBe('custom-model-xyz');
+  });
+});

--- a/frontend/src/utils/providerProfileTiers.ts
+++ b/frontend/src/utils/providerProfileTiers.ts
@@ -1,0 +1,174 @@
+export interface ProviderModelEffortTier {
+  label?: string | null;
+  model?: string | null;
+  effort?: string | null;
+  parameters?: Record<string, unknown> | null;
+  annotations?: Record<string, unknown> | null;
+}
+
+export interface ProviderProfileTierDraft {
+  clientId: string;
+  label: string;
+  model: string | null;
+  effort: string | null;
+  parameters: Record<string, unknown>;
+  annotations: Record<string, unknown>;
+}
+
+export interface TierNormalizationResult {
+  tiers: ProviderProfileTierDraft[];
+  defaultTierClientId: string | null;
+  invalidSavedDefaultIndex: number | null;
+  isRepair: boolean;
+  repairReason: string | null;
+}
+
+let tierClientIdCounter = 0;
+
+export function generateTierClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `tier-${crypto.randomUUID()}`;
+  }
+  tierClientIdCounter += 1;
+  return `tier-${Date.now()}-${tierClientIdCounter}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export function runtimeDefaultTierDraft(): ProviderProfileTierDraft {
+  return {
+    clientId: generateTierClientId(),
+    label: '',
+    model: null,
+    effort: null,
+    parameters: {},
+    annotations: {},
+  };
+}
+
+export function normalizeProviderProfileTiers(
+  modelTiers: ProviderModelEffortTier[] | null | undefined,
+  defaultModelTier: number | null | undefined,
+): TierNormalizationResult {
+  const raw = Array.isArray(modelTiers) ? modelTiers : null;
+  if (!raw || raw.length === 0) {
+    return {
+      tiers: [],
+      defaultTierClientId: null,
+      invalidSavedDefaultIndex: defaultModelTier ?? null,
+      isRepair: true,
+      repairReason: raw === null ? 'missing_tier_data' : 'empty_tier_data',
+    };
+  }
+
+  const tiers: ProviderProfileTierDraft[] = raw.map((tier) => ({
+    clientId: generateTierClientId(),
+    label: typeof tier.label === 'string' ? tier.label : tier.label == null ? '' : String(tier.label),
+    model: tier.model ?? null,
+    effort: tier.effort ?? null,
+    parameters: tier.parameters && typeof tier.parameters === 'object' && !Array.isArray(tier.parameters) ? { ...tier.parameters } as Record<string, unknown> : {},
+    annotations: tier.annotations && typeof tier.annotations === 'object' && !Array.isArray(tier.annotations) ? { ...tier.annotations } as Record<string, unknown> : {},
+  }));
+
+  let invalidSavedDefaultIndex: number | null = null;
+  let defaultTierClientId: string | null;
+  if (defaultModelTier != null) {
+    if (typeof defaultModelTier !== 'number' || !Number.isInteger(defaultModelTier) || defaultModelTier < 1 || defaultModelTier > tiers.length) {
+      invalidSavedDefaultIndex = defaultModelTier;
+      defaultTierClientId = tiers[0]?.clientId ?? null;
+    } else {
+      defaultTierClientId = tiers[defaultModelTier - 1]!.clientId;
+    }
+  } else {
+    defaultTierClientId = tiers[0]?.clientId ?? null;
+    invalidSavedDefaultIndex = null;
+  }
+
+  return {
+    tiers,
+    defaultTierClientId,
+    invalidSavedDefaultIndex,
+    isRepair: false,
+    repairReason: null,
+  };
+}
+
+export function buildProviderProfileTierPayload(
+  tiers: ProviderProfileTierDraft[],
+  defaultTierClientId: string | null,
+): { model_tiers: ProviderModelEffortTier[]; default_model_tier: number } {
+  if (tiers.length === 0) {
+    throw new Error('At least one tier is required.');
+  }
+  const defaultIndex = defaultTierClientId ? tiers.findIndex((t) => t.clientId === defaultTierClientId) : -1;
+  const effectiveDefaultIndex = defaultIndex >= 0 ? defaultIndex : 0;
+  const model_tiers: ProviderModelEffortTier[] = tiers.map((tier) => ({
+    label: tier.label.trim() ? tier.label.trim() : null,
+    model: tier.model,
+    effort: tier.effort,
+    parameters: tier.parameters,
+    annotations: tier.annotations,
+  }));
+  return {
+    model_tiers,
+    default_model_tier: effectiveDefaultIndex + 1,
+  };
+}
+
+export function computeTierRenumberingImpact(
+  tiers: ProviderProfileTierDraft[],
+  removeIndex: number,
+): Array<{ from: number; to: number; label: string }> {
+  const impacts: Array<{ from: number; to: number; label: string }> = [];
+  for (let idx = removeIndex + 1; idx < tiers.length; idx += 1) {
+    const tier = tiers[idx]!;
+    impacts.push({
+      from: idx + 1,
+      to: idx,
+      label: tier.label.trim() ? tier.label.trim() : `Tier ${idx + 1}`,
+    });
+  }
+  return impacts;
+}
+
+export function tierDisplayModel(model: string | null | undefined): string {
+  const trimmed = typeof model === 'string' ? model.trim() : '';
+  return trimmed ? trimmed : 'Runtime default';
+}
+
+export function tierDisplayEffort(effort: string | null | undefined): string {
+  const trimmed = typeof effort === 'string' ? effort.trim() : '';
+  return trimmed ? trimmed : 'Runtime default';
+}
+
+export function duplicateTierDraft(source: ProviderProfileTierDraft): ProviderProfileTierDraft {
+  return {
+    clientId: generateTierClientId(),
+    label: source.label ? `${source.label} copy` : '',
+    model: source.model,
+    effort: source.effort,
+    parameters: { ...source.parameters },
+    annotations: { ...source.annotations },
+  };
+}
+
+export function mapTierApiErrorsToClientIds(
+  errors: Array<{ path: string; message: string }>,
+  tiers: ProviderProfileTierDraft[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const err of errors) {
+    const match = err.path.match(/^model_tiers\.(\d+)\.(model|effort|label|parameters|annotations)$/);
+    if (match) {
+      const tierIndex = parseInt(match[1]!, 10);
+      const field = match[2]!;
+      const tier = tiers[tierIndex];
+      if (tier) {
+        map.set(`${tier.clientId}.${field}`, err.message);
+      }
+    } else if (err.path === 'default_model_tier') {
+      map.set('default_model_tier', err.message);
+    } else if (err.path === 'model_tiers') {
+      map.set('model_tiers', err.message);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

- add ordered model/effort tier utilities with stable draft-only IDs and canonical payload construction
- add Provider Profile summaries and a tier editor with default selection, duplicate/remove/undo/repair, and accessibility behavior
- preserve runtime-filter draft behavior and update route coverage for the new tier control

Closes #3348

## Testing

- `./tools/test_unit.sh --dashboard-only` — 77 files passed; 1,337 tests passed, 238 skipped
- `npm run ui:typecheck`
- `npm run ui:lint`
- focused Provider Profiles and tier utility tests — 89 passed