### PR TITLE
Fix Omnigent OpenCode policy bootstrap for review loops

### DIFF
--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -328,11 +328,27 @@ def _preserve_builtin_opencode_model(
     return preserved
 
 
+async def _default_builtin_opencode_launch_policy_refs(
+    session: AsyncSession,
+) -> list[str]:
+    """Resolve the exact active defaults bound into a new profile version."""
+
+    from api_service.services.omnigent_policies import OmnigentPolicyService
+
+    service = OmnigentPolicyService(session)
+    refs: list[str] = []
+    for policy_id in ("omnigent-on-demand", "opencode-on-demand"):
+        snapshot = await service.resolve_default_runtime_snapshot(policy_id)
+        refs.append(str(snapshot["policyRef"]))
+    return refs
+
+
 async def ensure_builtin_opencode_agent_profile(
     *, session: AsyncSession, catalog: Any
 ) -> dict[str, Any] | None:
     """Seed or advance the default OpenCode profile from live authority."""
 
+    from api_service.services.omnigent_policies import PolicyConflict, PolicyNotFound
     from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfileV2
     from moonmind.omnigent.harness_platform.catalog import TrustState
     from moonmind.omnigent.harness_platform.host_classes import (
@@ -389,6 +405,14 @@ async def ensure_builtin_opencode_agent_profile(
         )
     except Exception:
         host_ready = False
+    try:
+        allowed_launch_policy_refs = (
+            await _default_builtin_opencode_launch_policy_refs(session)
+        )
+    except (PolicyConflict, PolicyNotFound):
+        # The built-in profile must never advertise stale or synthetic policy
+        # authority while startup reconciliation is still materializing it.
+        return None
     document = OmnigentAgentProfileV2.model_validate(
         {
             "endpointRef": "default",
@@ -417,10 +441,7 @@ async def ensure_builtin_opencode_agent_profile(
             "capture": {"stream": True, "evidence": True},
             "continuations": {"checkpoint": True, "branch": True},
             "publish": {"mode": "none"},
-            "allowedLaunchPolicyRefs": [
-                "omnigent-on-demand@1",
-                "opencode-on-demand@1",
-            ],
+            "allowedLaunchPolicyRefs": allowed_launch_policy_refs,
         }
     ).model_dump(by_alias=True, mode="json")
     profile_id = "omnigent-opencode-default"

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -303,12 +303,24 @@ async def _sync_omnigent_bootstrap_policies(
         from moonmind.omnigent.bootstrap.image_resolution import (
             operator_image_configuration,
         )
+        from moonmind.omnigent.bootstrap.store import load_resolved_state
 
         # This is the only leg allowed to acquire images from the registry, and
         # it keys on the configured refs. Reading the live environment would
         # hand it a digest the image leg published, which is indistinguishable
         # from an operator pin and would silently disable tag refresh.
         configuration = operator_image_configuration()
+        resolved_state = load_resolved_state()
+        if resolved_state is not None and resolved_state.opencode_host_image_ref:
+            # The image leg already compatibility-qualified this exact pair.
+            # Re-resolving the mutable OpenCode tag here could pin a different
+            # digest than the Host Class and deployment evidence authorize.
+            configuration = {
+                **configuration,
+                "OMNIGENT_OPENCODE_HOST_IMAGE_REF": (
+                    resolved_state.opencode_host_image_ref
+                ),
+            }
         async with get_async_session_context() as session:
             if refresh_images:
                 await seed_bootstrap_policies(session, env=configuration)

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -217,125 +217,20 @@ async def _resolve_runtime_policy_snapshot(
 ) -> dict[str, Any]:
     """Read one active, validated policy before plan persistence."""
 
-    import os
+    from api_service.services.omnigent_policies import OmnigentPolicyService
 
-    from api_service.services.omnigent_policies import (
-        OmnigentPolicyService,
-        PolicyNotFound,
-    )
-
-    try:
-        if db_session is not None:
-            return await OmnigentPolicyService(db_session).resolve_runtime_snapshot(
-                policy_ref
-            )
-        if not callable(session_factory):
-            raise ValueError(
-                "Omnigent execution-plan compilation requires policy storage"
-            )
-        async with session_factory() as session:
-            return await OmnigentPolicyService(session).resolve_runtime_snapshot(
-                policy_ref
-            )
-    except PolicyNotFound:
-        # Fallback for generic opencode harness when deployment policy is not seeded
-        if policy_ref.startswith("opencode-") or policy_ref.startswith(
-            "omnigent-on-demand"
-        ):
-            # Synthesize from a known codex policy
-            try:
-                if db_session is not None:
-                    base = await OmnigentPolicyService(
-                        db_session
-                    ).resolve_runtime_snapshot("codex-on-demand@1")
-                else:
-                    async with session_factory() as session2:
-                        base = await OmnigentPolicyService(
-                            session2
-                        ).resolve_runtime_snapshot("codex-on-demand@1")
-                # Clone and adapt for opencode – replace every Codex identity
-                import copy
-
-                synthetic = copy.deepcopy(base)
-                boundaries = synthetic.get("boundaries", {})
-                execution = boundaries.get("execution", {})
-                execution["harness"] = "opencode-native"
-                execution["profileRef"] = "omnigent-opencode@1"
-                execution["agentIdentities"] = ["opencode"]
-                boundaries["execution"] = execution
-                # Replace every remaining Codex provider identity.
-                if "providerProfile" in boundaries and isinstance(
-                    boundaries["providerProfile"], dict
-                ):
-                    boundaries["providerProfile"]["compatibleProviders"] = [
-                        "opencode-go",
-                        "opencode",
-                    ]
-                else:
-                    boundaries["providerProfile"] = {
-                        "compatibleProviders": ["opencode-go", "opencode"]
-                    }
-
-                # Deep sweep: replace any lingering Codex strings that survived the shallow copy
-                def _deep_replace_codex(obj: Any) -> Any:
-                    if isinstance(obj, dict):
-                        return {k: _deep_replace_codex(v) for k, v in obj.items()}
-                    if isinstance(obj, list):
-                        return [_deep_replace_codex(v) for v in obj]
-                    if isinstance(obj, str):
-                        if obj == "codex":
-                            return "opencode-go"
-                        if obj == "codex-native":
-                            return "opencode-native"
-                        if obj == "codex-on-demand@1":
-                            return "opencode-on-demand@1"
-                        if obj == "omnigent-codex@1":
-                            return "omnigent-opencode@1"
-                        if "codex" in obj.lower():
-                            return obj.replace("codex", "opencode").replace(
-                                "Codex", "Opencode"
-                            )
-                        return obj
-                    return obj
-
-                boundaries = _deep_replace_codex(boundaries)
-                # Re-assert critical Opencode identities after deep sweep.
-                # Note: ExecutionPolicy forbids compatibleProviders on the
-                # execution section; provider compatibility belongs to the
-                # providerProfile boundary only.
-                boundaries["execution"]["harness"] = "opencode-native"
-                boundaries["execution"]["profileRef"] = "omnigent-opencode@1"
-                boundaries["execution"]["agentIdentities"] = ["opencode"]
-                boundaries.get("execution", {}).pop("compatibleProviders", None)
-                boundaries["providerProfile"]["compatibleProviders"] = [
-                    "opencode-go",
-                    "opencode",
-                ]
-                host = boundaries.get("host", {})
-                # Use resolved opencode image if available
-                opencode_ref = os.getenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", "").strip()
-                if opencode_ref and "@sha256:" in opencode_ref:
-                    host["hostImageRef"] = opencode_ref
-                # Also ensure server image is set
-                server_ref = os.getenv("OMNIGENT_IMAGE_REF", "").strip()
-                if server_ref and "@sha256:" in server_ref:
-                    host["serverImageRef"] = server_ref
-                boundaries["host"] = host
-                # Compile through the canonical policy snapshot boundary so the
-                # durable authority fields (policyRef/policyDigest/snapshotRef)
-                # match what workers re-verify at launch time.
-                from moonmind.omnigent.policies import compile_policy_snapshot
-
-                policy_id, _, version_text = policy_ref.rpartition("@")
-                return compile_policy_snapshot(
-                    policy_id=policy_id or "opencode-on-demand",
-                    version=int(version_text or "1"),
-                    document=boundaries,
-                    validation=synthetic.get("validation") or {"valid": True},
-                )
-            except Exception:
-                raise PolicyNotFound(f"{policy_ref} (synthetic fallback failed)")
-        raise
+    if db_session is not None:
+        return await OmnigentPolicyService(db_session).resolve_runtime_snapshot(
+            policy_ref
+        )
+    if not callable(session_factory):
+        raise ValueError(
+            "Omnigent execution-plan compilation requires policy storage"
+        )
+    async with session_factory() as session:
+        return await OmnigentPolicyService(session).resolve_runtime_snapshot(
+            policy_ref
+        )
 
 
 async def persist_json_artifact(

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -35,6 +35,10 @@ from moonmind.omnigent.harness_platform.execution_plan import (
     OmnigentExecutionPlanEnvelope,
     create_execution_plan_envelope,
 )
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
 from moonmind.omnigent.harness_platform.host_classes import (
     HostClass,
     OmnigentHostClassSelector,
@@ -217,20 +221,31 @@ async def _resolve_runtime_policy_snapshot(
 ) -> dict[str, Any]:
     """Read one active, validated policy before plan persistence."""
 
-    from api_service.services.omnigent_policies import OmnigentPolicyService
+    from api_service.services.omnigent_policies import (
+        OmnigentPolicyService,
+        PolicyConflict,
+        PolicyNotFound,
+    )
 
-    if db_session is not None:
-        return await OmnigentPolicyService(db_session).resolve_runtime_snapshot(
-            policy_ref
-        )
-    if not callable(session_factory):
-        raise ValueError(
-            "Omnigent execution-plan compilation requires policy storage"
-        )
-    async with session_factory() as session:
-        return await OmnigentPolicyService(session).resolve_runtime_snapshot(
-            policy_ref
-        )
+    try:
+        if db_session is not None:
+            return await OmnigentPolicyService(db_session).resolve_runtime_snapshot(
+                policy_ref
+            )
+        if not callable(session_factory):
+            raise ValueError(
+                "Omnigent execution-plan compilation requires policy storage"
+            )
+        async with session_factory() as session:
+            return await OmnigentPolicyService(session).resolve_runtime_snapshot(
+                policy_ref
+            )
+    except (PolicyConflict, PolicyNotFound) as exc:
+        raise HarnessPlatformError(
+            "Omnigent launch policy authority is not ready; wait for startup "
+            "reconciliation and retry",
+            code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+        ) from exc
 
 
 async def persist_json_artifact(

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -37,6 +38,7 @@ from moonmind.omnigent.policies import (
     document_digest,
     normalize_document,
 )
+from moonmind.omnigent.settings import opencode_support_enabled
 from moonmind.omnigent.stock_agents import CODEX_STOCK_AGENT_NAME
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 from moonmind.workflows.temporal.container_image_acquisition import (
@@ -50,29 +52,67 @@ logger = logging.getLogger(__name__)
 _DIGEST_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 _SERVER_IMAGE_REPOSITORY = "ghcr.io/omnigent-ai/omnigent-server"
 _HOST_IMAGE_REPOSITORY = "ghcr.io/omnigent-ai/omnigent-host"
+_OPENCODE_HOST_IMAGE_REPOSITORY = "ghcr.io/moonladderstudios/omnigent-host-opencode"
 _IMAGE_INSPECT_FORMAT = '{{.Id}}\t{{join .RepoDigests ","}}'
 ImageResolver = Callable[[str], Awaitable[str | None]]
 LiveServerImageResolver = Callable[[str], Awaitable[str | None]]
+
+@dataclass(frozen=True)
+class _BootstrapPolicyDefinition:
+    policy_id: str
+    name: str
+    host_mode: str
+    profile_ref: str
+    harness: str
+    agent_identities: tuple[str, ...]
+    compatible_providers: tuple[str, ...]
+    host_image_kind: str
+    requires_opencode: bool = False
+
+
 _BOOTSTRAP_POLICY_DEFINITIONS = (
-    (
-        "omnigent-codex",
-        "Omnigent Codex execution",
-        "static_compose",
-        "omnigent-codex@1",
+    _BootstrapPolicyDefinition(
+        policy_id="omnigent-codex", name="Omnigent Codex execution",
+        host_mode="static_compose", profile_ref="omnigent-codex@1",
+        harness="codex-native", agent_identities=(CODEX_STOCK_AGENT_NAME,),
+        compatible_providers=("codex",), host_image_kind="codex",
     ),
-    (
-        "codex-static",
-        "Codex static host",
-        "static_compose",
-        "omnigent-codex@1",
+    _BootstrapPolicyDefinition(
+        policy_id="codex-static", name="Codex static host",
+        host_mode="static_compose", profile_ref="omnigent-codex@1",
+        harness="codex-native", agent_identities=(CODEX_STOCK_AGENT_NAME,),
+        compatible_providers=("codex",), host_image_kind="codex",
     ),
-    (
-        "codex-on-demand",
-        "Codex on-demand host",
-        "on_demand_docker",
-        "omnigent-codex@1",
+    _BootstrapPolicyDefinition(
+        policy_id="codex-on-demand", name="Codex on-demand host",
+        host_mode="on_demand_docker", profile_ref="omnigent-codex@1",
+        harness="codex-native", agent_identities=(CODEX_STOCK_AGENT_NAME,),
+        compatible_providers=("codex",), host_image_kind="codex",
+    ),
+    _BootstrapPolicyDefinition(
+        policy_id="omnigent-on-demand", name="Generic Omnigent on-demand host",
+        host_mode="on_demand_docker", profile_ref="omnigent-opencode@1",
+        harness="opencode-native", agent_identities=("opencode",),
+        compatible_providers=("opencode-go", "opencode"),
+        host_image_kind="opencode", requires_opencode=True,
+    ),
+    _BootstrapPolicyDefinition(
+        policy_id="opencode-on-demand", name="OpenCode on-demand host",
+        host_mode="on_demand_docker", profile_ref="omnigent-opencode@1",
+        harness="opencode-native", agent_identities=("opencode",),
+        compatible_providers=("opencode-go", "opencode"),
+        host_image_kind="opencode", requires_opencode=True,
     ),
 )
+
+
+def _bootstrap_policy_definitions(
+    env: Mapping[str, Any] | None = None,
+) -> tuple[_BootstrapPolicyDefinition, ...]:
+    return tuple(
+        definition for definition in _BOOTSTRAP_POLICY_DEFINITIONS
+        if not definition.requires_opencode or opencode_support_enabled(env=env)
+    )
 
 
 class PolicyConflict(ValueError):
@@ -148,7 +188,9 @@ def validate_policy(
         "hostModes": {"static_compose"} | ({"on_demand_docker"} if container_backend_enabled else set()),
         "backends": {"compose"} | ({"container-backend"} if container_backend_enabled else set()),
         "architectures": {architecture},
-        "providers": {"codex"},
+        "providers": {"codex"} | (
+            {"opencode-go", "opencode"} if opencode_support_enabled() else set()
+        ),
         "workspaceClasses": {"workflow"},
     }
     declared = capabilities or deployment_capabilities
@@ -589,6 +631,21 @@ def configured_bootstrap_image_refs(
     )
 
 
+def configured_opencode_bootstrap_image_ref(
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Return the operator-facing OpenCode host image input."""
+
+    source = os.environ if env is None else env
+    return _configured_image_ref(
+        env=source,
+        ref_variable="OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        repository_variable="OMNIGENT_OPENCODE_HOST_IMAGE",
+        tag_variable="OMNIGENT_OPENCODE_HOST_IMAGE_TAG",
+        default_repository=_OPENCODE_HOST_IMAGE_REPOSITORY,
+    )
+
+
 def _repository_digest(image_ref: str, inspect_output: bytes) -> str | None:
     """Select the exact repository digest that matches ``image_ref``."""
 
@@ -747,13 +804,17 @@ async def resolve_bootstrap_image_refs(
     *,
     env: Mapping[str, str] | None = None,
     image_resolver: ImageResolver = resolve_bootstrap_image_ref,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str | None, str | None]:
     server_input, host_input = configured_bootstrap_image_refs(env)
-    server_image, host_image = await asyncio.gather(
+    opencode_host_input = configured_opencode_bootstrap_image_ref(env)
+    server_image, host_image, opencode_host_image = await asyncio.gather(
         image_resolver(server_input),
         image_resolver(host_input),
+        image_resolver(opencode_host_input)
+        if opencode_support_enabled(env=env)
+        else asyncio.sleep(0, result=None),
     )
-    return server_image, host_image
+    return server_image, host_image, opencode_host_image
 
 
 # Every production remediation adapter registered by
@@ -811,6 +872,9 @@ def bootstrap_document(
     execution_profile_ref: str,
     server_image_ref: str | None = None,
     host_image_ref: str | None = None,
+    harness: str = "codex-native",
+    agent_identities: tuple[str, ...] = (CODEX_STOCK_AGENT_NAME,),
+    compatible_providers: tuple[str, ...] = ("codex",),
 ) -> PolicyDocument:
     """Project legacy built-ins into an explicit, reviewable bootstrap policy."""
 
@@ -822,8 +886,8 @@ def bootstrap_document(
         "endpoint": {"ref": "default", "bridgeModes": ["embedded", "proxy"]},
         "execution": {
             "profileRef": execution_profile_ref,
-            "harness": "codex-native",
-            "agentIdentities": [CODEX_STOCK_AGENT_NAME],
+            "harness": harness,
+            "agentIdentities": list(agent_identities),
         },
         "host": {"mode": host_mode, "backendRef": "compose" if host_mode == "static_compose" else "container-backend",
                  "architectures": [architecture],
@@ -838,7 +902,7 @@ def bootstrap_document(
         "workspace": {"allowedClasses": ["workflow"], "repositoryMutation": True,
                       "mountClasses": ["workspace", "oauth_home", "omnigent_state", "skills_tools", "artifacts", "cache"],
                       "runtimeUid": 1000, "runtimeGid": 1000},
-        "providerProfile": {"compatibleProviders": ["codex"], "queueWhenBusy": True},
+        "providerProfile": {"compatibleProviders": list(compatible_providers), "queueWhenBusy": True},
         "session": {"create": True, "firstMessage": "required", "continuation": True, "interruption": True,
                     "cancellation": True, "cleanup": "drain" if host_mode == "static_compose" else "remove"},
         "capture": {"required": True, "artifactClasses": ["events", "snapshots", "workspace"], "maxLogBytes": 10000000, "redaction": "required"},
@@ -857,7 +921,8 @@ def _legacy_bootstrap_agent_identity(row: OmnigentPolicyVersion) -> bool:
     """Match only MoonMind's pre-release built-in ``codex`` identity."""
 
     if row.policy_id not in {
-        definition[0] for definition in _BOOTSTRAP_POLICY_DEFINITIONS
+        definition.policy_id for definition in _BOOTSTRAP_POLICY_DEFINITIONS
+        if not definition.requires_opencode
     } or row.version != 1:
         return False
     document = row.document_json
@@ -940,20 +1005,22 @@ async def _reconcile_bootstrap_image_authority(
     *,
     service: OmnigentPolicyService,
     server_image: str | None,
-    host_image: str | None,
+    host_images: Mapping[str, str | None],
+    definitions: tuple[_BootstrapPolicyDefinition, ...],
     live_server_image_resolver: LiveServerImageResolver,
 ) -> list[str]:
     """Advance bootstrap-owned defaults when their resolved images change."""
 
-    resolved_images_valid = bool(
-        _DIGEST_IMAGE.fullmatch(server_image or "")
-        and _DIGEST_IMAGE.fullmatch(host_image or "")
-    )
-
     reconciled: list[str] = []
     live_server_checked = False
     live_server_image: str | None = None
-    for policy_id, *_ in _BOOTSTRAP_POLICY_DEFINITIONS:
+    for definition in definitions:
+        policy_id = definition.policy_id
+        host_image = host_images.get(definition.host_image_kind)
+        resolved_images_valid = bool(
+            _DIGEST_IMAGE.fullmatch(server_image or "")
+            and _DIGEST_IMAGE.fullmatch(host_image or "")
+        )
         policy = await session.get(OmnigentPolicy, policy_id)
         if policy is None or policy.default_version is None:
             continue
@@ -1144,8 +1211,10 @@ async def seed_bootstrap_policies(
     """Idempotently persist and refresh the built-in image authorities."""
 
     service = OmnigentPolicyService(session)
+    definitions = _bootstrap_policy_definitions(env)
     reconciliation_required = False
-    for policy_id, *_ in _BOOTSTRAP_POLICY_DEFINITIONS:
+    for definition in definitions:
+        policy_id = definition.policy_id
         policy = await session.get(OmnigentPolicy, policy_id)
         if policy is None:
             reconciliation_required = True
@@ -1196,12 +1265,14 @@ async def seed_bootstrap_policies(
             reconciliation_required = True
             break
     seeded: list[str] = []
-    server_image, host_image = await resolve_bootstrap_image_refs(
+    server_image, host_image, opencode_host_image = await resolve_bootstrap_image_refs(
         env=env, image_resolver=image_resolver
     )
-    if not (
-        _DIGEST_IMAGE.fullmatch(server_image or "")
-        and _DIGEST_IMAGE.fullmatch(host_image or "")
+    host_images = {"codex": host_image, "opencode": opencode_host_image}
+    if not _DIGEST_IMAGE.fullmatch(server_image or "") or any(
+        not _DIGEST_IMAGE.fullmatch(
+            host_images.get(definition.host_image_kind) or ""
+        ) for definition in definitions
     ):
         # Readiness-local inspection may find no cached images on a first boot.
         # Do not persist placeholder drafts; the background acquisition pass
@@ -1211,7 +1282,8 @@ async def seed_bootstrap_policies(
             session,
             service=service,
             server_image=server_image,
-            host_image=host_image,
+            host_images=host_images,
+            definitions=definitions,
             live_server_image_resolver=live_server_image_resolver,
         )
     if not reconciliation_required:
@@ -1219,19 +1291,24 @@ async def seed_bootstrap_policies(
             session,
             service=service,
             server_image=server_image,
-            host_image=host_image,
+            host_images=host_images,
+            definitions=definitions,
             live_server_image_resolver=live_server_image_resolver,
         )
-    for policy_id, name, host_mode, profile_ref in _BOOTSTRAP_POLICY_DEFINITIONS:
+    for definition in definitions:
+        policy_id = definition.policy_id
         document = bootstrap_document(
-            host_mode=host_mode,
-            execution_profile_ref=profile_ref,
+            host_mode=definition.host_mode,
+            execution_profile_ref=definition.profile_ref,
             server_image_ref=server_image,
-            host_image_ref=host_image,
+            host_image_ref=host_images[definition.host_image_kind],
+            harness=definition.harness,
+            agent_identities=definition.agent_identities,
+            compatible_providers=definition.compatible_providers,
         )
         policy = await session.get(OmnigentPolicy, policy_id)
         if policy is None:
-            row = await service.create(policy_id=policy_id, name=name, owner_user_id=None, visibility="deployment",
+            row = await service.create(policy_id=policy_id, name=definition.name, owner_user_id=None, visibility="deployment",
                                        document=document, actor="bootstrap")
         else:
             row = await service.get_version(policy_id, 1)
@@ -1370,7 +1447,8 @@ async def seed_bootstrap_policies(
         session,
         service=service,
         server_image=server_image,
-        host_image=host_image,
+        host_images=host_images,
+        definitions=definitions,
         live_server_image_resolver=live_server_image_resolver,
     )
     seeded.extend(item for item in image_reconciled if item not in seeded)
@@ -1381,7 +1459,8 @@ async def bootstrap_policies_ready(session: AsyncSession) -> bool:
     """Return whether every built-in policy has immutable active authority."""
 
     service = OmnigentPolicyService(session)
-    for policy_id, *_ in _BOOTSTRAP_POLICY_DEFINITIONS:
+    for definition in _bootstrap_policy_definitions():
+        policy_id = definition.policy_id
         policy = await session.get(OmnigentPolicy, policy_id)
         if policy is None or policy.default_version is None:
             return False

--- a/api_service/services/omnigent_policies.py
+++ b/api_service/services/omnigent_policies.py
@@ -1269,15 +1269,17 @@ async def seed_bootstrap_policies(
         env=env, image_resolver=image_resolver
     )
     host_images = {"codex": host_image, "opencode": opencode_host_image}
-    if not _DIGEST_IMAGE.fullmatch(server_image or "") or any(
-        not _DIGEST_IMAGE.fullmatch(
+    resolvable_definitions = tuple(
+        definition for definition in definitions
+        if _DIGEST_IMAGE.fullmatch(server_image or "")
+        and _DIGEST_IMAGE.fullmatch(
             host_images.get(definition.host_image_kind) or ""
-        ) for definition in definitions
-    ):
-        # Readiness-local inspection may find no cached images on a first boot.
-        # Do not persist placeholder drafts; the background acquisition pass
-        # will seed once both immutable authorities exist. Existing active
-        # policies can still finish deferred binding cutovers meanwhile.
+        )
+    )
+    # Image families fail independently. An unavailable optional harness image
+    # keeps that family unready without withholding valid Codex authority (and
+    # vice versa). Placeholder drafts are never persisted.
+    if not resolvable_definitions:
         return await _reconcile_bootstrap_image_authority(
             session,
             service=service,
@@ -1295,7 +1297,7 @@ async def seed_bootstrap_policies(
             definitions=definitions,
             live_server_image_resolver=live_server_image_resolver,
         )
-    for definition in definitions:
+    for definition in resolvable_definitions:
         policy_id = definition.policy_id
         document = bootstrap_document(
             host_mode=definition.host_mode,

--- a/docs/Omnigent/PolicyAuthority.md
+++ b/docs/Omnigent/PolicyAuthority.md
@@ -80,11 +80,16 @@ Startup seeds `omnigent-codex@1`, `codex-static@1`, and
 enabled, startup also seeds `omnigent-on-demand@1` and
 `opencode-on-demand@1` with the qualified OpenCode harness, provider, and host
 image authority. Stock image tags are acquired and resolved during seeding;
-only repository digests are projected into immutable active versions.
+only repository digests are projected into immutable active versions. Each
+host-image family seeds independently, so an unavailable optional harness does
+not withhold another runtime's valid authority. OpenCode policies reuse the
+exact host digest already qualified by deployment image reconciliation.
 `codex-on-demand@1` is the normal Codex default and static hosting remains an
 explicit advanced choice. Normal work uses persisted selections; a planner or
 runtime may not synthesize one policy from another, and durable/environment
-conflicts fail closed.
+conflicts fail closed. Bootstrap Agent Profiles and unbound replay paths resolve
+the policy identity's current persisted default, then carry that exact version;
+already-bound runs continue using their recorded version.
 Transient acquisition failures are retried by the API's capped reconciliation
 loop; a failed first pull does not strand the deployment until restart.
 `OMNIGENT_IMAGE_REF` and `OMNIGENT_HOST_IMAGE_REF` may be removed after all

--- a/docs/Omnigent/PolicyAuthority.md
+++ b/docs/Omnigent/PolicyAuthority.md
@@ -76,11 +76,15 @@ re-evaluated.
 ## Bootstrap migration
 
 Startup seeds `omnigent-codex@1`, `codex-static@1`, and
-`codex-on-demand@1` as explicit policies. Stock image tags are acquired and
-resolved during seeding; only repository digests are projected into the
-immutable active versions. `codex-on-demand@1` is the normal default and static
-hosting remains an explicit advanced choice. Normal work uses persisted
-selections; durable/environment conflicts fail closed.
+`codex-on-demand@1` as explicit Codex policies. When OpenCode support is
+enabled, startup also seeds `omnigent-on-demand@1` and
+`opencode-on-demand@1` with the qualified OpenCode harness, provider, and host
+image authority. Stock image tags are acquired and resolved during seeding;
+only repository digests are projected into immutable active versions.
+`codex-on-demand@1` is the normal Codex default and static hosting remains an
+explicit advanced choice. Normal work uses persisted selections; a planner or
+runtime may not synthesize one policy from another, and durable/environment
+conflicts fail closed.
 Transient acquisition failures are retried by the API's capped reconciliation
 loop; a failed first pull does not strand the deployment until restart.
 `OMNIGENT_IMAGE_REF` and `OMNIGENT_HOST_IMAGE_REF` may be removed after all

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -2790,6 +2790,21 @@ async def _omnigent_client_context():
     return http_client, client
 
 
+async def _resolve_legacy_launch_policy_snapshot(
+    *, policy_service: Any, launch_policy_ref: str, resolve_default: bool
+) -> tuple[str, dict[str, Any]]:
+    """Resolve exact replay authority, following defaults only when unbound."""
+
+    if not resolve_default:
+        snapshot = await policy_service.resolve_runtime_snapshot(launch_policy_ref)
+        return launch_policy_ref, snapshot
+    policy_id, separator, _version = launch_policy_ref.rpartition("@")
+    if not separator:
+        raise ValueError("default launch policy reference is invalid")
+    snapshot = await policy_service.resolve_default_runtime_snapshot(policy_id)
+    return str(snapshot["policyRef"]), snapshot
+
+
 async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Materialize and bind one exact host without returning mutable paths."""
 
@@ -2863,6 +2878,7 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
     requested_target, requested_policy = selection_from_request(
         agent_request.parameters
     )
+    resolve_policy_default = False
     if execution_plan is not None:
         planned_registration = find_harness_registration(
             execution_plan.payload.harnessId
@@ -2890,6 +2906,7 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
             or requested_policy
             or PROFILES[execution_profile_ref].default_policy_ref
         )
+        resolve_policy_default = not binding.launch_policy_ref and not requested_policy
         if requested_target and requested_target != execution_profile_ref:
             raise ValueError("authored host selection conflicts with durable binding")
     else:
@@ -2899,6 +2916,7 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
         launch_policy_ref = (
             requested_policy or PROFILES[execution_profile_ref].default_policy_ref
         )
+        resolve_policy_default = not requested_policy
 
     parameters = dict(agent_request.parameters or {})
     if (
@@ -2922,9 +2940,14 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
         # stored with the plan. New product submissions never consult current
         # policy state here.
         async with async_session_maker() as db_session:
-            policy_snapshot = await OmnigentPolicyService(
-                db_session
-            ).resolve_runtime_snapshot(launch_policy_ref)
+            policy_service = OmnigentPolicyService(db_session)
+            launch_policy_ref, policy_snapshot = (
+                await _resolve_legacy_launch_policy_snapshot(
+                    policy_service=policy_service,
+                    launch_policy_ref=launch_policy_ref,
+                    resolve_default=resolve_policy_default,
+                )
+            )
         authored_follow_up = (
             parameters.get("followUpRetrieval")
             if isinstance(parameters.get("followUpRetrieval"), Mapping)

--- a/tests/integration/reliability/replays/omnigent-server-image-authority-drift/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-server-image-authority-drift/expected-outcome.json
@@ -3,7 +3,9 @@
   "reconciledPolicyIds": [
     "codex-on-demand",
     "codex-static",
-    "omnigent-codex"
+    "omnigent-codex",
+    "omnigent-on-demand",
+    "opencode-on-demand"
   ],
   "defaultPolicyVersion": 2,
   "serverImageRefObserved": "ghcr.io/omnigent-ai/omnigent-server@sha256:3333333333333333333333333333333333333333333333333333333333333333",

--- a/tests/unit/api/routers/test_omnigent_agent_profiles.py
+++ b/tests/unit/api/routers/test_omnigent_agent_profiles.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from api_service.api.routers.omnigent_agent_profiles import (
     AgentProfileDocument,
     GuidedProfileCreate,
+    _default_builtin_opencode_launch_policy_refs,
     _digest,
     _normalized,
     _preserve_builtin_opencode_model,
@@ -51,6 +52,29 @@ def test_catalog_refresh_preserves_bootstrap_qualified_opencode_model():
 
     assert reconciled["model"] == active["model"]
     assert seed["model"] == {}
+
+
+@pytest.mark.asyncio
+async def test_builtin_opencode_profile_binds_current_policy_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PolicyService:
+        def __init__(self, session):
+            assert session == "session"
+
+        async def resolve_default_runtime_snapshot(self, policy_id: str):
+            versions = {"omnigent-on-demand": 7, "opencode-on-demand": 9}
+            return {"policyRef": f"{policy_id}@{versions[policy_id]}"}
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_policies.OmnigentPolicyService",
+        _PolicyService,
+    )
+
+    assert await _default_builtin_opencode_launch_policy_refs("session") == [
+        "omnigent-on-demand@7",
+        "opencode-on-demand@9",
+    ]
 
 
 def test_guided_profile_rejects_unqualified_pi_preset() -> None:

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -28,6 +28,10 @@ from api_service.services.omnigent_policies import (
     resolve_live_server_image_ref,
     seed_bootstrap_policies,
 )
+from moonmind.omnigent.execution_profiles import (
+    PROFILES,
+    default_execution_profile_ref_for_runtime,
+)
 from moonmind.omnigent.policies import PolicyDocument, PolicyState, document_digest
 from moonmind.security.egress import OMNIGENT_EGRESS_PROFILE
 from tests.unit.omnigent.test_policy_authority import policy_document
@@ -544,10 +548,15 @@ async def test_bootstrap_policies_activate_with_resolved_latest_images(
     monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
     server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
     host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    opencode_host_digest = (
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "3" * 64
+    )
     resolution_calls: list[str] = []
 
     async def resolver(image_ref: str) -> str:
         resolution_calls.append(image_ref)
+        if "host-opencode" in image_ref:
+            return opencode_host_digest
         return host_digest if "host" in image_ref else server_digest
 
     async with policy_db(tmp_path) as sessions, sessions() as session:
@@ -564,6 +573,8 @@ async def test_bootstrap_policies_activate_with_resolved_latest_images(
             "omnigent-codex",
             "codex-static",
             "codex-on-demand",
+            "omnigent-on-demand",
+            "opencode-on-demand",
         }
         versions = list(
             (
@@ -576,23 +587,103 @@ async def test_bootstrap_policies_activate_with_resolved_latest_images(
             .scalars()
             .all()
         )
-        assert len(versions) == 3
+        assert len(versions) == 5
         assert all(version.state == "active" for version in versions)
         assert all(version.validation_json["valid"] is True for version in versions)
         assert all(
             version.document_json["host"]["serverImageRef"] == server_digest
             for version in versions
         )
-        assert all(
-            version.document_json["execution"]["agentIdentities"]
-            == ["codex-native-ui"]
-            for version in versions
-        )
+        by_policy = {version.policy_id: version for version in versions}
+        for policy_id in {
+            "omnigent-codex",
+            "codex-static",
+            "codex-on-demand",
+        }:
+            assert by_policy[policy_id].document_json["execution"] == {
+                "profileRef": "omnigent-codex@1",
+                "harness": "codex-native",
+                "agentIdentities": ["codex-native-ui"],
+            }
+            assert by_policy[policy_id].document_json["host"]["hostImageRef"] == host_digest
+        for policy_id in {"omnigent-on-demand", "opencode-on-demand"}:
+            assert by_policy[policy_id].document_json["execution"] == {
+                "profileRef": "omnigent-opencode@1",
+                "harness": "opencode-native",
+                "agentIdentities": ["opencode"],
+            }
+            assert by_policy[policy_id].document_json["providerProfile"]["compatibleProviders"] == ["opencode-go", "opencode"]
+            assert by_policy[policy_id].document_json["host"]["hostImageRef"] == opencode_host_digest
+            snapshot = await OmnigentPolicyService(session).resolve_runtime_snapshot(f"{policy_id}@1")
+            assert snapshot["policyRef"] == f"{policy_id}@1"
         assert await bootstrap_policies_ready(session) is True
         assert await seed_bootstrap_policies(
             session, env={}, image_resolver=resolver
         ) == []
-        assert len(resolution_calls) == 4
+        assert len(resolution_calls) == 6
+
+
+@pytest.mark.asyncio
+async def test_dynamic_opencode_child_resolves_bootstrapped_policy(
+    tmp_path, monkeypatch
+):
+    """Cover the review-loop child path that has no precompiled plan binding."""
+
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    codex_host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    opencode_host_digest = (
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "3" * 64
+    )
+
+    async def resolver(image_ref: str) -> str:
+        if "host-opencode" in image_ref:
+            return opencode_host_digest
+        return codex_host_digest if "host" in image_ref else server_digest
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        await seed_bootstrap_policies(session, image_resolver=resolver)
+
+        profile_ref = default_execution_profile_ref_for_runtime("opencode")
+        policy_ref = PROFILES[profile_ref].default_policy_ref
+        snapshot = await OmnigentPolicyService(session).resolve_runtime_snapshot(
+            policy_ref
+        )
+
+        assert profile_ref == "omnigent-opencode@1"
+        assert policy_ref == "opencode-on-demand@1"
+        assert snapshot["boundaries"]["execution"]["harness"] == "opencode-native"
+        assert snapshot["boundaries"]["host"]["hostImageRef"] == opencode_host_digest
+
+
+@pytest.mark.asyncio
+async def test_opencode_kill_switch_does_not_add_policy_or_image_dependencies(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    monkeypatch.setenv("MOONMIND_OMNIGENT_OPENCODE_ENABLED", "false")
+    server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+    resolution_calls: list[str] = []
+
+    async def resolver(image_ref: str) -> str:
+        resolution_calls.append(image_ref)
+        return host_digest if "host" in image_ref else server_digest
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        seeded = await seed_bootstrap_policies(
+            session,
+            env={"MOONMIND_OMNIGENT_OPENCODE_ENABLED": "false"},
+            image_resolver=resolver,
+        )
+
+        assert set(seeded) == {
+            "omnigent-codex",
+            "codex-static",
+            "codex-on-demand",
+        }
+        assert len(resolution_calls) == 2
+        assert await bootstrap_policies_ready(session) is True
 
 
 @pytest.mark.asyncio
@@ -655,6 +746,8 @@ async def test_bootstrap_advances_image_authority_when_mutable_inputs_move(
             "omnigent-codex",
             "codex-static",
             "codex-on-demand",
+            "omnigent-on-demand",
+            "opencode-on-demand",
         }
         policies = list((await session.execute(select(OmnigentPolicy))).scalars())
         assert all(policy.default_version == 2 for policy in policies)
@@ -669,7 +762,7 @@ async def test_bootstrap_advances_image_authority_when_mutable_inputs_move(
             .scalars()
             .all()
         )
-        assert len(defaults) == 3
+        assert len(defaults) == 5
         assert all(
             row.document_json["host"]["serverImageRef"] == next_server
             for row in defaults
@@ -996,6 +1089,12 @@ async def test_bootstrap_seed_cuts_over_legacy_stock_agent_identity(tmp_path, mo
             (await session.execute(select(OmnigentPolicyVersion))).scalars().all()
         )
         for version in versions:
+            if version.policy_id not in {
+                "omnigent-codex",
+                "codex-static",
+                "codex-on-demand",
+            }:
+                continue
             legacy = deepcopy(version.document_json)
             legacy["execution"]["agentIdentities"] = ["codex"]
             version.document_json = legacy
@@ -1074,7 +1173,14 @@ async def test_bootstrap_seed_cuts_over_legacy_stock_agent_identity(tmp_path, mo
         }
         assert seeded_after_drain == ["codex-on-demand"]
         policies = list((await session.execute(select(OmnigentPolicy))).scalars())
-        assert all(policy.default_version == 2 for policy in policies)
+        assert all(
+            policy.default_version == (
+                2 if policy.policy_id in {
+                    "omnigent-codex", "codex-static", "codex-on-demand"
+                } else 1
+            )
+            for policy in policies
+        )
         migrated_versions = list(
             (
                 await session.execute(
@@ -1087,11 +1193,18 @@ async def test_bootstrap_seed_cuts_over_legacy_stock_agent_identity(tmp_path, mo
             .scalars()
             .all()
         )
-        assert len(migrated_versions) == 6
+        assert len(migrated_versions) == 8
         for version in migrated_versions:
-            expected_identity = (
-                ["codex"] if version.version == 1 else ["codex-native-ui"]
-            )
+            if version.policy_id in {
+                "omnigent-codex",
+                "codex-static",
+                "codex-on-demand",
+            }:
+                expected_identity = (
+                    ["codex"] if version.version == 1 else ["codex-native-ui"]
+                )
+            else:
+                expected_identity = ["opencode"]
             assert version.state == PolicyState.ACTIVE.value
             assert version.document_json["execution"]["agentIdentities"] == (
                 expected_identity

--- a/tests/unit/api/test_omnigent_policy_service.py
+++ b/tests/unit/api/test_omnigent_policy_service.py
@@ -632,28 +632,77 @@ async def test_dynamic_opencode_child_resolves_bootstrapped_policy(
     monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
     server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
     codex_host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
-    opencode_host_digest = (
+    first_opencode_host_digest = (
         "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "3" * 64
     )
+    next_opencode_host_digest = (
+        "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:" + "4" * 64
+    )
+    resolved_opencode_host = {"image": first_opencode_host_digest}
 
     async def resolver(image_ref: str) -> str:
         if "host-opencode" in image_ref:
-            return opencode_host_digest
+            return resolved_opencode_host["image"]
         return codex_host_digest if "host" in image_ref else server_digest
 
+    async def live_server(_image_ref: str) -> str:
+        return server_digest
+
     async with policy_db(tmp_path) as sessions, sessions() as session:
-        await seed_bootstrap_policies(session, image_resolver=resolver)
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
+        resolved_opencode_host["image"] = next_opencode_host_digest
+        await seed_bootstrap_policies(
+            session,
+            image_resolver=resolver,
+            live_server_image_resolver=live_server,
+        )
 
         profile_ref = default_execution_profile_ref_for_runtime("opencode")
         policy_ref = PROFILES[profile_ref].default_policy_ref
-        snapshot = await OmnigentPolicyService(session).resolve_runtime_snapshot(
-            policy_ref
+        policy_id = policy_ref.rpartition("@")[0]
+        snapshot = await OmnigentPolicyService(
+            session
+        ).resolve_default_runtime_snapshot(
+            policy_id
         )
 
         assert profile_ref == "omnigent-opencode@1"
         assert policy_ref == "opencode-on-demand@1"
+        assert snapshot["policyRef"] == "opencode-on-demand@2"
         assert snapshot["boundaries"]["execution"]["harness"] == "opencode-native"
-        assert snapshot["boundaries"]["host"]["hostImageRef"] == opencode_host_digest
+        assert snapshot["boundaries"]["host"]["hostImageRef"] == next_opencode_host_digest
+
+
+@pytest.mark.asyncio
+async def test_unavailable_opencode_image_does_not_withhold_codex_policies(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_CONTAINER_JOBS_ENABLED", "true")
+    server_digest = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "1" * 64
+    codex_host_digest = "ghcr.io/omnigent-ai/omnigent-host@sha256:" + "2" * 64
+
+    async def resolver(image_ref: str) -> str | None:
+        if "host-opencode" in image_ref:
+            return None
+        return codex_host_digest if "host" in image_ref else server_digest
+
+    async with policy_db(tmp_path) as sessions, sessions() as session:
+        seeded = await seed_bootstrap_policies(session, image_resolver=resolver)
+
+        assert set(seeded) == {
+            "omnigent-codex",
+            "codex-static",
+            "codex-on-demand",
+        }
+        assert await OmnigentPolicyService(session).resolve_runtime_snapshot(
+            "codex-on-demand@1"
+        )
+        assert await session.get(OmnigentPolicy, "opencode-on-demand") is None
+        assert await bootstrap_policies_ready(session) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -99,6 +99,8 @@ async def test_api_startup_bootstrap_uses_only_local_image_evidence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from api_service.services import omnigent_policies
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.bootstrap.models import ResolvedOmnigentDeploymentState
 
     observed_resolver = None
     observed_env = None
@@ -118,12 +120,28 @@ async def test_api_startup_bootstrap_uses_only_local_image_evidence(
     monkeypatch.setattr(api_main, "get_async_session_context", session_context)
     monkeypatch.setattr(omnigent_policies, "seed_bootstrap_policies", seed)
     monkeypatch.setattr(omnigent_policies, "bootstrap_policies_ready", ready)
+    qualified_opencode_ref = "ghcr.io/example/opencode@sha256:" + "2" * 64
+    monkeypatch.setattr(
+        store,
+        "load_resolved_state",
+        lambda: ResolvedOmnigentDeploymentState.model_validate(
+            {
+                "serverImageRef": "ghcr.io/example/server@sha256:" + "1" * 64,
+                "opencodeHostImageRef": qualified_opencode_ref,
+                "omnigentBuildDigest": "sha256:" + "1" * 64,
+                "architecture": "linux/amd64",
+                "resolvedAt": datetime(2026, 9, 2, tzinfo=UTC),
+                "details": {},
+            }
+        ),
+    )
 
     assert await api_main._sync_omnigent_bootstrap_policies(refresh_images=False)
     assert observed_resolver is omnigent_policies.resolve_local_bootstrap_image_ref
-    # The registry-acquiring leg keys on the configured refs, so it must read the
-    # operator's own configuration rather than a digest publication exported.
+    # Mutable server/Codex inputs remain operator-owned, while OpenCode policy
+    # seeding reuses the exact digest already compatibility-qualified upstream.
     assert observed_env is not None
+    assert observed_env["OMNIGENT_OPENCODE_HOST_IMAGE_REF"] == qualified_opencode_ref
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -17,6 +17,7 @@ from moonmind.omnigent.execution_support_evidence import (
     EXECUTION_SUPPORT_EVIDENCE_VERSION,
 )
 from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.session_supervisor_rollback import (
     SUPERVISOR_ROLLBACK_POLICY_VERSION,
@@ -101,6 +102,30 @@ class _PlanStore:
     async def persist(self, envelope):
         self.__class__.persisted = envelope
         return envelope
+
+
+@pytest.mark.asyncio
+async def test_plan_compilation_gates_unseeded_policy_authority(monkeypatch) -> None:
+    from api_service.services import omnigent_policies
+
+    class _PolicyService:
+        def __init__(self, _session):
+            pass
+
+        async def resolve_runtime_snapshot(self, policy_ref: str):
+            raise omnigent_policies.PolicyNotFound(policy_ref)
+
+    monkeypatch.setattr(omnigent_policies, "OmnigentPolicyService", _PolicyService)
+
+    with pytest.raises(HarnessPlatformError) as exc_info:
+        await service._resolve_runtime_policy_snapshot(
+            policy_ref="opencode-on-demand@1",
+            session_factory=object(),
+            db_session=object(),
+        )
+
+    assert exc_info.value.code == "OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE"
+    assert "startup reconciliation" in str(exc_info.value)
 
 
 def test_skill_selector_includes_nested_dynamic_execution_skills() -> None:

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -470,6 +470,53 @@ def test_admission_contract_is_frozen_compact_and_fail_closed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unbound_legacy_host_launch_follows_durable_policy_default() -> None:
+    service = SimpleNamespace(
+        resolve_default_runtime_snapshot=AsyncMock(
+            return_value={"policyRef": "opencode-on-demand@4"}
+        ),
+        resolve_runtime_snapshot=AsyncMock(),
+    )
+
+    policy_ref, snapshot = await (
+        omnigent_session_activities._resolve_legacy_launch_policy_snapshot(
+            policy_service=service,
+            launch_policy_ref="opencode-on-demand@1",
+            resolve_default=True,
+        )
+    )
+
+    assert policy_ref == "opencode-on-demand@4"
+    assert snapshot["policyRef"] == policy_ref
+    service.resolve_default_runtime_snapshot.assert_awaited_once_with(
+        "opencode-on-demand"
+    )
+    service.resolve_runtime_snapshot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bound_legacy_host_launch_preserves_exact_policy_version() -> None:
+    service = SimpleNamespace(
+        resolve_default_runtime_snapshot=AsyncMock(),
+        resolve_runtime_snapshot=AsyncMock(
+            return_value={"policyRef": "opencode-on-demand@1"}
+        ),
+    )
+
+    policy_ref, _snapshot = await (
+        omnigent_session_activities._resolve_legacy_launch_policy_snapshot(
+            policy_service=service,
+            launch_policy_ref="opencode-on-demand@1",
+            resolve_default=False,
+        )
+    )
+
+    assert policy_ref == "opencode-on-demand@1"
+    service.resolve_runtime_snapshot.assert_awaited_once_with(policy_ref)
+    service.resolve_default_runtime_snapshot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_plan_bound_admission_uses_persisted_host_authority(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- persist the generic and OpenCode on-demand policies during startup when OpenCode support is enabled
- bind those policies to the immutable OpenCode host image and remove the synthetic Codex-to-OpenCode policy fallback
- cover the Fix and Review Loop nested resolver path and the OpenCode kill switch

## Root cause

A nested resolver created by Fix and Review Loop had no precompiled Omnigent plan. Its OpenCode runtime selected `opencode-on-demand@1`, but startup had never persisted that policy. Host preparation exhausted its retries with `PolicyNotFound` before an agent launched.

## Verification

- targeted Omnigent policy, execution-plan, startup, and qualification unit suites pass
- `./tools/test_integration.sh`: 618 passed, 1 skipped
- Ruff and diff checks pass