### PR TITLE
Fix GitHub batch child repository authority

### DIFF
--- a/.agents/skills/_shared/batch_workflows.py
+++ b/.agents/skills/_shared/batch_workflows.py
@@ -59,12 +59,8 @@ SUPPORTED_RUN_REFS = frozenset(
     }
 )
 _GITHUB_RANGE_PATTERN = re.compile(r"^(?P<start>\d+)-(?P<end>\d+)$")
-_SAFE_GIT_BRANCH = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9._/@+-]{0,253}(?<!\.lock)$"
-)
 _GITHUB_GRAPHQL_CHUNK_SIZE = 50
 _GITHUB_MAX_SEARCH_WIDTH = 1000
-_DEFAULT_GIT_CONNECTION_REF = "repository-connection:git-default"
 
 
 class BatchInputError(ValueError):
@@ -132,6 +128,25 @@ def _normalize_repo(value: Any) -> str | None:
     return candidate or None
 
 
+def _git_branch_is_valid(value: Any) -> bool:
+    """Validate a branch with Git's canonical ref-name implementation."""
+
+    branch = _text(value)
+    if branch is None:
+        return False
+    try:
+        completed = subprocess.run(
+            ["git", "check-ref-format", "--branch", branch],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except OSError as exc:
+        raise RuntimeError("Git branch validation is unavailable") from exc
+    return completed.returncode == 0
+
+
 def parse_github_issue_range(value: str) -> tuple[int, int]:
     """Parse an inclusive GitHub issue-number search range."""
 
@@ -185,6 +200,7 @@ def resolve_github_issue_range(
     repository: str,
     issue_range: str,
     *,
+    connection_ref: str,
     run_command: Any = subprocess.run,
 ) -> list[dict[str, Any]]:
     """Return only open GitHub Issues whose numbers fall in ``issue_range``.
@@ -197,6 +213,11 @@ def resolve_github_issue_range(
 
     owner, name = _github_repository_parts(repository)
     normalized_repository = f"{owner}/{name}"
+    normalized_connection_ref = _text(connection_ref)
+    if normalized_connection_ref is None:
+        raise BatchInputError(
+            "GitHub issue discovery requires parent repository connection authority"
+        )
     start, end = parse_github_issue_range(issue_range)
     search_width = end - start + 1
     if search_width > _GITHUB_MAX_SEARCH_WIDTH:
@@ -278,7 +299,7 @@ def resolve_github_issue_range(
             if isinstance(default_branch_ref, dict)
             else None
         )
-        if default_branch is None or _SAFE_GIT_BRANCH.fullmatch(default_branch) is None:
+        if not _git_branch_is_valid(default_branch):
             raise RuntimeError(
                 "GitHub repository default branch is unavailable or unsafe: "
                 f"{normalized_repository}"
@@ -294,7 +315,7 @@ def resolve_github_issue_range(
         resolved_default_branch = default_branch
         repository_target = {
             "provider": "git",
-            "connectionRef": _DEFAULT_GIT_CONNECTION_REF,
+            "connectionRef": normalized_connection_ref,
             "repository": {"name": normalized_repository},
             "branch": {"name": default_branch},
         }
@@ -587,7 +608,7 @@ def build_child_request(
             or connection_ref is None
             or target_repository is None
             or target_branch is None
-            or _SAFE_GIT_BRANCH.fullmatch(target_branch) is None
+            or not _git_branch_is_valid(target_branch)
         ):
             raise BatchInputError(
                 "resolved Git repository target requires provider, connection, "
@@ -836,6 +857,38 @@ def _load_parent_repository(task_context_path: str | None = None) -> str | None:
         normalized = _normalize_repo(payload.get("repository"))
         if normalized:
             return normalized
+    return None
+
+
+def _load_parent_repository_connection_ref(
+    task_context_path: str | None = None,
+) -> str | None:
+    seen: set[str] = set()
+    for candidate in _task_context_candidates(task_context_path):
+        identity = str(candidate.expanduser())
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for target in (payload.get("repositoryTarget"), payload.get("repository")):
+            if not isinstance(target, dict):
+                continue
+            if (_text(target.get("provider")) or "").lower() != "git":
+                continue
+            connection_ref = _text(target.get("connectionRef"))
+            if connection_ref:
+                return connection_ref
+        auth = payload.get("auth") if isinstance(payload.get("auth"), dict) else {}
+        connection_ref = _text(auth.get("repoAuthRef"))
+        if connection_ref:
+            return connection_ref
     return None
 
 
@@ -1091,6 +1144,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--github-repository",
         help="GitHub owner/repository; defaults to the parent task repository.",
     )
+    parser.add_argument(
+        "--repository-connection-ref",
+        help=(
+            "Canonical repository connection authority; defaults to the parent "
+            "task context or MOONMIND_REPOSITORY_CONNECTION_REF."
+        ),
+    )
     parser.add_argument("--run-ref", required=True)
     parser.add_argument("--publish-mode", default="pr")
     parser.add_argument("--constraints", default=None)
@@ -1198,9 +1258,20 @@ def main(argv: list[str] | None = None) -> int:
                 raise BatchInputError(
                     "--github-repository is required when parent repository context is unavailable"
                 )
+            repository_connection_ref = (
+                _text(args.repository_connection_ref)
+                or _load_parent_repository_connection_ref(args.task_context_path)
+                or _text(os.getenv("MOONMIND_REPOSITORY_CONNECTION_REF"))
+            )
+            if not repository_connection_ref:
+                raise BatchInputError(
+                    "--repository-connection-ref is required when parent repository "
+                    "connection context is unavailable"
+                )
             targets = resolve_github_issue_range(
                 github_repository,
                 args.github_issue_range,
+                connection_ref=repository_connection_ref,
             )
             targets_path = artifacts_dir / "batch-workflows-targets.json"
             _write_artifacts(targets_path, {"targets": targets})

--- a/.agents/skills/_shared/batch_workflows.py
+++ b/.agents/skills/_shared/batch_workflows.py
@@ -59,8 +59,12 @@ SUPPORTED_RUN_REFS = frozenset(
     }
 )
 _GITHUB_RANGE_PATTERN = re.compile(r"^(?P<start>\d+)-(?P<end>\d+)$")
+_SAFE_GIT_BRANCH = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._/@+-]{0,253}(?<!\.lock)$"
+)
 _GITHUB_GRAPHQL_CHUNK_SIZE = 50
 _GITHUB_MAX_SEARCH_WIDTH = 1000
+_DEFAULT_GIT_CONNECTION_REF = "repository-connection:git-default"
 
 
 class BatchInputError(ValueError):
@@ -170,6 +174,7 @@ def _github_issue_range_query(numbers: list[int]) -> str:
     return (
         "query($owner: String!, $name: String!) {\n"
         "  repository(owner: $owner, name: $name) {\n"
+        "    defaultBranchRef { name }\n"
         f"{selections}\n"
         "  }\n"
         "}"
@@ -200,6 +205,7 @@ def resolve_github_issue_range(
             f"{_GITHUB_MAX_SEARCH_WIDTH} numbers"
         )
     targets: list[dict[str, Any]] = []
+    resolved_default_branch: str | None = None
 
     for chunk_start in range(start, end + 1, _GITHUB_GRAPHQL_CHUNK_SIZE):
         numbers = list(
@@ -266,6 +272,32 @@ def resolve_github_issue_range(
             raise RuntimeError(
                 f"GitHub repository was not found or is not readable: {normalized_repository}"
             )
+        default_branch_ref = repository_data.get("defaultBranchRef")
+        default_branch = (
+            _text(default_branch_ref.get("name"))
+            if isinstance(default_branch_ref, dict)
+            else None
+        )
+        if default_branch is None or _SAFE_GIT_BRANCH.fullmatch(default_branch) is None:
+            raise RuntimeError(
+                "GitHub repository default branch is unavailable or unsafe: "
+                f"{normalized_repository}"
+            )
+        if (
+            resolved_default_branch is not None
+            and resolved_default_branch != default_branch
+        ):
+            raise RuntimeError(
+                "GitHub repository default branch changed during issue discovery: "
+                f"{normalized_repository}"
+            )
+        resolved_default_branch = default_branch
+        repository_target = {
+            "provider": "git",
+            "connectionRef": _DEFAULT_GIT_CONNECTION_REF,
+            "repository": {"name": normalized_repository},
+            "branch": {"name": default_branch},
+        }
 
         for number in numbers:
             issue = repository_data.get(f"issue{number}")
@@ -297,6 +329,7 @@ def resolve_github_issue_range(
                         "labels": labels,
                     },
                     "repository": normalized_repository,
+                    "repositoryTarget": repository_target,
                 }
             )
 
@@ -533,6 +566,39 @@ def build_child_request(
         or _normalize_repo(target.get("batch_repository"))
         or _normalize_repo(default_repository)
     )
+    repository_target = target.get("repositoryTarget")
+    if repository_target is not None:
+        if not isinstance(repository_target, dict):
+            raise BatchInputError("resolved repository target must be an object")
+        provider_name = (_text(repository_target.get("provider")) or "").lower()
+        connection_ref = _text(repository_target.get("connectionRef"))
+        repository_node = repository_target.get("repository")
+        branch_node = repository_target.get("branch")
+        target_repository = (
+            _normalize_repo(repository_node.get("name"))
+            if isinstance(repository_node, dict)
+            else None
+        )
+        target_branch = (
+            _text(branch_node.get("name")) if isinstance(branch_node, dict) else None
+        )
+        if (
+            provider_name != "git"
+            or connection_ref is None
+            or target_repository is None
+            or target_branch is None
+            or _SAFE_GIT_BRANCH.fullmatch(target_branch) is None
+        ):
+            raise BatchInputError(
+                "resolved Git repository target requires provider, connection, "
+                "repository, and a safe branch"
+            )
+        repository_target = {
+            "provider": "git",
+            "connectionRef": connection_ref,
+            "repository": {"name": target_repository},
+            "branch": {"name": target_branch},
+        }
     if not ref:
         return None
 
@@ -582,7 +648,9 @@ def build_child_request(
         "requiredCapabilities": required_capabilities,
         "task": task_payload,
     }
-    if repository:
+    if repository_target is not None:
+        payload_dict["repository"] = repository_target
+    elif repository:
         payload_dict["repository"] = repository
 
     # Server-side inheritance contract: when running inside a workflow with a

--- a/.agents/skills/batch-github-workflows/SKILL.md
+++ b/.agents/skills/batch-github-workflows/SKILL.md
@@ -60,10 +60,14 @@ execute the same portable fan-out engine from the resolved active Skill snapshot
    ```
 
    The portable engine uses trusted GitHub GraphQL `issue(number:)` lookups and
-   writes `artifacts/batch-workflows-targets.json` before queueing. It includes
-   only explicit open Issue objects; closed issues, pull requests, absent
-   numbers, and ambiguous states are omitted normally. Numeric spans wider than
-   1,000 are rejected before querying.
+   resolves the repository's current default branch in the same query before it
+   writes `artifacts/batch-workflows-targets.json` and queues children. Every
+   child receives the canonical Git repository target, including the default
+   connection and resolved branch. A missing, unreadable, changing, or unsafe
+   default branch fails discovery before queueing. The engine includes only
+   explicit open Issue objects; closed issues, pull requests, absent numbers,
+   and ambiguous states are omitted normally. Numeric spans wider than 1,000 are
+   rejected before querying.
 
    The engine binds GitHub issue data into the selected child, stamps
    `runtimeInheritance="caller"` plus the parent's effective runtime fallback,

--- a/.agents/skills/batch-github-workflows/SKILL.md
+++ b/.agents/skills/batch-github-workflows/SKILL.md
@@ -34,6 +34,8 @@ execute the same portable fan-out engine from the resolved active Skill snapshot
   `preset:github-issue-orchestrate`.
 - `repository` (string, optional): GitHub `owner/repository`; default to workflow
   repository context.
+- `repository_connection_ref` (string, optional): canonical repository connection
+  authority; default to workflow context or `MOONMIND_REPOSITORY_CONNECTION_REF`.
 - `max_workflows` (number, optional): hard cap on queued children; default `25`.
 - `constraints` (string, optional): shared child guidance.
 - `run_verify` (boolean, optional): verification toggle for child presets;
@@ -52,6 +54,7 @@ execute the same portable fan-out engine from the resolved active Skill snapshot
    python3 "$MOONMIND_ACTIVE_SKILLS_DIR/batch-github-workflows/bin/batch_workflows.py" \
      --github-issue-range <START-END> \
      --github-repository <owner/repository> \
+     --repository-connection-ref <repository connection ref> \
      --run-ref <curated GitHub run ref> \
      --publish-mode <none|branch|pr|pr_with_merge_automation> \
      --constraints-file <optional constraints path> \
@@ -62,9 +65,12 @@ execute the same portable fan-out engine from the resolved active Skill snapshot
    The portable engine uses trusted GitHub GraphQL `issue(number:)` lookups and
    resolves the repository's current default branch in the same query before it
    writes `artifacts/batch-workflows-targets.json` and queues children. Every
-   child receives the canonical Git repository target, including the default
-   connection and resolved branch. A missing, unreadable, changing, or unsafe
-   default branch fails discovery before queueing. The engine includes only
+   child receives the canonical Git repository target, including the caller's
+   exact connection authority and resolved branch. The connection is read from
+   the explicit argument, parent task context, or
+   `MOONMIND_REPOSITORY_CONNECTION_REF`; discovery fails before queueing when it
+   is unavailable. A missing, unreadable, changing, or Git-invalid default
+   branch also fails discovery before queueing. The engine includes only
    explicit open Issue objects; closed issues, pull requests, absent numbers,
    and ambiguous states are omitted normally. Numeric spans wider than 1,000 are
    rejected before querying.

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -111,6 +111,26 @@ In issue-brief verification mode:
 5. Inspect production code and tests directly; do not treat the assessment itself as proof that new work is complete.
 6. Do not require `spec.md`, `plan.md`, `tasks.md`, or a standalone constitution file.
 
+When verification follows a remediation attempt, rebuild every controlling
+classification from the current repository head. A previous verifier report,
+its `remainingWork`, and the original assessment are hypotheses and process
+context only; they are not current implementation evidence. For every prior
+`PARTIAL`, `MISSING`, or remaining-work item, inspect the current production
+code and tests and replace the old status, evidence, line numbers, and notes
+with current findings. Never copy or incrementally edit a previous verifier
+JSON report as the new report. If the current head differs from the head named
+by the assessment or previous report, no gap may remain solely because the old
+artifact said it existed or because the candidate is not on the base branch.
+
+Verify the candidate state at the boundary where this skill is invoked. In a
+pre-publication verification step, an uncommitted workspace, an absent pull
+request, an open issue, and an unmerged candidate are expected inputs, not
+implementation or documentation gaps. Do not require downstream commit, pull
+request, merge, deployment, or issue-closure evidence before returning
+`FULLY_IMPLEMENTED`. Gate on those outcomes only when the selected baseline
+explicitly makes publication itself part of this verification step and the
+workflow has already supplied the resulting publication evidence.
+
 ## Controlling vs Advisory Verification
 
 Separate verification evidence into controlling and advisory classes before choosing the verdict.
@@ -282,6 +302,21 @@ Run commands when available and safe:
 - Build, lint, or typecheck commands when they are part of the documented validation path or needed to resolve ambiguity.
 
 Record exact command results as `PASS`, `FAIL`, or `NOT RUN`.
+
+Follow the repository's managed-agent test boundary when `AGENTS.md` defines
+one. At the start of command discovery, treat a non-empty
+`MOONMIND_STEP_EXECUTION_ID` as proof that the workspace is MoonMind-managed
+and check `command -v moonmind` before attempting any Python test. When the
+boundary requires `moonmind container python-tests ...`, route every Python
+test through that command. In a managed workspace, do not run `pytest`,
+`python -m pytest`, `python3 -m pytest`, the Python portion of
+`./tools/test_unit.sh`, or any command that installs pytest into the agent
+host. Host-local Python results are invalid verification evidence at this
+boundary. The absence of `pytest` in the agent host does not make the
+repository test unavailable while the documented `moonmind container`
+capability exists. If that capability is missing or rejects the job, preserve
+its explicit container-job evidence and classify the environment according to
+`AGENTS.md`.
 
 Use `NOT RUN` with an exact reason when a command requires unavailable credentials, missing services, unsafe side effects, unsupported local tools, or excessive environment setup.
 Use the controlling/advisory split when interpreting results. Missing map assets, game/editor content assets, external services, credentials, or other non-hermetic integration/e2e prerequisites are advisory limitations unless the command output exposes a concrete in-scope implementation defect.

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -29,7 +29,7 @@ When `artifacts/moonspec/source-acceptance.json` or `artifacts/moonspec/acceptan
 
 ## Inputs
 
-- Treat explicitly identified original implementation instructions as a valid verification baseline, not merely optional focus.
+- Treat the user's instructions as a valid verification baseline, not merely optional focus.
 - Treat a referenced declarative document as a valid verification baseline. Read it directly and verify its in-scope desired-state claims without requiring a derived MoonSpec feature packet.
 - Do not treat ad hoc verifier guidance, such as "focus on API tests", workflow meta-instructions, or review-process instructions, as the verification baseline when an issue brief, `spec.md`, feature directory, original implementation request, or declarative source is available. Use that guidance only to prioritize evidence gathering within the real baseline.
 - In issue-brief verification mode, use the provided issue brief artifact, issue reference, acceptance criteria, and assessment artifact as the verification baseline without requiring a MoonSpec feature directory, `spec.md`, `plan.md`, or `tasks.md`.
@@ -304,19 +304,15 @@ Run commands when available and safe:
 Record exact command results as `PASS`, `FAIL`, or `NOT RUN`.
 
 Follow the repository's managed-agent test boundary when `AGENTS.md` defines
-one. At the start of command discovery, treat a non-empty
-`MOONMIND_STEP_EXECUTION_ID` as proof that the workspace is MoonMind-managed
-and check `command -v moonmind` before attempting any Python test. When the
-boundary requires `moonmind container python-tests ...`, route every Python
-test through that command. In a managed workspace, do not run `pytest`,
-`python -m pytest`, `python3 -m pytest`, the Python portion of
-`./tools/test_unit.sh`, or any command that installs pytest into the agent
-host. Host-local Python results are invalid verification evidence at this
-boundary. The absence of `pytest` in the agent host does not make the
-repository test unavailable while the documented `moonmind container`
-capability exists. If that capability is missing or rejects the job, preserve
-its explicit container-job evidence and classify the environment according to
-`AGENTS.md`.
+one. Before running tests, inspect that guidance for the documented managed-run
+signal and required delegated test command. When the current workspace meets
+that signal, confirm the required command is available and route every covered
+test through it. Do not run an equivalent host-local test command or install a
+test runner into the agent host; results from a path the repository forbids are
+invalid verification evidence. A missing host-local runner does not make a
+test unavailable while the documented delegated capability exists. If that
+capability is missing or rejects the job, preserve its explicit evidence and
+classify the environment according to `AGENTS.md`.
 
 Use `NOT RUN` with an exact reason when a command requires unavailable credentials, missing services, unsafe side effects, unsupported local tools, or excessive environment setup.
 Use the controlling/advisory split when interpreting results. Missing map assets, game/editor content assets, external services, credentials, or other non-hermetic integration/e2e prerequisites are advisory limitations unless the command output exposes a concrete in-scope implementation defect.

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -18460,9 +18460,10 @@ async def rerun_execution(
             canonical_identifier=canonical_workflow_id,
         )
 
-    execution = _serialize_execution(record, user=user)
     if snapshot_ref:
         await session.commit()
+        await session.refresh(record)
+    execution = _serialize_execution(record, user=user)
     return execution
 
 

--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -154,6 +154,7 @@ steps:
     python3 "$MOONMIND_ACTIVE_SKILLS_DIR/batch-github-workflows/bin/batch_workflows.py" \
     --github-issue-range "{{ inputs.issue_range }}" \
     --github-repository "{{ inputs.repository }}" \
+    --repository-connection-ref "$MOONMIND_REPOSITORY_CONNECTION_REF" \
     --run-ref "{{ inputs.run_ref }}" \
     --publish-mode "{{ inputs.publish_mode }}" \
     --max-workflows "{{ inputs.max_workflows }}" \

--- a/api_service/data/presets/github-issue-implement.yaml
+++ b/api_service/data/presets/github-issue-implement.yaml
@@ -193,6 +193,8 @@ steps:
     run_verify: '{{ inputs.run_verify }}'
 - title: Finalize GitHub issue status
   type: tool
+  annotations:
+    issueImplementRole: code-review-handoff
   instructions: 'Read artifacts/github-issue-implement-assessment.json (or the recorded
     verdict from the assess step) before changing GitHub.
 

--- a/moonmind/omnigent/bridge_artifacts.py
+++ b/moonmind/omnigent/bridge_artifacts.py
@@ -254,6 +254,50 @@ class TemporalOmnigentArtifactGateway(OmnigentArtifactGateway):
             )
         return payload
 
+    async def read_chunks(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool = False,
+        chunk_size: int,
+    ) -> tuple[Any, Any]:
+        """Expose the bounded artifact stream used by workspace projection."""
+
+        from moonmind.workflows.temporal.artifacts import (
+            TemporalArtifactRepository,
+            TemporalArtifactService,
+        )
+
+        async with self._session_factory() as session:
+            service = TemporalArtifactService(TemporalArtifactRepository(session))
+            return await service.read_chunks(
+                artifact_id=self._artifact_id(artifact_id),
+                principal=principal,
+                allow_restricted_raw=allow_restricted_raw,
+                chunk_size=chunk_size,
+            )
+
+    async def get_metadata(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+    ) -> tuple[Any, ...]:
+        """Expose artifact links so attachment authority is verified pre-launch."""
+
+        from moonmind.workflows.temporal.artifacts import (
+            TemporalArtifactRepository,
+            TemporalArtifactService,
+        )
+
+        async with self._session_factory() as session:
+            service = TemporalArtifactService(TemporalArtifactRepository(session))
+            return await service.get_metadata(
+                artifact_id=self._artifact_id(artifact_id),
+                principal=principal,
+            )
+
 
 class LocalOmnigentArtifactGateway(OmnigentArtifactGateway):
     """Local MoonMind artifact gateway for Omnigent evidence capture."""

--- a/moonmind/omnigent/host_services/workspace.py
+++ b/moonmind/omnigent/host_services/workspace.py
@@ -12,6 +12,10 @@ from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformError,
     HarnessPlatformFailure,
 )
+from moonmind.omnigent.workspace_artifacts import (
+    WorkspaceArtifactProjectionError,
+    WorkspaceArtifactProjector,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
 from moonmind.workflows.temporal.runtime.workspace_locators import (
@@ -22,9 +26,6 @@ from moonmind.workflows.temporal.runtime.workspace_locators import (
 )
 
 _SAFE_VOLUME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
-_SAFE_CLONE_REF = re.compile(
-    r"^[A-Za-z0-9][A-Za-z0-9._/@+-]{0,253}(?<!\.lock)$"
-)
 
 
 class DaemonCommandRunner(Protocol):
@@ -87,6 +88,7 @@ class OmnigentWorkspaceMaterializer:
         command_runner: DaemonCommandRunner,
         workspace_root: str | Path | None = None,
         workspace_volume: str | None = None,
+        artifact_service: Any | None = None,
     ) -> None:
         self._runner = command_runner
         self._root = Path(
@@ -98,6 +100,7 @@ class OmnigentWorkspaceMaterializer:
             or os.getenv("MOONMIND_AGENT_WORKSPACES_VOLUME_NAME")
             or "agent_workspaces"
         ).strip()
+        self._artifact_projector = WorkspaceArtifactProjector(artifact_service)
 
     async def materialize(
         self,
@@ -116,6 +119,17 @@ class OmnigentWorkspaceMaterializer:
             request.workspace_spec if isinstance(request.workspace_spec, dict) else {}
         )
         locator = spec.get("workspaceLocator")
+        step_execution = getattr(request, "step_execution", None)
+        owner_workflow_id = str(
+            getattr(step_execution, "workflow_id", None)
+            or getattr(request, "correlation_id", "")
+        ).strip()
+        owner_step_execution_id = str(
+            getattr(step_execution, "step_execution_id", None)
+            or getattr(request, "idempotency_key", "")
+        ).strip()
+        record_store: SandboxWorkspaceRecordStore | None = None
+        workspace_id: str | None = None
         authored = str(spec.get("workspacePath") or spec.get("path") or "").strip()
         if authored:
             candidate = Path(authored).resolve()
@@ -128,15 +142,6 @@ class OmnigentWorkspaceMaterializer:
                     "sandbox workspace locator is invalid",
                     code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
                 ) from exc
-            step_execution = getattr(request, "step_execution", None)
-            owner_workflow_id = str(
-                getattr(step_execution, "workflow_id", None)
-                or getattr(request, "correlation_id", "")
-            ).strip()
-            owner_step_execution_id = str(
-                getattr(step_execution, "step_execution_id", None)
-                or getattr(request, "idempotency_key", "")
-            ).strip()
             if not owner_workflow_id or not owner_step_execution_id:
                 raise HarnessPlatformError(
                     "sandbox workspace owner identity is unavailable",
@@ -158,6 +163,7 @@ class OmnigentWorkspaceMaterializer:
                 relative_path=sandbox_locator.relative_path,
             )
             record_store = SandboxWorkspaceRecordStore(self._root)
+            workspace_id = sandbox_locator.workspace_id
             record_store.ensure(owner_record)
             resolve_sandbox_workspace_locator(
                 sandbox_locator,
@@ -199,6 +205,35 @@ class OmnigentWorkspaceMaterializer:
                 "authoritative workspace is unavailable or unsafe",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+        materialization_complete = bool(
+            record_store is not None
+            and workspace_id is not None
+            and record_store.is_materialized(workspace_id)
+        )
+        if not materialization_complete:
+            restore_refs = spec.get("restoreInputRefs")
+            if not isinstance(restore_refs, (list, tuple)):
+                restore_refs = ()
+            attachment_refs = getattr(request, "input_refs", ())
+            if not isinstance(attachment_refs, (list, tuple)):
+                attachment_refs = ()
+            checkpoint_ref = str(
+                spec.get("workspaceCheckpointRestoreRef") or ""
+            ).strip()
+            try:
+                await self._artifact_projector.project(
+                    candidate,
+                    checkpoint_ref=checkpoint_ref or None,
+                    restore_refs=tuple(str(ref) for ref in restore_refs),
+                    attachment_refs=tuple(str(ref) for ref in attachment_refs),
+                    workflow_id=owner_workflow_id,
+                    runtime_uid=runtime_uid,
+                    runtime_gid=runtime_gid,
+                )
+            except WorkspaceArtifactProjectionError as exc:
+                raise HarnessPlatformError(str(exc), code=exc.code) from exc
+            if record_store is not None and workspace_id is not None:
+                record_store.mark_materialized(workspace_id)
         daemon_root = await resolve_daemon_workspace_root(
             runner=self._runner,
             workspace_volume=self._workspace_volume,
@@ -256,7 +291,7 @@ class OmnigentWorkspaceMaterializer:
             or ""
         ).strip()
         clone_source = normalize_github_clone_source(repo_ref)
-        if clone_source is None or not branch or not _SAFE_CLONE_REF.fullmatch(branch):
+        if clone_source is None or not branch or len(branch) > 400:
             raise HarnessPlatformError(
                 "sandbox workspace preparation needs a GitHub repository and safe branch ref",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
@@ -357,6 +392,7 @@ def build_daemon_git_clone_argv(
         "set -eu; umask 077; token_file=$(mktemp); "
         "trap 'rm -f \"$token_file\"' EXIT HUP INT TERM; "
         "cat > \"$token_file\"; "
+        "git check-ref-format --branch \"$1\" >/dev/null; "
         "credential_helper='!f() { test \"$1\" = get || exit 0; "
         "printf \"username=x-access-token\\npassword=\"; "
         "cat \"$MM_GIT_TOKEN_FILE\"; printf \"\\n\"; }; f'; "

--- a/moonmind/omnigent/oauth_host_runtime.py
+++ b/moonmind/omnigent/oauth_host_runtime.py
@@ -194,6 +194,7 @@ _RUNTIME_EXECUTION_PROFILE_ENV_NAMES = (
     "MOONMIND_TASK_WORKFLOW_ID",
     "MOONMIND_STEP_ID",
     "MOONMIND_RUNTIME_ID",
+    "MOONMIND_REPOSITORY_CONNECTION_REF",
     "MOONMIND_CONTAINER_JOBS_MCP_URL",
     "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
     "MOONMIND_CONTAINER_JOBS_SESSION_ID",
@@ -233,6 +234,11 @@ _SAFE_STEP_EXECUTION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,510}[A-Za-z
 _MAX_RESTORE_INPUT_REFS = 64
 _MAX_RESTORE_INPUT_BYTES = 64 * 1024 * 1024
 _MAX_RESTORE_TOTAL_BYTES = 256 * 1024 * 1024
+# A worktree checkpoint is one complete repository snapshot rather than one
+# member of the generic restore-input bundle. Keep it under the same aggregate
+# hostile-input ceiling while allowing normal repositories to exceed the
+# per-attachment limit.
+_MAX_WORKSPACE_CHECKPOINT_BYTES = _MAX_RESTORE_TOTAL_BYTES
 _HOST_EXEC_PREFLIGHT_ATTEMPTS = 11
 _HOST_EXEC_PREFLIGHT_INTERVAL_SECONDS = 1
 # Restore payloads are read through the durable artifact contract as raw bytes,
@@ -638,6 +644,7 @@ class OmnigentOAuthHostRuntime:
                 timeout_seconds=int(launch["limits"]["timeoutSeconds"]),
                 required_capabilities=required_capabilities,
                 execution_fanout_authorization=execution_fanout_authorization,
+                repository_connection_ref=repository_connection_ref,
             )
             daemon_runtime_scripts = self._prepare_daemon_runtime_scripts(
                 host_lease.lease_id,
@@ -2389,6 +2396,7 @@ class OmnigentOAuthHostRuntime:
         timeout_seconds: int,
         required_capabilities: Sequence[str] = (),
         execution_fanout_authorization: Mapping[str, Any] | None = None,
+        repository_connection_ref: str = "",
     ) -> dict[str, str]:
         """Materialize only the runtime capabilities declared for this host lease."""
 
@@ -2432,6 +2440,13 @@ class OmnigentOAuthHostRuntime:
             "MOONMIND_STEP_ID": current_step_execution_id,
             "MOONMIND_RUNTIME_ID": runtime_id,
         }
+        normalized_repository_connection_ref = str(
+            repository_connection_ref or ""
+        ).strip()
+        if normalized_repository_connection_ref:
+            environment["MOONMIND_REPOSITORY_CONNECTION_REF"] = (
+                normalized_repository_connection_ref
+            )
         if "docker" in normalized_capabilities:
             environment.update(
                 {
@@ -2748,13 +2763,20 @@ class OmnigentOAuthHostRuntime:
         #    pre-materialized by its external owner (for example a remediation
         #    workspace) and is reused as-is.
         already_materialized = workspace.is_dir()
+        materialization_complete = record_store.is_materialized(
+            locator.workspace_id
+        )
         if (
             source
             and already_materialized
-            and not record_store.is_materialized(locator.workspace_id)
+            and not materialization_complete
         ):
             shutil.rmtree(workspace)
             already_materialized = False
+        if not already_materialized:
+            # A completion marker without its owned workspace cannot authorize a
+            # skip. Rebuild from the authored source when one is available.
+            materialization_complete = False
         # 4. A workspace that is neither present nor accompanied by an authored
         #    repository source cannot be created here; reject before running any
         #    command.
@@ -2769,21 +2791,22 @@ class OmnigentOAuthHostRuntime:
         #    workspace and skip all git and archive mutation.
         self._last_workspace_denial_evidence = {}
         materialization: dict[str, Any] = {"action": "reused_pre_materialized"}
-        if not already_materialized:
+        if not materialization_complete:
             # Every mutation from here to the durable completion marker is owned by
             # this run. If any step fails, bounded reconciliation evidence records
             # whether owned partial state was created and that a retry must rebuild
             # it, because the absent completion marker forces a rebuild rather than
             # reuse of a partial directory.
             try:
-                materialization = await self._materialize_repository(
-                    workspace,
-                    repository_source=source,
-                    starting_branch=starting_branch,
-                    target_branch=target_branch,
-                    checkout_commit=checkout_commit,
-                    github_token=github_token,
-                )
+                if not already_materialized:
+                    materialization = await self._materialize_repository(
+                        workspace,
+                        repository_source=source,
+                        starting_branch=starting_branch,
+                        target_branch=target_branch,
+                        checkout_commit=checkout_commit,
+                        github_token=github_token,
+                    )
                 restore_evidence = await self._materialize_restore_inputs(
                     workspace,
                     restore_input_refs=restore_input_refs,
@@ -2794,6 +2817,9 @@ class OmnigentOAuthHostRuntime:
                         workspace,
                         artifact_ref=workspace_checkpoint_restore_ref,
                         artifact_gateway=artifact_gateway,
+                    )
+                    materialization["checkpointRestoreRef"] = (
+                        workspace_checkpoint_restore_ref
                     )
                 if restore_evidence:
                     materialization["restoreInputs"] = restore_evidence
@@ -3055,20 +3081,54 @@ class OmnigentOAuthHostRuntime:
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             )
         artifact_id = artifact_ref[len("artifact://") :]
-        _metadata, payload = await service.read(
-            artifact_id=artifact_id,
-            principal=_RESTORE_ARTIFACT_PRINCIPAL,
-            allow_restricted_raw=True,
+        await self._reject_oversized_restore_metadata(
+            service,
+            artifact_id,
+            _MAX_WORKSPACE_CHECKPOINT_BYTES,
         )
-        if len(payload) > _MAX_RESTORE_INPUT_BYTES:
-            raise OmnigentOAuthHostError(
-                "workspace checkpoint exceeds the authorized workspace bound",
-                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+        archive_path: Path
+        remove_archive = False
+        read_path = getattr(service, "read_path", None)
+        if read_path is not None:
+            _metadata, resolved_path = await read_path(
+                artifact_id=artifact_id,
+                principal=_RESTORE_ARTIFACT_PRINCIPAL,
+                allow_restricted_raw=True,
             )
+            archive_path = Path(resolved_path)
+            try:
+                archive_size = archive_path.stat().st_size
+            except OSError as exc:
+                raise OmnigentOAuthHostError(
+                    "workspace checkpoint archive is unavailable",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+            if archive_size > _MAX_WORKSPACE_CHECKPOINT_BYTES:
+                raise OmnigentOAuthHostError(
+                    "workspace checkpoint exceeds the authorized workspace bound",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+        else:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=".moonmind-checkpoint-",
+                suffix=".tar.gz",
+                dir=workspace.parent,
+            )
+            os.close(descriptor)
+            archive_path = Path(temporary_name)
+            remove_archive = True
+            try:
+                await self._write_restore_payload(
+                    service,
+                    artifact_id=artifact_id,
+                    target=archive_path,
+                    budget_bytes=_MAX_WORKSPACE_CHECKPOINT_BYTES,
+                )
+            except BaseException:
+                archive_path.unlink(missing_ok=True)
+                raise
         try:
-            with tarfile.open(
-                fileobj=__import__("io").BytesIO(payload), mode="r:gz"
-            ) as archive:
+            with tarfile.open(archive_path, mode="r:gz") as archive:
                 for member in archive.getmembers():
                     target = (workspace / member.name).resolve()
                     if not target.is_relative_to(workspace.resolve()) or member.isdev():
@@ -3089,6 +3149,9 @@ class OmnigentOAuthHostRuntime:
                 "workspace checkpoint archive could not be applied",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             ) from exc
+        finally:
+            if remove_archive:
+                archive_path.unlink(missing_ok=True)
 
     async def _materialize_attachments(
         self,

--- a/moonmind/omnigent/production.py
+++ b/moonmind/omnigent/production.py
@@ -188,6 +188,7 @@ def build_generic_omnigent_execution_services(
             command_runner=daemon_command,
             workspace_root=workspace_root,
             workspace_volume=workspace_volume,
+            artifact_service=artifacts,
         ),
         skill_service=OmnigentSkillDeliveryService(
             workspace_root=workspace_root,

--- a/moonmind/omnigent/profile_bound_execution.py
+++ b/moonmind/omnigent/profile_bound_execution.py
@@ -1566,13 +1566,19 @@ class OmnigentProfileBoundExecutionCoordinator:
                     ttl_seconds=int(effective_launch["limits"]["timeoutSeconds"]),
                 )
             except OmnigentSameSessionContinuationRequired as exc:
-                if publish_mode not in {"branch", "pr"}:
+                if (
+                    publish_mode not in {"branch", "pr"}
+                    and not self._repository_mutation_required(request)
+                ):
                     raise
                 # The provider response is complete enough to admit recovery,
                 # but the active session projection is explicitly non-terminal.
                 # Keep every lease and the original bridge authoritative until
                 # a separately claimed same-session continuation reaches a real
-                # terminal boundary.
+                # terminal boundary. Repository-mutating workflow stages may
+                # deliberately use ``publishMode=none`` because their parent
+                # owns the durable checkpoint and later publication; they need
+                # the same recovery without publishing this intermediate stage.
                 running_turn_recovery = exc
                 attempt_cleanup_deferred_code = (
                     "same_session_continuation_pending"
@@ -1630,7 +1636,10 @@ class OmnigentProfileBoundExecutionCoordinator:
                         ),
                     )
                     runtime_binding_ref = updated_binding.runtimeBindingRef
-            if result.failure_class is None and publish_mode in {"branch", "pr"}:
+            publication_requested = publish_mode in {"branch", "pr"}
+            if result.failure_class is None and (
+                publication_requested or running_turn_recovery is not None
+            ):
                 publication_stage = "repository_publication"
                 no_commit_policy = _trusted_no_commit_repository_policy(request)
                 for continuation_index in range(
@@ -1679,6 +1688,18 @@ class OmnigentProfileBoundExecutionCoordinator:
                         completion.get("terminalAssistantAfterWork") is True
                         and not recovering_running_turn
                     ):
+                        if not publication_requested:
+                            result = result.model_copy(
+                                update={
+                                    "metadata": {
+                                        **dict(result.metadata or {}),
+                                        "repositoryContinuationCount": (
+                                            continuation_index
+                                        ),
+                                    }
+                                }
+                            )
+                            break
                         await emit(
                             publication_stage,
                             "started",

--- a/moonmind/omnigent/workspace_artifacts.py
+++ b/moonmind/omnigent/workspace_artifacts.py
@@ -1,0 +1,408 @@
+"""Runtime-neutral projection of durable inputs into an Omnigent workspace."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+MAX_INPUT_REFS = 64
+MAX_INPUT_BYTES = 64 * 1024 * 1024
+MAX_TOTAL_BYTES = 256 * 1024 * 1024
+MAX_CHECKPOINT_BYTES = MAX_TOTAL_BYTES
+STREAM_CHUNK_BYTES = 1024 * 1024
+RESTORE_PRINCIPAL = "service:omnigent_workspace_restore"
+ATTACHMENT_PRINCIPAL = "service:omnigent_workspace_attachment"
+
+
+class WorkspaceArtifactProjectionError(RuntimeError):
+    """A durable workspace input could not be projected safely."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class WorkspaceArtifactProjector:
+    """Apply checkpoints and declared inputs through one bounded data plane."""
+
+    def __init__(self, artifact_service: Any | None) -> None:
+        self._service = self._as_artifact_service(artifact_service)
+
+    async def project(
+        self,
+        workspace: Path,
+        *,
+        checkpoint_ref: str | None = None,
+        restore_refs: tuple[str, ...] = (),
+        attachment_refs: tuple[str, ...] = (),
+        workflow_id: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> dict[str, Any]:
+        """Project every authored input before the workspace is mounted."""
+
+        evidence: dict[str, Any] = {}
+        if checkpoint_ref:
+            await self._apply_checkpoint(workspace, checkpoint_ref)
+            evidence["checkpointRestoreRef"] = checkpoint_ref
+        # Checkpoints preserve repository work, not the prior step's injected
+        # context. Remove both runtime-owned input directories after extraction
+        # so each step sees only its explicitly authorized refs. Project the
+        # current restore inputs after the checkpoint so stale archived files
+        # cannot overwrite current authority.
+        self._clear_runtime_inputs(workspace)
+        restore_evidence = await self._materialize_bundle(
+            workspace,
+            refs=restore_refs,
+            subdir="restore",
+            principal=RESTORE_PRINCIPAL,
+            noun="restore inputs",
+            runtime_uid=runtime_uid,
+            runtime_gid=runtime_gid,
+        )
+        if restore_evidence:
+            evidence["restoreInputs"] = restore_evidence
+        attachment_evidence = await self._materialize_bundle(
+            workspace,
+            refs=attachment_refs,
+            subdir="attachments",
+            principal=ATTACHMENT_PRINCIPAL,
+            noun="attachments",
+            required_workflow_id=workflow_id,
+            runtime_uid=runtime_uid,
+            runtime_gid=runtime_gid,
+        )
+        if attachment_evidence:
+            self._exclude_attachments_from_git(workspace)
+            evidence["attachments"] = attachment_evidence
+        return evidence
+
+    @staticmethod
+    def _clear_runtime_inputs(workspace: Path) -> None:
+        """Delete checkpoint-carried inputs without following archived links."""
+
+        workspace_root = workspace.resolve()
+        for subdir in ("restore", "attachments"):
+            target = workspace / ".moonmind" / subdir
+            if not target.is_symlink() and not target.exists():
+                continue
+            resolved_parent = target.parent.resolve()
+            if not resolved_parent.is_relative_to(workspace_root):
+                raise WorkspaceArtifactProjectionError(
+                    "runtime input cleanup escaped the authorized workspace",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+            try:
+                if target.is_symlink() or not target.is_dir():
+                    target.unlink()
+                else:
+                    shutil.rmtree(target)
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "stale runtime inputs could not be cleared",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+
+    async def _apply_checkpoint(self, workspace: Path, artifact_ref: str) -> None:
+        artifact_id = self._artifact_id(artifact_ref, noun="workspace checkpoint")
+        service = self._require_service("workspace checkpoint")
+        await self._validate_metadata(
+            service,
+            artifact_id=artifact_id,
+            budget_bytes=MAX_CHECKPOINT_BYTES,
+            principal=RESTORE_PRINCIPAL,
+        )
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".moonmind-checkpoint-",
+            suffix=".tar.gz",
+            dir=workspace.parent,
+        )
+        os.close(descriptor)
+        archive_path = Path(temporary_name)
+        try:
+            await self._write_payload(
+                service,
+                artifact_id=artifact_id,
+                target=archive_path,
+                budget_bytes=MAX_CHECKPOINT_BYTES,
+                principal=RESTORE_PRINCIPAL,
+            )
+            workspace_root = workspace.resolve()
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                for member in archive.getmembers():
+                    target = (workspace / member.name).resolve()
+                    if not target.is_relative_to(workspace_root) or member.isdev():
+                        raise WorkspaceArtifactProjectionError(
+                            "workspace checkpoint contains an unsafe archive member",
+                            code="WORKSPACE_AUTHORITY_MISMATCH",
+                        )
+                    if member.issym() or member.islnk():
+                        link_target = (target.parent / member.linkname).resolve()
+                        if not link_target.is_relative_to(workspace_root):
+                            raise WorkspaceArtifactProjectionError(
+                                "workspace checkpoint symlink escapes workspace",
+                                code="WORKSPACE_AUTHORITY_MISMATCH",
+                            )
+                archive.extractall(workspace, filter="data")
+        except WorkspaceArtifactProjectionError:
+            raise
+        except (tarfile.TarError, OSError) as exc:
+            raise WorkspaceArtifactProjectionError(
+                "workspace checkpoint archive could not be applied",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+        finally:
+            archive_path.unlink(missing_ok=True)
+
+    async def _materialize_bundle(
+        self,
+        workspace: Path,
+        *,
+        refs: tuple[str, ...],
+        subdir: str,
+        principal: str,
+        noun: str,
+        required_workflow_id: str | None = None,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> list[dict[str, Any]]:
+        cleaned = tuple(
+            dict.fromkeys(str(ref).strip() for ref in refs if str(ref).strip())
+        )
+        if not cleaned:
+            return []
+        if len(cleaned) > MAX_INPUT_REFS:
+            raise WorkspaceArtifactProjectionError(
+                f"too many {noun} for the authorized workspace",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        service = self._require_service(noun)
+        root = (workspace / ".moonmind" / subdir).resolve()
+        if not root.is_relative_to(workspace.resolve()):
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} materialization escaped the authorized workspace",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        root.mkdir(parents=True, exist_ok=True)
+        evidence: list[dict[str, Any]] = []
+        total_bytes = 0
+        for ref in cleaned:
+            artifact_id = self._artifact_id(ref, noun=noun)
+            budget = min(MAX_INPUT_BYTES, MAX_TOTAL_BYTES - total_bytes)
+            if budget <= 0:
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} exceed the cumulative authorized workspace bound",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            await self._validate_metadata(
+                service,
+                artifact_id=artifact_id,
+                budget_bytes=budget,
+                principal=principal,
+                required_workflow_id=required_workflow_id,
+            )
+            target = root / hashlib.sha256(ref.encode("utf-8")).hexdigest()[:24]
+            if target.is_symlink():
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} target must not be a symlink",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+            written = await self._write_payload(
+                service,
+                artifact_id=artifact_id,
+                target=target,
+                budget_bytes=budget,
+                principal=principal,
+            )
+            self._make_runtime_readable(
+                target,
+                runtime_uid=runtime_uid,
+                runtime_gid=runtime_gid,
+                noun=noun,
+            )
+            total_bytes += written
+            evidence.append({"ref": ref, "bytes": written})
+        return evidence
+
+    @staticmethod
+    def _make_runtime_readable(
+        target: Path,
+        *,
+        runtime_uid: int,
+        runtime_gid: int,
+        noun: str,
+    ) -> None:
+        """Give only the selected runtime identity read access to an input."""
+
+        if runtime_uid < 0 or runtime_gid < 0:
+            target.unlink(missing_ok=True)
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} runtime identity is invalid",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        try:
+            current = target.stat(follow_symlinks=False)
+            if current.st_uid != runtime_uid or current.st_gid != runtime_gid:
+                os.chown(
+                    target,
+                    runtime_uid,
+                    runtime_gid,
+                    follow_symlinks=False,
+                )
+            os.chmod(target, 0o400, follow_symlinks=False)
+        except OSError as exc:
+            target.unlink(missing_ok=True)
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} could not be assigned to the selected runtime identity",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+    @staticmethod
+    def _artifact_id(ref: str, *, noun: str) -> str:
+        value = str(ref or "").strip()
+        if not value.startswith("artifact://") or not value[len("artifact://") :]:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} must be durable artifact refs, not local paths",
+                code="WORKSPACE_LOCATOR_UNSUPPORTED",
+            )
+        return value[len("artifact://") :]
+
+    def _require_service(self, noun: str) -> Any:
+        if self._service is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} require an artifact service to resolve refs",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        return self._service
+
+    @staticmethod
+    async def _validate_metadata(
+        service: Any,
+        *,
+        artifact_id: str,
+        budget_bytes: int,
+        principal: str,
+        required_workflow_id: str | None = None,
+    ) -> None:
+        get_metadata = getattr(service, "get_metadata", None)
+        if get_metadata is None:
+            if required_workflow_id is not None:
+                raise WorkspaceArtifactProjectionError(
+                    "attachment authorization requires linked artifact metadata",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+            return
+        metadata = await get_metadata(artifact_id=artifact_id, principal=principal)
+        artifact = metadata[0] if isinstance(metadata, tuple) else metadata
+        if required_workflow_id is not None:
+            links = metadata[1] if isinstance(metadata, tuple) and len(metadata) > 1 else ()
+            family = f"{required_workflow_id}:"
+            if not any(
+                str(getattr(link, "workflow_id", "")) == required_workflow_id
+                or str(getattr(link, "workflow_id", "")).startswith(family)
+                for link in links
+            ):
+                raise WorkspaceArtifactProjectionError(
+                    "attachment artifact is not linked to the current workflow family",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        size = getattr(artifact, "size_bytes", None)
+        if isinstance(size, int) and size > budget_bytes:
+            raise WorkspaceArtifactProjectionError(
+                "restore input exceeds the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+
+    @staticmethod
+    async def _write_payload(
+        service: Any,
+        *,
+        artifact_id: str,
+        target: Path,
+        budget_bytes: int,
+        principal: str,
+    ) -> int:
+        read_chunks = getattr(service, "read_chunks", None)
+        if read_chunks is not None:
+            _artifact, chunks = await read_chunks(
+                artifact_id=artifact_id,
+                principal=principal,
+                allow_restricted_raw=True,
+                chunk_size=STREAM_CHUNK_BYTES,
+            )
+            written = 0
+            descriptor = os.open(
+                target,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                0o600,
+            )
+            with os.fdopen(descriptor, "wb") as stream:
+                for chunk in chunks:
+                    written += len(chunk)
+                    if written > budget_bytes:
+                        stream.close()
+                        target.unlink(missing_ok=True)
+                        raise WorkspaceArtifactProjectionError(
+                            "restore input exceeds the authorized workspace bound",
+                            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    stream.write(chunk)
+            return written
+        _artifact, payload = await service.read(
+            artifact_id=artifact_id,
+            principal=principal,
+            allow_restricted_raw=True,
+        )
+        if len(payload) > budget_bytes:
+            raise WorkspaceArtifactProjectionError(
+                "restore input exceeds the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        descriptor = os.open(
+            target,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+        return len(payload)
+
+    @staticmethod
+    def _exclude_attachments_from_git(workspace: Path) -> None:
+        info = workspace / ".git" / "info"
+        if not info.is_dir():
+            return
+        exclude = info / "exclude"
+        rule = "/.moonmind/attachments/"
+        existing = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+        if rule not in existing.splitlines():
+            with exclude.open("a", encoding="utf-8") as stream:
+                if existing and not existing.endswith("\n"):
+                    stream.write("\n")
+                stream.write(f"{rule}\n")
+
+    @staticmethod
+    def _as_artifact_service(gateway: Any | None) -> Any | None:
+        if gateway is None:
+            return None
+        if hasattr(gateway, "read") or hasattr(gateway, "read_chunks"):
+            return gateway
+
+        class _GatewayAdapter:
+            async def read(self, *, artifact_id: str, **_kwargs: Any):
+                payload = await gateway.read_bytes(f"artifact://{artifact_id}")
+                return {}, payload
+
+        return _GatewayAdapter()
+
+
+__all__ = [
+    "WorkspaceArtifactProjectionError",
+    "WorkspaceArtifactProjector",
+]

--- a/moonmind/schemas/omnigent_session_models.py
+++ b/moonmind/schemas/omnigent_session_models.py
@@ -205,6 +205,9 @@ class OmnigentResolveIntentRequest(_OmnigentSessionModel):
     execution_input_refs_digest: str | None = Field(
         None, alias="executionInputRefsDigest"
     )
+    workspace_checkpoint_restore_ref: str | None = Field(
+        None, alias="workspaceCheckpointRestoreRef"
+    )
     admitted_feature_generation: Literal[OMNIGENT_SESSION_FEATURE_GENERATION] = Field(
         OMNIGENT_SESSION_FEATURE_GENERATION,
         alias="admittedFeatureGeneration",
@@ -225,6 +228,7 @@ class OmnigentResolveIntentRequest(_OmnigentSessionModel):
                 self.execution_instruction_digest,
                 self.execution_input_refs,
                 self.execution_input_refs_digest,
+                self.workspace_checkpoint_restore_ref,
             )
         ):
             raise ValueError(
@@ -252,6 +256,11 @@ class OmnigentResolveIntentRequest(_OmnigentSessionModel):
             _require_compact_identifier(item, field_name="executionInputRefs[]")
             for item in self.execution_input_refs
         ]
+        if self.workspace_checkpoint_restore_ref is not None:
+            self.workspace_checkpoint_restore_ref = _require_artifact_ref(
+                self.workspace_checkpoint_restore_ref,
+                field_name="workspaceCheckpointRestoreRef",
+            )
         return self
 
 

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -462,6 +462,10 @@ async def _load_intent_request(
             execution_input_refs_digest=(
                 str(payload.get("executionInputRefsDigest") or "").strip() or None
             ),
+            workspace_checkpoint_restore_ref=(
+                str(payload.get("workspaceCheckpointRestoreRef") or "").strip()
+                or None
+            ),
         )
     binding = parsed.omnigent_execution_plan or agent_request.omnigent_execution_plan
     if binding is not None:
@@ -484,6 +488,7 @@ async def _reconstruct_plan_bound_request(
     execution_instruction_digest: str | None = None,
     execution_input_refs: list[str] | None = None,
     execution_input_refs_digest: str | None = None,
+    workspace_checkpoint_restore_ref: str | None = None,
 ) -> AgentExecutionRequest:
     """Reload authored input and project it through immutable plan authority."""
 
@@ -686,6 +691,10 @@ async def _reconstruct_plan_bound_request(
             "workspaceId": workspace_id,
             "relativePath": "repo",
         }
+    if workspace_checkpoint_restore_ref:
+        workspace_spec["workspaceCheckpointRestoreRef"] = (
+            workspace_checkpoint_restore_ref
+        )
     return AgentExecutionRequest(
         agentKind="external",
         agentId="omnigent",
@@ -1456,6 +1465,15 @@ def _omnigent_intent_snapshot_payload(
                 if resolved.execution_input_refs
                 else {}
             ),
+            **(
+                {
+                    "workspaceCheckpointRestoreRef": (
+                        resolved.workspace_checkpoint_restore_ref
+                    )
+                }
+                if resolved.workspace_checkpoint_restore_ref
+                else {}
+            ),
             "omnigentExecutionPlan": plan_binding.model_dump(
                 mode="json", by_alias=True
             ),
@@ -1503,6 +1521,9 @@ async def omnigent_resolve_intent_activity(
             execution_instruction_digest=resolved.execution_instruction_digest,
             execution_input_refs=resolved.execution_input_refs,
             execution_input_refs_digest=resolved.execution_input_refs_digest,
+            workspace_checkpoint_restore_ref=(
+                resolved.workspace_checkpoint_restore_ref
+            ),
         )
     if (
         request.agent_kind != "external"
@@ -3042,7 +3063,11 @@ async def omnigent_ensure_host_activity(payload: Mapping[str, Any]) -> dict[str,
         workspace_locator = workspace_intent.workspace_locator_payload()
         repository_source = workspace_intent.repository or ""
         restore_input_refs = tuple(workspace_intent.restore_input_refs)
-        attachment_refs = tuple(workspace_intent.attachment_refs)
+        attachment_refs = (
+            OmnigentProfileBoundExecutionCoordinator._attachment_refs(
+                agent_request
+            )
+        )
     github_token = await OmnigentProfileBoundExecutionCoordinator._github_token(
         agent_request
     )

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5300,6 +5300,25 @@ async def update_github_issue_status(
             )
     pull_request_url = _github_status_pull_request_url(inputs, _context)
     if mode == "finalize_after_pr_or_done":
+        if (
+            not pull_request_url
+            and assessment_available
+            and assessment_verdict
+            and assessment_verdict != "FULLY_IMPLEMENTED"
+        ):
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "assessmentVerdict": assessment_verdict,
+                    "summary": (
+                        "Skipped GitHub issue finalization because the initial "
+                        f"assessment was {assessment_verdict} and no authoritative "
+                        "pull request URL was available."
+                    ),
+                },
+            )
         push_status, commit_count = _github_status_publish_change_evidence(
             inputs,
             _context,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -243,6 +243,9 @@ OMNIGENT_SESSION_ADMISSION_PATCH_ID = (
 OMNIGENT_COMPACT_RESOLVE_INTENT_PATCH_ID = (
     "agent-run-omnigent-compact-resolve-intent-v1"
 )
+OMNIGENT_COMPACT_WORKSPACE_CHECKPOINT_PATCH_ID = (
+    "agent-run-omnigent-compact-workspace-checkpoint-v1"
+)
 OMNIGENT_EXECUTION_PLAN_ADMISSION_PATCH_ID = (
     "agent-run-omnigent-execution-plan-admission-v1"
 )
@@ -620,6 +623,7 @@ class MoonMindAgentRun:
         agent_run_id: str,
         admitted_feature_generation: str,
         compact_plan_authority: bool,
+        compact_workspace_checkpoint_authority: bool,
     ) -> dict[str, Any]:
         """Build the replay-versioned AgentRun-to-Activity handoff.
 
@@ -667,6 +671,19 @@ class MoonMindAgentRun:
                 ).encode("utf-8")
                 payload["executionInputRefsDigest"] = (
                     "sha256:" + hashlib.sha256(encoded_refs).hexdigest()
+                )
+            checkpoint_restore_ref = str(
+                (request.workspace_spec or {}).get(
+                    "workspaceCheckpointRestoreRef"
+                )
+                or ""
+            ).strip()
+            if (
+                compact_workspace_checkpoint_authority
+                and checkpoint_restore_ref
+            ):
+                payload["workspaceCheckpointRestoreRef"] = (
+                    checkpoint_restore_ref
                 )
         else:
             payload["request"] = request.model_dump(
@@ -4678,6 +4695,9 @@ class MoonMindAgentRun:
         use_compact_omnigent_resolve_intent = workflow.patched(
             OMNIGENT_COMPACT_RESOLVE_INTENT_PATCH_ID
         )
+        use_compact_omnigent_workspace_checkpoint = workflow.patched(
+            OMNIGENT_COMPACT_WORKSPACE_CHECKPOINT_PATCH_ID
+        )
         use_omnigent_execution_plan_admission = workflow.patched(
             OMNIGENT_EXECUTION_PLAN_ADMISSION_PATCH_ID
         )
@@ -5577,6 +5597,9 @@ class MoonMindAgentRun:
                                     compact_plan_authority=(
                                         use_compact_omnigent_resolve_intent
                                         and plan_bound_session
+                                    ),
+                                    compact_workspace_checkpoint_authority=(
+                                        use_compact_omnigent_workspace_checkpoint
                                     ),
                                 ),
                                 cancellation_type=(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -906,6 +906,40 @@ RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH = (
 # checkpoint; older histories that already failed the later materialization
 # guard must retain that failure when replayed.
 RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH = "run-headless-remediation-execution-v1"
+# Omnigent owns fresh sandbox materialization inside AgentRun, so a dynamic
+# remediation cannot archive its destination before that child starts. New
+# histories pass the workflow-owned archive ref into the existing host restore
+# boundary and validate the captured result after execution. Older histories
+# retain the prior pre-execution checkpoint command sequence.
+RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH = (
+    "run-omnigent-remediation-checkpoint-restore-v1"
+)
+# An authored Omnigent verification Step runs in a fresh sandbox just like a
+# dynamic remediation Step. Restore the latest preceding candidate archive into
+# that sandbox, and seed the remediation loop from the same candidate rather
+# than from the verifier's read-only checkout. The child request and loop-head
+# identity change, so histories that already launched their initial verifier
+# retain the previously recorded commands.
+RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH = (
+    "run-omnigent-initial-verification-checkpoint-restore-v1"
+)
+# A pull-request handoff is another fresh Omnigent sandbox and must publish the
+# exact candidate accepted by the controlling verifier. Restore the cumulative
+# remediation head (or the latest implementation archive when no remediation
+# ran) before the handoff agent can commit or push. Older histories retain the
+# previously recorded clean-checkout command.
+RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH = (
+    "run-omnigent-publication-checkpoint-restore-v1"
+)
+# An issue-implementation PR handoff may restore a candidate that was already
+# pushed by the implementation stage. ``no_commits`` at that later sandbox is
+# not authority to skip the PR: it only says the restored head needs no second
+# push. Before the issue-status handoff, create the PR through the trusted
+# integration boundary and inject its URL into the finalizer inputs. Older
+# histories retain their recorded agent-only handoff commands.
+RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH = (
+    "run-issue-implement-pr-handoff-authority-v1"
+)
 # External runtimes create a fresh sandbox only after their AgentRun starts, so
 # they cannot satisfy a pre-execution archive checkpoint. Continue from the
 # workflow-owned, remote-verified published branch instead. This changes both
@@ -4097,6 +4131,33 @@ class MoonMindRunWorkflow:
         self._remediation_loop_runtime = self._plan_node_runtime_block(
             controller_nodes[0]
         )
+        if (
+            workflow.patched(RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH)
+            and self._remediation_loop_uses_omnigent()
+        ):
+            controller_inputs = self._node_inputs_mapping(controller_nodes[0])
+            workspace_spec: dict[str, Any] = {}
+            controller_runtime = controller_inputs.get("runtime")
+            if isinstance(controller_runtime, Mapping):
+                runtime_workspace_spec = controller_runtime.get("workspaceSpec")
+                if isinstance(runtime_workspace_spec, Mapping):
+                    workspace_spec.update(dict(runtime_workspace_spec))
+            authored_workspace_spec = controller_inputs.get("workspaceSpec")
+            if isinstance(authored_workspace_spec, Mapping):
+                workspace_spec.update(dict(authored_workspace_spec))
+            for key in (
+                "repository",
+                "repositoryTarget",
+                "repo",
+                "startingBranch",
+                "targetBranch",
+                "baseBranch",
+                "branch",
+            ):
+                if controller_inputs.get(key) is not None:
+                    workspace_spec[key] = controller_inputs[key]
+            if workspace_spec:
+                self._remediation_loop_runtime["workspaceSpec"] = workspace_spec
         info = workflow.info()
         self._remediation_loop_spec = spec
         self._remediation_loop_state = RemediationLoopState(
@@ -4410,6 +4471,14 @@ class MoonMindRunWorkflow:
             return None
         return branch, head_sha
 
+    def _accepted_published_base_branch(self) -> str | None:
+        """Return the base recorded atomically with the accepted remote head."""
+
+        head = self._publish_context.get("acceptedPublishedHead")
+        if not isinstance(head, Mapping):
+            return None
+        return self._normalize_native_pr_base_branch(head.get("baseBranch"))
+
     def _record_accepted_published_head(self, outputs: Mapping[str, Any]) -> None:
         """Project one step's accepted repository evidence as the run's head.
 
@@ -4445,6 +4514,13 @@ class MoonMindRunWorkflow:
             "branch": branch,
             "headSha": head_sha,
         }
+        base_branch = self._normalize_native_pr_base_branch(
+            evidence.get("baseBranch") or evidence.get("base_branch")
+        )
+        if base_branch:
+            self._publish_context["acceptedPublishedHead"]["baseBranch"] = (
+                base_branch
+            )
 
     def _published_branch_remediation_workspace_spec(
         self,
@@ -5032,6 +5108,138 @@ class MoonMindRunWorkflow:
             "verification terminal disposition; no controlling verification gate "
             "has approved advancement."
         )
+
+    def _issue_implement_handoff_role(self, node: Mapping[str, Any]) -> str:
+        annotations = self._node_annotations_mapping(node)
+        return str(annotations.get("issueImplementRole") or "").strip().lower()
+
+    def _issue_implement_pr_required(self) -> bool:
+        verdict = str(
+            self._assessment_context.get("assessmentVerdict")
+            or self._assessment_context.get("assessment_verdict")
+            or ""
+        ).strip().upper()
+        return verdict in {"PARTIALLY_IMPLEMENTED", "NOT_IMPLEMENTED"}
+
+    def _github_issue_ref_from_parameters(
+        self,
+        parameters: Mapping[str, Any],
+    ) -> str | None:
+        task_payload = self._mapping_value(parameters, "workflow")
+        if not task_payload:
+            task_payload = self._mapping_value(parameters, "task")
+        inputs = self._mapping_value(task_payload, "inputs")
+        issue = self._mapping_value(inputs, "github_issue")
+        repository = str(issue.get("repository") or "").strip()
+        number = issue.get("number")
+        if not repository or isinstance(number, bool):
+            return None
+        try:
+            issue_number = int(number)
+        except (TypeError, ValueError):
+            return None
+        return f"{repository}#{issue_number}" if issue_number > 0 else None
+
+    async def _ensure_issue_implement_pr_before_status(
+        self,
+        *,
+        node: Mapping[str, Any],
+        parameters: Mapping[str, Any],
+    ) -> str | None:
+        """Create the required PR before the issue-status side effect runs."""
+
+        if (
+            self._issue_implement_handoff_role(node) != "code-review-handoff"
+            or self._publish_mode(parameters) != "pr"
+            or not self._issue_implement_pr_required()
+        ):
+            return None
+        existing = self._coerce_text(
+            self._pull_request_url or self._publish_context.get("pullRequestUrl"),
+            max_chars=500,
+        )
+        if existing:
+            return existing
+        accepted = self._accepted_published_head()
+        if accepted is None:
+            raise ValueError(
+                "issue implementation requires a remotely verified branch before "
+                "the Code Review status handoff"
+            )
+        head_branch, head_sha = accepted
+        publish_payload = self._resolve_publish_payload(parameters)
+        base_branch = (
+            self._resolve_publish_base_branch(publish_payload)
+            or self._accepted_published_base_branch()
+            or "main"
+        )
+        base_branch = self._normalize_native_pr_base_branch(base_branch) or "main"
+        if head_branch == base_branch:
+            raise ValueError(
+                "issue implementation PR head and base resolve to the same branch"
+            )
+        repository = str(self._repo or "").strip()
+        if not repository:
+            raise ValueError(
+                "issue implementation requires repository authority before PR creation"
+            )
+        task_payload = self._mapping_value(parameters, "workflow")
+        if not task_payload:
+            task_payload = self._mapping_value(parameters, "task")
+        title = self._resolve_native_pr_title(
+            publish_payload=publish_payload,
+            task_payload=task_payload,
+        )
+        body = self._resolve_native_pr_body(
+            publish_payload=publish_payload,
+            task_payload=task_payload,
+        )
+        issue_ref = self._github_issue_ref_from_parameters(parameters)
+        if issue_ref:
+            if issue_ref not in title:
+                title = f"{title.rstrip()} ({issue_ref})"
+            closing_line = f"Closes {issue_ref}"
+            if closing_line not in body.splitlines():
+                body = body.rstrip() + f"\n\n{closing_line}\n"
+        create_result = await workflow.execute_activity(
+            "repo.create_pr",
+            {
+                "repo": repository,
+                "head": head_branch,
+                "base": base_branch,
+                "title": title,
+                "body": body,
+            },
+            start_to_close_timeout=timedelta(minutes=2),
+            task_queue=INTEGRATIONS_TASK_QUEUE,
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        pull_request_url = self._coerce_text(
+            self._get_from_result(create_result, "url"),
+            max_chars=500,
+        )
+        if not pull_request_url:
+            summary = self._coerce_text(
+                self._get_from_result(create_result, "summary"),
+                max_chars=700,
+            )
+            raise ValueError(
+                "issue implementation PR creation returned no URL"
+                + (f": {summary}" if summary else "")
+            )
+        self._pull_request_url = pull_request_url
+        self._publish_status = "published"
+        self._publish_reason = "published pull request"
+        self._publish_context.update(
+            {
+                "pullRequestUrl": pull_request_url,
+                "branch": head_branch,
+                "baseRef": base_branch,
+                "headSha": head_sha,
+            }
+        )
+        return pull_request_url
 
     def _external_handoff_operation(self, node: Mapping[str, Any]) -> str:
         """Map a Jira Orchestrate handoff node to its external operation id."""
@@ -6767,6 +6975,7 @@ class MoonMindRunWorkflow:
                 workspace.get("workspaceIdentityDigest") or ""
             ).strip()
             checkpoint_manifest_ref = str(workspace.get("manifestRef") or "").strip()
+            workspace_archive_ref = str(workspace.get("archiveRef") or "").strip()
             evidence_by_boundary = (
                 self._step_checkpoint_workspace_evidence_by_boundary.setdefault(
                     logical_step_id,
@@ -6779,6 +6988,7 @@ class MoonMindRunWorkflow:
                 "workspaceDigest": workspace_digest,
                 "workspaceIdentityDigest": workspace_identity_digest,
                 "checkpointManifestRef": checkpoint_manifest_ref,
+                "workspaceArchiveRef": workspace_archive_ref,
             }
         return checkpoint_ref or None
 
@@ -7310,6 +7520,15 @@ class MoonMindRunWorkflow:
             checkpoint_ref = self._bounded_story_loop_artifact_ref(
                 evidence.get("checkpointRef")
             )
+            if (
+                workflow.patched(
+                    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+                )
+                and self._remediation_loop_uses_omnigent()
+            ):
+                checkpoint_ref = self._bounded_story_loop_artifact_ref(
+                    evidence.get("workspaceArchiveRef")
+                )
             workspace_kind = str(evidence.get("workspaceKind") or "").strip()
             workspace_digest = str(evidence.get("workspaceDigest") or "").strip()
             workspace_identity_digest = str(
@@ -7333,6 +7552,175 @@ class MoonMindRunWorkflow:
                 }
         return None
 
+    def _latest_prior_remediation_candidate_checkpoint_evidence(
+        self,
+        logical_step_id: str,
+    ) -> tuple[str, dict[str, str]] | None:
+        """Return the nearest completed candidate checkpoint before a verifier.
+
+        Verification sandboxes are read-only consumers of a candidate. Their
+        post-execution archives contain verifier artifacts and, for external
+        runtimes, may otherwise be a fresh source checkout. They must therefore
+        never replace the implementation archive that the verifier was meant to
+        inspect and that a later remediation attempt must continue from.
+        """
+
+        latest: tuple[str, dict[str, str]] | None = None
+        found_current = False
+        for row in self._step_ledger_rows:
+            candidate_step_id = str(row.get("logicalStepId") or "").strip()
+            if candidate_step_id == logical_step_id:
+                found_current = True
+                break
+            if not candidate_step_id:
+                continue
+            annotations = row.get("annotations")
+            role = (
+                str(annotations.get("issueImplementRole") or "").strip()
+                if isinstance(annotations, Mapping)
+                else ""
+            )
+            if role == "moonspec-verification-gate":
+                continue
+            if str(row.get("status") or "").strip().lower() != "completed":
+                continue
+            evidence = self._canonical_remediation_checkpoint_evidence(
+                candidate_step_id
+            )
+            if evidence is not None:
+                latest = (candidate_step_id, evidence)
+        return latest if found_current else None
+
+    def _initial_omnigent_verification_checkpoint_restore_ref(
+        self,
+        *,
+        node: Mapping[str, Any],
+    ) -> str | None:
+        """Return the candidate archive consumed by the authored verifier."""
+
+        state = self._remediation_loop_state
+        node_inputs = self._node_inputs_mapping(node)
+        tool = self._plan_node_tool_mapping(node) or {}
+        if (
+            self._remediation_loop_spec is None
+            or state is None
+            or state.phase != RemediationLoopPhase.INITIAL_VERIFICATION_PENDING
+            or self._remediation_workspace_head is not None
+            or not self._remediation_loop_uses_omnigent()
+            or not self._is_moonspec_verify_step(
+                tool_name=str(tool.get("name") or tool.get("id") or ""),
+                node_inputs=node_inputs,
+            )
+            or self._node_annotations_mapping(node).get("remediationLoopId")
+        ):
+            return None
+        candidate = self._latest_prior_remediation_candidate_checkpoint_evidence(
+            str(node.get("id") or "")
+        )
+        return candidate[1]["checkpointRef"] if candidate is not None else None
+
+    def _omnigent_publication_checkpoint_restore_ref(
+        self,
+        *,
+        node: Mapping[str, Any],
+        node_inputs: Mapping[str, Any],
+    ) -> str | None:
+        """Return the verified candidate archive consumed by a PR handoff."""
+
+        if (
+            self._node_annotations_mapping(node).get("issueImplementRole")
+            != "pull-request-handoff"
+            or not self._remediation_loop_uses_omnigent()
+        ):
+            return None
+        tool = self._plan_node_tool_mapping(node) or {}
+        agent_id = self._agent_id_from_runtime_inputs(
+            node_inputs=node_inputs,
+            fallback_name=str(tool.get("name") or tool.get("id") or ""),
+        )
+        if _normalize_agent_runtime_id(agent_id) != "omnigent":
+            return None
+        head = self._remediation_workspace_head
+        if head is not None:
+            return head.head_checkpoint_ref
+        candidate = self._latest_prior_remediation_candidate_checkpoint_evidence(
+            str(node.get("id") or "")
+        )
+        return candidate[1]["checkpointRef"] if candidate is not None else None
+
+    def _remediation_loop_uses_omnigent(self) -> bool:
+        runtime = self._remediation_loop_runtime
+        if not isinstance(runtime, Mapping):
+            return False
+        runtime_id = str(
+            runtime.get("mode")
+            or runtime.get("agentId")
+            or runtime.get("agent_id")
+            or ""
+        ).strip()
+        return _normalize_agent_runtime_id(runtime_id) == "omnigent"
+
+    def _is_omnigent_remediation_workspace_step(
+        self,
+        *,
+        node: Mapping[str, Any],
+        node_inputs: Mapping[str, Any],
+    ) -> bool:
+        annotations = self._node_annotations_mapping(node)
+        if not annotations.get("remediationLoopId"):
+            return False
+        if self._moonspec_step_role(node) not in {
+            "moonspec-remediation",
+            "moonspec-verification-gate",
+        }:
+            return False
+        tool = self._plan_node_tool_mapping(node) or {}
+        agent_id = self._agent_id_from_runtime_inputs(
+            node_inputs=node_inputs,
+            fallback_name=str(tool.get("name") or tool.get("id") or ""),
+        )
+        return _normalize_agent_runtime_id(agent_id) == "omnigent"
+
+    def _trusted_omnigent_remediation_checkpoint_restore_ref(
+        self,
+        *,
+        node: Mapping[str, Any],
+        node_inputs: Mapping[str, Any],
+    ) -> str | None:
+        """Return the controller-owned archive restored before Omnigent launch."""
+
+        head = self._remediation_workspace_head
+        if head is None or not self._is_omnigent_remediation_workspace_step(
+            node=node,
+            node_inputs=node_inputs,
+        ):
+            return None
+        attempt, _ = self._moonspec_remediation_attempt_metadata(node)
+        if attempt != head.head_attempt_ordinal + 1 and self._moonspec_step_role(
+            node
+        ) == "moonspec-remediation":
+            raise RemediationHeadError(
+                REMEDIATION_HEAD_MISMATCH,
+                "Omnigent remediation attempt does not follow the workspace head",
+            )
+        if (
+            self._moonspec_step_role(node) == "moonspec-verification-gate"
+            and attempt != head.head_attempt_ordinal
+        ):
+            raise RemediationHeadError(
+                REMEDIATION_HEAD_MISMATCH,
+                "Omnigent verifier attempt does not match the workspace head",
+            )
+        supplied_ref = str(
+            node_inputs.get("remediationWorkspaceHeadRef") or ""
+        ).strip()
+        if supplied_ref and supplied_ref != head.head_checkpoint_ref:
+            raise RemediationHeadError(
+                REMEDIATION_HEAD_MISMATCH,
+                "Omnigent remediation restore ref does not match the workspace head",
+            )
+        return head.head_checkpoint_ref
+
     def _initialize_remediation_head_from_canonical_checkpoint(
         self,
         *,
@@ -7345,10 +7733,24 @@ class MoonMindRunWorkflow:
         spec = self._remediation_loop_spec
         if spec is None:
             return None
-        evidence = self._canonical_remediation_checkpoint_evidence(logical_step_id)
+        checkpoint_step_id = logical_step_id
+        evidence: dict[str, str] | None = None
+        if (
+            workflow.patched(
+                RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH
+            )
+            and self._remediation_loop_uses_omnigent()
+        ):
+            candidate = self._latest_prior_remediation_candidate_checkpoint_evidence(
+                logical_step_id
+            )
+            if candidate is not None:
+                checkpoint_step_id, evidence = candidate
+        if evidence is None:
+            evidence = self._canonical_remediation_checkpoint_evidence(logical_step_id)
         if evidence is None:
             return None
-        identity = self._canonical_step_checkpoint_identity(logical_step_id)
+        identity = self._canonical_step_checkpoint_identity(checkpoint_step_id)
         normalized_verdict = str(verdict or "").strip().upper()
         head = RemediationWorkspaceHead(
             loopId=spec.loop_id,
@@ -7433,6 +7835,17 @@ class MoonMindRunWorkflow:
         if (
             workflow.patched(RUN_EXTERNAL_PUBLISHED_BRANCH_REMEDIATION_PATCH)
             and node_inputs.get("remediationWorkspaceMode") == "remote_published_branch"
+        ):
+            return False
+        if (
+            workflow.patched(
+                RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+            )
+            and self._remediation_workspace_head is not None
+            and self._is_omnigent_remediation_workspace_step(
+                node=node,
+                node_inputs=node_inputs,
+            )
         ):
             return False
         return not (
@@ -7653,17 +8066,47 @@ class MoonMindRunWorkflow:
         )
         if workflow_owned_head_enabled:
             output_payload = None
-            materialized = self._validate_remediation_workspace_materialization(
-                str(node.get("id") or "")
-            )
+            if (
+                workflow.patched(
+                    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+                )
+                and self._is_omnigent_remediation_workspace_step(
+                    node=node,
+                    node_inputs=node_inputs,
+                )
+            ):
+                materialized = {
+                    "checkpointRef": str(
+                        attempt_payload.get("baseCheckpointRef") or ""
+                    ),
+                    "workspaceDigest": str(
+                        attempt_payload.get("expectedBaseDigest") or ""
+                    ),
+                }
+            else:
+                materialized = self._validate_remediation_workspace_materialization(
+                    str(node.get("id") or "")
+                )
         else:
             materialized = None
         if captured is not None:
             captured_workspace_identity_digest = captured.get("workspaceIdentityDigest")
+            omnigent_checkpoint_restore = (
+                workflow.patched(
+                    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+                )
+                and self._is_omnigent_remediation_workspace_step(
+                    node=node,
+                    node_inputs=node_inputs,
+                )
+            )
             if (
                 not captured_workspace_identity_digest
-                or captured_workspace_identity_digest
-                != self._remediation_workspace_head.head_workspace_identity_digest
+                or (
+                    not omnigent_checkpoint_restore
+                    and captured_workspace_identity_digest
+                    != self._remediation_workspace_head.head_workspace_identity_digest
+                )
             ):
                 raise RemediationHeadError(
                     REMEDIATION_HEAD_MISMATCH,
@@ -11658,6 +12101,20 @@ class MoonMindRunWorkflow:
                     self._refresh_step_readiness(updated_at=workflow.now())
                     self._update_memo()
                     continue
+            if workflow.patched(
+                RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH
+            ):
+                native_pr_url = await self._ensure_issue_implement_pr_before_status(
+                    node=node,
+                    parameters=parameters,
+                )
+                if native_pr_url:
+                    previous_step_outputs = {
+                        **dict(previous_step_outputs),
+                        "pullRequestUrl": native_pr_url,
+                        "pull_request_url": native_pr_url,
+                        "publishContext": dict(self._publish_context),
+                    }
             handoff_block_reason = self._jira_orchestrate_external_handoff_block_reason(
                 node
             )
@@ -11955,6 +12412,51 @@ class MoonMindRunWorkflow:
                                     ),
                                 )
                             )
+                            trusted_remediation_checkpoint_restore_ref = None
+                            if (
+                                workflow.patched(
+                                    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+                                )
+                                and (
+                                    self._is_moonspec_remediation_step(node)
+                                    or (
+                                        self._moonspec_step_role(node)
+                                        == "moonspec-verification-gate"
+                                        and self._node_annotations_mapping(node).get(
+                                            "remediationLoopId"
+                                        )
+                                    )
+                                )
+                            ):
+                                trusted_remediation_checkpoint_restore_ref = (
+                                    self._trusted_omnigent_remediation_checkpoint_restore_ref(
+                                        node=node,
+                                        node_inputs=node_inputs,
+                                    )
+                                )
+                            if (
+                                workflow.patched(
+                                    RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH
+                                )
+                                and trusted_remediation_checkpoint_restore_ref is None
+                            ):
+                                trusted_remediation_checkpoint_restore_ref = (
+                                    self._initial_omnigent_verification_checkpoint_restore_ref(
+                                        node=node,
+                                    )
+                                )
+                            if (
+                                workflow.patched(
+                                    RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH
+                                )
+                                and trusted_remediation_checkpoint_restore_ref is None
+                            ):
+                                trusted_remediation_checkpoint_restore_ref = (
+                                    self._omnigent_publication_checkpoint_restore_ref(
+                                        node=node,
+                                        node_inputs=node_inputs,
+                                    )
+                                )
                             request = self._build_agent_execution_request(
                                 node_inputs=node_inputs,
                                 node_id=node_id,
@@ -11964,6 +12466,9 @@ class MoonMindRunWorkflow:
                                 step_execution=current_step_execution,
                                 queue_order=index,
                                 attempt_reason=attempt_reason,
+                                trusted_remediation_checkpoint_restore_ref=(
+                                    trusted_remediation_checkpoint_restore_ref
+                                ),
                             )
                             agent_request_for_context = request
                             if (
@@ -16092,11 +16597,20 @@ class MoonMindRunWorkflow:
         self._record_publish_metadata_context(outputs)
 
         if push_status == "no_commits":
+            canonical_no_commit = self._is_canonical_no_commit_task(parameters)
+            if (
+                self._patched_or_false_outside_workflow(
+                    RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH
+                )
+                and canonical_no_commit
+                and self._issue_implement_pr_required()
+            ):
+                canonical_no_commit = False
             if publish_mode == "pr" and (
                 self._pr_publish_optional_for_task(
                     parameters, include_applied_templates=True
                 )
-                or self._is_canonical_no_commit_task(parameters)
+                or canonical_no_commit
             ):
                 self._publish_status = "not_required"
                 self._publish_reason = self._compose_no_commit_publish_reason(
@@ -19290,6 +19804,7 @@ class MoonMindRunWorkflow:
         queue_order: int | None = None,
         attempt_reason: str = "initial_execution",
         trusted_remediation_authority: Mapping[str, Any] | None = None,
+        trusted_remediation_checkpoint_restore_ref: str | None = None,
     ) -> "AgentExecutionRequest":
         """Build an ``AgentExecutionRequest`` from plan-node inputs and workflow context."""
         node_inputs = self._append_trusted_previous_outputs_to_agent_inputs(node_inputs)
@@ -19390,6 +19905,29 @@ class MoonMindRunWorkflow:
             ws_val = node_inputs.get(ws_key)
             if ws_val is not None:
                 workspace_spec[ws_key] = ws_val
+        if trusted_remediation_checkpoint_restore_ref is not None:
+            restore_ref = str(
+                trusted_remediation_checkpoint_restore_ref or ""
+            ).strip()
+            if not restore_ref.startswith("artifact://"):
+                raise ValueError(
+                    "trusted remediation checkpoint restore must be an artifact ref"
+                )
+            if not (
+                agent_kind == "external"
+                and _normalize_agent_runtime_id(agent_id) == "omnigent"
+            ):
+                raise ValueError(
+                    "trusted remediation checkpoint restore requires external/omnigent"
+                )
+            authored_restore_ref = str(
+                workspace_spec.get("workspaceCheckpointRestoreRef") or ""
+            ).strip()
+            if authored_restore_ref and authored_restore_ref != restore_ref:
+                raise ValueError(
+                    "authored workspace checkpoint conflicts with remediation authority"
+                )
+            workspace_spec["workspaceCheckpointRestoreRef"] = restore_ref
 
         repository_operation = (
             str(node_inputs.get("repositoryOperation") or "").strip().lower()

--- a/tests/integration/reliability/replays/batch-github-fanout-repository-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/batch-github-fanout-repository-authority/expected-outcome.json
@@ -1,0 +1,9 @@
+{
+  "discardedRepository": "MoonLadderStudios/MoonMind",
+  "repositoryTarget": {
+    "provider": "git",
+    "connectionRef": "repository-connection:git-default",
+    "repository": {"name": "MoonLadderStudios/MoonMind"},
+    "branch": {"name": "main"}
+  }
+}

--- a/tests/integration/reliability/replays/batch-github-fanout-repository-authority/manifest.json
+++ b/tests/integration/reliability/replays/batch-github-fanout-repository-authority/manifest.json
@@ -1,0 +1,30 @@
+{
+  "failureShapeId": "batch-github-fanout-repository-authority",
+  "incidentWorkflowId": "mm:f724a9b2-5eac-5e0f-8644-d261379717f1",
+  "repository": "MoonLadderStudios/MoonMind",
+  "issueRange": "3815-3815",
+  "failedWorkspaceSpec": {
+    "repository": "MoonLadderStudios/MoonMind",
+    "repo": "MoonLadderStudios/MoonMind",
+    "workspaceLocator": {
+      "kind": "sandbox",
+      "workspaceId": "d4cbf0cec4185326133e3d20",
+      "relativePath": "repo"
+    }
+  },
+  "githubResponse": {
+    "data": {
+      "repository": {
+        "defaultBranchRef": {"name": "main"},
+        "issue3815": {
+          "number": 3815,
+          "title": "Settings",
+          "body": "Incident replay body omitted.",
+          "url": "https://github.com/MoonLadderStudios/MoonMind/issues/3815",
+          "state": "OPEN",
+          "labels": {"nodes": []}
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/replays/batch-github-fanout-repository-authority/manifest.json
+++ b/tests/integration/reliability/replays/batch-github-fanout-repository-authority/manifest.json
@@ -2,6 +2,12 @@
   "failureShapeId": "batch-github-fanout-repository-authority",
   "incidentWorkflowId": "mm:f724a9b2-5eac-5e0f-8644-d261379717f1",
   "repository": "MoonLadderStudios/MoonMind",
+  "repositoryTarget": {
+    "provider": "git",
+    "connectionRef": "repository-connection:git-default",
+    "repository": {"name": "MoonLadderStudios/MoonMind"},
+    "branch": {"name": "main"}
+  },
   "issueRange": "3815-3815",
   "failedWorkspaceSpec": {
     "repository": "MoonLadderStudios/MoonMind",

--- a/tests/integration/reliability/replays/omnigent-issue-implement-missing-pr-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-issue-implement-missing-pr-authority/expected-outcome.json
@@ -1,0 +1,5 @@
+{
+  "preHandoffPublishStatus": "skipped",
+  "postHandoffPublishStatus": "published",
+  "pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/3912"
+}

--- a/tests/integration/reliability/replays/omnigent-issue-implement-missing-pr-authority/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-issue-implement-missing-pr-authority/manifest.json
@@ -1,0 +1,20 @@
+{
+  "failureShapeId": "omnigent-issue-implement-missing-pr-authority",
+  "incidentWorkflowId": "mm:f194565c-aa34-4e0c-86b0-db751e4a04f0",
+  "cause": "the publication sandbox reported a GitHub authorization blocker after the candidate branch was already pushed, the generic host reduced the step to no_commits, and the parent finalized the issue as done without a pull request",
+  "repository": "MoonLadderStudios/MoonMind",
+  "githubIssue": {
+    "repository": "MoonLadderStudios/MoonMind",
+    "number": 3815
+  },
+  "assessmentVerdict": "PARTIALLY_IMPLEMENTED",
+  "assessmentArtifactRef": "art_01M1HE3XHC1CA72C8WWRNB0CKX",
+  "acceptedRepositoryEvidence": {
+    "publicationAuthorized": true,
+    "candidateContaminated": false,
+    "pushStatus": "pushed",
+    "branch": "moonmind-job-50a4d228",
+    "headSha": "4e11c2fed2df7ddfb8c73306b70c9e34238db72b",
+    "baseBranch": "main"
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-remediation-prematerialization-checkpoint/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-remediation-prematerialization-checkpoint/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "workspaceCheckpointRestoreRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R",
+  "publicationCheckpointRestoreRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R",
+  "compactIntentCheckpointRestoreRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R",
+  "restoredContent": "candidate restored before provider launch\n",
+  "retryPreservedContent": "agent progress survives host retry\n"
+}

--- a/tests/integration/reliability/replays/omnigent-remediation-prematerialization-checkpoint/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-remediation-prematerialization-checkpoint/manifest.json
@@ -1,0 +1,72 @@
+{
+  "failureShapeId": "omnigent-remediation-prematerialization-checkpoint",
+  "incidentWorkflowId": "mm:f724a9b2-5eac-5e0f-8644-d261379717f1",
+  "incidentChildWorkflowId": "mm:ac5b3aef-733e-523a-aedc-9e8c0c6fa75b",
+  "observedFailureCode": "REMEDIATION_HEAD_RESTORE_INVALID",
+  "repositoryTarget": {
+    "provider": "git",
+    "connectionRef": "repository-connection:git-default",
+    "repository": {"name": "MoonLadderStudios/MoonMind"},
+    "branch": {"name": "main"}
+  },
+  "remediationWorkspaceHead": {
+    "loopId": "issue-implementation-remediation",
+    "branchRef": "checkpoint-branch:issue-implementation-remediation",
+    "rootCheckpointRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R",
+    "rootWorkspaceDigest": "sha256:1b98577540b187965e433561532648fb8e67a2943bf3443c236c38b85e7200a3",
+    "rootWorkspaceIdentityDigest": "sha256:9ba5922484b44cc45f87dfb6f77fe26a8885359a1f5588398a33c858c8d1f26f",
+    "headCheckpointRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R",
+    "headWorkspaceDigest": "sha256:1b98577540b187965e433561532648fb8e67a2943bf3443c236c38b85e7200a3",
+    "headWorkspaceIdentityDigest": "sha256:9ba5922484b44cc45f87dfb6f77fe26a8885359a1f5588398a33c858c8d1f26f",
+    "headAttemptOrdinal": 0,
+    "headVersion": 1,
+    "latestVerificationRef": "artifact://art_verification_0",
+    "latestVerificationVerdict": "ADDITIONAL_WORK_NEEDED",
+    "status": "verified_incomplete"
+  },
+  "dynamicRemediationNode": {
+    "id": "dynamic-remediation-1",
+    "tool": {"type": "agent_runtime", "name": "omnigent"},
+    "annotations": {
+      "remediationLoopId": "issue-implementation-remediation",
+      "issueImplementRole": "moonspec-remediation",
+      "moonSpecRemediationAttempt": 1
+    },
+    "inputs": {
+      "runtime": {
+        "mode": "omnigent",
+        "executionProfileRef": "opencode-zen-free",
+        "workspaceSpec": {
+          "repository": "MoonLadderStudios/MoonMind",
+          "repositoryTarget": {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-default",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"}
+          },
+          "startingBranch": "main"
+        }
+      },
+      "remediationWorkspaceHeadRef": "artifact://art_01M1GK30EMCT08GVGT7S4PGD1R"
+    }
+  },
+  "publicationNode": {
+    "id": "publish-pull-request",
+    "tool": {
+      "type": "agent_runtime",
+      "name": "omnigent"
+    },
+    "annotations": {
+      "issueImplementRole": "pull-request-handoff"
+    },
+    "inputs": {
+      "runtime": {
+        "mode": "omnigent"
+      }
+    }
+  },
+  "archiveMember": {
+    "path": "artifacts/replay-candidate.txt",
+    "content": "candidate restored before provider launch\n"
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import json
 import re
 import runpy
 import sqlite3
 import subprocess
+import tarfile
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -111,6 +113,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRuntimeStepExecutionLaunch,
     AgentTerminalContract,
     ManagedRunRecord,
+    OmnigentExecutionPlanBinding,
 )
 from moonmind.schemas.workspace_locator_models import WorkspaceLocatorResolutionError
 from moonmind.provider_profiles.lease_client import (
@@ -161,6 +164,9 @@ from moonmind.workflows.temporal.remediation_loop import (
     RemediationLoopSpec,
     materialize_attempt_nodes,
 )
+from moonmind.workflows.temporal.remediation_workspace_head import (
+    RemediationWorkspaceHead,
+)
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
@@ -210,6 +216,9 @@ from moonmind.workflows.temporal.workflows.run import (
     NATIVE_PR_BRANCH_DEFAULTS_PATCH,
     RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
+    RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH,
+    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
     RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
     RUN_OMNIGENT_STOCK_AGENT_IDENTITY_PATCH,
@@ -2250,8 +2259,20 @@ async def test_invalid_batch_range_records_terminal_failure_without_retry(
     assert expected["parentState"] == "failed"
 
 
-async def test_batch_github_fanout_preserves_checkout_authority_replay() -> None:
-    """Replay mm:f724a9b2 at GitHub discovery and child authoring boundaries."""
+async def test_batch_github_fanout_preserves_checkout_authority_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:f724a9b2 through child authoring and workspace checkout."""
+    from api_service.api.routers.executions import (
+        _normalize_submitted_repository,
+        _validate_repository_submission_compatibility,
+    )
+    from moonmind.omnigent.host_services.workspace import (
+        OmnigentWorkspaceMaterializer,
+    )
+    from moonmind.omnigent.workspace_intent import compile_workspace_intent
+
     replay_id = "batch-github-fanout-repository-authority"
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
@@ -2277,6 +2298,7 @@ async def test_batch_github_fanout_preserves_checkout_authority_replay() -> None
     targets = skill["resolve_github_issue_range"](
         manifest["repository"],
         manifest["issueRange"],
+        connection_ref=manifest["repositoryTarget"]["connectionRef"],
         run_command=fake_github_query,
     )
     request = skill["build_child_request"](
@@ -2297,6 +2319,261 @@ async def test_batch_github_fanout_preserves_checkout_authority_replay() -> None
     assert "branch" not in manifest["failedWorkspaceSpec"]
     assert request is not None
     assert request["payload"]["repository"] == expected["repositoryTarget"]
+
+    normalized_repository, scalar_repository = _normalize_submitted_repository(
+        request["payload"]["repository"]
+    )
+    _validate_repository_submission_compatibility(
+        repository_payload=normalized_repository,
+        task_payload={
+            "inputs": {
+                "github_issue": {"repository": manifest["repository"]},
+            }
+        },
+        publish_payload={"mode": "none"},
+    )
+    assert scalar_repository == manifest["repository"]
+    workflow_id = "replay:mm:f724a9b2"
+    step_execution_id = f"{workflow_id}:implementation"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    execution_request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=workflow_id,
+        idempotencyKey=step_execution_id,
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": "repo",
+            },
+            "repository": normalized_repository,
+            "repositoryTarget": normalized_repository,
+        },
+    )
+    intent = compile_workspace_intent(
+        execution_request,
+        workflow_id=workflow_id,
+        step_execution_id=step_execution_id,
+    )
+    assert intent.repository == manifest["repository"]
+    assert intent.connection_ref == manifest["repositoryTarget"]["connectionRef"]
+    assert intent.starting_branch == "main"
+
+    captured: list[tuple[list[str], bytes | None]] = []
+
+    async def runner(
+        argv: list[str], input_bytes: bytes | None = None
+    ) -> tuple[int, str, str]:
+        captured.append((argv, input_bytes))
+        if "clone" in " ".join(argv):
+            relative_target = argv[-1].removeprefix("/work/")
+            (tmp_path / relative_target).mkdir(parents=True)
+        return 0, "", ""
+
+    async def fake_token() -> str:
+        return "fixture-replay-token"
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve."
+        "resolve_github_token_for_launch",
+        fake_token,
+    )
+    materialized = await OmnigentWorkspaceMaterializer(
+        command_runner=runner,
+        workspace_root=tmp_path,
+    ).materialize(execution_request)
+
+    clone_argv, clone_input = captured[0]
+    assert materialized["kind"] == "bind"
+    assert clone_argv[-3:] == [
+        "main",
+        "https://github.com/MoonLadderStudios/MoonMind.git",
+        f"/work/temporal_sandbox/{workspace_id}/repo",
+    ]
+    assert 'git check-ref-format --branch "$1"' in " ".join(clone_argv)
+    assert clone_input == b"fixture-replay-token"
+
+
+async def test_omnigent_dynamic_remediation_restores_workspace_archive_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay the failed child at the workflow-to-host restore boundary."""
+
+    replay_id = "omnigent-remediation-prematerialization-checkpoint"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent._remediation_workspace_head = RemediationWorkspaceHead.model_validate(
+        manifest["remediationWorkspaceHead"]
+    )
+    node = json.loads(json.dumps(manifest["dynamicRemediationNode"]))
+    node_inputs = dict(node["inputs"])
+    parent._remediation_loop_runtime = dict(node_inputs["runtime"])
+    parent._inject_remediation_workspace_baseline(
+        node=node,
+        node_inputs=node_inputs,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+            RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH,
+        },
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            workflow_id=manifest["incidentChildWorkflowId"],
+            run_id="replay-run",
+        ),
+    )
+
+    restore_ref = parent._trusted_omnigent_remediation_checkpoint_restore_ref(
+        node=node,
+        node_inputs=node_inputs,
+    )
+    request = parent._build_agent_execution_request(
+        node_inputs=node_inputs,
+        node_id=node["id"],
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=restore_ref,
+    )
+
+    assert restore_ref == expected["workspaceCheckpointRestoreRef"]
+    assert request.workspace_spec["workspaceCheckpointRestoreRef"] == restore_ref
+    assert request.workspace_spec["repositoryTarget"] == manifest["repositoryTarget"]
+
+    publication_node = json.loads(json.dumps(manifest["publicationNode"]))
+    publication_ref = parent._omnigent_publication_checkpoint_restore_ref(
+        node=publication_node,
+        node_inputs=publication_node["inputs"],
+    )
+    publication_request = parent._build_agent_execution_request(
+        node_inputs=publication_node["inputs"],
+        node_id=publication_node["id"],
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=publication_ref,
+    )
+    assert publication_ref == expected["publicationCheckpointRestoreRef"]
+    assert (
+        publication_request.workspace_spec["workspaceCheckpointRestoreRef"]
+        == publication_ref
+    )
+
+    plan_binding = OmnigentExecutionPlanBinding(
+        planRef="omnigent-execution-plan:sha256:" + "1" * 64,
+        planDigest="sha256:" + "1" * 64,
+        planArtifactRef="art_replay_plan",
+        taskInputSnapshotRef="art_replay_task_input",
+        taskInputSnapshotDigest="sha256:" + "2" * 64,
+    )
+    compact_request = request.model_copy(
+        update={"omnigent_execution_plan": plan_binding}
+    )
+    compact_payload = MoonMindAgentRun._omnigent_resolve_intent_payload(
+        compact_request,
+        workflow_id=manifest["incidentChildWorkflowId"],
+        step_execution_id="replay-step-execution",
+        agent_run_id="replay-agent-run",
+        admitted_feature_generation="omnigent-session-v1",
+        compact_plan_authority=True,
+        compact_workspace_checkpoint_authority=True,
+    )
+    assert compact_payload["workspaceCheckpointRestoreRef"] == expected[
+        "compactIntentCheckpointRestoreRef"
+    ]
+
+    archive_buffer = io.BytesIO()
+    restored_content = manifest["archiveMember"]["content"].encode("utf-8")
+    with tarfile.open(fileobj=archive_buffer, mode="w:gz") as archive:
+        member = tarfile.TarInfo(manifest["archiveMember"]["path"])
+        member.size = len(restored_content)
+        archive.addfile(member, io.BytesIO(restored_content))
+
+    class ReplayArtifactService:
+        async def read(self, *, artifact_id: str, **_kwargs: object):
+            assert f"artifact://{artifact_id}" == restore_ref
+            return {}, archive_buffer.getvalue()
+
+    workflow_id = "workflow-1"
+    step_execution_id = "step-1"
+    workspace_id = hashlib.sha256(
+        f"{workflow_id}:{step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    workspace.mkdir(parents=True)
+    runtime = OmnigentOAuthHostRuntime(
+        client=SimpleNamespace(),
+        workspace_root=tmp_path,
+    )
+    prepare_kwargs = dict(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_execution_id,
+        workspace_checkpoint_restore_ref=restore_ref,
+        artifact_gateway=ReplayArtifactService(),
+    )
+    await runtime._prepare_workspace(**prepare_kwargs)
+
+    restored = workspace / manifest["archiveMember"]["path"]
+    assert restored.read_text(encoding="utf-8") == expected["restoredContent"]
+    restored.write_text(expected["retryPreservedContent"], encoding="utf-8")
+    await runtime._prepare_workspace(**prepare_kwargs)
+    assert restored.read_text(encoding="utf-8") == expected["retryPreservedContent"]
+
+    # The incident's OpenCode profile is admitted through
+    # ``generic-omnigent-host@1``. Exercise that production materializer too;
+    # validating only the legacy OAuth host left the escaped regression intact.
+    from moonmind.omnigent.host_services.workspace import (
+        OmnigentWorkspaceMaterializer,
+    )
+
+    generic_workflow_id = "generic-workflow-1"
+    generic_step_execution_id = "generic-step-1"
+    generic_workspace_id = hashlib.sha256(
+        f"{generic_workflow_id}:{generic_step_execution_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    generic_workspace = (
+        tmp_path / "temporal_sandbox" / generic_workspace_id / "repo"
+    )
+    generic_workspace.mkdir(parents=True)
+    generic_request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=generic_workflow_id,
+        idempotencyKey=generic_step_execution_id,
+        workspaceSpec={
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": generic_workspace_id,
+                "relativePath": "repo",
+            },
+            "repository": "MoonLadderStudios/MoonMind",
+            "branch": "main",
+            "workspaceCheckpointRestoreRef": restore_ref,
+        },
+    )
+
+    async def no_clone(*_args: object, **_kwargs: object):
+        raise AssertionError("pre-materialized replay workspace must not be cloned")
+
+    await OmnigentWorkspaceMaterializer(
+        command_runner=no_clone,
+        workspace_root=tmp_path,
+        artifact_service=ReplayArtifactService(),
+    ).materialize(generic_request)
+    assert (
+        generic_workspace / manifest["archiveMember"]["path"]
+    ).read_text(encoding="utf-8") == expected["restoredContent"]
 
 
 async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without_retry(
@@ -6125,6 +6402,11 @@ async def test_instructionless_inflight_remediation_loop_remains_replayable(
         "info",
         lambda: SimpleNamespace(run_id="inflight-replay-run"),
     )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
 
     parent._initialize_remediation_loop_controller(
         ordered_nodes=[manifest["controllerPlanNode"]],
@@ -7221,3 +7503,89 @@ async def test_verified_no_commit_publication_reaches_the_workflow_publish_hando
             AgentRunResult(summary="Created the pull request for the pushed work."),
         )
     assert unverified.value.code == expected["staleRemoteEvidenceFailureCode"]
+
+
+@pytest.mark.asyncio
+async def test_partial_issue_no_commit_handoff_creates_pr_before_status_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay the false no-commit completion from mm:f194565c."""
+
+    replay_id = "omnigent-issue-implement-missing-pr-authority"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent._owner_type = "user"
+    parent._owner_id = "issue-pr-authority-replay"
+    parent._integration = None
+    parent._repo = manifest["repository"]
+    parent._canonical_no_commit_outcome_enabled = True
+    parent._assessment_context = {
+        "assessmentVerdict": manifest["assessmentVerdict"],
+        "assessmentArtifactRef": manifest["assessmentArtifactRef"],
+    }
+    parent._record_accepted_published_head(
+        {"acceptedRepositoryEvidence": manifest["acceptedRepositoryEvidence"]}
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    )
+    activity_calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute_activity(activity_type: str, payload: dict, **_kwargs):
+        activity_calls.append((activity_type, payload))
+        return {"url": expected["pullRequestUrl"]}
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "title": "Implement GitHub issue",
+            "publish": {"prBaseBranch": "main"},
+            "inputs": {"github_issue": manifest["githubIssue"]},
+            "appliedStepTemplates": [
+                {"slug": "github-issue-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    parent._record_publish_result(
+        parameters=parameters,
+        execution_result={"outputs": {"push_status": "no_commits"}},
+    )
+    assert parent._publish_status == expected["preHandoffPublishStatus"]
+
+    pull_request_url = await parent._ensure_issue_implement_pr_before_status(
+        node={
+            "annotations": {"issueImplementRole": "code-review-handoff"},
+        },
+        parameters=parameters,
+    )
+
+    assert pull_request_url == expected["pullRequestUrl"]
+    assert parent._publish_status == expected["postHandoffPublishStatus"]
+    assert parent._publish_context["pullRequestUrl"] == pull_request_url
+    assert activity_calls == [
+        (
+            "repo.create_pr",
+            {
+                "repo": manifest["repository"],
+                "head": manifest["acceptedRepositoryEvidence"]["branch"],
+                "base": manifest["acceptedRepositoryEvidence"]["baseBranch"],
+                "title": (
+                    "Implement GitHub issue "
+                    f"({manifest['repository']}#{manifest['githubIssue']['number']})"
+                ),
+                "body": (
+                    "Automated changes by MoonMind.\n\n"
+                    f"Closes {manifest['repository']}#{manifest['githubIssue']['number']}\n"
+                ),
+            },
+        )
+    ]

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -2250,6 +2250,55 @@ async def test_invalid_batch_range_records_terminal_failure_without_retry(
     assert expected["parentState"] == "failed"
 
 
+async def test_batch_github_fanout_preserves_checkout_authority_replay() -> None:
+    """Replay mm:f724a9b2 at GitHub discovery and child authoring boundaries."""
+    replay_id = "batch-github-fanout-repository-authority"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    skill = runpy.run_path(
+        str(
+            REPO_ROOT
+            / ".agents"
+            / "skills"
+            / "batch-github-workflows"
+            / "bin"
+            / "batch_workflows.py"
+        )
+    )
+
+    def fake_github_query(command: list[str], **_kwargs: object):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(manifest["githubResponse"]),
+            stderr="",
+        )
+
+    targets = skill["resolve_github_issue_range"](
+        manifest["repository"],
+        manifest["issueRange"],
+        run_command=fake_github_query,
+    )
+    request = skill["build_child_request"](
+        targets[0],
+        config=skill["TargetConfig"](
+            target_kind="preset",
+            target_slug="github-issue-implement",
+            publish_mode="none",
+        ),
+        runtime=skill["RuntimeSelection"](mode="omnigent"),
+        batch_scope="replay:mm:f724a9b2",
+        inherit_runtime_from_caller=True,
+    )
+
+    assert manifest["failedWorkspaceSpec"]["repository"] == expected[
+        "discardedRepository"
+    ]
+    assert "branch" not in manifest["failedWorkspaceSpec"]
+    assert request is not None
+    assert request["payload"]["repository"] == expected["repositoryTarget"]
+
+
 async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/agents/test_moonspec_verify_skill.py
+++ b/tests/unit/agents/test_moonspec_verify_skill.py
@@ -90,7 +90,7 @@ def test_moonspec_verify_skill_treats_publication_as_downstream_candidate_work()
     assert "Do not require downstream commit" in text
 
 
-def test_moonspec_verify_skill_uses_managed_python_test_boundary() -> None:
+def test_moonspec_verify_skill_uses_repository_managed_test_boundary() -> None:
     skill_path = (
         Path(__file__).resolve().parents[3]
         / ".agents"
@@ -100,17 +100,16 @@ def test_moonspec_verify_skill_uses_managed_python_test_boundary() -> None:
     )
 
     text = skill_path.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
 
-    assert "`MOONMIND_STEP_EXECUTION_ID`" in text
-    assert "check `command -v moonmind`" in text
-    assert "moonmind container python-tests ..." in text
-    assert "route every Python" in text
-    assert "test through that command" in text
-    assert "do not run `pytest`" in text
-    assert "any command that installs pytest" in text
-    assert "Host-local Python results are invalid verification evidence" in text
-    assert "absence of `pytest`" in text
-    assert "documented `moonmind container`" in text
+    assert "repository's managed-agent test boundary" in normalized
+    assert "documented managed-run signal" in normalized
+    assert "required delegated test command" in normalized
+    assert "route every covered test through it" in normalized
+    assert "Do not run an equivalent host-local test command" in normalized
+    assert "install a test runner into the agent host" in normalized
+    assert "results from a path the repository forbids" in normalized
+    assert "documented delegated capability exists" in normalized
 
 
 def test_moonspec_verify_skill_rebuilds_post_remediation_classifications() -> None:
@@ -147,7 +146,7 @@ def test_moonspec_verify_skill_defines_target_modes() -> None:
 
     text = skill_path.read_text(encoding="utf-8")
 
-    assert "Treat explicitly identified original implementation instructions" in text
+    assert "Treat the user's instructions as a valid verification baseline" in text
     assert "referenced declarative document as a valid verification baseline" in text
     assert "Do not treat ad hoc verifier guidance" in text
     assert "focus on API tests" in text

--- a/tests/unit/agents/test_moonspec_verify_skill.py
+++ b/tests/unit/agents/test_moonspec_verify_skill.py
@@ -72,6 +72,70 @@ def test_moonspec_verify_skill_supports_issue_brief_mode() -> None:
     assert "Recoverable In Current Runtime: true | false" in text
 
 
+def test_moonspec_verify_skill_treats_publication_as_downstream_candidate_work() -> None:
+    skill_path = (
+        Path(__file__).resolve().parents[3]
+        / ".agents"
+        / "skills"
+        / "moonspec-verify"
+        / "SKILL.md"
+    )
+
+    text = skill_path.read_text(encoding="utf-8")
+
+    assert "pre-publication verification step" in text
+    assert "open issue" in text
+    assert "unmerged candidate" in text
+    assert "expected inputs" in text
+    assert "Do not require downstream commit" in text
+
+
+def test_moonspec_verify_skill_uses_managed_python_test_boundary() -> None:
+    skill_path = (
+        Path(__file__).resolve().parents[3]
+        / ".agents"
+        / "skills"
+        / "moonspec-verify"
+        / "SKILL.md"
+    )
+
+    text = skill_path.read_text(encoding="utf-8")
+
+    assert "`MOONMIND_STEP_EXECUTION_ID`" in text
+    assert "check `command -v moonmind`" in text
+    assert "moonmind container python-tests ..." in text
+    assert "route every Python" in text
+    assert "test through that command" in text
+    assert "do not run `pytest`" in text
+    assert "any command that installs pytest" in text
+    assert "Host-local Python results are invalid verification evidence" in text
+    assert "absence of `pytest`" in text
+    assert "documented `moonmind container`" in text
+
+
+def test_moonspec_verify_skill_rebuilds_post_remediation_classifications() -> None:
+    skill_path = (
+        Path(__file__).resolve().parents[3]
+        / ".agents"
+        / "skills"
+        / "moonspec-verify"
+        / "SKILL.md"
+    )
+
+    text = skill_path.read_text(encoding="utf-8")
+    normalized = " ".join(text.split())
+
+    assert "verification follows a remediation attempt" in normalized
+    assert (
+        "rebuild every controlling classification from the current repository head"
+        in normalized
+    )
+    assert "are hypotheses and process context only" in normalized
+    assert "replace the old status, evidence, line numbers, and notes" in normalized
+    assert "Never copy or incrementally edit a previous verifier JSON report" in normalized
+    assert "no gap may remain solely because the old artifact said it existed" in normalized
+
+
 def test_moonspec_verify_skill_defines_target_modes() -> None:
     skill_path = (
         Path(__file__).resolve().parents[3]

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -15184,6 +15184,71 @@ def test_direct_rerun_rejects_stale_plan_before_execution_creation(
     service.create_execution.assert_not_awaited()
 
 
+def test_direct_rerun_commits_snapshot_lineage_before_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for mm:f724a9b2's rerun returning 500 after creation."""
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    source_record = _build_execution_record(state=MoonMindWorkflowState.FAILED)
+    source_record.owner_type = SimpleNamespace(value="user")
+    source_record.input_ref = None
+    source_record.parameters = {
+        "targetRuntime": "omnigent",
+        "workflow": {"instructions": "Retry the original task."},
+        "omnigentExecutionPlan": {
+            "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+            "planDigest": "sha256:" + "a" * 64,
+            "planArtifactRef": "art_original_plan",
+            "taskInputSnapshotRef": "art_original_input",
+            "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+        },
+    }
+    rerun_record = _build_execution_record(state=MoonMindWorkflowState.INITIALIZING)
+    rerun_record.workflow_id = "mm:created-rerun"
+    rerun_record.run_id = "run-created-rerun"
+    service.describe_execution.return_value = source_record
+    service._full_rerun_parameters = Mock(
+        side_effect=TemporalExecutionService._full_rerun_parameters
+    )
+    service.create_execution.return_value = rerun_record
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_temporal_client(app)
+    user = _override_user_dependencies(app, is_superuser=True)
+    session = AsyncMock()
+    session.get.return_value = source_record
+    app.dependency_overrides[get_async_session] = lambda: session
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+    reuse_snapshot = AsyncMock(return_value="art_snapshot_1")
+    monkeypatch.setattr(
+        executions_module,
+        "_reuse_original_task_input_snapshot_from_source",
+        reuse_snapshot,
+    )
+    serialized = _serialize_execution(rerun_record, user=user)
+
+    def serialize_after_snapshot_commit(record: Any, **_kwargs: Any):
+        session.commit.assert_awaited_once()
+        session.refresh.assert_awaited_once_with(record)
+        return serialized
+
+    monkeypatch.setattr(
+        executions_module,
+        "_serialize_execution",
+        serialize_after_snapshot_commit,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            f"/api/executions/{source_record.workflow_id}/rerun"
+        )
+
+    assert response.status_code == 201
+    assert response.json()["workflowId"] == "mm:created-rerun"
+    reuse_snapshot.assert_awaited_once()
+
+
 def test_task_input_snapshot_artifact_id_strips_input_prefix_without_scheme() -> None:
     assert _artifact_id_from_ref("input/art-full-input") == "art-full-input"
     assert _artifact_id_from_ref("artifact://input/art-full-input") == "art-full-input"

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -88,6 +88,10 @@ async def test_batch_github_workflows_seed_and_expansion_contract(tmp_path):
         '--github-repository "MoonLadderStudios/MoonMind"'
         in step["instructions"]
     )
+    assert (
+        '--repository-connection-ref "$MOONMIND_REPOSITORY_CONNECTION_REF"'
+        in step["instructions"]
+    )
     assert "only for open Issue objects returned by GitHub" in step["instructions"]
     assert (
         "$MOONMIND_ACTIVE_SKILLS_DIR/batch-github-workflows/bin/batch_workflows.py"

--- a/tests/unit/api/test_presets_service.py
+++ b/tests/unit/api/test_presets_service.py
@@ -3692,6 +3692,9 @@ async def test_seed_catalog_github_issue_implement_expands_shared_includes(tmp_p
         "artifacts/github-issue-implement-verify.json"
     )
     assert expanded["steps"][8]["tool"]["inputs"]["requireVerification"] is True
+    assert expanded["steps"][8]["annotations"]["issueImplementRole"] == (
+        "code-review-handoff"
+    )
     no_verify_titles = [step["title"] for step in no_verify["steps"]]
     assert no_verify_titles == [
         "Load GitHub issue brief",

--- a/tests/unit/omnigent/test_oauth_profile_lifecycle.py
+++ b/tests/unit/omnigent/test_oauth_profile_lifecycle.py
@@ -1,9 +1,11 @@
 import asyncio
 import hashlib
+import io
 import json
 import os
 import runpy
 import subprocess
+import tarfile
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -1192,6 +1194,9 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
             "MOONMIND_AGENT_RUN_ID": execution_id,
             "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
             "MOONMIND_RUNTIME_ID": "codex_cli",
+            "MOONMIND_REPOSITORY_CONNECTION_REF": (
+                "repository-connection:tactics"
+            ),
             "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "must-not-be-persisted",
             "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "also-must-not-be-persisted",
         },
@@ -1206,6 +1211,8 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
         f"export MOONMIND_AGENT_RUN_ID='{execution_id}'\n"
         "export MOONMIND_TASK_WORKFLOW_ID='workflow-1'\n"
         "export MOONMIND_RUNTIME_ID='codex_cli'\n"
+        "export MOONMIND_REPOSITORY_CONNECTION_REF="
+        "'repository-connection:tactics'\n"
         "export MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE="
         "'/opt/moonmind/capabilities/container-jobs'\n"
         "export MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE="
@@ -1231,9 +1238,12 @@ def test_runtime_script_snapshot_materializes_owned_step_identity(tmp_path) -> N
         runtime_environment={
             "MOONMIND_URL": "http://api:8000",
             "MOONMIND_AGENT_RUN_ID": execution_id,
-            "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
-            "MOONMIND_RUNTIME_ID": "codex_cli",
-            "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "retry-container-capability",
+                "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+                "MOONMIND_RUNTIME_ID": "codex_cli",
+                "MOONMIND_REPOSITORY_CONNECTION_REF": (
+                    "repository-connection:tactics"
+                ),
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "retry-container-capability",
             "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "retry-fanout-capability",
         },
     )
@@ -1957,6 +1967,7 @@ def test_omnigent_container_job_environment_is_sandbox_and_host_lease_scoped(
             "authorized": True,
             "sourceKind": "built_in",
         },
+        repository_connection_ref="repository-connection:tactics",
     )
 
     assert environment["MOONMIND_CONTAINER_JOBS_MCP_URL"] == (
@@ -1979,6 +1990,9 @@ def test_omnigent_container_job_environment_is_sandbox_and_host_lease_scoped(
     assert fanout.parent_workflow_id == "workflow-1"
     assert fanout.agent_run_id == "agent-run-1"
     assert fanout.session_id == "host-lease-1"
+    assert environment["MOONMIND_REPOSITORY_CONNECTION_REF"] == (
+        "repository-connection:tactics"
+    )
 
 
 def test_omnigent_runtime_authority_is_not_minted_without_required_capabilities(
@@ -4388,6 +4402,70 @@ async def test_coordinator_recovers_running_tool_output_without_terminalizing_it
 
 
 @pytest.mark.asyncio
+async def test_coordinator_recovers_running_tool_output_for_checkpoint_only_step(
+) -> None:
+    """Repository work can continue when its parent owns later publication."""
+
+    runner_calls: list[tuple[str, dict]] = []
+
+    async def execute(request, **kwargs):
+        runner_calls.append((request.idempotency_key, dict(kwargs)))
+        if len(runner_calls) == 1:
+            raise OmnigentSameSessionContinuationRequired(
+                "response completed while session remained active",
+                session_id="session-1",
+                snapshot={"status": "running", "items": []},
+            )
+        return AgentRunResult(
+            summary="continuation completed the checkpoint-only repository work",
+            metadata={
+                "omnigentSessionId": "session-1",
+                "deferredBridgeTerminal": {
+                    "idempotencyKey": request.idempotency_key,
+                    "status": "completed",
+                    "terminalRefs": {"summary": "continuation completed"},
+                },
+            },
+        )
+
+    ordered, _authority, metadata, result = (
+        await _drive_authority_chain_coordinator(
+            execute,
+            completion_evidence=[
+                {
+                    "sessionStatus": "running",
+                    "itemCount": 5,
+                    "assistantMessageCount": 1,
+                    "toolResultCount": 1,
+                    "terminalAssistantAfterWork": False,
+                },
+                {
+                    "sessionStatus": "idle",
+                    "itemCount": 7,
+                    "assistantMessageCount": 2,
+                    "toolResultCount": 1,
+                    "terminalAssistantAfterWork": True,
+                },
+            ],
+            request_parameters={
+                "publishMode": "none",
+                "repositoryMutationRequired": True,
+                "repositoryOperation": "write",
+            },
+        )
+    )
+
+    assert result.failure_class is None
+    assert metadata["repositoryContinuationCount"] == 1
+    assert "push_status" not in metadata
+    assert len(runner_calls) == 2
+    assert runner_calls[1][0].endswith(":repository-continuation:1")
+    assert runner_calls[1][1]["resume_session_id"] == "session-1"
+    assert "repository_continuation_1" in ordered
+    assert "repository_publication" not in ordered
+
+
+@pytest.mark.asyncio
 async def test_coordinator_projects_verified_pull_request_url() -> None:
     """Remote PR identity survives the runtime-to-finalizer handoff."""
 
@@ -5847,6 +5925,78 @@ async def test_prepare_workspace_materialization_is_idempotent(tmp_path) -> None
 
 
 @pytest.mark.asyncio
+async def test_prepare_workspace_projects_inputs_into_pre_materialized_sandbox(
+    tmp_path,
+) -> None:
+    """The host must project checkpoint and attachments after sandbox checkout."""
+
+    source = tmp_path / "source"
+    _init_source_repo(source)
+    runtime = _runtime_for(tmp_path)
+    workspace_id = _sandbox_id()
+    workspace = (
+        tmp_path / "workspaces" / "temporal_sandbox" / workspace_id / "repo"
+    )
+    subprocess.run(
+        ["git", "clone", "--branch", "main", str(source), str(workspace)],
+        check=True,
+        capture_output=True,
+    )
+
+    archive_stream = io.BytesIO()
+    with tarfile.open(fileobj=archive_stream, mode="w:gz") as archive:
+        payload = b"candidate-worktree\n"
+        member = tarfile.TarInfo("README.md")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+    checkpoint_ref = "artifact://checkpoint/candidate"
+    attachment_ref = "artifact://attachment/brief"
+    service = _FakeArtifactService(
+        {
+            "checkpoint/candidate": archive_stream.getvalue(),
+            "attachment/brief": b'{"issue":"3815"}',
+        }
+    )
+    kwargs = dict(
+        workspace_locator={"kind": "sandbox", "workspaceId": workspace_id},
+        current_workflow_id="workflow-1",
+        current_step_execution_id="step-1",
+        workspace_checkpoint_restore_ref=checkpoint_ref,
+        attachment_refs=(attachment_ref,),
+        artifact_gateway=service,
+    )
+
+    resolved = await runtime._prepare_workspace(**kwargs)
+
+    assert resolved == workspace
+    assert (resolved / "README.md").read_text(encoding="utf-8") == (
+        "candidate-worktree\n"
+    )
+    attachments = list((resolved / ".moonmind" / "attachments").iterdir())
+    assert len(attachments) == 1
+    assert attachments[0].read_bytes() == b'{"issue":"3815"}'
+    assert runtime._last_workspace_evidence["materialization"] == {
+        "action": "reused_pre_materialized",
+        "checkpointRestoreRef": checkpoint_ref,
+        "attachments": [
+            {"ref": attachment_ref, "bytes": len(b'{"issue":"3815"}')}
+        ],
+    }
+
+    # A retry observes the durable completion marker and must not overwrite work
+    # produced after host launch by reapplying the checkpoint archive.
+    (resolved / "README.md").write_text("agent-progress\n", encoding="utf-8")
+    await runtime._prepare_workspace(**kwargs)
+    assert (resolved / "README.md").read_text(encoding="utf-8") == (
+        "agent-progress\n"
+    )
+    assert [call["artifact_id"] for call in service.read_calls] == [
+        "checkpoint/candidate",
+        "attachment/brief",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_prepare_workspace_honors_authored_output_branch(tmp_path) -> None:
     source = tmp_path / "source"
     _init_source_repo(source)
@@ -6286,6 +6436,41 @@ async def test_prepare_workspace_streams_restore_inputs_when_supported(
     # The payload was pre-checked from metadata and streamed via chunked reads.
     assert service.metadata_calls == ["checkpoint/big-archive"]
     assert service.chunk_calls == ["checkpoint/big-archive"]
+
+
+@pytest.mark.asyncio
+async def test_workspace_checkpoint_streams_beyond_generic_input_limit(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime._MAX_RESTORE_INPUT_BYTES", 16
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.oauth_host_runtime._MAX_WORKSPACE_CHECKPOINT_BYTES",
+        4096,
+    )
+    archive_stream = io.BytesIO()
+    restored_payload = b"candidate" * 32
+    with tarfile.open(fileobj=archive_stream, mode="w:gz") as archive:
+        member = tarfile.TarInfo("candidate.txt")
+        member.size = len(restored_payload)
+        archive.addfile(member, io.BytesIO(restored_payload))
+    archive_payload = archive_stream.getvalue()
+    assert len(archive_payload) > 16
+    service = _StreamingArtifactService({"checkpoint/candidate": archive_payload})
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    await _runtime_for(tmp_path)._apply_workspace_checkpoint_restore(
+        workspace,
+        artifact_ref="artifact://checkpoint/candidate",
+        artifact_gateway=service,
+    )
+
+    assert (workspace / "candidate.txt").read_bytes() == restored_payload
+    assert service.metadata_calls == ["checkpoint/candidate"]
+    assert service.chunk_calls == ["checkpoint/candidate"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 import stat
 import tarfile
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from moonmind.omnigent.host_services.workspace import (
     build_daemon_workspace_chown_argv,
     normalize_github_clone_source,
 )
+from moonmind.omnigent.workspace_artifacts import WorkspaceArtifactProjector
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
@@ -320,7 +322,11 @@ async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount
         command_runner=fail_runner,
         workspace_root=tmp_path,
         artifact_service=service,
-    ).materialize(request)
+    ).materialize(
+        request,
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
 
     assert (existing / "tracked.txt").read_text() == "implementation checkpoint\n"
     assert (existing / "candidate.txt").read_text() == "new candidate file\n"
@@ -336,14 +342,39 @@ async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount
     assert not (existing / ".moonmind" / "restore" / "stale-restore").exists()
     assert stat.S_IMODE(restore_path.stat().st_mode) == 0o400
     assert stat.S_IMODE(attachment_path.stat().st_mode) == 0o400
-    assert restore_path.stat().st_uid == 1000
-    assert restore_path.stat().st_gid == 1000
-    assert attachment_path.stat().st_uid == 1000
-    assert attachment_path.stat().st_gid == 1000
+    assert restore_path.stat().st_uid == os.getuid()
+    assert restore_path.stat().st_gid == os.getgid()
+    assert attachment_path.stat().st_uid == os.getuid()
+    assert attachment_path.stat().st_gid == os.getgid()
     assert "/.moonmind/attachments/" in (
         existing / ".git" / "info" / "exclude"
     ).read_text()
     assert SandboxWorkspaceRecordStore(tmp_path).is_materialized(workspace_id)
+
+
+def test_runtime_input_ownership_handoff_targets_selected_identity(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "restore-input"
+    target.write_bytes(b"restore state")
+    selected_uid = os.getuid() + 1
+    selected_gid = os.getgid() + 1
+    chown_calls: list[tuple[object, int, int, bool]] = []
+
+    def record_chown(path, uid, gid, *, follow_symlinks):
+        chown_calls.append((path, uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(os, "chown", record_chown)
+
+    WorkspaceArtifactProjector._make_runtime_readable(
+        target,
+        runtime_uid=selected_uid,
+        runtime_gid=selected_gid,
+        noun="restore inputs",
+    )
+
+    assert chown_calls == [(target, selected_uid, selected_gid, False)]
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import io
+import stat
+import tarfile
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +29,7 @@ def _request(spec: dict) -> SimpleNamespace:
     return SimpleNamespace(
         workspace_spec=spec,
         parameters={},
+        input_refs=[],
         step_execution=None,
         correlation_id="workflow-1",
         idempotency_key="step-1",
@@ -66,8 +70,25 @@ def test_daemon_git_clone_argv_pins_target():
     assert "alpine/git:v2.43.0" in argv
     joined = " ".join(argv)
     assert " clone " in joined and "--single-branch" in joined
+    assert 'git check-ref-format --branch "$1"' in joined
     assert "--entrypoint" in argv
     assert all("x-access-token:tok" not in part for part in argv)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    ["feature/foo!bar", "feature/foo=bar", "développement"],
+)
+def test_daemon_git_clone_argv_preserves_git_valid_branch_names(branch: str):
+    argv = build_daemon_git_clone_argv(
+        volume="agent_workspaces",
+        target_in_volume="ws-1/repo",
+        source="https://github.com/org/repo.git",
+        branch=branch,
+        image="alpine/git:v2.43.0",
+    )
+
+    assert argv[-3] == branch
 
 
 def test_daemon_git_clone_argv_rejects_credentialed_source():
@@ -217,6 +238,112 @@ async def test_materializer_keeps_existing_authoritative_workspace(
         )
     )
     assert (existing / "KEEP").exists()
+
+
+@pytest.mark.asyncio
+async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount(
+    tmp_path,
+):
+    """The generic host must launch from the same workspace authority as Codex."""
+
+    workspace_id = _workspace_id()
+    existing = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    (existing / ".git" / "info").mkdir(parents=True)
+    (existing / "tracked.txt").write_text("base", encoding="utf-8")
+
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+        payload = b"implementation checkpoint\n"
+        member = tarfile.TarInfo("tracked.txt")
+        member.size = len(payload)
+        bundle.addfile(member, io.BytesIO(payload))
+        added = b"new candidate file\n"
+        member = tarfile.TarInfo("candidate.txt")
+        member.size = len(added)
+        bundle.addfile(member, io.BytesIO(added))
+        stale = b"prior verifier context"
+        member = tarfile.TarInfo(".moonmind/attachments/stale-verifier")
+        member.size = len(stale)
+        bundle.addfile(member, io.BytesIO(stale))
+        stale_restore = b"stale restore state"
+        member = tarfile.TarInfo(".moonmind/restore/stale-restore")
+        member.size = len(stale_restore)
+        bundle.addfile(member, io.BytesIO(stale_restore))
+
+    checkpoint_ref = "artifact://checkpoint"
+    restore_ref = "artifact://restore"
+    attachment_ref = "artifact://assessment"
+
+    class ArtifactService:
+        def __init__(self) -> None:
+            self.reads: list[tuple[str, str]] = []
+            self.payloads = {
+                "checkpoint": archive.getvalue(),
+                "restore": b"restore state",
+                "assessment": b'{"verdict":"PARTIALLY_IMPLEMENTED"}',
+            }
+
+        async def get_metadata(self, *, artifact_id, principal):
+            self.reads.append((artifact_id, principal))
+            artifact = SimpleNamespace(size_bytes=len(self.payloads[artifact_id]))
+            links = [SimpleNamespace(workflow_id="workflow-1")]
+            return artifact, links
+
+        async def read_chunks(
+            self, *, artifact_id, principal, allow_restricted_raw, chunk_size
+        ):
+            assert allow_restricted_raw is True
+            self.reads.append((artifact_id, principal))
+            return SimpleNamespace(), iter((self.payloads[artifact_id],))
+
+    service = ArtifactService()
+
+    async def fail_runner(*_args, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("existing authoritative checkout must not be cloned")
+
+    request = _request(
+        {
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": "repo",
+            },
+            "repository": "MoonLadderStudios/MoonMind",
+            "branch": "main",
+            "workspaceCheckpointRestoreRef": checkpoint_ref,
+            "restoreInputRefs": [restore_ref],
+        }
+    )
+    request.input_refs = [attachment_ref]
+
+    await OmnigentWorkspaceMaterializer(
+        command_runner=fail_runner,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    ).materialize(request)
+
+    assert (existing / "tracked.txt").read_text() == "implementation checkpoint\n"
+    assert (existing / "candidate.txt").read_text() == "new candidate file\n"
+    restore_path = existing / ".moonmind" / "restore" / hashlib.sha256(
+        restore_ref.encode()
+    ).hexdigest()[:24]
+    attachment_path = existing / ".moonmind" / "attachments" / hashlib.sha256(
+        attachment_ref.encode()
+    ).hexdigest()[:24]
+    assert restore_path.read_bytes() == b"restore state"
+    assert attachment_path.read_bytes() == b'{"verdict":"PARTIALLY_IMPLEMENTED"}'
+    assert not (existing / ".moonmind" / "attachments" / "stale-verifier").exists()
+    assert not (existing / ".moonmind" / "restore" / "stale-restore").exists()
+    assert stat.S_IMODE(restore_path.stat().st_mode) == 0o400
+    assert stat.S_IMODE(attachment_path.stat().st_mode) == 0o400
+    assert restore_path.stat().st_uid == 1000
+    assert restore_path.stat().st_gid == 1000
+    assert attachment_path.stat().st_uid == 1000
+    assert attachment_path.stat().st_gid == 1000
+    assert "/.moonmind/attachments/" in (
+        existing / ".git" / "info" / "exclude"
+    ).read_text()
+    assert SandboxWorkspaceRecordStore(tmp_path).is_materialized(workspace_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -182,6 +182,12 @@ _GITHUB_TARGET: dict[str, Any] = {
         "labels": ["bug"],
     },
     "repository": "MoonLadderStudios/MoonMind",
+    "repositoryTarget": {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "MoonLadderStudios/MoonMind"},
+        "branch": {"name": "main"},
+    },
 }
 
 
@@ -225,6 +231,7 @@ def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers
                 {
                     "data": {
                         "repository": {
+                            "defaultBranchRef": {"name": "main"},
                             "issue40": {
                                 "number": 40,
                                 "title": "Existing issue",
@@ -292,6 +299,12 @@ def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers
         "state": "open",
         "labels": ["bug"],
     }
+    assert targets[0]["repositoryTarget"] == {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {"name": "acme/widgets"},
+        "branch": {"name": "main"},
+    }
     assert len(calls) == 1
     query_arg = next(arg for arg in calls[0] if arg.startswith("query="))
     assert "issue40: issue(number: 40)" in query_arg
@@ -299,10 +312,49 @@ def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers
     assert "issue42: issue(number: 42)" in query_arg
     assert "issue43: issue(number: 43)" in query_arg
     assert "issue44: issue(number: 44)" in query_arg
+    assert "defaultBranchRef { name }" in query_arg
     assert "-F" not in calls[0]
     assert calls[0].count("-f") == 3
     assert "owner=acme" in calls[0]
     assert "name=widgets" in calls[0]
+
+
+def test_resolve_github_issue_range_requires_safe_default_branch_authority():
+    module = _load_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "defaultBranchRef": None,
+                            "issue42": {
+                                "number": 42,
+                                "title": "Issue without checkout authority",
+                                "body": "Body",
+                                "url": "https://github.com/acme/widgets/issues/42",
+                                "state": "OPEN",
+                                "labels": {"nodes": []},
+                            },
+                        }
+                    }
+                }
+            ),
+            stderr="",
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="default branch is unavailable or unsafe",
+    ):
+        module["resolve_github_issue_range"](
+            "acme/widgets",
+            "42-42",
+            run_command=fake_run,
+        )
 
 
 def test_resolve_github_issue_range_rejects_unbounded_scan_before_querying():
@@ -569,6 +621,20 @@ def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():
     key = payload["idempotencyKey"]
     assert key.startswith("batch-workflows:jira:THOR-123:sha256:")
     assert len(key) <= module["IDEMPOTENCY_KEY_MAX_LENGTH"]
+
+
+def test_build_github_child_request_preserves_canonical_repository_authority():
+    module = _load_module()
+    request = module["build_child_request"](
+        _GITHUB_TARGET,
+        config=_github_config(module),
+        runtime=module["RuntimeSelection"](mode="omnigent"),
+        batch_scope="run-1",
+        inherit_runtime_from_caller=True,
+    )
+
+    assert request is not None
+    assert request["payload"]["repository"] == _GITHUB_TARGET["repositoryTarget"]
 
 
 def test_build_child_request_passes_update_status_for_jira_verify():

--- a/tests/unit/test_batch_workflows.py
+++ b/tests/unit/test_batch_workflows.py
@@ -286,6 +286,7 @@ def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers
     targets = module["resolve_github_issue_range"](
         "acme/widgets",
         "40-44",
+        connection_ref="repository-connection:acme",
         run_command=fake_run,
     )
 
@@ -301,7 +302,7 @@ def test_resolve_github_issue_range_excludes_non_open_issues_and_missing_numbers
     }
     assert targets[0]["repositoryTarget"] == {
         "provider": "git",
-        "connectionRef": "repository-connection:git-default",
+        "connectionRef": "repository-connection:acme",
         "repository": {"name": "acme/widgets"},
         "branch": {"name": "main"},
     }
@@ -353,8 +354,25 @@ def test_resolve_github_issue_range_requires_safe_default_branch_authority():
         module["resolve_github_issue_range"](
             "acme/widgets",
             "42-42",
+            connection_ref="repository-connection:acme",
             run_command=fake_run,
         )
+
+
+@pytest.mark.parametrize(
+    "branch",
+    ["feature/foo!bar", "feature/foo=bar", "développement"],
+)
+def test_git_branch_validation_accepts_git_valid_default_branches(branch: str):
+    module = _load_module()
+
+    assert module["_git_branch_is_valid"](branch) is True
+
+
+def test_git_branch_validation_rejects_git_invalid_default_branch():
+    module = _load_module()
+
+    assert module["_git_branch_is_valid"]("feature/../escape") is False
 
 
 def test_resolve_github_issue_range_rejects_unbounded_scan_before_querying():
@@ -373,6 +391,7 @@ def test_resolve_github_issue_range_rejects_unbounded_scan_before_querying():
         module["resolve_github_issue_range"](
             "acme/widgets",
             "1-1001",
+            connection_ref="repository-connection:acme",
             run_command=unexpected_run,
         )
 
@@ -579,6 +598,29 @@ def test_load_parent_repository_reads_task_context(tmp_path):
         load_parent_repository(str(task_context))
         == "MoonLadderStudios/Tactics"
     )
+
+
+def test_load_parent_repository_connection_reads_canonical_task_context(tmp_path):
+    module = _load_module()
+    task_context = tmp_path / "task_context.json"
+    task_context.write_text(
+        json.dumps(
+            {
+                "repository": "MoonLadderStudios/Tactics",
+                "repositoryTarget": {
+                    "provider": "git",
+                    "connectionRef": "repository-connection:tactics",
+                    "repository": {"name": "MoonLadderStudios/Tactics"},
+                    "branch": {"name": "main"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert module["_load_parent_repository_connection_ref"](
+        str(task_context)
+    ) == "repository-connection:tactics"
 
 
 def test_build_child_request_sets_runtime_inheritance_publish_and_idempotency():

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -152,6 +152,14 @@ def test_agent_run_resolve_handoff_is_compact_with_legacy_replay_decode() -> Non
             omnigentExecutionPlan=binding,
             request={"persisted": "ambiguous-authority-payload"},
         )
+    with pytest.raises(ValidationError, match="opaque artifact reference"):
+        OmnigentResolveIntentRequest(
+            workflowId="workflow-1",
+            stepExecutionId="step-1",
+            agentRunId="agent-run-1",
+            omnigentExecutionPlan=binding,
+            workspaceCheckpointRestoreRef="/tmp/untrusted-checkpoint.tar.gz",
+        )
 
 
 def test_intent_snapshot_preserves_legacy_request_authority() -> None:
@@ -217,6 +225,7 @@ def test_intent_snapshot_keeps_plan_bound_authority_compact() -> None:
         executionInstructionDigest="sha256:" + "c" * 64,
         executionInputRefs=["art-input"],
         executionInputRefsDigest="sha256:" + "d" * 64,
+        workspaceCheckpointRestoreRef="artifact://art-checkpoint",
         omnigentExecutionPlan=binding,
     )
 
@@ -239,6 +248,7 @@ def test_intent_snapshot_keeps_plan_bound_authority_compact() -> None:
         "executionInstructionDigest": "sha256:" + "c" * 64,
         "executionInputRefs": ["art-input"],
         "executionInputRefsDigest": "sha256:" + "d" * 64,
+        "workspaceCheckpointRestoreRef": "artifact://art-checkpoint",
         "omnigentExecutionPlan": binding.model_dump(mode="json", by_alias=True),
     }
     assert artifact_name == "omnigent.agent-execution-request-snapshot.json"
@@ -344,6 +354,7 @@ async def test_compact_plan_handoff_reconstructs_selected_authored_step(
 
     continuation_instruction = "Continue using only the selected evidence."
     continuation_refs = ["art-continuation", "art-selected-evidence"]
+    checkpoint_restore_ref = "artifact://art-workspace-checkpoint"
     continued = await omnigent_session_activities._reconstruct_plan_bound_request(
         binding=binding,
         plan=plan,
@@ -365,9 +376,14 @@ async def test_compact_plan_handoff_reconstructs_selected_authored_step(
                 ).encode("utf-8")
             )
         ),
+        workspace_checkpoint_restore_ref=checkpoint_restore_ref,
     )
     assert continued.instruction_ref == continuation_instruction
     assert continued.input_refs[-2:] == continuation_refs
+    assert (
+        continued.workspace_spec["workspaceCheckpointRestoreRef"]
+        == checkpoint_restore_ref
+    )
 
     bundle_plan = SimpleNamespace(
         payload=SimpleNamespace(
@@ -1568,6 +1584,7 @@ def test_agent_run_patch_preserves_legacy_replay_and_selects_new_supervisor() ->
     assert "OMNIGENT_SESSION_SUPERVISOR_PATCH_ID" in source
     assert "OMNIGENT_SESSION_ADMISSION_PATCH_ID" in source
     assert "OMNIGENT_COMPACT_RESOLVE_INTENT_PATCH_ID" in source
+    assert "OMNIGENT_COMPACT_WORKSPACE_CHECKPOINT_PATCH_ID" in source
     assert '"omnigent.evaluate_session_admission"' in source
     assert '"MoonMind.OmnigentSession"' in source
     assert "omnigent_session_workflow_id" in source
@@ -1580,6 +1597,19 @@ def test_agent_run_patch_preserves_legacy_replay_and_selects_new_supervisor() ->
     )[0]
     assert "_omnigent_resolve_intent_payload" in resolve_call
     assert "compact_plan_authority" in resolve_call
+    assert "compact_workspace_checkpoint_authority" in resolve_call
+
+
+def test_ensure_host_materializes_canonical_execution_inputs_as_attachments() -> None:
+    source = inspect.getsource(
+        omnigent_session_activities.omnigent_ensure_host_activity
+    )
+
+    assert (
+        "OmnigentProfileBoundExecutionCoordinator._attachment_refs"
+        in source
+    )
+    assert "workspace_checkpoint_restore_ref" in source
 
 
 def test_agent_run_compact_intent_patch_preserves_legacy_activity_shape() -> None:
@@ -1598,6 +1628,10 @@ def test_agent_run_compact_intent_patch_preserves_legacy_activity_shape() -> Non
         correlationId="workflow-1",
         idempotencyKey="step-1",
         instructionRef="art_task",
+        inputRefs=["artifact://art-input"],
+        workspaceSpec={
+            "workspaceCheckpointRestoreRef": "artifact://art-workspace-checkpoint"
+        },
         parameters={"providerPayload": "must-not-enter-new-history"},
     )
     common = {
@@ -1605,6 +1639,7 @@ def test_agent_run_compact_intent_patch_preserves_legacy_activity_shape() -> Non
         "step_execution_id": "step-1",
         "agent_run_id": "agent-run-1",
         "admitted_feature_generation": OMNIGENT_SESSION_FEATURE_GENERATION,
+        "compact_workspace_checkpoint_authority": True,
     }
 
     compact = MoonMindAgentRun._omnigent_resolve_intent_payload(
@@ -1619,6 +1654,10 @@ def test_agent_run_compact_intent_patch_preserves_legacy_activity_shape() -> Non
     )
     assert compact["executionInstructionRef"] == "art_task"
     assert compact["executionInstructionDigest"].startswith("sha256:")
+    assert compact["executionInputRefs"] == ["artifact://art-input"]
+    assert compact["workspaceCheckpointRestoreRef"] == (
+        "artifact://art-workspace-checkpoint"
+    )
     assert "request" not in compact
     assert "providerPayload" not in json.dumps(compact)
     assert legacy["request"]["parameters"]["providerPayload"] == (

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -546,6 +546,43 @@ async def test_update_github_issue_status_blocks_done_when_pushed_changes_have_n
 
 
 @pytest.mark.asyncio
+async def test_update_github_issue_status_blocks_partial_no_commit_without_pr() -> None:
+    artifact_service = _FakeAssessmentArtifactService(
+        {"art_partial_assessment": {"verdict": "PARTIALLY_IMPLEMENTED"}}
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 3815,
+            "mode": "finalize_after_pr_or_done",
+            "previousOutputs": {
+                "assessmentArtifactRef": "art_partial_assessment",
+                "push_status": "no_commits",
+                "push_commit_count": 0,
+            },
+        },
+        {"temporal_artifact_service": artifact_service},
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs == {
+        "issueRef": "MoonLadderStudios/MoonMind#3815",
+        "decision": "blocked",
+        "assessmentVerdict": "PARTIALLY_IMPLEMENTED",
+        "summary": (
+            "Skipped GitHub issue finalization because the initial assessment "
+            "was PARTIALLY_IMPLEMENTED and no authoritative pull request URL "
+            "was available."
+        ),
+    }
+    assert artifact_service.read_calls == ["art_partial_assessment"]
+    assert service.token_requests == []
+
+
+@pytest.mark.asyncio
 async def test_update_github_issue_status_uses_pr_url_from_publish_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -23,9 +23,12 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_HANDOFF_ACCEPTED_DISPOSITION_GATE_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
+    RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
     RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH,
+    RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
+    RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
     RUN_PAUSE_SAFE_BOUNDARIES_PATCH,
     RUN_PUBLISH_REPAIR_FEEDBACK_PATCH,
     RUN_PR_RESOLVER_PUBLISH_EVIDENCE_REF_PATCH,
@@ -3738,10 +3741,21 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
         "sideEffectPolicy": "workflow_owned",
         "publicationPolicy": "evaluate_after_terminal",
     }
+    controller = _loop_controller_node(loop)
+    controller["tool"] = {"type": "agent_runtime", "name": "omnigent"}
+    controller["inputs"]["runtime"] = {
+        "mode": "omnigent",
+        "executionProfileRef": "opencode-zen-free",
+    }
     mock_run_workflow._initialize_remediation_loop_controller(
-        ordered_nodes=[_loop_controller_node(loop)]
+        ordered_nodes=[controller]
     )
     mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "implementation",
+            "status": "completed",
+            "attempt": 1,
+        },
         {
             "logicalStepId": "initial-verification",
             "status": "completed",
@@ -3750,9 +3764,20 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
     ]
     mock_run_workflow._rebuild_step_ledger_index()
     mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
+        "implementation": {
+            "before_publication": {
+                "checkpointRef": "art_implementation_checkpoint",
+                "workspaceArchiveRef": "art_implementation_archive",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:implementation-candidate",
+                "workspaceIdentityDigest": "sha256:" + ("b" * 64),
+                "checkpointManifestRef": "art_implementation_manifest",
+            }
+        },
         "initial-verification": {
             "before_publication": {
                 "checkpointRef": "art_initial_checkpoint",
+                "workspaceArchiveRef": "art_initial_archive",
                 "workspaceKind": "worktree_archive",
                 "workspaceDigest": "sha256:initial-candidate",
                 "workspaceIdentityDigest": "sha256:" + ("c" * 64),
@@ -3770,6 +3795,8 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
         in {
             RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
             RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+            RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
         },
     )
     ordered_nodes: list[dict[str, Any]] = []
@@ -3787,15 +3814,15 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
     state = mock_run_workflow._remediation_loop_state
     assert head is not None
     assert state is not None
-    assert head.root_checkpoint_ref == "artifact://art_initial_checkpoint"
-    assert head.head_checkpoint_ref == "artifact://art_initial_checkpoint"
-    assert head.head_workspace_digest == "sha256:initial-candidate"
-    assert head.head_workspace_identity_digest == "sha256:" + ("c" * 64)
+    assert head.root_checkpoint_ref == "artifact://art_implementation_archive"
+    assert head.head_checkpoint_ref == "artifact://art_implementation_archive"
+    assert head.head_workspace_digest == "sha256:implementation-candidate"
+    assert head.head_workspace_identity_digest == "sha256:" + ("b" * 64)
     assert head.latest_verification_ref == "artifact://verification/V0"
     assert head.latest_verification_verdict == "ADDITIONAL_WORK_NEEDED"
-    assert state.workspace_head_ref == "artifact://art_initial_checkpoint"
+    assert state.workspace_head_ref == "artifact://art_implementation_archive"
     assert ordered_nodes[0]["inputs"]["remediationWorkspaceHeadRef"] == (
-        "artifact://art_initial_checkpoint"
+        "artifact://art_implementation_archive"
     )
     assert ordered_nodes[0]["annotations"]["workspaceCaptureSourceIdentity"] == {
         "workflowId": "wf-1",
@@ -6038,7 +6065,9 @@ def test_existing_managed_session_keeps_prior_checkpoint_shape_during_replay(
 
 def test_remediation_head_uses_archive_not_git_patch_checkpoint(
     mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    mock_run_workflow._remediation_loop_runtime = {"mode": "omnigent"}
     mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
         "initial-verification": {
             "after_execution": {
@@ -6050,6 +6079,7 @@ def test_remediation_head_uses_archive_not_git_patch_checkpoint(
             },
             "before_publication": {
                 "checkpointRef": "art_archive_checkpoint",
+                "workspaceArchiveRef": "art_workspace_archive",
                 "workspaceKind": "worktree_archive",
                 "workspaceDigest": "sha256:archive-candidate",
                 "workspaceIdentityDigest": "sha256:" + ("c" * 64),
@@ -6057,17 +6087,545 @@ def test_remediation_head_uses_archive_not_git_patch_checkpoint(
             },
         }
     }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+        ),
+    )
 
     evidence = mock_run_workflow._canonical_remediation_checkpoint_evidence(
         "initial-verification"
     )
 
     assert evidence == {
-        "checkpointRef": "artifact://art_archive_checkpoint",
+        "checkpointRef": "artifact://art_workspace_archive",
         "workspaceDigest": "sha256:archive-candidate",
         "workspaceIdentityDigest": "sha256:" + ("c" * 64),
         "checkpointManifestRef": "artifact://art_archive_manifest",
     }
+
+
+def test_omnigent_remediation_restores_head_before_agent_launch(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = {
+        "id": "remediation-1",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "annotations": {
+            "remediationLoopId": "issue-implementation-remediation",
+            "issueImplementRole": "moonspec-remediation",
+            "moonSpecRemediationAttempt": 1,
+        },
+        "inputs": {
+            "runtime": {
+                "mode": "omnigent",
+                "executionProfileRef": "opencode-zen-free",
+            },
+        },
+    }
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(_remediation_head_payload())
+    )
+    mock_run_workflow._remediation_loop_runtime = {"mode": "omnigent"}
+    node_inputs = dict(node["inputs"])
+    mock_run_workflow._inject_remediation_workspace_baseline(
+        node=node,
+        node_inputs=node_inputs,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+        },
+    )
+
+    restore_ref = (
+        mock_run_workflow._trusted_omnigent_remediation_checkpoint_restore_ref(
+            node=node,
+            node_inputs=node_inputs,
+        )
+    )
+    request = mock_run_workflow._build_agent_execution_request(
+        node_inputs=node_inputs,
+        node_id="remediation-1",
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=restore_ref,
+    )
+
+    assert restore_ref == "artifact://workspace/C0"
+    assert request.workspace_spec["workspaceCheckpointRestoreRef"] == restore_ref
+    assert not mock_run_workflow._remediation_workspace_materialization_required(
+        node
+    )
+
+
+def test_initial_omnigent_verifier_restores_latest_candidate_before_launch(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _loop_controller_node(_dynamic_loop_spec_payload())
+    controller["tool"] = {"type": "agent_runtime", "name": "omnigent"}
+    controller["inputs"]["runtime"] = {"mode": "omnigent"}
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[controller]
+    )
+    mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "implementation",
+            "status": "completed",
+            "annotations": {"issueImplementRole": "issue-implementation"},
+        },
+        {
+            "logicalStepId": "initial-verification",
+            "status": "executing",
+            "annotations": {},
+        },
+    ]
+    mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
+        "implementation": {
+            "before_publication": {
+                "checkpointRef": "art_implementation_checkpoint",
+                "workspaceArchiveRef": "art_implementation_archive",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:implementation-candidate",
+                "workspaceIdentityDigest": "sha256:" + ("b" * 64),
+                "checkpointManifestRef": "art_implementation_manifest",
+            }
+        }
+    }
+    node = {
+        "id": "initial-verification",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "inputs": {
+            "runtime": {"mode": "omnigent"},
+            "selectedSkill": "moonspec-verify",
+        },
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+            RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
+        },
+    )
+
+    restore_ref = (
+        mock_run_workflow._initial_omnigent_verification_checkpoint_restore_ref(
+            node=node
+        )
+    )
+    request = mock_run_workflow._build_agent_execution_request(
+        node_inputs=dict(node["inputs"]),
+        node_id=node["id"],
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=restore_ref,
+    )
+
+    assert restore_ref == "artifact://art_implementation_archive"
+    assert request.workspace_spec["workspaceCheckpointRestoreRef"] == restore_ref
+
+
+def test_omnigent_publication_handoff_restores_verified_remediation_head(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = {
+        "id": "publish-pr",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "annotations": {"issueImplementRole": "pull-request-handoff"},
+        "inputs": {"runtime": {"mode": "omnigent"}},
+    }
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(
+            _remediation_head_payload(checkpoint="C1", version=2)
+        )
+    )
+    mock_run_workflow._remediation_loop_runtime = {"mode": "omnigent"}
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == "run-omnigent-publication-checkpoint-restore-v1"
+        ),
+    )
+
+    restore_ref = (
+        mock_run_workflow._omnigent_publication_checkpoint_restore_ref(
+            node=node,
+            node_inputs=node["inputs"],
+        )
+    )
+    request = mock_run_workflow._build_agent_execution_request(
+        node_inputs=dict(node["inputs"]),
+        node_id=node["id"],
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=restore_ref,
+    )
+
+    assert restore_ref == "artifact://workspace/C1"
+    assert request.workspace_spec["workspaceCheckpointRestoreRef"] == restore_ref
+
+
+def test_omnigent_publication_handoff_restores_implementation_without_remediation(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = {
+        "id": "publish-pr",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "annotations": {"issueImplementRole": "pull-request-handoff"},
+        "inputs": {"runtime": {"mode": "omnigent"}},
+    }
+    mock_run_workflow._remediation_loop_runtime = {"mode": "omnigent"}
+    mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "implementation",
+            "status": "completed",
+            "annotations": {"issueImplementRole": "issue-implementation"},
+        },
+        {
+            "logicalStepId": "initial-verification",
+            "status": "completed",
+            "annotations": {"issueImplementRole": "moonspec-verification-gate"},
+        },
+        {
+            "logicalStepId": "publish-pr",
+            "status": "executing",
+            "annotations": {"issueImplementRole": "pull-request-handoff"},
+        },
+    ]
+    mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
+        "implementation": {
+            "before_publication": {
+                "checkpointRef": "art_implementation_checkpoint",
+                "workspaceArchiveRef": "art_implementation_archive",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:implementation-candidate",
+                "workspaceIdentityDigest": "sha256:" + ("b" * 64),
+                "checkpointManifestRef": "art_implementation_manifest",
+            }
+        }
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            "run-omnigent-publication-checkpoint-restore-v1",
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+        },
+    )
+
+    restore_ref = (
+        mock_run_workflow._omnigent_publication_checkpoint_restore_ref(
+            node=node,
+            node_inputs=node["inputs"],
+        )
+    )
+
+    assert restore_ref == "artifact://art_implementation_archive"
+
+
+@pytest.mark.asyncio
+async def test_issue_implement_status_handoff_creates_pr_from_accepted_remote_head(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._integration = None
+    mock_run_workflow._repo = "MoonLadderStudios/MoonMind"
+    mock_run_workflow._assessment_context = {
+        "assessmentVerdict": "PARTIALLY_IMPLEMENTED",
+        "assessmentArtifactRef": "art_assessment",
+    }
+    mock_run_workflow._record_accepted_published_head(
+        {
+            "acceptedRepositoryEvidence": {
+                "publicationAuthorized": True,
+                "candidateContaminated": False,
+                "pushStatus": "pushed",
+                "branch": "moonmind-job-50a4d228",
+                "headSha": "4e11c2fed" + ("0" * 30),
+                "baseBranch": "main",
+            }
+        }
+    )
+    execute_activity = AsyncMock(
+        return_value={
+            "url": "https://github.com/MoonLadderStudios/MoonMind/pull/3912",
+            "summary": "Created pull request.",
+        }
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        execute_activity,
+    )
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "title": "Implement GitHub issue 3815",
+            "publish": {"prBaseBranch": "main"},
+            "inputs": {
+                "github_issue": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "number": 3815,
+                }
+            },
+        },
+    }
+
+    url = await mock_run_workflow._ensure_issue_implement_pr_before_status(
+        node={
+            "id": "finalize-status",
+            "annotations": {"issueImplementRole": "code-review-handoff"},
+        },
+        parameters=parameters,
+    )
+
+    assert url == "https://github.com/MoonLadderStudios/MoonMind/pull/3912"
+    execute_activity.assert_awaited_once()
+    activity_type, payload = execute_activity.await_args.args
+    assert activity_type == "repo.create_pr"
+    assert payload["repo"] == "MoonLadderStudios/MoonMind"
+    assert payload["head"] == "moonmind-job-50a4d228"
+    assert payload["base"] == "main"
+    assert "MoonLadderStudios/MoonMind#3815" in payload["title"]
+    assert payload["body"].splitlines()[-1] == (
+        "Closes MoonLadderStudios/MoonMind#3815"
+    )
+    assert mock_run_workflow._publish_status == "published"
+    assert mock_run_workflow._publish_context["pullRequestUrl"] == url
+    assert mock_run_workflow._accepted_published_base_branch() == "main"
+
+
+@pytest.mark.asyncio
+async def test_issue_implement_status_handoff_does_not_create_pr_for_fully_implemented_issue(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._assessment_context = {
+        "assessmentVerdict": "FULLY_IMPLEMENTED",
+        "assessmentArtifactRef": "art_assessment",
+    }
+    execute_activity = AsyncMock()
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        execute_activity,
+    )
+
+    url = await mock_run_workflow._ensure_issue_implement_pr_before_status(
+        node={
+            "annotations": {"issueImplementRole": "code-review-handoff"},
+        },
+        parameters={"publishMode": "pr"},
+    )
+
+    assert url is None
+    execute_activity.assert_not_awaited()
+
+
+def test_partial_issue_implementation_no_commits_cannot_satisfy_pr_handoff(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    mock_run_workflow._assessment_context = {
+        "assessmentVerdict": "PARTIALLY_IMPLEMENTED",
+        "assessmentArtifactRef": "art_assessment",
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    )
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "appliedStepTemplates": [
+                {"slug": "github-issue-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result={"outputs": {"push_status": "no_commits"}},
+    )
+
+    assert mock_run_workflow._publish_status == "skipped"
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+    assert status == "failed"
+    assert "no publishable diff was produced" in message
+    assert publish_failure is True
+
+
+def test_omnigent_remediation_attempt_inherits_controller_workspace_source(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _loop_controller_node(_dynamic_loop_spec_payload())
+    controller["tool"] = {"type": "agent_runtime", "name": "omnigent"}
+    controller["inputs"] = {
+        "runtime": {
+            "mode": "omnigent",
+            "executionProfileRef": "opencode-zen-free",
+        },
+        "repository": "MoonLadderStudios/MoonMind",
+        "repositoryTarget": {
+            "provider": "git",
+            "connectionRef": "repository-connection:git-exact",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+        },
+        "startingBranch": "main",
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+        ),
+    )
+
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[controller]
+    )
+    remediation, verification = mock_run_workflow._materialize_remediation_attempt(
+        ordinal=1
+    )
+
+    for attempt_node in (remediation, verification):
+        assert attempt_node["inputs"]["runtime"]["workspaceSpec"] == {
+            "repository": "MoonLadderStudios/MoonMind",
+            "repositoryTarget": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-exact",
+                "repository": {"name": "MoonLadderStudios/MoonMind"},
+                "branch": {"name": "main"},
+            },
+            "startingBranch": "main",
+        }
+
+
+def test_omnigent_dynamic_verifier_restores_advanced_workspace_head(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = {
+        "id": "verification-1",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "annotations": {
+            "remediationLoopId": "loop-3473",
+            "issueImplementRole": "moonspec-verification-gate",
+            "moonSpecRemediationAttempt": 1,
+        },
+        "inputs": {
+            "runtime": {"mode": "omnigent"},
+            "remediationWorkspaceHeadRef": "artifact://workspace/C1",
+        },
+    }
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(
+            _remediation_head_payload(checkpoint="C1", version=2)
+        )
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: (
+            patch_id == RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH
+        ),
+    )
+
+    restore_ref = (
+        mock_run_workflow._trusted_omnigent_remediation_checkpoint_restore_ref(
+            node=node,
+            node_inputs=node["inputs"],
+        )
+    )
+    request = mock_run_workflow._build_agent_execution_request(
+        node_inputs=dict(node["inputs"]),
+        node_id=node["id"],
+        tool_name="omnigent",
+        workflow_parameters={},
+        trusted_remediation_checkpoint_restore_ref=restore_ref,
+    )
+
+    assert restore_ref == "artifact://workspace/C1"
+    assert request.workspace_spec["workspaceCheckpointRestoreRef"] == restore_ref
+
+
+def test_omnigent_remediation_accepts_capture_from_restored_sandbox(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = {
+        "id": "remediation-1",
+        "tool": {"type": "agent_runtime", "name": "omnigent"},
+        "annotations": {
+            "remediationLoopId": "loop-3473",
+            "issueImplementRole": "moonspec-remediation",
+            "moonSpecRemediationAttempt": 1,
+        },
+        "inputs": {"runtime": {"mode": "omnigent"}},
+    }
+    mock_run_workflow._remediation_workspace_head = (
+        RemediationWorkspaceHead.model_validate(_remediation_head_payload())
+    )
+    mock_run_workflow._remediation_loop_runtime = {"mode": "omnigent"}
+    node_inputs = dict(node["inputs"])
+    mock_run_workflow._inject_remediation_workspace_baseline(
+        node=node,
+        node_inputs=node_inputs,
+    )
+    mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
+        "remediation-1": {
+            "before_publication": {
+                "checkpointRef": "art_checkpoint_envelope",
+                "workspaceArchiveRef": "art_restored_sandbox_archive",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:remediated-candidate",
+                "workspaceIdentityDigest": "sha256:" + ("d" * 64),
+                "checkpointManifestRef": "art_restored_sandbox_manifest",
+            }
+        }
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
+        },
+    )
+
+    mock_run_workflow._advance_remediation_workspace_head(
+        node=node,
+        node_inputs=node_inputs,
+        execution_result={"outputs": {}},
+        step_execution_id="wf:run:remediation-1:execution:1",
+    )
+
+    head = mock_run_workflow._remediation_workspace_head
+    assert head is not None
+    assert head.head_checkpoint_ref == "artifact://art_restored_sandbox_archive"
+    assert head.head_workspace_digest == "sha256:remediated-candidate"
+    assert head.head_attempt_ordinal == 1
 
 
 def test_remediation_step_rejects_root_fallback_after_workflow_head_is_owned(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -3471,6 +3471,7 @@ async def test_run_records_pre_execution_checkpoint_from_node_workspace_inputs(
                 "checkpointManifestRef": (
                     "artifact://patch-manifest/before_execution"
                 ),
+                "workspaceArchiveRef": "",
             }
         }
     }
@@ -4514,12 +4515,13 @@ async def test_run_uses_external_omnigent_identity_for_checkpoint_capture(
     assert "archiveRef" in captured[1]["payload"]["workspace"]
     assert workflow._step_checkpoint_workspace_evidence_by_boundary == {
         "implement": {
-                "before_execution": {
-                    "checkpointRef": "artifact://checkpoint/before_execution",
-                    "workspaceKind": "worktree_archive",
-                    "workspaceDigest": "sha256:" + ("d" * 64),
-                    "workspaceIdentityDigest": "sha256:" + ("c" * 64),
-                    "checkpointManifestRef": "artifact://managed/manifest",
+            "before_execution": {
+                "checkpointRef": "artifact://checkpoint/before_execution",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:" + ("d" * 64),
+                "workspaceIdentityDigest": "sha256:" + ("c" * 64),
+                "checkpointManifestRef": "artifact://managed/manifest",
+                "workspaceArchiveRef": "artifact://managed/archive",
             }
         }
     }


### PR DESCRIPTION
## Summary

- preserve canonical repository and branch authority when batch GitHub workflows fan out issue implementations
- restore cumulative Omnigent candidate workspaces across verification, remediation, retry, and publication sandboxes
- project durable checkpoint and input artifacts into each runtime with bounded archives and restrictive ownership
- require partially implemented GitHub issue workflows to create a PR through the trusted integration boundary before Code Review finalization
- align moonspec-verify with managed container testing and current-head post-remediation evidence

## Verification

- 1040 targeted unit and reliability tests passed
- skill validation passed for batch-github-workflows and moonspec-verify
- git diff --check passed
- rebuilt and deployed moonmind-local:f724-fix-15 at sha256:eb5b3ee0d7cf321cc5aff429e7cb832a517e4eb02458bed5798d18362e9a98ee
- fresh workflow mm:8edca15e-bbd7-424b-aa43-de0d4765a4a0 completed with PUBLISHED_PR
- trusted repo.create_pr activity ran on mm.activity.integrations before GitHub Code Review finalization
- validation output: https://github.com/MoonLadderStudios/MoonMind/pull/3913 (open, non-draft, base main, tested head fb4be6825d6647bb12ff8d991a328f4fd4344496)

## Failure replays

- original batch repository-authority failure: mm:f724a9b2-5eac-5e0f-8644-d261379717f1
- remediation pre-materialization checkpoint failure
- partially implemented no-commit publication falsely closing an issue without a PR
