### PR TITLE
Fix Omnigent concurrency status projection

### DIFF
--- a/moonmind/omnigent/production.py
+++ b/moonmind/omnigent/production.py
@@ -219,6 +219,19 @@ def build_generic_omnigent_execution_services(
             session_authority_sink=session_authority_sink,
         )
 
+    temporal_adapter = TemporalClientAdapter()
+
+    async def notify_execution_state(
+        workflow_id: str,
+        state: str,
+        reason: str,
+    ) -> None:
+        handle = await temporal_adapter.get_workflow_handle(workflow_id)
+        await handle.signal(
+            "child_state_changed",
+            args=[state, reason],
+        )
+
     runtime_bindings = DbRuntimeBindingStore(session_factory)
     host_leases = DbOmnigentHostLeaseRepository(session_factory)
     realizer = GenericOmnigentHostRealizer(
@@ -247,6 +260,7 @@ def build_generic_omnigent_execution_services(
         cleanup_authority=CanonicalCleanupAuthority(
             OmnigentControlPlaneStore(session_factory)
         ),
+        execution_state_notifier=notify_execution_state,
     )
     registry = OmnigentExecutionRealizerRegistry()
     registry.register(

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -92,6 +92,8 @@ class GenericOmnigentHostRealizer:
         artifact_gateway: Any | None = None,
         turn_command_service: Any | None = None,
         cleanup_authority: Any | None = None,
+        execution_state_notifier: Callable[[str, str, str], Awaitable[None]]
+        | None = None,
         heartbeat_interval_seconds: float = 60.0,
         heartbeat_ttl_seconds: int = 900,
     ) -> None:
@@ -128,6 +130,11 @@ class GenericOmnigentHostRealizer:
         # (#3707 §4). ``None`` keeps unit harnesses that do not wire the control
         # plane runnable, exactly like ``turn_command_service``.
         self._cleanup_authority = cleanup_authority
+        # Provider Profile capacity is acquired inside this Activity-owned
+        # lifecycle, outside the AgentRun workflow's managed-runtime slot loop.
+        # The notifier projects that authoritative wait into the owning user
+        # workflow without moving or duplicating lease semantics.
+        self._execution_state_notifier = execution_state_notifier
         if heartbeat_interval_seconds <= 0 or heartbeat_ttl_seconds <= 0:
             raise ValueError("generic host heartbeat interval and TTL must be positive")
         self._heartbeat_interval = heartbeat_interval_seconds
@@ -198,11 +205,21 @@ class GenericOmnigentHostRealizer:
 
         host_class, launch_policy = await self._resolve_host(plan)
         try:
+            await self._notify_execution_state(
+                workflow_id,
+                "awaiting_slot",
+                "Waiting for Provider Profile capacity.",
+            )
             acquired = await self._provider_leases.acquire_all(
                 plan=plan,
                 workflow_id=workflow_id,
                 step_execution_id=step_execution_id,
                 idempotency_key=request.idempotency_key,
+            )
+            await self._notify_execution_state(
+                workflow_id,
+                "launching",
+                "Provider Profile capacity acquired.",
             )
             materializers = {
                 slot: value.materializerRef
@@ -836,6 +853,12 @@ class GenericOmnigentHostRealizer:
     ) -> AgentRunResult:
         """Keep both durable ownership leases fresh while a turn is active."""
 
+        workflow_id, _step_execution_id = _execution_identity(request)
+        await self._notify_execution_state(
+            workflow_id,
+            "running",
+            "Agent is running.",
+        )
         stop = asyncio.Event()
 
         async def heartbeat_loop() -> None:
@@ -882,6 +905,28 @@ class GenericOmnigentHostRealizer:
                     task.cancel()
                     with suppress(asyncio.CancelledError):
                         await task
+
+    async def _notify_execution_state(
+        self,
+        workflow_id: str,
+        state: str,
+        reason: str,
+    ) -> None:
+        """Best-effort projection of Activity-owned lifecycle state."""
+
+        if self._execution_state_notifier is None:
+            return
+        try:
+            await self._execution_state_notifier(workflow_id, state, reason)
+        except Exception:
+            # Capacity, host, session, and cleanup authority remain primary.
+            # A projection failure must not create or erase provider capacity.
+            logger.warning(
+                "Could not project generic Omnigent execution state %s for %s",
+                state,
+                workflow_id,
+                exc_info=True,
+            )
 
     def _bind_exact_host(
         self,

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -1502,6 +1502,8 @@ async def test_host_cleanup_claim_fences_a_stale_activity() -> None:
 
 async def _generic_publication_harness(
     publication: dict[str, object],
+    *,
+    execution_state_notifier=None,
 ) -> SimpleNamespace:
     """Build the real generic-host realizer around one publication outcome."""
 
@@ -1729,6 +1731,7 @@ async def _generic_publication_harness(
         session_cleanup_service=SessionCleanup(),
         workspace_publisher=WorkspacePublisher(),
         turn_command_service=TurnCommands(),
+        execution_state_notifier=execution_state_notifier,
         heartbeat_interval_seconds=0.005,
         heartbeat_ttl_seconds=60,
     )
@@ -1835,6 +1838,62 @@ async def test_generic_realizer_persists_authority_and_releases_provider_last() 
 
     assert replay.summary == "done"
     assert events[len(first_execution_events) :] == []
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_projects_provider_capacity_wait() -> None:
+    projected: list[tuple[str, str, str]] = []
+
+    async def notify(workflow_id: str, state: str, reason: str) -> None:
+        projected.append((workflow_id, state, reason))
+
+    harness = await _generic_publication_harness(
+        _PUSHED_PUBLICATION,
+        execution_state_notifier=notify,
+    )
+
+    result = await harness.realizer.execute(
+        harness.publish_request,
+        _plan("opencode-go/model"),
+    )
+
+    assert result.failure_class is None
+    assert projected == [
+        (
+            "workflow-1",
+            "awaiting_slot",
+            "Waiting for Provider Profile capacity.",
+        ),
+        (
+            "workflow-1",
+            "launching",
+            "Provider Profile capacity acquired.",
+        ),
+        ("workflow-1", "running", "Agent is running."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generic_realizer_ignores_state_projection_failure() -> None:
+    async def unavailable_notifier(
+        _workflow_id: str,
+        _state: str,
+        _reason: str,
+    ) -> None:
+        raise RuntimeError("projection unavailable")
+
+    harness = await _generic_publication_harness(
+        _PUSHED_PUBLICATION,
+        execution_state_notifier=unavailable_notifier,
+    )
+
+    result = await harness.realizer.execute(
+        harness.publish_request,
+        _plan("opencode-go/model"),
+    )
+
+    assert result.failure_class is None
+    assert result.summary == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -1254,6 +1254,87 @@ def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
     assert workflow_instance._waiting_reason is None
     assert workflow_instance._attention_required is False
 
+
+@pytest.mark.asyncio
+async def test_generic_omnigent_production_projection_crosses_temporal_boundary(
+    mock_run_environment,
+    monkeypatch,
+):
+    from moonmind.omnigent import production as omnigent_production
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    monkeypatch.setattr(omnigent_production, "generic_host_enabled", lambda: True)
+    monkeypatch.setattr(omnigent_production, "opencode_support_enabled", lambda: True)
+    monkeypatch.setattr(
+        omnigent_production,
+        "resolved_server_url",
+        lambda: "http://omnigent.test",
+    )
+    monkeypatch.setattr(
+        omnigent_production,
+        "resolve_deployed_server_build_digest",
+        lambda: "sha256:" + "a" * 64,
+    )
+    monkeypatch.setenv(
+        "MOONMIND_OMNIGENT_HOST_SERVER_URL",
+        "http://omnigent-host.test",
+    )
+    monkeypatch.setenv("MOONMIND_OMNIGENT_EXPECTED_HOST_OWNER", "moonmind-test")
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        injected_adapter = TemporalClientAdapter(env.client)
+        monkeypatch.setattr(
+            omnigent_production,
+            "TemporalClientAdapter",
+            lambda: injected_adapter,
+        )
+        async with Worker(
+            env.client,
+            task_queue="test-omnigent-state-projection",
+            workflows=[MoonMindUserWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            workflow_id = "test-generic-omnigent-state-projection"
+            handle = await env.client.start_workflow(
+                MoonMindUserWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.UserWorkflow",
+                    "initial_parameters": {},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id=workflow_id,
+                task_queue="test-omnigent-state-projection",
+            )
+            services = omnigent_production.build_generic_omnigent_execution_services(
+                session_factory=object(),
+                artifact_gateway=object(),
+                run_store=object(),
+            )
+
+            await services.generic_realizer._notify_execution_state(
+                workflow_id,
+                "awaiting_slot",
+                "Waiting for Provider Profile capacity.",
+            )
+            status = await handle.query("get_status")
+            assert status["state"] == STATE_AWAITING_SLOT
+            assert status["waiting_reason"] == "provider_profile_slot"
+            assert status["summary"] == "Waiting for Provider Profile capacity."
+
+            await services.generic_realizer._notify_execution_state(
+                workflow_id,
+                "running",
+                "Agent is running.",
+            )
+            status = await handle.query("get_status")
+            assert status["state"] == "executing"
+            assert status["waiting_reason"] is None
+            assert status["summary"] == "Agent is running."
+
+            result = await handle.result()
+            assert result["status"] == "success"
+
+
 def test_mm_started_at_stamped_on_launch_and_immutable_across_requeue(monkeypatch):
     """``mm_started_at`` is set exactly once when the child reports it has
     crossed from awaiting_slot into launching/running. A subsequent return to


### PR DESCRIPTION
## Summary
- project Activity-owned Omnigent provider-capacity waits to the parent workflow
- report launching and running transitions after capacity is acquired
- keep projection failures auxiliary to lease, host, session, and cleanup authority

## Verification
- `python3 -m pytest tests/unit/omnigent/test_generic_platform_production_services.py -q --tb=short` (42 passed)
- live deployment: 1 executing workflow, 3 awaiting-slot workflows, 1 host, and 1 lease at `max_parallel_runs=1`