### PR TITLE
Fix late remediation checkpoint attempt ordinal

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -923,6 +923,13 @@ RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH = (
 RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH = (
     "run-omnigent-initial-verification-checkpoint-restore-v1"
 )
+# A checkpoint may first become available after a headless remediation attempt.
+# Adopt that archive at the attempt the controller just verified instead of
+# resetting the workspace head to attempt zero.  The head payload changes, so
+# histories that already adopted a late checkpoint retain their recorded value.
+RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH = (
+    "run-late-remediation-head-attempt-ordinal-v1"
+)
 # A pull-request handoff is another fresh Omnigent sandbox and must publish the
 # exact candidate accepted by the controlling verifier. Restore the cumulative
 # remediation head (or the latest implementation archive when no remediation
@@ -7752,6 +7759,18 @@ class MoonMindRunWorkflow:
             return None
         identity = self._canonical_step_checkpoint_identity(checkpoint_step_id)
         normalized_verdict = str(verdict or "").strip().upper()
+        head_attempt_ordinal = 0
+        state = self._remediation_loop_state
+        if (
+            workflow.patched(RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH)
+            and state is not None
+            and state.loop_id == spec.loop_id
+        ):
+            # Initial verification owns attempt zero.  When checkpoint capture
+            # first succeeds after a headless remediation, however, the archive
+            # already represents that completed attempt and must be admitted at
+            # the same ordinal as the loop controller.
+            head_attempt_ordinal = state.attempt_ordinal
         head = RemediationWorkspaceHead(
             loopId=spec.loop_id,
             branchRef=f"checkpoint-branch:{spec.loop_id}",
@@ -7764,6 +7783,7 @@ class MoonMindRunWorkflow:
             headStepExecutionId=(
                 build_step_execution_id(identity) if identity is not None else None
             ),
+            headAttemptOrdinal=head_attempt_ordinal,
             latestVerificationRef=gate_result_ref,
             latestVerificationVerdict=normalized_verdict,
             status=(

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -16,6 +16,7 @@ from moonmind.workflows.temporal.remediation_loop import (
     ConsumedRemediationBudgets,
     RemediationContinuationDecision,
     RemediationLoopPhase,
+    RemediationLoopSpec,
     RemediationLoopState,
     apply_continuation_decision,
 )
@@ -25,10 +26,12 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH,
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
+    RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
     RUN_OMNIGENT_AGENT_PROFILE_SNAPSHOT_COMPILER_PATCH,
     RUN_OMNIGENT_AUTHORED_SELECTION_COMPILER_PATCH,
+    RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
     RUN_PLAN_ROUTED_MOONSPEC_REMEDIATION_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_REMEDIATION_LOOP_ARTIFACT_REF_NORMALIZATION_PATCH,
@@ -179,6 +182,77 @@ class _CurrentWorkflowOwnedRemediationHeadReplayFixture:
                 "headWorkspaceDigest": "sha256:c1",
             }
         return continuation
+
+
+def _late_remediation_head_fixture() -> MoonMindRunWorkflow:
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._remediation_loop_spec = RemediationLoopSpec.model_validate(
+        {
+            "kind": "remediation_loop",
+            "loopId": "loop",
+            "remediationTool": {
+                "type": "agent_runtime",
+                "name": "codex_cli",
+                "inputs": {"instructions": "Remediate."},
+            },
+            "verificationTool": {
+                "type": "agent_runtime",
+                "name": "codex_cli",
+                "inputs": {"instructions": "Verify."},
+            },
+            "workspacePolicy": "continue_from_loop_head",
+            "budgets": {"hardMaxAttempts": 2},
+            "terminalPolicy": {
+                "fullyImplemented": "advance",
+                "additionalWorkNeeded": "continue_when_allowed",
+                "blocked": "stop",
+                "noDetermination": "retry_evidence_or_stop",
+                "failedUnrecoverable": "stop",
+            },
+            "sideEffectPolicy": "workflow_owned",
+            "publicationPolicy": "evaluate_after_terminal",
+        }
+    )
+    workflow_instance._remediation_loop_state = RemediationLoopState(
+        loopId="loop",
+        attemptOrdinal=1,
+        phase=RemediationLoopPhase.VERIFICATION_PENDING,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=1),
+    )
+    workflow_instance._step_checkpoint_workspace_evidence_by_boundary = {
+        "verification-1": {
+            "before_publication": {
+                "checkpointRef": "artifact://workspace/C1",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:c1",
+                "workspaceIdentityDigest": "sha256:" + ("c" * 64),
+                "checkpointManifestRef": "artifact://manifest/C1",
+            }
+        }
+    }
+    return workflow_instance
+
+
+@workflow.defn(name="MMLateRemediationHeadAttemptReplayFixture")
+class _LegacyLateRemediationHeadAttemptReplayFixture:
+    @workflow.run
+    async def run(self) -> int:
+        workflow.patched(RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH)
+        return 0
+
+
+@workflow.defn(name="MMLateRemediationHeadAttemptReplayFixture")
+class _CurrentLateRemediationHeadAttemptReplayFixture:
+    @workflow.run
+    async def run(self) -> int:
+        workflow_instance = _late_remediation_head_fixture()
+        head = workflow_instance._initialize_remediation_head_from_canonical_checkpoint(
+            logical_step_id="verification-1",
+            gate_result_ref="artifact://verification/V1",
+            verdict="ADDITIONAL_WORK_NEEDED",
+        )
+        assert head is not None
+        return head.head_attempt_ordinal
 
 
 @workflow.defn(name="MMHeadlessRemediationExecutionReplayFixture")
@@ -871,6 +945,47 @@ async def test_workflow_owned_remediation_head_histories_replay() -> None:
     )
     replayer = Replayer(
         workflows=[_CurrentWorkflowOwnedRemediationHeadReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(legacy_history)
+    await replayer.replay_workflow(current_history)
+
+
+@pytest.mark.asyncio
+async def test_late_remediation_head_attempt_ordinal_histories_replay() -> None:
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-late-remediation-head-legacy-replay",
+            workflows=[_LegacyLateRemediationHeadAttemptReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            legacy_handle = await env.client.start_workflow(
+                _LegacyLateRemediationHeadAttemptReplayFixture.run,
+                id="test-late-remediation-head-legacy",
+                task_queue="test-late-remediation-head-legacy-replay",
+            )
+            legacy_result = await legacy_handle.result()
+            legacy_history = await legacy_handle.fetch_history()
+
+        async with Worker(
+            env.client,
+            task_queue="test-late-remediation-head-current-replay",
+            workflows=[_CurrentLateRemediationHeadAttemptReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            current_handle = await env.client.start_workflow(
+                _CurrentLateRemediationHeadAttemptReplayFixture.run,
+                id="test-late-remediation-head-current",
+                task_queue="test-late-remediation-head-current-replay",
+            )
+            current_result = await current_handle.result()
+            current_history = await current_handle.fetch_history()
+
+    assert legacy_result == 0
+    assert current_result == 1
+    replayer = Replayer(
+        workflows=[_CurrentLateRemediationHeadAttemptReplayFixture],
         workflow_runner=UnsandboxedWorkflowRunner(),
     )
     await replayer.replay_workflow(legacy_history)

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -24,6 +24,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
     RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
     RUN_MOONSPEC_VERIFY_REMAINING_WORK_EVIDENCE_PATCH,
@@ -3797,6 +3798,7 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
             RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
             RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
             RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
+            RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
         },
     )
     ordered_nodes: list[dict[str, Any]] = []
@@ -3818,6 +3820,7 @@ async def test_dynamic_verifier_promotes_canonical_checkpoint_to_remediation_hea
     assert head.head_checkpoint_ref == "artifact://art_implementation_archive"
     assert head.head_workspace_digest == "sha256:implementation-candidate"
     assert head.head_workspace_identity_digest == "sha256:" + ("b" * 64)
+    assert head.head_attempt_ordinal == 0
     assert head.latest_verification_ref == "artifact://verification/V0"
     assert head.latest_verification_verdict == "ADDITIONAL_WORK_NEEDED"
     assert state.workspace_head_ref == "artifact://art_implementation_archive"
@@ -4112,6 +4115,91 @@ async def test_dynamic_attempt_captures_head_verifies_and_admits_next_pair(
     assert projection["attemptOrdinal"] == 2
     assert projection["workspaceHeadRef"] == "artifact://workspace/C1"
     assert len(projection["materializedAttempts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_late_checkpoint_head_adoption_preserves_completed_attempt_ordinal(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for workflow mm:ea55d1c9-b296-4db0-8e1a-50f428dd2db2."""
+
+    from moonmind.workflows.temporal.remediation_loop import (
+        ConsumedRemediationBudgets,
+        RemediationLoopPhase,
+        RemediationLoopState,
+    )
+
+    mock_run_workflow._initialize_remediation_loop_controller(
+        ordered_nodes=[_loop_controller_node(_dynamic_loop_spec_payload())]
+    )
+    mock_run_workflow._remediation_loop_runtime = {
+        **_LOOP_RUNTIME,
+        "mode": "omnigent",
+    }
+    mock_run_workflow._remediation_loop_state = RemediationLoopState(
+        loopId="issue-implementation-remediation",
+        attemptOrdinal=1,
+        phase=RemediationLoopPhase.VERIFICATION_PENDING,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=1),
+    )
+    mock_run_workflow._step_ledger_rows = [
+        {
+            "logicalStepId": "remediation-1",
+            "status": "completed",
+            "annotations": {"issueImplementRole": "moonspec-remediation"},
+        },
+        {
+            "logicalStepId": "verification-1",
+            "status": "completed",
+            "annotations": {"issueImplementRole": "moonspec-verification-gate"},
+        },
+    ]
+    mock_run_workflow._step_checkpoint_workspace_evidence_by_boundary = {
+        "remediation-1": {
+            "before_publication": {
+                "checkpointRef": "artifact://workspace/C1",
+                "workspaceKind": "worktree_archive",
+                "workspaceDigest": "sha256:c1",
+                "workspaceIdentityDigest": "sha256:" + ("c" * 64),
+                "checkpointManifestRef": "artifact://manifest/C1",
+            }
+        }
+    }
+    mock_run_workflow._write_json_artifact = AsyncMock(
+        return_value="artifact://decision/D1"
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_id
+        in {
+            RUN_WORKFLOW_OWNED_REMEDIATION_HEAD_PATCH,
+            RUN_OMNIGENT_INITIAL_VERIFICATION_CHECKPOINT_RESTORE_PATCH,
+            RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
+        },
+    )
+    ordered_nodes: list[dict[str, Any]] = []
+
+    admitted = await mock_run_workflow._evaluate_dynamic_remediation_verification(
+        ordered_nodes=ordered_nodes,
+        verdict="ADDITIONAL_WORK_NEEDED",
+        gate_result_ref="artifact://verification/V1",
+        remaining_work_ref="artifact://remaining/R1",
+        logical_step_id="verification-1",
+    )
+
+    assert admitted is True
+    head = mock_run_workflow._remediation_workspace_head
+    assert head is not None
+    assert head.head_checkpoint_ref == "artifact://workspace/C1"
+    assert head.head_attempt_ordinal == 1
+    remediation_inputs = dict(ordered_nodes[0]["inputs"])
+    mock_run_workflow._inject_remediation_workspace_baseline(
+        node=ordered_nodes[0],
+        node_inputs=remediation_inputs,
+    )
+    assert remediation_inputs["remediationAttemptInput"]["attemptOrdinal"] == 2
 
 
 def _dynamic_loop_spec_payload() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- preserve the completed remediation attempt ordinal when a checkpoint head is first adopted after a headless attempt
- keep pre-change Temporal histories replay-compatible behind a versioned patch marker
- add a regression for workflow mm:ea55d1c9-b296-4db0-8e1a-50f428dd2db2 and pre/post-change replay coverage

## Root cause

Attempt 1 ran without a canonical checkpoint. When its verifier later exposed the first canonical archive, the workflow adopted that archive with head attempt ordinal 0 even though the controller had completed attempt 1. Admission of attempt 2 then failed because the workspace-head invariant expected attempt 1.

## Tests

- ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/test_run_replayer.py --python-only (236 passed)
- ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_workspace_head.py tests/integration/reliability_journey/test_omnigent_cumulative_remediation_journey.py --python-only (15 passed)
- replayed the recorded failed workflow history against the patched worker implementation (compatible)

## Remaining risks

None known. The behavior change is replay-gated, and initial verification continues to seed attempt ordinal 0.