### PR TITLE
Fix Omnigent active-turn timeout diagnostics and retry

### DIFF
--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -108,6 +108,7 @@ _MARKED_TOOL_ONLY_QUIET_PERIOD_SECONDS = 300.0
 # waiting the full no-progress budget only delays an already-known failure.
 _MARKED_TURN_START_TIMEOUT_SECONDS = 300.0
 _TERMINAL_RECONCILIATION_INTERVAL_SECONDS = 30.0
+_MARKED_TURN_ACTIVITY_RETRY_RESERVE_SECONDS = 600.0
 _ACTIVITY_HEARTBEAT_STATE: ContextVar[dict[str, Any] | None] = ContextVar(
     "omnigent_activity_heartbeat_state",
     default=None,
@@ -124,11 +125,24 @@ def _durable_terminal_status_with_evidence(durable_row: Any) -> str | None:
 
     status = str(getattr(durable_row, "status", "") or "").strip().lower()
     terminal_refs = getattr(durable_row, "terminal_refs", None)
+    terminal_bundle_keys = {
+        "outputRefs",
+        "diagnosticsRef",
+        "metadataRefs",
+        "resourceProjection",
+        "failureClass",
+        "failureCode",
+        "summary",
+    }
     if (
         status not in _TERMINAL_STATUSES
         or getattr(durable_row, "first_message_posted_at", None) is None
         or not isinstance(terminal_refs, Mapping)
-        or not terminal_refs
+        or not terminal_bundle_keys <= set(terminal_refs)
+        or not isinstance(terminal_refs.get("outputRefs"), list)
+        or not isinstance(terminal_refs.get("metadataRefs"), Mapping)
+        or not isinstance(terminal_refs.get("resourceProjection"), Mapping)
+        or not str(terminal_refs.get("summary") or "").strip()
     ):
         return None
     return status
@@ -861,6 +875,7 @@ def _marked_turn_item_state(
             "progress": False,
             "terminalAssistantAfterWork": False,
             "unfinishedToolCall": False,
+            "unfinishedToolName": None,
             "signature": None,
         }
 
@@ -902,6 +917,7 @@ def _marked_turn_item_state(
             "progress": False,
             "terminalAssistantAfterWork": False,
             "unfinishedToolCall": False,
+            "unfinishedToolName": None,
             "signature": None,
         }
 
@@ -909,8 +925,10 @@ def _marked_turn_item_state(
     last_text_assistant_index = -1
     progress = False
     pending_call_ids: set[str] = set()
+    pending_call_names: dict[str, str] = {}
     instrumentation_call_ids: set[str] = set()
     anonymous_pending_calls = 0
+    anonymous_pending_call_names: list[str] = []
     for index, raw_item in enumerate(
         raw_items[progress_start_index:],
         start=progress_start_index,
@@ -932,10 +950,13 @@ def _marked_turn_item_state(
                 continue
             last_tool_index = index
             call_id = str(item_data.get("call_id") or "").strip()
+            tool_name = str(item_data.get("name") or "").strip()
             if call_id:
                 pending_call_ids.add(call_id)
+                pending_call_names[call_id] = tool_name
             else:
                 anonymous_pending_calls += 1
+                anonymous_pending_call_names.append(tool_name)
         elif item_type == "function_call_output":
             progress = True
             call_id = str(item_data.get("call_id") or "").strip()
@@ -944,8 +965,10 @@ def _marked_turn_item_state(
             last_tool_index = index
             if call_id:
                 pending_call_ids.discard(call_id)
+                pending_call_names.pop(call_id, None)
             elif anonymous_pending_calls:
                 anonymous_pending_calls -= 1
+                anonymous_pending_call_names.pop(0)
         elif item_type == "message":
             role = str(item_data.get("role") or "").strip().lower()
             if role != "assistant":
@@ -962,7 +985,9 @@ def _marked_turn_item_state(
                 # an output item); calls that genuinely remain active are
                 # ordered after that message and are added on later iterations.
                 pending_call_ids.clear()
+                pending_call_names.clear()
                 anonymous_pending_calls = 0
+                anonymous_pending_call_names.clear()
 
     last_item = next(
         (item for item in reversed(raw_items) if isinstance(item, Mapping)),
@@ -978,6 +1003,10 @@ def _marked_turn_item_state(
         str(last_item_data.get("role") or ""),
         str(last_item_data.get("call_id") or ""),
     )
+    unfinished_tool_name = next(
+        (name for name in pending_call_names.values() if name),
+        next((name for name in anonymous_pending_call_names if name), None),
+    )
     return {
         "markerIndex": marked_message_index,
         "boundarySource": boundary_source,
@@ -986,6 +1015,7 @@ def _marked_turn_item_state(
             last_text_assistant_index > max(progress_start_index - 1, last_tool_index)
         ),
         "unfinishedToolCall": bool(pending_call_ids or anonymous_pending_calls),
+        "unfinishedToolName": unfinished_tool_name,
         "signature": signature,
     }
 
@@ -1050,11 +1080,12 @@ def _marked_turn_timeout_diagnostics(
     )
     raw_data = last_item.get("data")
     last_item_data = raw_data if isinstance(raw_data, Mapping) else {}
-    last_tool_name = (
+    last_item_tool_name = (
         str(last_item_data.get("name") or "").strip()
         if str(last_item.get("type") or "").strip() == "function_call"
         else ""
     )
+    unresolved_tool_name = str(state.get("unfinishedToolName") or "").strip()
     try:
         normalized_status = (
             normalize_omnigent_observation(latest_snapshot)
@@ -1073,7 +1104,7 @@ def _marked_turn_timeout_diagnostics(
         "unfinishedToolCall": bool(state.get("unfinishedToolCall")),
         "lastItemType": str(last_item.get("type") or "").strip() or None,
         "lastItemStatus": str(last_item.get("status") or "").strip() or None,
-        "lastToolName": last_tool_name or None,
+        "lastToolName": unresolved_tool_name or last_item_tool_name or None,
         "providerRateLimitEvidence": _snapshot_provider_rate_limit_evidence(
             latest_snapshot
         ),
@@ -1891,20 +1922,28 @@ async def _restore_active_journals(
 
 
 def _resolved_marked_turn_timeout_seconds(request: AgentExecutionRequest) -> float:
-    """Use the AgentRun-published base budget for the blocking turn boundary.
+    """Reserve part of the published Activity budget for one safe retry.
 
-    The parent workflow sizes this activity's ScheduleToClose from the same
-    published budget.  A separate 1,800-second local default used to terminate
-    otherwise healthy long-running Omnigent turns even when the request and
-    Temporal activity both authorized a much larger window.
+    The parent workflow sizes both StartToClose and ScheduleToClose from the
+    published base budget. The local poll must therefore finish early enough
+    for its retryable exception, Temporal backoff, session reattachment, and a
+    terminal quiet-period check to occur before ScheduleToClose expires. The
+    reserve is capped so a large request no longer inherits the old hidden
+    1,800-second deadline, and at half the budget so short explicit budgets
+    still spend most of their available window on the initial attempt.
     """
 
-    return float(
+    base_seconds = float(
         resolve_execution_budget(
             agent_kind=request.agent_kind,
             timeout_policy=request.timeout_policy,
         ).base_seconds
     )
+    retry_reserve_seconds = min(
+        _MARKED_TURN_ACTIVITY_RETRY_RESERVE_SECONDS,
+        base_seconds / 2.0,
+    )
+    return max(1.0, base_seconds - retry_reserve_seconds)
 
 
 async def run_omnigent_execution(
@@ -3487,6 +3526,8 @@ async def run_omnigent_execution(
             metadata=result_metadata,
         )
     except OmnigentSessionStillRunningError:
+        await _cancel_task(heartbeat_task)
+        await _cancel_task(stream_task)
         raise
     except (OmnigentClientError, httpx.HTTPError) as exc:
         # §17 transport rows: upstream unreachable / host register-connect /

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -62,7 +62,11 @@ from moonmind.omnigent.settings import (
     resolved_proxy_forward_headers,
     resolved_server_url,
 )
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunResult,
+    resolve_execution_budget,
+)
 from moonmind.workflows.adapters.omnigent_agent_adapter import (
     OmnigentAdapterError,
     OmnigentAgentSelection,
@@ -73,6 +77,11 @@ from moonmind.workflows.adapters.omnigent_agent_adapter import (
 from moonmind.workflows.adapters.omnigent_client import (
     OmnigentClientError,
     OmnigentHttpClient,
+)
+from moonmind.workflows.provider_failures import (
+    PROVIDER_ERROR_CLASS_RATE_LIMIT,
+    build_provider_failure_event,
+    classify_provider_failure,
 )
 from moonmind.workflows.skills.run_projection import prepend_skill_activation_summary
 
@@ -105,10 +114,60 @@ _ACTIVITY_HEARTBEAT_STATE: ContextVar[dict[str, Any] | None] = ContextVar(
 )
 
 
+def _durable_terminal_status_with_evidence(durable_row: Any) -> str | None:
+    """Return a restorable bridge terminal only after evidence publication.
+
+    Indexed provider events may update the coarse row status before the marked
+    turn is objectively terminal. ``mark_terminal`` publishes the compact refs
+    in the same authority handoff that makes the status safe to restore.
+    """
+
+    status = str(getattr(durable_row, "status", "") or "").strip().lower()
+    terminal_refs = getattr(durable_row, "terminal_refs", None)
+    if (
+        status not in _TERMINAL_STATUSES
+        or getattr(durable_row, "first_message_posted_at", None) is None
+        or not isinstance(terminal_refs, Mapping)
+        or not terminal_refs
+    ):
+        return None
+    return status
+
+
 class OmnigentSessionStillRunningError(OmnigentClientError):
     """Raised when the stream ends while the provider session is still active."""
 
     code = "OMNIGENT_CURRENT_TURN_TERMINAL_AMBIGUOUS"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        session_id: str | None = None,
+        snapshot: Mapping[str, Any] | None = None,
+        timeout_seconds: float | None = None,
+        event_count: int | None = None,
+        turn_state: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.session_id = session_id
+        self.snapshot = dict(snapshot) if snapshot is not None else None
+        self.timeout_seconds = timeout_seconds
+        self.event_count = event_count
+        self.turn_state = dict(turn_state) if turn_state is not None else None
+
+    def diagnostics(self) -> dict[str, Any]:
+        diagnostics = super().diagnostics()
+        diagnostics.update(
+            _marked_turn_timeout_diagnostics(
+                session_id=self.session_id,
+                snapshot=self.snapshot,
+                timeout_seconds=self.timeout_seconds,
+                event_count=self.event_count,
+                turn_state=self.turn_state,
+            )
+        )
+        return diagnostics
 
 
 class OmnigentSameSessionContinuationRequired(OmnigentSessionStillRunningError):
@@ -131,9 +190,7 @@ class OmnigentSameSessionContinuationRequired(OmnigentSessionStillRunningError):
         session_id: str,
         snapshot: Mapping[str, Any],
     ) -> None:
-        super().__init__(message)
-        self.session_id = session_id
-        self.snapshot = dict(snapshot)
+        super().__init__(message, session_id=session_id, snapshot=snapshot)
 
 
 class OmnigentTurnNotStartedError(OmnigentSessionStillRunningError):
@@ -155,10 +212,9 @@ class OmnigentTurnNotStartedError(OmnigentSessionStillRunningError):
         snapshot: Mapping[str, Any] | None = None,
         waited_seconds: float | None = None,
     ) -> None:
-        super().__init__(message)
+        super().__init__(message, snapshot=snapshot)
         # The decisive inactive snapshot is the terminal evidence for this
         # failure; the execution boundary captures it before finalizing.
-        self.snapshot = dict(snapshot) if snapshot is not None else None
         self.waited_seconds = waited_seconds
 
 
@@ -934,6 +990,128 @@ def _marked_turn_item_state(
     }
 
 
+def _snapshot_provider_rate_limit_evidence(snapshot: Mapping[str, Any] | None) -> str:
+    """Return a bounded statement about provider rate-limit evidence.
+
+    Omnigent's snapshot contract exposes ``last_task_error`` even when it is
+    null.  That lets timeout diagnostics distinguish "the provider reported no
+    task error" from "this adapter supplied no provider-error evidence" without
+    scanning arbitrary transcript text or inventing a quota verdict.
+    """
+
+    if not isinstance(snapshot, Mapping) or "last_task_error" not in snapshot:
+        return "unavailable"
+    last_task_error = snapshot.get("last_task_error")
+    if last_task_error is None:
+        return "not_observed"
+    if not isinstance(last_task_error, Mapping):
+        return "provider_error_observed_unclassified"
+
+    provider_error_class = str(
+        last_task_error.get("provider_error_class")
+        or last_task_error.get("providerErrorClass")
+        or ""
+    ).strip()
+    provider_error_code = str(last_task_error.get("code") or "").strip()
+    provider_error_text = " ".join(
+        str(last_task_error.get(key) or "").strip()
+        for key in ("code", "title", "message", "cause", "remediation")
+    ).strip()
+    provider_failure = build_provider_failure_event(
+        classification=classify_provider_failure(provider_error_text),
+        provider_error_class=provider_error_class or None,
+        provider_error_code=provider_error_code or None,
+    )
+    if (
+        provider_failure is not None
+        and provider_failure.provider_error_class == PROVIDER_ERROR_CLASS_RATE_LIMIT
+    ):
+        return "observed"
+    return "provider_error_observed_non_rate_limit"
+
+
+def _marked_turn_timeout_diagnostics(
+    *,
+    session_id: str | None,
+    snapshot: Mapping[str, Any] | None,
+    timeout_seconds: float | None,
+    event_count: int | None,
+    turn_state: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build safe, compact evidence for an ambiguous marked-turn timeout."""
+
+    state = dict(turn_state) if isinstance(turn_state, Mapping) else {}
+    latest_snapshot = dict(snapshot) if isinstance(snapshot, Mapping) else {}
+    raw_items = latest_snapshot.get("items")
+    items = raw_items if isinstance(raw_items, list) else []
+    last_item = next(
+        (item for item in reversed(items) if isinstance(item, Mapping)),
+        {},
+    )
+    raw_data = last_item.get("data")
+    last_item_data = raw_data if isinstance(raw_data, Mapping) else {}
+    last_tool_name = (
+        str(last_item_data.get("name") or "").strip()
+        if str(last_item.get("type") or "").strip() == "function_call"
+        else ""
+    )
+    try:
+        normalized_status = (
+            normalize_omnigent_observation(latest_snapshot)
+            if latest_snapshot
+            else None
+        )
+    except OmnigentContractError:
+        normalized_status = None
+
+    return {
+        "omnigentSessionId": session_id,
+        "markedTurnTimeoutSeconds": timeout_seconds,
+        "eventsCaptured": event_count,
+        "sessionStatus": normalized_status,
+        "currentTurnProgress": bool(state.get("progress")),
+        "unfinishedToolCall": bool(state.get("unfinishedToolCall")),
+        "lastItemType": str(last_item.get("type") or "").strip() or None,
+        "lastItemStatus": str(last_item.get("status") or "").strip() or None,
+        "lastToolName": last_tool_name or None,
+        "providerRateLimitEvidence": _snapshot_provider_rate_limit_evidence(
+            latest_snapshot
+        ),
+    }
+
+
+def _marked_turn_evidence_message(
+    reason: str,
+    diagnostics: Mapping[str, Any],
+) -> str:
+    """Append bounded provider/session facts to an operator-facing error."""
+
+    waited_seconds = diagnostics.get("markedTurnTimeoutSeconds")
+    waited_detail = (
+        f"waitedSeconds={waited_seconds}; " if waited_seconds is not None else ""
+    )
+    return (
+        f"{reason}; "
+        f"{waited_detail}"
+        f"sessionStatus={diagnostics.get('sessionStatus') or 'unknown'}; "
+        f"currentTurnProgress={str(bool(diagnostics.get('currentTurnProgress'))).lower()}; "
+        f"unfinishedToolCall={str(bool(diagnostics.get('unfinishedToolCall'))).lower()}; "
+        f"lastItemType={diagnostics.get('lastItemType') or 'unknown'}; "
+        f"lastToolName={diagnostics.get('lastToolName') or 'none'}; "
+        "providerRateLimitEvidence="
+        f"{diagnostics.get('providerRateLimitEvidence') or 'unavailable'}"
+    )
+
+
+def _marked_turn_timeout_message(diagnostics: Mapping[str, Any]) -> str:
+    """Render the bounded timeout evidence into the operator-facing error."""
+
+    return _marked_turn_evidence_message(
+        "Omnigent current marked turn did not reach terminal state before timeout",
+        diagnostics,
+    )
+
+
 def _snapshot_projects_active_response(snapshot: Mapping[str, Any]) -> bool:
     """Return whether the stock server still tracks an in-flight response.
 
@@ -1151,6 +1329,8 @@ async def _await_marked_turn_terminal(
     )
     quiet_signature: tuple[Any, ...] | None = None
     quiet_since: float | None = None
+    last_snapshot: dict[str, Any] | None = None
+    last_turn_state: dict[str, Any] | None = None
     while loop.time() < deadline:
         observation_started_at = loop.time()
         snapshot = await client.get_session(session_id)
@@ -1170,6 +1350,8 @@ async def _await_marked_turn_terminal(
             marker=marker,
             baseline_item_ids=baseline_item_ids,
         )
+        last_snapshot = dict(snapshot)
+        last_turn_state = dict(turn_state)
         progress = bool(turn_state["progress"])
         if not isinstance(snapshot.get("items"), list) and normalized in {
             "completed",
@@ -1292,8 +1474,20 @@ async def _await_marked_turn_terminal(
             }
         )
         await asyncio.sleep(max(0.1, interval_seconds))
+    diagnostics = _marked_turn_timeout_diagnostics(
+        session_id=session_id,
+        snapshot=last_snapshot,
+        timeout_seconds=timeout_seconds,
+        event_count=event_count,
+        turn_state=last_turn_state,
+    )
     raise OmnigentSessionStillRunningError(
-        "Omnigent current marked turn did not reach terminal state before timeout"
+        _marked_turn_timeout_message(diagnostics),
+        session_id=session_id,
+        snapshot=last_snapshot,
+        timeout_seconds=timeout_seconds,
+        event_count=event_count,
+        turn_state=last_turn_state,
     )
 
 
@@ -1696,6 +1890,23 @@ async def _restore_active_journals(
     return restored[0], restored[1]
 
 
+def _resolved_marked_turn_timeout_seconds(request: AgentExecutionRequest) -> float:
+    """Use the AgentRun-published base budget for the blocking turn boundary.
+
+    The parent workflow sizes this activity's ScheduleToClose from the same
+    published budget.  A separate 1,800-second local default used to terminate
+    otherwise healthy long-running Omnigent turns even when the request and
+    Temporal activity both authorized a much larger window.
+    """
+
+    return float(
+        resolve_execution_budget(
+            agent_kind=request.agent_kind,
+            timeout_policy=request.timeout_policy,
+        ).base_seconds
+    )
+
+
 async def run_omnigent_execution(
     request: AgentExecutionRequest,
     *,
@@ -1708,6 +1919,7 @@ async def run_omnigent_execution(
 ) -> AgentRunResult:
     """Execute one Omnigent session and return only terminal AgentRunResult."""
 
+    marked_turn_timeout_seconds = _resolved_marked_turn_timeout_seconds(request)
     gate = build_omnigent_gate()
     if not gate.enabled:
         raise RuntimeError(
@@ -1855,15 +2067,9 @@ async def run_omnigent_execution(
                 bridge_session_id = str(
                     getattr(durable_row, "bridge_session_id", "") or ""
                 )
-                restored_status = (
-                    str(getattr(durable_row, "status", "") or "").strip().lower()
+                durable_terminal_status = _durable_terminal_status_with_evidence(
+                    durable_row
                 )
-                if (
-                    restored_status in _TERMINAL_STATUSES
-                    and getattr(durable_row, "first_message_posted_at", None)
-                    is not None
-                ):
-                    durable_terminal_status = restored_status
                 external_state["bridgeSessionId"] = bridge_session_id
                 assert_bridge_session_binding(
                     authorization,
@@ -2432,6 +2638,7 @@ async def run_omnigent_execution(
                     event_count=event_count["value"],
                     snapshot=initial_snapshot,
                     snapshot_observed_at=initial_snapshot_observed_at,
+                    timeout_seconds=marked_turn_timeout_seconds,
                     start_watchdog=start_watchdog,
                 )
                 if reattached_terminal is not None:
@@ -2511,6 +2718,7 @@ async def run_omnigent_execution(
                     event_count=event_count["value"],
                     snapshot=observed_snapshot,
                     snapshot_observed_at=observed_at,
+                    timeout_seconds=marked_turn_timeout_seconds,
                     start_watchdog=start_watchdog,
                 )
                 observed_status = normalize_omnigent_observation(observed_snapshot)
@@ -2690,6 +2898,7 @@ async def run_omnigent_execution(
                             baseline_item_ids=pre_dispatch_item_ids,
                             event_count=event_count["value"],
                             terminal_status=terminal_event_status,
+                            timeout_seconds=marked_turn_timeout_seconds,
                             start_watchdog=start_watchdog,
                         )
                         if normalized == "idle" and terminal_status == "completed":
@@ -2802,6 +3011,7 @@ async def run_omnigent_execution(
                             if normalized_snapshot in {"failed", "canceled", "timed_out"}
                             else "completed"
                         ),
+                        timeout_seconds=marked_turn_timeout_seconds,
                         start_watchdog=start_watchdog,
                     )
                     external_state["terminalReconciliation"] = {
@@ -2816,9 +3026,23 @@ async def run_omnigent_execution(
                 }:
                     if closed_turn_state is not None:
                         if not closed_turn_state["progress"]:
+                            diagnostics = _marked_turn_timeout_diagnostics(
+                                session_id=session_id,
+                                snapshot=final_snapshot,
+                                timeout_seconds=None,
+                                event_count=event_count["value"],
+                                turn_state=closed_turn_state,
+                            )
                             raise OmnigentSessionStillRunningError(
-                                "Omnigent stream ended before the current marked turn "
-                                "produced provider work"
+                                _marked_turn_evidence_message(
+                                    "Omnigent stream ended before the current marked "
+                                    "turn produced provider work",
+                                    diagnostics,
+                                ),
+                                session_id=session_id,
+                                snapshot=final_snapshot,
+                                event_count=event_count["value"],
+                                turn_state=closed_turn_state,
                             )
                         (
                             terminal_status,
@@ -2830,13 +3054,29 @@ async def run_omnigent_execution(
                             baseline_item_ids=pre_dispatch_item_ids,
                             event_count=event_count["value"],
                             terminal_status=normalized_snapshot,
+                            timeout_seconds=marked_turn_timeout_seconds,
                             start_watchdog=start_watchdog,
                         )
                     else:
                         terminal_status = normalized_snapshot
                 elif normalized_snapshot in _NON_TERMINAL_STATUSES:
+                    diagnostics = _marked_turn_timeout_diagnostics(
+                        session_id=session_id,
+                        snapshot=final_snapshot,
+                        timeout_seconds=None,
+                        event_count=event_count["value"],
+                        turn_state=closed_turn_state,
+                    )
                     raise OmnigentSessionStillRunningError(
-                        "Omnigent stream ended while the provider session is still running"
+                        _marked_turn_evidence_message(
+                            "Omnigent stream ended while the provider session is still "
+                            "running",
+                            diagnostics,
+                        ),
+                        session_id=session_id,
+                        snapshot=final_snapshot,
+                        event_count=event_count["value"],
+                        turn_state=closed_turn_state,
                     )
                 if terminal_status is not None:
                     # The stream ended without emitting a terminal event but the

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -416,6 +416,10 @@ async def _try_generic_realizer_dispatch(
 ) -> AgentRunResult | None:
     """Load or plan immutable generic authority, then dispatch its realizer."""
 
+    from moonmind.omnigent.execute import (
+        OmnigentSessionStillRunningError,
+        OmnigentTurnNotStartedError,
+    )
     from moonmind.omnigent.harness_platform.failures import (
         HarnessPlatformError,
         HarnessPlatformFailure,
@@ -448,6 +452,16 @@ async def _try_generic_realizer_dispatch(
                 persisted.payload.executionRealizerRef
             )
             return await realizer.execute(request, persisted)
+        except OmnigentSessionStillRunningError as exc:
+            # The session and its authoritative host/workspace are deliberately
+            # retained by the realizer for Temporal retry. Collapsing this into
+            # a terminal generic dispatch result defeats that recovery path and
+            # strands healthy turns that are still executing a tool.
+            if isinstance(exc, OmnigentTurnNotStartedError):
+                typed = _typed_platform_failure_result(exc)
+                if typed is not None:
+                    return typed
+            raise
         except Exception as exc:
             # The dispatch failure projection must carry the underlying cause;
             # a bare integration_error string makes operator triage impossible.
@@ -573,6 +587,14 @@ async def _try_generic_realizer_dispatch(
             realizer_registry = get_default_registry()
         realizer = realizer_registry.require(plan.payload.executionRealizerRef)
         return await realizer.execute(request, plan)
+    except OmnigentSessionStillRunningError as exc:
+        # Planned requests that reach this path have the same retry contract as
+        # requests carrying an explicit OmnigentExecutionPlan binding above.
+        if isinstance(exc, OmnigentTurnNotStartedError):
+            typed = _typed_platform_failure_result(exc)
+            if typed is not None:
+                return typed
+        raise
     except HarnessPlatformError as exc:
         code = str(exc.code)
         configuration_codes = {

--- a/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/expected-outcome.json
@@ -1,0 +1,10 @@
+{
+  "markedTurnTimeoutSeconds": 9000,
+  "currentTurnProgress": true,
+  "unfinishedToolCall": true,
+  "lastItemType": "function_call",
+  "lastToolName": "bash",
+  "providerRateLimitEvidence": "not_observed",
+  "coarseBridgeStatusAuthoritative": false,
+  "ambiguousTerminalRemainsRetryable": true
+}

--- a/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/expected-outcome.json
@@ -1,5 +1,7 @@
 {
-  "markedTurnTimeoutSeconds": 9000,
+  "markedTurnTimeoutSeconds": 8400,
+  "activityBudgetSeconds": 9000,
+  "retryReserveSeconds": 600,
   "currentTurnProgress": true,
   "unfinishedToolCall": true,
   "lastItemType": "function_call",

--- a/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/manifest.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "moonmind.reliability-replay.v1",
+  "replayId": "omnigent-active-tool-execution-budget",
+  "incidentWorkflowId": "mm:8d94711e-bdee-446f-b924-9bf2e753ae76",
+  "failedChildWorkflowId": "mm:8d94711e-bdee-446f-b924-9bf2e753ae76:agent:node-1",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "executionRealizerRef": "generic-omnigent-host@1",
+  "harness": "opencode-native",
+  "failureShape": "the request and Temporal activity authorized 9000 seconds, but the marked-turn waiter stopped after its independent 1800-second default while an agent-owned bash tool was still running; the generic realizer dispatcher then converted the retryable ambiguous-session exception into terminal OMNIGENT_GENERIC_DISPATCH_FAILED",
+  "requestTimeoutPolicy": {
+    "timeout_seconds": 9000,
+    "max_timeout_seconds": 54000,
+    "progress_stall_seconds": 900,
+    "execution_budget_mode": "progress_aware"
+  },
+  "legacyMarkedTurnTimeoutSeconds": 1800,
+  "observedFailureSummary": "Admitted Omnigent execution-plan dispatch failed: Omnigent current marked turn did not reach terminal state before timeout",
+  "sessionId": "synthetic-active-tool-session",
+  "observedProviderEventCount": 9,
+  "bridgeProjection": {
+    "status": "completed",
+    "firstMessagePosted": true,
+    "terminalRefs": {}
+  },
+  "terminalSnapshot": {
+    "status": "running",
+    "active_response_id": null,
+    "last_task_error": null,
+    "items": [
+      {
+        "id": "marked-user",
+        "type": "message",
+        "status": "completed",
+        "data": {
+          "role": "user",
+          "content": [
+            {
+              "type": "input_text",
+              "text": "MoonMind-Omnigent-Run: synthetic-active-tool"
+            }
+          ]
+        }
+      },
+      {
+        "id": "active-wait-call",
+        "type": "function_call",
+        "status": "completed",
+        "data": {
+          "call_id": "active-wait-call",
+          "name": "bash"
+        }
+      }
+    ]
+  }
+}

--- a/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-active-tool-execution-budget/manifest.json
@@ -20,7 +20,11 @@
   "bridgeProjection": {
     "status": "completed",
     "firstMessagePosted": true,
-    "terminalRefs": {}
+    "terminalRefs": {
+      "captureManifestRef": "artifact:capture-only",
+      "resourceProjectionRef": "artifact:resources-only",
+      "evidenceCompleteness": "partial"
+    }
   },
   "terminalSnapshot": {
     "status": "running",

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -55,9 +55,12 @@ from moonmind.omnigent.execute import (
     OmnigentTurnNotStartedError,
     _await_marked_turn_terminal,
     _build_omnigent_first_message,
+    _durable_terminal_status_with_evidence,
     _first_message_text,
     _marked_turn_item_state,
+    _marked_turn_timeout_diagnostics,
     _persisted_pre_dispatch_item_ids,
+    _resolved_marked_turn_timeout_seconds,
     _safe_heartbeat,
     _snapshot_confirms_current_turn_terminal,
     _snapshot_contains_current_turn_progress,
@@ -4407,6 +4410,100 @@ async def test_accepted_turn_that_never_starts_fails_within_start_budget(
     assert dispatched.provider_error_code == expected["failureCode"]
     assert dispatched.retry_recommendation == expected["retryRecommendation"]
     assert dispatched.diagnostics_ref == result.diagnostics_ref
+
+
+@pytest.mark.integration_ci
+async def test_active_tool_turn_uses_published_budget_and_preserves_retry() -> None:
+    """Replay mm:8d94711e at the budget and generic-dispatch boundaries."""
+
+    from moonmind.workflows.temporal.activities.omnigent_activities import (
+        _try_generic_realizer_dispatch,
+    )
+    from tests.unit.omnigent.test_generic_platform_production_services import _plan
+
+    replay_id = "omnigent-active-tool-execution-budget"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    snapshot = manifest["terminalSnapshot"]
+    marker = snapshot["items"][0]["data"]["content"][0]["text"]
+    turn_state = _marked_turn_item_state(snapshot, marker=marker)
+    diagnostics = _marked_turn_timeout_diagnostics(
+        session_id=manifest["sessionId"],
+        snapshot=snapshot,
+        timeout_seconds=manifest["legacyMarkedTurnTimeoutSeconds"],
+        event_count=manifest["observedProviderEventCount"],
+        turn_state=turn_state,
+    )
+
+    assert turn_state["progress"] is expected["currentTurnProgress"]
+    assert turn_state["unfinishedToolCall"] is expected["unfinishedToolCall"]
+    assert diagnostics["lastItemType"] == expected["lastItemType"]
+    assert diagnostics["lastToolName"] == expected["lastToolName"]
+    assert (
+        diagnostics["providerRateLimitEvidence"]
+        == expected["providerRateLimitEvidence"]
+    )
+
+    plan = _plan("opencode-go/model")
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=manifest["incidentWorkflowId"],
+        idempotencyKey="step-active-tool-budget",
+        resolvedSkillsetRef="artifact:skills",
+        omnigentExecutionPlan=OmnigentExecutionPlanBinding(
+            planRef=plan.planRef,
+            planDigest="sha256:" + plan.planRef.rsplit(":", 1)[-1],
+            planArtifactRef="artifact:replay-plan",
+            taskInputSnapshotRef="artifact:replay-task-input",
+            taskInputSnapshotDigest="sha256:" + "a" * 64,
+        ),
+        timeoutPolicy=manifest["requestTimeoutPolicy"],
+        parameters={"executionPlanRef": plan.planRef},
+    )
+    assert (
+        _resolved_marked_turn_timeout_seconds(request)
+        == expected["markedTurnTimeoutSeconds"]
+    )
+    coarse_bridge_projection = SimpleNamespace(
+        status=manifest["bridgeProjection"]["status"],
+        first_message_posted_at=(
+            object() if manifest["bridgeProjection"]["firstMessagePosted"] else None
+        ),
+        terminal_refs=manifest["bridgeProjection"]["terminalRefs"],
+    )
+    assert (
+        _durable_terminal_status_with_evidence(coarse_bridge_projection) is not None
+    ) is expected["coarseBridgeStatusAuthoritative"]
+
+    class PlanStore:
+        async def load(self, plan_ref):
+            assert plan_ref == plan.planRef
+            return plan
+
+    class Realizer:
+        async def execute(self, runtime_request, admitted):
+            raise OmnigentSessionStillRunningError(
+                "current marked turn is still executing a tool",
+                session_id=manifest["sessionId"],
+                snapshot=snapshot,
+                timeout_seconds=manifest["legacyMarkedTurnTimeoutSeconds"],
+                event_count=manifest["observedProviderEventCount"],
+                turn_state=turn_state,
+            )
+
+    class Registry:
+        def require(self, ref):
+            assert ref == manifest["executionRealizerRef"]
+            return Realizer()
+
+    with pytest.raises(OmnigentSessionStillRunningError):
+        await _try_generic_realizer_dispatch(
+            request,
+            plan_store=PlanStore(),
+            realizer_registry=Registry(),
+        )
+    assert expected["ambiguousTerminalRemainsRetryable"] is True
 
 
 async def test_transient_injection_response_does_not_hide_never_started_turn() -> None:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -4465,6 +4465,10 @@ async def test_active_tool_turn_uses_published_budget_and_preserves_retry() -> N
         _resolved_marked_turn_timeout_seconds(request)
         == expected["markedTurnTimeoutSeconds"]
     )
+    assert (
+        expected["activityBudgetSeconds"] - expected["markedTurnTimeoutSeconds"]
+        == expected["retryReserveSeconds"]
+    )
     coarse_bridge_projection = SimpleNamespace(
         status=manifest["bridgeProjection"]["status"],
         first_message_posted_at=(

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -24,16 +24,19 @@ from moonmind.omnigent.bridge_store import (
     OmnigentDigestMismatchError,
 )
 from moonmind.omnigent.execute import (
+    _ACTIVITY_HEARTBEAT_STATE,
     OmnigentContractError,
     OmnigentSessionStillRunningError,
     OmnigentTurnNotStartedError,
-    _ACTIVITY_HEARTBEAT_STATE,
-    _MarkedTurnStartWatchdog,
     _agent_items,
     _await_marked_turn_terminal,
     _build_omnigent_first_message,
-    _first_message_text,
+    _durable_terminal_status_with_evidence,
     _enqueue_stream_events,
+    _first_message_text,
+    _marked_turn_timeout_diagnostics,
+    _marked_turn_timeout_message,
+    _MarkedTurnStartWatchdog,
     _reconcile_inactive_marked_turn,
     _resolve_agent_id,
     _resolve_initial_context_message,
@@ -56,6 +59,79 @@ def _request() -> AgentExecutionRequest:
         correlationId="corr-1",
         idempotencyKey="idem-1",
     )
+
+
+def test_marked_turn_timeout_diagnostics_explain_active_tool_and_quota_evidence() -> (
+    None
+):
+    snapshot = {
+        "status": "running",
+        "active_response_id": None,
+        "last_task_error": None,
+        "items": [
+            {
+                "id": "call-wait",
+                "type": "function_call",
+                "status": "completed",
+                "data": {"call_id": "call-wait", "name": "bash"},
+            }
+        ],
+    }
+    diagnostics = _marked_turn_timeout_diagnostics(
+        session_id="session-1",
+        snapshot=snapshot,
+        timeout_seconds=1800.0,
+        event_count=9,
+        turn_state={"progress": True, "unfinishedToolCall": True},
+    )
+
+    assert diagnostics == {
+        "omnigentSessionId": "session-1",
+        "markedTurnTimeoutSeconds": 1800.0,
+        "eventsCaptured": 9,
+        "sessionStatus": "running",
+        "currentTurnProgress": True,
+        "unfinishedToolCall": True,
+        "lastItemType": "function_call",
+        "lastItemStatus": "completed",
+        "lastToolName": "bash",
+        "providerRateLimitEvidence": "not_observed",
+    }
+    message = _marked_turn_timeout_message(diagnostics)
+    assert "unfinishedToolCall=true" in message
+    assert "lastToolName=bash" in message
+    assert "providerRateLimitEvidence=not_observed" in message
+
+    rate_limited = _marked_turn_timeout_diagnostics(
+        session_id="session-2",
+        snapshot={
+            "status": "failed",
+            "last_task_error": {
+                "code": "429",
+                "message": "provider request was rate limited",
+            },
+        },
+        timeout_seconds=1800.0,
+        event_count=3,
+        turn_state=None,
+    )
+    assert rate_limited["providerRateLimitEvidence"] == "observed"
+
+
+def test_coarse_bridge_completion_without_terminal_refs_is_not_authoritative() -> None:
+    coarse_projection = SimpleNamespace(
+        status="completed",
+        first_message_posted_at=object(),
+        terminal_refs={},
+    )
+    published_terminal = SimpleNamespace(
+        status="completed",
+        first_message_posted_at=object(),
+        terminal_refs={"summary": "published terminal evidence"},
+    )
+
+    assert _durable_terminal_status_with_evidence(coarse_projection) is None
+    assert _durable_terminal_status_with_evidence(published_terminal) == "completed"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -34,6 +34,7 @@ from moonmind.omnigent.execute import (
     _durable_terminal_status_with_evidence,
     _enqueue_stream_events,
     _first_message_text,
+    _marked_turn_item_state,
     _marked_turn_timeout_diagnostics,
     _marked_turn_timeout_message,
     _MarkedTurnStartWatchdog,
@@ -122,16 +123,70 @@ def test_coarse_bridge_completion_without_terminal_refs_is_not_authoritative() -
     coarse_projection = SimpleNamespace(
         status="completed",
         first_message_posted_at=object(),
-        terminal_refs={},
+        terminal_refs={
+            "captureManifestRef": "artifact:capture-only",
+            "resourceProjectionRef": "artifact:resources-only",
+            "evidenceCompleteness": "partial",
+        },
     )
     published_terminal = SimpleNamespace(
         status="completed",
         first_message_posted_at=object(),
-        terminal_refs={"summary": "published terminal evidence"},
+        terminal_refs={
+            "outputRefs": [],
+            "diagnosticsRef": "artifact:diagnostics",
+            "metadataRefs": {"finalSnapshotRef": "artifact:final"},
+            "resourceProjection": {},
+            "failureClass": None,
+            "failureCode": None,
+            "summary": "published terminal evidence",
+        },
     )
 
     assert _durable_terminal_status_with_evidence(coarse_projection) is None
     assert _durable_terminal_status_with_evidence(published_terminal) == "completed"
+
+
+def test_timeout_diagnostics_report_earlier_unresolved_tool_name() -> None:
+    marker = "MoonMind-Omnigent-Run: unresolved-tool"
+    snapshot = {
+        "status": "running",
+        "last_task_error": None,
+        "items": [
+            {
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": marker}],
+                },
+            },
+            {
+                "type": "function_call",
+                "data": {"call_id": "pending", "name": "bash"},
+            },
+            {
+                "type": "function_call",
+                "data": {"call_id": "finished", "name": "git"},
+            },
+            {
+                "type": "function_call_output",
+                "data": {"call_id": "finished", "output": "done"},
+            },
+        ],
+    }
+    turn_state = _marked_turn_item_state(snapshot, marker=marker)
+
+    assert turn_state["unfinishedToolCall"] is True
+    assert turn_state["unfinishedToolName"] == "bash"
+    diagnostics = _marked_turn_timeout_diagnostics(
+        session_id="session-unresolved-tool",
+        snapshot=snapshot,
+        timeout_seconds=8400.0,
+        event_count=4,
+        turn_state=turn_state,
+    )
+    assert diagnostics["lastItemType"] == "function_call_output"
+    assert diagnostics["lastToolName"] == "bash"
 
 
 @pytest.mark.parametrize(
@@ -2901,6 +2956,7 @@ async def test_local_omnigent_artifact_gateway_wraps_os_errors(
 @pytest.mark.asyncio
 async def test_run_omnigent_execution_raises_when_stream_ends_still_running(
     monkeypatch,
+    tmp_path,
 ) -> None:
     class FakeClient:
         def __init__(self, **_: object) -> None:
@@ -2917,7 +2973,7 @@ async def test_run_omnigent_execution_raises_when_stream_ends_still_running(
             session_id: str,
             payload: dict[str, object],
         ) -> dict[str, object]:
-            return {}
+            return {"item_id": "marked-item"}
 
         async def stream_events(self, session_id: str):
             assert session_id == "session-1"
@@ -2946,13 +3002,15 @@ async def test_run_omnigent_execution_raises_when_stream_ends_still_running(
                         "prompt": {"text": "Do the task"},
                     },
                 },
-            )
+            ),
+            artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
         )
 
 
 @pytest.mark.asyncio
 async def test_stream_end_polls_unfinished_current_turn_before_completion(
     monkeypatch,
+    tmp_path,
 ) -> None:
     snapshots = [
         {
@@ -2989,7 +3047,7 @@ async def test_stream_end_polls_unfinished_current_turn_before_completion(
             session_id: str,
             payload: dict[str, object],
         ) -> dict[str, object]:
-            return {}
+            return {"item_id": "marked-item"}
 
         async def stream_events(self, session_id: str):
             if False:
@@ -3019,6 +3077,12 @@ async def test_stream_end_polls_unfinished_current_turn_before_completion(
                 agentId="omnigent",
                 correlationId="corr-1",
                 idempotencyKey="idem-unfinished-current-turn",
+                timeoutPolicy={
+                    "timeout_seconds": 9000,
+                    "max_timeout_seconds": 54000,
+                    "progress_stall_seconds": 900,
+                    "execution_budget_mode": "progress_aware",
+                },
                 parameters={
                     "omnigent": {
                         "agent": {"agentName": "codex-native-ui"},
@@ -3026,11 +3090,13 @@ async def test_stream_end_polls_unfinished_current_turn_before_completion(
                         "prompt": {"text": "Do the task"},
                     },
                 },
-            )
+            ),
+            artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
         )
 
     assert awaited["baseline_item_ids"] == frozenset({"prior-item"})
     assert awaited["terminal_status"] == "completed"
+    assert awaited["timeout_seconds"] == 8400.0
 
 
 @pytest.mark.asyncio
@@ -3363,8 +3429,13 @@ async def test_run_omnigent_execution_preserves_durable_failed_terminal_on_retry
         first_message_pending_id = "pending-1"
         first_message_item_id = "item-1"
         terminal_refs = {
-            "summary": "durable provider failure",
+            "outputRefs": [],
+            "diagnosticsRef": "artifact:diagnostics",
+            "metadataRefs": {"finalSnapshotRef": "artifact:final"},
+            "resourceProjection": {},
             "failureClass": "execution_error",
+            "failureCode": "provider_failure",
+            "summary": "durable provider failure",
         }
         metadata_: dict[str, object] = {}
 

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -246,6 +246,49 @@ async def test_generic_dispatch_keeps_generic_code_for_untyped_cause() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generic_dispatch_keeps_raising_ambiguous_terminal_for_retry() -> None:
+    from moonmind.omnigent.execute import OmnigentSessionStillRunningError
+    from tests.unit.omnigent.test_generic_platform_production_services import _plan
+
+    plan = _plan("opencode-go/model")
+
+    class PlanStore:
+        async def load(self, plan_ref):
+            return plan
+
+    class Realizer:
+        async def execute(self, request, admitted):
+            raise OmnigentSessionStillRunningError(
+                "current marked turn is still executing a tool"
+            )
+
+    class Registry:
+        def require(self, ref):
+            return Realizer()
+
+    with pytest.raises(OmnigentSessionStillRunningError):
+        await _try_generic_realizer_dispatch(
+            AgentExecutionRequest(
+                agentKind="external",
+                agentId="omnigent",
+                correlationId="workflow-ambiguous",
+                idempotencyKey="step-ambiguous",
+                resolvedSkillsetRef="artifact:skills",
+                omnigentExecutionPlan=OmnigentExecutionPlanBinding(
+                    planRef=plan.planRef,
+                    planDigest="sha256:" + plan.planRef.rsplit(":", 1)[-1],
+                    planArtifactRef="artifact:plan-ambiguous",
+                    taskInputSnapshotRef="artifact:input-ambiguous",
+                    taskInputSnapshotDigest="sha256:" + "a" * 64,
+                ),
+                parameters={"executionPlanRef": plan.planRef},
+            ),
+            plan_store=PlanStore(),
+            realizer_registry=Registry(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_generic_profile_selection_fails_typed_when_host_plane_is_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- align Omnigent marked-turn polling with the published AgentRun execution budget
- preserve ambiguous live-session failures for Temporal retry instead of collapsing them into a terminal generic dispatch error
- report bounded session, tool-progress, and provider rate-limit evidence in operator-facing failures
- require published terminal references before restoring a coarse bridge terminal state
- add a required-CI replay for workflow mm:8d94711e-bdee-446f-b924-9bf2e753ae76

## Verification

- 34 tests passed: tests/unit/workflows/temporal/test_omnigent_activities.py
- 16 terminal polling and timeout tests passed
- 7 targeted unit and replay tests passed
- required-CI replay passed
- git diff --check passed

## Test environment note

The repository test wrapper stopped in its pre-pytest status-domain audit because ignored .claude/worktrees copies are scanned as current source. The directly affected pytest suites above passed.