### PR TITLE
Fix Omnigent merge resolver plan authority

### DIFF
--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -450,6 +450,11 @@ context, and resolver launch template:
 }
 ```
 
+When `targetRuntime` is `omnigent`, the resolver template also carries the
+parent run's compact `parentOmnigentExecutionPlan` binding. The binding is
+authority from which the gate prepares a new resolver plan; it is not itself
+the resolver child's execution plan.
+
 ### 10.4 Terminal status summary
 
 ```json
@@ -792,6 +797,24 @@ plus setup and artifact-publication time. The default resolver launch carries a
 level and inside the task payload that becomes plan node inputs. This is
 intentionally larger than the `pr-resolver` tool's 7200-second default
 `finalizeMaxElapsedSeconds`.
+
+For an Omnigent resolver, `MoonMind.MergeAutomation` MUST prepare immutable
+child-scoped execution authority before starting `MoonMind.UserWorkflow`. A
+bounded Activity on the agent-runtime queue validates the parent plan, preserves
+its exact Agent Profile and Provider Profile authority, canonicalizes the
+resolver task plus its exact head/base workspace binding, resolves a fresh Skill
+snapshot containing `pr-resolver`, and persists a new Omnigent execution plan
+owned by the deterministic resolver workflow ID. The child request carries that
+new `omnigentExecutionPlan` and `resolvedSkillsetRef`.
+
+The parent plan MUST NOT be reused as the child plan: its task snapshot,
+publication policy, workspace intent, and resolved Skills belong to the parent
+run. For an in-flight merge-automation input recorded before the compact parent
+binding was present, the preparation Activity resolves the same binding from
+the canonical `parentWorkflowId` execution record. Missing or ambiguous parent
+plan, profile, task, workspace, or Skill authority fails before host creation or
+credential acquisition; a flat Provider Profile identifier alone never selects
+the legacy OAuth host path for this resolver.
 
 ### 13.3 Resolver child result contract extension
 

--- a/moonmind/workflows/temporal/activities/omnigent_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_activities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -56,6 +57,159 @@ class _OnDemandTemporalArtifactService:
 
     async def write_complete(self, *, artifact_id: str, **kwargs: Any) -> Any:
         return await self._invoke("write_complete", artifact_id=artifact_id, **kwargs)
+
+
+@activity.defn(name="omnigent.prepare_child_execution_plan")
+async def omnigent_prepare_child_execution_plan_activity(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compile immutable Omnigent authority for a Temporal-started child run."""
+
+    from api_service.db.base import async_session_maker
+    from api_service.db.models import (
+        ManagedAgentProviderProfile,
+        TemporalExecutionCanonicalRecord,
+    )
+    from api_service.services.omnigent_execution_plan_service import (
+        compile_and_persist_execution_plan,
+        persist_json_artifact,
+    )
+    from moonmind.schemas.agent_runtime_models import OmnigentExecutionPlanBinding
+    from moonmind.workflows.temporal.activities.omnigent_session_activities import (
+        _load_verified_execution_plan,
+        _read_json_artifact,
+    )
+
+    child_workflow_id = str(payload.get("childWorkflowId") or "").strip()
+    if not child_workflow_id:
+        raise ValueError("childWorkflowId is required")
+    child_request_value = payload.get("childWorkflowRequest")
+    if not isinstance(child_request_value, Mapping):
+        raise ValueError("childWorkflowRequest must be an object")
+    child_request = dict(child_request_value)
+    initial_parameters_value = child_request.get("initial_parameters")
+    if not isinstance(initial_parameters_value, Mapping):
+        raise ValueError("childWorkflowRequest.initial_parameters is required")
+    initial_parameters = dict(initial_parameters_value)
+    if str(initial_parameters.get("targetRuntime") or "").strip().lower() != "omnigent":
+        raise ValueError("child execution-plan preparation requires Omnigent")
+
+    parent_binding_value = payload.get("parentExecutionPlan")
+    if not isinstance(parent_binding_value, Mapping):
+        parent_workflow_id = str(payload.get("parentWorkflowId") or "").strip()
+        if not parent_workflow_id:
+            raise ValueError(
+                "parentWorkflowId is required when parentExecutionPlan is omitted"
+            )
+        async with async_session_maker() as db_session:
+            parent_record = await db_session.get(
+                TemporalExecutionCanonicalRecord,
+                parent_workflow_id,
+            )
+        if parent_record is None:
+            raise ValueError("parent workflow execution authority is unavailable")
+        parent_parameters = getattr(parent_record, "parameters", None)
+        if not isinstance(parent_parameters, Mapping):
+            raise ValueError("parent workflow execution parameters are unavailable")
+        parent_binding_value = parent_parameters.get("omnigentExecutionPlan")
+    parent_binding = OmnigentExecutionPlanBinding.model_validate(parent_binding_value)
+    parent_plan = await _load_verified_execution_plan(parent_binding)
+    profile_snapshot_ref = str(
+        parent_plan.payload.agentProfileSnapshotRef or ""
+    ).strip()
+    if not profile_snapshot_ref.startswith("artifact:"):
+        raise ValueError("parent execution plan lacks Agent Profile authority")
+    agent_profile_snapshot = await _read_json_artifact(
+        profile_snapshot_ref.removeprefix("artifact:")
+    )
+    provider_profile_refs = {
+        binding.providerProfileRef
+        for binding in parent_plan.payload.credentialBindings.values()
+    }
+    if len(provider_profile_refs) != 1:
+        raise ValueError("parent execution plan has ambiguous Provider Profile authority")
+    provider_profile_ref = next(iter(provider_profile_refs))
+
+    task_value = initial_parameters.get("workflow")
+    if not isinstance(task_value, Mapping):
+        task_value = initial_parameters.get("task")
+    if not isinstance(task_value, Mapping):
+        raise ValueError("child workflow request lacks canonical task authority")
+    canonical_snapshot_parameters = dict(initial_parameters)
+    canonical_snapshot_parameters.pop("task", None)
+    canonical_workflow = dict(task_value)
+    workspace_value = initial_parameters.get("workspaceSpec")
+    if isinstance(workspace_value, Mapping):
+        authored_workspace = canonical_workflow.get("workspace")
+        canonical_workspace = (
+            dict(authored_workspace)
+            if isinstance(authored_workspace, Mapping)
+            else {}
+        )
+        canonical_workspace.update(dict(workspace_value))
+        canonical_workflow["workspace"] = canonical_workspace
+        canonical_snapshot_parameters["workspace"] = canonical_workspace
+    canonical_snapshot_parameters["workflow"] = canonical_workflow
+    runtime_value = canonical_workflow.get("runtime")
+    authored_runtime = dict(runtime_value) if isinstance(runtime_value, Mapping) else {}
+    model_config = parent_plan.payload.modelConfig
+    for field_name, planned_value in (
+        ("model", str(model_config.qualifiedId or "").strip()),
+        ("effort", str(model_config.effort or "").strip()),
+    ):
+        authored_value = str(
+            canonical_snapshot_parameters.get(field_name)
+            or authored_runtime.get(field_name)
+            or ""
+        ).strip()
+        if authored_value and authored_value != planned_value:
+            raise ValueError(
+                f"resolver {field_name} conflicts with parent execution-plan authority"
+            )
+        if planned_value:
+            canonical_snapshot_parameters[field_name] = planned_value
+    task_snapshot = {
+        "snapshotVersion": 1,
+        "source": {"kind": "merge_automation_resolver_child"},
+        "target": {"initialParameters": canonical_snapshot_parameters},
+    }
+    principal = str(payload.get("principal") or "").strip() or (
+        "service:merge_automation"
+    )
+    artifact_service = _OnDemandTemporalArtifactService(async_session_maker)
+    input_snapshot_ref, input_snapshot_digest = await persist_json_artifact(
+        artifact_service=artifact_service,
+        principal=principal,
+        artifact_class="original_task_input_snapshot",
+        payload=task_snapshot,
+    )
+    async with async_session_maker() as db_session:
+        provider_profile = await db_session.get(
+            ManagedAgentProviderProfile,
+            provider_profile_ref,
+        )
+        if provider_profile is None:
+            raise ValueError("parent execution plan Provider Profile is unavailable")
+        child_plan = await compile_and_persist_execution_plan(
+            session_factory=async_session_maker,
+            artifact_service=artifact_service,
+            principal=principal,
+            workflow_id=child_workflow_id,
+            agent_profile_snapshot=agent_profile_snapshot,
+            provider_profile=provider_profile,
+            initial_parameters=canonical_snapshot_parameters,
+            authored_request_ref=input_snapshot_ref,
+            authored_request_digest=input_snapshot_digest,
+            task_input_snapshot_ref=input_snapshot_ref,
+            task_input_snapshot_digest=input_snapshot_digest,
+            db_session=db_session,
+        )
+    initial_parameters["omnigentExecutionPlan"] = child_plan.binding.model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+    initial_parameters["resolvedSkillsetRef"] = child_plan.resolved_skillset_ref
+    child_request["initial_parameters"] = initial_parameters
+    return child_request
 
 
 def _checkpoint_branch_capable(recovery: dict[str, Any]) -> bool:
@@ -988,6 +1142,7 @@ __all__ = [
     "_checkpoint_recovery_from_request",
     "_resolve_live_recovery_authority",
     "omnigent_execute_activity",
+    "omnigent_prepare_child_execution_plan_activity",
     "omnigent_profile_bound_execute_activity",
     "omnigent_oauth_host_janitor_activity",
 ]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1055,6 +1055,7 @@ def build_default_activity_catalog(
                 ),
             )
             for activity_type, start_to_close, schedule_to_close in (
+                ("omnigent.prepare_child_execution_plan", 300, 600),
                 ("omnigent.ensure_provider_profile_lease", 60, 180),
                 ("omnigent.ensure_host", 300, 600),
                 ("omnigent.ensure_provider_session", 60, 180),

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1099,6 +1099,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "agent_runtime",
         "omnigent_load_failure_authority",
     ),
+    "omnigent.prepare_child_execution_plan": (
+        "agent_runtime",
+        "omnigent_prepare_child_execution_plan",
+    ),
     "omnigent.ensure_provider_profile_lease": (
         "agent_runtime",
         "omnigent_ensure_provider_profile_lease",
@@ -7733,6 +7737,20 @@ class TemporalAgentRuntimeActivities:
             request,
             **kwargs,
         )
+
+    async def omnigent_prepare_child_execution_plan(
+        self, request: Any = None, /, **kwargs: Any
+    ) -> dict[str, Any]:
+        from moonmind.workflows.temporal.activities.omnigent_activities import (
+            omnigent_prepare_child_execution_plan_activity,
+        )
+
+        payload = _coerce_activity_payload_input(
+            request,
+            activity_type="omnigent.prepare_child_execution_plan",
+            kwargs=kwargs,
+        )
+        return await omnigent_prepare_child_execution_plan_activity(payload)
 
     async def omnigent_ensure_host(
         self, request: Any = None, /, **kwargs: Any

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -25,6 +25,7 @@ with workflow.unsafe.imports_passed_through():
         build_review_request_key,
     )
     from moonmind.workflows.temporal.activity_catalog import (
+        AGENT_RUNTIME_TASK_QUEUE,
         ARTIFACTS_TASK_QUEUE,
         INTEGRATIONS_TASK_QUEUE,
         WORKFLOW_TASK_QUEUE,
@@ -88,6 +89,9 @@ MERGE_AUTOMATION_CONTINUATION_OBSERVABILITY_PATCH = (
 )
 MERGE_AUTOMATION_RESOLVER_ATTEMPT_TITLE_PATCH = (
     "merge-automation-resolver-attempt-title-v1"
+)
+MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH = (
+    "merge-automation-omnigent-resolver-plan-v1"
 )
 # Request/remediate/request loop for one configured automated review provider.
 # Guarded so histories recorded before the loop existed keep replaying their
@@ -294,6 +298,58 @@ class MoonMindMergeAutomationWorkflow:
         if target_skill:
             memo["targetSkill"] = target_skill
         return memo
+
+    async def _prepare_omnigent_resolver_request(
+        self,
+        resolver_request: Mapping[str, Any],
+        *,
+        resolver_workflow_id: str,
+    ) -> dict[str, Any]:
+        """Compile fresh Omnigent authority for a Temporal-started child."""
+
+        if self._input is None:
+            raise RuntimeError("merge automation input is unavailable")
+        template = self._input.resolver_template
+        target_runtime = str(template.get("targetRuntime") or "").strip().lower()
+        if target_runtime != "omnigent":
+            return dict(resolver_request)
+        parent_plan = template.get("parentOmnigentExecutionPlan")
+        activity_payload: dict[str, Any] = {
+            "principal": self._principal(),
+            "parentWorkflowId": self._input.parent_workflow_id,
+            "childWorkflowId": resolver_workflow_id,
+            "childWorkflowRequest": dict(resolver_request),
+        }
+        if isinstance(parent_plan, Mapping):
+            activity_payload["parentExecutionPlan"] = dict(parent_plan)
+        prepared = await workflow.execute_activity(
+            "omnigent.prepare_child_execution_plan",
+            activity_payload,
+            task_queue=AGENT_RUNTIME_TASK_QUEUE,
+            start_to_close_timeout=timedelta(minutes=5),
+            schedule_to_close_timeout=timedelta(minutes=10),
+            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        if not isinstance(prepared, Mapping):
+            raise ValueError(
+                "Omnigent child execution-plan preparation returned an invalid "
+                "workflow request."
+            )
+        initial_parameters = prepared.get("initial_parameters")
+        if not isinstance(initial_parameters, Mapping):
+            raise ValueError(
+                "Omnigent child execution-plan preparation omitted initial parameters."
+            )
+        if not isinstance(initial_parameters.get("omnigentExecutionPlan"), Mapping):
+            raise ValueError(
+                "Omnigent child execution-plan preparation omitted plan authority."
+            )
+        if not str(initial_parameters.get("resolvedSkillsetRef") or "").strip():
+            raise ValueError(
+                "Omnigent child execution-plan preparation omitted Skill authority."
+            )
+        return dict(prepared)
 
     async def _write_json_artifact(self, *, name: str, payload: dict[str, Any]) -> str | None:
         try:
@@ -1254,6 +1310,11 @@ class MoonMindMergeAutomationWorkflow:
                 )
                 resolver_attempt = len(self._resolver_child_workflow_ids) + 1
                 resolver_workflow_id = f"{resolver_workflow_id}:{resolver_attempt}"
+                if workflow.patched(MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH):
+                    resolver_request = await self._prepare_omnigent_resolver_request(
+                        resolver_request,
+                        resolver_workflow_id=resolver_workflow_id,
+                    )
                 self._resolver_child_workflow_ids.append(resolver_workflow_id)
                 child_kwargs: dict[str, Any] = {
                     "id": resolver_workflow_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -539,6 +539,9 @@ MERGE_AUTOMATION_TERMINAL_STATUSES = (
     | MERGE_AUTOMATION_FAILURE_STATUSES
     | frozenset({MERGE_AUTOMATION_CANCELED_STATUS})
 )
+RUN_MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH = (
+    "run-merge-automation-omnigent-resolver-plan-v1"
+)
 OWNER_ID_SEARCH_ATTRIBUTE = "mm_owner_id"
 OWNER_TYPE_SEARCH_ATTRIBUTE = "mm_owner_type"
 _GITHUB_PR_URL_PATTERN = re.compile(
@@ -18828,19 +18831,35 @@ class MoonMindRunWorkflow:
             if isinstance(task_payload, Mapping)
             else {}
         ) or {}
+        target_runtime = (
+            self._coerce_text(
+                parameters.get("targetRuntime")
+                or task_runtime_payload.get("mode")
+                or task_runtime_payload.get("targetRuntime"),
+                max_chars=80,
+            )
+            or "codex"
+        ).lower()
         resolver_template: dict[str, Any] = {
             "repository": repo,
-            "targetRuntime": (
-                self._coerce_text(
-                    parameters.get("targetRuntime")
-                    or task_runtime_payload.get("mode")
-                    or task_runtime_payload.get("targetRuntime"),
-                    max_chars=80,
-                )
-                or "codex"
-            ),
+            "targetRuntime": target_runtime,
             "requiredCapabilities": ["git", "gh"],
         }
+        if (
+            target_runtime == "omnigent"
+            and self._workflow_patch_enabled(
+                RUN_MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH
+            )
+        ):
+            parent_execution_plan = parameters.get("omnigentExecutionPlan")
+            if not isinstance(parent_execution_plan, WorkflowMapping):
+                raise ValueError(
+                    "Omnigent merge automation requires persisted parent "
+                    "execution-plan authority."
+                )
+            resolver_template["parentOmnigentExecutionPlan"] = dict(
+                parent_execution_plan
+            )
         profile_id = self._inherited_execution_profile_ref(parameters)
         if profile_id:
             resolver_template["executionProfileRef"] = profile_id

--- a/tests/integration/reliability/replays/omnigent-merge-resolver-child-plan/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-merge-resolver-child-plan/expected-outcome.json
@@ -1,0 +1,10 @@
+{
+  "preparationActivity": "omnigent.prepare_child_execution_plan",
+  "activityTaskQueue": "mm.activity.agent_runtime",
+  "childWorkflowId": "resolver:pr:813:head:1430266ef052:h:546a49d948b70256:1",
+  "childPlanArtifactRef": "art-child-plan",
+  "resolvedSkillsetRef": "art-child-skills",
+  "resolvedSkill": "pr-resolver",
+  "startingBranch": "main",
+  "targetBranch": "resolver-plan-replay"
+}

--- a/tests/integration/reliability/replays/omnigent-merge-resolver-child-plan/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-merge-resolver-child-plan/manifest.json
@@ -1,0 +1,43 @@
+{
+  "failureShapeId": "omnigent-merge-resolver-child-plan",
+  "incidentWorkflowId": "resolver:pr:813:head:1430266ef052:h:546a49d948b70256:1",
+  "parentWorkflowId": "mm:125990d1-b9aa-4c65-beba-c5b402666e47",
+  "parentRunId": "replay-parent-run",
+  "boundary": "root execution plan to merge-automation resolver child admission",
+  "escapedFailure": {
+    "activity": "omnigent.ensure_host",
+    "message": "profile is not a supported Omnigent OAuth profile",
+    "cause": "the Temporal-started resolver child inherited only the flat Provider Profile id, so generic OpenCode execution reached the legacy OAuth host path without immutable plan authority"
+  },
+  "repository": "MoonLadderStudios/MoonMind",
+  "pullRequest": {
+    "number": 813,
+    "url": "https://github.com/MoonLadderStudios/MoonMind/pull/813",
+    "headSha": "1430266ef0520000000000000000000000000000",
+    "headBranch": "resolver-plan-replay",
+    "baseBranch": "main"
+  },
+  "parentParameters": {
+    "publishMode": "none",
+    "targetRuntime": "omnigent",
+    "profileId": "opencode-zen-free",
+    "model": "opencode/muse-spark-1.3-contributor-free",
+    "effort": "xhigh",
+    "omnigentExecutionPlan": {
+      "planRef": "omnigent-execution-plan:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "planDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "planArtifactRef": "art-parent-plan",
+      "taskInputSnapshotRef": "art-parent-task",
+      "taskInputSnapshotDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "workflow": {
+      "publish": {
+        "mergeAutomation": {
+          "enabled": true,
+          "mergeMethod": "squash"
+        }
+      }
+    }
+  },
+  "invariant": "an Omnigent resolver child is admitted with a freshly compiled child-scoped plan and Skill snapshot before any host side effect"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -183,6 +183,9 @@ from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows import (
     checkpoint_branch_turn as checkpoint_branch_turn_module,
 )
+from moonmind.workflows.temporal.workflows import (
+    merge_automation as merge_automation_module,
+)
 
 
 def _egress_attestation() -> EgressAttestation:
@@ -217,6 +220,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_AGENT_REQUIRED_CAPABILITIES_PROPAGATION_PATCH,
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    RUN_MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH,
     RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH,
     RUN_OMNIGENT_REMEDIATION_CHECKPOINT_RESTORE_PATCH,
     RUN_WORKFLOW_HEADLESS_REMEDIATION_PATCH,
@@ -228,6 +232,9 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_REMEDIATION_EXPLICIT_EVIDENCE_INPUTS_PATCH,
     RUN_TERMINAL_GATE_PUBLISHED_HEAD_FEASIBILITY_PATCH,
     MoonMindRunWorkflow,
+)
+from moonmind.workflows.temporal.workflows.merge_automation import (
+    MoonMindMergeAutomationWorkflow,
 )
 from moonmind.workflows.terminal_evidence import evaluate_terminal_evidence
 from tests.integration.reliability.helpers import (
@@ -2607,6 +2614,123 @@ async def test_standalone_omnigent_resolver_rejects_unowned_continuation_without
     assert retryable is expected["retryable"]
     assert expected["genericRetryCount"] == 0
     assert expected["parentState"] == "failed"
+
+
+async def test_omnigent_merge_resolver_recompiles_child_plan_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay resolver:pr:813 at both workflow authority handoffs."""
+
+    replay_id = "omnigent-merge-resolver-child-plan"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    parent = MoonMindRunWorkflow()
+    parent._repo = manifest["repository"]
+    parent._publish_context.update(
+        {
+            "branch": manifest["pullRequest"]["headBranch"],
+            "baseRef": manifest["pullRequest"]["baseBranch"],
+        }
+    )
+    monkeypatch.setattr(
+        parent,
+        "_workflow_patch_enabled",
+        lambda patch_id: patch_id
+        == RUN_MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH,
+    )
+
+    merge_input = parent._build_merge_gate_start_payload(
+        parameters=manifest["parentParameters"],
+        pull_request_url=manifest["pullRequest"]["url"],
+        head_sha=manifest["pullRequest"]["headSha"],
+        parent_workflow_id=manifest["parentWorkflowId"],
+        parent_run_id=manifest["parentRunId"],
+    )
+
+    assert merge_input is not None
+    parent_plan = manifest["parentParameters"]["omnigentExecutionPlan"]
+    assert merge_input["resolverTemplate"]["parentOmnigentExecutionPlan"] == (
+        parent_plan
+    )
+    resolver = MoonMindMergeAutomationWorkflow()
+    resolver._input = merge_automation_module.MergeAutomationStartInput.model_validate(
+        merge_input
+    )
+    resolver_request = merge_automation_module.build_resolver_run_request(
+        parent_workflow_id=manifest["parentWorkflowId"],
+        pull_request=resolver._input.pull_request,
+        jira_issue_key=resolver._input.jira_issue_key,
+        merge_method=resolver._input.config.resolver.merge_method,
+        resolver_template=resolver._input.resolver_template,
+    )
+    child_plan = {
+        "planRef": "omnigent-execution-plan:sha256:" + "c" * 64,
+        "planDigest": "sha256:" + "c" * 64,
+        "planArtifactRef": expected["childPlanArtifactRef"],
+        "taskInputSnapshotRef": "art-child-task",
+        "taskInputSnapshotDigest": "sha256:" + "d" * 64,
+    }
+    calls: list[dict[str, object]] = []
+
+    async def prepare_child_plan(
+        activity_type: str,
+        activity_payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        calls.append(
+            {
+                "activityType": activity_type,
+                "payload": activity_payload,
+                "taskQueue": kwargs.get("task_queue"),
+            }
+        )
+        prepared = json.loads(json.dumps(activity_payload["childWorkflowRequest"]))
+        prepared["initial_parameters"]["omnigentExecutionPlan"] = child_plan
+        prepared["initial_parameters"]["resolvedSkillsetRef"] = expected[
+            "resolvedSkillsetRef"
+        ]
+        return prepared
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        prepare_child_plan,
+    )
+    prepared = await resolver._prepare_omnigent_resolver_request(
+        resolver_request,
+        resolver_workflow_id=expected["childWorkflowId"],
+    )
+
+    assert calls[0]["activityType"] == expected["preparationActivity"]
+    assert calls[0]["taskQueue"] == expected["activityTaskQueue"]
+    assert calls[0]["payload"]["parentExecutionPlan"] == parent_plan
+    assert prepared["initial_parameters"]["omnigentExecutionPlan"] == child_plan
+    assert prepared["initial_parameters"]["resolvedSkillsetRef"] == expected[
+        "resolvedSkillsetRef"
+    ]
+    assert prepared["initial_parameters"]["task"]["tool"]["name"] == expected[
+        "resolvedSkill"
+    ]
+    workspace_spec = prepared["initial_parameters"]["workspaceSpec"]
+    assert workspace_spec["startingBranch"] == expected["startingBranch"]
+    assert workspace_spec["targetBranch"] == expected["targetBranch"]
+
+    # Inputs created before the parent-plan field existed recover the same
+    # immutable authority from the canonical parent execution in the Activity.
+    legacy_merge_input = json.loads(json.dumps(merge_input))
+    legacy_merge_input["resolverTemplate"].pop("parentOmnigentExecutionPlan")
+    legacy_resolver = MoonMindMergeAutomationWorkflow()
+    legacy_resolver._input = (
+        merge_automation_module.MergeAutomationStartInput.model_validate(
+            legacy_merge_input
+        )
+    )
+    await legacy_resolver._prepare_omnigent_resolver_request(
+        resolver_request,
+        resolver_workflow_id=expected["childWorkflowId"],
+    )
+    assert calls[1]["payload"]["parentWorkflowId"] == manifest["parentWorkflowId"]
+    assert "parentExecutionPlan" not in calls[1]["payload"]
 
 
 async def test_completed_batch_no_op_replays_through_production_activity_route(

--- a/tests/unit/workflows/temporal/test_omnigent_activities.py
+++ b/tests/unit/workflows/temporal/test_omnigent_activities.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -26,7 +27,175 @@ from moonmind.workflows.temporal.activities.omnigent_activities import (
     _resolve_live_recovery_authority,
     _try_generic_realizer_dispatch,
     omnigent_execute_activity,
+    omnigent_prepare_child_execution_plan_activity,
 )
+
+
+@pytest.mark.asyncio
+async def test_prepare_child_execution_plan_recompiles_child_skill_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api_service.services import omnigent_execution_plan_service
+    from moonmind.workflows.temporal.activities import omnigent_session_activities
+
+    parent_binding = {
+        "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+        "planDigest": "sha256:" + "a" * 64,
+        "planArtifactRef": "art-parent-plan",
+        "taskInputSnapshotRef": "art-parent-task",
+        "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+    }
+    child_binding = OmnigentExecutionPlanBinding(
+        planRef="omnigent-execution-plan:sha256:" + "c" * 64,
+        planDigest="sha256:" + "c" * 64,
+        planArtifactRef="art-child-plan",
+        taskInputSnapshotRef="art-child-task",
+        taskInputSnapshotDigest="sha256:" + "d" * 64,
+    )
+    parent_plan = SimpleNamespace(
+        payload=SimpleNamespace(
+            agentProfileSnapshotRef="artifact:art-agent-profile",
+            modelConfig=SimpleNamespace(
+                qualifiedId="opencode/muse-spark-1.3-contributor-free",
+                effort="xhigh",
+            ),
+            credentialBindings={
+                "primary-model": SimpleNamespace(
+                    providerProfileRef="opencode-zen-free"
+                )
+            },
+        )
+    )
+    provider_profile = SimpleNamespace(profile_id="opencode-zen-free")
+    observed: dict[str, Any] = {}
+
+    async def fake_load_verified(binding):
+        assert binding == OmnigentExecutionPlanBinding.model_validate(parent_binding)
+        return parent_plan
+
+    async def fake_read_json(ref):
+        assert ref == "art-agent-profile"
+        return {"document": {"harness": {"id": "opencode-native"}}}
+
+    async def fake_persist_json_artifact(**kwargs):
+        observed["taskSnapshot"] = kwargs["payload"]
+        return "art-child-task", "sha256:" + "d" * 64
+
+    async def fake_compile_and_persist_execution_plan(**kwargs):
+        observed["compile"] = kwargs
+        return SimpleNamespace(
+            binding=child_binding,
+            resolved_skillset_ref="art-child-skills",
+        )
+
+    class FakeDbSession:
+        async def get(self, model, record_id):
+            if model.__name__ == "TemporalExecutionCanonicalRecord":
+                assert record_id == "mm:parent"
+                return SimpleNamespace(
+                    parameters={"omnigentExecutionPlan": parent_binding}
+                )
+            assert model.__name__ == "ManagedAgentProviderProfile"
+            assert record_id == "opencode-zen-free"
+            return provider_profile
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return FakeDbSession()
+
+        async def __aexit__(self, _exc_type, _exc, _tb):
+            return False
+
+    def fake_session_factory():
+        return FakeSessionContext()
+
+    monkeypatch.setattr(
+        omnigent_session_activities,
+        "_load_verified_execution_plan",
+        fake_load_verified,
+    )
+    monkeypatch.setattr(
+        omnigent_session_activities,
+        "_read_json_artifact",
+        fake_read_json,
+    )
+    monkeypatch.setattr(
+        omnigent_execution_plan_service,
+        "persist_json_artifact",
+        fake_persist_json_artifact,
+    )
+    monkeypatch.setattr(
+        omnigent_execution_plan_service,
+        "compile_and_persist_execution_plan",
+        fake_compile_and_persist_execution_plan,
+    )
+    import api_service.db.base as db_base
+
+    monkeypatch.setattr(db_base, "async_session_maker", fake_session_factory)
+
+    result = await omnigent_prepare_child_execution_plan_activity(
+        {
+            "principal": "user-1",
+            "parentWorkflowId": "mm:parent",
+            "childWorkflowId": "resolver:child:1",
+            "childWorkflowRequest": {
+                "workflow_type": "MoonMind.UserWorkflow",
+                "title": "Resolve PR #350",
+                "initial_parameters": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "omnigent",
+                    "requiredCapabilities": ["git", "gh"],
+                    "workspaceSpec": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "startingBranch": "main",
+                        "targetBranch": "feature",
+                    },
+                    "task": {
+                        "instructions": "Resolve PR #350.",
+                        "tool": {"type": "skill", "name": "pr-resolver"},
+                        "skill": {"id": "pr-resolver", "args": {"pr": "350"}},
+                        "runtime": {
+                            "mode": "omnigent",
+                            "model": "opencode/muse-spark-1.3-contributor-free",
+                            "effort": "xhigh",
+                        },
+                        "publish": {"mode": "auto"},
+                    },
+                },
+            },
+        }
+    )
+
+    assert result["initial_parameters"]["omnigentExecutionPlan"] == (
+        child_binding.model_dump(mode="json", by_alias=True)
+    )
+    assert result["initial_parameters"]["resolvedSkillsetRef"] == (
+        "art-child-skills"
+    )
+    snapshot_parameters = observed["taskSnapshot"]["target"]["initialParameters"]
+    assert "task" not in snapshot_parameters
+    assert snapshot_parameters["workflow"]["tool"]["name"] == "pr-resolver"
+    assert snapshot_parameters["workflow"]["workspace"] == {
+        "repository": "MoonLadderStudios/MoonMind",
+        "startingBranch": "main",
+        "targetBranch": "feature",
+    }
+    assert observed["compile"]["workflow_id"] == "resolver:child:1"
+    assert observed["compile"]["provider_profile"] is provider_profile
+    compiled_parameters = observed["compile"]["initial_parameters"]
+    assert "task" not in compiled_parameters
+    assert compiled_parameters["workflow"]["skill"]["id"] == "pr-resolver"
+    assert compiled_parameters["workflow"]["workspace"]["targetBranch"] == (
+        "feature"
+    )
+    assert compiled_parameters["workspace"]["targetBranch"] == "feature"
+    assert compiled_parameters["model"] == (
+        "opencode/muse-spark-1.3-contributor-free"
+    )
+    assert compiled_parameters["effort"] == "xhigh"
+    assert omnigent_execution_plan_service.selected_skill_names(
+        compiled_parameters
+    ) == ["pr-resolver"]
 
 
 @pytest_asyncio.fixture()

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from moonmind.workflows.temporal.workflows.run import (
     MoonMindRunWorkflow,
     _worker_capability_unavailable_error,
@@ -536,6 +538,75 @@ def test_build_merge_gate_start_payload_preserves_parent_runtime_profile() -> No
     assert resolver_template["effort"] == "high"
     assert "profileId" not in resolver_template
     assert "providerProfile" not in resolver_template
+
+
+def test_build_merge_gate_start_payload_preserves_parent_omnigent_plan(
+    monkeypatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    monkeypatch.setattr(workflow, "_workflow_patch_enabled", lambda _patch_id: True)
+    parent_plan = {
+        "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+        "planDigest": "sha256:" + "a" * 64,
+        "planArtifactRef": "art-parent-plan",
+        "taskInputSnapshotRef": "art-parent-task",
+        "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+    }
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters={
+            "publishMode": "none",
+            "targetRuntime": "omnigent",
+            "profileId": "opencode-zen-free",
+            "model": "opencode/muse-spark-1.3-contributor-free",
+            "effort": "xhigh",
+            "omnigentExecutionPlan": parent_plan,
+            "workflow": {
+                "publish": {"mergeAutomation": {"enabled": True}},
+            },
+        },
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/341",
+        head_sha="abc123",
+        parent_workflow_id="mm:parent",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    assert payload["resolverTemplate"]["targetRuntime"] == "omnigent"
+    assert payload["resolverTemplate"]["executionProfileRef"] == (
+        "opencode-zen-free"
+    )
+    assert payload["resolverTemplate"]["parentOmnigentExecutionPlan"] == parent_plan
+
+
+def test_build_merge_gate_start_payload_rejects_missing_omnigent_plan(
+    monkeypatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    monkeypatch.setattr(workflow, "_workflow_patch_enabled", lambda _patch_id: True)
+
+    with pytest.raises(
+        ValueError,
+        match="requires persisted parent execution-plan authority",
+    ):
+        workflow._build_merge_gate_start_payload(
+            parameters={
+                "publishMode": "none",
+                "targetRuntime": "omnigent",
+                "workflow": {
+                    "publish": {"mergeAutomation": {"enabled": True}},
+                },
+            },
+            pull_request_url=(
+                "https://github.com/MoonLadderStudios/MoonMind/pull/341"
+            ),
+            head_sha="abc123",
+            parent_workflow_id="mm:parent",
+            parent_run_id="run-1",
+        )
+
 
 def test_build_merge_gate_start_payload_inherits_task_runtime_profile() -> None:
     workflow = MoonMindRunWorkflow()

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -166,6 +166,90 @@ def test_merge_automation_summary_payload_bounds_published_artifact_refs() -> No
     assert len(workflow._resolver_attempt_artifact_refs) == max_refs + 3
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("include_parent_plan", [True, False])
+async def test_prepare_omnigent_resolver_request_compiles_child_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    include_parent_plan: bool,
+) -> None:
+    payload = _payload()
+    parent_plan = {
+        "planRef": "omnigent-execution-plan:sha256:" + "a" * 64,
+        "planDigest": "sha256:" + "a" * 64,
+        "planArtifactRef": "art-parent-plan",
+        "taskInputSnapshotRef": "art-parent-task",
+        "taskInputSnapshotDigest": "sha256:" + "b" * 64,
+    }
+    payload["resolverTemplate"] = {
+        "targetRuntime": "omnigent",
+    }
+    if include_parent_plan:
+        payload["resolverTemplate"]["parentOmnigentExecutionPlan"] = parent_plan
+    workflow = MoonMindMergeAutomationWorkflow()
+    workflow._input = merge_automation_module.MergeAutomationStartInput.model_validate(
+        payload
+    )
+    child_plan = {
+        "planRef": "omnigent-execution-plan:sha256:" + "c" * 64,
+        "planDigest": "sha256:" + "c" * 64,
+        "planArtifactRef": "art-child-plan",
+        "taskInputSnapshotRef": "art-child-task",
+        "taskInputSnapshotDigest": "sha256:" + "d" * 64,
+    }
+    child_request = {
+        "workflow_type": "MoonMind.UserWorkflow",
+        "title": "Resolve PR #350",
+        "initial_parameters": {
+            "targetRuntime": "omnigent",
+            "task": {"tool": {"type": "skill", "name": "pr-resolver"}},
+        },
+    }
+    observed: dict[str, Any] = {}
+
+    async def fake_execute_activity(
+        activity_type: str,
+        activity_payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        observed.update(
+            {
+                "activityType": activity_type,
+                "payload": activity_payload,
+                "taskQueue": kwargs.get("task_queue"),
+            }
+        )
+        prepared = dict(activity_payload["childWorkflowRequest"])
+        prepared_parameters = dict(prepared["initial_parameters"])
+        prepared_parameters["omnigentExecutionPlan"] = child_plan
+        prepared_parameters["resolvedSkillsetRef"] = "art-child-skills"
+        prepared["initial_parameters"] = prepared_parameters
+        return prepared
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+
+    prepared = await workflow._prepare_omnigent_resolver_request(
+        child_request,
+        resolver_workflow_id="resolver:child:1",
+    )
+
+    assert observed["activityType"] == "omnigent.prepare_child_execution_plan"
+    assert observed["taskQueue"] == "mm.activity.agent_runtime"
+    assert observed["payload"]["parentWorkflowId"] == "wf-parent"
+    assert observed["payload"]["childWorkflowId"] == "resolver:child:1"
+    if include_parent_plan:
+        assert observed["payload"]["parentExecutionPlan"] == parent_plan
+    else:
+        assert "parentExecutionPlan" not in observed["payload"]
+    assert prepared["initial_parameters"]["omnigentExecutionPlan"] == child_plan
+    assert prepared["initial_parameters"]["resolvedSkillsetRef"] == (
+        "art-child-skills"
+    )
+
+
 def test_legacy_gated_continuation_uses_fallback_poll_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- preserve the parent Omnigent plan binding when `MoonMind.UserWorkflow` starts merge automation
- compile a fresh child-scoped Omnigent plan and resolved `pr-resolver` Skill snapshot before the resolver child starts
- retain exact model, Provider Profile, and PR workspace authority, including compatibility recovery for in-flight merge payloads
- add the escaped-production replay fixture and document the authority handoff

## Root cause

The merge-automation resolver child inherited only `targetRuntime` and the flat Provider Profile id. Because that Temporal-started child bypassed API plan compilation, generic OpenCode execution reached the legacy OAuth host path and `omnigent.ensure_host` rejected `opencode-zen-free` as an OAuth profile.

## Validation

- targeted workflow, Activity, catalog, and worker tests: 131 passed
- Temporal boundary suite: 3,759 passed, 9 subtests passed
- reliability journeys: 135 passed
- API/component suite: 1,868 passed, 1 expected xfail
- hermetic integration CI suite: 618 passed, 1 skipped
- runtime terminology guardrail and Ruff checks passed

The deterministic Omnigent conformance command was also exercised locally. Its Python and UI shards passed 3,101 tests; the macOS host could not run 13 PostgreSQL fixtures and hit 3 existing read-only bundle publication permission failures. The selected Linux PR gates will run deterministic and exact-artifact conformance.