### PR TITLE
Fix stale runtime source reconciliation during updates

### DIFF
--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -32,6 +32,9 @@ metadata:
      (unless `noComposePull` is set)
    - recreate the resolver worker only when it still exists in the post-checkout
      Compose topology
+   - stamp each recreated application container with the exact checked-out git
+     revision and force-recreate any existing application process whose recorded
+     revision is missing or stale, even when no new commit was fetched
    - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
    - restart services with image drift or stopped service state so runtime stays healthy
    - exclude the deployment-control worker from update targets so it can finish and verify the operation

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -32,9 +32,12 @@ metadata:
      (unless `noComposePull` is set)
    - recreate the resolver worker only when it still exists in the post-checkout
      Compose topology
-   - stamp each recreated application container with the exact checked-out git
-     revision and force-recreate any existing application process whose recorded
-     revision is missing or stale, even when no new commit was fetched
+   - persist the exact checked-out git revision as the non-secret
+     `MOONMIND_RUNTIME_SOURCE_REVISION` entry in the ignored project `.env`, so
+     later ordinary `docker compose up -d` runs preserve the revision evidence
+   - stamp each recreated application container with that revision and
+     force-recreate any existing application process whose recorded revision is
+     missing or stale, even when no new commit was fetched
    - detect files changed between pre-pull and post-pull commits, force-recreate only application processes affected by bind-mounted runtime source, and use normal Compose reconciliation for other selected services
    - restart services with image drift or stopped service state so runtime stays healthy
    - exclude the deployment-control worker from update targets so it can finish and verify the operation

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -503,6 +503,11 @@ if [[ "$POST_PULL_COMMIT" != "$REMOTE_COMMIT" ]]; then
   die "Checked-out commit $POST_PULL_COMMIT does not match fetched commit $REMOTE_COMMIT."
 fi
 
+# Compose persists this value as container metadata. It records the checkout
+# revision selected before each long-lived application process is created, so a
+# later update can detect a stale process even when git was updated separately.
+export MOONMIND_RUNTIME_SOURCE_REVISION="$POST_PULL_COMMIT"
+
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then
   say "Pulling updated compose images"
   compose_pull_output=""
@@ -589,20 +594,63 @@ add_force_recreate_target() {
   fi
 }
 
+is_runtime_source_service() {
+  local service="$1"
+  case "$service" in
+    api | orchestrator | temporal-worker-*)
+      [[ "$service" != "temporal-worker-deployment-control" ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 add_runtime_source_services_for_recreate() {
   local service
   for service in "${COMPOSE_SERVICES[@]}"; do
-    case "$service" in
-      api | orchestrator | temporal-worker-*)
-        add_force_recreate_target "$service"
-        ;;
-    esac
+    if is_runtime_source_service "$service"; then
+      add_force_recreate_target "$service"
+    fi
+  done
+}
+
+mark_stale_runtime_source_services_for_recreate() {
+  local service container_id loaded_revision loaded_revision_display
+  local -a container_ids=()
+
+  for service in "${COMPOSE_SERVICES[@]}"; do
+    is_runtime_source_service "$service" || continue
+    if [[ "$service" == "orchestrator" && "$RESTART_ORCHESTRATOR" != "true" ]]; then
+      continue
+    fi
+
+    mapfile -t container_ids < <("${COMPOSE_CMD[@]}" ps -a -q "$service" 2>/dev/null || true)
+    [[ ${#container_ids[@]} -gt 0 ]] || continue
+
+    for container_id in "${container_ids[@]}"; do
+      [[ -n "${container_id//[[:space:]]/}" ]] || continue
+      loaded_revision="$(
+        docker inspect "$container_id" \
+          --format '{{index .Config.Labels "moonmind.runtime_source_revision"}}' \
+          2>/dev/null || true
+      )"
+      if [[ "$loaded_revision" == "$POST_PULL_COMMIT" ]]; then
+        continue
+      fi
+
+      loaded_revision_display="${loaded_revision:-missing}"
+      say "Marking service '$service' for force recreation: loaded runtime source revision '$loaded_revision_display' does not match checked-out revision '$POST_PULL_COMMIT'."
+      add_force_recreate_target "$service"
+      break
+    done
   done
 }
 
 if load_compose_service_images; then
   mark_stale_services_for_restart
 fi
+mark_stale_runtime_source_services_for_recreate
 mark_not_running_services_for_restart
 
 for changed_file in "${CHANGED_FILES[@]}"; do

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -132,6 +132,51 @@ is_compose_pull_policy_blocked() {
     [[ "$normalized" == *"request forbidden by administrative rules"* ]]
 }
 
+persist_runtime_source_revision() {
+  local revision="$1"
+  local env_path=".env"
+  local temp_path
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    say "Would persist the selected runtime source revision in $env_path."
+    return
+  fi
+
+  temp_path="$(mktemp "${env_path}.runtime-source.XXXXXX")" || \
+    die "Could not create a temporary file for $env_path."
+
+  if [[ -f "$env_path" ]]; then
+    if ! awk -v revision="$revision" '
+      BEGIN { written = 0 }
+      /^[[:space:]]*(export[[:space:]]+)?MOONMIND_RUNTIME_SOURCE_REVISION[[:space:]]*=/ {
+        if (written == 0) {
+          print "MOONMIND_RUNTIME_SOURCE_REVISION=" revision
+          written = 1
+        }
+        next
+      }
+      { print }
+      END {
+        if (written == 0) {
+          print "MOONMIND_RUNTIME_SOURCE_REVISION=" revision
+        }
+      }
+    ' "$env_path" > "$temp_path"; then
+      rm -f -- "$temp_path"
+      die "Could not update $env_path with the selected runtime source revision."
+    fi
+    chmod --reference="$env_path" "$temp_path" 2>/dev/null || true
+  else
+    printf 'MOONMIND_RUNTIME_SOURCE_REVISION=%s\n' "$revision" > "$temp_path"
+  fi
+
+  if ! mv -f -- "$temp_path" "$env_path"; then
+    rm -f -- "$temp_path"
+    die "Could not persist the selected runtime source revision in $env_path."
+  fi
+  say "Persisted the selected runtime source revision for ordinary Compose reconciliation."
+}
+
 load_compose_service_images() {
   if ! command -v jq >/dev/null 2>&1; then
     say "jq unavailable; skipping compose image drift checks."
@@ -507,6 +552,7 @@ fi
 # revision selected before each long-lived application process is created, so a
 # later update can detect a stale process even when git was updated separately.
 export MOONMIND_RUNTIME_SOURCE_REVISION="$POST_PULL_COMMIT"
+persist_runtime_source_revision "$POST_PULL_COMMIT"
 
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then
   say "Pulling updated compose images"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,6 +176,7 @@ services:
     labels:
       - "ai.model.context.protocol.version=2025-03-26"
       - "ai.model.context.protocol.endpoint=/mcp"
+      - "moonmind.runtime_source_revision=${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     depends_on:
       init-db:
         condition: service_completed_successfully
@@ -356,6 +357,8 @@ services:
   temporal-worker-workflow:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -421,6 +424,8 @@ services:
   temporal-worker-artifacts:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -477,6 +482,8 @@ services:
   temporal-worker-llm:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -535,6 +542,8 @@ services:
   temporal-worker-sandbox:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -622,6 +631,8 @@ services:
   temporal-worker-agent-runtime:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
@@ -859,6 +870,8 @@ services:
   temporal-worker-integrations:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
     init: true
+    labels:
+      moonmind.runtime_source_revision: "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -4536,7 +4536,6 @@ async def test_accepted_turn_that_never_starts_fails_within_start_budget(
     assert dispatched.diagnostics_ref == result.diagnostics_ref
 
 
-@pytest.mark.integration_ci
 async def test_active_tool_turn_uses_published_budget_and_preserves_retry() -> None:
     """Replay mm:8d94711e at the budget and generic-dispatch boundaries."""
 

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -156,6 +156,39 @@ def _network_aliases(service_config: dict, network_name: str) -> set[str]:
         return set()
     return {str(alias) for alias in network_config.get("aliases", [])}
 
+
+def _label_map(service_config: dict) -> dict[str, str]:
+    labels = service_config.get("labels", {})
+    if isinstance(labels, dict):
+        return {str(key): str(value) for key, value in labels.items()}
+    if isinstance(labels, list):
+        return {
+            key: value
+            for key, value in (
+                str(label).split("=", 1) for label in labels if "=" in str(label)
+            )
+        }
+    return {}
+
+
+def test_reloadable_runtime_services_record_checked_out_source_revision():
+    services = _load_compose()["services"]
+    runtime_services = {
+        "api",
+        *(
+            service
+            for service in services
+            if service.startswith("temporal-worker-")
+            and service != "temporal-worker-deployment-control"
+        ),
+    }
+
+    for service in runtime_services:
+        assert _label_map(services[service])["moonmind.runtime_source_revision"] == (
+            "${MOONMIND_RUNTIME_SOURCE_REVISION:-untracked}"
+        )
+
+
 def test_temporal_compose_topology_and_private_exposure():
     compose = _load_compose()
     services = compose["services"]

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -57,7 +57,10 @@ def _run_update_scenario(
     tmp_path: Path,
     *,
     changed_file: str,
+    checkout_already_current: bool = False,
+    agent_runtime_revision_state: str | None = None,
     include_all_commands: bool = False,
+    no_compose_pull: bool = False,
     remove_agent_runtime_after_update: bool = False,
 ) -> list[str]:
     bash = _modern_bash()
@@ -90,6 +93,23 @@ def _run_update_scenario(
     _run_git("push", "origin", "main", cwd=seed)
     expected_head = _run_git("rev-parse", "HEAD", cwd=seed).stdout.strip()
 
+    if checkout_already_current:
+        _run_git("fetch", "origin", "main", cwd=checkout)
+        _run_git("reset", "--hard", expected_head, cwd=checkout)
+
+    if agent_runtime_revision_state is None:
+        agent_runtime_revision = ""
+    elif agent_runtime_revision_state == "missing":
+        agent_runtime_revision = ""
+    elif agent_runtime_revision_state == "stale":
+        agent_runtime_revision = initial_head
+    elif agent_runtime_revision_state == "current":
+        agent_runtime_revision = expected_head
+    else:
+        raise AssertionError(
+            f"unsupported agent runtime revision state: {agent_runtime_revision_state}"
+        )
+
     fake_bin.mkdir()
     fake_docker = fake_bin / "docker"
     fake_docker_script = """#!/usr/bin/env bash
@@ -97,6 +117,14 @@ set -euo pipefail
 printf '%s\\n' "$*" >> "$DOCKER_LOG"
 
 if [[ "${1:-}" == "ps" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "inspect" ]]; then
+  if [[ "$*" == *".State.Status"* ]]; then
+    printf '%s\\n' running
+  elif [[ "$*" == *"moonmind.runtime_source_revision"* ]]; then
+    printf '%s\\n' "$FAKE_AGENT_RUNTIME_SOURCE_REVISION"
+  fi
   exit 0
 fi
 if [[ "${1:-}" != "compose" ]]; then
@@ -127,10 +155,23 @@ case "${1:-} ${2:-}" in
   "pull ")
     exit 0
     ;;
-  "ps -a"|"ps -q")
-    exit 0
+  "ps -a")
+    if [[ "${4:-}" == "temporal-worker-agent-runtime" ]] \
+      && [[ "$FAKE_AGENT_RUNTIME_CONTAINER" == "true" ]]; then
+      printf '%s\\n' container-agent-runtime
+    fi
+    ;;
+  "ps -q")
+    if [[ "${3:-}" == "temporal-worker-agent-runtime" ]] \
+      && [[ "$FAKE_AGENT_RUNTIME_CONTAINER" == "true" ]]; then
+      printf '%s\\n' container-agent-runtime
+    fi
     ;;
   "up -d")
+    if [[ "${MOONMIND_RUNTIME_SOURCE_REVISION:-}" != "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" ]]; then
+      printf 'runtime source revision was not exported for compose up\\n' >&2
+      exit 42
+    fi
     exit 0
     ;;
 esac
@@ -149,8 +190,22 @@ esac
     env["DOCKER_LOG"] = str(docker_log)
     env["UPDATE_CHECKOUT"] = str(checkout)
     env["UPDATE_INITIAL_HEAD"] = initial_head
+    env["FAKE_AGENT_RUNTIME_CONTAINER"] = str(
+        agent_runtime_revision_state is not None
+    ).lower()
+    env["FAKE_AGENT_RUNTIME_SOURCE_REVISION"] = agent_runtime_revision
+    update_command = [
+        bash,
+        str(UPDATE_SCRIPT),
+        "--repo",
+        str(checkout),
+        "--branch",
+        "main",
+    ]
+    if no_compose_pull:
+        update_command.append("--no-compose-pull")
     update = subprocess.run(
-        [bash, str(UPDATE_SCRIPT), "--repo", str(checkout), "--branch", "main"],
+        update_command,
         cwd=ROOT,
         env=env,
         check=False,
@@ -206,6 +261,42 @@ def test_documentation_update_does_not_force_recreate_services(
     assert "postgres" in up_commands[0]
     assert "temporal-worker-workflow" in up_commands[0]
     assert "temporal-worker-deployment-control" not in up_commands[0]
+
+
+@pytest.mark.parametrize("agent_runtime_revision_state", ["missing", "stale"])
+def test_stale_runtime_source_revision_is_recreated_when_checkout_is_current(
+    tmp_path: Path,
+    agent_runtime_revision_state: str,
+) -> None:
+    up_commands = _run_update_scenario(
+        tmp_path,
+        changed_file="moonmind/example.py",
+        checkout_already_current=True,
+        agent_runtime_revision_state=agent_runtime_revision_state,
+        no_compose_pull=True,
+    )
+
+    recreate_commands = [
+        command for command in up_commands if "--force-recreate" in command
+    ]
+    assert len(recreate_commands) == 1
+    assert "temporal-worker-agent-runtime" in recreate_commands[0]
+    assert "api" not in recreate_commands[0]
+    assert "temporal-worker-workflow" not in recreate_commands[0]
+
+
+def test_current_runtime_source_revision_is_not_recreated_without_changes(
+    tmp_path: Path,
+) -> None:
+    up_commands = _run_update_scenario(
+        tmp_path,
+        changed_file="moonmind/example.py",
+        checkout_already_current=True,
+        agent_runtime_revision_state="current",
+        no_compose_pull=True,
+    )
+
+    assert all("--force-recreate" not in command for command in up_commands)
 
 
 def test_skill_source_update_quiesces_resolver_before_checkout_mutation(

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -60,6 +60,7 @@ def _run_update_scenario(
     checkout_already_current: bool = False,
     agent_runtime_revision_state: str | None = None,
     include_all_commands: bool = False,
+    initial_env_contents: str | None = None,
     no_compose_pull: bool = False,
     remove_agent_runtime_after_update: bool = False,
 ) -> list[str]:
@@ -74,10 +75,11 @@ def _run_update_scenario(
     _run_git("init", "-b", "main", cwd=seed)
     _run_git("config", "user.name", "MoonMind Test", cwd=seed)
     _run_git("config", "user.email", "moonmind-test@example.invalid", cwd=seed)
+    (seed / ".gitignore").write_text(".env\n", encoding="utf-8")
     source_file = seed / changed_file
     source_file.parent.mkdir(parents=True)
     source_file.write_text("VERSION = 1\n", encoding="utf-8")
-    _run_git("add", changed_file, cwd=seed)
+    _run_git("add", ".gitignore", changed_file, cwd=seed)
     _run_git("commit", "-m", "initial", cwd=seed)
 
     _run_git("init", "--bare", str(remote), cwd=tmp_path)
@@ -86,6 +88,8 @@ def _run_update_scenario(
     _run_git("symbolic-ref", "HEAD", "refs/heads/main", cwd=remote)
     _run_git("clone", str(remote), str(checkout), cwd=tmp_path)
     initial_head = _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip()
+    if initial_env_contents is not None:
+        (checkout / ".env").write_text(initial_env_contents, encoding="utf-8")
 
     source_file.write_text("VERSION = 2\n", encoding="utf-8")
     _run_git("add", changed_file, cwd=seed)
@@ -297,6 +301,31 @@ def test_current_runtime_source_revision_is_not_recreated_without_changes(
     )
 
     assert all("--force-recreate" not in command for command in up_commands)
+
+
+def test_update_persists_revision_without_clobbering_operator_env(
+    tmp_path: Path,
+) -> None:
+    _run_update_scenario(
+        tmp_path,
+        changed_file="moonmind/example.py",
+        checkout_already_current=True,
+        initial_env_contents=(
+            "KEEP_ME=yes\n"
+            "export MOONMIND_RUNTIME_SOURCE_REVISION=old\n"
+            "MOONMIND_RUNTIME_SOURCE_REVISION=duplicate\n"
+            "AFTER=preserved\n"
+        ),
+        no_compose_pull=True,
+    )
+
+    checkout = tmp_path / "checkout"
+    expected_revision = _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip()
+    assert (checkout / ".env").read_text(encoding="utf-8").splitlines() == [
+        "KEEP_ME=yes",
+        f"MOONMIND_RUNTIME_SOURCE_REVISION={expected_revision}",
+        "AFTER=preserved",
+    ]
 
 
 def test_skill_source_update_quiesces_resolver_before_checkout_mutation(


### PR DESCRIPTION
## Summary
- stamp reloadable application containers with the checked-out MoonMind revision
- force-recreate running services when their recorded revision is missing or differs, even when Git is already current
- preserve the deployment-control self-exclusion and avoid recreation when the recorded revision matches

## Root cause
Workflow mm:4fb8c9fb-d709-46e1-b62d-107c61801815 ran in an agent-runtime worker process that had loaded pre-fix Python. The checkout already contained the timeout fix, so update-moonmind saw no Git delta and skipped source-based recreation. Container image checks could not detect stale bind-mounted code retained by a long-lived process.

## Verification
- updater unit regression suite: 8 passed
- targeted integration_ci Compose contract: 1 passed
- update-moonmind skill validation: passed
- docker compose config validation: passed
- git diff --check: passed