### PR TITLE
Complete MoonLadderStudios/MoonMind#3816: canonical Settings routes, retired ?section=, trailing-slash direct loads

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -1535,8 +1535,13 @@ async def settings_spa_fallback_route(
     session: AsyncSession = Depends(get_async_session),
     _user: User = Depends(get_current_user()),
 ) -> HTMLResponse:
-    """Serve the settings SPA shell for extensionless settings sub-routes."""
-    if not _is_extensionless_dashboard_path(dashboard_path):
+    """Serve the settings SPA shell for extensionless settings sub-routes.
+
+    An empty sub-path is the trailing-slash form of the bare `/settings` entry
+    point. The client normalizes it the same way, so a direct load must resolve
+    to the same page and boot payload rather than 404.
+    """
+    if dashboard_path and not _is_extensionless_dashboard_path(dashboard_path):
         _raise_dashboard_route_not_found()
     return await task_settings_route(request, session=session, _user=_user)
 

--- a/frontend/src/entrypoints/dashboard.test.tsx
+++ b/frontend/src/entrypoints/dashboard.test.tsx
@@ -1670,6 +1670,33 @@ describe('Dashboard shared entry', () => {
     expect(screen.queryByRole('radiogroup', { name: 'Workflow list display' })).toBeNull();
   });
 
+  it.each([
+    '/settings/',
+    '/settings/providers-secrets/',
+    '/settings/user-workspace/',
+    '/settings/operations/',
+  ])(
+    'MoonLadderStudios/MoonMind#3816 mounts the route-owned Settings page for the trailing-slash direct load %s',
+    async (path) => {
+      window.history.replaceState({}, '', path);
+      renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+      expect(await screen.findByText('Settings permissions:')).toBeTruthy();
+      expect(screen.queryByText('Unknown dashboard page:')).toBeNull();
+      // A trailing slash is a canonical route, not an unknown Settings alias, so
+      // it is never rewritten back to the /settings entry point.
+      expect(window.location.pathname).toBe(path);
+    },
+  );
+
+  it('MoonLadderStudios/MoonMind#3816 sends an unknown Settings alias back to the entry point', async () => {
+    window.history.replaceState({}, '', '/settings/provider-profiles/?runtime=codex');
+    renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+    await waitFor(() => expect(window.location.pathname).toBe('/settings'));
+    expect(window.location.search).toBe('');
+  });
+
   it('does not register a dashboard proposal review page for MM-859', async () => {
     window.history.replaceState({}, '', '/proposals');
     renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, useLocation, useSearchParams } from 'react-router-dom';
 
 import type { BootPayload } from '../boot/parseBootPayload';
 import { LoadingPlaceholder } from '../components/dashboard/LoadingPlaceholder';
@@ -25,6 +25,7 @@ import {
   SettingsDraftGuardProvider,
   useSettingsDraftGuard,
 } from '../components/settings/SettingsDraftGuard';
+import { filterSettingsQueryForTarget } from '../lib/dashboardRoutes';
 import { resetDashboardPreferences } from '../utils/dashboardPreferences';
 
 const NON_PROFILE_OWNING_RUNTIMES = new Set(['omnigent']);
@@ -483,18 +484,24 @@ export function OperationsSettingsPage({ payload }: { payload: BootPayload }) {
 
 export function SettingsEntryPage({ payload }: { payload: BootPayload }) {
   const permissions = settingsPermissions(payload);
+  const { search } = useLocation();
+  // SettingsPage.md 5.2: /settings is an entry point, not a destination. It
+  // resolves with replacement history to the first authorized Configuration
+  // page, keeping only that page's approved filters. `section` is retired page
+  // identity (5.3) and is dropped rather than mapped back to a destination.
+  const entryTarget = (target: string) => filterSettingsQueryForTarget(search, target);
   if (
     permissions.has('provider_profiles.read') ||
     permissions.has('secrets.metadata.read') ||
     permissions.has('settings.effective.read')
   ) {
-    return <Navigate to="/settings/providers-secrets" replace />;
+    return <Navigate to={entryTarget('/settings/providers-secrets')} replace />;
   }
   if (permissions.has('settings.catalog.read')) {
-    return <Navigate to="/settings/user-workspace" replace />;
+    return <Navigate to={entryTarget('/settings/user-workspace')} replace />;
   }
   if (permissions.has('operations.read')) {
-    return <Navigate to="/settings/operations" replace />;
+    return <Navigate to={entryTarget('/settings/operations')} replace />;
   }
   return (
     <SettingsPageFrame

--- a/frontend/src/entrypoints/settingsRoutes.test.tsx
+++ b/frontend/src/entrypoints/settingsRoutes.test.tsx
@@ -298,4 +298,70 @@ describe('MoonLadderStudios/MoonMind#3818 route-owned Settings pages', () => {
 
     await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
   });
+
+  describe('MoonLadderStudios/MoonMind#3816 retired ?section= page identity', () => {
+    it.each([
+      ['?section=providers-secrets', ['settings.catalog.read'], '/settings/user-workspace'],
+      ['?section=user-workspace', ['provider_profiles.read'], '/settings/providers-secrets'],
+      ['?section=operations', ['provider_profiles.read'], '/settings/providers-secrets'],
+      ['?section=unknown-alias', ['operations.read'], '/settings/operations'],
+    ])(
+      'ignores the retired %s page identity when resolving the Settings entry',
+      async (search, settingsPermissions, expectedPath) => {
+        window.history.replaceState({}, '', `/settings${search}`);
+        renderWithClient(
+          <BrowserRouter>
+            <SettingsEntryPage
+              payload={{
+                page: 'settings-entry',
+                apiBase: '/api',
+                initialData: { settingsPermissions },
+              } as BootPayload}
+            />
+          </BrowserRouter>,
+        );
+
+        await waitFor(() => expect(window.location.pathname).toBe(expectedPath));
+        expect(window.location.search).toBe('');
+      },
+    );
+
+    it('keeps target page filters while dropping the retired section identity', async () => {
+      window.history.replaceState({}, '', '/settings?section=operations&runtime=codex&status=paused');
+      renderWithClient(
+        <BrowserRouter>
+          <SettingsEntryPage
+            payload={{
+              page: 'settings-entry',
+              apiBase: '/api',
+              initialData: { settingsPermissions: ['provider_profiles.read'] },
+            } as BootPayload}
+          />
+        </BrowserRouter>,
+      );
+
+      await waitFor(() => expect(window.location.pathname).toBe('/settings/providers-secrets'));
+      // Providers & Secrets owns `runtime`; `status` belongs to Operations and
+      // `section` is retired page identity, so both are dropped.
+      expect(window.location.search).toBe('?runtime=codex');
+    });
+
+    it('keeps User / Workspace scope filters through the Settings entry redirect', async () => {
+      window.history.replaceState({}, '', '/settings?section=providers-secrets&scope=user&q=workflow');
+      renderWithClient(
+        <BrowserRouter>
+          <SettingsEntryPage
+            payload={{
+              page: 'settings-entry',
+              apiBase: '/api',
+              initialData: { settingsPermissions: ['settings.catalog.read'] },
+            } as BootPayload}
+          />
+        </BrowserRouter>,
+      );
+
+      await waitFor(() => expect(window.location.pathname).toBe('/settings/user-workspace'));
+      expect(window.location.search).toBe('?scope=user&q=workflow');
+    });
+  });
 });

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4404,6 +4404,10 @@ export interface paths {
         /**
          * Settings Spa Fallback Route
          * @description Serve the settings SPA shell for extensionless settings sub-routes.
+         *
+         *     An empty sub-path is the trailing-slash form of the bare `/settings` entry
+         *     point. The client normalizes it the same way, so a direct load must resolve
+         *     to the same page and boot payload rather than 404.
          */
         get: operations["settings_spa_fallback_route_settings__dashboard_path__get"];
         put?: never;

--- a/frontend/src/lib/dashboardRoutes.test.ts
+++ b/frontend/src/lib/dashboardRoutes.test.ts
@@ -6,6 +6,7 @@ import {
   DASHBOARD_REACT_ROUTE_PATHS,
   destinationState,
   destinationForPath,
+  filterSettingsQueryForTarget,
   isDashboardInternalUrl,
   legacySettingsRedirect,
   matchesDashboardDestinationRegistry,
@@ -268,6 +269,68 @@ describe('dashboard route resolution', () => {
       expect(dest.menuGroupKey).toBe('configuration');
       expect(dest.navigationGroup).toBe('system');
     }
+  });
+
+  describe('MoonLadderStudios/MoonMind#3816 canonical configuration routes', () => {
+    it.each([
+      ['/settings/', 'settings-entry', '/settings'],
+      ['/settings/providers-secrets/', 'settings-providers-secrets', '/settings/providers-secrets'],
+      ['/settings/user-workspace/', 'settings-user-workspace', '/settings/user-workspace'],
+      ['/settings/operations/', 'settings-operations', '/settings/operations'],
+    ])('normalizes the trailing-slash Settings route %s to %s', (path, page, currentPath) => {
+      expect(resolveDashboardRoute(path)).toEqual({
+        page,
+        dataWidePanel: true,
+        currentPath,
+      });
+    });
+
+    it.each([
+      ['/settings/providers-secrets/', 'settings-providers-secrets'],
+      ['/settings/user-workspace/', 'settings-user-workspace'],
+      ['/settings/operations/', 'settings-operations'],
+    ])('resolves the trailing-slash Settings route %s to the %s destination', (path, key) => {
+      expect(destinationForPath(path)?.key).toBe(key);
+    });
+
+    it('keeps trailing-slash unknown Settings aliases outside the route-owned page registry', () => {
+      expect(resolveDashboardRoute('/settings/provider-profiles/')).toBeNull();
+      expect(destinationForPath('/settings/provider-profiles/')).toBeNull();
+    });
+
+    it('retires ?section= as Settings page identity instead of aliasing it', () => {
+      // SettingsPage.md 5.3: `section` carries no page identity. It is dropped from
+      // every redirect target and never maps back to a sibling Configuration page.
+      for (const section of ['providers-secrets', 'user-workspace', 'operations', 'legacy-alias']) {
+        expect(filterSettingsQueryForTarget(`?section=${section}`, '/settings/providers-secrets'))
+          .toBe('/settings/providers-secrets');
+        expect(filterSettingsQueryForTarget(`?section=${section}`, '/settings/user-workspace'))
+          .toBe('/settings/user-workspace');
+        expect(filterSettingsQueryForTarget(`?section=${section}`, '/settings/operations'))
+          .toBe('/settings/operations');
+        expect(legacySettingsRedirect('/secrets', `?section=${section}`))
+          .toBe('/settings/providers-secrets');
+        expect(legacySettingsRedirect('/workers', `?section=${section}`))
+          .toBe('/settings/operations');
+      }
+    });
+
+    it('keeps a canonical Settings route resolution independent of any ?section= value', () => {
+      const origin = window.location.origin;
+      for (const path of [
+        '/settings/providers-secrets',
+        '/settings/user-workspace',
+        '/settings/operations',
+      ]) {
+        const url = new URL(`${origin}${path}?section=operations`);
+        expect(isDashboardInternalUrl(url)).toBe(true);
+        expect(resolveDashboardRoute(url.pathname)).toEqual({
+          page: path.slice(1).replace('/', '-'),
+          dataWidePanel: true,
+          currentPath: path,
+        });
+      }
+    });
   });
 
   describe('resolveAuthorizedLegacySettingsTarget', () => {

--- a/tests/integration/api/test_workflow_console_routes.py
+++ b/tests/integration/api/test_workflow_console_routes.py
@@ -148,9 +148,13 @@ async def test_supported_workflow_routes_render_console_shell(
         "/skills",
         "/skills/local/editor",
         "/settings",
+        "/settings/",
         "/settings/providers-secrets",
+        "/settings/providers-secrets/",
         "/settings/user-workspace",
+        "/settings/user-workspace/",
         "/settings/operations",
+        "/settings/operations/",
         "/manifests",
         "/manifests/default-workflow",
         "/oauth-terminal",
@@ -169,6 +173,47 @@ async def test_supported_dashboard_deep_links_share_spa_shell(
 
     boot_payload = _extract_boot_payload(response.text)
     assert boot_payload == {"page": "dashboard", "apiBase": "/api"}
+
+
+@pytest.mark.parametrize(
+    "section",
+    ("providers-secrets", "user-workspace", "operations", "legacy-alias"),
+)
+async def test_settings_entry_ignores_retired_section_page_identity(
+    async_client: AsyncClient,
+    section: str,
+) -> None:
+    """MoonLadderStudios/MoonMind#3816 + SettingsPage.md 5.3: `?section=` is retired
+    page identity, so the server neither redirects on it nor leaks it into boot."""
+    response = await async_client.get(
+        f"/settings?section={section}", follow_redirects=False
+    )
+
+    assert response.status_code == 200
+    boot_payload = _extract_boot_payload(response.text)
+    assert boot_payload == {"page": "dashboard", "apiBase": "/api"}
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_location"),
+    (
+        ("/secrets", "/settings/providers-secrets"),
+        ("/workers", "/settings/operations"),
+    ),
+)
+async def test_legacy_settings_paths_redirect_and_strip_retired_section(
+    async_client: AsyncClient,
+    path: str,
+    expected_location: str,
+) -> None:
+    """MoonLadderStudios/MoonMind#3816: user-visible legacy paths keep a redirect,
+    but `section` never selects a sibling Configuration page."""
+    response = await async_client.get(
+        f"{path}?section=user-workspace", follow_redirects=False
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == expected_location
 
 
 async def test_ui_info_endpoint_exposes_spa_capabilities_and_endpoints(

--- a/tests/unit/api/routers/test_workflow_console.py
+++ b/tests/unit/api/routers/test_workflow_console.py
@@ -727,6 +727,89 @@ def test_legacy_settings_subroutes_fall_back_to_bare_entry_without_permissions()
     assert secrets.headers["location"] == "/settings"
 
 
+def test_canonical_settings_routes_tolerate_a_trailing_slash(
+    client: TestClient,
+) -> None:
+    """MoonLadderStudios/MoonMind#3816: trailing-slash canonical Settings routes
+    serve the same SPA shell as their canonical form."""
+    for path in (
+        "/settings/",
+        "/settings/providers-secrets/",
+        "/settings/user-workspace/",
+        "/settings/operations/",
+    ):
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 200, path
+        assert "moonmind-ui-boot" in response.text
+        assert _extract_boot_payload(response.text)["page"] == "dashboard"
+
+    # Only the single trailing slash is the bare entry point; malformed and
+    # asset-looking Settings sub-paths still fail closed.
+    for path in ("/settings//", "/settings/providers-secrets/app.js"):
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 404, path
+        assert "moonmind-ui-boot" not in response.text
+
+
+def test_settings_entry_serves_the_spa_shell_without_honoring_section(
+    client: TestClient,
+) -> None:
+    """MoonLadderStudios/MoonMind#3816 + SettingsPage.md 5.3: the server never
+    resolves `?section=` to a page; `/settings` stays the SPA entry point."""
+    for section in ("providers-secrets", "user-workspace", "operations", "unknown"):
+        response = client.get(f"/settings?section={section}", follow_redirects=False)
+        assert response.status_code == 200, section
+        boot_payload = _extract_boot_payload(response.text)
+        assert boot_payload["page"] == "dashboard"
+        assert section not in json.dumps(boot_payload)
+
+
+def test_legacy_settings_redirects_drop_section_without_mapping_it() -> None:
+    """MoonLadderStudios/MoonMind#3816 + SettingsPage.md 5.3: `section` is retired
+    page identity. It is stripped from redirect targets and never selects a
+    sibling Configuration page; approved page-local filters still survive."""
+    with _client_with_mock_service(
+        user_settings_permissions={
+            "provider_profiles.read",
+            "settings.catalog.read",
+            "operations.read",
+        }
+    ) as (client, _mock_service):
+        for section in ("providers-secrets", "user-workspace", "operations", "legacy"):
+            secrets = client.get(
+                f"/secrets?section={section}&runtime=codex", follow_redirects=False
+            )
+            workers = client.get(
+                f"/workers?section={section}&status=paused", follow_redirects=False
+            )
+
+            assert secrets.status_code == 307
+            assert (
+                secrets.headers["location"]
+                == "/settings/providers-secrets?runtime=codex"
+            )
+            assert workers.status_code == 307
+            assert workers.headers["location"] == "/settings/operations?status=paused"
+
+
+def test_legacy_settings_redirects_drop_filters_the_target_page_does_not_own() -> None:
+    with _client_with_mock_service(
+        user_settings_permissions={"provider_profiles.read", "operations.read"}
+    ) as (client, _mock_service):
+        secrets = client.get(
+            "/secrets?status=paused&scope=user&section=operations",
+            follow_redirects=False,
+        )
+        workers = client.get(
+            "/workers?runtime=codex&section=providers-secrets", follow_redirects=False
+        )
+
+    assert secrets.status_code == 307
+    assert secrets.headers["location"] == "/settings/providers-secrets"
+    assert workers.status_code == 307
+    assert workers.headers["location"] == "/settings/operations"
+
+
 def test_react_tasks_list_and_detail_boot_exclude_route_specific_config(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Issue

MoonLadderStudios/MoonMind#3816 — [Settings redesign] Add canonical configuration routes, destination identities, and legacy redirects
(https://github.com/MoonLadderStudios/MoonMind/issues/3816)

Closes MoonLadderStudios/MoonMind#3816

## Summary

Nine of the eleven acceptance criteria for #3816 already landed on `main` via #3855 (#3817 Configuration grouping), #3856 (#3818 route-owned Settings pages), and #3911 (#3815 validation): the three destination identities (`settings-providers-secrets`, `settings-user-workspace`, `settings-operations`), their canonical paths and path patterns, route resolution, payload construction, permission-aware legacy redirects, per-target query allowlists, page-specific document titles, and frontend/server registry parity guards.

This PR closes the two remaining gaps recorded as `PARTIALLY_IMPLEMENTED` by the assessment.

**1. Legacy `?section=` — resolved as a documented supersession, not a mapping.**

The issue's redirect table asks `/settings?section=user-workspace` and `?section=operations` to map to their matching canonical pages. That conflicts with the issue's own cited design source: `docs/UI/SettingsPage.md` §5.3 retires `?section=` as a page-identity mechanism and states that no redirect table preserves it (`docs/tmp/SettingsConfigurationPagesMigration.md` §6 records the same decision). Mapping a `section` value back to a sibling page would reintroduce a compatibility alias for a superseded internal contract, which the pre-release "delete, don't deprecate" policy in `AGENTS.md` forbids. The canonical doc and repo policy win: `section` is now dropped everywhere and never selects a page, and `/settings` resolves per §5.2 to the first authorized Configuration destination. The issue's `?section=` redirect rows are superseded and should be edited or annotated — flagged for issue-text reconciliation rather than silently dropped.

**2. Trailing slashes and query-allowlist parity on the Settings entry redirect.**

- The `/settings` entry redirect now runs the same per-target query allowlist as the legacy path redirects, so approved page-local filters survive `/settings` → first authorized destination while `section` is dropped.
- `/settings/` (bare entry with a trailing slash) served the SPA shell on the client but 404'd on direct load. The settings SPA fallback now treats an empty sub-path as the bare entry, so direct loads and client-side navigation resolve to the same page and the same boot payload.

Changed files: `api_service/api/routers/workflow_console.py`, `frontend/src/entrypoints/settings.tsx`, plus test coverage in `frontend/src/lib/dashboardRoutes.test.ts`, `frontend/src/entrypoints/settingsRoutes.test.tsx`, `frontend/src/entrypoints/dashboard.test.tsx`, `tests/unit/api/routers/test_workflow_console.py`, and `tests/integration/api/test_workflow_console_routes.py` (302 insertions, 6 deletions).

New coverage: trailing-slash variants of all three canonical routes plus the bare entry (client route resolution, `destinationForPath`, app-level direct load, server unit, hermetic integration); `?section=` selecting nothing on canonical routes, the Settings entry, and the `/secrets` / `/workers` redirects; the narrowed SPA fallback guard still failing closed on `/settings//` and asset paths.

## Tests run

| Suite | Command | Result |
|---|---|---|
| Unit (Python, server routes) | `./tools/test_unit.sh --python-only -- tests/unit/api/routers/test_workflow_console.py` | PASS — 67 passed in 5.62s |
| Unit (frontend: routes, settings pages, app shell) | `./tools/test_unit.sh --dashboard-only --ui-args src/lib/dashboardRoutes.test.ts src/entrypoints/settingsRoutes.test.tsx src/entrypoints/dashboard.test.tsx src/entrypoints/settingsDraftNavigation.test.tsx` | PASS — 4 files, 230 tests in 15.64s |
| Unit (frontend: settings content, route error boundary) | `./tools/test_unit.sh --dashboard-only --ui-args src/entrypoints/settings.test.tsx src/components/DashboardRouteErrorBoundary.test.tsx` | PASS — 2 files, 12 tests in 2.37s |
| Hermetic Integration (`integration_ci`) | `pytest tests/integration/api/test_workflow_console_routes.py -m integration_ci -q --tb=short` | PASS — 35 passed in 7.29s |
| Typecheck | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS — exit 0, no diagnostics |
| Lint | `./node_modules/.bin/eslint -c frontend/eslint.config.mjs` on the three changed source files | PASS — exit 0, no findings |
| Cross-boundary registry parity probe | live Python `DASHBOARD_DESTINATIONS[*].to_ui_info()` fed to the live TS `matchesDashboardDestinationRegistry` guard | PASS — server 12, local 12, match `true` |

`npm run ui:typecheck` / `ui:lint` could not resolve `tsc` / `eslint` from `PATH` in this runtime; the identical binaries were invoked from `node_modules/.bin`.

Not run in this environment (non-gating): `moonmind container python-tests` (container-jobs session env and bearer token unset, so the CLI refuses to submit); `./tools/test_integration.sh` (needs the Docker socket, which `AGENTS.md` forbids from a managed agent workspace — the single in-scope module is hermetic and was run directly under the `integration_ci` marker); browser E2E dashboard mount (`tests/e2e/test_dashboard_react_mount_browser.py` skips at module level, no built bundle in the checkout).

## Remaining risks

- **Issue-text drift (definite, non-blocking).** The issue's `?section=` redirect rows are superseded by `docs/UI/SettingsPage.md` §5.3. Code follows the canonical doc; the issue text should be updated or annotated so the conflict reads as resolved rather than missed.
- **Permission-aware entry resolution.** `/settings` and unknown Settings aliases resolve to the first *authorized* Configuration destination (Providers & Secrets first) and render the Configuration-unavailable state when none is accessible, per §5.2/§5.4. For an authorized user the observable result matches the issue; for a restricted user the landing page differs from a literal reading of "redirects to Providers & Secrets".
- **Real-browser history semantics.** Back/Forward traversal across configuration pages is covered by jsdom history tests plus inspection confirming no `section`-identity `popstate` synchronization remains. True browser history behavior is only provable in a real browser.
- **No rendered-UI confirmation.** No built or deployed dashboard bundle was available, so this change is verified by unit/integration tests and typecheck only, not by a screenshot of the running dashboard.
- **Scope.** Page content rendering (#3815) and the Settings dropdown grouping/trigger behavior remain out of scope per the issue's non-goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
