### PR TITLE
Fix OpenCode Go Omnigent readiness

### DIFF
--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -60,6 +60,11 @@ from moonmind.omnigent.bridge_proxy import (
     OmnigentBridgeError,
     OmnigentBridgeSessionProxy,
 )
+from moonmind.omnigent.harness_platform import (
+    HarnessCatalogSnapshot,
+    HarnessPlatformError,
+    assert_catalog_refresh_attests,
+)
 from moonmind.workflows.temporal.artifacts import TemporalArtifactService
 
 router = APIRouter(
@@ -85,6 +90,34 @@ _SAFE_REFERENCE_KEYS = {
     "maxtokens",
 }
 _CONSUMER_TYPES = Literal["workflow", "schedule", "checkpoint", "remediation", "smoke"]
+
+
+def _catalog_refresh_preserves_builtin_binding(
+    *,
+    authority_payload: Any,
+    observation: HarnessCatalogSnapshot,
+    harness_id: str,
+    implementation_ref: str,
+) -> bool:
+    """Return whether a new observation still attests profile authority.
+
+    Host inventory is deliberately part of a catalog snapshot's source digest,
+    but it is not part of the immutable harness/build identity selected by an
+    Agent Profile. Requiring equal source digests would therefore mint a new
+    built-in profile version whenever an ephemeral host starts or stops.
+    """
+
+    try:
+        authority = HarnessCatalogSnapshot.model_validate(authority_payload)
+        assert_catalog_refresh_attests(
+            authority=authority,
+            observation=observation,
+            harness_id=harness_id,
+            implementation_ref=implementation_ref,
+        )
+    except (HarnessPlatformError, ValueError, TypeError):
+        return False
+    return True
 
 
 class AgentSource(BaseModel):
@@ -459,10 +492,10 @@ async def ensure_builtin_opencode_agent_profile(
             ).scalars()
         )
     )
-    # Re-observations of identical inventory produce timestamp-shifted
-    # catalogRefs because observation time is part of the catalog identity.
-    # The active immutable version already binds equivalent authority, so
-    # reuse its document verbatim instead of minting a new version per sync.
+    # Re-observations produce new catalogRefs because observation time and live
+    # host inventory are part of the catalog identity. The active immutable
+    # version can retain its binding when the canonical refresh contract proves
+    # that endpoint, Omnigent build, and harness implementation are unchanged.
     if profile is not None and profile.active_version is not None:
         active = next(
             (
@@ -482,9 +515,11 @@ async def ensure_builtin_opencode_agent_profile(
                 bound_row = await session.get(
                     OmnigentHarnessCatalogSnapshotRecord, bound_ref
                 )
-                if (
-                    bound_row is not None
-                    and bound_row.source_digest == catalog.snapshot.sourceDigest
+                if bound_row is not None and _catalog_refresh_preserves_builtin_binding(
+                    authority_payload=bound_row.snapshot_json,
+                    observation=catalog.snapshot,
+                    harness_id="opencode-native",
+                    implementation_ref=implementation_ref,
                 ):
                     # Pin only the volatile catalog binding to the active
                     # version's authority. Everything else keeps the freshly

--- a/api_service/api/routers/omnigent_bootstrap.py
+++ b/api_service/api/routers/omnigent_bootstrap.py
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/omnigent/bootstrap", tags=["Omnigent Bootstrap"]
 class BootstrapOpencodeRequest(BaseModel):
     api_key: str = Field(alias="apiKey", min_length=1, max_length=8192)
     model_display_name: str = Field(
-        default="Muse Spark 1.2 Contributor",
+        default="Muse Spark 1.3 Contributor",
         alias="modelDisplayName",
         max_length=255,
     )

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1872,6 +1872,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
             go_profile_id = "opencode-go-default"
             go_current = existing_by_id.get(go_profile_id)
             legacy_go_model = "opencode-go/muse-spark-1.2-contributor"
+            legacy_go_display = "Muse Spark 1.2 Contributor"
             if (
                 opencode_defaults_enabled
                 and go_current is not None
@@ -1879,30 +1880,69 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 == legacy_go_model
             ):
                 go_tiers = list(go_current.get("model_tiers") or [])
+                expected_go_effort = str(
+                    go_current.get("default_effort") or "xhigh"
+                )
+                # Bootstrap-owned labels only: an operator who kept the legacy
+                # model but customized label/effort/parameters/annotations must
+                # not have the tier silently replaced.
+                bootstrap_owned_labels = {
+                    "",
+                    "Runtime default",
+                    legacy_go_display,
+                    DEFAULT_OPENCODE_MODEL_DISPLAY,
+                }
+
+                def _is_bootstrap_owned_go_tier(tier: Any) -> bool:
+                    if not isinstance(tier, dict):
+                        return False
+                    if (
+                        str(tier.get("model") or "").strip()
+                        not in {"", legacy_go_model}
+                    ):
+                        return False
+                    if str(tier.get("label") or "").strip() not in (
+                        bootstrap_owned_labels
+                    ):
+                        return False
+                    tier_effort = str(tier.get("effort") or "").strip()
+                    if tier_effort and tier_effort != expected_go_effort:
+                        return False
+                    if tier.get("parameters") not in (None, {}):
+                        return False
+                    if tier.get("annotations") not in (None, {}):
+                        return False
+                    return True
+
                 bootstrap_owned_tiers = (
                     not go_tiers
                     or (
                         len(go_tiers) == 1
-                        and str(go_tiers[0].get("model") or "").strip()
-                        in {"", legacy_go_model}
+                        and _is_bootstrap_owned_go_tier(go_tiers[0])
                     )
                 )
                 if bootstrap_owned_tiers:
-                    go_updates = {
+                    # Migrating the model changes the launchable identity. The
+                    # revalidation fingerprint does not include the model, so a
+                    # previously exhausted failure record would otherwise skip
+                    # every probe for the newly selected model.
+                    go_behavior = dict(go_current.get("command_behavior") or {})
+                    go_behavior.pop("runtime_revalidation_failure", None)
+                    go_updates: dict[str, Any] = {
                         "default_model": DEFAULT_OPENCODE_QUALIFIED,
                         "model_tiers": [
                             {
                                 "label": DEFAULT_OPENCODE_MODEL_DISPLAY,
                                 "model": DEFAULT_OPENCODE_QUALIFIED,
-                                "effort": str(
-                                    go_current.get("default_effort") or "xhigh"
-                                ),
+                                "effort": expected_go_effort,
                                 "parameters": {},
                                 "annotations": {},
                             }
                         ],
                         "default_model_tier": 1,
                     }
+                    if go_behavior != (go_current.get("command_behavior") or {}):
+                        go_updates["command_behavior"] = go_behavior
                     await session.execute(
                         update(ManagedAgentProviderProfile)
                         .where(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1521,8 +1521,15 @@ async def _auto_seed_provider_profiles() -> list[str]:
         generic_host_enabled,
         opencode_support_enabled,
     )
+    from moonmind.omnigent.bootstrap.opencode import (
+        DEFAULT_OPENCODE_MODEL_DISPLAY,
+        DEFAULT_OPENCODE_QUALIFIED,
+        ZEN_FREE_MODEL_DISPLAY,
+        ZEN_FREE_QUALIFIED,
+    )
 
-    if opencode_support_enabled() and generic_host_enabled():
+    opencode_defaults_enabled = opencode_support_enabled() and generic_host_enabled()
+    if opencode_defaults_enabled:
         _DEFAULT_PROFILES.append(
             {
                 "profile_id": "opencode-zen-free",
@@ -1530,12 +1537,12 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 "is_default": False,
                 "provider_id": "opencode",
                 "provider_label": "OpenCode Zen",
-                "default_model": "opencode/muse-spark-1.2-contributor-free",
+                "default_model": ZEN_FREE_QUALIFIED,
                 "default_effort": "xhigh",
                 "model_tiers": [
                     {
-                        "label": "Muse Spark 1.2 Contributor Free",
-                        "model": "opencode/muse-spark-1.2-contributor-free",
+                        "label": ZEN_FREE_MODEL_DISPLAY,
+                        "model": ZEN_FREE_QUALIFIED,
                         "effort": "xhigh",
                         "parameters": {},
                         "annotations": {},
@@ -1855,6 +1862,56 @@ async def _auto_seed_provider_profiles() -> list[str]:
                     )
                     existing_by_id[zen_profile_id].update(zen_updates)
                     touched_runtime_ids.add(str(zen_current["runtime_id"]))
+                    needs_commit = True
+
+            # Upgrade only the bootstrap-owned OpenCode Go default policy. A
+            # custom or multi-tier policy is operator-authored and remains
+            # untouched. This also repairs profiles created before bootstrap
+            # explicitly populated the tier contract, whose sole tier was
+            # persisted as Runtime default.
+            go_profile_id = "opencode-go-default"
+            go_current = existing_by_id.get(go_profile_id)
+            legacy_go_model = "opencode-go/muse-spark-1.2-contributor"
+            if (
+                opencode_defaults_enabled
+                and go_current is not None
+                and str(go_current.get("default_model") or "").strip()
+                == legacy_go_model
+            ):
+                go_tiers = list(go_current.get("model_tiers") or [])
+                bootstrap_owned_tiers = (
+                    not go_tiers
+                    or (
+                        len(go_tiers) == 1
+                        and str(go_tiers[0].get("model") or "").strip()
+                        in {"", legacy_go_model}
+                    )
+                )
+                if bootstrap_owned_tiers:
+                    go_updates = {
+                        "default_model": DEFAULT_OPENCODE_QUALIFIED,
+                        "model_tiers": [
+                            {
+                                "label": DEFAULT_OPENCODE_MODEL_DISPLAY,
+                                "model": DEFAULT_OPENCODE_QUALIFIED,
+                                "effort": str(
+                                    go_current.get("default_effort") or "xhigh"
+                                ),
+                                "parameters": {},
+                                "annotations": {},
+                            }
+                        ],
+                        "default_model_tier": 1,
+                    }
+                    await session.execute(
+                        update(ManagedAgentProviderProfile)
+                        .where(
+                            ManagedAgentProviderProfile.profile_id == go_profile_id
+                        )
+                        .values(**go_updates)
+                    )
+                    existing_by_id[go_profile_id].update(go_updates)
+                    touched_runtime_ids.add(str(go_current["runtime_id"]))
                     needs_commit = True
 
             to_insert = [

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -3,7 +3,7 @@
 **Status:** OpenCode implementation is current; shared-image migration is desired state  
 **Document Class:** System / Operator Guide  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-08-31
+**Last updated:** 2026-09-03
 **Authority:** OpenCode runtime contract and transition from `omnigent-host-opencode` to the shared MoonMind Omnigent host image
 
 ## Related documents
@@ -253,7 +253,7 @@ runtimeMaterializationMode: composite
 secretRefs: {}
 enabled: true
 authState: connected
-defaultModel: opencode/muse-spark-1.2-contributor-free
+defaultModel: opencode/muse-spark-1.3-contributor-free
 defaultEffort: xhigh
 ```
 
@@ -283,10 +283,14 @@ maxParallelRuns: 1
 queueWhenBusy: true
 enabled: true
 authState: connected
-defaultModel: opencode-go/<model-id>
+defaultModel: opencode-go/muse-spark-1.3-contributor
 ```
 
-A user may enroll it through Settings with a write-only API-key field. A deployment may also bootstrap it from `OPENCODE_API_KEY`.
+A user may enroll it through Settings with a write-only API-key field. A
+deployment may also bootstrap it from `OPENCODE_API_KEY`. On restart, that
+deployment setting repairs a missing, partially enrolled, or automatically
+disabled `opencode-go-default` profile through the same pinned-runtime
+validation path. Explicit user and policy disables remain authoritative.
 
 The raw key is never returned after submission.
 

--- a/docs/UI/ProviderProfileModelEffortTierSettings.md
+++ b/docs/UI/ProviderProfileModelEffortTierSettings.md
@@ -723,8 +723,8 @@ The example values are illustrative. The backend response, not this document, is
 8. The frontend must not infer effort support from provider name.
 9. The frontend must not infer model options from runtime name.
 10. Capabilities for a saved profile are requested by `profile_id`. A runtime-and-provider draft response must not be substituted for a saved profile.
-11. A response whose `profile_id`, `credential_generation`, or `image_ref` no longer matches the loaded profile is stale. The editor refetches, and until that succeeds it treats the option catalog as unavailable for new values rather than authoritative.
-12. `evidence.stale = true` means the profile's catalog evidence needs re-validation. Existing values stay visible and new values follow the degradation rules in §12.4.
+11. A response whose `profile_id`, `credential_generation`, or `image_ref` no longer matches the loaded profile is stale. The editor refetches, and until that succeeds it treats observed catalog options as unavailable for new selections rather than authoritative.
+12. `evidence.stale = true` means the profile's catalog evidence needs re-validation. Existing values stay visible, observed catalog choices are disabled, and an explicit `model.allow_custom = true` remains authoritative for manual entry.
 
 ### 12.4 Safe degradation
 
@@ -734,12 +734,17 @@ If capabilities fail to load:
 - `Runtime default` remains available,
 - no existing value is erased,
 - an inline warning states that model choices could not be refreshed,
-- custom entry follows the last successfully loaded capability policy when backed by a validated cache,
-- otherwise unknown new custom entry is disabled,
+- custom entry follows the loaded capability policy independently of catalog freshness,
+- `model.allow_custom = true` keeps manual entry available while observed catalog choices are stale,
+- unknown new custom entry is disabled when no authoritative capability response allows it,
 - saving unchanged tier values remains possible when server validation permits it, and
 - server validation errors are mapped back to the affected tier and field.
 
-The same rules apply when the profile's catalog evidence is missing or stale. The editor states that model choices reflect no current profile evidence, preserves existing values, and does not accept a new value that only unscoped runtime metadata would justify.
+The same rules apply when the profile's catalog evidence is missing or stale.
+The editor states that observed choices reflect no current profile evidence and
+preserves existing values. Manual entry is permitted only when the
+profile-scoped capability response explicitly sets `model.allow_custom = true`;
+the write and launch boundaries remain responsible for validation.
 
 A capability failure must not turn the whole Provider Profiles section into an empty state.
 

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1090,7 +1090,7 @@ describe('ProviderProfilesManager form controls', () => {
     expect(payload).not.toHaveProperty('default_effort');
   });
 
-  it('disables catalog model choices while evidence is stale but preserves existing values', async () => {
+  it('disables stale catalog choices while preserving backend-authorized custom entry', async () => {
     const staleCapabilities = { version: 'tier-cap-v1-stale', profile_id: profile.profile_id, runtime_id: profile.runtime_id, provider_id: profile.provider_id, evidence: { source: 'profile_catalog_evidence', credential_generation: 1, image_ref: null, observed_at: null, stale: true }, tier_constraints: { min_count: 1, max_count: null }, model: { runtime_default: 'gpt-5.5', allow_custom: true, options: [{ value: 'gpt-5.5', label: 'GPT-5.5', description: null, status: 'available' }, { value: 'gpt-4o', label: 'GPT-4o', description: null, status: 'available', compatible_models: null }] }, effort: { supported: true, runtime_default: 'medium', allow_custom: false, application: 'native', options: [{ value: 'medium', label: 'Medium', description: null, status: 'available', compatible_models: null }] }, diagnostics: [] };
     vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
@@ -1108,7 +1108,7 @@ describe('ProviderProfilesManager form controls', () => {
     renderProviderProfilesManager([staleProfile]);
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
-    await screen.findByText(/catalog choices are disabled/);
+    await screen.findByText(/observed catalog choices are disabled/);
     const modelSelect = screen.getByLabelText('Tier 1 model') as HTMLSelectElement;
     expect(modelSelect.value).toBe('gpt-4o');
     const options = within(modelSelect).getAllByRole('option') as HTMLOptionElement[];
@@ -1116,8 +1116,12 @@ describe('ProviderProfilesManager form controls', () => {
     expect(byValue.get('__runtime_default__')?.disabled).toBe(false);
     expect(byValue.get('gpt-5.5')?.disabled).toBe(true);
     expect(byValue.get('gpt-4o')?.disabled).toBe(false);
-    expect(within(modelSelect).queryByRole('option', { name: 'Custom value…' })).toBeNull();
-    expect(screen.queryByLabelText('Tier 1 custom model')).toBeNull();
+    expect(within(modelSelect).getByRole('option', { name: 'Custom value…' })).toBeTruthy();
+    fireEvent.change(modelSelect, { target: { value: '__custom__' } });
+    const customInput = screen.getByLabelText('Tier 1 custom model') as HTMLInputElement;
+    expect(customInput.disabled).toBe(false);
+    fireEvent.change(customInput, { target: { value: 'opencode-go/manual-model' } });
+    expect(customInput.value).toBe('opencode-go/manual-model');
   });
 
   it('offers a custom model entry when the backend allows custom models', async () => {
@@ -2881,4 +2885,3 @@ describe('MoonLadderStudios/MoonMind#3815 cross-boundary verification (#3822 cov
     expect(screen.getByDisplayValue('db://custom-secret')).toBeTruthy();
   });
 });
-

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -3844,7 +3844,7 @@ export function ProviderProfilesManager({
             ) : null}
             {tierCapabilities?.evidence?.stale ? (
               <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-3 text-xs text-amber-800 dark:text-amber-300">
-                Model catalog evidence is stale; catalog choices are disabled until the profile is revalidated. Existing tier values and Runtime default remain available.
+                Model catalog evidence is stale; observed catalog choices are disabled until the profile is revalidated. Runtime default and custom model entry remain available.
               </div>
             ) : null}
             {tierCapabilities?.diagnostics?.length ? (
@@ -3901,13 +3901,11 @@ export function ProviderProfilesManager({
                                 const currentValue = tier.model ?? '__runtime_default__';
                                 const isCustomValue = tier.model != null && tier.model !== '' && !knownValues.has(tier.model);
                                 const isCustomDraft = customModelEntryTiers.has(tier.clientId);
-                                // While catalog evidence is stale, a custom draft falls back to
-                                // Runtime default rather than offering new selection. A preserved
-                                // custom value stays visible but uneditable.
-                                const selectValue = isCustomValue && staleCatalog
-                                  ? tier.model as string
-                                  : (!staleCatalog && (isCustomValue || isCustomDraft) ? '__custom__' : currentValue);
-                                const showCustomInput = allowCustomModel && (isCustomValue || (!staleCatalog && isCustomDraft));
+                                // Catalog freshness controls observed options. The backend's
+                                // explicit allow_custom policy independently authorizes manual
+                                // entry, which the write/launch boundaries still validate.
+                                const selectValue = isCustomValue || isCustomDraft ? '__custom__' : currentValue;
+                                const showCustomInput = allowCustomModel && (isCustomValue || isCustomDraft);
                                 return (
                                   <>
                                     <select className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={selectValue} onChange={(e) => {
@@ -3941,7 +3939,7 @@ export function ProviderProfilesManager({
                                       {tier.model && !knownValues.has(tier.model) && tier.model !== '' ? (
                                         <option value={tier.model}>{tier.model} (existing — custom or unavailable)</option>
                                       ) : null}
-                                      {allowCustomModel && !staleCatalog ? (
+                                      {allowCustomModel ? (
                                         <option value="__custom__">Custom value…</option>
                                       ) : null}
                                     </select>
@@ -3949,7 +3947,6 @@ export function ProviderProfilesManager({
                                       <input
                                         className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm font-normal"
                                         value={tier.model ?? ''}
-                                        disabled={staleCatalog}
                                         onChange={(e) => {
                                           const text = e.target.value.trim();
                                           handleTierModelChange(tier.clientId, text === '' ? null : text);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1021,22 +1021,24 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
   });
 
-  it("submits the exact generic v2 profile digest selected from readiness", async () => {
+  it("follows current generic v2 readiness and submits its latest refresh", async () => {
     vi.mocked(navigateTo).mockClear();
-    const digest = `sha256:${"d".repeat(64)}`;
+    const staleDigest = `sha256:${"c".repeat(64)}`;
+    const currentDigest = `sha256:${"d".repeat(64)}`;
+    const submitDigest = `sha256:${"e".repeat(64)}`;
     const genericProfiles = [{
       profileId: "omnigent-opencode-default",
       displayName: "OpenCode via Omnigent",
       state: "active",
-      activeVersion: 1,
+      activeVersion: 197,
       defaultForRuntime: true,
       versions: [{
-        version: 1,
-        digest,
+        version: 197,
+        digest: staleDigest,
         document: {
           schemaVersion: "moonmind.omnigent-agent-profile.v2",
           execution: {
-            defaultExecutionProfileRef: "omnigent-opencode-default@1",
+            defaultExecutionProfileRef: "omnigent-opencode-default@197",
           },
         },
         validationResult: { ready: true },
@@ -1047,12 +1049,12 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       runtimeId: "omnigent",
       displayName: "Omnigent",
       executionTargets: [{
-        ref: "omnigent-opencode-default@1",
+        ref: "omnigent-opencode-default@201",
         harnessId: "opencode-native",
         agentProfileRef: {
           profileId: "omnigent-opencode-default",
-          version: 1,
-          digest,
+          version: 201,
+          digest: currentDigest,
         },
         available: true,
         supportTier: "experimental",
@@ -1068,6 +1070,19 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         gateReasons: [],
       }],
     };
+    const submitReadiness = {
+      ...genericReadiness,
+      executionTargets: [{
+        ...genericReadiness.executionTargets[0],
+        ref: "omnigent-opencode-default@202",
+        agentProfileRef: {
+          profileId: "omnigent-opencode-default",
+          version: 202,
+          digest: submitDigest,
+        },
+      }],
+    };
+    let genericReadinessRequests = 0;
 
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -1075,7 +1090,13 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         return Promise.resolve({ ok: true, json: async () => readyOmnigentCatalog } as Response);
       }
       if (url === "/api/omnigent/execution-readiness") {
-        return Promise.resolve({ ok: true, json: async () => genericReadiness } as Response);
+        genericReadinessRequests += 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () => genericReadinessRequests > 1
+            ? submitReadiness
+            : genericReadiness,
+        } as Response);
       }
       if (url === "/api/omnigent/agent-profiles") {
         return Promise.resolve({ ok: true, json: async () => genericProfiles } as Response);
@@ -1111,7 +1132,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     });
     await waitFor(() => expect(
       (screen.getByLabelText("Execution target") as HTMLSelectElement).value,
-    ).toBe("omnigent-opencode-default@1"));
+    ).toBe("omnigent-opencode-default@201"));
     const startButton = screen.getByRole("button", { name: "Start Workflow" });
     await waitFor(() => expect((startButton as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(startButton);
@@ -1126,14 +1147,14 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
     expect(request.payload.agentProfile).toEqual({
       profileId: "omnigent-opencode-default",
-      version: 1,
-      digest,
+      version: 202,
+      digest: submitDigest,
       providerProfileRef: "opencode-1",
       launchPolicyRef: "omnigent-on-demand@1",
     });
     expect(request.payload.task.runtime.agentProfile).toEqual(request.payload.agentProfile);
     expect(request.payload.omnigent).toEqual({
-      executionTargetRef: "omnigent-opencode-default@1",
+      executionTargetRef: "omnigent-opencode-default@202",
       launchPolicyRef: "omnigent-on-demand@1",
     });
   });

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6585,11 +6585,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const selectedProfileIsGenericV2 =
     selectedOmnigentAgentProfileVersion?.document?.schemaVersion ===
       "moonmind.omnigent-agent-profile.v2";
-  const submittedOmnigentAgentProfileVersion = selectedProfileIsGenericV2
-    ? selectedOmnigentAgentProfileVersion?.version
-    : authoredOmnigentAgentProfileVersion;
   useEffect(() => {
-    if (runtime !== "omnigent") return;
+    if (runtime !== "omnigent" || selectedProfileIsGenericV2) return;
     const profileExecutionTargetRef = String(
       selectedOmnigentAgentProfileVersion?.document?.execution
         ?.defaultExecutionProfileRef || "",
@@ -6604,6 +6601,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     omnigentExecutionTargetRef,
     runtime,
     selectedOmnigentAgentProfileVersion,
+    selectedProfileIsGenericV2,
   ]);
   useEffect(() => {
     if (runtime !== "omnigent" || agentProfile) return;
@@ -6648,10 +6646,20 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     refetchOnWindowFocus: true,
   });
   const selectedGenericOmnigentTarget = omnigentExecutionReadinessQuery.data?.executionTargets?.find(
-    (target) => target.agentProfileRef.profileId === agentProfile &&
-      target.agentProfileRef.version === selectedOmnigentAgentProfileVersion?.version &&
-      target.agentProfileRef.digest === selectedOmnigentAgentProfileVersion?.digest,
+    (target) =>
+      target.agentProfileRef.profileId === agentProfile &&
+      (authoredOmnigentAgentProfileVersion === undefined ||
+        (target.agentProfileRef.version === selectedOmnigentAgentProfileVersion?.version &&
+          target.agentProfileRef.digest === selectedOmnigentAgentProfileVersion?.digest)),
   );
+  const submittedOmnigentAgentProfileVersion = selectedProfileIsGenericV2
+    ? selectedGenericOmnigentTarget?.agentProfileRef.version ||
+      selectedOmnigentAgentProfileVersion?.version
+    : authoredOmnigentAgentProfileVersion;
+  const submittedOmnigentAgentProfileDigest = selectedProfileIsGenericV2
+    ? selectedGenericOmnigentTarget?.agentProfileRef.digest ||
+      selectedOmnigentAgentProfileVersion?.digest
+    : undefined;
   const activeProviderProfiles: ProviderProfile[] = runtime === "omnigent"
     ? selectedProfileIsGenericV2
       ? (selectedGenericOmnigentTarget?.compatibleProviderProfiles || []).map((profile) => {
@@ -10402,6 +10410,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 
     const normalizedRuntime = runtime.trim().toLowerCase();
     let submittedOmnigentLaunchPolicyRef = omnigentLaunchPolicyRef;
+    let effectiveOmnigentAgentProfileVersion =
+      submittedOmnigentAgentProfileVersion;
+    let effectiveOmnigentAgentProfileDigest = submittedOmnigentAgentProfileDigest;
+    let effectiveOmnigentExecutionTargetRef = omnigentExecutionTargetRef;
     const supportedAgentRuntimeIds = runtimeOptions.map((item) =>
       item.trim().toLowerCase(),
     );
@@ -10418,8 +10430,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         const target = refreshed.data?.executionTargets?.find(
           (item) =>
             item.agentProfileRef.profileId === agentProfile &&
-            item.agentProfileRef.version === selectedOmnigentAgentProfileVersion?.version &&
-            item.agentProfileRef.digest === selectedOmnigentAgentProfileVersion?.digest,
+            (authoredOmnigentAgentProfileVersion === undefined ||
+              (item.agentProfileRef.version === selectedOmnigentAgentProfileVersion?.version &&
+                item.agentProfileRef.digest === selectedOmnigentAgentProfileVersion?.digest)),
         );
         if (refreshed.isError || !target?.available) {
           setSubmitMessage(
@@ -10428,6 +10441,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           );
           clearSubmitBusy();
           return;
+        }
+        effectiveOmnigentAgentProfileVersion = target.agentProfileRef.version;
+        effectiveOmnigentAgentProfileDigest = target.agentProfileRef.digest;
+        effectiveOmnigentExecutionTargetRef = target.ref;
+        if (target.ref !== omnigentExecutionTargetRef) {
+          setOmnigentExecutionTargetRef(target.ref);
         }
         if (!target.compatibleProviderProfiles.some(
           (profile) => profile.profileId === providerProfile,
@@ -11601,12 +11620,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? {
               agentProfile: {
                 profileId: agentProfile,
-                ...(submittedOmnigentAgentProfileVersion
-                  ? { version: submittedOmnigentAgentProfileVersion }
+                ...(effectiveOmnigentAgentProfileVersion
+                  ? { version: effectiveOmnigentAgentProfileVersion }
                   : {}),
                 ...(selectedProfileIsGenericV2 &&
-                selectedOmnigentAgentProfileVersion?.digest
-                  ? { digest: selectedOmnigentAgentProfileVersion.digest }
+                effectiveOmnigentAgentProfileDigest
+                  ? { digest: effectiveOmnigentAgentProfileDigest }
                   : {}),
                 providerProfileRef: providerProfile,
                 ...(submittedOmnigentLaunchPolicyRef
@@ -11677,12 +11696,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? {
               agentProfile: {
                 profileId: agentProfile,
-                ...(submittedOmnigentAgentProfileVersion
-                  ? { version: submittedOmnigentAgentProfileVersion }
+                ...(effectiveOmnigentAgentProfileVersion
+                  ? { version: effectiveOmnigentAgentProfileVersion }
                   : {}),
                 ...(selectedProfileIsGenericV2 &&
-                selectedOmnigentAgentProfileVersion?.digest
-                  ? { digest: selectedOmnigentAgentProfileVersion.digest }
+                effectiveOmnigentAgentProfileDigest
+                  ? { digest: effectiveOmnigentAgentProfileDigest }
                   : {}),
                 providerProfileRef: providerProfile,
                 ...(submittedOmnigentLaunchPolicyRef
@@ -11691,10 +11710,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               },
             }
           : {}),
-        ...(normalizedRuntime === "omnigent" && omnigentExecutionTargetRef
+        ...(normalizedRuntime === "omnigent" && effectiveOmnigentExecutionTargetRef
           ? {
               omnigent: {
-                executionTargetRef: omnigentExecutionTargetRef,
+                executionTargetRef: effectiveOmnigentExecutionTargetRef,
                 ...(submittedOmnigentLaunchPolicyRef
                   ? { launchPolicyRef: submittedOmnigentLaunchPolicyRef }
                   : {}),

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5855,7 +5855,7 @@ export interface components {
             apiKey: string;
             /**
              * Modeldisplayname
-             * @default Muse Spark 1.2 Contributor
+             * @default Muse Spark 1.3 Contributor
              */
             modelDisplayName: string;
             /**

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -18,6 +18,7 @@ from moonmind.omnigent.bootstrap.models import (
 )
 from moonmind.omnigent.bootstrap.opencode import (
     DEFAULT_OPENCODE_MODEL_DISPLAY,
+    DEFAULT_OPENCODE_QUALIFIED,
     resolve_model_by_display,
     validate_effort,
 )
@@ -85,7 +86,7 @@ class BootstrapController:
             and not accept_contributor_data_use
         ):
             raise ValueError(
-                "Contributor data-use acknowledgement is required for Muse Spark 1.2 Contributor"
+                "Contributor data-use acknowledgement is required for Muse Spark 1.3 Contributor"
             )
 
         # Validate effort
@@ -853,6 +854,11 @@ class BootstrapController:
         )
 
         profile_id = "opencode-go-default"
+        tier_label = (
+            DEFAULT_OPENCODE_MODEL_DISPLAY
+            if qualified_model == DEFAULT_OPENCODE_QUALIFIED
+            else qualified_model
+        )
         async with async_session_maker() as session:
             profile = await session.get(ManagedAgentProviderProfile, profile_id)
             needs_create = profile is None
@@ -889,6 +895,16 @@ class BootstrapController:
                     rate_limit_policy=ManagedAgentRateLimitPolicy.QUEUE,
                     default_model=qualified_model,
                     default_effort=effort,
+                    model_tiers=[
+                        {
+                            "label": tier_label,
+                            "model": qualified_model,
+                            "effort": effort,
+                            "parameters": {},
+                            "annotations": {},
+                        }
+                    ],
+                    default_model_tier=1,
                     # Default authority belongs only to a launch-ready profile.
                     # The credentialless Zen seed may already be the runtime
                     # default, and the database enforces that invariant with a
@@ -1096,6 +1112,29 @@ class BootstrapController:
                 prof.credential_generation = candidate_generation
                 prof.default_model = qualified_model
                 prof.default_effort = effort
+                existing_tiers = list(prof.model_tiers or [])
+                # Bootstrap owns the initial single-tier policy. Preserve an
+                # operator-authored multi-tier or custom single-tier policy
+                # when deployment configuration is only reconnecting the
+                # credential after a restart.
+                if (
+                    needs_create
+                    or not existing_tiers
+                    or (
+                        len(existing_tiers) == 1
+                        and not str(existing_tiers[0].get("model") or "").strip()
+                    )
+                ):
+                    prof.model_tiers = [
+                        {
+                            "label": tier_label,
+                            "model": qualified_model,
+                            "effort": effort,
+                            "parameters": {},
+                            "annotations": {},
+                        }
+                    ]
+                    prof.default_model_tier = 1
                 # Persist the exact credential-scoped catalog returned by the
                 # pinned runtime. Never replace it with the requested model;
                 # that would turn an unverified selection into readiness

--- a/moonmind/omnigent/bootstrap/models.py
+++ b/moonmind/omnigent/bootstrap/models.py
@@ -26,7 +26,7 @@ class BootstrapState(StrEnum):
 class BootstrapDesired(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
     provider: str = Field(default="opencode-go")
-    model_display_name: str = Field(alias="modelDisplayName", default="Muse Spark 1.2 Contributor")
+    model_display_name: str = Field(alias="modelDisplayName", default="Muse Spark 1.3 Contributor")
     model_id: str | None = Field(default=None, alias="modelId")
     effort: str = Field(default="xhigh")
     accept_contributor_data_use: bool = Field(default=False, alias="acceptContributorDataUse")

--- a/moonmind/omnigent/bootstrap/opencode.py
+++ b/moonmind/omnigent/bootstrap/opencode.py
@@ -6,13 +6,13 @@ import re
 from typing import Any
 
 # Official model IDs per OpenCode docs
-DEFAULT_OPENCODE_MODEL_DISPLAY = "Muse Spark 1.2 Contributor"
-DEFAULT_OPENCODE_PROVIDER_ID = "muse-spark-1.2-contributor"
+DEFAULT_OPENCODE_MODEL_DISPLAY = "Muse Spark 1.3 Contributor"
+DEFAULT_OPENCODE_PROVIDER_ID = "muse-spark-1.3-contributor"
 DEFAULT_OPENCODE_QUALIFIED = f"opencode-go/{DEFAULT_OPENCODE_PROVIDER_ID}"
 
 # Zen free tier — available via OpenCode's built-in provider
-ZEN_FREE_MODEL_DISPLAY = "Muse Spark 1.2 Contributor Free"
-ZEN_FREE_PROVIDER_ID = "muse-spark-1.2-contributor-free"
+ZEN_FREE_MODEL_DISPLAY = "Muse Spark 1.3 Contributor Free"
+ZEN_FREE_PROVIDER_ID = "muse-spark-1.3-contributor-free"
 ZEN_FREE_QUALIFIED = f"opencode/{ZEN_FREE_PROVIDER_ID}"
 
 # Friendly name normalization: case-insensitive, punctuation-insensitive
@@ -26,12 +26,7 @@ _MODEL_ALIASES = {
         "providerModelId": DEFAULT_OPENCODE_PROVIDER_ID,
         "qualifiedId": DEFAULT_OPENCODE_QUALIFIED,
     },
-    normalize_model_display("muse-spark-1.2-contributor"): {
-        "displayName": DEFAULT_OPENCODE_MODEL_DISPLAY,
-        "providerModelId": DEFAULT_OPENCODE_PROVIDER_ID,
-        "qualifiedId": DEFAULT_OPENCODE_QUALIFIED,
-    },
-    normalize_model_display("mus spark 1.2 contributor"): {
+    normalize_model_display("mus spark 1.3 contributor"): {
         "displayName": DEFAULT_OPENCODE_MODEL_DISPLAY,
         "providerModelId": DEFAULT_OPENCODE_PROVIDER_ID,
         "qualifiedId": DEFAULT_OPENCODE_QUALIFIED,
@@ -41,17 +36,7 @@ _MODEL_ALIASES = {
         "providerModelId": ZEN_FREE_PROVIDER_ID,
         "qualifiedId": ZEN_FREE_QUALIFIED,
     },
-    normalize_model_display("muse-spark-1.2-contributor-free"): {
-        "displayName": ZEN_FREE_MODEL_DISPLAY,
-        "providerModelId": ZEN_FREE_PROVIDER_ID,
-        "qualifiedId": ZEN_FREE_QUALIFIED,
-    },
     normalize_model_display(ZEN_FREE_QUALIFIED): {
-        "displayName": ZEN_FREE_MODEL_DISPLAY,
-        "providerModelId": ZEN_FREE_PROVIDER_ID,
-        "qualifiedId": ZEN_FREE_QUALIFIED,
-    },
-    normalize_model_display("opencode/muse-spark-1.2-contributor-free"): {
         "displayName": ZEN_FREE_MODEL_DISPLAY,
         "providerModelId": ZEN_FREE_PROVIDER_ID,
         "qualifiedId": ZEN_FREE_QUALIFIED,

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -366,7 +366,7 @@ async def reconcile_opencode_provider_readiness(
     recoverable_deployment_profile = next(
         (
             profile
-            for profile in enrolled
+            for profile in profiles
             if profile.profile_id == "opencode-go-default"
             and str(getattr(profile, "provider_id", "") or "")
             == OPENCODE_PROVIDER_ID
@@ -375,6 +375,16 @@ async def reconcile_opencode_provider_readiness(
         ),
         None,
     )
+    # An authoritative disable on the deployment-owned default remains
+    # authoritative even when the profile lacks runtime authority (for example
+    # policy_disabled with auth_state=not_configured is excluded from enrolled).
+    # Detect it from all matching profiles before deciding enrollment is absent.
+    has_authoritative_disable_on_default = any(
+        profile.profile_id == "opencode-go-default"
+        and str(getattr(profile, "provider_id", "") or "") == OPENCODE_PROVIDER_ID
+        and _has_authoritative_disable(profile)
+        for profile in profiles
+    )
     # OpenCode Zen and OpenCode Go are distinct provider routes. A launchable
     # credential-free Zen profile must not consume an explicitly configured Go
     # credential or prevent its separate enrollment.
@@ -382,6 +392,7 @@ async def reconcile_opencode_provider_readiness(
         api_key
         and profile_ids is None
         and (not key_backed_enrolled or recoverable_deployment_profile is not None)
+        and not has_authoritative_disable_on_default
     ):
         if not allow_enrollment:
             return ProviderReconcileOutcome(
@@ -403,6 +414,14 @@ async def reconcile_opencode_provider_readiness(
     launchable = [profile for profile in enrolled if profile.enabled]
 
     if not enrolled:
+        if has_authoritative_disable_on_default:
+            # The deployment-owned default is explicitly disabled. Preserve
+            # that authority instead of re-enrolling from configuration.
+            return ProviderReconcileOutcome(
+                ready=True,
+                checked=len(profiles),
+                reason="every enrolled OpenCode Provider Profile is disabled",
+            )
         if not api_key:
             # Nothing configured: the console enrollment path stays available and
             # readiness correctly reports that no compatible profile exists.

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -243,12 +243,11 @@ def _has_configured_runtime_authority(profile: Any) -> bool:
     """Report whether this profile can authorize an OpenCode runtime probe.
 
     Deliberately independent of ``enabled``. Enrollment applies API-key setup
-    with ``enabled=True``, so treating a disabled-but-connected profile as
-    absent would let deployment configuration silently undo an operator's
-    decision to disable it. The credential identity is what enrollment owns;
-    ``enabled`` belongs to the operator. The one pending state accepted here is
-    the startup seed's exact deployment SecretRef: it is already materializable
-    and must be promoted only by the pinned-runtime evidence path below.
+    with ``enabled=True``, but only an explicit user or policy disable prevents
+    deployment configuration from repairing a disabled profile. The one
+    pending state accepted here is the startup seed's exact deployment
+    SecretRef: it is already materializable and must be promoted only by the
+    pinned-runtime evidence path below.
     """
 
     from api_service.db.models import ProviderProfileAuthState
@@ -270,6 +269,17 @@ def _has_configured_runtime_authority(profile: Any) -> bool:
         state == ProviderProfileAuthState.API_KEY_PENDING.value
         and secret_ref == OPENCODE_DEPLOYMENT_SECRET_REF
     )
+
+
+def _has_authoritative_disable(profile: Any) -> bool:
+    """Report whether startup configuration must preserve the disabled state."""
+
+    reason = getattr(
+        getattr(profile, "disabled_reason", None),
+        "value",
+        getattr(profile, "disabled_reason", None),
+    )
+    return str(reason or "") in {"user_disabled", "policy_disabled"}
 
 
 def _pinned_image_ref() -> str | None:
@@ -353,10 +363,26 @@ async def reconcile_opencode_provider_readiness(
         str(getattr(profile, "provider_id", "") or "") == OPENCODE_PROVIDER_ID
         for profile in enrolled
     )
+    recoverable_deployment_profile = next(
+        (
+            profile
+            for profile in enrolled
+            if profile.profile_id == "opencode-go-default"
+            and str(getattr(profile, "provider_id", "") or "")
+            == OPENCODE_PROVIDER_ID
+            and not profile.enabled
+            and not _has_authoritative_disable(profile)
+        ),
+        None,
+    )
     # OpenCode Zen and OpenCode Go are distinct provider routes. A launchable
     # credential-free Zen profile must not consume an explicitly configured Go
     # credential or prevent its separate enrollment.
-    if api_key and not key_backed_enrolled and profile_ids is None:
+    if (
+        api_key
+        and profile_ids is None
+        and (not key_backed_enrolled or recoverable_deployment_profile is not None)
+    ):
         if not allow_enrollment:
             return ProviderReconcileOutcome(
                 ready=False,
@@ -371,9 +397,9 @@ async def reconcile_opencode_provider_readiness(
             checked=len(profiles),
             controller=controller,
         )
-    # A disabled profile cannot launch, and re-validating it would neither help
-    # nor honor the operator. Its credential still counts as enrolled above, so
-    # deployment configuration never re-enables it.
+    # Explicit user and policy disables remain authoritative. Any other
+    # inconsistent disabled state on the stable deployment-owned Go profile was
+    # repaired through canonical bootstrap above when OPENCODE_API_KEY exists.
     launchable = [profile for profile in enrolled if profile.enabled]
 
     if not enrolled:

--- a/tests/integration/test_startup_profile_seeding.py
+++ b/tests/integration/test_startup_profile_seeding.py
@@ -53,5 +53,5 @@ async def test_startup_profile_seeding(disabled_env_keys, tmp_path):
         assert zen.auth_state == ProviderProfileAuthState.CONNECTED
         assert zen.credential_source == ProviderCredentialSource.NONE
         assert zen.secret_refs == {}
-        assert zen.default_model == "opencode/muse-spark-1.2-contributor-free"
+        assert zen.default_model == "opencode/muse-spark-1.3-contributor-free"
         assert zen.default_effort == "xhigh"

--- a/tests/unit/api/routers/test_omnigent_agent_profiles.py
+++ b/tests/unit/api/routers/test_omnigent_agent_profiles.py
@@ -8,12 +8,14 @@ from api_service.api.routers.omnigent_agent_profiles import (
     AgentProfileDocument,
     GuidedProfileCreate,
     _default_builtin_opencode_launch_policy_refs,
+    _catalog_refresh_preserves_builtin_binding,
     _digest,
     _normalized,
     _preserve_builtin_opencode_model,
     _response,
     router,
 )
+from moonmind.omnigent.harness_platform import create_catalog_snapshot
 
 
 def document(**source):
@@ -52,6 +54,79 @@ def test_catalog_refresh_preserves_bootstrap_qualified_opencode_model():
 
     assert reconciled["model"] == active["model"]
     assert seed["model"] == {}
+
+
+def test_catalog_refresh_preserves_binding_when_only_live_inventory_changes():
+    implementation = {
+        "sourceKind": "core",
+        "package": "omnigent.harnesses.opencode",
+        "version": "1.0.0",
+        "digest": "sha256:" + "1" * 64,
+    }
+    harnesses = [
+        {
+            "id": "opencode-native",
+            "label": "OpenCode",
+            "implementation": implementation,
+        }
+    ]
+    authority = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="1.2.3",
+        omnigentBuildDigest="sha256:" + "2" * 64,
+        sourceDigest="sha256:" + "3" * 64,
+        harnesses=harnesses,
+    )
+    observation = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="1.2.3",
+        omnigentBuildDigest="sha256:" + "2" * 64,
+        sourceDigest="sha256:" + "4" * 64,
+        harnesses=harnesses,
+    )
+
+    assert _catalog_refresh_preserves_builtin_binding(
+        authority_payload=authority.model_dump(by_alias=True, mode="json"),
+        observation=observation,
+        harness_id="opencode-native",
+        implementation_ref=authority.harnesses[0].implementation.implementation_ref(),
+    )
+
+
+def test_catalog_refresh_rejects_a_changed_omnigent_build():
+    harnesses = [
+        {
+            "id": "opencode-native",
+            "label": "OpenCode",
+            "implementation": {
+                "sourceKind": "core",
+                "package": "omnigent.harnesses.opencode",
+                "version": "1.0.0",
+                "digest": "sha256:" + "1" * 64,
+            },
+        }
+    ]
+    authority = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="1.2.3",
+        omnigentBuildDigest="sha256:" + "2" * 64,
+        sourceDigest="sha256:" + "3" * 64,
+        harnesses=harnesses,
+    )
+    observation = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="1.2.4",
+        omnigentBuildDigest="sha256:" + "5" * 64,
+        sourceDigest="sha256:" + "4" * 64,
+        harnesses=harnesses,
+    )
+
+    assert not _catalog_refresh_preserves_builtin_binding(
+        authority_payload=authority.model_dump(by_alias=True, mode="json"),
+        observation=observation,
+        harness_id="opencode-native",
+        implementation_ref=authority.harnesses[0].implementation.implementation_ref(),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/test_omnigent_bootstrap.py
+++ b/tests/unit/api/routers/test_omnigent_bootstrap.py
@@ -18,6 +18,22 @@ from moonmind.omnigent.bootstrap.models import (
     BootstrapResolved,
     BootstrapState,
 )
+from moonmind.omnigent.bootstrap.opencode import (
+    DEFAULT_OPENCODE_MODEL_DISPLAY,
+    DEFAULT_OPENCODE_QUALIFIED,
+    ZEN_FREE_QUALIFIED,
+)
+
+
+def test_opencode_bootstrap_defaults_use_muse_spark_1_3() -> None:
+    request = bootstrap_router.BootstrapOpencodeRequest(apiKey="configured-key")
+
+    assert request.model_display_name == "Muse Spark 1.3 Contributor"
+    assert BootstrapDesired().model_display_name == DEFAULT_OPENCODE_MODEL_DISPLAY
+    assert DEFAULT_OPENCODE_QUALIFIED == (
+        "opencode-go/muse-spark-1.3-contributor"
+    )
+    assert ZEN_FREE_QUALIFIED == "opencode/muse-spark-1.3-contributor-free"
 
 
 def _record(state: BootstrapState = BootstrapState.ready) -> BootstrapRecord:

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -196,12 +196,12 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert claude_profile.clear_env_keys is None
 
     zen_profile = next(p for p in profiles if p.profile_id == "opencode-zen-free")
-    assert zen_profile.default_model == "opencode/muse-spark-1.2-contributor-free"
+    assert zen_profile.default_model == "opencode/muse-spark-1.3-contributor-free"
     assert zen_profile.default_effort == "xhigh"
     assert zen_profile.model_tiers == [
         {
-            "label": "Muse Spark 1.2 Contributor Free",
-            "model": "opencode/muse-spark-1.2-contributor-free",
+            "label": "Muse Spark 1.3 Contributor Free",
+            "model": "opencode/muse-spark-1.3-contributor-free",
             "effort": "xhigh",
             "parameters": {},
             "annotations": {},
@@ -261,7 +261,7 @@ async def _enroll_opencode_go_with_pinned_runtime(
     from moonmind.workflows.temporal import client as temporal_client
 
     image_ref = "ghcr.io/example/opencode@sha256:" + "a" * 64
-    qualified_model = "opencode-go/muse-spark-1.2-contributor"
+    qualified_model = "opencode-go/muse-spark-1.3-contributor"
     manager_sync_signals: list[tuple[str, dict]] = []
 
     class Guard:
@@ -351,6 +351,18 @@ async def test_opencode_go_enrollment_atomically_replaces_seeded_zen_default(
     assert profiles["opencode-zen-free"].is_default is False
     assert profiles["opencode-go-default"].enabled is True
     assert profiles["opencode-go-default"].is_default is True
+    assert profiles["opencode-go-default"].default_model == (
+        "opencode-go/muse-spark-1.3-contributor"
+    )
+    assert profiles["opencode-go-default"].model_tiers == [
+        {
+            "label": "Muse Spark 1.3 Contributor",
+            "model": "opencode-go/muse-spark-1.3-contributor",
+            "effort": "xhigh",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
     assert sum(profile.is_default for profile in profiles.values()) == 1
 
     assert len(manager_sync_signals) == 1
@@ -363,6 +375,89 @@ async def test_opencode_go_enrollment_atomically_replaces_seeded_zen_default(
     ]
     assert manager_profiles[0]["is_default"] is True
     assert manager_profiles[0]["launch_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_upgrades_bootstrap_owned_opencode_go_model_tier(
+    _module_db, monkeypatch
+):
+    from api_service.main import _auto_seed_provider_profiles
+
+    await _auto_seed_provider_profiles()
+    await _enroll_opencode_go_with_pinned_runtime(monkeypatch)
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(
+            ManagedAgentProviderProfile, "opencode-go-default"
+        )
+        assert profile is not None
+        profile.default_model = "opencode-go/muse-spark-1.2-contributor"
+        profile.model_tiers = [
+            {
+                "label": "Runtime default",
+                "model": None,
+                "effort": "xhigh",
+                "parameters": {},
+                "annotations": {},
+            }
+        ]
+        await session.commit()
+
+    assert await _auto_seed_provider_profiles() == []
+
+    async with db_base.async_session_maker() as session:
+        migrated = await session.get(
+            ManagedAgentProviderProfile, "opencode-go-default"
+        )
+    assert migrated is not None
+    assert migrated.default_model == "opencode-go/muse-spark-1.3-contributor"
+    assert migrated.model_tiers == [
+        {
+            "label": "Muse Spark 1.3 Contributor",
+            "model": "opencode-go/muse-spark-1.3-contributor",
+            "effort": "xhigh",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_preserves_operator_authored_opencode_go_tiers(
+    _module_db, monkeypatch
+):
+    from api_service.main import _auto_seed_provider_profiles
+
+    await _auto_seed_provider_profiles()
+    await _enroll_opencode_go_with_pinned_runtime(monkeypatch)
+    custom_tiers = [
+        {
+            "label": "Custom",
+            "model": "opencode-go/operator-model",
+            "effort": "high",
+            "parameters": {},
+            "annotations": {},
+        }
+    ]
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(
+            ManagedAgentProviderProfile, "opencode-go-default"
+        )
+        assert profile is not None
+        profile.default_model = "opencode-go/muse-spark-1.2-contributor"
+        profile.model_tiers = custom_tiers
+        await session.commit()
+
+    assert await _auto_seed_provider_profiles() == []
+
+    async with db_base.async_session_maker() as session:
+        preserved = await session.get(
+            ManagedAgentProviderProfile, "opencode-go-default"
+        )
+    assert preserved is not None
+    assert preserved.default_model == "opencode-go/muse-spark-1.2-contributor"
+    assert preserved.model_tiers == custom_tiers
 
 
 @pytest.mark.asyncio
@@ -471,9 +566,9 @@ async def test_auto_seed_migrates_the_zen_profile_to_the_exact_runtime_model(
     assert migrated.is_default is True
     assert migrated.auth_state == ProviderProfileAuthState.CONNECTED
     assert migrated.disabled_reason is None
-    assert migrated.default_model == "opencode/muse-spark-1.2-contributor-free"
+    assert migrated.default_model == "opencode/muse-spark-1.3-contributor-free"
     assert migrated.model_tiers[0]["model"] == (
-        "opencode/muse-spark-1.2-contributor-free"
+        "opencode/muse-spark-1.3-contributor-free"
     )
 
 

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -51,6 +51,7 @@ def _profile(
     provider_id: str = "opencode-go",
     default_model: str = "opencode-go/muse-spark-1.2-contributor",
     credential_source: str = "secret_ref",
+    disabled_reason: str | None = None,
 ) -> SimpleNamespace:
     evidence = None
     if evidence_image is not None:
@@ -76,6 +77,7 @@ def _profile(
         provider_id=provider_id,
         enabled=enabled,
         auth_state=auth_state,
+        disabled_reason=disabled_reason,
         credential_source=credential_source,
         credential_generation=generation,
         capacity_scope_ref=None,
@@ -792,17 +794,19 @@ async def test_unenrolled_profile_rows_are_re_enrolled_from_configuration(
 
 
 @pytest.mark.asyncio
-async def test_operator_disabled_profile_is_never_re_enabled_by_configuration(
+@pytest.mark.parametrize("disabled_reason", ["user_disabled", "policy_disabled"])
+async def test_authoritatively_disabled_profile_is_never_re_enabled_by_configuration(
     monkeypatch: pytest.MonkeyPatch,
+    disabled_reason: str,
 ) -> None:
-    """Enrollment applies enabled=True, so a disabled profile must be left alone."""
+    """Enrollment must preserve explicit user and policy disable authority."""
 
     _install_stubs(monkeypatch)
     monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
     controller = _Controller()
     # Connected and enrolled, but the operator turned it off. Its evidence is
     # also stale, which must not become a reason to touch it either.
-    rows = [_profile(enabled=False)]
+    rows = [_profile(enabled=False, disabled_reason=disabled_reason)]
 
     outcome = await reconcile_opencode_provider_readiness(
         session_factory=_session_factory(rows), controller=controller
@@ -813,6 +817,26 @@ async def test_operator_disabled_profile_is_never_re_enabled_by_configuration(
     assert outcome.refreshed == ()
     assert outcome.ready is True
     assert rows[0].enabled is False
+
+
+@pytest.mark.asyncio
+async def test_deployment_configuration_repairs_non_authoritative_disabled_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart repairs partial enrollment without overriding user intent."""
+
+    _install_stubs(monkeypatch)
+    monkeypatch.setenv("OPENCODE_API_KEY", API_KEY)
+    controller = _Controller()
+    rows = [_profile(enabled=False, disabled_reason="auth_invalid")]
+
+    outcome = await reconcile_opencode_provider_readiness(
+        session_factory=_session_factory(rows), controller=controller
+    )
+
+    assert len(controller.calls) == 1
+    assert outcome.enrolled is True
+    assert outcome.checked == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stabilize built-in OpenCode Agent Profile identity across live host catalog refreshes
- follow the current Omnigent execution target during new workflow submission
- update OpenCode Zen and Go defaults to Muse Spark 1.3
- repair deployment-configured OpenCode Go enrollment while preserving explicit disables
- allow capability-authorized custom model entry with stale catalog evidence

## Verification

- 123 targeted Python tests passed
- 243 affected frontend tests passed
- TypeScript typecheck and targeted ESLint passed
- OpenAPI client regeneration passed
- integration_ci: 619 passed, 1 skipped