### PR TITLE
Fix Omnigent native bootstrap timeout margin

### DIFF
--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -579,6 +579,12 @@ For `host_type = external`:
 }
 ```
 
+Event dispatch has a 150-second transport budget because a native message can
+synchronously ensure the runner terminal before the provider accepts it. This
+budget covers a connect-time bootstrap and one serialized recovery attempt with
+margin. Ordinary JSON operations retain a 60-second budget, while the SSE read
+remains unbounded and is governed by the marked-turn progress budgets below.
+
 ### 9.2 First-message marker
 
 ```text

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -582,8 +582,10 @@ For `host_type = external`:
 Event dispatch has a 150-second transport budget because a native message can
 synchronously ensure the runner terminal before the provider accepts it. This
 budget covers a connect-time bootstrap and one serialized recovery attempt with
-margin. Ordinary JSON operations retain a 60-second budget, while the SSE read
-remains unbounded and is governed by the marked-turn progress budgets below.
+margin. The enclosing `omnigent.submit_turn` Activity allows 180 seconds per
+attempt and 600 seconds across retries. Ordinary JSON and non-message control
+events retain a 60-second budget, while the SSE read remains unbounded and is
+governed by the marked-turn progress budgets below.
 
 ### 9.2 First-message marker
 

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -19,6 +19,15 @@ from moonmind.utils.logging import (
 
 _AGENT_CATALOG_PAGE_SIZE = 1000
 _MAX_AGENT_CATALOG_PAGES = 100
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
+# A message event can synchronously wait for the runner's native-terminal
+# bootstrap. The runner may spend 30 seconds resolving the harness version and
+# another 30 seconds waiting for its loopback server; when a connect-time
+# bootstrap loses that race, the serialized event ensure can repeat the same
+# bounded work. Keep enough margin for both attempts so the provider returns
+# its authoritative success or structured startup failure before MoonMind
+# releases the on-demand host.
+_DEFAULT_EVENT_TIMEOUT_SECONDS = 150.0
 
 
 class OmnigentClientError(RuntimeError):
@@ -58,7 +67,8 @@ class OmnigentHttpClient:
         *,
         base_url: str,
         api_token: str = "",
-        timeout_seconds: float = 60.0,
+        timeout_seconds: float = _DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        event_timeout_seconds: float = _DEFAULT_EVENT_TIMEOUT_SECONDS,
         stream_timeout_seconds: float | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
         client: httpx.AsyncClient | None = None,
@@ -68,6 +78,7 @@ class OmnigentHttpClient:
         self._base = str(base_url).rstrip("/")
         self._api_token = api_token
         self._timeout = httpx.Timeout(timeout_seconds)
+        self._event_timeout = httpx.Timeout(event_timeout_seconds)
         self._stream_timeout = httpx.Timeout(
             timeout_seconds,
             read=stream_timeout_seconds,
@@ -251,6 +262,7 @@ class OmnigentHttpClient:
             "POST",
             f"/v1/sessions/{quote(session_id, safe='')}/events",
             json=dict(event),
+            request_timeout=self._event_timeout,
         )
 
     async def stream_events(self, session_id: str) -> AsyncIterator[dict[str, Any]]:
@@ -267,7 +279,7 @@ class OmnigentHttpClient:
                         yield event
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
             return
@@ -286,7 +298,7 @@ class OmnigentHttpClient:
                         yield event
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
 
@@ -380,25 +392,33 @@ class OmnigentHttpClient:
             f"/v1/sessions/{quote(session_id, safe='')}{query}",
         )
 
-    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        request_timeout: httpx.Timeout | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        timeout = request_timeout or self._timeout
         if self._client is not None:
             try:
                 response = await self._client.request(
                     method,
                     f"{self._base}{path}",
                     headers=self._headers(),
-                    timeout=self._timeout,
+                    timeout=timeout,
                     **kwargs,
                 )
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
             return self._parse_json_response(response)
 
         async with httpx.AsyncClient(
-            timeout=self._timeout,
+            timeout=timeout,
             transport=self._transport,
         ) as client:
             try:
@@ -410,7 +430,7 @@ class OmnigentHttpClient:
                 )
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
         return self._parse_json_response(response)
@@ -439,7 +459,7 @@ class OmnigentHttpClient:
                 )
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
             if response.status_code < 200 or response.status_code >= 300:
@@ -458,7 +478,7 @@ class OmnigentHttpClient:
                 )
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
-                    self._redact(f"Omnigent transport error: {exc!s}"),
+                    self._transport_error_message(exc),
                     failure_class="integration_error",
                 ) from exc
         if response.status_code < 200 or response.status_code >= 300:
@@ -484,6 +504,12 @@ class OmnigentHttpClient:
 
     def _redact(self, value: str) -> str:
         return redact_sensitive_text(self._redactor.scrub(value))
+
+    def _transport_error_message(self, exc: httpx.HTTPError) -> str:
+        """Return a useful redacted message even for empty httpx timeout text."""
+
+        detail = str(exc).strip() or type(exc).__name__
+        return self._redact(f"Omnigent transport error: {detail}")
 
 
 def parse_sse_line(line: str) -> dict[str, Any] | None:

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -258,11 +258,15 @@ class OmnigentHttpClient:
         session_id: str,
         event: Mapping[str, Any],
     ) -> dict[str, Any]:
+        event_payload = dict(event)
+        event_type = str(event_payload.get("type") or "").strip()
         return await self._request(
             "POST",
             f"/v1/sessions/{quote(session_id, safe='')}/events",
-            json=dict(event),
-            request_timeout=self._event_timeout,
+            json=event_payload,
+            request_timeout=(
+                self._event_timeout if event_type == "message" else self._timeout
+            ),
         )
 
     async def stream_events(self, session_id: str) -> AsyncIterator[dict[str, Any]]:

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1059,7 +1059,11 @@ def build_default_activity_catalog(
                 ("omnigent.ensure_provider_profile_lease", 60, 180),
                 ("omnigent.ensure_host", 300, 600),
                 ("omnigent.ensure_provider_session", 60, 180),
-                ("omnigent.submit_turn", 60, 180),
+                # The first-message transport allows 150 seconds for native
+                # terminal bootstrap plus serialized recovery. Preserve
+                # activity-level bookkeeping margin and enough total time for
+                # all three retry attempts.
+                ("omnigent.submit_turn", 180, 600),
                 ("omnigent.heartbeat_host_lease", 30, 60),
                 ("omnigent.read_event_batch", 30, 60),
                 ("omnigent.observe_snapshot", 30, 60),

--- a/moonmind/workflows/temporal/workflows/omnigent_session.py
+++ b/moonmind/workflows/temporal/workflows/omnigent_session.py
@@ -64,6 +64,7 @@ MAX_PENDING_SIGNAL_INTENTS = 100
 # The janitor reclaims an assigned host this long after its last heartbeat,
 # independently of the much longer lease expiry.
 HOST_LEASE_HEARTBEAT_TIMEOUT_SECONDS = 90
+OMNIGENT_SUBMIT_TURN_TIMEOUT_PATCH = "omnigent-submit-turn-timeout-margin-v1"
 
 
 def _align_with_workflow_clock(
@@ -238,13 +239,22 @@ class MoonMindOmnigentSessionWorkflow:
         self, activity_name: str, payload: Mapping[str, Any]
     ) -> object:
         route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(activity_name)
+        start_to_close_seconds = route.timeouts.start_to_close_seconds
+        schedule_to_close_seconds = route.timeouts.schedule_to_close_seconds
+        if activity_name == "omnigent.submit_turn" and not workflow.patched(
+            OMNIGENT_SUBMIT_TURN_TIMEOUT_PATCH
+        ):
+            # Preserve the command attributes already recorded by workflows
+            # whose histories predate the extended first-message budget.
+            start_to_close_seconds = 60
+            schedule_to_close_seconds = 180
         kwargs: dict[str, Any] = {
             "task_queue": route.task_queue,
             "start_to_close_timeout": timedelta(
-                seconds=route.timeouts.start_to_close_seconds
+                seconds=start_to_close_seconds
             ),
             "schedule_to_close_timeout": timedelta(
-                seconds=route.timeouts.schedule_to_close_seconds
+                seconds=schedule_to_close_seconds
             ),
             "retry_policy": self._retry_policy(route),
             "summary": f"Reconcile Omnigent session: {activity_name}",

--- a/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/expected-outcome.json
@@ -1,6 +1,12 @@
 {
-  "invariant": "injected HTTP clients use MoonMind's bounded request timeout and unbounded SSE read timeout",
-  "requestTimeout": {
+  "invariant": "injected HTTP clients use MoonMind's bounded ordinary, event-dispatch, and SSE timeout contracts",
+  "eventTimeout": {
+    "connect": 150.0,
+    "read": 150.0,
+    "write": 150.0,
+    "pool": 150.0
+  },
+  "ordinaryTimeout": {
     "connect": 60.0,
     "read": 60.0,
     "write": 60.0,

--- a/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-injected-client-timeout-contract/manifest.json
@@ -6,6 +6,7 @@
   "omnigentSessionId": "6bbdd1e661c649ebbd59c20582283581",
   "sessionId": "session-replay",
   "requestTimeoutSeconds": 60.0,
+  "eventTimeoutSeconds": 150.0,
   "failureShape": "an injected default httpx client replaced MoonMind's request and SSE timeout contract, timed out during native terminal bootstrap, and cleanup disconnected the live host and runner",
   "boundary": "MoonMind Omnigent adapter to injected HTTP transport"
 }

--- a/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/expected-outcome.json
@@ -1,0 +1,17 @@
+{
+  "invariant": "the bounded first-message dispatch outlives two serialized native bootstrap attempts while ordinary calls remain independently bounded",
+  "minimumEventTimeoutSeconds": 120.0,
+  "ordinaryTimeout": {
+    "connect": 60.0,
+    "read": 60.0,
+    "write": 60.0,
+    "pool": 60.0
+  },
+  "eventTimeout": {
+    "connect": 150.0,
+    "read": 150.0,
+    "write": 150.0,
+    "pool": 150.0
+  },
+  "emptyReadTimeoutMessage": "Omnigent transport error: ReadTimeout"
+}

--- a/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/expected-outcome.json
@@ -1,6 +1,10 @@
 {
   "invariant": "the bounded first-message dispatch outlives two serialized native bootstrap attempts while ordinary calls remain independently bounded",
   "minimumEventTimeoutSeconds": 120.0,
+  "submitTurnActivityTimeout": {
+    "startToCloseSeconds": 180,
+    "scheduleToCloseSeconds": 600
+  },
   "ordinaryTimeout": {
     "connect": 60.0,
     "read": 60.0,

--- a/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-native-bootstrap-timeout-margin/manifest.json
@@ -1,0 +1,14 @@
+{
+  "incidentWorkflowId": "mm:4a85769c-4126-4689-88bb-87b486f25d37",
+  "incidentRunId": "01a06993-80c2-7581-a49b-a1d68c5defb6",
+  "failedChildWorkflowId": "mm:4a85769c-4126-4689-88bb-87b486f25d37:agent:tpl:batch-github-workflows:01:bb5d79f2",
+  "failedChildRunId": "01a06993-8371-71d5-b740-d34ab8ed1ef8",
+  "omnigentSessionId": "3ab4c98455e7487a9072df7690d58353",
+  "sessionId": "bootstrap-boundary-replay",
+  "ordinaryTimeoutSeconds": 60.0,
+  "eventTimeoutSeconds": 150.0,
+  "nativeBootstrapAttemptSeconds": 60.0,
+  "serializedAttemptCount": 2,
+  "failureShape": "the first-message HTTP request used the same 60-second bound as ordinary JSON calls, reached its read timeout while native terminal ensure was still authoritative, and cleanup disconnected the host before Omnigent could return terminal evidence",
+  "boundary": "MoonMind first-message dispatch to Omnigent native-terminal bootstrap"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -134,6 +134,7 @@ from moonmind.workflows.adapters.omnigent_agent_adapter import (
     build_omnigent_selection,
     resolve_omnigent_target,
 )
+from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
 from moonmind.workflows.executions.repository_contract import (
     RepositoryClientEvidence,
     RepositoryClientPolicy,
@@ -4808,18 +4809,73 @@ async def test_omnigent_injected_client_preserves_execution_timeouts() -> None:
         client = oauth_host_runtime_module.OmnigentHttpClient(
             base_url="https://omnigent.test",
             timeout_seconds=manifest["requestTimeoutSeconds"],
+            event_timeout_seconds=manifest["eventTimeoutSeconds"],
             stream_timeout_seconds=None,
             client=injected_client,
         )
+        await client.get_session(manifest["sessionId"])
         await client.post_event(manifest["sessionId"], {"type": "message"})
         assert [event async for event in client.stream_events(manifest["sessionId"])] == []
 
+    assert observed[f"/v1/sessions/{manifest['sessionId']}"] == expected[
+        "ordinaryTimeout"
+    ]
     assert observed[f"/v1/sessions/{manifest['sessionId']}/events"] == expected[
-        "requestTimeout"
+        "eventTimeout"
     ]
     assert observed[f"/v1/sessions/{manifest['sessionId']}/stream"] == expected[
         "streamTimeout"
     ]
+
+
+async def test_omnigent_native_bootstrap_has_dispatch_timeout_margin() -> None:
+    """Replay mm:4a85769c at the first-message transport boundary."""
+
+    replay_id = "omnigent-native-bootstrap-timeout-margin"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    observed: dict[str, dict[str, float | None]] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed[request.url.path] = dict(request.extensions["timeout"])
+        return httpx.Response(202, json={"queued": True})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    ) as injected_client:
+        client = oauth_host_runtime_module.OmnigentHttpClient(
+            base_url="https://omnigent.test",
+            client=injected_client,
+        )
+        await client.get_session(manifest["sessionId"])
+        await client.post_event(manifest["sessionId"], {"type": "message"})
+
+    ordinary = observed[f"/v1/sessions/{manifest['sessionId']}"]
+    event = observed[f"/v1/sessions/{manifest['sessionId']}/events"]
+    assert ordinary == expected["ordinaryTimeout"]
+    assert event == expected["eventTimeout"]
+    assert event["read"] == manifest["eventTimeoutSeconds"]
+    assert event["read"] is not None
+    assert event["read"] >= (
+        manifest["nativeBootstrapAttemptSeconds"]
+        * manifest["serializedAttemptCount"]
+    )
+    assert event["read"] >= expected["minimumEventTimeoutSeconds"]
+
+    async def timeout_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("", request=request)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(timeout_handler)
+    ) as injected_client:
+        client = oauth_host_runtime_module.OmnigentHttpClient(
+            base_url="https://omnigent.test",
+            client=injected_client,
+        )
+        with pytest.raises(OmnigentClientError) as excinfo:
+            await client.post_event(manifest["sessionId"], {"type": "message"})
+
+    assert str(excinfo.value) == expected["emptyReadTimeoutMessage"]
 
 
 async def test_omnigent_stock_sse_event_catalog_is_normalized() -> None:

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -4861,6 +4861,15 @@ async def test_omnigent_native_bootstrap_has_dispatch_timeout_margin() -> None:
         * manifest["serializedAttemptCount"]
     )
     assert event["read"] >= expected["minimumEventTimeoutSeconds"]
+    submit_turn_route = build_default_activity_catalog().resolve_activity(
+        "omnigent.submit_turn"
+    )
+    assert submit_turn_route.timeouts.start_to_close_seconds == expected[
+        "submitTurnActivityTimeout"
+    ]["startToCloseSeconds"]
+    assert submit_turn_route.timeouts.schedule_to_close_seconds == expected[
+        "submitTurnActivityTimeout"
+    ]["scheduleToCloseSeconds"]
 
     async def timeout_handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ReadTimeout("", request=request)

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -115,9 +117,15 @@ async def test_injected_http_client_preserves_omnigent_timeout_contract() -> Non
     """An injected client must not replace Omnigent's transport timeouts."""
 
     observed_timeouts: dict[str, dict[str, float | None]] = {}
+    observed_event_timeouts: dict[str, dict[str, float | None]] = {}
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        observed_timeouts[request.url.path] = dict(request.extensions["timeout"])
+        timeout = dict(request.extensions["timeout"])
+        if request.url.path.endswith("/events"):
+            payload = json.loads(request.content)
+            observed_event_timeouts[str(payload["type"])] = timeout
+        else:
+            observed_timeouts[request.url.path] = timeout
         if request.url.path.endswith("/stream"):
             return httpx.Response(
                 200,
@@ -141,6 +149,8 @@ async def test_injected_http_client_preserves_omnigent_timeout_contract() -> Non
         assert await client.post_event("sess_1", {"type": "message"}) == {
             "ok": True
         }
+        assert await client.interrupt("sess_1") == {"ok": True}
+        assert await client.stop_session("sess_1") == {"ok": True}
         assert [event async for event in client.stream_events("sess_1")] == []
 
     ordinary_timeout = observed_timeouts["/v1/sessions/sess_1"]
@@ -150,13 +160,14 @@ async def test_injected_http_client_preserves_omnigent_timeout_contract() -> Non
         "write": 47.0,
         "pool": 47.0,
     }
-    request_timeout = observed_timeouts["/v1/sessions/sess_1/events"]
-    assert request_timeout == {
+    assert observed_event_timeouts["message"] == {
         "connect": 131.0,
         "read": 131.0,
         "write": 131.0,
         "pool": 131.0,
     }
+    assert observed_event_timeouts["interrupt"] == ordinary_timeout
+    assert observed_event_timeouts["stop_session"] == ordinary_timeout
     stream_timeout = observed_timeouts["/v1/sessions/sess_1/stream"]
     assert stream_timeout == {
         "connect": 47.0,

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -132,21 +132,30 @@ async def test_injected_http_client_preserves_omnigent_timeout_contract() -> Non
         client = OmnigentHttpClient(
             base_url="https://omnigent.test",
             timeout_seconds=47.0,
+            event_timeout_seconds=131.0,
             stream_timeout_seconds=None,
             client=injected_client,
         )
 
+        assert await client.get_session("sess_1") == {"ok": True}
         assert await client.post_event("sess_1", {"type": "message"}) == {
             "ok": True
         }
         assert [event async for event in client.stream_events("sess_1")] == []
 
-    request_timeout = observed_timeouts["/v1/sessions/sess_1/events"]
-    assert request_timeout == {
+    ordinary_timeout = observed_timeouts["/v1/sessions/sess_1"]
+    assert ordinary_timeout == {
         "connect": 47.0,
         "read": 47.0,
         "write": 47.0,
         "pool": 47.0,
+    }
+    request_timeout = observed_timeouts["/v1/sessions/sess_1/events"]
+    assert request_timeout == {
+        "connect": 131.0,
+        "read": 131.0,
+        "write": 131.0,
+        "pool": 131.0,
     }
     stream_timeout = observed_timeouts["/v1/sessions/sess_1/stream"]
     assert stream_timeout == {
@@ -155,6 +164,25 @@ async def test_injected_http_client_preserves_omnigent_timeout_contract() -> Non
         "write": 47.0,
         "pool": 47.0,
     }
+
+
+@pytest.mark.asyncio
+async def test_omnigent_client_names_empty_transport_timeout() -> None:
+    """httpx timeout strings may be empty, but diagnostics must identify them."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("", request=request)
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(
+        OmnigentClientError,
+        match="Omnigent transport error: ReadTimeout",
+    ):
+        await client.post_event("sess_1", {"type": "message"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
+++ b/tests/unit/workflows/temporal/test_omnigent_session_workflow.py
@@ -1373,6 +1373,45 @@ def test_production_registry_and_catalog_include_supervisor_boundary() -> None:
     assert catalog.resolve_activity(
         "omnigent.read_event_batch"
     ).timeouts.start_to_close_seconds <= 30
+    submit_turn = catalog.resolve_activity("omnigent.submit_turn")
+    assert submit_turn.timeouts.start_to_close_seconds == 180
+    assert submit_turn.timeouts.schedule_to_close_seconds == 600
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("timeout_patch_active", "start_to_close_seconds", "schedule_to_close_seconds"),
+    ((True, 180, 600), (False, 60, 180)),
+)
+async def test_submit_turn_activity_timeout_covers_event_dispatch_and_replay(
+    timeout_patch_active: bool,
+    start_to_close_seconds: int,
+    schedule_to_close_seconds: int,
+) -> None:
+    """The workflow outlives dispatch while old histories retain prior commands."""
+
+    supervisor = MoonMindOmnigentSessionWorkflow()
+    execute_activity = AsyncMock(return_value={"outcome": "submitted"})
+
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.omnigent_session.workflow.patched",
+            return_value=timeout_patch_active,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.omnigent_session.workflow.execute_activity",
+            execute_activity,
+        ),
+    ):
+        result = await supervisor._execute_activity("omnigent.submit_turn", {})
+
+    assert result == {"outcome": "submitted"}
+    assert execute_activity.await_args.kwargs["start_to_close_timeout"] == timedelta(
+        seconds=start_to_close_seconds
+    )
+    assert execute_activity.await_args.kwargs["schedule_to_close_timeout"] == timedelta(
+        seconds=schedule_to_close_seconds
+    )
 
 
 def test_continue_as_new_carries_only_bounded_summary_state() -> None:


### PR DESCRIPTION
## Summary

- give first-message Omnigent event dispatch a dedicated 150-second transport budget so the native terminal bootstrap and one serialized recovery attempt can return authoritative evidence
- keep ordinary JSON calls at 60 seconds and SSE reads unbounded, and retain the httpx exception type when its message is empty
- add unit coverage plus an escaped-production replay fixture for workflow `mm:4a85769c-4126-4689-88bb-87b486f25d37`

## Verification

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/adapters/test_omnigent_client.py tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_injected_client_preserves_execution_timeouts tests/integration/reliability/test_escaped_failure_journeys.py::test_omnigent_native_bootstrap_has_dispatch_timeout_margin` (16 passed)
- reran the failed production journey as `mm:8fa4cb7e-ebbd-40fa-9645-7bc10f6bfd2d`; it completed successfully and queued all 9 expected child workflows
- `git diff --check`
