### PR TITLE
Recommendation **I recommend adding `workflowPublish.mode: none` to seven presets. I do not recommend changing any current preset to `Auto`.** The imp

### DIFF
--- a/api_service/data/presets/batch-github-workflows.yaml
+++ b/api_service/data/presets/batch-github-workflows.yaml
@@ -63,6 +63,8 @@ annotations:
       publish_mode:
         type: string
         title: Publish override
+        description: Publish mode applied to every queued child workflow. Both run
+          options implement code, so children publish a pull request by default.
         enum:
         - none
         - branch
@@ -82,7 +84,7 @@ annotations:
     run_ref: preset:github-issue-implement
     max_workflows: '25'
     run_verify: true
-    publish_mode: none
+    publish_mode: pr
 inputs:
 - name: issue_range
   label: GitHub Issue Number Range
@@ -116,7 +118,7 @@ inputs:
   label: Publish Override
   type: enum
   required: false
-  default: none
+  default: pr
   options:
   - none
   - branch

--- a/api_service/data/presets/batch-workflows.yaml
+++ b/api_service/data/presets/batch-workflows.yaml
@@ -90,6 +90,9 @@ annotations:
       publish_mode:
         type: string
         title: Publish override
+        description: Publish mode applied to every queued child workflow. Defaults to
+          the mode the selected run needs - none for read-only verification, pr for
+          the implementation presets - until an operator selects one explicitly.
         enum:
         - none
         - branch
@@ -121,6 +124,15 @@ annotations:
     publish_mode:
       widget: select
       advanced: true
+      # The child publish default follows the selected run so an implementation
+      # cohort is never queued with its work left unpublished. An explicitly
+      # submitted publish_mode always wins.
+      defaultFrom:
+        field: run_ref
+        map:
+          'skill:jira-verify': none
+          'preset:jira-implement': pr
+          'preset:jira-orchestrate': pr
   defaults:
     run_ref: skill:jira-verify
     max_workflows: '25'

--- a/api_service/data/presets/document-update-orchestrate.yaml
+++ b/api_service/data/presets/document-update-orchestrate.yaml
@@ -11,6 +11,10 @@ requiredCapabilities:
 annotations:
   sourceSkill: document-update-orchestrate
   output: document-update-tasks
+  # Parent discovery only: each child document-update workflow carries its own
+  # publish and merge-automation policy, so this workflow has nothing to publish.
+  workflowPublish:
+    mode: none
 inputs:
   - name: document_directory
     label: Document Directory

--- a/api_service/data/presets/github-issue-breakdown-implement.yaml
+++ b/api_service/data/presets/github-issue-breakdown-implement.yaml
@@ -14,6 +14,11 @@ annotations:
   sourceSkill: github-issue-breakdown
   githubWorkflow: breakdown-to-dependent-implement
   output: dependent-github-issue-implement-workflows
+  # Parent creates GitHub issues and queues dependent GitHub Issue Implement
+  # children; each child receives the selected publish mode, so the parent
+  # publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
   - name: feature_request
     label: Workflow Instructions

--- a/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/github-issue-breakdown-orchestrate.yaml
@@ -14,6 +14,11 @@ annotations:
   sourceSkill: github-issue-breakdown
   githubWorkflow: breakdown-to-dependent-orchestrate
   output: dependent-github-issue-orchestrate-workflows
+  # Parent creates GitHub issues and queues dependent GitHub Issue Orchestrate
+  # children; each child receives the selected publish mode, so the parent
+  # publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
   - name: feature_request
     label: Workflow Instructions

--- a/api_service/data/presets/issue-implement-assessment.yaml
+++ b/api_service/data/presets/issue-implement-assessment.yaml
@@ -12,6 +12,10 @@ requiredCapabilities:
 annotations:
   sourceSkill: issue-implement-assessment
   issueProvider: neutral
+  # Repository-read assessment: this preset forbids code changes and only writes
+  # local handoff artifacts for later steps, so it publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
 - name: issue_provider
   label: Issue Provider

--- a/api_service/data/presets/jira-breakdown-implement.yaml
+++ b/api_service/data/presets/jira-breakdown-implement.yaml
@@ -14,6 +14,10 @@ annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-implement
   output: dependent-jira-implement-workflows
+  # Parent creates Jira issues and queues dependent Jira Implement children; each
+  # child receives its own publish policy, so the parent publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
   - name: feature_request
     label: Workflow Instructions

--- a/api_service/data/presets/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/presets/jira-breakdown-orchestrate.yaml
@@ -14,6 +14,10 @@ annotations:
   sourceSkill: jira-breakdown
   jiraWorkflow: breakdown-to-dependent-orchestrate
   output: dependent-jira-orchestrate-workflows
+  # Parent creates Jira issues and queues dependent Jira Orchestrate children; each
+  # child receives its own publish policy, so the parent publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
   - name: feature_request
     label: Workflow Instructions

--- a/api_service/data/presets/jira-breakdown.yaml
+++ b/api_service/data/presets/jira-breakdown.yaml
@@ -13,6 +13,10 @@ requiredCapabilities:
 annotations:
   sourceSkill: moonspec-breakdown
   output: jira
+  # Jira issue creation is an external side effect, not repository publication: the
+  # story breakdown is a temporary artifact, so this workflow publishes nothing.
+  workflowPublish:
+    mode: none
 inputs:
   - name: feature_request
     label: Workflow Instructions

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -1154,8 +1154,54 @@ def _input_schema_defaults_by_name(inputs_schema: list[dict[str, Any]]) -> dict[
     }
 
 
+def _dependent_default_input_properties(
+    annotations: Mapping[str, Any] | None,
+    inputs_schema: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Mapping[str, Any]]:
+    """Return the field schemas a ``defaultFrom`` rule may reference.
+
+    A preset declares its inputs either as a capability ``inputSchema``
+    annotation or as the legacy ``inputs`` list, so both are reduced to the same
+    ``{name: field schema}`` view before a rule is validated.
+    """
+
+    raw_input_schema = (annotations or {}).get("inputSchema")
+    raw_properties = (
+        raw_input_schema.get("properties")
+        if isinstance(raw_input_schema, Mapping)
+        else None
+    )
+    if isinstance(raw_properties, Mapping) and raw_properties:
+        return {
+            str(name or "").strip(): field
+            for name, field in raw_properties.items()
+            if isinstance(field, Mapping)
+        }
+    properties: dict[str, Mapping[str, Any]] = {}
+    for definition in inputs_schema or []:
+        if not isinstance(definition, Mapping):
+            continue
+        name = str(definition.get("name") or "").strip()
+        if not name:
+            continue
+        field_schema = definition.get("schema")
+        if isinstance(field_schema, Mapping):
+            properties[name] = field_schema
+            continue
+        options = definition.get("options")
+        input_type = str(definition.get("type") or "text").strip().lower()
+        if input_type == "enum" and isinstance(options, list):
+            properties[name] = {"enum": [str(option) for option in options]}
+        elif input_type == "boolean":
+            properties[name] = {"type": "boolean"}
+        else:
+            properties[name] = {"type": "string"}
+    return properties
+
+
 def _dependent_input_default_rules(
     annotations: Mapping[str, Any] | None,
+    inputs_schema: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, tuple[str, dict[str, Any]]]:
     """Parse ``uiSchema.<field>.defaultFrom`` rules into ``{field: (source, map)}``.
 
@@ -1163,11 +1209,16 @@ def _dependent_input_default_rules(
     selection instead of a single static value - for example a batch parent
     whose child publish mode depends on the selected child capability. The rule
     is declarative so the Create page and expansion derive the same default.
+
+    Each rule is validated against the preset input schema so an unresolvable
+    reference fails at seed time instead of silently reinstating the static
+    default when an operator runs the preset.
     """
 
     ui_schema = (annotations or {}).get("uiSchema")
     if not isinstance(ui_schema, Mapping):
         return {}
+    properties = _dependent_default_input_properties(annotations, inputs_schema)
     rules: dict[str, tuple[str, dict[str, Any]]] = {}
     for raw_name, raw_field_ui in ui_schema.items():
         if not isinstance(raw_field_ui, Mapping):
@@ -1191,11 +1242,82 @@ def _dependent_input_default_rules(
             raise PresetValidationError(
                 f"uiSchema.{name}.defaultFrom map contains a secret-like value."
             )
-        rules[name] = (
-            source,
-            {str(key or "").strip(): value for key, value in mapping.items()},
+        normalized_map = {
+            str(key or "").strip(): value for key, value in mapping.items()
+        }
+        _validate_dependent_default_references(
+            properties=properties,
+            name=name,
+            source=source,
+            mapping=normalized_map,
         )
+        rules[name] = (source, normalized_map)
     return rules
+
+
+def _validate_dependent_default_references(
+    *,
+    properties: Mapping[str, Any],
+    name: str,
+    source: str,
+    mapping: Mapping[str, Any],
+) -> None:
+    """Reject a ``defaultFrom`` rule that can never derive its declared value.
+
+    An unknown target or source field, a source value the source field cannot
+    hold, or a mapped value the target field would reject all leave the input
+    silently falling back to its static default. That is exactly how a typo
+    restores the unsafe default this rule exists to replace, so the rule is
+    checked against the preset input schema instead of only its own shape.
+    """
+
+    target_schema = properties.get(name)
+    if not isinstance(target_schema, Mapping):
+        raise PresetValidationError(
+            f"uiSchema.{name}.defaultFrom targets '{name}', which is not a "
+            "preset input."
+        )
+    source_schema = properties.get(source)
+    if not isinstance(source_schema, Mapping):
+        raise PresetValidationError(
+            f"uiSchema.{name}.defaultFrom reads '{source}', which is not a "
+            "preset input."
+        )
+    source_enum = source_schema.get("enum")
+    if isinstance(source_enum, list):
+        allowed_sources = {str(option or "").strip() for option in source_enum}
+        for key in mapping:
+            if key not in allowed_sources:
+                raise PresetValidationError(
+                    f"uiSchema.{name}.defaultFrom maps '{key}', which is not a "
+                    f"'{source}' option."
+                )
+    for key, value in mapping.items():
+        if not _value_matches_input_schema(target_schema, value):
+            raise PresetValidationError(
+                f"uiSchema.{name}.defaultFrom maps '{key}' to a value "
+                f"'{name}' cannot hold."
+            )
+
+
+def _value_matches_input_schema(field_schema: Mapping[str, Any], value: Any) -> bool:
+    enum = field_schema.get("enum")
+    if isinstance(enum, list):
+        return value in enum
+    field_type = str(field_schema.get("type") or "").strip().lower()
+    if field_type == "boolean":
+        return isinstance(value, bool)
+    if field_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if field_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if field_type == "string":
+        return isinstance(value, str)
+    if field_type == "array":
+        return isinstance(value, list)
+    if field_type == "object":
+        return isinstance(value, Mapping)
+    return value is not None
 
 
 def _apply_dependent_input_defaults(
@@ -1211,7 +1333,7 @@ def _apply_dependent_input_defaults(
     wins.
     """
 
-    rules = _dependent_input_default_rules(annotations)
+    rules = _dependent_input_default_rules(annotations, inputs_schema)
     if not rules:
         return submitted
     adjusted = dict(submitted)
@@ -1342,10 +1464,17 @@ def _normalize_seed_annotations(item: Mapping[str, Any]) -> dict[str, Any]:
         raise PresetValidationError(
             "Capability schema defaults contain a secret-like value."
         )
-    return _normalize_preset_annotations(annotations)
+    raw_inputs = item.get("inputs")
+    return _normalize_preset_annotations(
+        annotations,
+        raw_inputs if isinstance(raw_inputs, list) else None,
+    )
 
 
-def _normalize_preset_annotations(annotations: Mapping[str, Any] | None) -> dict[str, Any]:
+def _normalize_preset_annotations(
+    annotations: Mapping[str, Any] | None,
+    inputs_schema: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
     normalized = dict(annotations or {})
     checkpoint_branching_alias = normalized.pop("checkpoint_branching", None)
     if (
@@ -1358,9 +1487,10 @@ def _normalize_preset_annotations(annotations: Mapping[str, Any] | None) -> dict
         normalized["checkpointBranching"] = _normalize_checkpoint_branching_policy(
             checkpoint_branching
         )
-    # Reject a malformed dependent-default rule at seed time rather than letting
-    # an input silently fall back to its static default at expansion.
-    _dependent_input_default_rules(normalized)
+    # Reject a malformed or unresolvable dependent-default rule at seed time
+    # rather than letting an input silently fall back to its static default at
+    # expansion.
+    _dependent_input_default_rules(normalized, inputs_schema)
     return normalized
 
 
@@ -1995,7 +2125,7 @@ class PresetCatalogService:
             required_capabilities=derived_capabilities,
             inputs_schema=validated_inputs,
             steps=validated_steps,
-            annotations=_normalize_preset_annotations(annotations),
+            annotations=_normalize_preset_annotations(annotations, validated_inputs),
             max_step_count=max(25, len(validated_steps)),
             release_status=release_status,
             seed_source=seed_source,

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -1098,6 +1098,11 @@ def _apply_contextual_input_overrides(
         annotations=annotations,
         submitted=dict(submitted),
     )
+    adjusted = _apply_dependent_input_defaults(
+        annotations=annotations,
+        inputs_schema=inputs_schema,
+        submitted=adjusted,
+    )
 
     if slug in {_BATCH_WORKFLOWS_SLUG, _BATCH_GITHUB_WORKFLOWS_SLUG}:
         repository = _repository_from_context(context)
@@ -1147,6 +1152,80 @@ def _input_schema_defaults_by_name(inputs_schema: list[dict[str, Any]]) -> dict[
         for definition in inputs_schema
         if str(definition.get("name") or "").strip()
     }
+
+
+def _dependent_input_default_rules(
+    annotations: Mapping[str, Any] | None,
+) -> dict[str, tuple[str, dict[str, Any]]]:
+    """Parse ``uiSchema.<field>.defaultFrom`` rules into ``{field: (source, map)}``.
+
+    A preset uses this when one input's default has to follow another operator
+    selection instead of a single static value - for example a batch parent
+    whose child publish mode depends on the selected child capability. The rule
+    is declarative so the Create page and expansion derive the same default.
+    """
+
+    ui_schema = (annotations or {}).get("uiSchema")
+    if not isinstance(ui_schema, Mapping):
+        return {}
+    rules: dict[str, tuple[str, dict[str, Any]]] = {}
+    for raw_name, raw_field_ui in ui_schema.items():
+        if not isinstance(raw_field_ui, Mapping):
+            continue
+        default_from = raw_field_ui.get("defaultFrom")
+        if default_from is None:
+            continue
+        name = str(raw_name or "").strip()
+        if not isinstance(default_from, Mapping):
+            raise PresetValidationError(
+                f"uiSchema.{name}.defaultFrom must be an object."
+            )
+        source = str(default_from.get("field") or "").strip()
+        mapping = default_from.get("map")
+        if not source or not isinstance(mapping, Mapping) or not mapping:
+            raise PresetValidationError(
+                f"uiSchema.{name}.defaultFrom requires a source 'field' and a "
+                "non-empty 'map'."
+            )
+        if _contains_secret_like_value(mapping):
+            raise PresetValidationError(
+                f"uiSchema.{name}.defaultFrom map contains a secret-like value."
+            )
+        rules[name] = (
+            source,
+            {str(key or "").strip(): value for key, value in mapping.items()},
+        )
+    return rules
+
+
+def _apply_dependent_input_defaults(
+    *,
+    annotations: Mapping[str, Any] | None,
+    inputs_schema: list[dict[str, Any]],
+    submitted: dict[str, Any],
+) -> dict[str, Any]:
+    """Fill omitted inputs from their declared ``defaultFrom`` rule.
+
+    Only an omitted or blank value is derived, so an explicitly submitted value
+    - including one the operator changed away from the derived default - always
+    wins.
+    """
+
+    rules = _dependent_input_default_rules(annotations)
+    if not rules:
+        return submitted
+    adjusted = dict(submitted)
+    schema_defaults = _input_schema_defaults_by_name(inputs_schema)
+    for name, (source, mapping) in rules.items():
+        if adjusted.get(name) not in (None, ""):
+            continue
+        source_value = adjusted.get(source)
+        if source_value in (None, ""):
+            source_value = schema_defaults.get(source)
+        mapped = mapping.get(str(source_value or "").strip())
+        if mapped is not None:
+            adjusted[name] = mapped
+    return adjusted
 
 def _contains_secret_like_value(value: Any) -> bool:
     if isinstance(value, Mapping):
@@ -1279,6 +1358,9 @@ def _normalize_preset_annotations(annotations: Mapping[str, Any] | None) -> dict
         normalized["checkpointBranching"] = _normalize_checkpoint_branching_policy(
             checkpoint_branching
         )
+    # Reject a malformed dependent-default rule at seed time rather than letting
+    # an input silently fall back to its static default at expansion.
+    _dependent_input_default_rules(normalized)
     return normalized
 
 

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -423,6 +423,59 @@ annotation. Workflow-level publish policy is still validated by the same publish
 and merge-automation contracts as a manually authored submission; a preset cannot
 grant publish rights that a submitted payload could not.
 
+Expansion reads `workflowPublish` from the **root** preset only. A preset that is
+included as a child keeps its own annotation for the case where an operator runs
+it directly, and that annotation never overwrites the including workflow's policy.
+
+A preset declares `mode: none` when the workflow itself publishes nothing to the
+repository:
+
+- parent orchestrators whose only repository work happens in child workflows,
+  each of which carries its own publish policy;
+- workflows whose side effects are external, such as creating tracker issues;
+- repository reads that only write local handoff artifacts for later steps.
+
+A preset that edits the repository and expects MoonMind to push and open the pull
+request declares no `workflowPublish` annotation and stays a managed `pr`
+workflow. That includes a preset whose final step creates or identifies the pull
+request early because a later trusted side effect needs its URL: the step's PR
+instructions override the generic commit-only instruction for that step, and the
+workflow remains managed.
+
+`mode: auto` is reserved for a root capability that declares agent-owned
+publication and produces execution-bound `artifacts/publish_result.json`
+evidence, such as `pr-resolver`, `fix-comments`, `fix-ci`, and
+`fix-merge-conflicts`. Declaring `auto` for any other preset would require valid
+publish evidence on every terminal path, including no-change and blocked runs,
+and would otherwise finish as `auto_publish_evidence_missing`.
+
+## Dependent Input Defaults
+
+An input's default may follow another operator selection instead of a single
+static value. A preset declares this with `uiSchema.<field>.defaultFrom`:
+
+```yaml
+uiSchema:
+  publish_mode:
+    widget: select
+    defaultFrom:
+      field: run_ref
+      map:
+        'skill:jira-verify': none
+        'preset:jira-implement': pr
+        'preset:jira-orchestrate': pr
+```
+
+The Create page and expansion derive the same value from the same rule, so an
+omitted input resolves identically whether a run is authored in the UI or
+submitted through the API. Only an omitted or blank value is derived: an
+explicitly submitted value, including one the operator changed away from the
+derived default, is never replaced. A source value with no entry in `map` falls
+back to the field's static default.
+
+A malformed `defaultFrom` is rejected when the preset is seeded rather than
+silently falling back to the static default.
+
 ## Nested Presets
 
 A preset may include child preset steps. Parent presets must explicitly map inputs into child presets.

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -427,6 +427,11 @@ Expansion reads `workflowPublish` from the **root** preset only. A preset that i
 included as a child keeps its own annotation for the case where an operator runs
 it directly, and that annotation never overwrites the including workflow's policy.
 
+A preset expanded at submit time supplies the workflow publish mode only while
+the visible Publish Mode control still shows a derived value. Once the operator
+changes that control, their selection is an explicit override and wins over the
+annotation, exactly as it does for a preset that was expanded before submit.
+
 A preset declares `mode: none` when the workflow itself publishes nothing to the
 repository:
 
@@ -473,8 +478,13 @@ explicitly submitted value, including one the operator changed away from the
 derived default, is never replaced. A source value with no entry in `map` falls
 back to the field's static default.
 
-A malformed `defaultFrom` is rejected when the preset is seeded rather than
-silently falling back to the static default.
+A `defaultFrom` rule is validated against the preset's own inputs when the
+preset is seeded, rather than silently falling back to the static default when
+an operator runs it. Seeding fails when the rule is malformed, when its target
+or source names an input the preset does not declare, when a `map` key is not a
+value the source field can hold, or when a mapped value is one the target field
+would reject. Only a declared `map` entry supplies a default, so a source value
+that happens to name an inherited object member resolves nothing.
 
 ## Nested Presets
 

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -18586,6 +18586,39 @@ describe("Task Create MM-578 Preset expansion", () => {
 });
 
 describe("Task Create schema-driven capability inputs", () => {
+  // A batch parent whose child publish default follows the selected run: a
+  // read-only verification cohort publishes nothing, an implementation cohort
+  // publishes a PR.
+  const batchSchemaPresetContract = {
+    inputSchema: {
+      type: "object",
+      required: ["run_ref"],
+      properties: {
+        run_ref: {
+          type: "string",
+          title: "Run",
+          enum: ["skill:verify", "preset:implement"],
+        },
+        publish_mode: {
+          type: "string",
+          title: "Publish override",
+          enum: ["none", "branch", "pr"],
+        },
+      },
+    },
+    uiSchema: {
+      run_ref: { widget: "select" },
+      publish_mode: {
+        widget: "select",
+        advanced: true,
+        defaultFrom: {
+          field: "run_ref",
+          map: { "skill:verify": "none", "preset:implement": "pr" },
+        },
+      },
+    },
+    defaults: { run_ref: "skill:verify", publish_mode: "none" },
+  };
   let fetchSpy: MockInstance;
 
   function mockSchemaCapabilityFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -18840,6 +18873,15 @@ describe("Task Create schema-driven capability inputs", () => {
               defaults: {},
             },
             {
+              slug: "batch-schema-preset",
+              scope: "global",
+              title: "Batch Schema Preset",
+              description: "Schema-driven batch preset.",
+              latestVersion: "1",
+              version: "1",
+              ...batchSchemaPresetContract,
+            },
+            {
               slug: "generic-schema-preset",
               scope: "global",
               title: "Generic Schema Preset",
@@ -18979,6 +19021,45 @@ describe("Task Create schema-driven capability inputs", () => {
             },
           },
           defaults: {},
+        }),
+      } as Response);
+    }
+    if (url.startsWith("/api/presets/batch-schema-preset?scope=global")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          slug: "batch-schema-preset",
+          scope: "global",
+          title: "Batch Schema Preset",
+          description: "Schema-driven batch preset.",
+          latestVersion: "1",
+          version: "1",
+          ...batchSchemaPresetContract,
+        }),
+      } as Response);
+    }
+    if (url.startsWith("/api/presets/batch-schema-preset:expand?scope=global")) {
+      const payload = JSON.parse(String(init?.body || "{}")) as {
+        inputs?: Record<string, unknown>;
+      };
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          steps: [
+            {
+              id: "tpl:batch-schema-preset:1:01",
+              title: "Queue child workflows",
+              instructions: "Queue child workflows.",
+              skill: { id: "batch-workflows", inputs: payload.inputs },
+            },
+          ],
+          appliedTemplate: {
+            slug: "batch-schema-preset",
+            version: "1",
+            inputs: payload.inputs,
+          },
+          capabilities: ["git"],
+          warnings: [],
         }),
       } as Response);
     }
@@ -19225,6 +19306,98 @@ describe("Task Create schema-driven capability inputs", () => {
   });
 
 
+
+  async function selectBatchSchemaPreset(): Promise<HTMLElement> {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    selectStepType(step, "Preset");
+    const presetSelect = within(step).getByLabelText(
+      "Preset Template",
+    ) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(presetSelect.options.length).toBeGreaterThan(1);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::batch-schema-preset" },
+    });
+    await within(step).findByLabelText("Run");
+    return step;
+  }
+
+  function latestBatchExpandInputs(): Record<string, unknown> {
+    const call = fetchSpy.mock.calls
+      .filter(([url]) =>
+        String(url).startsWith("/api/presets/batch-schema-preset:expand"),
+      )
+      .at(-1);
+    expect(call).toBeTruthy();
+    const payload = JSON.parse(String(call?.[1]?.body || "{}")) as {
+      inputs?: Record<string, unknown>;
+    };
+    return payload.inputs || {};
+  }
+
+  it("derives a dependent input default from the selected run", async () => {
+    const step = await selectBatchSchemaPreset();
+    const publishSelect = within(step).getByLabelText(
+      "Publish override",
+    ) as HTMLSelectElement;
+    // The default run is read-only verification, so children publish nothing.
+    expect(publishSelect.value).toBe("none");
+
+    fireEvent.change(within(step).getByLabelText("Run"), {
+      target: { value: "preset:implement" },
+    });
+
+    // Switching to the implementation run must not queue children that
+    // implement each target and then leave the work unpublished.
+    await waitFor(() => {
+      expect(
+        (within(step).getByLabelText("Publish override") as HTMLSelectElement)
+          .value,
+      ).toBe("pr");
+    });
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    await waitFor(() => {
+      expect(latestBatchExpandInputs().publish_mode).toBe("pr");
+    });
+  });
+
+  it("never replaces a dependent default the operator changed", async () => {
+    const step = await selectBatchSchemaPreset();
+    fireEvent.change(within(step).getByLabelText("Run"), {
+      target: { value: "preset:implement" },
+    });
+    await waitFor(() => {
+      expect(
+        (within(step).getByLabelText("Publish override") as HTMLSelectElement)
+          .value,
+      ).toBe("pr");
+    });
+
+    fireEvent.change(within(step).getByLabelText("Publish override"), {
+      target: { value: "branch" },
+    });
+    fireEvent.change(within(step).getByLabelText("Run"), {
+      target: { value: "skill:verify" },
+    });
+    fireEvent.change(within(step).getByLabelText("Run"), {
+      target: { value: "preset:implement" },
+    });
+
+    expect(
+      (within(step).getByLabelText("Publish override") as HTMLSelectElement)
+        .value,
+    ).toBe("branch");
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    await waitFor(() => {
+      expect(latestBatchExpandInputs().publish_mode).toBe("branch");
+    });
+  });
 
   it("renders github.issue-picker from schema metadata and normalizes manual issue URL", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -17088,6 +17088,77 @@ describe("Task Create MM-578 Preset expansion", () => {
     );
   });
 
+  it("keeps an edited publish mode over a submit-time preset publish policy", async () => {
+    let expansionCount = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/presets/mm-578-preset:expand?scope=global")) {
+        expansionCount += 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:mm-578-preset:edited-publish:1",
+                title: "Expanded preset",
+                type: "tool",
+                repositoryOperation: "read",
+                instructions: "Resolve preset.",
+                tool: {
+                  type: "tool",
+                  id: "github.resolve_pull_request_target",
+                  inputs: { pullRequest: "3974" },
+                },
+              },
+            ],
+            // A publish-nothing preset: without an override its children own
+            // every repository side effect.
+            publish: { mode: "none" },
+            appliedTemplate: {
+              slug: "mm-578-preset",
+              presetDigest: "digest-1",
+              stepIds: ["tpl:mm-578-preset:edited-publish:1"],
+            },
+            capabilities: ["gh"],
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return mockMm578PresetFetch(input);
+    });
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const step = (await screen.findByText("Step 1")).closest(
+      "section",
+    ) as HTMLElement;
+    await chooseMm578Preset(step);
+
+    // The operator changes the visible control and then starts without
+    // expanding, so expansion runs at submit time. The explicit choice must not
+    // be silently replaced by the preset annotation.
+    fireEvent.change(screen.getByLabelText("Publish Mode"), {
+      target: { value: "pr" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest() as {
+      payload: {
+        publishMode?: string;
+        task: { publish?: Record<string, unknown> };
+      };
+    };
+    expect(expansionCount).toBe(1);
+    expect(request.payload.publishMode).toBe("pr");
+    expect(request.payload.task.publish).toEqual({ mode: "pr" });
+  });
+
   it("preserves a publish override when a later submit-time preset has no policy", async () => {
     const workflowPublish = {
       mode: "pr",
@@ -18604,6 +18675,8 @@ describe("Task Create schema-driven capability inputs", () => {
           title: "Publish override",
           enum: ["none", "branch", "pr"],
         },
+        run_label: { type: "string", title: "Run label" },
+        branch_prefix: { type: "string", title: "Branch prefix" },
       },
     },
     uiSchema: {
@@ -18616,8 +18689,21 @@ describe("Task Create schema-driven capability inputs", () => {
           map: { "skill:verify": "none", "preset:implement": "pr" },
         },
       },
+      // A free-text source: the operator can type any value, including one that
+      // names an inherited `Object.prototype` member.
+      branch_prefix: {
+        defaultFrom: {
+          field: "run_label",
+          map: { verify: "verify/", implement: "implement/" },
+        },
+      },
     },
-    defaults: { run_ref: "skill:verify", publish_mode: "none" },
+    defaults: {
+      run_ref: "skill:verify",
+      publish_mode: "none",
+      run_label: "",
+      branch_prefix: "",
+    },
   };
   let fetchSpy: MockInstance;
 
@@ -19397,6 +19483,49 @@ describe("Task Create schema-driven capability inputs", () => {
     await waitFor(() => {
       expect(latestBatchExpandInputs().publish_mode).toBe("branch");
     });
+  });
+
+  it("derives a dependent default for a blank dependent target", async () => {
+    const step = await selectBatchSchemaPreset();
+    fireEvent.change(within(step).getByLabelText("Run label"), {
+      target: { value: "implement" },
+    });
+    await waitFor(() => {
+      expect(
+        (within(step).getByLabelText("Branch prefix") as HTMLInputElement).value,
+      ).toBe("implement/");
+    });
+
+    // Clearing a dependent text target stores "", which expansion treats as
+    // omitted. The Create page must submit the same derived value the server
+    // would resolve rather than an empty string.
+    fireEvent.change(within(step).getByLabelText("Branch prefix"), {
+      target: { value: "" },
+    });
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    await waitFor(() => {
+      expect(latestBatchExpandInputs().branch_prefix).toBe("implement/");
+    });
+  });
+
+  it("ignores an inherited object member named by a dependent source", async () => {
+    const step = await selectBatchSchemaPreset();
+    // `constructor` is not a declared map entry, so it must not resolve an
+    // `Object.prototype` member that structuredClone would throw on.
+    fireEvent.change(within(step).getByLabelText("Run label"), {
+      target: { value: "constructor" },
+    });
+
+    const branchPrefix = within(step).getByLabelText(
+      "Branch prefix",
+    ) as HTMLInputElement;
+    expect(branchPrefix.value).toBe("");
+
+    fireEvent.click(within(step).getByRole("button", { name: "Expand" }));
+    await waitFor(() => {
+      expect(latestBatchExpandInputs().run_label).toBe("constructor");
+    });
+    expect(latestBatchExpandInputs().branch_prefix).toBe("");
   });
 
   it("renders github.issue-picker from schema metadata and normalizes manual issue URL", async () => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3938,6 +3938,45 @@ function safeCapabilityDefault(
   return structuredClone(value);
 }
 
+// A preset may declare `uiSchema.<field>.defaultFrom` when one input's default
+// has to follow another operator selection rather than a single static value.
+// The rule only supplies a default: once the operator sets the field, their
+// value lives in `values` and is never replaced.
+function dependentCapabilityDefault(
+  detail: Pick<PresetDetail, "uiSchema" | "defaults">,
+  values: Record<string, unknown>,
+  name: string,
+): unknown {
+  const defaultFrom = recordValue(
+    capabilityFieldUiSchema(detail.uiSchema, name)["defaultFrom"],
+  );
+  const field = String(defaultFrom["field"] ?? "").trim();
+  const map = recordValue(defaultFrom["map"]);
+  if (!field || Object.keys(map).length === 0) {
+    return undefined;
+  }
+  const source = capabilityInputValue(values, detail.defaults, field);
+  const mapped = map[String(source ?? "").trim()];
+  if (mapped === undefined || containsSecretLikeCapabilityValue(mapped)) {
+    return undefined;
+  }
+  return structuredClone(mapped);
+}
+
+function capabilityEffectiveDefaults(
+  detail: Pick<PresetDetail, "uiSchema" | "defaults">,
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const effective = { ...(detail.defaults || {}) };
+  for (const name of Object.keys(recordValue(detail.uiSchema))) {
+    const derived = dependentCapabilityDefault(detail, values, name);
+    if (derived !== undefined) {
+      effective[name] = derived;
+    }
+  }
+  return effective;
+}
+
 function capabilityInputValue(
   values: Record<string, unknown>,
   defaults: Record<string, unknown> | undefined,
@@ -4050,6 +4089,7 @@ function resolveSchemaCapabilityValues(
       explicit = normalizeJiraIssuePickerValue(explicit);
     }
     const fallback =
+      dependentCapabilityDefault(detail, explicitValues, name) ??
       safeCapabilityDefault(detail.defaults, name) ??
       safeCapabilityDefault(fieldSchema, "default");
     if (explicit !== undefined) {
@@ -4396,6 +4436,9 @@ function SchemaCapabilityFields({
   if (fields.length === 0) {
     return null;
   }
+  // Dependent defaults are resolved against the current values so a field whose
+  // default follows another selection re-renders with the derived value.
+  const effectiveDefaults = capabilityEffectiveDefaults(detail, values);
   return (
     <div className="grid-2">
       {fields.map(([name, rawSchema]) => {
@@ -4403,7 +4446,7 @@ function SchemaCapabilityFields({
         const uiSchema = capabilityFieldUiSchema(detail.uiSchema, name);
         const widget = capabilityWidgetName(fieldSchema, uiSchema);
         const label = capabilityFieldLabel(name, fieldSchema);
-        const value = capabilityInputValue(values, detail.defaults, name);
+        const value = capabilityInputValue(values, effectiveDefaults, name);
         const inputId = `queue-capability-input-${name}`;
         const error = errors[name];
         const description = String(fieldSchema.description || "").trim();
@@ -4424,7 +4467,7 @@ function SchemaCapabilityFields({
                 id={inputId}
                 aria-label={label}
                 type="text"
-                value={capabilityInputTextValue(values, detail.defaults, name)}
+                value={capabilityInputTextValue(values, effectiveDefaults, name)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
                 onChange={(event) => onChange(name, event.target.value)}
@@ -4574,7 +4617,7 @@ function SchemaCapabilityFields({
               <select
                 id={inputId}
                 aria-label={label}
-                value={capabilityInputTextValue(values, detail.defaults, name)}
+                value={capabilityInputTextValue(values, effectiveDefaults, name)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
                 onChange={(event) => {
@@ -4605,7 +4648,7 @@ function SchemaCapabilityFields({
               <textarea
                 id={inputId}
                 aria-label={label}
-                value={capabilityInputTextValue(values, detail.defaults, name)}
+                value={capabilityInputTextValue(values, effectiveDefaults, name)}
                 disabled={disabled}
                 aria-invalid={Boolean(error)}
                 onChange={(event) =>
@@ -4658,7 +4701,7 @@ function SchemaCapabilityFields({
                   ? `${inputId}-options`
                   : undefined
               }
-              value={capabilityInputTextValue(values, detail.defaults, name)}
+              value={capabilityInputTextValue(values, effectiveDefaults, name)}
               disabled={disabled}
               aria-invalid={Boolean(error)}
               onChange={(event) =>

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3956,7 +3956,14 @@ function dependentCapabilityDefault(
     return undefined;
   }
   const source = capabilityInputValue(values, detail.defaults, field);
-  const mapped = map[String(source ?? "").trim()];
+  const key = String(source ?? "").trim();
+  // Only an entry the preset actually declared may supply a default. A source
+  // value such as `constructor` would otherwise resolve an inherited
+  // `Object.prototype` member that `structuredClone` cannot clone.
+  if (!Object.hasOwn(map, key)) {
+    return undefined;
+  }
+  const mapped = map[key];
   if (mapped === undefined || containsSecretLikeCapabilityValue(mapped)) {
     return undefined;
   }
@@ -4088,11 +4095,21 @@ function resolveSchemaCapabilityValues(
     } else if (explicit !== undefined && widget === "jira.issue-picker") {
       explicit = normalizeJiraIssuePickerValue(explicit);
     }
+    const dependentDefault = dependentCapabilityDefault(
+      detail,
+      explicitValues,
+      name,
+    );
     const fallback =
-      dependentCapabilityDefault(detail, explicitValues, name) ??
+      dependentDefault ??
       safeCapabilityDefault(detail.defaults, name) ??
       safeCapabilityDefault(fieldSchema, "default");
-    if (explicit !== undefined) {
+    // Expansion treats a blank dependent target as omitted, so clearing a text
+    // or textarea field must derive the rule's value here too instead of
+    // submitting an empty string the server would replace.
+    const derivesBlank =
+      dependentDefault !== undefined && (explicit === "" || explicit === null);
+    if (explicit !== undefined && !derivesBlank) {
       if (
         explicit === "" &&
         !required.has(name) &&
@@ -6169,6 +6186,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const [publishMode, setPublishMode] = useState(
     normalizePublishModeForSubmit(defaultPublishMode),
   );
+  // Set only by the visible Publish Mode control. A preset expanded during
+  // submit may not overwrite a mode the operator chose for this run.
+  const [publishModeTouched, setPublishModeTouched] = useState(false);
   const [produceReport, setProduceReport] = useState(false);
   const [priority, setPriority] = useState(DEFAULT_PRIORITY);
   const [maxAttempts, setMaxAttempts] = useState(DEFAULT_MAX_ATTEMPTS);
@@ -10675,11 +10695,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       String(submitExpandedWorkflowPublish?.mode || ""),
     );
     // A preset expanded during this submit has not yet had a chance to update
-    // the visible form control. Use its workflow-level policy for this request.
-    // For an already-applied preset, a different visible mode is an explicit
-    // operator override and therefore wins over the annotation.
+    // the visible form control. Use its workflow-level policy for this request
+    // unless the operator already chose a mode: an edited control is an
+    // explicit override and wins over the annotation, exactly as it does for an
+    // already-applied preset.
     const requestedPublishMode =
-      submitExpandedWorkflowPublish && submitExpandedPublishMode
+      submitExpandedWorkflowPublish &&
+      submitExpandedPublishMode &&
+      !publishModeTouched
         ? submitExpandedPublishMode
         : formPublishMode;
     const effectiveSubmissionSkillId = primarySkillId;
@@ -14743,7 +14766,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 aria-label="Publish Mode"
                 title={publishModeTooltip}
                 value={publishMode}
-                onChange={(event) => setPublishMode(event.target.value)}
+                onChange={(event) => {
+                  setPublishModeTouched(true);
+                  setPublishMode(event.target.value);
+                }}
               >
                 <option
                   value="auto"

--- a/tests/integration/test_startup_preset_seeding.py
+++ b/tests/integration/test_startup_preset_seeding.py
@@ -866,6 +866,16 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert batch_annotations["uiSchema"]["run_ref"]["widget"] == "select"
         assert batch_annotations["uiSchema"]["constraints"]["widget"] == "textarea"
         assert batch_annotations["uiSchema"]["run_verify"]["widget"] == "checkbox"
+        # The parent publishes nothing, but its children own the repository
+        # work, so the child publish default follows the selected run.
+        assert batch_annotations["uiSchema"]["publish_mode"]["defaultFrom"] == {
+            "field": "run_ref",
+            "map": {
+                "skill:jira-verify": "none",
+                "preset:jira-implement": "pr",
+                "preset:jira-orchestrate": "pr",
+            },
+        }
         assert batch_annotations["bindings"]["skill:jira-verify"][
             "jira_issue_key"
         ] == "{{ target.jiraIssue.key }}"

--- a/tests/unit/api/test_batch_github_workflows_preset.py
+++ b/tests/unit/api/test_batch_github_workflows_preset.py
@@ -199,3 +199,44 @@ async def test_batch_github_workflows_uses_repository_context(tmp_path):
         "MoonLadderStudios/MoonMind"
     )
     assert expanded["steps"][0]["skill"]["id"] == "batch-github-workflows"
+
+
+async def test_batch_github_workflows_defaults_child_publish_to_pr(tmp_path):
+    """Both run options implement code, so children publish a PR by default.
+
+    A default batch run previously queued an implementation child per issue
+    with ``publish_mode = none``, which implemented every issue and then left
+    the work unpublished.
+    """
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+            template = await service.get_template(
+                slug="batch-github-workflows",
+                scope="global",
+                scope_ref=None,
+            )
+
+            expanded = await service.expand_template(
+                slug="batch-github-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "issue_range": "3142-3150",
+                    "repository": "MoonLadderStudios/MoonMind",
+                },
+            )
+
+    assert template["defaults"]["publish_mode"] == "pr"
+    assert template["defaults"]["run_ref"] == "preset:github-issue-implement"
+    step = expanded["steps"][0]
+    assert step["batchOrchestration"]["target"]["runRef"] == (
+        "preset:github-issue-implement"
+    )
+    assert step["batchOrchestration"]["publish"]["mode"] == "pr"
+    assert '--publish-mode "pr"' in step["instructions"]
+    # The parent queues children and writes summary artifacts; it never
+    # publishes repository changes itself.
+    assert expanded["publish"] == {"mode": "none"}

--- a/tests/unit/api/test_batch_workflows_preset.py
+++ b/tests/unit/api/test_batch_workflows_preset.py
@@ -143,7 +143,20 @@ async def test_batch_workflows_seed_validates_and_exposes_batch_contract(tmp_pat
                 "advanced": True,
             }
             assert ui_schema["repository"]["advanced"] is True
-            assert ui_schema["publish_mode"] == {"widget": "select", "advanced": True}
+            # The child publish default follows the selected run so an
+            # implementation cohort is never queued with unpublished work.
+            assert ui_schema["publish_mode"] == {
+                "widget": "select",
+                "advanced": True,
+                "defaultFrom": {
+                    "field": "run_ref",
+                    "map": {
+                        "skill:jira-verify": "none",
+                        "preset:jira-implement": "pr",
+                        "preset:jira-orchestrate": "pr",
+                    },
+                },
+            }
 
             # Default issue bindings for the known issue presets.
             bindings = annotations["bindings"]
@@ -322,3 +335,77 @@ async def test_batch_workflows_ignores_removed_target_preset_version_input(tmp_p
     orchestration = expanded["steps"][0]["batchOrchestration"]
     assert orchestration["target"]["runRef"] == "preset:jira-implement"
     assert "targetPreset" not in orchestration
+
+
+@pytest.mark.parametrize(
+    ("run_ref", "expected_publish_mode"),
+    [
+        ("skill:jira-verify", "none"),
+        ("preset:jira-implement", "pr"),
+        ("preset:jira-orchestrate", "pr"),
+    ],
+)
+async def test_batch_workflows_child_publish_default_follows_run_ref(
+    tmp_path,
+    run_ref,
+    expected_publish_mode,
+):
+    """An omitted publish override resolves to what the selected run needs.
+
+    The batch parent itself publishes nothing, but its children own the
+    repository work. Defaulting an implementation cohort to ``none`` would
+    implement every issue and then discard the result, so the child publish
+    default is derived from ``run_ref``.
+    """
+
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="batch-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "jira_project_key": "MM",
+                    "jira_status": "In Progress",
+                    "run_ref": run_ref,
+                },
+            )
+
+    orchestration = expanded["steps"][0]["batchOrchestration"]
+    assert orchestration["publish"]["mode"] == expected_publish_mode
+    assert expanded["appliedTemplate"]["inputs"]["publish_mode"] == (
+        expected_publish_mode
+    )
+    assert (
+        f'--publish-mode "{expected_publish_mode}"'
+        in expanded["steps"][0]["instructions"]
+    )
+    # The parent queues children and writes summary artifacts; it never
+    # publishes repository changes itself.
+    assert expanded["publish"] == {"mode": "none"}
+
+
+async def test_batch_workflows_explicit_publish_override_wins_over_run_ref(tmp_path):
+    """An explicitly submitted publish override is never replaced."""
+
+    async with _catalog_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="batch-workflows",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "jira_project_key": "MM",
+                    "jira_status": "In Progress",
+                    "run_ref": "preset:jira-implement",
+                    "publish_mode": "none",
+                },
+            )
+
+    assert expanded["steps"][0]["batchOrchestration"]["publish"]["mode"] == "none"

--- a/tests/unit/api/test_preset_workflow_publish_policy.py
+++ b/tests/unit/api/test_preset_workflow_publish_policy.py
@@ -320,3 +320,172 @@ async def test_malformed_dependent_default_rule_is_rejected_at_seed_time(
             service = PresetCatalogService(session)
             with pytest.raises(PresetValidationError, match=expected_message):
                 await service.sync_seed_templates(seed_dir=seed_dir)
+
+
+def _write_schema_dependent_default_preset(seed_dir: Path, ui_schema: dict) -> None:
+    """Seed a capability-contract preset carrying the given ``uiSchema``."""
+
+    seed_dir.mkdir(exist_ok=True)
+    (seed_dir / "dependent.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "slug": "dependent-default-preset",
+                "title": "Dependent Default Preset",
+                "description": "Preset with a dependent input default.",
+                "scope": "global",
+                "annotations": {
+                    "inputSchema": {
+                        "type": "object",
+                        "required": ["run_ref"],
+                        "properties": {
+                            "run_ref": {
+                                "type": "string",
+                                "title": "Run",
+                                "enum": ["skill:verify", "preset:implement"],
+                            },
+                            "publish_mode": {
+                                "type": "string",
+                                "title": "Publish override",
+                                "enum": ["none", "branch", "pr"],
+                            },
+                        },
+                    },
+                    "uiSchema": ui_schema,
+                    "defaults": {
+                        "run_ref": "skill:verify",
+                        "publish_mode": "none",
+                    },
+                },
+                "inputs": [
+                    {
+                        "name": "run_ref",
+                        "label": "Run",
+                        "type": "enum",
+                        "required": True,
+                        "options": ["skill:verify", "preset:implement"],
+                        "default": "skill:verify",
+                    },
+                    {
+                        "name": "publish_mode",
+                        "label": "Publish override",
+                        "type": "enum",
+                        "options": ["none", "branch", "pr"],
+                        "default": "none",
+                    },
+                ],
+                "steps": [
+                    {
+                        "title": "Do nothing",
+                        "instructions": "Do nothing.",
+                        "skill": {"id": "noop"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("ui_schema", "expected_message"),
+    [
+        # A typo in the source field silently reinstates the static default.
+        (
+            {
+                "publish_mode": {
+                    "defaultFrom": {
+                        "field": "run_reff",
+                        "map": {"skill:verify": "none"},
+                    }
+                }
+            },
+            "reads 'run_reff'",
+        ),
+        # A typo in the target field derives a value nothing reads.
+        (
+            {
+                "publish_modee": {
+                    "defaultFrom": {
+                        "field": "run_ref",
+                        "map": {"skill:verify": "none"},
+                    }
+                }
+            },
+            "targets 'publish_modee'",
+        ),
+        # A source value the source field cannot hold never matches.
+        (
+            {
+                "publish_mode": {
+                    "defaultFrom": {
+                        "field": "run_ref",
+                        "map": {"skill:verifyy": "none"},
+                    }
+                }
+            },
+            "which is not a 'run_ref' option",
+        ),
+        # A mapped value outside the target enum fails only at run time.
+        (
+            {
+                "publish_mode": {
+                    "defaultFrom": {
+                        "field": "run_ref",
+                        "map": {"preset:implement": "pr_with_merge_automation"},
+                    }
+                }
+            },
+            "cannot hold",
+        ),
+    ],
+)
+async def test_unresolvable_dependent_default_reference_is_rejected_at_seed_time(
+    tmp_path,
+    ui_schema,
+    expected_message,
+):
+    """A rule that can never derive its value fails before an operator runs it."""
+
+    seed_dir = tmp_path / "presets"
+    _write_schema_dependent_default_preset(seed_dir, ui_schema)
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            with pytest.raises(PresetValidationError, match=expected_message):
+                await service.sync_seed_templates(seed_dir=seed_dir)
+
+
+async def test_valid_dependent_default_reference_seeds_and_expands(tmp_path):
+    """The validated rule still derives the dependent default at expansion."""
+
+    seed_dir = tmp_path / "presets"
+    _write_schema_dependent_default_preset(
+        seed_dir,
+        {
+            "publish_mode": {
+                "widget": "select",
+                "defaultFrom": {
+                    "field": "run_ref",
+                    "map": {
+                        "skill:verify": "none",
+                        "preset:implement": "pr",
+                    },
+                },
+            }
+        },
+    )
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+            expanded = await service.expand_template(
+                slug="dependent-default-preset",
+                scope="global",
+                scope_ref=None,
+                inputs={"run_ref": "preset:implement"},
+                context=None,
+            )
+
+    assert expanded["appliedTemplate"]["inputs"]["publish_mode"] == "pr"

--- a/tests/unit/api/test_preset_workflow_publish_policy.py
+++ b/tests/unit/api/test_preset_workflow_publish_policy.py
@@ -1,0 +1,322 @@
+"""Catalog-boundary tests for the seed presets' workflow-level publish policy.
+
+`workflowPublish` decides which seed presets carry MoonMind-managed repository
+publication and which publish nothing at all. Getting it wrong is silent in
+both directions: a parent that only queues children or writes local artifacts
+would be pushed through the managed publisher, and an implementation preset
+that lost its managed policy would finish without publishing its work. These
+tests pin the classification at the real seed + expansion boundary.
+"""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base, Preset, PresetScopeType
+from api_service.services.presets.catalog import (
+    PresetCatalogService,
+    PresetValidationError,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRESET_DIR = _REPO_ROOT / "api_service" / "data" / "presets"
+
+# Presets that publish nothing to the repository. Parent orchestrators own only
+# child workflows or external tracker side effects; assessment presets are
+# repository reads that write local handoff artifacts.
+_PUBLISH_NOTHING_PRESETS = frozenset(
+    {
+        "batch-github-workflows",
+        "batch-workflows",
+        "document-update-orchestrate",
+        "github-issue-breakdown-implement",
+        "github-issue-breakdown-orchestrate",
+        "issue-implement-assessment",
+        "jira-breakdown",
+        "jira-breakdown-implement",
+        "jira-breakdown-orchestrate",
+        "pr-review-resolve",
+    }
+)
+
+# Presets that edit the repository and hand publication to the MoonMind-managed
+# publisher. None of them declares agent-owned publication, so none may default
+# to `auto`: that would require execution-bound publish evidence on every
+# terminal path, including no-change and blocked runs.
+_MANAGED_PUBLISH_PRESETS = frozenset(
+    {
+        "document-author",
+        "document-health-update",
+        "github-issue-implement",
+        "github-issue-orchestrate",
+        "issue-implement-work-pr",
+        "jira-implement",
+        "jira-orchestrate",
+        "moonspec-orchestrate",
+    }
+)
+
+
+@asynccontextmanager
+async def _catalog_db(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/preset_publish_policy.db",
+        future=True,
+    )
+    sessions = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+def _seed_dir(tmp_path) -> Path:
+    seed_dir = tmp_path / "presets"
+    shutil.copytree(_PRESET_DIR, seed_dir)
+    return seed_dir
+
+
+async def _seeded_annotations(session, tmp_path) -> dict[str, dict]:
+    service = PresetCatalogService(session)
+    await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+    result = await session.execute(
+        select(Preset).where(
+            Preset.scope_type == PresetScopeType.GLOBAL,
+            Preset.scope_ref.is_(None),
+        )
+    )
+    return {
+        template.slug: template.annotations or {}
+        for template in result.scalars().all()
+    }
+
+
+async def test_seed_presets_declare_the_expected_publish_policy(tmp_path):
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            annotations_by_slug = await _seeded_annotations(session, tmp_path)
+
+    # Every seed preset is classified: a new one must make a deliberate choice.
+    assert set(annotations_by_slug) == (
+        _PUBLISH_NOTHING_PRESETS | _MANAGED_PUBLISH_PRESETS
+    )
+
+    for slug in sorted(_PUBLISH_NOTHING_PRESETS):
+        publish = annotations_by_slug[slug].get("workflowPublish")
+        assert publish is not None, f"{slug} must declare workflowPublish"
+        assert publish["mode"] == "none", slug
+
+    for slug in sorted(_MANAGED_PUBLISH_PRESETS):
+        assert "workflowPublish" not in annotations_by_slug[slug], (
+            f"{slug} publishes through the MoonMind-managed publisher and must "
+            "not pin a workflow-level publish mode"
+        )
+
+
+async def test_no_seed_preset_declares_auto_publish(tmp_path):
+    """`auto` requires an agent-owned publication skill and publish evidence."""
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            annotations_by_slug = await _seeded_annotations(session, tmp_path)
+
+    for slug, preset_annotations in sorted(annotations_by_slug.items()):
+        publish = preset_annotations.get("workflowPublish") or {}
+        assert str(publish.get("mode") or "").strip().lower() != "auto", slug
+
+
+@pytest.mark.parametrize(
+    ("slug", "inputs"),
+    [
+        (
+            "document-update-orchestrate",
+            {"document_directory": "docs", "publish_mode": "pr"},
+        ),
+        (
+            "issue-implement-assessment",
+            {
+                "issue_provider": "github",
+                "issue_ref": "MoonLadderStudios/MoonMind#1",
+                "brief_artifact_path": "artifacts/brief.md",
+                "assessment_artifact_path": "artifacts/assessment.json",
+            },
+        ),
+        (
+            "jira-breakdown",
+            {
+                "feature_request": "Break this down into stories.",
+                "jira_project_key": "MM",
+                "jira_issue_type": "Story",
+                "jira_dependency_mode": "linear_blocker_chain",
+            },
+        ),
+        (
+            "jira-breakdown-implement",
+            {
+                "feature_request": "Break this down into stories.",
+                "jira_project_key": "MM",
+                "jira_issue_type": "Story",
+                "jira_dependency_mode": "linear_blocker_chain",
+                "publish_mode": "pr",
+            },
+        ),
+        (
+            "jira-breakdown-orchestrate",
+            {
+                "feature_request": "Break this down into stories.",
+                "jira_project_key": "MM",
+                "jira_issue_type": "Story",
+                "jira_dependency_mode": "linear_blocker_chain",
+                "publish_mode": "pr",
+            },
+        ),
+        (
+            "github-issue-breakdown-implement",
+            {
+                "feature_request": "Break this down into issues.",
+                "github_repository": "MoonLadderStudios/MoonMind",
+                "publish_mode": "pr",
+            },
+        ),
+        (
+            "github-issue-breakdown-orchestrate",
+            {
+                "feature_request": "Break this down into issues.",
+                "github_repository": "MoonLadderStudios/MoonMind",
+                "publish_mode": "pr",
+            },
+        ),
+    ],
+)
+async def test_publish_nothing_presets_expand_with_publish_none(
+    tmp_path,
+    slug,
+    inputs,
+):
+    """The annotation reaches the expanded workflow payload.
+
+    The breakdown presets take a `publish_mode` input, but it configures the
+    dependent child workflows they create. The parent itself only creates
+    tracker issues and child workflows, so its own publish mode stays `none`.
+    """
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug=slug,
+                scope="global",
+                scope_ref=None,
+                inputs=inputs,
+                context={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex_cli",
+                },
+            )
+
+    assert expanded["publish"] == {"mode": "none"}
+
+
+async def test_included_assessment_preset_does_not_disable_parent_publishing(
+    tmp_path,
+):
+    """A child preset's publish policy never overwrites the root workflow's.
+
+    `issue-implement-assessment` is reused by the implementation presets, which
+    do publish. Expansion reads `workflowPublish` from the root preset only.
+    """
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+
+            expanded = await service.expand_template(
+                slug="github-issue-implement",
+                scope="global",
+                scope_ref=None,
+                inputs={
+                    "github_issue": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "number": 3142,
+                    },
+                    "github_issue_ref": "MoonLadderStudios/MoonMind#3142",
+                },
+                context={"repository": "MoonLadderStudios/MoonMind"},
+            )
+
+    assert "publish" not in expanded
+    assert any(
+        step.get("presetProvenance", {}).get("source", {}).get("slug")
+        == "issue-implement-assessment"
+        for step in expanded["steps"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("default_from", "expected_message"),
+    [
+        ("run_ref", "must be an object"),
+        ({"map": {"a": "b"}}, "requires a source 'field'"),
+        ({"field": "run_ref"}, "requires a source 'field'"),
+        ({"field": "run_ref", "map": {}}, "requires a source 'field'"),
+        (
+            {"field": "run_ref", "map": {"a": "token=raw-secret"}},
+            "secret-like value",
+        ),
+    ],
+)
+async def test_malformed_dependent_default_rule_is_rejected_at_seed_time(
+    tmp_path,
+    default_from,
+    expected_message,
+):
+    """A broken rule fails fast instead of silently using the static default."""
+
+    seed_dir = tmp_path / "presets"
+    seed_dir.mkdir()
+    (seed_dir / "broken.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "slug": "broken-dependent-default",
+                "title": "Broken Dependent Default",
+                "description": "Preset with an invalid defaultFrom rule.",
+                "scope": "global",
+                "annotations": {
+                    "uiSchema": {"publish_mode": {"defaultFrom": default_from}}
+                },
+                "inputs": [
+                    {"name": "run_ref", "label": "Run", "type": "text"},
+                    {"name": "publish_mode", "label": "Publish", "type": "text"},
+                ],
+                "steps": [
+                    {
+                        "title": "Do nothing",
+                        "instructions": "Do nothing.",
+                        "skill": {"id": "noop"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            with pytest.raises(PresetValidationError, match=expected_message):
+                await service.sync_seed_templates(seed_dir=seed_dir)


### PR DESCRIPTION
# Recommendation

**I recommend adding `workflowPublish.mode: none` to seven presets. I do not recommend changing any current preset to `Auto`.** The implementation presets should remain on MoonMind-managed `PR` publishing, even though some contain an explicit PR handoff step.

## Presets to change to `None`

| Preset                               | Recommendation       | Reason                                                                                                                                                                                    |
| ------------------------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `document-update-orchestrate`        | **Change to `None`** | The parent discovers documents and creates child document-update workflows. Each child already receives its own PR and merge-automation configuration. The parent has nothing to publish. |
| `issue-implement-assessment`         | **Change to `None`** | This is explicitly a repository-read operation. It forbids code changes and only writes local handoff artifacts for later steps.                                                          |
| `jira-breakdown`                     | **Change to `None`** | It reads source material, creates a temporary story breakdown, and creates Jira issues. Those are external side effects, not repository publication.                                      |
| `jira-breakdown-implement`           | **Change to `None`** | The parent creates Jira issues and queues dependent Jira Implement children. Each child already receives an explicit publish policy.                                                      |
| `jira-breakdown-orchestrate`         | **Change to `None`** | Same parent-child ownership model, except the children run Jira Orchestrate.                                                                                                              |
| `github-issue-breakdown-implement`   | **Change to `None`** | The parent creates GitHub issues and child workflows. The children receive the selected publish mode. The parent does not implement or publish code.                                      |
| `github-issue-breakdown-orchestrate` | **Change to `None`** | Same as the implementation variant, with GitHub Issue Orchestrate children owning repository work.                                                                                        |

The annotation would be:

```yaml
annotations:
  workflowPublish:
    mode: none
```

This is safe for reusable presets such as `issue-implement-assessment`. Expansion reads `workflowPublish` only from the **root** preset. An included child preset’s annotation does not overwrite the parent workflow’s policy.

## Existing `None` settings that are correct

These should remain unchanged:

| Preset                   | Why `None` is correct                                                                                                           |
| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
| `batch-workflows`        | The parent queues Jira child workflows and writes summary artifacts.                                                            |
| `batch-github-workflows` | The parent resolves GitHub issues and queues child workflows.                                                                   |
| `pr-review-resolve`      | The parent publishes nothing. `pr-resolver` and `MoonMind.MergeAutomation` own commits, pushes, review requests, and any merge. |

## Why I would not add any new `Auto` defaults

MoonMind’s contract defines `Auto` narrowly. It is for a skill that declares **agent-owned publication**, and it requires execution-bound `artifacts/publish_result.json` evidence. The documented built-in examples are `pr-resolver`, `fix-comments`, `fix-ci`, and `fix-merge-conflicts`. `Auto` is invalid for a task that does not declare this capability.

The following presets should therefore **remain managed `PR` workflows**, not become `Auto`:

| Presets                                           | Why                                                                                                                             |
| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| `issue-implement-work-pr`                         | It implements code and has an explicit PR handoff step, but that does not make the entire preset an auto-publish-capable skill. |
| `github-issue-implement` and `jira-implement`     | They use `issue-implement-work-pr` and require the resulting PR URL for tracker status handoff.                                 |
| `github-issue-orchestrate` and `jira-orchestrate` | They run the MoonSpec lifecycle, then need an early PR URL before completing GitHub or Jira status transitions.                 |
| `document-author` and `document-health-update`    | They edit repository documents but do not own remote publication.                                                               |
| `moonspec-orchestrate`                            | It edits code and documentation but expects the managed publisher to push and create the PR.                                    |

MoonMind explicitly supports higher-level managed-PR presets having a step that creates or identifies the PR early because a later trusted side effect needs its URL. That step’s PR instructions override the generic commit-only instruction for that step, while the workflow remains managed `PR`.

`issue-implement-work-pr` matches that model precisely. Its final step commits, pushes, creates a ready-for-review PR, and records the URL so the parent can run merge automation or update the issue tracker.

Moving these presets to `Auto` would create several problems:

* They do not currently declare the required auto-publish skill metadata.
* Every terminal path, including no-change and blocked paths, would need valid `publish_result.json` evidence.
* Missing evidence would convert an otherwise valid run into `auto_publish_evidence_missing`.
* It would blur the existing ownership boundary between preset-controlled handoff and MoonMind-managed workflow publication.

A future preset whose root capability directly runs `fix-ci`, `fix-comments`, `fix-merge-conflicts`, or `pr-resolver` should normally default to `Auto`. `pr-review-resolve` remains the exception because it is a parent orchestration workflow operating on an existing PR, so its current `None` setting is correct.

## Additional batch preset issue

There is a related mismatch inside the batch presets that is separate from the parent’s publish mode.

`batch-github-workflows` defaults to running `preset:github-issue-implement`, but its **child publish override defaults to `none`**. A default batch run can therefore implement each issue without publishing the resulting work.

I recommend:

| Preset                                           | Child publish default                                                  |
| ------------------------------------------------ | ---------------------------------------------------------------------- |
| `batch-github-workflows`                         | Change from `none` to **`pr`**                                         |
| `batch-workflows` with `skill:jira-verify`       | Keep **`none`**                                                        |
| `batch-workflows` with `preset:jira-implement`   | Automatically use **`pr`** unless the operator explicitly overrides it |
| `batch-workflows` with `preset:jira-orchestrate` | Automatically use **`pr`** unless explicitly overridden                |

`batch-workflows` currently defaults to `jira-verify`, so `none` is sensible initially. The problem occurs when the operator changes `run_ref` to an implementation preset but the hidden advanced publish field remains `none`.

A clean UI rule would be:

```text
When run_ref changes:
  jira-verify       -> none
  jira-implement    -> pr
  jira-orchestrate  -> pr

Do not replace publish_mode after the operator has manually changed it.
```

## Proposed change set

The resulting distribution across the 18 presets would be:

| Classification                  | Count |
| ------------------------------- | ----: |
| Add `None` now                  | **7** |
| Already correctly set to `None` | **3** |
| Add `Auto` now                  | **0** |
| Keep managed publishing         | **8** |

The preset annotation remains a default rather than a lock. MoonMind’s existing contract allows an explicitly submitted `workflow.publish` payload to override it, so advanced users retain control without requiring Create-page special cases.

The cleanest implementation is therefore **seven new `None` annotations, no new `Auto` annotations, and corrected child publish defaults in the two batch presets**.