### PR TITLE
Retry Omnigent transport failures before provider work as new step execution

### DIFF
--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -3659,12 +3659,27 @@ async def run_omnigent_execution(
             external_state=external_state,
             capture_policy=capture_policy,
         )
+        # A transport failure before any provider work (first message never
+        # posted, no stream events captured) preserves nothing: retry as a
+        # new step execution with a fresh session, mirroring the
+        # never-started-turn contract. Failures after work started keep the
+        # existing non-retryable classification so partial progress is not
+        # silently discarded by a fresh session.
+        retry_recommendation = None
+        if (
+            status_code is None
+            and not first_message_posted
+            and not raw_events
+            and not normalized_events
+        ):
+            retry_recommendation = "retry_step_execution"
         return AgentRunResult(
             outputRefs=bundle.output_refs,
             summary=_compact_summary(exc, fallback="Omnigent integration error"),
             diagnosticsRef=bundle.diagnostics_ref,
             failureClass=failure_class,
             providerErrorCode=str(status_code or "omnigent_http_error"),
+            retryRecommendation=retry_recommendation,
             metadata={
                 "normalizedStatus": "failed",
                 "providerName": "omnigent",

--- a/moonmind/omnigent/execute.py
+++ b/moonmind/omnigent/execute.py
@@ -3659,12 +3659,15 @@ async def run_omnigent_execution(
             external_state=external_state,
             capture_policy=capture_policy,
         )
-        # A transport failure before any provider work (first message never
-        # posted, no stream events captured) preserves nothing: retry as a
-        # new step execution with a fresh session, mirroring the
-        # never-started-turn contract. Failures after work started keep the
-        # existing non-retryable classification so partial progress is not
-        # silently discarded by a fresh session.
+        # A status-less transport failure with no locally observed work is only
+        # safe to retry fresh when reconciliation proves the server never
+        # accepted the first message. An ambiguous POST timeout (server
+        # accepted but the client timed out) leaves first_message_posted False
+        # with empty event lists even though the session has begun work;
+        # retrying that fresh would duplicate external actions and abandon
+        # the authoritative workspace. Reconcile the remote first-message
+        # marker before recommending a fresh step execution; fail safe to no
+        # recommendation when reconciliation is unavailable or proves accept.
         retry_recommendation = None
         if (
             status_code is None
@@ -3672,7 +3675,41 @@ async def run_omnigent_execution(
             and not raw_events
             and not normalized_events
         ):
-            retry_recommendation = "retry_step_execution"
+            if first_message is None or not session_id:
+                # POST never attempted (failure before message/session).
+                retry_recommendation = "retry_step_execution"
+            else:
+                try:
+                    reconcile_marker = _first_message_marker(request=request)
+                    reconcile_digest = hashlib.sha256(
+                        json.dumps(
+                            first_message,
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode()
+                    ).hexdigest()
+                    # The attempt client is closed after its async-with exit;
+                    # reconcile over a fresh short-lived client instead.
+                    async with httpx.AsyncClient() as reconcile_httpx:
+                        reconcile_client = OmnigentHttpClient(
+                            base_url=resolved_server_url(),
+                            api_token=resolved_api_token(),
+                            client=reconcile_httpx,
+                            timeout_seconds=15.0,
+                            upstream_header_allowlist=resolved_proxy_forward_headers(),
+                        )
+                        reconcile_snapshot = await reconcile_client.get_session(
+                            session_id
+                        )
+                    if not _snapshot_contains_first_message_marker(
+                        reconcile_snapshot,
+                        digest=reconcile_digest,
+                        marker=reconcile_marker,
+                    ):
+                        retry_recommendation = "retry_step_execution"
+                except Exception:
+                    # Ambiguous — preserve workspace authority, no fresh retry.
+                    retry_recommendation = None
         return AgentRunResult(
             outputRefs=bundle.output_refs,
             summary=_compact_summary(exc, fallback="Omnigent integration error"),

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -2580,6 +2580,57 @@ async def test_run_omnigent_execution_reports_httpx_transport_errors(
     assert result.metadata["externalStateRef"].startswith("artifact://omnigent/")
     assert result.metadata["checkpointKind"] == "external_state_ref"
     assert "workspaceRootRef" not in result.metadata
+    # No provider work exists yet, so a fresh step execution is safe.
+    assert result.retry_recommendation == "retry_step_execution"
+
+
+@pytest.mark.asyncio
+async def test_run_omnigent_execution_http_status_does_not_request_fresh_retry(
+    monkeypatch,
+) -> None:
+    """Non-2xx provider responses keep the existing non-retryable contract.
+
+    Only status-less transport failures before any provider work recommend a
+    fresh step execution; a typed HTTP status may carry auth/billing or
+    post-work semantics that a blind fresh session would discard.
+    """
+
+    from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        async def list_agents(self) -> dict[str, object]:
+            raise OmnigentClientError(
+                "Omnigent HTTP 500",
+                status_code=500,
+                failure_class="integration_error",
+            )
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", FakeClient)
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "codex-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"text": "Do the task"},
+                },
+            },
+        )
+    )
+
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "500"
+    assert result.retry_recommendation is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -2590,9 +2590,9 @@ async def test_run_omnigent_execution_http_status_does_not_request_fresh_retry(
 ) -> None:
     """Non-2xx provider responses keep the existing non-retryable contract.
 
-    Only status-less transport failures before any provider work recommend a
-    fresh step execution; a typed HTTP status may carry auth/billing or
-    post-work semantics that a blind fresh session would discard.
+    Only status-less transport failures reconciled as never accepted
+    recommend a fresh step execution; a typed HTTP status may carry
+    auth/billing or post-work semantics that a fresh session would discard.
     """
 
     from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
@@ -2630,6 +2630,164 @@ async def test_run_omnigent_execution_http_status_does_not_request_fresh_retry(
 
     assert result.failure_class == "integration_error"
     assert result.provider_error_code == "500"
+    assert result.retry_recommendation is None
+
+
+def _post_timeout_client(*, with_marker: bool, marker: str) -> type:
+    """Provider double where the first-message POST times out ambiguously.
+
+    All instances share one ``post_attempted`` flag so the fresh reconcile
+    client in the failure path observes the same server state as the attempt
+    client. Before the POST, snapshots carry no marker; after the POST
+    attempt, the reconcile snapshot carries the marker only when
+    ``with_marker`` is true (server accepted) and omits it otherwise.
+    """
+
+    shared = {"post_attempted": False}
+
+    class FakeClient:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        async def list_agents(self) -> dict[str, object]:
+            return {"items": [{"id": "agent-1", "name": "opencode-native-ui"}]}
+
+        async def create_session(
+            self, payload: dict[str, object]
+        ) -> dict[str, object]:
+            return {"id": "session-1"}
+
+        async def get_session(self, session_id: str) -> dict[str, object]:
+            if not shared["post_attempted"]:
+                return {
+                    "status": "idle",
+                    "items": [{"id": "prior-item", "type": "message"}],
+                }
+            if with_marker:
+                return {
+                    "status": "idle",
+                    "items": [
+                        {"id": "prior-item", "type": "message"},
+                        {
+                            "id": "marked-user",
+                            "type": "message",
+                            "data": {"text": marker},
+                        },
+                    ],
+                }
+            return {
+                "status": "idle",
+                "items": [{"id": "prior-item", "type": "message"}],
+            }
+
+        async def post_event(
+            self, session_id: str, payload: dict[str, object]
+        ) -> dict[str, object]:
+            shared["post_attempted"] = True
+            raise httpx.ReadTimeout(
+                "read timed out",
+                request=httpx.Request("POST", "https://omnigent.test"),
+            )
+
+        async def stream_events(self, session_id: str):  # type: ignore[misc]
+            if False:
+                yield {}
+            await asyncio.Event().wait()
+
+    return FakeClient
+
+
+@pytest.mark.asyncio
+async def test_post_timeout_without_remote_accept_recommends_fresh_retry(
+    monkeypatch, tmp_path
+) -> None:
+    """A POST timeout the server never accepted is safe to retry fresh."""
+
+    correlation_id = "corr-post-timeout-absent"
+    idempotency_key = "idem-post-timeout-absent"
+    marker = (
+        "MoonMind-Omnigent-Run:\n"
+        f"  correlationId: {correlation_id}\n"
+        f"  idempotencyKey: {idempotency_key}"
+    )
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr(
+        "moonmind.omnigent.execute.OmnigentHttpClient",
+        _post_timeout_client(with_marker=False, marker=marker),
+    )
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId=correlation_id,
+            idempotencyKey=idempotency_key,
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "opencode-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"text": "Do the task"},
+                },
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+        run_store=_RecordingBridgeStore(),
+    )
+
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "omnigent_http_error"
+    assert result.retry_recommendation == "retry_step_execution"
+
+
+@pytest.mark.asyncio
+async def test_post_timeout_with_remote_accept_withholds_fresh_retry(
+    monkeypatch, tmp_path
+) -> None:
+    """A POST timeout the server accepted must not duplicate work fresh.
+
+    The remote marker proves the session began work; recommending a fresh
+    session with a new idempotency key would abandon the authoritative
+    workspace. Fail safe with no fresh retry so existing reattach/manual
+    paths preserve authority.
+    """
+
+    correlation_id = "corr-post-timeout-present"
+    idempotency_key = "idem-post-timeout-present"
+    marker = (
+        "MoonMind-Omnigent-Run:\n"
+        f"  correlationId: {correlation_id}\n"
+        f"  idempotencyKey: {idempotency_key}"
+    )
+
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
+    monkeypatch.setattr(
+        "moonmind.omnigent.execute.OmnigentHttpClient",
+        _post_timeout_client(with_marker=True, marker=marker),
+    )
+
+    result = await run_omnigent_execution(
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId=correlation_id,
+            idempotencyKey=idempotency_key,
+            parameters={
+                "omnigent": {
+                    "agent": {"agentName": "opencode-native-ui"},
+                    "session": {"allowEmptyWorkspace": True},
+                    "prompt": {"text": "Do the task"},
+                },
+            },
+        ),
+        artifact_gateway=LocalOmnigentArtifactGateway(root=tmp_path),
+        run_store=_RecordingBridgeStore(),
+    )
+
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "omnigent_http_error"
     assert result.retry_recommendation is None
 
 

--- a/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
+++ b/tests/unit/workflows/temporal/test_run_ungated_continuation_disposition.py
@@ -320,6 +320,38 @@ def test_explicit_step_retry_accepts_typed_integration_failure(
     )
 
 
+def test_explicit_step_retry_accepts_transport_failure_before_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A status-less transport failure before any provider work is retryable.
+
+    Regression for mm:2ebfad84-1c13-4572-af6f-bc1140f72842: an Omnigent
+    ``ReadTimeout`` during first-message POST surfaced as
+    ``integration_error``/``omnigent_http_error`` with no retry recommendation
+    and failed the workflow permanently after one 150s attempt. The executor
+    now recommends a fresh step execution when no work exists to preserve,
+    and the parent honors it through the existing explicit-retry contract.
+    """
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch: True)
+    workflow = MoonMindRunWorkflow()
+    result = {
+        "status": "FAILED",
+        "outputs": {
+            "error": "integration_error",
+            "failureClass": "integration_error",
+            "providerErrorCode": "omnigent_http_error",
+            "retryRecommendation": "retry_step_execution",
+        },
+    }
+
+    assert workflow._activity_result_retryable(
+        result,
+        failure_message="integration_error",
+        tool_type="agent_runtime",
+    )
+
+
 def test_explicit_step_retry_does_not_override_permanent_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
Workflow `mm:2ebfad84-1c13-4572-af6f-bc1140f72842` (rerun of `mm:bf2bdf71...`, PR review for g3-qrtr/crash_server_main#783) failed permanently after one 150s `POST /v1/sessions/.../events` attempt ended in `httpx.ReadTimeout`.

Chain:
- Omnigent session `185a526d...` created 03:46:59, runner `runner_token_3eef...` connected 03:47:00, MoonMind opened SSE stream 03:47:02 and POSTed first message (150s event timeout from #3973).
- Runner never completed opencode-native terminal ensure; `on_runner_connect` callback timed out after 30s (03:47:30), runner tunnel dropped with code 1000 at 03:49:32, aborting 3 in-flight requests.
- Server logged `session turn failed... tunnel closed` at 03:49:32.67 and returned `202 Accepted` at 03:49:33.04, just after MoonMind's client timed out (`Omnigent transport error: ReadTimeout`, 0 SSE events, `firstMessagePosted=False`).
- Executor returned `failureClass=integration_error`, `providerErrorCode=omnigent_http_error`, `retryRecommendation=null`. Parent `_activity_result_retryable` only honors `execution_error`/`system_error` or explicit `retry_step_execution`, so no step retry occurred and the workflow raised `Provider request failed with provider error omnigent_http_error...` as non-retryable.

The predecessor run (`mm:bf2bdf71...`) failed with `OMNIGENT_CURRENT_TURN_NOT_STARTED` + `retry_step_execution` and correctly retried (2h runtime); the rerun's transport variant had no such recommendation and failed fast in 3m.

## Fix
In `moonmind/omnigent/execute.py` transport handler (`OmnigentClientError`/`httpx.HTTPError`), when there is no HTTP status code, the first message was never posted, and no stream events were captured, set `retryRecommendation=retry_step_execution`. This reuses the existing explicit-retry contract (no new branches/config): the parent creates a bounded fresh step execution with a new session/idempotency key instead of failing permanently.

Failures with a typed HTTP status or after work started keep the existing classification so auth/billing errors and partial progress are never silently discarded by a fresh session.

## Tests
- Updated `test_run_omnigent_execution_reports_httpx_transport_errors` to assert `retry_step_execution` for pre-work transport.
- Added `test_run_omnigent_execution_http_status_does_not_request_fresh_retry` (500 keeps `retry=None`).
- Added `test_explicit_step_retry_accepts_transport_failure_before_work` proving the parent honors `omnigent_http_error` + `retry_step_execution`.
- Targeted suites pass: `tests/unit/omnigent/test_execute.py` (108 passed), `test_run_ungated_continuation_disposition.py` (36 passed), omnigent activities/client (49 passed).