### PR TITLE
[Settings redesign] Add migration, accessibility, and end-to-end conformance coverage (MoonLadderStudios/MoonMind#3822)

### DIFF
--- a/docs/UI/ProviderProfileCreation.md
+++ b/docs/UI/ProviderProfileCreation.md
@@ -576,6 +576,23 @@ validateProviderProfileDraft
 - Cancel restores the normalized server profile.
 - Read-only users can inspect effective advanced policy without edit controls.
 
+### 14.6 Conformance suite
+
+The end-to-end contract above is machine-verified by
+`frontend/src/components/settings/providerProfileRedesignConformance.test.tsx`,
+which exercises the standard-creation matrix for every authentication and
+materialization class the repository supports, progressive disclosure and draft
+preservation, hidden-field validation focus, the integrated model-tier create
+journey, existing-profile compatibility, and the guard that rejects a second
+hand-maintained creation-preset schema in React. The per-behavior unit tests
+remain in `frontend/src/components/settings/ProviderProfilesManager.test.tsx`.
+
+Focused local command:
+
+```bash
+npm run ui:test:settings-redesign
+```
+
 ---
 
 ## 15. Acceptance Criteria

--- a/docs/UI/SettingsPage.md
+++ b/docs/UI/SettingsPage.md
@@ -676,6 +676,34 @@ The design is satisfied when:
 28. A concurrent-change `version_conflict` stops the save, refreshes the affected descriptors, shows the conflict, and requires explicit resubmission.
 29. Rendered rows keep the descriptor fields section 9 declares load-bearing, including active state, activation guidance, application requirements, and ordering.
 
+### 15.1 Conformance suite
+
+The acceptance criteria above are machine-verified by one conformance suite that
+crosses the routing, navigation, page-boundary, draft-guard, and Provider
+Profile boundaries:
+
+| File | Covers |
+|---|---|
+| `frontend/src/entrypoints/settingsRedesignConformance.test.tsx` | canonical route resolution and document titles, legacy `/settings`, `?section=`, `/secrets`, `/workers`, and retained-alias replacement redirects, dirty-draft departure after successful and failed saves, and the architecture guards for sections 12 and 14 |
+| `frontend/src/components/settings/providerProfileRedesignConformance.test.tsx` | the Provider Profile standard-creation matrix, progressive disclosure, model-tier integration, existing-profile compatibility, and the generated-contract guard described in `docs/UI/ProviderProfileCreation.md` |
+| `tests/unit/api/routers/test_dashboard_destination_registry_agreement.py` | exact agreement between the server destination registry and `frontend/src/lib/dashboardRoutes.ts`, including Configuration group membership and order |
+
+Focused local commands:
+
+```bash
+# Both frontend conformance files.
+npm run ui:test:settings-redesign
+
+# Server/frontend destination registry agreement.
+./tools/test_unit.sh --python-only tests/unit/api/routers/test_dashboard_destination_registry_agreement.py
+```
+
+The suite runs in required CI through the frontend and unit suites; it is not a
+substitute for the per-page unit tests, which remain in
+`frontend/src/entrypoints/settingsRoutes.test.tsx`,
+`frontend/src/entrypoints/settingsDraftNavigation.test.tsx`, and
+`frontend/src/entrypoints/dashboard.test.tsx`.
+
 ---
 
 ## 16. Decision Summary

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -645,11 +645,32 @@ function extractErrorCode(payload: unknown): string | null {
   return null;
 }
 
+/**
+ * FastAPI request validation answers with `detail: [{ loc: ['body', <field>, ...] }]`,
+ * so read the first body-scoped location instead of treating the array as an
+ * object that carries a `field` key.
+ */
+function extractValidationDetailField(detail: readonly unknown[]): string | null {
+  for (const entry of detail) {
+    if (!entry || typeof entry !== 'object') continue;
+    const loc = (entry as Record<string, unknown>).loc;
+    if (!Array.isArray(loc)) continue;
+    const bodyIndex = loc.indexOf('body');
+    if (bodyIndex < 0) continue;
+    const field = loc[bodyIndex + 1];
+    if (typeof field === 'string') return field;
+  }
+  return null;
+}
+
 /** Canonical Provider Profile field a server validation failure targets. */
 function extractErrorField(payload: unknown): string | null {
   if (!payload || typeof payload !== 'object') return null;
   const record = payload as Record<string, unknown>;
   if (typeof record.field === 'string') return record.field;
+  if (Array.isArray(record.detail)) {
+    return extractValidationDetailField(record.detail);
+  }
   if (record.detail && typeof record.detail === 'object') {
     const detail = record.detail as Record<string, unknown>;
     if (typeof detail.field === 'string') return detail.field;

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -66,44 +66,34 @@ export interface ProviderProfileLaunchIsolation {
   audit_reason_present: boolean;
 }
 
-type AuthenticationMethod = 'oauth' | 'api_key' | 'none';
+// The backend owns every creation-preset and creation-capability shape. These
+// aliases are the single frontend binding to the generated contract; a second
+// hand-maintained copy is rejected by
+// providerProfileRedesignConformance.test.tsx (#3822).
+type AuthenticationMethod = components['schemas']['ProviderProfileAuthenticationMethod'];
 
-interface CreationPresetField {
-  value: unknown;
-  source: string;
-  editable: boolean;
-  lock_reason: string;
-}
+type AuthenticationMethodCapability =
+  components['schemas']['ProviderProfileAuthenticationMethodCapability'];
 
-interface SecretRoleCapability {
-  role: string;
-  label: string;
-  required: boolean;
-  compatible_schemes: string[];
-}
+type ProviderProfileCreationCapabilities =
+  components['schemas']['ProviderProfileCreationCapabilitiesResponse'];
 
-interface AuthenticationMethodCapability {
-  id: AuthenticationMethod;
-  label: string;
-  setup_action: AuthenticationMethod;
-  launch_ready_after_setup: boolean;
-  fields: Record<string, CreationPresetField>;
-  secret_roles: SecretRoleCapability[];
-  imported_volume: {
-    supported: boolean;
-    mount_path: string | null;
-    source: string;
-    lock_reason: string;
-  };
-}
+const AUTHENTICATION_METHODS: readonly AuthenticationMethod[] = [
+  'oauth',
+  'api_key',
+  'none',
+];
 
-interface ProviderProfileCreationCapabilities {
-  version: string;
-  runtime_id: string;
-  provider_id: string;
-  supported: boolean;
-  authentication_methods: AuthenticationMethodCapability[];
-  diagnostics: string[];
+/**
+ * Narrow a server-declared authentication method id to the canonical enum.
+ * The generated capability contract types `id` as a plain string, so an
+ * unrecognized value selects nothing instead of being coerced into a
+ * credential contract the browser cannot honor.
+ */
+function asAuthenticationMethod(value: string | null | undefined): AuthenticationMethod | '' {
+  return AUTHENTICATION_METHODS.includes(value as AuthenticationMethod)
+    ? (value as AuthenticationMethod)
+    : '';
 }
 
 interface ProviderProfileTierCapabilities {
@@ -655,15 +645,57 @@ function extractErrorCode(payload: unknown): string | null {
   return null;
 }
 
+/** Canonical Provider Profile field a server validation failure targets. */
+function extractErrorField(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.field === 'string') return record.field;
+  if (record.detail && typeof record.detail === 'object') {
+    const detail = record.detail as Record<string, unknown>;
+    if (typeof detail.field === 'string') return detail.field;
+    const requiredFields = detail.required_fields;
+    if (Array.isArray(requiredFields) && typeof requiredFields[0] === 'string') {
+      return requiredFields[0];
+    }
+  }
+  return null;
+}
+
 class ProviderProfileRequestError extends Error {
   constructor(
     message: string,
     readonly code: string | null,
+    readonly field: string | null = null,
   ) {
     super(message);
     this.name = 'ProviderProfileRequestError';
   }
 }
+
+/**
+ * Provider Profile fields that only exist inside the `Show advanced options`
+ * region. Server validation aimed at one of these must reveal the region and
+ * move focus to the offending control (ProviderProfileCreation.md 10.2-10.3).
+ */
+const ADVANCED_DISCLOSURE_FIELDS: ReadonlySet<string> = new Set([
+  'provider_label',
+  'credential_source',
+  'runtime_materialization_mode',
+  'secret_refs',
+  'volume_ref',
+  'volume_mount_path',
+  'cooldown_after_429_seconds',
+  'rate_limit_policy',
+  'priority',
+  'tags',
+  'command_behavior',
+  'clear_env_keys',
+]);
+
+const ADVANCED_REGION_ID = 'provider-profile-advanced-region';
+
+const FOCUSABLE_ADVANCED_CONTROL =
+  'input:not([disabled]):not([readonly]), select:not([disabled]), textarea:not([disabled]):not([readonly]), button:not([disabled])';
 
 function isFirstPartyOAuthProfile(profile: ProviderProfile): boolean {
   const authActions = commandBehaviorStringArray(profile, 'auth_actions') ?? [];
@@ -1104,6 +1136,9 @@ export function ProviderProfilesManager({
     useState<ProviderProfileCreationCapabilities | null>(null);
   const [creationCapabilitiesError, setCreationCapabilitiesError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [advancedFocusRequest, setAdvancedFocusRequest] = useState<
+    { field: string; nonce: number } | null
+  >(null);
   const [showImportedVolume, setShowImportedVolume] = useState(false);
   const [importedVolumeRef, setImportedVolumeRef] = useState('');
   const [importedVolumeValidated, setImportedVolumeValidated] = useState(false);
@@ -1197,7 +1232,7 @@ export function ProviderProfilesManager({
     () => profiles.find((profile) => profile.profile_id === editingProfileId) ?? null,
     [editingProfileId, profiles],
   );
-  const selectedAuthenticationCapability = useMemo(
+  const selectedAuthenticationCapability = useMemo<AuthenticationMethodCapability | null>(
     () =>
       creationCapabilities?.authentication_methods.find(
         (method) => method.id === form.authenticationMethod,
@@ -1272,7 +1307,9 @@ export function ProviderProfilesManager({
             ? current
             : {
                 ...current,
-                authenticationMethod: capabilities.authentication_methods[0]?.id ?? '',
+                authenticationMethod: asAuthenticationMethod(
+                  capabilities.authentication_methods[0]?.id,
+                ),
               };
         });
         if (!capabilities.supported) {
@@ -1655,6 +1692,21 @@ export function ProviderProfilesManager({
   }, [tierBaseline, tierBaselineDefaultId, tierDrafts, defaultTierClientId]);
 
   const hasTierDraft = tierDrafts.length > 0 || isTierRepair || invalidSavedDefaultIndex !== null;
+
+  // Server validation aimed at a collapsed advanced field reveals the region
+  // and hands focus to that control. The region is keyed by the canonical
+  // backend field name, so no per-error branch is needed.
+  useEffect(() => {
+    if (!advancedFocusRequest || !showAdvanced) return;
+    const region = document.getElementById(ADVANCED_REGION_ID);
+    const container = region?.querySelector<HTMLElement>(
+      `[data-advanced-field="${advancedFocusRequest.field}"]`,
+    );
+    const control =
+      container?.querySelector<HTMLElement>(FOCUSABLE_ADVANCED_CONTROL) ?? container ?? null;
+    control?.focus();
+    setAdvancedFocusRequest(null);
+  }, [advancedFocusRequest, showAdvanced]);
 
   useSettingsDraftRegistration(
     'provider-profile',
@@ -2179,7 +2231,11 @@ export function ProviderProfilesManager({
           errorPayload,
           `Failed to ${isEditing ? 'update' : 'create'} provider profile.`,
         );
-        throw new ProviderProfileRequestError(detail, extractErrorCode(errorPayload));
+        throw new ProviderProfileRequestError(
+          detail,
+          extractErrorCode(errorPayload),
+          extractErrorField(errorPayload),
+        );
       }
       return response.json() as Promise<ProviderProfile>;
     },
@@ -2280,6 +2336,16 @@ export function ProviderProfilesManager({
     },
     onError: (error: Error) => {
       setShowAdvanced(true);
+      const targetField =
+        error instanceof ProviderProfileRequestError ? error.field : null;
+      if (targetField && ADVANCED_DISCLOSURE_FIELDS.has(targetField)) {
+        // The control is inside the region we just revealed, so the focus move
+        // has to wait for that render.
+        setAdvancedFocusRequest((current) => ({
+          field: targetField,
+          nonce: (current?.nonce ?? 0) + 1,
+        }));
+      }
       if (
         !isEditing &&
         error instanceof ProviderProfileRequestError &&
@@ -3746,7 +3812,10 @@ export function ProviderProfilesManager({
                       checked={form.authenticationMethod === method.id}
                       disabled={isEditing}
                       onChange={() => {
-                        setForm((current) => ({ ...current, authenticationMethod: method.id }));
+                        setForm((current) => ({
+                          ...current,
+                          authenticationMethod: asAuthenticationMethod(method.id),
+                        }));
                         setShowImportedVolume(false);
                         setImportedVolumeValidated(false);
                       }}
@@ -4138,7 +4207,7 @@ export function ProviderProfilesManager({
               <input
                 type="checkbox"
                 checked={showAdvanced}
-                aria-controls="provider-profile-advanced-region"
+                aria-controls={ADVANCED_REGION_ID}
                 onChange={(event) => setShowAdvanced(event.target.checked)}
               />
               Show advanced options
@@ -4156,14 +4225,14 @@ export function ProviderProfilesManager({
           </div>
 
           {showAdvanced ? (
-            <div id="provider-profile-advanced-region" className="space-y-6">
+            <div id={ADVANCED_REGION_ID} className="space-y-6">
               <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
                 <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
                   Credential launch contract
                 </legend>
                 <div className="grid gap-4 md:grid-cols-2">
                   {manualCreationAllowed ? (
-                    <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                    <label data-advanced-field="credential_source" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                       <span>Credential source</span>
                       <select
                         className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm"
@@ -4182,7 +4251,7 @@ export function ProviderProfilesManager({
                       </select>
                     </label>
                   ) : (
-                    <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 p-4 text-sm">
+                    <div data-advanced-field="credential_source" tabIndex={-1} className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 p-4 text-sm">
                     <div className="font-semibold text-slate-800 dark:text-slate-200">
                       Credential source: {String(selectedCredentialSource)}
                     </div>
@@ -4195,7 +4264,7 @@ export function ProviderProfilesManager({
                   </div>
                   )}
                   {manualCreationAllowed ? (
-                    <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                    <label data-advanced-field="runtime_materialization_mode" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                       <span>Materialization mode</span>
                       <select
                         className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm"
@@ -4216,7 +4285,7 @@ export function ProviderProfilesManager({
                       </select>
                     </label>
                   ) : (
-                    <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 p-4 text-sm">
+                    <div data-advanced-field="runtime_materialization_mode" tabIndex={-1} className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 p-4 text-sm">
                     <div className="font-semibold text-slate-800 dark:text-slate-200">
                       Materialization mode: {String(selectedMaterializationMode)}
                     </div>
@@ -4235,6 +4304,7 @@ export function ProviderProfilesManager({
                 <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
                   Role-aware SecretRef bindings
                 </legend>
+                <div data-advanced-field="secret_refs" className="space-y-4">
                 {(selectedAuthenticationCapability?.secret_roles ?? []).map((role) => {
                   const controlId = `provider-profile-secret-role-${role.role}`;
                   return (
@@ -4279,19 +4349,20 @@ export function ProviderProfilesManager({
                 {(selectedAuthenticationCapability?.secret_roles.length ?? 0) === 0 && unknownSecretRoleBindings.length === 0 ? (
                   <p className="text-sm text-slate-500 dark:text-slate-400">This authentication method declares no SecretRef roles.</p>
                 ) : null}
+                </div>
               </fieldset>
 
               <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
                 <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
                   Credential volume metadata
                 </legend>
-                <dl className="grid gap-3 text-sm md:grid-cols-2">
+                <dl data-advanced-field="volume_ref" tabIndex={-1} className="grid gap-3 text-sm md:grid-cols-2">
                   <div className="rounded-xl bg-slate-50 dark:bg-slate-900 p-3">
                     <dt className="font-medium text-slate-700 dark:text-slate-300">Volume reference</dt>
                     <dd className="font-mono text-slate-600 dark:text-slate-400">{volumeReferenceLabel}</dd>
                   </div>
                   <div className="rounded-xl bg-slate-50 dark:bg-slate-900 p-3">
-                    <dt className="font-medium text-slate-700 dark:text-slate-300">Mount path</dt>
+                    <dt data-advanced-field="volume_mount_path" tabIndex={-1} className="font-medium text-slate-700 dark:text-slate-300">Mount path</dt>
                     <dd className="font-mono text-slate-600 dark:text-slate-400">{volumeMountPathLabel}</dd>
                   </div>
                 </dl>
@@ -4346,15 +4417,15 @@ export function ProviderProfilesManager({
               <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
                 <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">Advanced profile policy</legend>
                 <div className="grid gap-4 md:grid-cols-2">
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="provider_label" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Provider label override</span>
                     <input className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={form.providerLabel} onChange={(event) => setForm((current) => ({ ...current, providerLabel: event.target.value }))} />
                   </label>
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="cooldown_after_429_seconds" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Cooldown after 429 (seconds)</span>
                     <input type="number" min="0" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={form.cooldownAfter429Seconds} onChange={(event) => setForm((current) => ({ ...current, cooldownAfter429Seconds: event.target.value }))} />
                   </label>
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="rate_limit_policy" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Rate limit policy</span>
                     <select className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={form.rateLimitPolicy} onChange={(event) => setForm((current) => ({ ...current, rateLimitPolicy: event.target.value }))}>
                       <option value="backoff">backoff</option>
@@ -4362,21 +4433,21 @@ export function ProviderProfilesManager({
                       <option value="fail_fast">fail_fast</option>
                     </select>
                   </label>
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="priority" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Priority</span>
                     <input type="number" min="0" className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={form.priority} onChange={(event) => setForm((current) => ({ ...current, priority: event.target.value }))} placeholder="100" />
                   </label>
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="tags" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Tags</span>
                     <input className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm" value={form.tagsText} onChange={(event) => setForm((current) => ({ ...current, tagsText: event.target.value }))} placeholder="team, preferred" />
                   </label>
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label data-advanced-field="command_behavior" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Command behavior</span>
                     <textarea rows={4} className="w-full rounded-xl border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 font-mono text-sm" value={form.commandBehavior} onChange={(event) => setForm((current) => ({ ...current, commandBehavior: event.target.value }))} />
                   </label>
                 </div>
                 {manualCreationAllowed ? (
-                  <label className="flex flex-col gap-1.5 text-sm font-medium text-amber-800 dark:text-amber-300">
+                  <label data-advanced-field="clear_env_keys" className="flex flex-col gap-1.5 text-sm font-medium text-amber-800 dark:text-amber-300">
                     <span>Clear env keys — manual expert path (validated; overrides are audited)</span>
                     <textarea
                       rows={3}
@@ -4392,7 +4463,7 @@ export function ProviderProfilesManager({
                     <p className="text-xs text-amber-700 dark:text-amber-300">Warning: freeform clear_env_keys is only allowed for unsupported combinations via the manual creation path. Values are validated by the backend (known keys, valid names, bounded list, no unsafe keys); updates to supported profiles require superuser permission with an audit reason and warning acknowledgement, and are recorded with actor metadata. Bypassing backend-recommended isolation can break launches or leak credentials, so review it carefully.</p>
                   </label>
                 ) : (
-                  <div className="rounded-xl bg-slate-50 dark:bg-slate-900 p-3 text-xs text-slate-500 dark:text-slate-400">
+                  <div data-advanced-field="clear_env_keys" tabIndex={-1} className="rounded-xl bg-slate-50 dark:bg-slate-900 p-3 text-xs text-slate-500 dark:text-slate-400">
                     <div className="font-medium text-slate-700 dark:text-slate-300">Launch environment isolation — clear environment keys</div>
                     {isEditing && editingProfile?.launch_isolation ? (
                       <>

--- a/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
+++ b/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
@@ -1,0 +1,1024 @@
+/**
+ * Provider Profile creation conformance suite.
+ *
+ * MoonLadderStudios/MoonMind#3822 (parent MoonLadderStudios/MoonMind#3815).
+ *
+ * Covers the standard-creation matrix for every authentication and
+ * materialization class the repository supports, progressive disclosure and
+ * draft preservation, hidden-field validation focus, the integrated model-tier
+ * create journey, existing-profile compatibility, and the guard that rejects a
+ * second hand-maintained creation-preset schema in React.
+ *
+ * Run it on its own with `npm run ui:test:settings-redesign`.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { QueryClient } from '@tanstack/react-query';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithClient } from '../../utils/test-utils';
+import { ProviderProfilesManager, type ProviderProfile } from './ProviderProfilesManager';
+
+type CreationCapabilities = NonNullable<ProviderProfile['creation_capabilities']>;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+type AuthMethodId = 'oauth' | 'api_key' | 'none';
+
+interface CreationClass {
+  name: string;
+  runtimeId: string;
+  providerId: string;
+  method: AuthMethodId;
+  methodLabel: string;
+  materialization: string;
+  secretRole: string | null;
+  secretRoleLabel: string;
+  importedVolumeMountPath: string | null;
+  clearEnvKeys: string[];
+  /** Backend activation state returned by an atomic guided create. */
+  savedAuthState: string;
+}
+
+/**
+ * Every runtime/provider/authentication combination that
+ * api_service/services/provider_profile_creation_presets.py currently ships a
+ * validated standard creation preset for, plus the credential-free capability
+ * declared by provider_profile_creation.py.
+ */
+const CREATION_CLASSES: readonly CreationClass[] = [
+  {
+    name: 'Codex + OpenAI OAuth',
+    runtimeId: 'codex_cli',
+    providerId: 'openai',
+    method: 'oauth',
+    methodLabel: 'OAuth',
+    materialization: 'oauth_home',
+    secretRole: null,
+    secretRoleLabel: '',
+    importedVolumeMountPath: '/home/app/.codex',
+    clearEnvKeys: ['OPENAI_API_KEY'],
+    savedAuthState: 'oauth_pending',
+  },
+  {
+    name: 'Codex + OpenAI API key',
+    runtimeId: 'codex_cli',
+    providerId: 'openai',
+    method: 'api_key',
+    methodLabel: 'API key',
+    materialization: 'api_key_env',
+    secretRole: 'openai_api_key',
+    secretRoleLabel: 'OpenAI API key',
+    importedVolumeMountPath: null,
+    clearEnvKeys: ['CODEX_HOME'],
+    savedAuthState: 'api_key_pending',
+  },
+  {
+    name: 'Claude Code + Anthropic OAuth',
+    runtimeId: 'claude_code',
+    providerId: 'anthropic',
+    method: 'oauth',
+    methodLabel: 'OAuth',
+    materialization: 'oauth_home',
+    secretRole: null,
+    secretRoleLabel: '',
+    importedVolumeMountPath: '/home/app/.claude',
+    clearEnvKeys: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
+    savedAuthState: 'oauth_pending',
+  },
+  {
+    name: 'Claude Code + Anthropic API key',
+    runtimeId: 'claude_code',
+    providerId: 'anthropic',
+    method: 'api_key',
+    methodLabel: 'API key',
+    materialization: 'api_key_env',
+    secretRole: 'anthropic_api_key',
+    secretRoleLabel: 'Anthropic API key',
+    importedVolumeMountPath: null,
+    clearEnvKeys: ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_BASE_URL'],
+    savedAuthState: 'api_key_pending',
+  },
+  {
+    name: 'OpenCode Go API key with composite materialization',
+    runtimeId: 'opencode',
+    providerId: 'opencode-go',
+    method: 'api_key',
+    methodLabel: 'API key',
+    materialization: 'composite',
+    secretRole: 'opencode_api_key',
+    secretRoleLabel: 'OpenCode API key',
+    importedVolumeMountPath: null,
+    clearEnvKeys: ['OPENCODE_API_KEY'],
+    savedAuthState: 'api_key_pending',
+  },
+  {
+    name: 'Credential-free OpenCode capability',
+    runtimeId: 'opencode',
+    providerId: 'opencode',
+    method: 'none',
+    methodLabel: 'No credential',
+    materialization: 'composite',
+    secretRole: null,
+    secretRoleLabel: '',
+    importedVolumeMountPath: null,
+    clearEnvKeys: [],
+    savedAuthState: 'connected',
+  },
+];
+
+/** Advanced/plumbing fields a supported standard creation path must omit. */
+const OMITTED_ADVANCED_FIELDS = [
+  'credential_source',
+  'runtime_materialization_mode',
+  'secret_refs',
+  'volume_ref',
+  'volume_mount_path',
+  'max_parallel_runs',
+  'cooldown_after_429_seconds',
+  'rate_limit_policy',
+  'enabled',
+  'is_default',
+  'command_behavior',
+  'tags',
+  'priority',
+  'clear_env_keys',
+];
+
+function presetField(value: unknown, editable = true, source = 'runtime_provider_strategy') {
+  return {
+    value,
+    source,
+    editable,
+    required: false,
+    lock_reason: editable ? null : 'Backend launch policy owns this value.',
+  };
+}
+
+function capabilitiesFor(creationClass: CreationClass) {
+  return {
+    version: `provider-profile-creation-v1-${creationClass.runtimeId}-${creationClass.providerId}`,
+    runtime_id: creationClass.runtimeId,
+    provider_id: creationClass.providerId,
+    supported: true,
+    authentication_methods: [
+      {
+        id: creationClass.method,
+        label: creationClass.methodLabel,
+        setup_action: creationClass.method,
+        launch_ready_after_setup: true,
+        fields: {
+          credential_source: presetField(
+            creationClass.method === 'oauth'
+              ? 'oauth_volume'
+              : creationClass.method === 'api_key'
+                ? 'secret_ref'
+                : 'none',
+            false,
+          ),
+          runtime_materialization_mode: presetField(creationClass.materialization, false),
+          clear_env_keys: presetField(
+            creationClass.clearEnvKeys,
+            false,
+            'runtime_provider_isolation_policy',
+          ),
+        },
+        secret_roles: creationClass.secretRole
+          ? [
+              {
+                role: creationClass.secretRole,
+                label: creationClass.secretRoleLabel,
+                required: true,
+                compatible_schemes: ['db', 'env'],
+              },
+            ]
+          : [],
+        imported_volume: {
+          supported: creationClass.importedVolumeMountPath !== null,
+          mount_path: creationClass.importedVolumeMountPath,
+          source: 'runtime_provider_strategy',
+          lock_reason: 'The runtime strategy owns the credential mount path.',
+        },
+      },
+    ],
+    diagnostics: [],
+  };
+}
+
+function presetFor(creationClass: CreationClass) {
+  const capabilities = capabilitiesFor(creationClass);
+  const method = capabilities.authentication_methods[0]!;
+  return {
+    version: capabilities.version,
+    supported: true,
+    runtime_id: creationClass.runtimeId,
+    provider_id: creationClass.providerId,
+    authentication_method: creationClass.method,
+    fields: {
+      credential_source: method.fields.credential_source,
+      runtime_materialization_mode: method.fields.runtime_materialization_mode,
+      secret_refs: presetField({}),
+      volume_ref: presetField(null, false),
+      volume_mount_path: presetField(null, false),
+      max_parallel_runs: presetField(1, creationClass.method !== 'oauth'),
+      cooldown_after_429_seconds: presetField(300),
+      rate_limit_policy: presetField('backoff'),
+      enabled: presetField(creationClass.method === 'none', false),
+      is_default: presetField(false),
+      command_behavior: presetField({ auth_strategy: creationClass.materialization }, false),
+      user_tags: presetField([]),
+      priority: presetField(100),
+      clear_env_keys: method.fields.clear_env_keys,
+    },
+    diagnostics: [],
+    manual_creation_allowed: false,
+    required_manual_fields: [],
+  };
+}
+
+function tierCapabilitiesResponse(url: string): Response | null {
+  if (
+    !url.startsWith('/api/v1/provider-profiles/capabilities?') &&
+    !/\/api\/v1\/provider-profiles\/[^/]+\/capabilities/.test(url)
+  ) {
+    return null;
+  }
+  return {
+    ok: true,
+    json: async () => ({
+      version: 'tier-cap-v1-conformance',
+      profile_id: null,
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      evidence: {
+        source: 'runtime_draft',
+        credential_generation: null,
+        image_ref: null,
+        observed_at: null,
+        stale: false,
+      },
+      tier_constraints: { min_count: 1, max_count: null },
+      model: {
+        runtime_default: 'gpt-5.5',
+        allow_custom: true,
+        options: [
+          { value: 'gpt-5.5', label: 'GPT-5.5', description: null, status: 'available', recommended: true },
+          { value: 'gpt-4o', label: 'GPT-4o', description: null, status: 'available', recommended: false },
+        ],
+      },
+      effort: {
+        supported: true,
+        runtime_default: 'medium',
+        allow_custom: false,
+        application: 'native',
+        options: [
+          { value: 'low', label: 'Low', description: null, status: 'available', compatible_models: null },
+          { value: 'medium', label: 'Medium', description: null, status: 'available', compatible_models: null },
+          { value: 'high', label: 'High', description: null, status: 'available', compatible_models: null },
+        ],
+      },
+      diagnostics: [],
+    }),
+  } as Response;
+}
+
+function savedProfileFor(creationClass: CreationClass, profileId: string): ProviderProfile {
+  return {
+    profile_id: profileId,
+    runtime_id: creationClass.runtimeId,
+    provider_id: creationClass.providerId,
+    authentication_method: creationClass.method,
+    credential_source:
+      creationClass.method === 'oauth'
+        ? 'oauth_volume'
+        : creationClass.method === 'api_key'
+          ? 'secret_ref'
+          : 'none',
+    runtime_materialization_mode: creationClass.materialization,
+    secret_refs: {},
+    max_parallel_runs: 1,
+    cooldown_after_429_seconds: 300,
+    rate_limit_policy: 'backoff',
+    enabled: creationClass.method === 'none',
+    is_default: false,
+    auth_state: creationClass.savedAuthState,
+    disabled_reason: creationClass.method === 'none' ? null : 'missing_credentials',
+    volume_ref: creationClass.method === 'oauth' ? 'moonmind_oauth_generated' : null,
+    volume_mount_path: creationClass.importedVolumeMountPath,
+    clear_env_keys: creationClass.clearEnvKeys,
+    creation_capabilities: capabilitiesFor(creationClass) as unknown as CreationCapabilities,
+  };
+}
+
+function renderManager(profiles: ProviderProfile[] = []) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onNotice = vi.fn();
+  renderWithClient(
+    <ProviderProfilesManager
+      profiles={profiles}
+      secretSlugs={['OPENAI_API_KEY']}
+      onNotice={onNotice}
+      queryClient={queryClient}
+      defaultTaskModelByRuntime={{}}
+    />,
+  );
+  return { onNotice, queryClient };
+}
+
+async function startStandardCreation(creationClass: CreationClass, profileId: string) {
+  fireEvent.change(screen.getByLabelText(/Profile ID/), { target: { value: profileId } });
+  fireEvent.change(screen.getByLabelText(/Runtime ID/), {
+    target: { value: creationClass.runtimeId },
+  });
+  fireEvent.change(screen.getByLabelText(/Provider ID/), {
+    target: { value: creationClass.providerId },
+  });
+  fireEvent.click(await screen.findByLabelText(creationClass.methodLabel));
+  await screen.findByText(new RegExp(`Backend preset ${presetFor(creationClass).version} loaded`));
+  // Flush passive effects so the save mutation observes the loaded preset,
+  // exactly as it has by the time a real user can reach the submit button.
+  await act(async () => undefined);
+}
+
+function creationFetch(creationClass: CreationClass, profileId: string) {
+  const preset = presetFor(creationClass);
+  const capabilities = capabilitiesFor(creationClass);
+  const saved = savedProfileFor(creationClass, profileId);
+  return vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+    const url = String(input);
+    const tier = tierCapabilitiesResponse(url);
+    if (tier) return tier;
+    if (url.startsWith('/api/v1/provider-profiles/creation-capabilities?')) {
+      return { ok: true, json: async () => capabilities } as Response;
+    }
+    if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+      return { ok: true, json: async () => preset } as Response;
+    }
+    if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+      return { ok: true, json: async () => saved } as Response;
+    }
+    if (url === '/api/v1/oauth-sessions' && init?.method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({
+          session_id: 'oas_conformance',
+          runtime_id: creationClass.runtimeId,
+          profile_id: profileId,
+          status: 'awaiting_user',
+          session_transport: 'tmate',
+          tmate_web_url: 'https://tmate.example/session',
+        }),
+      } as Response;
+    }
+    if (url.startsWith('/api/v1/oauth-sessions/oas_conformance')) {
+      return {
+        ok: true,
+        json: async () => ({
+          session_id: 'oas_conformance',
+          runtime_id: creationClass.runtimeId,
+          profile_id: profileId,
+          status: 'awaiting_user',
+          session_transport: 'tmate',
+          tmate_web_url: 'https://tmate.example/session',
+        }),
+      } as Response;
+    }
+    if (
+      url === `/api/v1/provider-profiles/${profileId}/credentials/api-key` &&
+      init?.method === 'POST'
+    ) {
+      return {
+        ok: true,
+        json: async () => ({
+          status: 'ready',
+          status_label: `${creationClass.secretRoleLabel} ready`,
+          readiness: { connected: true, backing_secret_exists: true, launch_ready: true },
+        }),
+      } as Response;
+    }
+    if (
+      url === `/api/v1/provider-profiles/${profileId}/manual-auth/commit` &&
+      init?.method === 'POST'
+    ) {
+      return {
+        ok: true,
+        json: async () => ({
+          status: 'ready',
+          status_label: 'Anthropic API key ready',
+          readiness: { connected: true, backing_secret_exists: true, launch_ready: true },
+        }),
+      } as Response;
+    }
+    throw new Error(`Unexpected fetch: ${url} ${String(init?.method)}`);
+  });
+}
+
+interface FetchSpyLike {
+  mock: { calls: unknown[][] };
+}
+
+function postPayload(fetchSpy: FetchSpyLike): Record<string, unknown> {
+  const call = fetchSpy.mock.calls.find(
+    (args) =>
+      args[0] === '/api/v1/provider-profiles' &&
+      (args[1] as RequestInit | undefined)?.method === 'POST',
+  );
+  expect(call).toBeTruthy();
+  return JSON.parse(String((call?.[1] as RequestInit).body)) as Record<string, unknown>;
+}
+
+describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation matrix', () => {
+  it.each(CREATION_CLASSES.map((creationClass) => [creationClass.name, creationClass] as const))(
+    'creates %s without any low-level plumbing interaction',
+    async (_name, creationClass) => {
+      vi.spyOn(window, 'open').mockReturnValue(null);
+      const profileId = `conformance-${creationClass.runtimeId}-${creationClass.method}`;
+      const fetchSpy = creationFetch(creationClass, profileId);
+      renderManager();
+      await startStandardCreation(creationClass, profileId);
+
+      // The standard form exposes no low-level credential or launch plumbing.
+      expect(screen.queryByLabelText(/Credential source/)).toBeNull();
+      expect(screen.queryByLabelText(/Materialization mode/)).toBeNull();
+      expect(screen.queryByLabelText(/Secret refs/)).toBeNull();
+      expect(screen.queryByLabelText(/Volume ref/)).toBeNull();
+      expect(screen.queryByLabelText(/Mount path/)).toBeNull();
+      expect(screen.queryByLabelText(/Cooldown after 429/)).toBeNull();
+      expect(screen.queryByLabelText(/Rate limit policy/)).toBeNull();
+      expect(screen.queryByLabelText(/Command behavior/)).toBeNull();
+      expect(screen.queryByLabelText(/^Tags$/)).toBeNull();
+      expect(screen.queryByLabelText(/^Priority$/)).toBeNull();
+      expect(screen.queryByLabelText(/Clear env keys/)).toBeNull();
+      // Standard identity and capacity controls stay visible.
+      expect(screen.getByLabelText(/Account label/)).toBeTruthy();
+      expect(screen.getByLabelText(/Max parallel runs/)).toBeTruthy();
+      expect(screen.getByLabelText('Runtime default')).toBeTruthy();
+      expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(false);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+      await waitFor(() =>
+        expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+      );
+
+      const payload = postPayload(fetchSpy);
+      expect(payload).toMatchObject({
+        profile_id: profileId,
+        runtime_id: creationClass.runtimeId,
+        provider_id: creationClass.providerId,
+        authentication_method: creationClass.method,
+        preset_version: presetFor(creationClass).version,
+      });
+      for (const field of OMITTED_ADVANCED_FIELDS) {
+        expect(payload).not.toHaveProperty(field);
+      }
+      // Model tier policy is canonical; no legacy default-model mirror.
+      expect(payload).toHaveProperty('model_tiers');
+      expect(payload).toHaveProperty('default_model_tier');
+      expect(payload).not.toHaveProperty('default_model');
+      expect(payload).not.toHaveProperty('default_effort');
+    },
+  );
+
+  it('continues Claude Code + Anthropic API-key creation through the one-way enrollment drawer', async () => {
+    const creationClass = CREATION_CLASSES.find(
+      (item) => item.runtimeId === 'claude_code' && item.method === 'api_key',
+    )!;
+    const profileId = 'conformance-claude-api-key';
+    const consoleArgs: unknown[] = [];
+    for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
+      vi.spyOn(console, level).mockImplementation((...args: unknown[]) => {
+        consoleArgs.push(...args);
+      });
+    }
+    const fetchSpy = creationFetch(creationClass, profileId);
+    renderManager();
+    await startStandardCreation(creationClass, profileId);
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue to API key paste' }));
+    const keyInput = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
+    expect(keyInput.type).toBe('password');
+    fireEvent.change(keyInput, { target: { value: 'sk-ant-conformance-secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Validate and save Anthropic API key' }));
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([url]) => url === `/api/v1/provider-profiles/${profileId}/manual-auth/commit`,
+        ),
+      ).toBe(true),
+    );
+    // Plaintext leaves through the one-way credential flow only, never the
+    // profile payload, the URL, or browser storage.
+    expect(JSON.stringify(postPayload(fetchSpy))).not.toContain('sk-ant-conformance-secret');
+    expect(window.location.href).not.toContain('sk-ant-conformance-secret');
+    expect(JSON.stringify(window.localStorage)).not.toContain('sk-ant-conformance-secret');
+    expect(JSON.stringify(window.sessionStorage)).not.toContain('sk-ant-conformance-secret');
+    expect(JSON.stringify(consoleArgs)).not.toContain('sk-ant-conformance-secret');
+    await waitFor(() => expect(document.body.textContent).not.toContain('sk-ant-conformance-secret'));
+  });
+
+  it('continues OpenCode Go API-key creation through the composite-materialization drawer', async () => {
+    const creationClass = CREATION_CLASSES.find((item) => item.providerId === 'opencode-go')!;
+    const profileId = 'conformance-opencode-api-key';
+    const fetchSpy = creationFetch(creationClass, profileId);
+    renderManager();
+    await startStandardCreation(creationClass, profileId);
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue to API key paste' }));
+    fireEvent.change(screen.getByLabelText('OpenCode API key'), {
+      target: { value: 'oc-conformance-secret' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Validate and save OpenCode API key' }),
+    );
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([url]) => url === `/api/v1/provider-profiles/${profileId}/credentials/api-key`,
+        ),
+      ).toBe(true),
+    );
+    expect(postPayload(fetchSpy)).not.toHaveProperty('runtime_materialization_mode');
+    await waitFor(() => expect(document.body.textContent).not.toContain('oc-conformance-secret'));
+  });
+
+  it('starts Claude Code + Anthropic OAuth enrollment without asking for volume data', async () => {
+    const creationClass = CREATION_CLASSES.find(
+      (item) => item.runtimeId === 'claude_code' && item.method === 'oauth',
+    )!;
+    const profileId = 'conformance-claude-oauth';
+    const fetchSpy = creationFetch(creationClass, profileId);
+    renderManager();
+    await startStandardCreation(creationClass, profileId);
+
+    expect(screen.queryByLabelText(/Volume/)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([url]) => url === '/api/v1/oauth-sessions')).toBe(true),
+    );
+    const payload = postPayload(fetchSpy);
+    expect(payload).not.toHaveProperty('volume_ref');
+    expect(payload).not.toHaveProperty('volume_mount_path');
+    const sessionCall = fetchSpy.mock.calls.find(([url]) => url === '/api/v1/oauth-sessions');
+    // Volume metadata reaches the OAuth session from the saved backend profile,
+    // not from anything the user typed.
+    expect(JSON.parse(String((sessionCall?.[1] as RequestInit).body))).toMatchObject({
+      runtime_id: 'claude_code',
+      provider_id: 'anthropic',
+      profile_id: profileId,
+      volume_ref: 'moonmind_oauth_generated',
+      volume_mount_path: '/home/app/.claude',
+    });
+  });
+
+  it('routes an env_bundle expert-manual combination through explicit manual creation', async () => {
+    // claude_code + minimax declares only an expert manual env_bundle contract,
+    // so no safe standard preset exists.
+    const unsupportedPreset = {
+      version: 'provider-profile-create-v1-minimax-manual',
+      supported: false,
+      runtime_id: 'claude_code',
+      provider_id: 'minimax',
+      authentication_method: 'api_key',
+      fields: {},
+      diagnostics: [
+        {
+          code: 'no_safe_standard_creation_preset',
+          severity: 'error',
+          message: 'Use the authorized manual profile path.',
+          field: null,
+          action: 'open_manual_profile',
+        },
+      ],
+      manual_creation_allowed: true,
+      required_manual_fields: ['credential_source', 'runtime_materialization_mode'],
+    };
+    const savedProfile: ProviderProfile = {
+      profile_id: 'conformance-minimax-env-bundle',
+      runtime_id: 'claude_code',
+      provider_id: 'minimax',
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'env_bundle',
+      secret_refs: { provider_api_key: 'db://OPENAI_API_KEY' },
+      max_parallel_runs: 1,
+      cooldown_after_429_seconds: 300,
+      rate_limit_policy: 'backoff',
+      enabled: false,
+    };
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      const tier = tierCapabilitiesResponse(url);
+      if (tier) return tier;
+      if (url.startsWith('/api/v1/provider-profiles/creation-capabilities?')) {
+        return {
+          ok: true,
+          json: async () => ({
+            version: unsupportedPreset.version,
+            runtime_id: 'claude_code',
+            provider_id: 'minimax',
+            supported: true,
+            authentication_methods: [
+              {
+                id: 'api_key',
+                label: 'MiniMax API key (expert)',
+                setup_action: 'api_key',
+                launch_ready_after_setup: false,
+                fields: {
+                  credential_source: presetField('secret_ref', true, 'expert_manual'),
+                  runtime_materialization_mode: presetField('env_bundle', true, 'expert_manual'),
+                },
+                secret_roles: [
+                  {
+                    role: 'provider_api_key',
+                    label: 'Provider API key',
+                    required: true,
+                    compatible_schemes: ['db'],
+                  },
+                ],
+                imported_volume: {
+                  supported: false,
+                  mount_path: null,
+                  source: 'expert_manual',
+                  lock_reason: 'Manual profiles do not import a volume.',
+                },
+              },
+            ],
+            diagnostics: [],
+          }),
+        } as Response;
+      }
+      if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+        return { ok: true, json: async () => unsupportedPreset } as Response;
+      }
+      if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+        return { ok: true, json: async () => savedProfile } as Response;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderManager();
+    fireEvent.change(screen.getByLabelText(/Profile ID/), {
+      target: { value: 'conformance-minimax-env-bundle' },
+    });
+    fireEvent.change(screen.getByLabelText(/Runtime ID/), { target: { value: 'claude_code' } });
+    fireEvent.change(screen.getByLabelText(/Provider ID/), { target: { value: 'minimax' } });
+    fireEvent.click(await screen.findByLabelText('MiniMax API key (expert)'));
+    await screen.findByText('Use the authorized manual profile path.');
+
+    // An unsupported combination reveals the expert region on its own and
+    // requires explicit low-level fields instead of inheriting a guessed
+    // materialization contract.
+    expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true);
+    fireEvent.change(screen.getByLabelText('Credential source'), {
+      target: { value: 'secret_ref' },
+    });
+    fireEvent.change(screen.getByLabelText('Materialization mode'), {
+      target: { value: 'env_bundle' },
+    });
+    fireEvent.change(screen.getByLabelText('Provider API key (required)'), {
+      target: { value: 'db://OPENAI_API_KEY' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+    );
+    const payload = postPayload(fetchSpy);
+    expect(payload).toMatchObject({
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'env_bundle',
+      secret_refs: { provider_api_key: 'db://OPENAI_API_KEY' },
+    });
+    // Manual creation never carries a preset version it did not validate.
+    expect(payload).not.toHaveProperty('preset_version');
+  });
+});
+
+describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts', () => {
+  const creationClass = CREATION_CLASSES[1]!; // Codex + OpenAI API key
+
+  it('preserves advanced draft values across collapse and expand', async () => {
+    creationFetch(creationClass, 'conformance-disclosure');
+    renderManager();
+    await startStandardCreation(creationClass, 'conformance-disclosure');
+
+    const toggle = screen.getByLabelText('Show advanced options') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.change(screen.getByLabelText('Cooldown after 429 (seconds)'), {
+      target: { value: '900' },
+    });
+    fireEvent.change(screen.getByLabelText('Tags'), { target: { value: 'team, preferred' } });
+
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(false);
+    expect(document.getElementById('provider-profile-advanced-region')).toBeNull();
+    // The collapsed summary comes from backend preset metadata.
+    expect(screen.getByText('Using recommended API key launch settings')).toBeTruthy();
+
+    fireEvent.click(toggle);
+    expect((screen.getByLabelText('Cooldown after 429 (seconds)') as HTMLInputElement).value).toBe('900');
+    expect((screen.getByLabelText('Tags') as HTMLInputElement).value).toBe('team, preferred');
+  });
+
+  it('opens the disclosure and focuses the control a hidden-field validation error targets', async () => {
+    const preset = presetFor(creationClass);
+    const capabilities = capabilitiesFor(creationClass);
+    vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      const tier = tierCapabilitiesResponse(url);
+      if (tier) return tier;
+      if (url.startsWith('/api/v1/provider-profiles/creation-capabilities?')) {
+        return { ok: true, json: async () => capabilities } as Response;
+      }
+      if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+        return { ok: true, json: async () => preset } as Response;
+      }
+      if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+        return {
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          json: async () => ({
+            detail: {
+              code: 'provider_profile_creation_preset_field_locked',
+              message: 'cooldown_after_429_seconds is locked by the selected creation preset.',
+              field: 'cooldown_after_429_seconds',
+              lock_reason: 'Backend launch policy owns this value.',
+            },
+          }),
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderManager();
+    await startStandardCreation(creationClass, 'conformance-hidden-error');
+    expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
+    );
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByLabelText('Cooldown after 429 (seconds)')),
+    );
+    expect(
+      document.getElementById('provider-profile-advanced-region')?.contains(document.activeElement),
+    ).toBe(true);
+  });
+
+  it('reveals and focuses backend-owned launch isolation when validation targets clear_env_keys', async () => {
+    const preset = presetFor(creationClass);
+    const capabilities = capabilitiesFor(creationClass);
+    vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      const tier = tierCapabilitiesResponse(url);
+      if (tier) return tier;
+      if (url.startsWith('/api/v1/provider-profiles/creation-capabilities?')) {
+        return { ok: true, json: async () => capabilities } as Response;
+      }
+      if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+        return { ok: true, json: async () => preset } as Response;
+      }
+      if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+        return {
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          json: async () => ({
+            detail: {
+              code: 'provider_profile_clear_env_keys_locked',
+              message: 'clear_env_keys is backend-owned launch-security metadata.',
+              field: 'clear_env_keys',
+              source: 'runtime_provider_isolation_policy',
+            },
+          }),
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderManager();
+    await startStandardCreation(creationClass, 'conformance-clear-env');
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
+    );
+    await waitFor(() =>
+      expect(
+        (document.activeElement as HTMLElement | null)?.getAttribute('data-advanced-field'),
+      ).toBe('clear_env_keys'),
+    );
+    // Standard creation still cannot author the policy.
+    expect(screen.queryByLabelText(/Clear env keys/)).toBeNull();
+    expect(screen.getByText(/Launch environment isolation — clear environment keys/)).toBeTruthy();
+  });
+
+  it('keeps tier drafts and advanced drafts independent across collapse', async () => {
+    creationFetch(creationClass, 'conformance-tier-draft');
+    renderManager();
+    await startStandardCreation(creationClass, 'conformance-tier-draft');
+
+    // One runtime-default tier at the start of the standard form.
+    expect(screen.getAllByRole('radio', { name: 'Default tier' })).toHaveLength(1);
+
+    const toggle = screen.getByLabelText('Show advanced options') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.change(screen.getByLabelText('Priority'), { target: { value: '55' } });
+
+    // Build a custom ordered tier policy while advanced options are open.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add tier' })[0]!);
+    fireEvent.change(screen.getByLabelText('Tier 2 label'), { target: { value: 'Deep work' } });
+    fireEvent.change(screen.getByLabelText('Tier 2 model'), { target: { value: 'gpt-4o' } });
+    fireEvent.click(screen.getByRole('radio', { name: 'Use Tier 2 as default' }));
+
+    // Collapsing advanced options must not erase the tier draft...
+    fireEvent.click(toggle);
+    expect((screen.getByLabelText('Tier 2 label') as HTMLInputElement).value).toBe('Deep work');
+    expect((screen.getByLabelText('Tier 2 model') as HTMLSelectElement).value).toBe('gpt-4o');
+    expect(screen.getByText('2 tiers · Default: Tier 2')).toBeTruthy();
+
+    // ...and editing tiers while collapsed must not erase the advanced draft.
+    fireEvent.change(screen.getByLabelText('Tier 1 label'), { target: { value: 'Quick' } });
+    fireEvent.click(toggle);
+    expect((screen.getByLabelText('Priority') as HTMLInputElement).value).toBe('55');
+    expect((screen.getByLabelText('Tier 1 label') as HTMLInputElement).value).toBe('Quick');
+  });
+
+  it('saves the custom ordered tier policy canonically from the integrated create journey', async () => {
+    const profileId = 'conformance-tier-save';
+    const fetchSpy = creationFetch(creationClass, profileId);
+    renderManager();
+    await startStandardCreation(creationClass, profileId);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add tier' })[0]!);
+    fireEvent.change(screen.getByLabelText('Tier 2 label'), { target: { value: 'Deep work' } });
+    fireEvent.change(screen.getByLabelText('Tier 2 model'), { target: { value: 'gpt-4o' } });
+    fireEvent.change(screen.getByLabelText('Tier 2 effort'), { target: { value: 'high' } });
+    fireEvent.click(screen.getByRole('radio', { name: 'Use Tier 2 as default' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
+    );
+    const payload = postPayload(fetchSpy);
+    expect(payload.model_tiers).toEqual([
+      { label: null, model: null, effort: null, parameters: {}, annotations: {} },
+      { label: 'Deep work', model: 'gpt-4o', effort: 'high', parameters: {}, annotations: {} },
+    ]);
+    expect(payload.default_model_tier).toBe(2);
+    expect(payload).not.toHaveProperty('default_model');
+    expect(payload).not.toHaveProperty('default_effort');
+  });
+});
+
+describe('MoonLadderStudios/MoonMind#3822 existing-profile compatibility', () => {
+  it('does not normalize, erase, or resubmit a malformed environment-clearing policy during edit', async () => {
+    const legacyProfile: ProviderProfile = {
+      profile_id: 'legacy-unsafe-isolation',
+      runtime_id: 'codex_cli',
+      provider_id: 'openai',
+      authentication_method: 'api_key',
+      credential_source: 'secret_ref',
+      runtime_materialization_mode: 'api_key_env',
+      secret_refs: { openai_api_key: 'db://OPENAI_API_KEY' },
+      max_parallel_runs: 1,
+      cooldown_after_429_seconds: 120,
+      rate_limit_policy: 'backoff',
+      enabled: false,
+      is_default: false,
+      auth_state: 'validation_failed',
+      disabled_reason: 'auth_invalid',
+      // Malformed/unsafe stored policy: a lowercase name, an invalid name, and
+      // an unsafe key the backend classifies rather than silently rewrites.
+      clear_env_keys: ['path', 'not a key', 'LD_PRELOAD'],
+      model_tiers: [{ label: 'Only', model: 'gpt-4o', effort: 'medium', parameters: {}, annotations: {} }],
+      default_model_tier: 1,
+      launch_isolation: {
+        effective_keys: ['path', 'not a key', 'LD_PRELOAD'],
+        source: 'legacy_custom',
+        derived: false,
+        editable: false,
+        lock_reason: 'Stored policy is not derivable; readiness is blocked until it is reviewed.',
+        strategy_id: 'unknown',
+        classification: 'legacy_custom',
+        explanations: { 'not a key': 'Invalid environment variable name.' },
+        audit_reason_present: false,
+      },
+      readiness: {
+        status: 'blocked',
+        launch_ready: false,
+        summary: 'Isolation policy cannot be derived.',
+        checks: [
+          {
+            id: 'clear_env_keys',
+            label: 'Launch isolation',
+            status: 'error',
+            message: 'Stored environment-clearing policy is invalid.',
+          },
+        ],
+      },
+      creation_capabilities: capabilitiesFor(CREATION_CLASSES[1]!) as unknown as CreationCapabilities,
+    };
+
+    const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      const tier = tierCapabilitiesResponse(url);
+      if (tier) return tier;
+      if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+        return { ok: true, json: async () => presetFor(CREATION_CLASSES[1]!) } as Response;
+      }
+      if (url === '/api/v1/provider-profiles/legacy-unsafe-isolation' && init?.method === 'PATCH') {
+        return { ok: true, json: async () => ({ ...legacyProfile, cooldown_after_429_seconds: 600 }) } as Response;
+      }
+      throw new Error(`Unexpected fetch: ${url} ${String(init?.method)}`);
+    });
+
+    renderManager([legacyProfile]);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByLabelText('Show advanced options'));
+
+    // The invalid stored policy stays visible, attributed, and read-only.
+    expect(screen.getByText(/Effective keys: path, not a key, LD_PRELOAD/)).toBeTruthy();
+    expect(screen.getByText(/Classification: legacy_custom/)).toBeTruthy();
+    expect(screen.getByText(/Locked by backend launch-safety policy/)).toBeTruthy();
+    expect(screen.getByText(/Invalid environment variable name\./)).toBeTruthy();
+    expect(screen.queryByLabelText(/Clear env keys/)).toBeNull();
+
+    // An unrelated advanced edit must not resubmit, rewrite, or clear it, and
+    // must not enable a profile the backend left disabled.
+    fireEvent.change(screen.getByLabelText('Cooldown after 429 (seconds)'), {
+      target: { value: '600' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Update provider profile' }));
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([url, init]) =>
+            url === '/api/v1/provider-profiles/legacy-unsafe-isolation' &&
+            (init as RequestInit | undefined)?.method === 'PATCH',
+        ),
+      ).toBe(true),
+    );
+    const patchCall = fetchSpy.mock.calls.find(
+      ([url, init]) =>
+        url === '/api/v1/provider-profiles/legacy-unsafe-isolation' &&
+        (init as RequestInit | undefined)?.method === 'PATCH',
+    );
+    const payload = JSON.parse(String((patchCall?.[1] as RequestInit).body)) as Record<string, unknown>;
+    expect(payload).toEqual({
+      profile_id: 'legacy-unsafe-isolation',
+      cooldown_after_429_seconds: 600,
+    });
+    expect(payload).not.toHaveProperty('clear_env_keys');
+    expect(payload).not.toHaveProperty('enabled');
+    expect(payload).not.toHaveProperty('is_default');
+  });
+});
+
+describe('MoonLadderStudios/MoonMind#3822 generated-contract guard', () => {
+  const managerSource = readFileSync(
+    join(process.cwd(), 'frontend', 'src', 'components', 'settings', 'ProviderProfilesManager.tsx'),
+    'utf8',
+  );
+
+  it('binds the creation preset, capability, and authentication contracts to generated types', () => {
+    for (const generatedSchema of [
+      'ProviderProfileCreationPresetResponse',
+      'ProviderProfileCreationCapabilitiesResponse',
+      'ProviderProfileAuthenticationMethodCapability',
+      'ProviderProfileAuthenticationMethod',
+    ]) {
+      expect(managerSource).toContain(`components['schemas']['${generatedSchema}']`);
+    }
+  });
+
+  it('rejects a second hand-maintained Provider Profile creation-preset schema in React', () => {
+    // Any local interface or type literal redeclaring a generated
+    // creation-preset/capability shape is a second source of truth.
+    const handMaintainedDeclaration =
+      /\b(?:interface|type)\s+(\w*(?:CreationPreset|CreationCapabilit|CreationField|AuthenticationMethodCapabilit|SecretRoleCapabilit|ImportedVolumeCapabilit)\w*)\b(?!\s*=\s*\n?\s*components\[)/g;
+    const offenders: string[] = [];
+    for (const match of managerSource.matchAll(handMaintainedDeclaration)) {
+      offenders.push(match[1]!);
+    }
+    expect(offenders).toEqual([]);
+
+    // The generated schema field set is not restated as a local object type.
+    expect(managerSource).not.toMatch(/interface\s+\w+\s*\{[^}]*\bcompatible_schemes\b/);
+    expect(managerSource).not.toMatch(/interface\s+\w+\s*\{[^}]*\blaunch_ready_after_setup\b/);
+    expect(managerSource).not.toMatch(/interface\s+\w+\s*\{[^}]*\bmanual_creation_allowed\b/);
+  });
+});

--- a/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
+++ b/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
@@ -777,6 +777,70 @@ describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts
     ).toBe(true);
   });
 
+  it('focuses the collapsed control a FastAPI request-validation array targets', async () => {
+    const preset = presetFor(creationClass);
+    const capabilities = capabilitiesFor(creationClass);
+    vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      const tier = tierCapabilitiesResponse(url);
+      if (tier) return tier;
+      if (url.startsWith('/api/v1/provider-profiles/creation-capabilities?')) {
+        return { ok: true, json: async () => capabilities } as Response;
+      }
+      if (url.startsWith('/api/v1/provider-profiles/creation-preset?')) {
+        return { ok: true, json: async () => preset } as Response;
+      }
+      if (url === '/api/v1/provider-profiles' && init?.method === 'POST') {
+        // The real `ProviderProfileCreate` boundary: `cooldown_after_429_seconds`
+        // is `Field(ge=0)`, so a negative draft raises FastAPI's standard
+        // RequestValidationError payload rather than a custom error object.
+        return {
+          ok: false,
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          json: async () => ({
+            detail: [
+              {
+                type: 'greater_than_equal',
+                loc: ['body', 'cooldown_after_429_seconds'],
+                msg: 'Input should be greater than or equal to 0',
+                input: -1,
+                ctx: { ge: 0 },
+              },
+            ],
+          }),
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderManager();
+    await startStandardCreation(creationClass, 'conformance-validation-array');
+
+    // Author the invalid value, then collapse the disclosure so the unmounted
+    // input can no longer enforce its native `min` before submission.
+    const toggle = screen.getByLabelText('Show advanced options') as HTMLInputElement;
+    fireEvent.click(toggle);
+    fireEvent.change(screen.getByLabelText('Cooldown after 429 (seconds)'), {
+      target: { value: '-1' },
+    });
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(false);
+    expect(document.getElementById('provider-profile-advanced-region')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
+    );
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByLabelText('Cooldown after 429 (seconds)')),
+    );
+    expect(
+      document.getElementById('provider-profile-advanced-region')?.contains(document.activeElement),
+    ).toBe(true);
+  });
+
   it('reveals and focuses backend-owned launch isolation when validation targets clear_env_keys', async () => {
     const preset = presetFor(creationClass);
     const capabilities = capabilitiesFor(creationClass);

--- a/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
+++ b/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
@@ -500,6 +500,18 @@ describe('MoonLadderStudios/MoonMind#3822 Settings redesign conformance', () => 
             expect(candidate.closest(switcherSelector)).toBeNull();
           }
         }
+        // A plain wrapper-label radio group carries its text on the label, not
+        // on the control, so check the radios themselves too.
+        for (const radio of Array.from(
+          document.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+        )) {
+          const radioLabel = (
+            radio.getAttribute('aria-label') ??
+            radio.closest('label')?.textContent ??
+            ''
+          ).trim();
+          expect(destinationLabels).not.toContain(radioLabel);
+        }
       },
     );
 

--- a/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
+++ b/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
@@ -1,0 +1,577 @@
+/**
+ * Settings redesign conformance suite — navigation, migration, accessibility,
+ * and architecture guards.
+ *
+ * MoonLadderStudios/MoonMind#3822 (parent MoonLadderStudios/MoonMind#3815).
+ *
+ * This suite proves the independently implemented pieces of the redesign agree
+ * at their boundaries. It must fail when the implementation drifts back to one
+ * tabbed Settings page or to browser-owned Settings destination state.
+ *
+ * Run it on its own with `npm run ui:test:settings-redesign`.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { BrowserRouter } from 'react-router-dom';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+
+import type { BootPayload } from '../boot/parseBootPayload';
+import { act, fireEvent, renderWithClient, screen, waitFor, within } from '../utils/test-utils';
+import {
+  legacySettingsRedirect,
+  resolveDashboardRoute,
+  DASHBOARD_DESTINATIONS,
+  DASHBOARD_DESTINATION_GROUPS,
+} from '../lib/dashboardRoutes';
+import { DashboardApp } from './dashboard-app';
+import {
+  OperationsSettingsPage,
+  ProvidersSecretsSettingsPage,
+  UserWorkspaceSettingsPage,
+} from './settings';
+
+vi.mock('lucide-animated', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const AnimatedIcon = React.forwardRef<unknown, { className?: string }>((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      startAnimation: () => undefined,
+      stopAnimation: () => undefined,
+    }));
+    return React.createElement('svg', { className: props.className, 'aria-hidden': true });
+  });
+  return {
+    MoonIcon: AnimatedIcon,
+    RocketIcon: AnimatedIcon,
+    SettingsIcon: AnimatedIcon,
+    SparklesIcon: AnimatedIcon,
+  };
+});
+
+vi.mock('./workflows-workspace', () => ({
+  default: () => <div>Workflow list route loaded</div>,
+}));
+
+const CANONICAL_SETTINGS_ROUTES = [
+  {
+    path: '/settings/providers-secrets',
+    heading: 'Providers & Secrets',
+    title: 'Providers & Secrets | MoonMind',
+    menuItem: 'Providers & Secrets',
+  },
+  {
+    path: '/settings/user-workspace',
+    heading: 'User / Workspace',
+    title: 'User / Workspace | MoonMind',
+    menuItem: 'User / Workspace',
+  },
+  {
+    path: '/settings/operations',
+    heading: 'Operations',
+    title: 'Operations | MoonMind',
+    menuItem: 'Operations',
+  },
+] as const;
+
+const ALL_SETTINGS_PERMISSIONS = [
+  'provider_profiles.read',
+  'provider_profiles.write',
+  'secrets.metadata.read',
+  'settings.effective.read',
+  'settings.catalog.read',
+  'settings.workspace.write',
+  'settings.user.write',
+  'operations.read',
+  'operations.invoke',
+];
+
+const userWorkspaceDescriptor = {
+  key: 'workflow.default_publish_mode',
+  title: 'Default Publish Mode',
+  description: 'Default publication behavior.',
+  category: 'Workflow',
+  section: 'user-workspace',
+  type: 'enum',
+  ui: 'select',
+  scopes: ['workspace', 'user'],
+  default_value: 'pr',
+  effective_value: 'pr',
+  override_value: null,
+  source: 'default',
+  source_explanation: 'Default value.',
+  apply_mode: 'next_request',
+  activation_state: 'active',
+  active: true,
+  options: [
+    { value: 'pr', label: 'Pull request' },
+    { value: 'branch', label: 'Branch' },
+  ],
+  constraints: null,
+  sensitive: false,
+  read_only: false,
+  requires_reload: false,
+  requires_worker_restart: false,
+  requires_process_restart: false,
+  applies_to: ['workflows'],
+  order: 1,
+  value_version: 1,
+  diagnostics: [],
+};
+
+function ok(body: unknown): Response {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as Response;
+}
+
+function notFound(): Response {
+  return {
+    ok: false,
+    status: 404,
+    statusText: 'Not Found',
+    json: async () => ({}),
+    text: async () => 'Not Found',
+  } as Response;
+}
+
+function uiInfo(overrides: Record<string, unknown> = {}) {
+  return {
+    app: 'moonmind',
+    buildId: 'test-build',
+    apiBase: '/api',
+    features: {
+      workflowList: true,
+      workflowActions: true,
+      artifacts: true,
+      schedules: true,
+      skills: true,
+      manifests: true,
+      settingsProvidersSecrets: true,
+      settingsUserWorkspace: true,
+      settingsOperations: true,
+    },
+    limits: {},
+    endpoints: { workflows: '/api/executions' },
+    dashboardConfig: { initialPath: '/workflows', pollIntervalsMs: { list: 60_000, detail: 60_000, events: 60_000 } },
+    settingsPermissions: ALL_SETTINGS_PERMISSIONS,
+    workerPause: {
+      get: '/api/system/worker-pause',
+      post: '/api/system/worker-pause',
+      shardHealth: '/api/v1/operations/codex/shards',
+    },
+    ...overrides,
+  };
+}
+
+function settingsFetch(url: string): Response | null {
+  if (url === '/api/v1/provider-profiles') return ok([]);
+  if (url === '/api/v1/secrets') return ok({ items: [] });
+  if (url === '/me') return ok({ id: 'user-1', email: 'user@example.com' });
+  if (url.startsWith('/api/v1/settings/catalog')) {
+    return ok({
+      section: 'user-workspace',
+      scope: url.includes('scope=user') ? 'user' : 'workspace',
+      categories: { Workflow: [userWorkspaceDescriptor] },
+    });
+  }
+  if (url === '/api/system/worker-pause') {
+    return ok({ system: { workersPaused: false }, metrics: {}, commands: [] });
+  }
+  if (url === '/api/v1/operations/codex/shards') return ok({ shards: [] });
+  if (url === '/api/v1/operations/deployment/stacks/moonmind') {
+    return ok({
+      stack: 'moonmind',
+      projectName: 'moonmind',
+      currentImage: { evidence: 'available' },
+      recentActions: [],
+      policy: {
+        repository: 'moonmind',
+        allowedReferences: [],
+        recentTags: [],
+        mutableReferences: [],
+        allowedModes: [],
+      },
+    });
+  }
+  if (url === '/api/v1/operations/deployment/image-targets?stack=moonmind') {
+    return ok({ stack: 'moonmind', repositories: [] });
+  }
+  return null;
+}
+
+function frontendFiles(root: string, keep: (name: string) => boolean): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const absolute = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...frontendFiles(absolute, keep));
+      continue;
+    }
+    if (keep(entry.name)) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+function frontendSourceFiles(root: string): string[] {
+  return frontendFiles(root, (name) => /\.(ts|tsx)$/.test(name) && !/\.test\.tsx?$/.test(name));
+}
+
+function frontendSourceTestFiles(root: string): string[] {
+  return frontendFiles(root, (name) => /\.test\.tsx?$/.test(name));
+}
+
+describe('MoonLadderStudios/MoonMind#3822 Settings redesign conformance', () => {
+  let fetchSpy: MockInstance;
+  let requestedUrls: string[];
+
+  beforeEach(() => {
+    requestedUrls = [];
+    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === '/api/ui/info') return Promise.resolve(ok(uiInfo()));
+      return Promise.resolve(settingsFetch(url) ?? notFound());
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    document.querySelectorAll('a[data-conformance-link]').forEach((node) => node.remove());
+    window.history.replaceState({}, '', '/');
+    document.title = '';
+  });
+
+  describe('canonical navigation journey', () => {
+    it.each(CANONICAL_SETTINGS_ROUTES)(
+      'resolves $path to its own page, title, stable Settings trigger, and active dropdown child',
+      async ({ path, heading, title, menuItem }) => {
+        window.history.replaceState({}, '', path);
+        renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+        expect(await screen.findByRole('heading', { name: heading }, { timeout: 10000 })).toBeTruthy();
+        await waitFor(() => expect(document.title).toBe(title));
+
+        // The Configuration group keeps one stable trigger on every child route.
+        const trigger = screen.getByRole('button', { name: 'Settings' });
+        expect(trigger.classList.contains('active')).toBe(true);
+        expect(screen.queryByRole('button', { name: 'System' })).toBeNull();
+
+        fireEvent.click(trigger);
+        // Exactly one Configuration label in the navigation menu. The page
+        // header eyebrow is page content, not a second navigation group.
+        const configurationLabels = Array.from(
+          document.querySelectorAll<HTMLElement>('.dashboard-system-menu-label'),
+        ).filter((label) => label.textContent?.trim() === 'Configuration');
+        expect(configurationLabels).toHaveLength(1);
+
+        const configuration = configurationLabels[0]?.closest(
+          '.dashboard-system-menu-section',
+        ) as HTMLElement;
+        const activeChildren = within(configuration)
+          .getAllByRole('menuitem')
+          .filter((item) => item.getAttribute('aria-current') === 'page')
+          .map((item) => item.textContent?.trim());
+        expect(activeChildren).toEqual([menuItem]);
+      },
+    );
+
+    it('loads only the primary datasets owned by the requested canonical route', async () => {
+      window.history.replaceState({}, '', '/settings/operations');
+      renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+      expect(await screen.findByRole('heading', { name: 'Operations' }, { timeout: 10000 })).toBeTruthy();
+      await waitFor(() => expect(requestedUrls).toContain('/api/system/worker-pause'));
+      expect(requestedUrls.some((url) => url.startsWith('/api/v1/settings/catalog'))).toBe(false);
+      expect(requestedUrls).not.toContain('/me');
+    });
+  });
+
+  describe('legacy migration journey', () => {
+    it.each([
+      // Default entry point.
+      ['/settings', '', '/settings/providers-secrets', ''],
+      // All three retired ?section= page identities.
+      ['/settings', '?section=providers-secrets', '/settings/providers-secrets', ''],
+      ['/settings', '?section=user-workspace', '/settings/providers-secrets', ''],
+      ['/settings', '?section=operations&runtime=codex', '/settings/providers-secrets', '?runtime=codex'],
+      // Legacy pathnames.
+      ['/secrets', '?runtime=codex&status=paused&section=providers-secrets', '/settings/providers-secrets', '?runtime=codex'],
+      ['/workers', '?status=paused&runtime=codex&section=operations', '/settings/operations', '?status=paused'],
+      // Retained historical alias documented by #3816: an unmatched
+      // /settings/* child resolves through the entry point.
+      ['/settings/provider-profiles', '', '/settings/providers-secrets', ''],
+    ])(
+      'replaces %s%s with %s%s, keeping only that page\'s filters and no legacy history entry',
+      async (legacyPath, legacySearch, expectedPath, expectedSearch) => {
+        window.history.replaceState({}, '', '/workflows');
+        window.history.pushState({}, '', `${legacyPath}${legacySearch}`);
+        const historyLengthAtLegacyEntry = window.history.length;
+
+        renderWithClient(<DashboardApp payload={{ page: 'dashboard', apiBase: '/api' }} />);
+
+        await waitFor(() => expect(window.location.pathname).toBe(expectedPath), { timeout: 10000 });
+        expect(window.location.search).toBe(expectedSearch);
+        expect(window.location.search).not.toContain('section=');
+
+        // No redirect loop: the resolved location is a fixpoint of the
+        // production redirect chain and stays put once the app settles.
+        expect(legacySettingsRedirect(window.location.pathname, window.location.search)).toBeNull();
+        expect(resolveDashboardRoute(window.location.pathname)).not.toBeNull();
+        const settled = `${window.location.pathname}${window.location.search}`;
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(`${window.location.pathname}${window.location.search}`).toBe(settled);
+
+        // Replacement, not a push: the whole chain must not add a history
+        // entry, and Back must not return to a retired legacy URL.
+        expect(window.history.length).toBe(historyLengthAtLegacyEntry);
+        act(() => window.history.back());
+        await waitFor(() => expect(window.location.pathname).toBe('/workflows'));
+      },
+    );
+  });
+
+  describe('dirty-draft departure after save outcomes', () => {
+    function renderUserWorkspace() {
+      window.history.replaceState({}, '', '/settings/user-workspace?scope=workspace');
+      renderWithClient(
+        <BrowserRouter>
+          <UserWorkspaceSettingsPage
+            payload={{
+              page: 'settings-user-workspace',
+              apiBase: '/api',
+              initialData: {
+                settingsPermissions: ['settings.catalog.read', 'settings.workspace.write'],
+              },
+            } as BootPayload}
+          />
+        </BrowserRouter>,
+      );
+    }
+
+    function departureLink(): HTMLAnchorElement {
+      const link = document.createElement('a');
+      link.href = '/settings/operations';
+      link.textContent = 'Operations';
+      link.setAttribute('data-conformance-link', 'true');
+      document.body.appendChild(link);
+      return link;
+    }
+
+    it('keeps guarding departure after a failed save and still allows an explicit discard', async () => {
+      fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === '/api/v1/settings/workspace' && init?.method === 'PATCH') {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            statusText: 'Server Error',
+            json: async () => ({ detail: 'Settings save failed.' }),
+          } as Response);
+        }
+        return Promise.resolve(settingsFetch(url) ?? notFound());
+      });
+
+      renderUserWorkspace();
+      const control = (await screen.findByLabelText('Default Publish Mode')) as HTMLSelectElement;
+      fireEvent.change(control, { target: { value: 'branch' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+      await screen.findByText(/Settings save failed with status 500\./);
+      // Flush passive effects so the draft guard has observed the post-save
+      // draft state, as it has by the time a real user can click a link.
+      await act(async () => undefined);
+
+      // A failed save keeps the draft, so departure must still be guarded.
+      expect(control.value).toBe('branch');
+      const link = departureLink();
+      // fireEvent returns false when the guard cancels the navigation.
+      expect(fireEvent.click(link)).toBe(false);
+      expect(screen.getByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
+      fireEvent.click(screen.getByRole('button', { name: 'Stay' }));
+      expect(window.location.pathname).toBe('/settings/user-workspace');
+      expect(control.value).toBe('branch');
+
+      fireEvent.click(link);
+      fireEvent.click(screen.getByRole('button', { name: 'Discard and leave' }));
+      await waitFor(() => expect(window.location.pathname).toBe('/settings/operations'));
+    });
+
+    it('stops guarding departure after a successful save', async () => {
+      fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === '/api/v1/settings/workspace' && init?.method === 'PATCH') {
+          return Promise.resolve(ok({ applied: ['workflow.default_publish_mode'] }));
+        }
+        return Promise.resolve(settingsFetch(url) ?? notFound());
+      });
+
+      renderUserWorkspace();
+      const control = (await screen.findByLabelText('Default Publish Mode')) as HTMLSelectElement;
+      fireEvent.change(control, { target: { value: 'branch' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+      await screen.findByText('Settings saved.');
+      // Flush passive effects so the draft guard has observed the cleared
+      // draft, as it has by the time a real user can click a link.
+      await act(async () => undefined);
+
+      const link = departureLink();
+      // The guard lets the navigation through untouched once the draft is
+      // saved: no dialog and no cancelled click.
+      expect(fireEvent.click(link)).toBe(true);
+      expect(screen.queryByRole('dialog', { name: 'Unsaved changes' })).toBeNull();
+    });
+  });
+
+  describe('architecture guards', () => {
+    it.each([
+      ['Providers & Secrets', ProvidersSecretsSettingsPage, 'settings-providers-secrets'],
+      ['User / Workspace', UserWorkspaceSettingsPage, 'settings-user-workspace'],
+      ['Operations', OperationsSettingsPage, 'settings-operations'],
+    ])(
+      'never re-exposes the three destinations as local tabs or radios on %s',
+      async (heading, Page, page) => {
+        window.history.replaceState({}, '', `/${page.replace('settings-', 'settings/')}`);
+        renderWithClient(
+          <BrowserRouter>
+            <Page
+              payload={{
+                page,
+                apiBase: '/api',
+                initialData: {
+                  settingsPermissions: ALL_SETTINGS_PERMISSIONS,
+                  workerPause: {
+                    get: '/api/system/worker-pause',
+                    post: '/api/system/worker-pause',
+                    shardHealth: '/api/v1/operations/codex/shards',
+                  },
+                },
+              } as BootPayload}
+            />
+          </BrowserRouter>,
+        );
+        await screen.findByRole('heading', { name: heading });
+
+        const destinationLabels = DASHBOARD_DESTINATION_GROUPS.flatMap((group) =>
+          group.destinationKeys.map(
+            (key) => DASHBOARD_DESTINATIONS.find((destination) => destination.key === key)!.label,
+          ),
+        );
+        expect(destinationLabels).toEqual([
+          'Providers & Secrets',
+          'User / Workspace',
+          'Operations',
+        ]);
+
+        // No local switcher — tab, radio, segmented control, pill, card, or
+        // sidebar — whose options are the sibling Configuration destinations.
+        const switcherSelector =
+          '[role="tab"], [role="tablist"], [role="radiogroup"], .segmented-control, .segmented-control-field';
+        for (const switcher of Array.from(document.querySelectorAll<HTMLElement>(switcherSelector))) {
+          const containedDestinations = destinationLabels.filter((label) =>
+            (switcher.textContent ?? '').includes(label),
+          );
+          expect(containedDestinations).toEqual([]);
+        }
+        for (const label of destinationLabels) {
+          for (const candidate of Array.from(
+            document.querySelectorAll<HTMLElement>('input, button, a, [role]'),
+          )) {
+            const accessibleText = (
+              candidate.getAttribute('aria-label') ??
+              candidate.textContent ??
+              ''
+            ).trim();
+            if (accessibleText !== label) continue;
+            expect(candidate.getAttribute('type')).not.toBe('radio');
+            expect(candidate.getAttribute('role')).not.toBe('radio');
+            expect(candidate.getAttribute('role')).not.toBe('tab');
+            expect(candidate.closest(switcherSelector)).toBeNull();
+          }
+        }
+      },
+    );
+
+    it('retains no Settings destination section-state helper in frontend source', () => {
+      // Standalone identifiers only: `GeneratedSettingsSection` and
+      // `OperationsSettingsSection` are page-owned components, not the removed
+      // cross-destination section state.
+      const forbiddenSymbols = [
+        /\bactiveSection\b/,
+        /\bsetActiveSection\b/,
+        /\bsectionState\b/,
+        /\bSETTINGS_SECTIONS?\b/,
+        /\bSettingsSection(Id|Key)?\b/,
+        /\bsettingsSectionFor[A-Za-z]*\b/,
+        /\bresolveSettingsSection[A-Za-z]*\b/,
+      ];
+      const offenders: string[] = [];
+      for (const file of frontendSourceFiles(join(process.cwd(), 'frontend', 'src'))) {
+        const source = readFileSync(file, 'utf8');
+        for (const symbol of forbiddenSymbols) {
+          const match = source.match(symbol);
+          if (match) {
+            offenders.push(`${file}: ${match[0]}`);
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('builds no ?section= Settings destination link in frontend source', () => {
+      // The generated-settings catalog request legitimately carries a backend
+      // `section` query parameter; Settings *destination* links must not.
+      const settingsDestinationLink =
+        /\/settings(\/(providers-secrets|user-workspace|operations))?\?[^\s'"`]*section=/g;
+      const offenders: string[] = [];
+      for (const file of frontendSourceFiles(join(process.cwd(), 'frontend', 'src'))) {
+        const source = readFileSync(file, 'utf8');
+        for (const match of source.matchAll(settingsDestinationLink)) {
+          offenders.push(`${file}: ${match[0]}`);
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('keeps the shared segmented-control system owned by a non-Settings surface', () => {
+      const owners = frontendSourceFiles(join(process.cwd(), 'frontend', 'src')).filter((file) =>
+        readFileSync(file, 'utf8').includes('"segmented-control'),
+      );
+      expect(owners.length).toBeGreaterThan(0);
+      expect(owners.every((file) => !file.includes(join('components', 'settings')))).toBe(true);
+      expect(owners.every((file) => !file.endsWith(join('entrypoints', 'settings.tsx')))).toBe(true);
+    });
+  });
+
+  describe('documented focused command', () => {
+    it('exposes one focused npm command that selects both conformance files', () => {
+      const packageJson = JSON.parse(
+        readFileSync(join(process.cwd(), 'package.json'), 'utf8'),
+      ) as { scripts?: Record<string, string> };
+      const command = packageJson.scripts?.['ui:test:settings-redesign'];
+      expect(command).toBeTruthy();
+      // The vitest filter must select this file and the Provider Profile
+      // conformance file, and nothing else.
+      const filter = command?.split('--ui-args ')[1]?.trim() ?? '';
+      expect(filter).toBeTruthy();
+      const selected = frontendSourceTestFiles(join(process.cwd(), 'frontend', 'src')).filter(
+        (file) => new RegExp(filter).test(file),
+      );
+      expect(selected.map((file) => file.split('/').pop()).sort()).toEqual([
+        'providerProfileRedesignConformance.test.tsx',
+        'settingsRedesignConformance.test.tsx',
+      ]);
+    });
+  });
+});

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -12,6 +12,10 @@ declare const process: {
 
 declare module "node:fs" {
   export function readFileSync(path: string, encoding: "utf8"): string;
+  export function readdirSync(
+    path: string,
+    options: { withFileTypes: true },
+  ): Array<{ name: string; isDirectory(): boolean }>;
 }
 
 declare module "node:module" {
@@ -20,4 +24,5 @@ declare module "node:module" {
 
 declare module "node:path" {
   export function resolve(...paths: string[]): string;
+  export function join(...paths: string[]): string;
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ui:test": "./tools/test_unit.sh --dashboard-only --ui-args",
     "ui:test:browser": "vitest run --config frontend/vitest.browser.config.ts",
     "ui:test:workflow-start": "./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/workflow-start.test.tsx",
+    "ui:test:settings-redesign": "./tools/test_unit.sh --dashboard-only --ui-args RedesignConformance",
     "ui:test:watch": "node ./node_modules/vitest/vitest.mjs --config frontend/vite.config.ts",
     "api:types": "bash tools/run_repo_python.sh tools/generate_openapi_types.py",
     "api:types:check": "npm run api:types && git diff --exit-code -- frontend/src/generated/openapi.ts",

--- a/tests/unit/api/routers/test_dashboard_destination_registry_agreement.py
+++ b/tests/unit/api/routers/test_dashboard_destination_registry_agreement.py
@@ -1,0 +1,184 @@
+"""Server/frontend dashboard destination registry agreement.
+
+MoonLadderStudios/MoonMind#3822 (parent MoonLadderStudios/MoonMind#3815).
+
+The dashboard resolves destination metadata from the server at runtime and
+falls back to the checked-in client registry, so the two must declare the same
+destinations, in the same order, with the same Configuration group membership.
+``matchesDashboardDestinationRegistry`` only raises a version-skew alert in the
+browser; this test fails the build when either side drifts.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from api_service.api.routers.workflow_console import DASHBOARD_DESTINATIONS
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DASHBOARD_ROUTES_TS = REPO_ROOT / "frontend" / "src" / "lib" / "dashboardRoutes.ts"
+
+_ARRAY_START = "export const DASHBOARD_DESTINATIONS: readonly DashboardDestination[] = ["
+_GROUPS_START = (
+    "export const DASHBOARD_DESTINATION_GROUPS: readonly DashboardDestinationGroup[] = ["
+)
+
+
+def _array_body(source: str, start_marker: str) -> str:
+    start = source.index(start_marker) + len(start_marker)
+    depth = 1
+    for index in range(start, len(source)):
+        character = source[index]
+        if character == "[":
+            depth += 1
+        elif character == "]":
+            depth -= 1
+            if depth == 0:
+                return source[start:index]
+    raise AssertionError(f"Unterminated array for marker {start_marker!r}")
+
+
+def _object_literals(body: str) -> list[str]:
+    literals: list[str] = []
+    depth = 0
+    start = 0
+    for index, character in enumerate(body):
+        if character == "{":
+            if depth == 0:
+                start = index + 1
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                literals.append(body[start:index])
+    return literals
+
+
+def _scalar(literal: str, key: str) -> Any:
+    match = re.search(
+        rf"\b{key}:\s*(?:'([^']*)'|\"([^\"]*)\"|(true|false))",
+        literal,
+    )
+    if match is None:
+        return None
+    if match.group(3) is not None:
+        return match.group(3) == "true"
+    return match.group(1) if match.group(1) is not None else match.group(2)
+
+
+def _string_list(literal: str, key: str) -> list[str] | None:
+    match = re.search(rf"\b{key}:\s*\[([^\]]*)\]", literal)
+    if match is None:
+        return None
+    return [
+        single or double
+        for single, double in re.findall(r"'([^']*)'|\"([^\"]*)\"", match.group(1))
+    ]
+
+
+@pytest.fixture(scope="module")
+def dashboard_routes_source() -> str:
+    assert DASHBOARD_ROUTES_TS.is_file(), f"missing {DASHBOARD_ROUTES_TS}"
+    return DASHBOARD_ROUTES_TS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontend_destinations(dashboard_routes_source: str) -> list[dict[str, Any]]:
+    literals = _object_literals(_array_body(dashboard_routes_source, _ARRAY_START))
+    # A parser that silently matched nothing would make this test vacuous.
+    assert literals, "failed to parse the frontend DASHBOARD_DESTINATIONS registry"
+    parsed: list[dict[str, Any]] = []
+    for literal in literals:
+        parsed.append(
+            {
+                "key": _scalar(literal, "key"),
+                "label": _scalar(literal, "label"),
+                "iconKey": _scalar(literal, "iconKey"),
+                "canonicalPath": _scalar(literal, "canonicalPath"),
+                "pathPatterns": _string_list(literal, "pathPatterns"),
+                "navigationGroup": _scalar(literal, "navigationGroup"),
+                "pageClassification": _scalar(literal, "pageClassification"),
+                "capabilityKey": _scalar(literal, "capabilityKey"),
+                "endpointKey": _scalar(literal, "endpointKey"),
+                "displayMode": _scalar(literal, "displayMode"),
+                "menuGroupKey": _scalar(literal, "menuGroupKey"),
+            }
+        )
+    return parsed
+
+
+def test_frontend_and_server_destination_registries_agree_exactly(
+    frontend_destinations: list[dict[str, Any]],
+) -> None:
+    server = [destination.to_ui_info() for destination in DASHBOARD_DESTINATIONS]
+    expected = [
+        {
+            "key": item["key"],
+            "label": item["label"],
+            "iconKey": item["iconKey"],
+            "canonicalPath": item["canonicalPath"],
+            "pathPatterns": item["pathPatterns"],
+            "navigationGroup": item["navigationGroup"],
+            "pageClassification": item["pageClassification"],
+            "capabilityKey": item["capabilityKey"],
+            **(
+                {"endpointKey": item["endpointKey"]}
+                if item["endpointKey"] is not None
+                else {}
+            ),
+            **(
+                {"displayMode": item["displayMode"]}
+                if item["displayMode"] is not None
+                else {}
+            ),
+            **(
+                {"menuGroupKey": item["menuGroupKey"]}
+                if item["menuGroupKey"] is not None
+                else {}
+            ),
+        }
+        for item in frontend_destinations
+    ]
+    # Order matters: the browser compares the two registries index by index.
+    assert json.dumps(server, indent=2) == json.dumps(expected, indent=2)
+
+
+def test_configuration_group_membership_matches_the_three_canonical_destinations(
+    dashboard_routes_source: str,
+) -> None:
+    group_literals = _object_literals(
+        _array_body(dashboard_routes_source, _GROUPS_START)
+    )
+    assert len(group_literals) == 1, "Settings exposes exactly one Configuration group"
+    group = group_literals[0]
+    assert _scalar(group, "key") == "configuration"
+    assert _scalar(group, "label") == "Configuration"
+    assert _scalar(group, "triggerLabel") == "Settings"
+    assert _scalar(group, "triggerIconKey") == "settings"
+    assert _string_list(group, "destinationKeys") == [
+        "settings-providers-secrets",
+        "settings-user-workspace",
+        "settings-operations",
+    ]
+
+    server_configuration = [
+        destination.key
+        for destination in DASHBOARD_DESTINATIONS
+        if destination.menu_group_key == "configuration"
+    ]
+    assert server_configuration == [
+        "settings-providers-secrets",
+        "settings-user-workspace",
+        "settings-operations",
+    ]
+    for destination in DASHBOARD_DESTINATIONS:
+        if destination.menu_group_key != "configuration":
+            continue
+        # Each Configuration child owns its own canonical /settings pathname.
+        assert destination.canonical_path.startswith("/settings/")
+        assert destination.path_patterns == (destination.canonical_path,)


### PR DESCRIPTION
Issue: [MoonLadderStudios/MoonMind#3822](https://github.com/MoonLadderStudios/MoonMind/issues/3822) — [Settings redesign] Add migration, accessibility, and end-to-end conformance coverage

Closes MoonLadderStudios/MoonMind#3822

## Summary

Adds the machine-verifiable acceptance suite for the complete Settings redesign, so the redesign's cross-boundary contract fails automatically if the implementation drifts back to one tabbed Settings page, browser-owned Provider Profile defaults, raw credential plumbing, or hidden unsafe launch policy.

The per-issue unit suites (`settingsRoutes.test.tsx`, `settingsDraftNavigation.test.tsx`, `dashboard.test.tsx`, `ProviderProfilesManager.test.tsx`) already covered each piece in isolation. This change adds the conformance layer that proves the pieces agree at their boundaries, plus the guards that keep them from regressing.

New conformance suite:

| File | Covers |
|---|---|
| `frontend/src/entrypoints/settingsRedesignConformance.test.tsx` | canonical route resolution and document titles; legacy `/settings`, all three `?section=` values, `/secrets`, `/workers`, and retained-alias replacement redirects (safe filters survive, `section` removed, no redirect loop, no redundant history entry); dirty-draft departure across successful and failed saves; architecture guards for §12 and §14 |
| `frontend/src/components/settings/providerProfileRedesignConformance.test.tsx` | Provider Profile standard-creation matrix across every supported authentication/materialization class; progressive disclosure; credential/secret safety; integrated model-tier create journey; existing-profile compatibility; generated-contract guard |
| `tests/unit/api/routers/test_dashboard_destination_registry_agreement.py` | exact cross-language agreement between the server destination registry and `frontend/src/lib/dashboardRoutes.ts`, including Configuration group membership and order |

Supporting production changes:

- `ProviderProfilesManager.tsx` now binds creation-preset and creation-capability shapes to the generated OpenAPI contract (`components['schemas'][...]`) instead of a second hand-maintained copy, with an explicit narrowing helper so an unrecognized server-declared authentication method selects nothing rather than being coerced into a credential contract the browser cannot honor.
- Backend validation aimed at a field inside `Show advanced options` now reveals the disclosure and moves focus to the offending control (`ProviderProfileCreation.md` §§10.2–10.3).
- `npm run ui:test:settings-redesign` runs both frontend conformance files with one focused command.
- `docs/UI/SettingsPage.md` §15.1 and `docs/UI/ProviderProfileCreation.md` §14.6 document the suite and its focused commands.
- `frontend/src/types/global.d.ts` gains the `node:fs`/`node:path` declarations the architecture guards need.

Architecture guards are load-bearing, not vacuous: replaying them against the pre-redesign revisions flags the reintroduced tablist, segmented control, plain wrapper-label radio group, aria-labelled radio group, `SETTINGS_SECTIONS`/`SettingsSectionId` state, `?section=` destination links, and the four previously hand-maintained creation-preset interfaces.

## Tests run

Passing:

- `npm run ui:test:settings-redesign` — 2 files, 38 tests, 0 failed
- `npm run ui:test -- ProviderProfilesManager.test.tsx settingsRoutes.test.tsx settingsDraftNavigation.test.tsx dashboard.test.tsx dashboardRoutes.test.ts dashboardBrand.test.ts` — 6 files, 329 tests, 0 failed
- `npm run ui:test` (full frontend unit suite) — 79 files, 1416 passed, 238 skipped, 0 failed
- Frontend typecheck (`tsc --noEmit -p frontend/tsconfig.json`) — exit 0, no diagnostics
- Frontend lint (`eslint -c frontend/eslint.config.mjs frontend/src`) — exit 0, no findings
- Generated OpenAPI contract currency — regenerated and diffed against `frontend/src/generated/openapi.ts`, zero diff
- Architecture-guard, generated-contract-guard, and section-state-guard load-bearing replays against synthetic and historical drift — all flagged as expected
- `tools/select_test_suites.py` over the change set — `frontend_static=true`, `api_component=true`, so both new frontend files and the new Python module are selected by required CI

Not run in this environment (all disclosed, none blocking):

- `tests/unit/api/routers/test_dashboard_destination_registry_agreement.py` under pytest — the delegated `moonmind container python-tests` path rejected the job (`MOONMIND_AGENT_RUN_ID is required`) and host pytest is absent with installation forbidden by `AGENTS.md`. Both test functions were replicated verbatim without the pytest import and both pass. **Please confirm green in CI's `api_component` leg.**
- `npm run ui:test:browser` — no Playwright browser cache; the suite's glob covers computed styles/CSS scoping and this change touches no CSS.
- `./tools/test_integration.sh` (`integration_ci`) — no Docker socket in the managed agent workspace, and the change touches no integration boundary in the `AGENTS.md` taxonomy.

## Remaining risks

- `ADVANCED_DISCLOSURE_FIELDS` (`ProviderProfilesManager.tsx`) restates which canonical fields live in the advanced region, duplicating information already carried by the `data-advanced-field` DOM attributes. A future advanced field added with the attribute but omitted from the set would silently lose focus targeting, and no guard covers that. It is the one place in this change where two sources describe the same fact.
- The generated-contract guard scans only `ProviderProfilesManager.tsx`. No other `frontend/src` production file currently declares a creation-preset or capability schema, so the narrow scope is sufficient today, but it would not catch a duplicate introduced in a new file.
- The frontend conformance matrix drives mocked backend preset and capability payloads. The fixture enumeration matches `api_service/services/provider_profile_creation_presets.py` exactly today, but nothing fails automatically if the backend catalog gains a seventh class — only the destination registry has a true cross-language agreement test.
- Screen-reader announcement of the automatic disclosure expansion (`ProviderProfileCreation.md` §11) is provable only by manual assistive-technology testing. Not part of the #3822 acceptance criteria, which require hidden-field error focus (implemented and automated).

Branch merges cleanly onto current `origin/main` (verified with `git merge-tree`, no conflicts) despite unrelated Omnigent commits landing during this run.
