### PR TITLE
Fix Omnigent launch policy v2 admission after host image refresh

### DIFF
--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -529,15 +529,18 @@ def get_launch_policy(ref: str) -> LaunchPolicy:
         return policy
     # Deployment policy versions evolve with image digests (persisted in DB
     # snapshots), while code-level features (hostMode, requiredFeatures) are
-    # stable per policy_id. Resolve any version of a known policy_id to its
-    # registered definition so bootstrap version bumps do not block admission.
-    # The DB snapshot remains authoritative for image and limits.
+    # stable per policy_id. Resolve any version of a known policy_id by
+    # borrowing the registered definition but preserving the requested exact
+    # ref, so compile_execution_plan pins the same version its persisted
+    # policy/effective-launch artifacts carry. The DB snapshot remains
+    # authoritative for image and limits.
     cleaned = str(ref or "").strip()
     policy_id, _, version_text = cleaned.rpartition("@")
     if policy_id and version_text.isdigit() and int(version_text) >= 1:
-        for registered_ref, registered in LAUNCH_POLICIES.items():
+        requested_version = int(version_text)
+        for registered in LAUNCH_POLICIES.values():
             if registered.policyId == policy_id:
-                return registered
+                return registered.model_copy(update={"version": requested_version})
     raise HarnessPlatformError(
         f"launch policy {ref} incompatible or unavailable",
         code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -465,11 +465,12 @@ def _register_policy(
     policy_id: str,
     host_mode: Literal["on-demand", "static-connected"],
     required_features: list[str],
+    version: int = 1,
 ) -> None:
     register_launch_policy(
         {
             "policyId": policy_id,
-            "version": 1,
+            "version": version,
             "hostMode": host_mode,
             "hostClassSelector": {"requiredFeatures": required_features},
             "isolation": {"runDedicated": host_mode == "on-demand"},
@@ -497,9 +498,21 @@ _register_policy(
     ["readOnlyRoot", "restrictedEgress", "workspaceBind"],
 )
 _register_policy(
+    "omnigent-on-demand",
+    "on-demand",
+    ["readOnlyRoot", "restrictedEgress", "workspaceBind"],
+    version=2,
+)
+_register_policy(
     "opencode-on-demand",
     "on-demand",
     ["readOnlyRoot", "restrictedEgress", "workspaceBind"],
+)
+_register_policy(
+    "opencode-on-demand",
+    "on-demand",
+    ["readOnlyRoot", "restrictedEgress", "workspaceBind"],
+    version=2,
 )
 _register_policy("opencode-static", "static-connected", ["workspaceBind"])
 _register_policy(
@@ -512,12 +525,23 @@ _register_policy("codex-static", "static-connected", ["workspaceBind"])
 
 def get_launch_policy(ref: str) -> LaunchPolicy:
     policy = LAUNCH_POLICIES.get(ref)
-    if policy is None:
-        raise HarnessPlatformError(
-            f"launch policy {ref} incompatible or unavailable",
-            code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
-        )
-    return policy
+    if policy is not None:
+        return policy
+    # Deployment policy versions evolve with image digests (persisted in DB
+    # snapshots), while code-level features (hostMode, requiredFeatures) are
+    # stable per policy_id. Resolve any version of a known policy_id to its
+    # registered definition so bootstrap version bumps do not block admission.
+    # The DB snapshot remains authoritative for image and limits.
+    cleaned = str(ref or "").strip()
+    policy_id, _, version_text = cleaned.rpartition("@")
+    if policy_id and version_text.isdigit() and int(version_text) >= 1:
+        for registered_ref, registered in LAUNCH_POLICIES.items():
+            if registered.policyId == policy_id:
+                return registered
+    raise HarnessPlatformError(
+        f"launch policy {ref} incompatible or unavailable",
+        code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+    )
 
 
 def validate_policy_for_host_class(


### PR DESCRIPTION
## Summary
Workflow mm:052fcc12-4717-48e8-8e3a-f9f593fb028f failed with OMNIGENT_HOST_REGISTRATION_TIMEOUT: exact launched host never registered online.

Root cause:
- Execution plan pinned omnigent-on-demand@1 with host image 0910e94e, which lacks /opt/moonmind/opencode-npm-cache required since #3976. Entrypoint exits 78, host never registers, registration polls 91x2s then fails.
- Deployment bootstrap had published @2 policies with new image ae856178, but code only registered @1, so get_launch_policy(@2) failed and qualification deferred.

Fix:
- Register omnigent-on-demand@2 and opencode-on-demand@2 explicitly.
- Make get_launch_policy version-tolerant per policy_id (DB snapshot authoritative for image/limits, code authoritative for hostMode/features).

Verification:
- Old image missing cache, new image has cache (docker run ls).
- Fresh workflow mm:5151c917-2789-432a-ba3c-cd3de07597b1 with @2/v89 registers online (1 online vs 0 before) and runs past previous 3m19s failure point.
- Unit: tests/unit/omnigent/test_harness_platform.py, test_bootstrap_deployment_qualification.py pass; full frontend suite passes.

Deployment:
- Restarted api/agent-runtime/workflow workers to pick up mounted code change.
- Relaunched with fresh execution plan (@2/v89/new image).

## Test plan
- ./tools/test_unit.sh tests/unit/omnigent/test_harness_platform.py tests/unit/omnigent/test_bootstrap_deployment_qualification.py
- docker exec moonmind-api-1 python -c get_launch_policy(@2)
- curl /v1/hosts shows 1 online with opencode-native needs-auth
- Fresh workflow executes past registration