### PR TITLE
Fix stale Omnigent host reruns and update to v0.12.0

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -4402,6 +4402,13 @@ async def _dispatch_native_ui_http(
     """Relay one explicitly inventoried HTTP operation through its binding."""
 
     route = match.route
+    if route.disposition != DISPOSITION_SERVED:
+        raise NativeUiCompatibilityError(
+            "The requested native UI operation requires compatibility review.",
+            failure_class="user_error",
+            status_code=status.HTTP_409_CONFLICT,
+            code=CODE_COMPAT_REVIEW_REQUIRED,
+        )
     provider_session_id = str(getattr(row, "omnigent_session_id", "") or "").strip()
     session_status = str(getattr(row, "status", "") or "")
     body = b""

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -719,6 +719,14 @@ async def compile_and_persist_execution_plan(
         provider_profile_id=provider_profile_ref,
         follow_up_retrieval=follow_up,
     )
+    from moonmind.omnigent.harness_platform.host_classes import (
+        launch_policy_from_effective_launch,
+    )
+
+    planner_launch_policy = launch_policy_from_effective_launch(
+        effective_launch,
+        expected_ref=launch_policy_ref,
+    )
     expected_execution_profile = str(
         agent_profile_snapshot.get("executionProfileRef") or ""
     ).strip()
@@ -1032,6 +1040,7 @@ async def compile_and_persist_execution_plan(
         host_class_ref=host_class.ref,
         host_class=host_class,
         launch_policy_ref=launch_policy_ref,
+        launch_policy=planner_launch_policy,
         model_qualified_id=(
             str(
                 initial_parameters.get("model") or model_mapping.get("model") or ""

--- a/docs/Omnigent/EmbeddedHostAuthCompatibility.md
+++ b/docs/Omnigent/EmbeddedHostAuthCompatibility.md
@@ -1,9 +1,11 @@
 # Embedded host authentication compatibility
 
+**Document Class:** Canonical declarative
+
 **Compatibility declaration:** `omnigent.server.v1` with embedded runner
 authentication profile `omnigent.runner_tunnel.983c93c6`, verified against
 upstream Omnigent source commit
-`8aaf72c91a53ed4791766716b43c9bdfcfadae99`.
+`f04b0354fb5344c1ea8b92795ceb6760a9ad7595`.
 
 This is an Omnigent-compatible adapter boundary, not a MoonMind host protocol.
 Only an unchanged stock host speaking the declared profiles may connect.
@@ -11,7 +13,7 @@ Unknown protocol or authentication profiles fail closed.
 
 MoonMind embedded compatibility mode delegates runner authentication to the
 Omnigent submodule pinned at commit
-`8aaf72c91a53ed4791766716b43c9bdfcfadae99`. The supported protocol profile
+`f04b0354fb5344c1ea8b92795ceb6760a9ad7595`. The supported protocol profile
 identifier remains `omnigent.runner_tunnel.983c93c6`; the source-pin boundary
 test proves that this profile's verifier entrypoints remain available at the
 new revision.

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -1493,6 +1493,27 @@ class BootstrapController:
         qualified_launch_policy_ref = default_launch_policy_ref(
             snapshot["document"].get("allowedLaunchPolicyRefs")
         )
+        from api_service.services.omnigent_policies import OmnigentPolicyService
+        from moonmind.omnigent.harness_platform.host_classes import (
+            launch_policy_from_effective_launch,
+        )
+        from moonmind.omnigent.profile_bound_execution import (
+            _compile_persisted_effective_launch,
+        )
+
+        async with async_session_maker() as session:
+            policy_service = OmnigentPolicyService(session)
+            policy_snapshot = await policy_service.resolve_runtime_snapshot(
+                qualified_launch_policy_ref
+            )
+        effective_launch = _compile_persisted_effective_launch(
+            policy_snapshot,
+            provider_profile_id=provider_profile_ref,
+        )
+        planner_launch_policy = launch_policy_from_effective_launch(
+            effective_launch,
+            expected_ref=qualified_launch_policy_ref,
+        )
         # Build V2 profile as planner does
         v2_profile = _build_v2_profile(
             snapshot=snapshot,
@@ -1535,6 +1556,7 @@ class BootstrapController:
             host_class_ref=host_class.ref,
             host_class=host_class,
             launch_policy_ref=qualified_launch_policy_ref,
+            launch_policy=planner_launch_policy,
             model_qualified_id=qualified_model,
             model_effort=effort,
             model_route_ref=model_route_ref,

--- a/moonmind/omnigent/deployment_identity.py
+++ b/moonmind/omnigent/deployment_identity.py
@@ -57,6 +57,21 @@ def resolve_deployed_server_build_digest() -> str:
     )
 
 
+def _resolve_deployed_host_image_ref(harness_id: str) -> str | None:
+    """Resolve the deployment image for a supported generic host harness."""
+
+    from moonmind.omnigent.harness_platform.host_classes import (
+        get_opencode_host_image_ref,
+        get_pi_host_image_ref,
+    )
+
+    if harness_id == "opencode-native":
+        return get_opencode_host_image_ref()
+    if harness_id == "pi-native":
+        return get_pi_host_image_ref()
+    return None
+
+
 def assert_plan_matches_deployed_runtime(plan_payload: Any) -> None:
     """Reject a plan whose qualified server or host is no longer deployed.
 
@@ -82,20 +97,18 @@ def assert_plan_matches_deployed_runtime(plan_payload: Any) -> None:
             "execution plan targets an Omnigent server build that is no longer "
             "deployed; create a fresh execution to compile current runtime authority"
         )
-    if getattr(plan_payload, "harnessId", None) != "opencode-native":
+    harness_id = str(getattr(plan_payload, "harnessId", None) or "").strip()
+    deployed_host = _resolve_deployed_host_image_ref(harness_id)
+    if deployed_host is None:
         return
     planned_host = str(getattr(plan_payload, "hostImageRef", None) or "").strip()
     if not _IMAGE_REF.fullmatch(planned_host):
         raise OmnigentDeploymentIdentityConflict(
-            "execution plan lacks exact OpenCode host image authority"
+            "execution plan lacks exact host image authority"
         )
-    from moonmind.omnigent.harness_platform.host_classes import (
-        get_opencode_host_image_ref,
-    )
-
-    if planned_host != get_opencode_host_image_ref():
+    if planned_host != deployed_host:
         raise OmnigentDeploymentIdentityConflict(
-            "execution plan targets an OpenCode host image that is no longer "
+            "execution plan targets a host image that is no longer "
             "deployed; create a fresh execution to compile current runtime authority"
         )
 

--- a/moonmind/omnigent/deployment_identity.py
+++ b/moonmind/omnigent/deployment_identity.py
@@ -17,7 +17,7 @@ _BUILD_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 class OmnigentDeploymentIdentityConflict(ValueError):
-    """Raised when a plan targets a different deployed server build."""
+    """Raised when a plan targets a different deployed runtime build."""
 
 
 def resolve_deployed_server_build_digest() -> str:
@@ -57,8 +57,8 @@ def resolve_deployed_server_build_digest() -> str:
     )
 
 
-def assert_plan_matches_deployed_server(plan_payload: Any) -> None:
-    """Reject a plan whose qualified server is no longer deployed.
+def assert_plan_matches_deployed_runtime(plan_payload: Any) -> None:
+    """Reject a plan whose qualified server or host is no longer deployed.
 
     This check does not re-select or rewrite immutable plan authority. It
     verifies that the mutable endpoint the plan is about to call is still the
@@ -82,10 +82,26 @@ def assert_plan_matches_deployed_server(plan_payload: Any) -> None:
             "execution plan targets an Omnigent server build that is no longer "
             "deployed; create a fresh execution to compile current runtime authority"
         )
+    if getattr(plan_payload, "harnessId", None) != "opencode-native":
+        return
+    planned_host = str(getattr(plan_payload, "hostImageRef", None) or "").strip()
+    if not _IMAGE_REF.fullmatch(planned_host):
+        raise OmnigentDeploymentIdentityConflict(
+            "execution plan lacks exact OpenCode host image authority"
+        )
+    from moonmind.omnigent.harness_platform.host_classes import (
+        get_opencode_host_image_ref,
+    )
+
+    if planned_host != get_opencode_host_image_ref():
+        raise OmnigentDeploymentIdentityConflict(
+            "execution plan targets an OpenCode host image that is no longer "
+            "deployed; create a fresh execution to compile current runtime authority"
+        )
 
 
 __all__ = [
     "OmnigentDeploymentIdentityConflict",
-    "assert_plan_matches_deployed_server",
+    "assert_plan_matches_deployed_runtime",
     "resolve_deployed_server_build_digest",
 ]

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -520,6 +520,69 @@ def get_launch_policy(ref: str) -> LaunchPolicy:
     return policy
 
 
+def launch_policy_from_effective_launch(
+    effective_launch: Mapping[str, Any],
+    *,
+    expected_ref: str | None = None,
+) -> LaunchPolicy:
+    """Adapt immutable persisted launch authority to planner/runtime policy."""
+
+    policy_ref = str(effective_launch.get("launchPolicyRef") or "").strip()
+    if expected_ref is not None and policy_ref != expected_ref:
+        raise HarnessPlatformError(
+            "effective launch policy conflicts with the selected policy",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        )
+    policy_id, separator, version_text = policy_ref.rpartition("@")
+    try:
+        version = int(version_text)
+    except ValueError as exc:
+        raise HarnessPlatformError(
+            "effective launch policy identity is invalid",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        ) from exc
+    if not separator or not policy_id:
+        raise HarnessPlatformError(
+            "effective launch policy identity is invalid",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        )
+    limits = effective_launch.get("limits")
+    capture = effective_launch.get("capture")
+    cleanup = effective_launch.get("cleanup")
+    if not all(isinstance(value, Mapping) for value in (limits, capture, cleanup)):
+        raise HarnessPlatformError(
+            "effective launch artifact lacks bounded runtime policy",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        )
+    try:
+        return LaunchPolicy.model_validate(
+            {
+                "policyId": policy_id,
+                "version": version,
+                "hostMode": effective_launch.get("hostMode"),
+                "hostClassSelector": {"requiredFeatures": []},
+                "isolation": {
+                    "runDedicated": effective_launch.get("hostMode")
+                    in {"on-demand", "on_demand_docker"}
+                },
+                "limits": dict(limits),
+                "network": {
+                    "egressPolicyRef": effective_launch.get("egressProfileRef")
+                },
+                "capture": dict(capture),
+                "cleanup": dict(cleanup),
+                "controlCapabilities": list(
+                    effective_launch.get("controlCapabilities") or []
+                ),
+            }
+        )
+    except (TypeError, ValueError) as exc:
+        raise HarnessPlatformError(
+            "effective launch runtime policy is invalid",
+            code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+        ) from exc
+
+
 def validate_policy_for_host_class(
     *,
     policy: LaunchPolicy,

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -48,6 +48,7 @@ from moonmind.omnigent.harness_platform.failures import (
 )
 from moonmind.omnigent.harness_platform.host_classes import (
     HostClass,
+    LaunchPolicy,
     get_host_class,
     get_launch_policy,
     validate_policy_for_host_class,
@@ -96,6 +97,7 @@ def compile_execution_plan(
     host_class_ref: str,
     host_class: HostClass | None = None,
     launch_policy_ref: str,
+    launch_policy: LaunchPolicy | None = None,
     model_qualified_id: str | None,
     model_effort: str | None,
     model_route_ref: str | None,
@@ -210,7 +212,13 @@ def compile_execution_plan(
             f"selected Host Class {selected_host_class.ref} does not match {host_class_ref}",
             code=HarnessPlatformFailure.OMNIGENT_HOST_CLASS_UNAVAILABLE,
         )
-    launch_policy = get_launch_policy(launch_policy_ref)
+    selected_launch_policy = launch_policy or get_launch_policy(launch_policy_ref)
+    if selected_launch_policy.ref != launch_policy_ref:
+        raise HarnessPlatformError(
+            f"selected launch policy {selected_launch_policy.ref} does not match "
+            f"{launch_policy_ref}",
+            code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+        )
     # Reject launch policies outside the profile allowlist
     if (
         profile.allowedLaunchPolicyRefs
@@ -240,14 +248,14 @@ def compile_execution_plan(
         b.materializerRef for b in credential_binding_set.bindings.values()
     ]
     validate_policy_for_host_class(
-        policy=launch_policy,
+        policy=selected_launch_policy,
         host_class=selected_host_class,
         harness_integration_mode=integration_mode,
         materializer_refs=materializer_refs,
     )
 
     # Validate each materializer supports harness and host mode
-    host_mode_for_materializer = launch_policy.hostMode
+    host_mode_for_materializer = selected_launch_policy.hostMode
     # Normalize legacy modes
     if host_mode_for_materializer == "on_demand_docker":
         host_mode_for_materializer = "on-demand"
@@ -303,7 +311,7 @@ def compile_execution_plan(
             _ = exc
             continue
     bridge_caps = bridge_capabilities or {}
-    policy_caps = list(launch_policy.controlCapabilities)
+    policy_caps = list(selected_launch_policy.controlCapabilities)
 
     class_decision = compute_class_admission(
         workflow_requirements=wf_reqs,
@@ -416,7 +424,7 @@ def compile_execution_plan(
             "providerCompatibilityClass": credential_binding_set.bindingSetId,
             "hostClassRef": selected_host_class.ref,
             "architecture": support_architecture,
-            "launchPolicyRef": launch_policy.ref,
+            "launchPolicyRef": selected_launch_policy.ref,
             "modelConfigDigest": model_digest,
             "executionRealizerRef": realizer,
             "requiredCapabilitiesDigest": required_caps_digest,
@@ -444,7 +452,7 @@ def compile_execution_plan(
         )
     if policy_snapshot_ref is None:
         policy_payload = _json.dumps(
-            launch_policy.model_dump(by_alias=True, mode="json"),
+            selected_launch_policy.model_dump(by_alias=True, mode="json"),
             sort_keys=True,
             separators=(",", ":"),
         ).encode()
@@ -473,7 +481,7 @@ def compile_execution_plan(
             "hostImageRef": host_image_ref,
             "omnigentHostBuildDigest": omnigent_host_build_digest,
             "hostArchitecture": host_architecture,
-            "launchPolicyRef": launch_policy.ref,
+            "launchPolicyRef": selected_launch_policy.ref,
             "executionRealizerRef": realizer,
             "model": {
                 "qualifiedId": model_qualified_id,

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -39,9 +39,9 @@ from moonmind.omnigent.harness_platform.failures import (
 )
 from moonmind.omnigent.harness_platform.host_classes import (
     HostClass,
-    LaunchPolicy,
     OmnigentHostClassSelector,
     get_launch_policy,
+    launch_policy_from_effective_launch,
 )
 from moonmind.omnigent.harness_platform.materializers import (
     get_materializer,
@@ -372,7 +372,21 @@ class OmnigentExecutionPlanningService:
             )
             skills = await self._skills.resolve(request=request, profile=profile)
             policy_ref = self._launch_policy_ref(request, profile)
-            policy = get_launch_policy(policy_ref)
+            from api_service.services.omnigent_policies import OmnigentPolicyService
+            from moonmind.omnigent.profile_bound_execution import (
+                _compile_persisted_effective_launch,
+            )
+
+            policy_service = OmnigentPolicyService(session)
+            policy_snapshot = await policy_service.resolve_runtime_snapshot(policy_ref)
+            effective_launch = _compile_persisted_effective_launch(
+                policy_snapshot,
+                provider_profile_id=str(provider_profile.profile_id),
+            )
+            policy = launch_policy_from_effective_launch(
+                effective_launch,
+                expected_ref=policy_ref,
+            )
             integration_mode = harness.capabilities.integrationMode or "native-server"
             host_class = self._host_classes.select(
                 harness=harness,
@@ -409,6 +423,7 @@ class OmnigentExecutionPlanningService:
                 host_class_ref=host_class.ref,
                 host_class=host_class,
                 launch_policy_ref=policy.ref,
+                launch_policy=policy,
                 model_qualified_id=model,
                 model_effort=effort,
                 model_route_ref=route_ref,
@@ -826,7 +841,15 @@ class OmnigentPlannedHostResolver:
                 "execution plan harness implementation is absent from its catalog",
                 code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
             )
-        policy = get_launch_policy(plan.payload.launchPolicyRef)
+        launch: Mapping[str, Any] | None = None
+        if plan.payload.hostImageRef is not None:
+            launch = await self._load_exact_launch(plan)
+            policy = launch_policy_from_effective_launch(
+                launch,
+                expected_ref=plan.payload.launchPolicyRef,
+            )
+        else:
+            policy = get_launch_policy(plan.payload.launchPolicyRef)
         host_class = self._selector.select(
             harness=harness,
             omnigent_version=catalog.snapshot.omnigentVersion,
@@ -841,20 +864,18 @@ class OmnigentPlannedHostResolver:
             requested_host_class_ref=plan.payload.hostClassRef,
         )
         if plan.payload.hostImageRef is not None:
-            host_class, policy = await self._resolve_exact_launch(
+            host_class = self._resolve_exact_host(
                 plan=plan,
                 host_class=host_class,
+                launch=launch,
             )
         return host_class, policy
 
-    async def _resolve_exact_launch(
+    async def _load_exact_launch(
         self,
-        *,
         plan: OmnigentExecutionPlanEnvelope,
-        host_class: HostClass,
-    ) -> tuple[HostClass, LaunchPolicy]:
-        """Rehydrate runtime inputs from the plan's immutable launch artifact."""
-
+    ) -> Mapping[str, Any]:
+        """Load and validate the plan's immutable launch artifact."""
         if self._artifacts is None:
             raise HarnessPlatformError(
                 "exact execution plan launch artifact cannot be resolved",
@@ -897,6 +918,22 @@ class OmnigentPlannedHostResolver:
                 "effective launch artifact conflicts with the execution plan",
                 code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
             )
+        return launch
+
+    @staticmethod
+    def _resolve_exact_host(
+        *,
+        plan: OmnigentExecutionPlanEnvelope,
+        host_class: HostClass,
+        launch: Mapping[str, Any] | None,
+    ) -> HostClass:
+        """Rehydrate exact Host Class inputs from immutable launch authority."""
+
+        if launch is None:
+            raise HarnessPlatformError(
+                "exact execution plan launch artifact cannot be resolved",
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
+            )
         architecture = str(plan.payload.hostArchitecture or "").strip()
         normalized_architectures = tuple(
             value if "/" in value else f"linux/{value}"
@@ -928,38 +965,7 @@ class OmnigentPlannedHostResolver:
                 },
             }
         )
-        limits = launch.get("limits")
-        capture = launch.get("capture")
-        cleanup = launch.get("cleanup")
-        if not all(isinstance(value, Mapping) for value in (limits, capture, cleanup)):
-            raise HarnessPlatformError(
-                "effective launch artifact lacks bounded runtime policy",
-                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
-            )
-        policy_id, separator, version = plan.payload.launchPolicyRef.rpartition("@")
-        if not separator:
-            raise HarnessPlatformError(
-                "execution plan launch policy identity is invalid",
-                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_PLAN_CONFLICT,
-            )
-        exact_policy = LaunchPolicy.model_validate(
-            {
-                "policyId": policy_id,
-                "version": int(version),
-                "hostMode": launch.get("hostMode"),
-                "hostClassSelector": {"requiredFeatures": []},
-                "isolation": {
-                    "runDedicated": launch.get("hostMode")
-                    in {"on-demand", "on_demand_docker"}
-                },
-                "limits": dict(limits),
-                "network": {"egressPolicyRef": launch.get("egressProfileRef")},
-                "capture": dict(capture),
-                "cleanup": dict(cleanup),
-                "controlCapabilities": list(launch.get("controlCapabilities") or []),
-            }
-        )
-        return exact_host, exact_policy
+        return exact_host
 
 
 __all__ = [

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -68,6 +68,15 @@ def _digest(value: Any) -> str:
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
 def _ref(prefix: str, value: Any) -> str:
     return f"{prefix}:sha256:{_digest(value).split(':', 1)[1]}"
 
@@ -387,6 +396,9 @@ class OmnigentExecutionPlanningService:
                 effective_launch,
                 expected_ref=policy_ref,
             )
+            host_architecture = str(
+                request.parameters.get("architecture") or "linux/amd64"
+            )
             integration_mode = harness.capabilities.integrationMode or "native-server"
             host_class = self._host_classes.select(
                 harness=harness,
@@ -396,9 +408,7 @@ class OmnigentExecutionPlanningService:
                 materializer_refs=[
                     item.materializerRef for item in binding_set.bindings.values()
                 ],
-                architecture=str(
-                    request.parameters.get("architecture") or "linux/amd64"
-                ),
+                architecture=host_architecture,
                 requested_host_mode=policy.hostMode,
                 requested_host_class_ref=self._requested_host_class_ref(request),
             )
@@ -407,12 +417,29 @@ class OmnigentExecutionPlanningService:
                 model,
                 expected_image_ref=host_class.imageRef,
             )
+            if str(effective_launch.get("hostImageRef") or "") != (
+                host_class.imageRef
+            ):
+                raise HarnessPlatformError(
+                    "effective launch host image conflicts with the selected "
+                    "Host Class",
+                    code=HarnessPlatformFailure.OMNIGENT_LAUNCH_POLICY_INCOMPATIBLE,
+                )
+            (
+                policy_artifact_ref,
+                policy_artifact_digest,
+                effective_launch_artifact_ref,
+                effective_launch_artifact_digest,
+            ) = await self._persist_exact_launch_authority(
+                request=request,
+                policy_snapshot=policy_snapshot,
+                effective_launch=effective_launch,
+            )
             workspace_payload = {
                 "profile": profile.workspace,
                 "request": request.workspace_spec,
             }
             capture_payload = dict(profile.capture)
-            policy_payload = policy.model_dump(by_alias=True, mode="json")
             return compile_execution_plan(
                 agent_profile=profile,
                 harness_catalog=catalog_result.snapshot,
@@ -436,8 +463,46 @@ class OmnigentExecutionPlanningService:
                 },
                 workspace_intent_ref=_ref("workspace-intent", workspace_payload),
                 capture_policy_ref=_ref("capture-policy", capture_payload),
-                policy_snapshot_ref=_ref("omnigent-policy", policy_payload),
+                policy_snapshot_ref=policy_artifact_ref,
+                policy_snapshot_digest=policy_artifact_digest,
+                effective_launch_snapshot_ref=effective_launch_artifact_ref,
+                effective_launch_snapshot_digest=effective_launch_artifact_digest,
+                host_image_ref=host_class.imageRef,
+                omnigent_host_build_digest=host_class.omnigentBuildDigest,
+                host_architecture=host_architecture,
             )
+
+    async def _persist_exact_launch_authority(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        policy_snapshot: Mapping[str, Any],
+        effective_launch: Mapping[str, Any],
+    ) -> tuple[str, str, str, str]:
+        """Persist the exact launch inputs with digests over stored bytes."""
+
+        policy_body = _canonical_json_bytes(policy_snapshot)
+        effective_launch_body = _canonical_json_bytes(effective_launch)
+        policy_ref = await self._artifacts.write_bytes(
+            request=request,
+            name="launch-policy-snapshot.json",
+            payload=policy_body,
+            link_type="input.launch_policy_snapshot",
+            content_type="application/json",
+        )
+        effective_launch_ref = await self._artifacts.write_bytes(
+            request=request,
+            name="effective-launch-snapshot.json",
+            payload=effective_launch_body,
+            link_type="input.effective_launch_snapshot",
+            content_type="application/json",
+        )
+        return (
+            policy_ref,
+            "sha256:" + hashlib.sha256(policy_body).hexdigest(),
+            effective_launch_ref,
+            "sha256:" + hashlib.sha256(effective_launch_body).hexdigest(),
+        )
 
     @staticmethod
     def _trust_record(

--- a/moonmind/omnigent/host_auth_adapter.py
+++ b/moonmind/omnigent/host_auth_adapter.py
@@ -13,7 +13,7 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any, Mapping
 
-PINNED_OMNIGENT_COMMIT = "ed9369474f3ea3e28cb1871e731100be5da923e1"
+PINNED_OMNIGENT_COMMIT = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
 PINNED_PROTOCOL_PROFILE = "omnigent.runner_tunnel.983c93c6"
 
 

--- a/moonmind/omnigent/native_ui_compat.py
+++ b/moonmind/omnigent/native_ui_compat.py
@@ -71,6 +71,7 @@ DISPOSITION_COMPAT_REVIEW = "compatibility_review_required"
 CLASS_LIVENESS = "liveness"
 CLASS_RECONNECT = "reconnect"
 CLASS_SESSION_READ = "session_read"
+CLASS_SESSION_IMPORT = "session_import"
 CLASS_STREAM = "event_stream"
 CLASS_CONTROL = "control"
 CLASS_RESOURCE_READ = "resource_read"
@@ -250,11 +251,40 @@ def _reviewed_http(
     )
 
 
+def _compat_review_http(
+    path: str,
+    *,
+    name: str,
+    methods: tuple[str, ...],
+    operation_class: str,
+    mutation: bool = False,
+) -> NativeUiRoute:
+    """Inventory a pinned stock route without granting proxy authority."""
+
+    return NativeUiRoute(
+        name=name,
+        transport=TRANSPORT_HTTP,
+        methods=methods,
+        operation_class=operation_class,
+        disposition=DISPOSITION_COMPAT_REVIEW,
+        capability=None,
+        mutation=mutation,
+        pattern=re.compile("^" + path + "$"),
+    )
+
+
 # Network contract used by the pinned native workspace UI beyond the #3634
 # transcript facade.  The paths are taken from the vendored server route set;
 # each reviewed operation is explicitly allowlisted rather than falling through
 # to a generic proxy.
 _PINNED_HTTP_ROUTES: tuple[NativeUiRoute, ...] = (
+    _compat_review_http(
+        r"v1/imports/local",
+        name="local_session_import",
+        methods=("POST",),
+        operation_class=CLASS_SESSION_IMPORT,
+        mutation=True,
+    ),
     _reviewed_http(rf"v1/sessions/{_SESSION}/items", name="session_items", methods=("GET",), operation_class=CLASS_RESOURCE_READ, capability=CAP_VIEW_TRANSCRIPT),
     _reviewed_http(rf"v1/sessions/{_SESSION}/resources/terminals", name="terminal_view", methods=("GET",), operation_class=CLASS_TERMINAL_VIEW, capability=CAP_VIEW_TERMINAL),
     _reviewed_http(rf"v1/sessions/{_SESSION}/resources/terminals", name="terminal_create", methods=("POST",), operation_class=CLASS_TERMINAL_CREATE, capability=CAP_CREATE_TERMINAL, mutation=True),
@@ -531,6 +561,7 @@ __all__ = [
     "CLASS_RESOURCE_MUTATE",
     "CLASS_RESOURCE_READ",
     "CLASS_SESSION_READ",
+    "CLASS_SESSION_IMPORT",
     "CLASS_STREAM",
     "CLASS_SUBAGENT",
     "CLASS_TASK",

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -8,6 +8,7 @@ the existing Omnigent session driver owns provider interaction after creation.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from contextlib import suppress
 from typing import Any, Awaitable, Callable
@@ -94,6 +95,7 @@ class GenericOmnigentHostRealizer:
         cleanup_authority: Any | None = None,
         execution_state_notifier: Callable[[str, str, str], Awaitable[None]]
         | None = None,
+        deployment_validator: Callable[[Any], None] | None = None,
         heartbeat_interval_seconds: float = 60.0,
         heartbeat_ttl_seconds: int = 900,
     ) -> None:
@@ -135,6 +137,13 @@ class GenericOmnigentHostRealizer:
         # The notifier projects that authoritative wait into the owning user
         # workflow without moving or duplicating lease semantics.
         self._execution_state_notifier = execution_state_notifier
+        if deployment_validator is None:
+            from moonmind.omnigent.deployment_identity import (
+                assert_plan_matches_deployed_runtime,
+            )
+
+            deployment_validator = assert_plan_matches_deployed_runtime
+        self._deployment_validator = deployment_validator
         if heartbeat_interval_seconds <= 0 or heartbeat_ttl_seconds <= 0:
             raise ValueError("generic host heartbeat interval and TTL must be positive")
         self._heartbeat_interval = heartbeat_interval_seconds
@@ -203,7 +212,6 @@ class GenericOmnigentHostRealizer:
         primary_error: BaseException | None = None
         cleanup_error: BaseException | None = None
 
-        host_class, launch_policy = await self._resolve_host(plan)
         try:
             await self._notify_execution_state(
                 workflow_id,
@@ -277,6 +285,10 @@ class GenericOmnigentHostRealizer:
                     RuntimeBindingState.session_creating,
                     RuntimeBindingState.session_active,
                 }:
+                    await self._validate_bound_host_identity(
+                        plan=plan,
+                        host_context=host_context,
+                    )
                     return await self._resume_attested_host(
                         request=request,
                         plan=plan,
@@ -291,6 +303,8 @@ class GenericOmnigentHostRealizer:
                     code=HarnessPlatformFailure.OMNIGENT_CLEANUP_DEFERRED,
                 )
 
+            self._deployment_validator(plan.payload)
+            host_class, launch_policy = await self._resolve_host(plan)
             credential_handles = await self._credentials.materialize_all(
                 request=request,
                 plan=plan,
@@ -494,6 +508,50 @@ class GenericOmnigentHostRealizer:
         # not overwrite an objectively completed provider turn.
         _ = cleanup_error
         return result
+
+    async def _validate_bound_host_identity(
+        self,
+        *,
+        plan: OmnigentExecutionPlanEnvelope,
+        host_context: dict[str, Any] | None,
+    ) -> None:
+        """Validate a continuation against its immutable host attestation."""
+
+        if plan.payload.hostImageRef is None:
+            return
+        attestation_ref = str(
+            (host_context or {}).get("hostHarnessAttestationRef") or ""
+        ).strip()
+        if self._artifacts is None or not attestation_ref:
+            raise HarnessPlatformError(
+                "attested host retry authority is incomplete",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
+        try:
+            evidence = json.loads(await self._artifacts.read_bytes(attestation_ref))
+        except Exception as exc:  # noqa: BLE001 - normalize artifact boundary failures
+            raise HarnessPlatformError(
+                "attested host retry evidence is unavailable or invalid",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            ) from exc
+        expected = {
+            "imageRef": plan.payload.hostImageRef,
+            "architecture": plan.payload.hostArchitecture,
+            "omnigentBuildDigest": plan.payload.omnigentHostBuildDigest,
+            "harnessId": plan.payload.harnessId,
+            "harnessImplementationRef": plan.payload.harnessImplementationRef,
+            "omnigentHostId": str(
+                (host_context or {}).get("omnigentHostId") or ""
+            ),
+        }
+        if not isinstance(evidence, dict) or any(
+            str(evidence.get(key) or "") != str(value or "")
+            for key, value in expected.items()
+        ):
+            raise HarnessPlatformError(
+                "attested host retry identity conflicts with the execution plan",
+                code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
+            )
 
     @staticmethod
     def _persisted_host_context(

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -318,11 +318,12 @@ async def omnigent_evaluate_session_admission_activity(
 
 
 def _validate_plan_support_authority(plan: Any) -> None:
-    """Validate immutable support identity against its mutable endpoint.
+    """Validate the plan's immutable support identity.
 
-    Host Class and policy defaults are never re-selected here. The plan's
-    qualified server build must still be the server currently deployed before
-    a new runtime binding can acquire leases or launch the selected host.
+    Mutable deployment identity is checked by exact-rerun admission and at the
+    fresh-host launch boundary. Session admission may be replayed while an
+    already-attested host remains bound, so it must not compare that host with
+    newly deployed image defaults.
     """
 
     from moonmind.omnigent.harness_platform.capabilities import (
@@ -409,11 +410,6 @@ def _validate_plan_support_authority(plan: Any) -> None:
         or not plan.payload.effectiveLaunchSnapshotDigest
     ):
         raise ValueError("persisted exact-artifact evidence is incomplete")
-    from moonmind.omnigent.deployment_identity import (
-        assert_plan_matches_deployed_runtime,
-    )
-
-    assert_plan_matches_deployed_runtime(plan.payload)
 
 
 async def _load_intent_request(

--- a/moonmind/workflows/temporal/activities/omnigent_session_activities.py
+++ b/moonmind/workflows/temporal/activities/omnigent_session_activities.py
@@ -410,10 +410,10 @@ def _validate_plan_support_authority(plan: Any) -> None:
     ):
         raise ValueError("persisted exact-artifact evidence is incomplete")
     from moonmind.omnigent.deployment_identity import (
-        assert_plan_matches_deployed_server,
+        assert_plan_matches_deployed_runtime,
     )
 
-    assert_plan_matches_deployed_server(plan.payload)
+    assert_plan_matches_deployed_runtime(plan.payload)
 
 
 async def _load_intent_request(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -2665,14 +2665,14 @@ class TemporalExecutionService:
         *,
         parameters: Mapping[str, Any],
     ) -> None:
-        """Reject an exact rerun whose endpoint authority is no longer live."""
+        """Reject an exact rerun whose runtime authority is no longer live."""
 
         raw_binding = parameters.get("omnigentExecutionPlan")
         if not isinstance(raw_binding, Mapping):
             return
         from moonmind.omnigent.deployment_identity import (
             OmnigentDeploymentIdentityConflict,
-            assert_plan_matches_deployed_server,
+            assert_plan_matches_deployed_runtime,
         )
         from moonmind.omnigent.harness_platform.stores import (
             SessionExecutionPlanStore,
@@ -2702,11 +2702,11 @@ class TemporalExecutionService:
                 code="exact_rerun_execution_plan_unavailable",
             )
         try:
-            assert_plan_matches_deployed_server(plan.payload)
+            assert_plan_matches_deployed_runtime(plan.payload)
         except OmnigentDeploymentIdentityConflict as exc:
             raise TemporalExecutionRerunPlanError(
                 "Exact rerun preserves the original Omnigent execution plan, "
-                "but that plan targets a server build that is no longer deployed. "
+                "but that plan targets runtime images that are no longer deployed. "
                 "Use Edit for rerun to compile fresh runtime authority."
             ) from exc
         except HarnessPlatformError as exc:

--- a/tests/fixtures/omnigent/native_ui_network_contract_v1.json
+++ b/tests/fixtures/omnigent/native_ui_network_contract_v1.json
@@ -4,19 +4,19 @@
   "source": "vendored pinned omnigent server and native workspace UI",
   "evidence": {
     "capture": "stock-ui-and-server-static-analysis",
-    "sourceCommit": "ed9369474f3ea3e28cb1871e731100be5da923e1",
+    "sourceCommit": "f04b0354fb5344c1ea8b92795ceb6760a9ad7595",
     "sourceFiles": [
       {
         "path": "omnigent/omnigent/server/routes/sessions/routes_resources.py",
-        "sha256": "4b1c24a75254f1148aa8efdebabf8bb94c137bb069c5bd0c144c886d898f5374"
+        "sha256": "76c9915e22ab4ab345220fb4bafcea67381c3071eaef3c6968cab790a184eb19"
       },
       {
         "path": "omnigent/omnigent/server/routes/sessions/routes_core.py",
-        "sha256": "be0c53116424599d0a1fdefdf04b0fc89c7891dedb19de3eaf682d5cbdb53e70"
+        "sha256": "c647ca6aac092f0ea7d29154bc1f447fe1efa323a196bf81ba6e28e3a3af3eb0"
       },
       {
         "path": "omnigent/omnigent/server/routes/terminal_attach.py",
-        "sha256": "f22703d59cfc3411b89d86d903d0f4c149d9f690c6a389e46d19dc9e11948c4b"
+        "sha256": "655e3dddfc62f53082996238ac685fc8e65a41878f3083e6f62a8d1a1bcf7b74"
       },
       {
         "path": "omnigent/omnigent/server/routes/dictation.py",
@@ -27,12 +27,16 @@
         "sha256": "c84871c429df5e76e0653d0322ad2a676f2e25df1cdc557418629dd0e168283a"
       },
       {
+        "path": "omnigent/omnigent/server/routes/imports.py",
+        "sha256": "ee575c1682a53158929bb12860df081561f673d3dcf2445b6e0705b9254b843d"
+      },
+      {
         "path": "omnigent/web/src/hooks/useTerminals.ts",
-        "sha256": "f40acde15f68c48bc290d67d5c13700838a900fa08f78819ab96f6b0a5f2ee14"
+        "sha256": "ee5601dd9aab60424182409fe79df089f335266c9942b19ecd91bf16637d8a72"
       },
       {
         "path": "omnigent/web/src/components/blocks/TerminalView.tsx",
-        "sha256": "f6c706644721f5015eff7ca33cd57be47e688513bb34bc3942200493da25de3d"
+        "sha256": "80a367b8ab8873956cd8a63417ab95293beb16af63f1749a7de14c355c5acab4"
       },
       {
         "path": "omnigent/web/src/lib/sessionUpdatesSocket.ts",
@@ -41,9 +45,17 @@
       {
         "path": "omnigent/web/src/lib/dictation.ts",
         "sha256": "752be18f9e4fd47229c7785fbdb45a303035b8946d03a012693d467188a8d3db"
+      },
+      {
+        "path": "omnigent/web/src/lib/sessionsApi.ts",
+        "sha256": "2df2ca3baa8dda7e20c6dcaac32a70b885d63a70b70860650c26d4d94ed4d2ae"
+      },
+      {
+        "path": "omnigent/web/src/shell/ImportSessionsPanel.tsx",
+        "sha256": "f78b0ac8bb1ad3d0c01a9230ef6414e66158bac2a15ef1f6e57b01eae28e62f5"
       }
     ],
-    "routeCount": 40,
+    "routeCount": 41,
     "dimensions": [
       "pathPattern",
       "methods",
@@ -55,8 +67,8 @@
       "apiBaseDiscovery"
     ]
   },
-  "contractSha256": "f5b10f18be36a0524ee5211d36e5734cf45db266771371e99423426218c9293a",
-  "moonmindFacadeDigest": "5a062011bdb0957fc005528e3070fa3209aac54f88ccdddb7653d038b0d7a54d",
+  "contractSha256": "54d09228d5a37d73830647223b1c381d41e6bf95fe0e85d236e41e174557a3f2",
+  "moonmindFacadeDigest": "2761e379eb13c6b46fc4b2b66208642e45123ca2ab6244ef66b3f20deb0d1fac",
   "routes": [
     "liveness",
     "native_server_info",
@@ -97,7 +109,8 @@
     "session_reconnect",
     "ws_session_updates",
     "terminal_attach",
-    "dictation_stream"
+    "dictation_stream",
+    "local_session_import"
   ],
   "payloadClasses": [
     "json",

--- a/tests/integration/reliability/replays/omnigent-stale-plan-host-image/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-stale-plan-host-image/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "invariant": "an exact rerun must prove that its immutable OpenCode host image is still the deployment-qualified image before any provider lease or host launch",
+  "code": "exact_rerun_execution_plan_stale",
+  "nextAction": "edit_for_rerun",
+  "hostLaunchAttempted": false
+}

--- a/tests/integration/reliability/replays/omnigent-stale-plan-host-image/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stale-plan-host-image/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:814cd965-7882-4a93-a362-75d1f3144c1a",
+  "planRef": "omnigent-execution-plan:sha256:d830806b41bc1c20b2228f7a4af4e5c37e555d89feedc898449273476e63d3c5",
+  "serverBuildRef": "sha256:caa84ada76a34857e297f12d2a82b0cfb12ca03755df31c40d1d30bd37a3730e",
+  "planHostImageRef": "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:0910e94e45f68601398e94dfed5ca638c5028440a01981c24b83b50ccf78dec5",
+  "deployedHostImageRef": "ghcr.io/moonladderstudios/omnigent-host-opencode@sha256:ae8561787caab8f84ce7e41d778410d762c454478386d4f7a4c30584716bb1e1",
+  "failureShape": "an exact rerun preserved a host image from before the required warm OpenCode plugin cache, launched it under the current runtime contract, and timed out waiting for registration"
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -6546,6 +6546,62 @@ async def test_exact_rerun_rejects_replaced_omnigent_server_before_launch(
     load.assert_awaited_once_with(manifest["planRef"])
 
 
+async def test_exact_rerun_rejects_replaced_opencode_host_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay mm:814cd965 at the exact-rerun authority boundary."""
+
+    replay_id = "omnigent-stale-plan-host-image"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    plan = SimpleNamespace(
+        payload=SimpleNamespace(
+            executionRealizerRef="generic-omnigent-host@1",
+            harnessId="opencode-native",
+            hostImageRef=manifest["planHostImageRef"],
+            supportIdentity=SimpleNamespace(
+                omnigentServerBuildRef=manifest["serverBuildRef"]
+            ),
+        )
+    )
+    load = AsyncMock(return_value=plan)
+    monkeypatch.setattr(
+        "moonmind.omnigent.harness_platform.stores.SessionExecutionPlanStore",
+        lambda _session: SimpleNamespace(load=load),
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.deployment_identity."
+        "resolve_deployed_server_build_digest",
+        lambda: manifest["serverBuildRef"],
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.harness_platform.host_classes."
+        "get_opencode_host_image_ref",
+        lambda: manifest["deployedHostImageRef"],
+    )
+    service = TemporalExecutionService(SimpleNamespace())
+
+    with pytest.raises(TemporalExecutionRerunPlanError) as exc_info:
+        await service.validate_exact_rerun_execution_plan(
+            parameters={
+                "omnigentExecutionPlan": {
+                    "planRef": manifest["planRef"],
+                    "planDigest": manifest["planRef"].replace(
+                        "omnigent-execution-plan:", ""
+                    ),
+                    "planArtifactRef": "art_replay_plan",
+                    "taskInputSnapshotRef": "art_replay_task_input",
+                    "taskInputSnapshotDigest": "sha256:" + "1" * 64,
+                }
+            }
+        )
+
+    assert exc_info.value.detail["code"] == expected["code"]
+    assert exc_info.value.detail["nextAction"] == expected["nextAction"]
+    assert expected["hostLaunchAttempted"] is False
+    load.assert_awaited_once_with(manifest["planRef"])
+
+
 async def test_checkpointless_remediation_keeps_the_verified_repository_branch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/routers/test_omnigent_workflow_chat.py
+++ b/tests/unit/api/routers/test_omnigent_workflow_chat.py
@@ -705,6 +705,7 @@ def test_stock_native_mutation_cases_exactly_cover_the_pinned_inventory() -> Non
         (route.name, method)
         for route in native_ui_compat.NATIVE_UI_ROUTES
         if route.transport == native_ui_compat.TRANSPORT_HTTP
+        and route.disposition == native_ui_compat.DISPOSITION_SERVED
         and route.mutation
         and route.name not in base_operation_names
         for method in route.methods

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -14,6 +14,7 @@ import pytest
 from api_service.services.omnigent_agent_profile_selection import (
     default_launch_policy_ref,
 )
+from api_service.services.omnigent_policies import bootstrap_document
 from moonmind.omnigent.bootstrap import controller as controller_module
 from moonmind.omnigent.bootstrap.models import (
     BootstrapDesired,
@@ -24,6 +25,7 @@ from moonmind.omnigent.bootstrap.models import (
 )
 from moonmind.omnigent.bootstrap.opencode import resolve_model_by_display
 from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
+from moonmind.omnigent.policies import compile_policy_snapshot
 
 _SERVER_IMAGE_REF = "ghcr.io/example/omnigent-server@sha256:" + "a" * 64
 _HOST_IMAGE_REF = "ghcr.io/example/omnigent-host-opencode@sha256:" + "7" * 64
@@ -203,6 +205,29 @@ def qualification_boundary(monkeypatch, tmp_path):
 
     monkeypatch.setattr(qualification_module, "run_qualification", _run_qualification)
     monkeypatch.setattr(store_module, "load_resolved_state", _resolved_state)
+
+    async def _resolve_runtime_snapshot(_service, policy_ref: str):
+        policy_id, _, version_text = policy_ref.rpartition("@")
+        return compile_policy_snapshot(
+            policy_id=policy_id,
+            version=int(version_text),
+            document=bootstrap_document(
+                host_mode="on_demand_docker",
+                execution_profile_ref="omnigent-opencode@1",
+                server_image_ref=_SERVER_IMAGE_REF,
+                host_image_ref=_HOST_IMAGE_REF,
+                harness="opencode-native",
+                agent_identities=("opencode",),
+                compatible_providers=("opencode-go", "opencode"),
+            ),
+            validation={"valid": True},
+        )
+
+    monkeypatch.setattr(
+        "api_service.services.omnigent_policies.OmnigentPolicyService."
+        "resolve_runtime_snapshot",
+        _resolve_runtime_snapshot,
+    )
     monkeypatch.setattr(
         evidence_module,
         "write_deployment_evidence",
@@ -318,6 +343,23 @@ async def test_qualification_follows_a_reordered_allow_list(
     evidence = await _qualify(qualification_boundary)
 
     assert evidence["supportIdentity"]["launchPolicyRef"] == ("opencode-on-demand@1")
+
+
+@pytest.mark.asyncio
+async def test_qualification_accepts_current_immutable_policy_version(
+    qualification_boundary,
+) -> None:
+    """Image cutover policy versions remain compilable after bootstrap."""
+
+    document = _profile_document()
+    document["allowedLaunchPolicyRefs"] = ["omnigent-on-demand@2"]
+    qualification_boundary.session.version = _version_row(document, version=29)
+
+    evidence = await _qualify(qualification_boundary)
+
+    assert evidence["supportIdentity"]["launchPolicyRef"] == (
+        "omnigent-on-demand@2"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_deployment_identity.py
+++ b/tests/unit/omnigent/test_deployment_identity.py
@@ -14,6 +14,16 @@ def _generic_plan_payload(server_build: str) -> SimpleNamespace:
     )
 
 
+def _opencode_plan_payload(
+    server_build: str,
+    host_image_ref: str,
+) -> SimpleNamespace:
+    payload = _generic_plan_payload(server_build)
+    payload.harnessId = "opencode-native"
+    payload.hostImageRef = host_image_ref
+    return payload
+
+
 def test_plan_deployment_identity_accepts_exact_server_build(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -24,7 +34,7 @@ def test_plan_deployment_identity_accepts_exact_server_build(
         lambda: digest,
     )
 
-    deployment_identity.assert_plan_matches_deployed_server(
+    deployment_identity.assert_plan_matches_deployed_runtime(
         _generic_plan_payload(digest)
     )
 
@@ -42,8 +52,36 @@ def test_plan_deployment_identity_rejects_stale_server_before_launch(
         deployment_identity.OmnigentDeploymentIdentityConflict,
         match="no longer deployed",
     ):
-        deployment_identity.assert_plan_matches_deployed_server(
+        deployment_identity.assert_plan_matches_deployed_runtime(
             _generic_plan_payload("sha256:" + "a" * 64)
+        )
+
+
+def test_plan_deployment_identity_rejects_stale_opencode_host_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.omnigent.harness_platform import host_classes
+
+    server_digest = "sha256:" + "a" * 64
+    current_host = "ghcr.io/example/opencode@sha256:" + "b" * 64
+    stale_host = "ghcr.io/example/opencode@sha256:" + "c" * 64
+    monkeypatch.setattr(
+        deployment_identity,
+        "resolve_deployed_server_build_digest",
+        lambda: server_digest,
+    )
+    monkeypatch.setattr(
+        host_classes,
+        "get_opencode_host_image_ref",
+        lambda: current_host,
+    )
+
+    with pytest.raises(
+        deployment_identity.OmnigentDeploymentIdentityConflict,
+        match="host image that is no longer deployed",
+    ):
+        deployment_identity.assert_plan_matches_deployed_runtime(
+            _opencode_plan_payload(server_digest, stale_host)
         )
 
 
@@ -59,7 +97,7 @@ def test_non_generic_replay_does_not_consult_generic_server_identity(
         probe,
     )
 
-    deployment_identity.assert_plan_matches_deployed_server(
+    deployment_identity.assert_plan_matches_deployed_runtime(
         SimpleNamespace(
             executionRealizerRef="codex-profile-bound@1",
             supportIdentity=None,

--- a/tests/unit/omnigent/test_deployment_identity.py
+++ b/tests/unit/omnigent/test_deployment_identity.py
@@ -24,6 +24,16 @@ def _opencode_plan_payload(
     return payload
 
 
+def _pi_plan_payload(
+    server_build: str,
+    host_image_ref: str,
+) -> SimpleNamespace:
+    payload = _generic_plan_payload(server_build)
+    payload.harnessId = "pi-native"
+    payload.hostImageRef = host_image_ref
+    return payload
+
+
 def test_plan_deployment_identity_accepts_exact_server_build(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -82,6 +92,30 @@ def test_plan_deployment_identity_rejects_stale_opencode_host_before_launch(
     ):
         deployment_identity.assert_plan_matches_deployed_runtime(
             _opencode_plan_payload(server_digest, stale_host)
+        )
+
+
+def test_plan_deployment_identity_rejects_stale_pi_host_before_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.omnigent.harness_platform import host_classes
+
+    server_digest = "sha256:" + "a" * 64
+    current_host = "ghcr.io/example/pi@sha256:" + "b" * 64
+    stale_host = "ghcr.io/example/pi@sha256:" + "c" * 64
+    monkeypatch.setattr(
+        deployment_identity,
+        "resolve_deployed_server_build_digest",
+        lambda: server_digest,
+    )
+    monkeypatch.setattr(host_classes, "get_pi_host_image_ref", lambda: current_host)
+
+    with pytest.raises(
+        deployment_identity.OmnigentDeploymentIdentityConflict,
+        match="host image that is no longer deployed",
+    ):
+        deployment_identity.assert_plan_matches_deployed_runtime(
+            _pi_plan_payload(server_digest, stale_host)
         )
 
 

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -6,6 +6,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -18,6 +19,7 @@ from moonmind.omnigent.credential_materializers import (
     CredentialRuntimeHandle,
     DockerOmnigentProviderConfigMaterializer,
     DockerOpencodeAuthJsonMaterializer,
+    credential_runtime_identity,
 )
 from moonmind.omnigent.generic_host_janitor import GenericOmnigentHostJanitor
 from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfileV2
@@ -42,6 +44,7 @@ from moonmind.omnigent.harness_platform.host_classes import HostClass, get_launc
 from moonmind.omnigent.harness_platform.planning_service import (
     OmnigentExecutionPlanningService,
     OmnigentPlannedHostResolver,
+    _canonical_json_bytes,
     _ref,
 )
 from moonmind.omnigent.harness_platform.stores import (
@@ -547,6 +550,22 @@ def _plan(model: str):
     )
 
 
+def _exact_plan(model: str):
+    payload = _plan(model).payload.model_dump(mode="json", by_alias=True)
+    payload.update(
+        {
+            "hostImageRef": "ghcr.io/example/opencode@sha256:" + "f" * 64,
+            "omnigentHostBuildDigest": "sha256:" + "1" * 64,
+            "hostArchitecture": "linux/amd64",
+            "policySnapshotRef": "artifact:policy",
+            "policySnapshotDigest": "sha256:" + "2" * 64,
+            "effectiveLaunchSnapshotRef": "artifact:launch",
+            "effectiveLaunchSnapshotDigest": "sha256:" + "3" * 64,
+        }
+    )
+    return create_execution_plan_envelope(payload)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "policy_ref", ["omnigent-on-demand@1", "omnigent-on-demand@2"]
@@ -836,6 +855,53 @@ def _request() -> AgentExecutionRequest:
             "parameters": {},
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_planning_persists_exact_policy_and_effective_launch_bytes() -> None:
+    writes: list[dict[str, object]] = []
+
+    class Artifacts:
+        async def write_bytes(self, **kwargs):
+            writes.append(dict(kwargs))
+            return f"artifact:{kwargs['name']}"
+
+    service = object.__new__(OmnigentExecutionPlanningService)
+    service._artifacts = Artifacts()
+    policy = {
+        "policyId": "omnigent-on-demand",
+        "policyVersion": 2,
+        "policyRef": "omnigent-on-demand@2",
+        "boundaries": {},
+        "validation": {},
+    }
+    launch = {
+        "schemaVersion": 3,
+        "launchPolicyRef": "omnigent-on-demand@2",
+        "harness": "opencode-native",
+        "hostImageRef": "ghcr.io/example/opencode@sha256:" + "f" * 64,
+    }
+
+    result = await service._persist_exact_launch_authority(
+        request=_request(),
+        policy_snapshot=policy,
+        effective_launch=launch,
+    )
+
+    assert result == (
+        "artifact:launch-policy-snapshot.json",
+        "sha256:" + hashlib.sha256(_canonical_json_bytes(policy)).hexdigest(),
+        "artifact:effective-launch-snapshot.json",
+        "sha256:" + hashlib.sha256(_canonical_json_bytes(launch)).hexdigest(),
+    )
+    assert [write["payload"] for write in writes] == [
+        _canonical_json_bytes(policy),
+        _canonical_json_bytes(launch),
+    ]
+    assert [write["link_type"] for write in writes] == [
+        "input.launch_policy_snapshot",
+        "input.effective_launch_snapshot",
+    ]
 
 
 @pytest.mark.asyncio
@@ -1604,6 +1670,10 @@ async def _generic_publication_harness(
             events.append("credentials-materialized")
             return (handle,)
 
+        async def load_cleanup_handles(self, *_args):
+            events.append("credentials-reloaded")
+            return (handle,)
+
         async def cleanup_all(self, handles):
             assert handles == (handle,)
             events.append("credentials-cleaned")
@@ -1757,6 +1827,7 @@ async def _generic_publication_harness(
         workspace_publisher=WorkspacePublisher(),
         turn_command_service=TurnCommands(),
         execution_state_notifier=execution_state_notifier,
+        deployment_validator=lambda _payload: None,
         heartbeat_interval_seconds=0.005,
         heartbeat_ttl_seconds=60,
     )
@@ -1784,7 +1855,178 @@ async def _generic_publication_harness(
         events=events,
         runtime_store=runtime_store,
         host_leases=host_leases,
+        acquired=acquired,
+        credential_handle=handle,
     )
+
+
+@pytest.mark.asyncio
+async def test_bound_host_retry_uses_attestation_not_current_deployment() -> None:
+    harness = await _generic_publication_harness(_PUSHED_PUBLICATION)
+    plan = _exact_plan("opencode-go/model")
+    evidence = {
+        "imageRef": plan.payload.hostImageRef,
+        "architecture": plan.payload.hostArchitecture,
+        "omnigentBuildDigest": plan.payload.omnigentHostBuildDigest,
+        "harnessId": plan.payload.harnessId,
+        "harnessImplementationRef": plan.payload.harnessImplementationRef,
+        "omnigentHostId": "host-1",
+    }
+
+    class Artifacts:
+        async def read_bytes(self, ref: str) -> bytes:
+            assert ref == "artifact:host-attestation"
+            return _canonical_json_bytes(evidence)
+
+        async def write_json(self, **_kwargs):
+            return "artifact:cleanup-attestation"
+
+        async def write_text(self, **_kwargs):
+            return "artifact:host-logs"
+
+    harness.realizer._artifacts = Artifacts()
+    harness.realizer._deployment_validator = lambda _payload: (_ for _ in ()).throw(
+        AssertionError("continuation consulted mutable deployment identity")
+    )
+    harness.realizer._resolve_host = AsyncMock(
+        side_effect=AssertionError("continuation re-resolved current host defaults")
+    )
+    materializer_ref = plan.payload.credentialBindings[
+        "primary-model"
+    ].materializerRef
+    provider_authority = {
+        "primary-model": {
+            **harness.acquired.runtime_binding_value(
+                credential_runtime_ref=credential_runtime_identity(
+                    harness.acquired, materializer_ref
+                )[0]
+            ),
+            "materializerRef": materializer_ref,
+        }
+    }
+    binding = await harness.runtime_store.create_initial(
+        execution_plan_ref=plan.planRef,
+        idempotency_key=harness.publish_request.idempotency_key,
+        provider_leases=provider_authority,
+    )
+    binding = await harness.runtime_store.update(
+        binding.bindingId,
+        expected_revision=binding.revision,
+        expected_fencing_generation=binding.fencingGeneration,
+        state=RuntimeBindingState.credentials_materialized,
+        updates={
+            "credentialRuntimeHandles": {
+                "primary-model": harness.credential_handle.model_dump(
+                    by_alias=True, mode="json"
+                )
+            },
+            "cleanupAuthorityRefs": [harness.credential_handle.cleanupRef],
+        },
+    )
+    host_lease = await harness.host_leases.acquire(
+        execution_plan_ref=plan.planRef,
+        runtime_binding_id=binding.bindingId,
+        host_class_ref=plan.payload.hostClassRef,
+        launch_policy_ref=plan.payload.launchPolicyRef,
+        harness_id=plan.payload.harnessId,
+        harness_implementation_ref=plan.payload.harnessImplementationRef,
+        provider_profile_refs=(harness.acquired.provider_profile_ref,),
+    )
+    binding = await harness.runtime_store.update(
+        binding.bindingId,
+        expected_revision=binding.revision,
+        expected_fencing_generation=binding.fencingGeneration,
+        state=RuntimeBindingState.host_allocating,
+        updates={
+            "hostBindingRef": host_lease.bindingRef,
+            "hostLeaseRef": host_lease.leaseRef,
+            "hostLeaseGeneration": host_lease.generation,
+        },
+    )
+    host_lease = await harness.host_leases.mark_ready(
+        host_lease.leaseRef,
+        expected_generation=host_lease.generation,
+        omnigent_host_id="host-1",
+        cleanup_handle={
+            "kind": "host",
+            "containerName": "mm-host-1",
+            "stateVolumeRef": "mm-state-1",
+            "launchGeneration": host_lease.launchGeneration,
+        },
+    )
+    await harness.runtime_store.update(
+        binding.bindingId,
+        expected_revision=binding.revision,
+        expected_fencing_generation=binding.fencingGeneration,
+        state=RuntimeBindingState.host_ready,
+        updates={
+            "omnigentHostId": "host-1",
+            "hostLeaseGeneration": host_lease.generation,
+            "attestationRefs": {
+                "hostHarnessAttestationRef": "artifact:host-attestation"
+            },
+        },
+    )
+
+    result = await harness.realizer._execute_lifecycle(
+        harness.publish_request,
+        plan,
+    )
+
+    assert result.summary == "done"
+    assert "credentials-reloaded" in harness.events
+    harness.realizer._resolve_host.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bound_host_retry_rejects_mismatched_attestation() -> None:
+    harness = await _generic_publication_harness(_PUSHED_PUBLICATION)
+    plan = _exact_plan("opencode-go/model")
+
+    class Artifacts:
+        async def read_bytes(self, _ref: str) -> bytes:
+            return _canonical_json_bytes(
+                {
+                    "imageRef": "ghcr.io/example/opencode@sha256:" + "9" * 64,
+                    "architecture": plan.payload.hostArchitecture,
+                    "omnigentBuildDigest": plan.payload.omnigentHostBuildDigest,
+                    "harnessId": plan.payload.harnessId,
+                    "harnessImplementationRef": (
+                        plan.payload.harnessImplementationRef
+                    ),
+                    "omnigentHostId": "host-1",
+                }
+            )
+
+    harness.realizer._artifacts = Artifacts()
+    with pytest.raises(HarnessPlatformError, match="retry identity conflicts"):
+        await harness.realizer._validate_bound_host_identity(
+            plan=plan,
+            host_context={
+                "omnigentHostId": "host-1",
+                "hostHarnessAttestationRef": "artifact:host-attestation",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_fresh_host_launch_checks_current_deployment_before_prepare() -> None:
+    harness = await _generic_publication_harness(_PUSHED_PUBLICATION)
+
+    class StaleDeployment(ValueError):
+        pass
+
+    harness.realizer._deployment_validator = lambda _payload: (_ for _ in ()).throw(
+        StaleDeployment("stale host image")
+    )
+
+    with pytest.raises(StaleDeployment, match="stale host image"):
+        await harness.realizer._execute_lifecycle(
+            harness.publish_request,
+            _plan("opencode-go/model"),
+        )
+
+    assert "host-inputs-prepared" not in harness.events
 
 
 _PUSHED_PUBLICATION: dict[str, object] = {

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -548,7 +548,12 @@ def _plan(model: str):
 
 
 @pytest.mark.asyncio
-async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
+@pytest.mark.parametrize(
+    "policy_ref", ["omnigent-on-demand@1", "omnigent-on-demand@2"]
+)
+async def test_planned_host_resolver_uses_exact_launch_artifact(
+    policy_ref: str,
+) -> None:
     implementation = HarnessImplementationIdentity.model_validate(
         {
             "sourceKind": "core",
@@ -596,7 +601,7 @@ async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
     exact_image = "ghcr.io/example/admitted@sha256:" + "a" * 64
     launch = {
         "schemaVersion": 3,
-        "launchPolicyRef": "omnigent-on-demand@1",
+        "launchPolicyRef": policy_ref,
         "harness": "opencode-native",
         "hostImageRef": exact_image,
         "hostMode": "on_demand_docker",
@@ -626,6 +631,7 @@ async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
     payload.update(
         {
             "harnessImplementationRef": implementation.implementation_ref(),
+            "launchPolicyRef": policy_ref,
             "hostImageRef": exact_image,
             "omnigentHostBuildDigest": "sha256:" + "b" * 64,
             "hostArchitecture": "linux/amd64",
@@ -666,6 +672,7 @@ async def test_planned_host_resolver_uses_exact_launch_artifact() -> None:
 
     assert host.imageRef == exact_image
     assert host.runtime["uid"] == 1000
+    assert policy.ref == policy_ref
     assert policy.limits["timeoutSeconds"] == 5400
 
 

--- a/tests/unit/omnigent/test_native_ui_compat.py
+++ b/tests/unit/omnigent/test_native_ui_compat.py
@@ -75,7 +75,8 @@ def test_network_contract_is_anchored_to_pinned_stock_sources() -> None:
     fixture = json.loads(_CONTRACT_FIXTURE.read_text(encoding="utf-8"))
     evidence = fixture["evidence"]
     pinned_commit = subprocess.run(
-        ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD:omnigent"],
+        ["git", "rev-parse", "HEAD"],
+        cwd=_REPO_ROOT / "omnigent",
         check=True,
         capture_output=True,
         text=True,
@@ -169,6 +170,15 @@ def test_native_http_classifier_fails_closed_on_unknown_method_or_route() -> Non
     assert compat.classify_native_ui_http(
         "PATCH", "v1/sessions/b1/resources/terminals/t1"
     ) is None
+
+
+def test_v012_local_import_requires_compatibility_review() -> None:
+    match = compat.classify_native_ui_http("POST", "v1/imports/local")
+
+    assert match is not None
+    assert match.route.name == "local_session_import"
+    assert match.route.operation_class == compat.CLASS_SESSION_IMPORT
+    assert match.route.disposition == compat.DISPOSITION_COMPAT_REVIEW
 
 
 def test_every_native_ui_transport_class_is_represented() -> None:

--- a/tests/unit/omnigent/test_omnigent_facade_unknown_route_fails_closed.py
+++ b/tests/unit/omnigent/test_omnigent_facade_unknown_route_fails_closed.py
@@ -222,6 +222,21 @@ def test_unknown_stock_route_cannot_reach_upstream_root(method: str, suffix: str
     assert _CHAT_BINDING_ID not in response.text or suffix.count(_CHAT_BINDING_ID)  # binding may echo but provider never
 
 
+def test_v012_local_import_cannot_reach_upstream_before_compatibility_review() -> None:
+    client, proxy, _store = _build()
+
+    response = client.post(
+        _path("v1/imports/local"),
+        json={"host_id": "host-1", "source": "all", "limit": 25},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == compat.CODE_COMPAT_REVIEW_REQUIRED
+    assert proxy.sessions == []
+    assert proxy.resources == []
+    assert proxy.posted == []
+
+
 def test_every_inventory_entry_has_explicit_disposition() -> None:
     cmap = compat.compatibility_map()
     assert cmap["version"] == compat.NATIVE_UI_COMPAT_VERSION

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -521,20 +521,14 @@ async def test_product_boundary_uses_exact_arm64_architecture_for_support_identi
     monkeypatch.setattr(
         deployment_identity,
         "resolve_deployed_server_build_digest",
-        lambda: result.envelope.payload.supportIdentity.omnigentServerBuildRef,
+        lambda: (_ for _ in ()).throw(
+            AssertionError("session admission consulted mutable deployment identity")
+        ),
     )
+    # Session admission validates immutable support only. Mutable deployment
+    # drift is enforced for exact reruns and immediately before a fresh launch,
+    # while a continuation uses its bound host attestation.
     _validate_plan_support_authority(result.envelope)
-
-    monkeypatch.setattr(
-        deployment_identity,
-        "resolve_deployed_server_build_digest",
-        lambda: "sha256:" + "9" * 64,
-    )
-    with pytest.raises(
-        deployment_identity.OmnigentDeploymentIdentityConflict,
-        match="no longer deployed",
-    ):
-        _validate_plan_support_authority(result.envelope)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -349,6 +349,7 @@ def _protected_support_evidence(plan_payload) -> dict[str, object]:
     [
         ("codex-native", "codex-on-demand@1", "codex-profile-bound@1"),
         ("opencode-native", "opencode-on-demand@1", "generic-omnigent-host@1"),
+        ("opencode-native", "opencode-on-demand@2", "generic-omnigent-host@1"),
     ],
 )
 async def test_product_boundary_persists_secret_free_plan_and_exact_realizer(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -433,7 +433,7 @@ async def test_exact_rerun_rejects_plan_for_replaced_server_before_creation(
         "code": "exact_rerun_execution_plan_stale",
         "message": (
             "Exact rerun preserves the original Omnigent execution plan, but "
-            "that plan targets a server build that is no longer deployed. Use "
+            "that plan targets runtime images that are no longer deployed. Use "
             "Edit for rerun to compile fresh runtime authority."
         ),
         "nextAction": "edit_for_rerun",


### PR DESCRIPTION
## Summary

- reject exact Omnigent reruns when either the deployed server or selected OpenCode host image differs from the persisted execution plan
- rehydrate persisted effective launch policies so current @2 policy snapshots compile and launch without falling back to the retired @1 registry
- update the Omnigent submodule and embedded compatibility pin to upstream v0.12.0
- inventory the new v0.12 local-session import route as compatibility-review-required and fail closed before proxy dispatch
- add a minimized replay fixture for workflow mm:814cd965-7882-4a93-a362-75d1f3144c1a

## Root cause

The failed exact rerun pinned an obsolete OpenCode host image that no longer satisfied the warm plugin-cache contract. Admission checked the Omnigent server build but not the host image, so the stale host was launched, exited before registration, and surfaced as OMNIGENT_HOST_REGISTRATION_TIMEOUT.

## Verification

- 466 targeted backend tests passed on current origin/main
- broader Omnigent selection: 3,135 passed and 1 skipped before the new review-gated inventory expectation was adjusted; the affected 195-test rerun passed
- frontend suite: 1,378 passed and 238 skipped
- relevant Omnigent integration and incident replay tests: 56 passed
- v0.12.0 server and host multi-architecture manifests verified
- diff, JSON fixture, documentation architecture, and secret scans passed

## Remaining external verification

The protected credentialed live OAuth conformance matrix was not run locally because it requires an operator-provisioned action adapter and enrolled provider profile.