### PR TITLE
[Omnigent concurrency] Capacity scopes, incremental leases, targeted registration, waiting-state (#3882-3885)

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -21,6 +21,7 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     ManagedAgentRateLimitPolicy,
     ManagedSecret,
+    ProviderCapacityScope,
     ProviderCredentialSource,
     ProviderProfileAuthMethod,
     ProviderProfileAuthState,
@@ -1189,12 +1190,13 @@ async def _enforce_scope_compatibility(
     *,
     runtime_id: str,
     capacity_scope_ref: str | None,
+    provider_id: str | None = None,
 ) -> None:
     """Prevent unrelated runtimes/providers sharing one scope.
 
     A scope is owned by the runtime (and provider class) of the first
     profile that references it; a second profile with a different runtime
-    cannot attach without a compatible trusted scope policy.
+    or provider cannot attach without a compatible trusted scope policy.
     """
     scope_ref = str(capacity_scope_ref or "").strip()
     if not scope_ref:
@@ -1212,6 +1214,14 @@ async def _enforce_scope_compatibility(
             detail={
                 "code": "provider_profile_scope_incompatible",
                 "message": "Capacity scope belongs to a different runtime.",
+            },
+        )
+    if provider_id and scope.provider_class not in ("unknown", "", provider_id):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "provider_profile_scope_incompatible",
+                "message": "Capacity scope belongs to a different provider.",
             },
         )
 
@@ -1315,7 +1325,21 @@ async def create_profile(
         session,
         runtime_id=str(values.get("runtime_id") or body.runtime_id),
         capacity_scope_ref=str(values.get("capacity_scope_ref") or ""),
+        provider_id=str(values.get("provider_id") or ""),
     )
+    _scope_ref = str(
+        values.get("capacity_scope_ref") or f"provider-profile:{body.profile_id}"
+    ).strip()
+    if await session.get(ProviderCapacityScope, _scope_ref) is None:
+        session.add(
+            ProviderCapacityScope(
+                scope_ref=_scope_ref,
+                runtime_id=str(values.get("runtime_id") or body.runtime_id),
+                provider_class=str(values.get("provider_id") or "unknown"),
+                configured_limit=int(values.get("max_parallel_runs") or 1),
+                effective_limit=int(values.get("max_parallel_runs") or 1),
+            )
+        )
 
     profile = ManagedAgentProviderProfile(
         profile_id=body.profile_id,
@@ -1884,7 +1908,7 @@ async def update_profile(
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         profile.model_tiers = model_tiers
         profile.default_model_tier = default_model_tier
-    if "max_parallel_runs" in update_data or "capacity_scope_ref" in update_data:
+    if "max_parallel_runs" in update_data or "capacity_scope_ref" in update_data or "provider_id" in update_data:
         _enforce_parallel_ceiling(update_data.get("max_parallel_runs", profile.max_parallel_runs))
         await _enforce_scope_compatibility(
             session,
@@ -1892,7 +1916,35 @@ async def update_profile(
             capacity_scope_ref=str(
                 update_data.get("capacity_scope_ref", profile.capacity_scope_ref) or ""
             ),
+            provider_id=str(update_data.get("provider_id", profile.provider_id) or ""),
         )
+        if "max_parallel_runs" in update_data:
+            try:
+                _new_max = int(update_data.get("max_parallel_runs") or 0)
+            except (TypeError, ValueError):
+                _new_max = 0
+            if _new_max > 0 and _new_max != profile.max_parallel_runs:
+                _default_scope = f"provider-profile:{profile.profile_id}"
+                if (profile.capacity_scope_ref or _default_scope) == _default_scope:
+                    from sqlalchemy import select as _select_scope_count
+
+                    from api_service.db.models import ManagedAgentProviderProfile as _Profile
+
+                    _count_result = await session.execute(
+                        _select_scope_count(_Profile.profile_id).where(
+                            _Profile.capacity_scope_ref == _default_scope
+                        )
+                    )
+                    if len(list(_count_result.scalars().all())) == 1:
+                        _scope_row = await session.get(ProviderCapacityScope, _default_scope)
+                        if _scope_row is not None:
+                            _scope_row.configured_limit = _new_max
+                            if _new_max > profile.max_parallel_runs:
+                                _scope_row.effective_limit = _new_max
+                            else:
+                                _scope_row.effective_limit = min(
+                                    _scope_row.effective_limit, _new_max
+                                )
     for key, value in update_data.items():
         if key == "rate_limit_policy" and value is not None:
             value = ManagedAgentRateLimitPolicy(value)

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -1157,6 +1157,65 @@ async def get_profile(
     )
 
 
+def _deployment_parallel_ceiling() -> int:
+    import os as _os
+
+    try:
+        value = int(str(_os.getenv("MOONMIND_MAX_PROVIDER_PROFILE_PARALLEL_RUNS") or "").strip())
+    except (TypeError, ValueError):
+        return 32
+    return max(1, min(256, value))
+
+
+def _enforce_parallel_ceiling(max_parallel_runs: int | None) -> None:
+    if max_parallel_runs is None:
+        return
+    ceiling = _deployment_parallel_ceiling()
+    if int(max_parallel_runs) > ceiling:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "provider_profile_parallel_ceiling_exceeded",
+                "message": (
+                    f"max_parallel_runs {max_parallel_runs} exceeds deployment "
+                    f"safety ceiling {ceiling}."
+                ),
+            },
+        )
+
+
+async def _enforce_scope_compatibility(
+    session: AsyncSession,
+    *,
+    runtime_id: str,
+    capacity_scope_ref: str | None,
+) -> None:
+    """Prevent unrelated runtimes/providers sharing one scope.
+
+    A scope is owned by the runtime (and provider class) of the first
+    profile that references it; a second profile with a different runtime
+    cannot attach without a compatible trusted scope policy.
+    """
+    scope_ref = str(capacity_scope_ref or "").strip()
+    if not scope_ref:
+        return
+    from sqlalchemy import select as _select
+
+    from api_service.db.models import ProviderCapacityScope as _Scope
+
+    scope = await session.get(_Scope, scope_ref)
+    if scope is None:
+        return
+    if scope.runtime_id and scope.runtime_id != runtime_id:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "provider_profile_scope_incompatible",
+                "message": "Capacity scope belongs to a different runtime.",
+            },
+        )
+
+
 @router.post("", response_model=ProviderProfileResponse, status_code=201)
 async def create_profile(
     body: ProviderProfileCreate,
@@ -1250,6 +1309,13 @@ async def create_profile(
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    _enforce_parallel_ceiling(values.get("max_parallel_runs"))
+    await _enforce_scope_compatibility(
+        session,
+        runtime_id=str(values.get("runtime_id") or body.runtime_id),
+        capacity_scope_ref=str(values.get("capacity_scope_ref") or ""),
+    )
 
     profile = ManagedAgentProviderProfile(
         profile_id=body.profile_id,
@@ -1818,6 +1884,15 @@ async def update_profile(
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         profile.model_tiers = model_tiers
         profile.default_model_tier = default_model_tier
+    if "max_parallel_runs" in update_data or "capacity_scope_ref" in update_data:
+        _enforce_parallel_ceiling(update_data.get("max_parallel_runs", profile.max_parallel_runs))
+        await _enforce_scope_compatibility(
+            session,
+            runtime_id=profile.runtime_id,
+            capacity_scope_ref=str(
+                update_data.get("capacity_scope_ref", profile.capacity_scope_ref) or ""
+            ),
+        )
     for key, value in update_data.items():
         if key == "rate_limit_policy" and value is not None:
             value = ManagedAgentRateLimitPolicy(value)

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3331,9 +3331,7 @@ class ManagedAgentProviderProfile(Base):
 
     __tablename__ = "managed_agent_provider_profiles"
     __table_args__ = (
-        UniqueConstraint(
-            "capacity_scope_ref", name="uq_provider_profile_capacity_scope"
-        ),
+        Index("ix_provider_profile_capacity_scope", "capacity_scope_ref"),
         Index("ix_provider_profiles_runtime", "runtime_id"),
         Index("ix_provider_profiles_provider", "provider_id"),
         Index("ix_provider_profiles_runtime_provider", "runtime_id", "provider_id"),
@@ -3561,6 +3559,84 @@ class ManagedAgentProviderProfile(Base):
         Integer, nullable=False, default=7200, server_default=text("7200")
     )
     owner_user_id: Mapped[Optional[UUID]] = mapped_column(Uuid, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class ProviderCapacityScope(Base):
+    """Durable provider-capacity aggregate shared by compatible profiles.
+
+    ``scope_ref`` identifies a real upstream allowance (route, account,
+    deployment, model family, or provider/IP limit) that one or more
+    Provider Profiles draw from. Admission grants only when both the
+    profile effective limit and the scope effective limit have room.
+    Configured and effective limits are persisted separately so adaptive
+    backpressure can reduce future admission without rewriting operator
+    intent or active lease authority. Contains no secret, token,
+    session identity, repository identity, or unbounded provider output.
+    """
+
+    __tablename__ = "provider_capacity_scopes"
+    __table_args__ = (
+        Index("ix_capacity_scopes_runtime", "runtime_id"),
+        CheckConstraint(
+            "configured_limit >= 1",
+            name="ck_capacity_scopes_configured_positive",
+        ),
+        CheckConstraint(
+            "effective_limit >= 1",
+            name="ck_capacity_scopes_effective_positive",
+        ),
+        CheckConstraint(
+            "generation >= 1",
+            name="ck_capacity_scopes_generation_positive",
+        ),
+        CheckConstraint(
+            "backpressure_state IN ("
+            "'healthy', 'reduced', 'cooldown', 'probing', 'disabled'"
+            ")",
+            name="ck_capacity_scopes_backpressure_state",
+        ),
+    )
+
+    scope_ref: Mapped[str] = mapped_column(String(255), primary_key=True)
+    runtime_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider_class: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="unknown", server_default=text("'unknown'")
+    )
+    generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=text("1")
+    )
+    configured_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    effective_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    cooldown_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    backpressure_state: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="healthy", server_default=text("'healthy'")
+    )
+    recovery_policy_ref: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        default="additive-increase-multiplicative-decrease@1",
+        server_default=text("'additive-increase-multiplicative-decrease@1'"),
+    )
+    healthy_since: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_decrease_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_increase_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
@@ -3830,9 +3906,14 @@ class ProviderProfileSlotLease(Base):
     __table_args__ = (
         Index("ix_provider_slot_leases_runtime", "runtime_id"),
         Index("ix_provider_slot_leases_workflow", "workflow_id"),
+        Index("ix_provider_slot_leases_lease", "lease_id"),
+        Index("ix_provider_slot_leases_owner", "owner_id"),
+        Index("ix_provider_slot_leases_profile", "profile_id"),
+        Index("ix_provider_slot_leases_scope", "capacity_scope_ref"),
         UniqueConstraint(
             "runtime_id", "workflow_id", name="uq_provider_slot_lease_runtime_workflow"
         ),
+        UniqueConstraint("lease_id", name="uq_provider_slot_lease_lease_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -3841,11 +3922,17 @@ class ProviderProfileSlotLease(Base):
     profile_id: Mapped[str] = mapped_column(String(128), nullable=False)
     lease_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     owner_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    owner_kind: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="workflow", server_default=text("'workflow'")
+    )
     purpose: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
         default="execution_direct",
         server_default=text("'execution_direct'"),
+    )
+    compatibility_class: Mapped[str] = mapped_column(
+        String(128), nullable=False, default="execution_direct", server_default=text("'execution_direct'")
     )
     owner_is_workflow: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
@@ -3853,11 +3940,30 @@ class ProviderProfileSlotLease(Base):
     step_execution_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     oauth_session_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    execution_plan_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    capacity_scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    scope_generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=text("1")
+    )
+    credential_generation: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    lease_state: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="held", server_default=text("'held'")
+    )
+    fencing_generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default=text("1")
+    )
+    safe_metadata_json: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     granted_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    heartbeat_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    released_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1122,6 +1122,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
     from sqlalchemy import select
     from api_service.db.models import (
         ManagedAgentProviderProfile,
+        ProviderCapacityScope,
         ProviderCredentialSource,
         ProviderProfileAuthMethod,
         ProviderProfileAuthState,
@@ -2085,6 +2086,17 @@ async def _auto_seed_provider_profiles() -> list[str]:
                     last_validated_at=profile_def.get("last_validated_at"),
                     last_auth_method=profile_def.get("last_auth_method"),
                 )
+                _seed_scope_ref = f"provider-profile:{profile_def['profile_id']}"
+                if await session.get(ProviderCapacityScope, _seed_scope_ref) is None:
+                    session.add(
+                        ProviderCapacityScope(
+                            scope_ref=_seed_scope_ref,
+                            runtime_id=profile_def["runtime_id"],
+                            provider_class=str(profile_def.get("provider_id") or "unknown"),
+                            configured_limit=int(profile_def.get("max_parallel_runs", 1) or 1),
+                            effective_limit=int(profile_def.get("max_parallel_runs", 1) or 1),
+                        )
+                    )
                 session.add(profile)
                 runtime_id = profile_def["runtime_id"]
                 touched_runtime_ids.add(runtime_id)

--- a/api_service/migrations/versions/368_provider_capacity_scopes.py
+++ b/api_service/migrations/versions/368_provider_capacity_scopes.py
@@ -90,17 +90,10 @@ def upgrade() -> None:
     with op.batch_alter_table("managed_agent_provider_profiles") as batch:
         batch.drop_constraint("uq_provider_profile_capacity_scope", type_="unique")
         batch.create_index("ix_provider_profile_capacity_scope", ["capacity_scope_ref"])
-        batch.create_foreign_key(
-            "fk_provider_profiles_capacity_scope",
-            "provider_capacity_scopes",
-            ["capacity_scope_ref"],
-            ["scope_ref"],
-        )
 
 
 def downgrade() -> None:
     with op.batch_alter_table("managed_agent_provider_profiles") as batch:
-        batch.drop_constraint("fk_provider_profiles_capacity_scope", type_="foreignkey")
         batch.drop_index("ix_provider_profile_capacity_scope")
         # Fail-closed when scopes are shared: restoring 1:1 uniqueness with
         # shared refs would silently discard the shared allowance.

--- a/api_service/migrations/versions/368_provider_capacity_scopes.py
+++ b/api_service/migrations/versions/368_provider_capacity_scopes.py
@@ -1,0 +1,114 @@
+"""Introduce authoritative provider capacity scopes with adaptive backpressure.
+
+Revision ID: 368_provider_capacity_scopes
+Revises: 367_remove_workflow_proposals
+Create Date: 2026-09-04
+
+Each existing Provider Profile is migrated to an automatically created
+one-profile scope without changing effective behavior. Several profiles may
+intentionally reference the same scope afterwards; admission must satisfy
+both profile and scope effective limits.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "368_provider_capacity_scopes"
+down_revision: Union[str, None] = "367_remove_workflow_proposals"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_capacity_scopes",
+        sa.Column("scope_ref", sa.String(length=255), nullable=False),
+        sa.Column("runtime_id", sa.String(length=64), nullable=False),
+        sa.Column(
+            "provider_class",
+            sa.String(length=64),
+            nullable=False,
+            server_default="unknown",
+        ),
+        sa.Column("generation", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("configured_limit", sa.Integer(), nullable=False),
+        sa.Column("effective_limit", sa.Integer(), nullable=False),
+        sa.Column("cooldown_until", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "backpressure_state",
+            sa.String(length=32),
+            nullable=False,
+            server_default="healthy",
+        ),
+        sa.Column(
+            "recovery_policy_ref",
+            sa.String(length=128),
+            nullable=False,
+            server_default="additive-increase-multiplicative-decrease@1",
+        ),
+        sa.Column("healthy_since", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_decrease_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_increase_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint("configured_limit >= 1", name="ck_capacity_scopes_configured_positive"),
+        sa.CheckConstraint("effective_limit >= 1", name="ck_capacity_scopes_effective_positive"),
+        sa.CheckConstraint("generation >= 1", name="ck_capacity_scopes_generation_positive"),
+        sa.CheckConstraint(
+            "backpressure_state IN ('healthy', 'reduced', 'cooldown', 'probing', 'disabled')",
+            name="ck_capacity_scopes_backpressure_state",
+        ),
+        sa.PrimaryKeyConstraint("scope_ref"),
+    )
+    op.create_index(
+        "ix_capacity_scopes_runtime", "provider_capacity_scopes", ["runtime_id"]
+    )
+    # One equivalent default scope per existing profile; effective behavior unchanged.
+    op.execute(
+        "INSERT INTO provider_capacity_scopes "
+        "(scope_ref, runtime_id, provider_class, generation, configured_limit, "
+        "effective_limit, backpressure_state, recovery_policy_ref) "
+        "SELECT capacity_scope_ref, runtime_id, provider_id, 1, max_parallel_runs, "
+        "max_parallel_runs, 'healthy', 'additive-increase-multiplicative-decrease@1' "
+        "FROM managed_agent_provider_profiles"
+    )
+    with op.batch_alter_table("managed_agent_provider_profiles") as batch:
+        batch.drop_constraint("uq_provider_profile_capacity_scope", type_="unique")
+        batch.create_index("ix_provider_profile_capacity_scope", ["capacity_scope_ref"])
+        batch.create_foreign_key(
+            "fk_provider_profiles_capacity_scope",
+            "provider_capacity_scopes",
+            ["capacity_scope_ref"],
+            ["scope_ref"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("managed_agent_provider_profiles") as batch:
+        batch.drop_constraint("fk_provider_profiles_capacity_scope", type_="foreignkey")
+        batch.drop_index("ix_provider_profile_capacity_scope")
+        # Fail-closed when scopes are shared: restoring 1:1 uniqueness with
+        # shared refs would silently discard the shared allowance.
+        batch.create_unique_constraint(
+            "uq_provider_profile_capacity_scope", ["capacity_scope_ref"]
+        )
+    op.drop_index("ix_capacity_scopes_runtime", table_name="provider_capacity_scopes")
+    op.drop_table("provider_capacity_scopes")
+
+
+_ = (revision, down_revision, branch_labels, depends_on)

--- a/api_service/migrations/versions/369_provider_lease_incr_contract.py
+++ b/api_service/migrations/versions/369_provider_lease_incr_contract.py
@@ -19,7 +19,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "369_provider_lease_incremental_contract"
+revision: str = "369_provider_lease_incr_contract"
 down_revision: Union[str, None] = "368_provider_capacity_scopes"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/api_service/migrations/versions/369_provider_lease_incremental_contract.py
+++ b/api_service/migrations/versions/369_provider_lease_incremental_contract.py
@@ -73,6 +73,10 @@ def upgrade() -> None:
         "UPDATE provider_profile_slot_leases SET lease_state = 'held' "
         "WHERE lease_state IS NULL"
     )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET lease_id = workflow_id "
+        "WHERE lease_id IS NULL"
+    )
     with op.batch_alter_table("provider_profile_slot_leases") as batch:
         batch.alter_column("owner_kind", existing_type=sa.String(32), nullable=False)
         batch.alter_column(

--- a/api_service/migrations/versions/369_provider_lease_incremental_contract.py
+++ b/api_service/migrations/versions/369_provider_lease_incremental_contract.py
@@ -1,0 +1,115 @@
+"""Version Provider Profile leases for incremental durable operations.
+
+Revision ID: 369_provider_lease_incremental_contract
+Revises: 368_provider_capacity_scopes
+Create Date: 2026-09-04
+
+Extends provider_profile_slot_leases with a versioned incremental contract
+(state, fencing, scope, credential generation, compatibility, plan ref,
+owner kind, heartbeat/release times, bounded metadata) plus indexes for
+lease/owner/profile/scope lookups. Existing rows remain readable; new
+non-null lease_ids are unique (nulls allowed for pre-contract rows).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "369_provider_lease_incremental_contract"
+down_revision: Union[str, None] = "368_provider_capacity_scopes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("provider_profile_slot_leases") as batch:
+        batch.add_column(sa.Column("owner_kind", sa.String(length=32), nullable=True))
+        batch.add_column(
+            sa.Column("compatibility_class", sa.String(length=128), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("execution_plan_ref", sa.String(length=255), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("capacity_scope_ref", sa.String(length=255), nullable=True)
+        )
+        batch.add_column(sa.Column("scope_generation", sa.Integer(), nullable=True))
+        batch.add_column(
+            sa.Column("credential_generation", sa.Integer(), nullable=True)
+        )
+        batch.add_column(sa.Column("lease_state", sa.String(length=32), nullable=True))
+        batch.add_column(
+            sa.Column("fencing_generation", sa.Integer(), nullable=True)
+        )
+        batch.add_column(sa.Column("safe_metadata_json", sa.JSON(), nullable=True))
+        batch.add_column(
+            sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("released_at", sa.DateTime(timezone=True), nullable=True)
+        )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET owner_kind = "
+        "CASE WHEN owner_is_workflow THEN 'workflow' ELSE 'activity' END "
+        "WHERE owner_kind IS NULL"
+    )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET compatibility_class = purpose "
+        "WHERE compatibility_class IS NULL"
+    )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET scope_generation = 1 "
+        "WHERE scope_generation IS NULL"
+    )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET fencing_generation = 1 "
+        "WHERE fencing_generation IS NULL"
+    )
+    op.execute(
+        "UPDATE provider_profile_slot_leases SET lease_state = 'held' "
+        "WHERE lease_state IS NULL"
+    )
+    with op.batch_alter_table("provider_profile_slot_leases") as batch:
+        batch.alter_column("owner_kind", existing_type=sa.String(32), nullable=False)
+        batch.alter_column(
+            "compatibility_class", existing_type=sa.String(128), nullable=False
+        )
+        batch.alter_column("scope_generation", existing_type=sa.Integer(), nullable=False)
+        batch.alter_column("lease_state", existing_type=sa.String(32), nullable=False)
+        batch.alter_column(
+            "fencing_generation", existing_type=sa.Integer(), nullable=False
+        )
+        batch.create_index("ix_provider_slot_leases_lease", ["lease_id"])
+        batch.create_index("ix_provider_slot_leases_owner", ["owner_id"])
+        batch.create_index("ix_provider_slot_leases_profile", ["profile_id"])
+        batch.create_index("ix_provider_slot_leases_scope", ["capacity_scope_ref"])
+        batch.create_unique_constraint(
+            "uq_provider_slot_lease_lease_id", ["lease_id"]
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("provider_profile_slot_leases") as batch:
+        batch.drop_constraint("uq_provider_slot_lease_lease_id", type_="unique")
+        batch.drop_index("ix_provider_slot_leases_scope")
+        batch.drop_index("ix_provider_slot_leases_profile")
+        batch.drop_index("ix_provider_slot_leases_owner")
+        batch.drop_index("ix_provider_slot_leases_lease")
+        batch.drop_column("released_at")
+        batch.drop_column("heartbeat_at")
+        batch.drop_column("safe_metadata_json")
+        batch.drop_column("fencing_generation")
+        batch.drop_column("lease_state")
+        batch.drop_column("credential_generation")
+        batch.drop_column("scope_generation")
+        batch.drop_column("capacity_scope_ref")
+        batch.drop_column("execution_plan_ref")
+        batch.drop_column("compatibility_class")
+        batch.drop_column("owner_kind")
+
+
+_ = (revision, down_revision, branch_labels, depends_on)

--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -50,6 +50,9 @@ class HostLaunchSpec(BaseModel):
     limits: dict[str, int]
     runtime: dict[str, Any]
     correlationName: str = Field(alias="correlationName")
+    expectedOmnigentHostId: str | None = Field(
+        default=None, alias="expectedOmnigentHostId"
+    )
     workspaceAttachment: dict[str, Any] = Field(alias="workspaceAttachment")
     skillAttachment: dict[str, Any] = Field(alias="skillAttachment")
     toolAttachments: tuple[dict[str, Any], ...] = Field(
@@ -87,6 +90,20 @@ class HostLaunchSpec(BaseModel):
 def host_correlation_identity(host_lease_ref: str) -> str:
     digest = hashlib.sha256(host_lease_ref.encode("utf-8")).hexdigest()[:24]
     return f"mm-host-{digest}"
+
+
+def expected_omnigent_host_id(host_lease_ref: str, host_lease_generation: int) -> str:
+    """Derive the fenced expected Omnigent host identity.
+
+    Deterministic from the exact host lease and generation before container
+    creation, so Activity retry and host reconciliation derive the same value
+    and a replacement generation receives a distinct identity. Contains no
+    provider, repository, credential, or secret material.
+    """
+    import uuid as _uuid
+
+    seed = f"{host_lease_ref}:{int(host_lease_generation)}"
+    return str(_uuid.uuid5(_uuid.NAMESPACE_URL, seed))
 
 @runtime_checkable
 class OmnigentWorkspaceMaterializationPort(Protocol):
@@ -197,6 +214,7 @@ class OmnigentHostRegistrationPort(Protocol):
         correlation_name: str,
         harness_id: str,
         credentialless: bool = False,
+        expected_host_id: str | None = None,
     ) -> dict[str, Any]: ...
 
 
@@ -318,5 +336,6 @@ __all__ = [
     "OmnigentMountedToolPort",
     "OmnigentSkillDeliveryPort",
     "OmnigentWorkspaceMaterializationPort",
+    "expected_omnigent_host_id",
     "host_correlation_identity",
 ]

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -35,6 +35,7 @@ from moonmind.omnigent.host_ports import (
     OmnigentRuntimeEnvironmentPort,
     OmnigentSkillDeliveryPort,
     OmnigentWorkspaceMaterializationPort,
+    expected_omnigent_host_id,
     host_correlation_identity,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
@@ -267,6 +268,9 @@ class GenericOmnigentHostRuntime:
                 "limits": launch_policy.limits,
                 "runtime": host_class.runtime,
                 "correlationName": correlation,
+                "expectedOmnigentHostId": expected_omnigent_host_id(
+                    host_lease_ref, host_lease_generation
+                ),
                 "workspaceAttachment": prepared.workspace_attachment,
                 "skillAttachment": prepared.skill_attachment,
                 "toolAttachments": list(prepared.tool_attachments),
@@ -327,6 +331,7 @@ class GenericOmnigentHostRuntime:
                         for handle in credential_handles
                     )
                 ),
+                expected_host_id=(str(spec.expectedOmnigentHostId) or None),
             )
             attestations = await self._attestor.attest(
                 request=request,

--- a/moonmind/omnigent/host_services/launcher.py
+++ b/moonmind/omnigent/host_services/launcher.py
@@ -276,12 +276,18 @@ class DockerOmnigentHostLauncher:
         }
         # The upstream Omnigent CLI treats managed-host launches as
         # (host_id, host_name) pairs: setting only one crashes identity
-        # loading. Derive a stable per-lease host id.
-        import uuid as _uuid
+        # loading. Use the pure spec identity when present; old specs
+        # without it fall back to the legacy per-lease derivation so
+        # in-flight hosts launched before the identity contract keep
+        # their addressable ID across Activity retry.
+        if getattr(spec, "expectedOmnigentHostId", None):
+            environment["OMNIGENT_HOST_ID"] = str(spec.expectedOmnigentHostId)
+        else:
+            import uuid as _uuid
 
-        environment["OMNIGENT_HOST_ID"] = str(
-            _uuid.uuid5(_uuid.NAMESPACE_URL, spec.hostLeaseRef)
-        )
+            environment["OMNIGENT_HOST_ID"] = str(
+                _uuid.uuid5(_uuid.NAMESPACE_URL, spec.hostLeaseRef)
+            )
         # The root filesystem is read-only; HOME must point at the image's
         # app home so both the Omnigent CLI (~/.omnigent backed by the state
         # volume) and harness credentials (~/.local/share/opencode/auth.json

--- a/moonmind/omnigent/host_services/registration.py
+++ b/moonmind/omnigent/host_services/registration.py
@@ -123,7 +123,6 @@ class OmnigentHostRegistrationService:
         from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
 
         for attempt in range(self._attempts):
-            observed_at = datetime.now(UTC)
             try:
                 host = await self._client.get_host(expected_host_id)
             except OmnigentClientError as exc:

--- a/moonmind/omnigent/host_services/registration.py
+++ b/moonmind/omnigent/host_services/registration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 from datetime import UTC, datetime
 from typing import Any
 
@@ -20,6 +21,8 @@ from moonmind.omnigent.harness_platform.failures import (
 # host lifecycle implementations.
 HOST_REGISTRATION_ATTEMPTS = 91
 HOST_REGISTRATION_INTERVAL_SECONDS = 2.0
+_HOST_REGISTRATION_BASE_DELAY_SECONDS = 0.5
+_HOST_REGISTRATION_MAX_DELAY_SECONDS = 2.0
 
 
 def _harness_readiness(host: dict[str, Any], harness_id: str) -> Any:
@@ -79,6 +82,122 @@ class OmnigentHostRegistrationService:
         correlation_name: str,
         harness_id: str,
         credentialless: bool = False,
+        expected_host_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Wait for the exact launched host to register ready.
+
+        When ``expected_host_id`` is present (new launches), poll the exact
+        host identity with bounded exponential backoff and jitter, verifying
+        ID, name, owner, status, and harness readiness. A host found only
+        under another ID is never accepted by name alone. When absent (old
+        histories), fall back to the legacy list-and-filter path so replay
+        remains compatible; the fallback is observable via ``lookupMode``.
+        """
+        if expected_host_id:
+            return await self._wait_for_targeted_registration(
+                correlation_name=correlation_name,
+                harness_id=harness_id,
+                credentialless=credentialless,
+                expected_host_id=expected_host_id,
+            )
+        return await self._wait_for_compat_registration(
+            correlation_name=correlation_name,
+            harness_id=harness_id,
+            credentialless=credentialless,
+        )
+
+    def _registration_delay(self, attempt: int) -> float:
+        base = _HOST_REGISTRATION_BASE_DELAY_SECONDS * (2.0**min(attempt, 3))
+        capped = min(base, _HOST_REGISTRATION_MAX_DELAY_SECONDS)
+        jitter = random.uniform(-0.2 * capped, 0.2 * capped)
+        return max(0.1, capped + jitter)
+
+    async def _wait_for_targeted_registration(
+        self,
+        *,
+        correlation_name: str,
+        harness_id: str,
+        credentialless: bool,
+        expected_host_id: str,
+    ) -> dict[str, Any]:
+        from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
+
+        for attempt in range(self._attempts):
+            observed_at = datetime.now(UTC)
+            try:
+                host = await self._client.get_host(expected_host_id)
+            except OmnigentClientError as exc:
+                if exc.status_code == 404:
+                    host = None
+                else:
+                    raise HarnessPlatformError(
+                        "targeted host lookup failed before registration",
+                        code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,
+                    ) from exc
+            if isinstance(host, dict) and host:
+                verified = self._verify_targeted_host(
+                    host,
+                    expected_host_id=expected_host_id,
+                    correlation_name=correlation_name,
+                    harness_id=harness_id,
+                    credentialless=credentialless,
+                )
+                if verified is not None:
+                    return verified
+            if attempt + 1 < self._attempts:
+                await asyncio.sleep(self._registration_delay(attempt))
+        raise HarnessPlatformError(
+            "exact launched Omnigent host did not register ready before timeout",
+            code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,
+        )
+
+    def _verify_targeted_host(
+        self,
+        host: dict[str, Any],
+        *,
+        expected_host_id: str,
+        correlation_name: str,
+        harness_id: str,
+        credentialless: bool,
+    ) -> dict[str, Any] | None:
+        observed_at = datetime.now(UTC)
+        host_id = str(host.get("host_id") or host.get("id") or "").strip()
+        if host_id != expected_host_id:
+            raise HarnessPlatformError(
+                "launched host identity mismatch",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,
+            )
+        if str(host.get("name") or "") != correlation_name:
+            raise HarnessPlatformError(
+                "launched host name mismatch",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,
+            )
+        if str(host.get("owner") or "") != self._owner:
+            raise HarnessPlatformError(
+                "launched host owner mismatch",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,
+            )
+        if str(host.get("status") or "").lower() != "online":
+            return None
+        if not _harness_ready(host, harness_id, credentialless=credentialless):
+            return None
+        readiness = _harness_readiness(host, harness_id)
+        return {
+            "host": host,
+            "omnigentHostId": host_id,
+            "observedAt": observed_at.isoformat(),
+            "harnessReady": True,
+            "observedHarnessReadiness": readiness,
+            "credentialless": credentialless,
+            "lookupMode": "targeted",
+        }
+
+    async def _wait_for_compat_registration(
+        self,
+        *,
+        correlation_name: str,
+        harness_id: str,
+        credentialless: bool,
     ) -> dict[str, Any]:
         for attempt in range(self._attempts):
             observed_at = datetime.now(UTC)
@@ -106,6 +225,7 @@ class OmnigentHostRegistrationService:
                     "harnessReady": True,
                     "observedHarnessReadiness": readiness,
                     "credentialless": credentialless,
+                    "lookupMode": "compat",
                 }
             if len(matches) > 1:
                 raise HarnessPlatformError(

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -94,6 +94,7 @@ async def aclose_shared_pool_client() -> None:
         try:
             await client.aclose()
         except Exception:
+            # Best-effort shutdown; a close failure must not fail worker teardown.
             pass
 
 
@@ -428,12 +429,42 @@ class OmnigentHttpClient:
                 errors="replace",
             )
             raise self._error_from_response(response.status_code, body)
-        async for line in response.aiter_lines():
-            if len(line) > _MAX_SSE_LINE_BYTES:
+        pending = bytearray()
+        async for chunk in response.aiter_bytes():
+            pending.extend(chunk)
+            if len(pending) > _MAX_SSE_LINE_BYTES + 1_000_000:
+                raise OmnigentClientError(
+                    "Omnigent SSE frame exceeds bounded buffer size",
+                    failure_class="integration_error",
+                )
+            while True:
+                newline = pending.find(b"\n")
+                if newline < 0:
+                    break
+                raw = bytes(pending[:newline])
+                del pending[: newline + 1]
+                if len(raw) > _MAX_SSE_LINE_BYTES:
+                    raise OmnigentClientError(
+                        "Omnigent SSE frame exceeds bounded line size",
+                        failure_class="integration_error",
+                    )
+                try:
+                    line = raw.decode("utf-8", errors="replace")
+                except Exception:
+                    continue
+                event = parse_sse_line(line)
+                if event is not None:
+                    yield event
+        if pending:
+            if len(pending) > _MAX_SSE_LINE_BYTES:
                 raise OmnigentClientError(
                     "Omnigent SSE frame exceeds bounded line size",
                     failure_class="integration_error",
                 )
+            try:
+                line = bytes(pending).decode("utf-8", errors="replace")
+            except Exception:
+                return
             event = parse_sse_line(line)
             if event is not None:
                 yield event

--- a/moonmind/workflows/adapters/omnigent_client.py
+++ b/moonmind/workflows/adapters/omnigent_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import AsyncIterator, Iterable, Mapping
 from typing import Any
 from urllib.parse import quote
@@ -28,6 +29,72 @@ _DEFAULT_REQUEST_TIMEOUT_SECONDS = 60.0
 # its authoritative success or structured startup failure before MoonMind
 # releases the on-demand host.
 _DEFAULT_EVENT_TIMEOUT_SECONDS = 150.0
+_MAX_SSE_LINE_BYTES = 1_000_000
+
+
+def _bounded_int(env_key: str, default: int, minimum: int, maximum: int) -> int:
+    try:
+        value = int(str(os.getenv(env_key) or "").strip())
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def default_omnigent_pool_limits() -> httpx.Limits:
+    """Return the bounded lifecycle-managed pool configuration.
+
+    Defaults safely exceed maximum active Omnigent execution and control
+    concurrency with headroom for registration, cleanup, readiness, catalog
+    refresh, validation, and operator control traffic. All values are
+    deployment-overridable within safe bounds via environment.
+    """
+    return httpx.Limits(
+        max_connections=_bounded_int(
+            "MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS", 100, 10, 500
+        ),
+        max_keepalive_connections=_bounded_int(
+            "MOONMIND_OMNIGENT_HTTP_MAX_KEEPALIVE", 20, 1, 100
+        ),
+        keepalive_expiry=_bounded_int(
+            "MOONMIND_OMNIGENT_HTTP_KEEPALIVE_EXPIRY_SECONDS", 30, 5, 300
+        ),
+    )
+
+
+_SHARED_POOL_CLIENT: httpx.AsyncClient | None = None
+
+
+def shared_pool_client() -> httpx.AsyncClient | None:
+    """Return the worker-owned shared pool when initialized, else None."""
+    return _SHARED_POOL_CLIENT
+
+
+async def init_shared_pool_client(
+    *,
+    timeout_seconds: float = _DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.AsyncClient:
+    """Create and remember one lifecycle-managed pool per worker process."""
+    global _SHARED_POOL_CLIENT
+    if _SHARED_POOL_CLIENT is not None:
+        return _SHARED_POOL_CLIENT
+    _SHARED_POOL_CLIENT = httpx.AsyncClient(
+        timeout=httpx.Timeout(timeout_seconds),
+        limits=default_omnigent_pool_limits(),
+        transport=transport,
+    )
+    return _SHARED_POOL_CLIENT
+
+
+async def aclose_shared_pool_client() -> None:
+    """Close the worker-owned shared pool; safe to call when absent."""
+    global _SHARED_POOL_CLIENT
+    client, _SHARED_POOL_CLIENT = _SHARED_POOL_CLIENT, None
+    if client is not None:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
 
 
 class OmnigentClientError(RuntimeError):
@@ -72,6 +139,7 @@ class OmnigentHttpClient:
         stream_timeout_seconds: float | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
         client: httpx.AsyncClient | None = None,
+        limits: httpx.Limits | None = None,
         forward_headers: Mapping[str, Any] | None = None,
         upstream_header_allowlist: Iterable[str] | None = None,
     ) -> None:
@@ -85,6 +153,7 @@ class OmnigentHttpClient:
         )
         self._transport = transport
         self._client = client
+        self._limits = limits or default_omnigent_pool_limits()
         # Proxy mode never leaks MoonMind internal auth headers upstream unless
         # the operator explicitly allowlists them (OmnigentBridge.md §16 rule 7).
         self._forward_headers = sanitize_proxy_headers(
@@ -281,6 +350,40 @@ class OmnigentHttpClient:
                 ) as response:
                     async for event in self._iter_stream_response(response):
                         yield event
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._transport_error_message(exc),
+                    failure_class="integration_error",
+                ) from exc
+            return
+
+        shared = shared_pool_client() if self._transport is None else None
+        if shared is not None:
+            try:
+                async with shared.stream(
+                    "GET",
+                    f"{self._base}{path}",
+                    headers=self._headers(accept="text/event-stream"),
+                    timeout=self._stream_timeout,
+                ) as response:
+                    async for event in self._iter_stream_response(response):
+                        yield event
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -290,6 +393,7 @@ class OmnigentHttpClient:
 
         async with httpx.AsyncClient(
             timeout=self._stream_timeout,
+            limits=self._limits,
             transport=self._transport,
         ) as client:
             try:
@@ -300,6 +404,14 @@ class OmnigentHttpClient:
                 ) as response:
                     async for event in self._iter_stream_response(response):
                         yield event
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -317,6 +429,11 @@ class OmnigentHttpClient:
             )
             raise self._error_from_response(response.status_code, body)
         async for line in response.aiter_lines():
+            if len(line) > _MAX_SSE_LINE_BYTES:
+                raise OmnigentClientError(
+                    "Omnigent SSE frame exceeds bounded line size",
+                    failure_class="integration_error",
+                )
             event = parse_sse_line(line)
             if event is not None:
                 yield event
@@ -414,6 +531,39 @@ class OmnigentHttpClient:
                     timeout=timeout,
                     **kwargs,
                 )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._transport_error_message(exc),
+                    failure_class="integration_error",
+                ) from exc
+            return self._parse_json_response(response)
+
+        shared = shared_pool_client() if self._transport is None else None
+        if shared is not None:
+            try:
+                response = await shared.request(
+                    method,
+                    f"{self._base}{path}",
+                    headers=self._headers(),
+                    timeout=timeout,
+                    **kwargs,
+                )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -423,6 +573,7 @@ class OmnigentHttpClient:
 
         async with httpx.AsyncClient(
             timeout=timeout,
+            limits=self._limits,
             transport=self._transport,
         ) as client:
             try:
@@ -432,6 +583,14 @@ class OmnigentHttpClient:
                     headers=self._headers(),
                     **kwargs,
                 )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -461,6 +620,40 @@ class OmnigentHttpClient:
                     headers=self._headers(),
                     timeout=self._timeout,
                 )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise OmnigentClientError(
+                    self._transport_error_message(exc),
+                    failure_class="integration_error",
+                ) from exc
+            if response.status_code < 200 or response.status_code >= 300:
+                raise self._error_from_response(response.status_code, response.text)
+            return response.content
+
+        shared = shared_pool_client() if self._transport is None else None
+        if shared is not None:
+            try:
+                response = await shared.request(
+                    method,
+                    f"{self._base}{path}",
+                    headers=self._headers(),
+                    timeout=self._timeout,
+                )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -472,6 +665,7 @@ class OmnigentHttpClient:
 
         async with httpx.AsyncClient(
             timeout=self._timeout,
+            limits=self._limits,
             transport=self._transport,
         ) as client:
             try:
@@ -480,6 +674,14 @@ class OmnigentHttpClient:
                     f"{self._base}{path}",
                     headers=self._headers(),
                 )
+            except httpx.PoolTimeout as exc:
+                raise OmnigentClientError(
+                    self._redact(
+                        "Omnigent transport pool exhausted; "
+                        f"increase MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS: {exc}"
+                    ),
+                    failure_class="integration_error",
+                ) from exc
             except httpx.HTTPError as exc:
                 raise OmnigentClientError(
                     self._transport_error_message(exc),
@@ -557,5 +759,9 @@ def _scrub_payload_with_redactor(payload: Any, *, redactor: SecretRedactor) -> A
 __all__ = [
     "OmnigentClientError",
     "OmnigentHttpClient",
+    "aclose_shared_pool_client",
+    "default_omnigent_pool_limits",
+    "init_shared_pool_client",
     "parse_sse_line",
+    "shared_pool_client",
 ]

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -3644,6 +3644,7 @@ class TemporalArtifactActivities:
 
         from api_service.db.models import (
             ManagedAgentProviderProfile,
+            ProviderCapacityScope,
             ProviderProfileSlotLease,
         )
         from api_service.db.base import get_async_session_context
@@ -3679,6 +3680,33 @@ class TemporalArtifactActivities:
             managed_secret_statuses = await _managed_secret_statuses_for_profiles(
                 session=session,
                 rows=rows,
+            )
+            try:
+                scope_result = await session.execute(select(ProviderCapacityScope))
+                scope_rows = list(scope_result.scalars().all())
+            except Exception:
+                # Migration 368 may not have run yet; fall back to
+                # per-profile derived scopes so new workers stay up.
+                scope_rows = []
+
+        profiles = []
+        profile_statuses = []
+        scopes = []
+        for scope in scope_rows:
+            scopes.append(
+                {
+                    "scope_ref": scope.scope_ref,
+                    "runtime_id": scope.runtime_id,
+                    "provider_class": scope.provider_class,
+                    "generation": scope.generation,
+                    "configured_limit": scope.configured_limit,
+                    "effective_limit": scope.effective_limit,
+                    "cooldown_until": (
+                        scope.cooldown_until.isoformat() if scope.cooldown_until else None
+                    ),
+                    "backpressure_state": scope.backpressure_state,
+                    "recovery_policy_ref": scope.recovery_policy_ref,
+                }
             )
 
         profiles = []
@@ -3749,6 +3777,7 @@ class TemporalArtifactActivities:
                     "model_overrides": row.model_overrides or {},
                     "model_tiers": row.model_tiers or [],
                     "default_model_tier": row.default_model_tier,
+                    "capacity_scope_ref": row.capacity_scope_ref,
                     "max_parallel_runs": row.max_parallel_runs,
                     "cooldown_after_429_seconds": row.cooldown_after_429_seconds,
                     "rate_limit_policy": row.rate_limit_policy.value,
@@ -3775,7 +3804,7 @@ class TemporalArtifactActivities:
                 }
             )
 
-        return {"profiles": profiles, "profile_statuses": profile_statuses}
+        return {"profiles": profiles, "profile_statuses": profile_statuses, "scopes": scopes}
 
     async def provider_profile_ensure_manager(
         self,
@@ -4208,6 +4237,14 @@ class TemporalArtifactActivities:
         from api_service.db.models import ProviderProfileSlotLease
         from api_service.db.base import get_async_session_context
 
+        def _parse_lease_time(value: Any) -> Any:
+            if not value:
+                return None
+            try:
+                return datetime.fromisoformat(str(value))
+            except (ValueError, TypeError):
+                return None
+
         async with get_async_session_context() as session:
             if action == "load":
                 stmt = select(ProviderProfileSlotLease).where(
@@ -4300,6 +4337,141 @@ class TemporalArtifactActivities:
                 )
                 await session.commit()
                 return {"removed": True}
+
+            elif action == "grant":
+                from sqlalchemy import select as _select
+
+                payload = (leases or [{}])[0]
+                lease_id = str(payload.get("lease_id") or payload.get("leaseId") or "").strip()
+                if not lease_id:
+                    return {"error": "grant requires lease_id"}
+                existing = (
+                    await session.execute(
+                        _select(ProviderProfileSlotLease).where(
+                            ProviderProfileSlotLease.lease_id == lease_id
+                        )
+                    )
+                ).scalars().first()
+                if existing is not None:
+                    if (
+                        str(existing.runtime_id) != str(runtime_id)
+                        or str(existing.profile_id) != str(payload.get("profile_id") or "")
+                        or str(existing.owner_id or "") != str(payload.get("owner_id") or payload.get("ownerId") or "")
+                    ):
+                        return {"error": "lease identity conflict"}
+                    return {"granted": True, "duplicate": True}
+                new_lease = ProviderProfileSlotLease(
+                    runtime_id=runtime_id,
+                    workflow_id=str(payload.get("workflow_id") or lease_id),
+                    profile_id=str(payload.get("profile_id") or ""),
+                    lease_id=lease_id,
+                    owner_id=str(payload.get("owner_id") or payload.get("ownerId") or lease_id),
+                    owner_kind=str(payload.get("owner_kind") or payload.get("ownerKind") or "workflow"),
+                    purpose=str(payload.get("purpose") or "execution_direct"),
+                    compatibility_class=str(
+                        payload.get("compatibility_class") or payload.get("purpose") or "execution_direct"
+                    ),
+                    owner_is_workflow=payload.get("ownerIsWorkflow", True) is not False,
+                    step_execution_id=payload.get("stepExecutionId"),
+                    oauth_session_id=payload.get("oauthSessionId"),
+                    idempotency_key=payload.get("idempotencyKey"),
+                    execution_plan_ref=payload.get("executionPlanRef"),
+                    capacity_scope_ref=payload.get("capacity_scope_ref"),
+                    scope_generation=int(payload.get("scope_generation") or 1),
+                    credential_generation=payload.get("credential_generation"),
+                    lease_state=str(payload.get("lease_state") or "held"),
+                    fencing_generation=int(payload.get("fencing_generation") or 1),
+                    safe_metadata_json=payload.get("safe_metadata"),
+                    expires_at=_parse_lease_time(payload.get("expiresAt")),
+                    heartbeat_at=_parse_lease_time(payload.get("heartbeatAt")),
+                )
+                session.add(new_lease)
+                await session.commit()
+                return {"granted": True, "duplicate": False}
+
+            elif action == "heartbeat":
+                from sqlalchemy import select as _select
+
+                payload = (leases or [{}])[0]
+                lease_id = str(payload.get("lease_id") or "").strip()
+                if not lease_id:
+                    return {"error": "heartbeat requires lease_id"}
+                try:
+                    expected_fence = int(payload.get("fencing_generation") or 0)
+                except (TypeError, ValueError):
+                    expected_fence = 0
+                row = (
+                    await session.execute(
+                        _select(ProviderProfileSlotLease).where(
+                            ProviderProfileSlotLease.lease_id == lease_id
+                        )
+                    )
+                ).scalars().first()
+                if row is None:
+                    return {"heartbeat": False, "stale": True}
+                if expected_fence and int(row.fencing_generation) != expected_fence:
+                    return {"heartbeat": False, "stale": True}
+                row.heartbeat_at = _parse_lease_time(payload.get("heartbeatAt")) or datetime.now(timezone.utc)
+                await session.commit()
+                return {"heartbeat": True}
+
+            elif action == "release_one":
+                from sqlalchemy import select as _select
+
+                payload = (leases or [{}])[0]
+                lease_id = str(payload.get("lease_id") or "").strip()
+                if not lease_id:
+                    return {"error": "release_one requires lease_id"}
+                try:
+                    expected_fence = int(payload.get("fencing_generation") or 0)
+                except (TypeError, ValueError):
+                    expected_fence = 0
+                row = (
+                    await session.execute(
+                        _select(ProviderProfileSlotLease).where(
+                            ProviderProfileSlotLease.lease_id == lease_id
+                        )
+                    )
+                ).scalars().first()
+                if row is None:
+                    return {"released": True, "duplicate": True}
+                if expected_fence and int(row.fencing_generation) != expected_fence:
+                    return {"released": False, "stale": True}
+                await session.execute(
+                    delete(ProviderProfileSlotLease).where(
+                        ProviderProfileSlotLease.lease_id == lease_id
+                    )
+                )
+                await session.commit()
+                return {"released": True}
+
+            elif action == "list_active":
+                from sqlalchemy import select as _select
+
+                scope_filter = None
+                if leases:
+                    scope_filter = str((leases[0] or {}).get("capacity_scope_ref") or "").strip() or None
+                stmt = _select(ProviderProfileSlotLease).where(
+                    ProviderProfileSlotLease.runtime_id == runtime_id
+                )
+                if scope_filter:
+                    stmt = stmt.where(ProviderProfileSlotLease.capacity_scope_ref == scope_filter)
+                result = await session.execute(stmt)
+                rows = result.scalars().all()
+                return {
+                    "leases": [
+                        {
+                            "lease_id": row.lease_id,
+                            "workflow_id": row.workflow_id,
+                            "profile_id": row.profile_id,
+                            "owner_id": row.owner_id,
+                            "lease_state": row.lease_state,
+                            "fencing_generation": row.fencing_generation,
+                            "capacity_scope_ref": row.capacity_scope_ref,
+                        }
+                        for row in rows
+                    ]
+                }
 
             else:
                 return {"error": f"Unknown action: {action}"}

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -2761,6 +2761,26 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
     activity fleets (llm, sandbox, etc.).
     """
     resources = AsyncExitStack()
+    activity_types = set(getattr(topology, "activity_types", []) or [])
+    uses_omnigent_transport = bool(
+        getattr(topology, "fleet", "") == AGENT_RUNTIME_FLEET
+        or any(
+            str(name).startswith("integration.omnigent") or str(name).startswith("omnigent.")
+            for name in activity_types
+        )
+    )
+    if uses_omnigent_transport:
+        # One lifecycle-managed bounded pool per worker process, shared by
+        # ordinary requests and SSE streams with headroom for registration,
+        # cleanup, readiness, catalog, validation, and operator traffic.
+        # Worker shutdown closes streams and the pool cleanly via resources.
+        from moonmind.workflows.adapters.omnigent_client import (
+            aclose_shared_pool_client,
+            init_shared_pool_client,
+        )
+
+        await init_shared_pool_client()
+        resources.push_async_callback(aclose_shared_pool_client)
     if "integration.omnigent.execute" in topology.activity_types:
         from moonmind.omnigent.settings import generic_host_enabled
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1150,7 +1150,11 @@ class MoonMindAgentRun:
         runtime_id: str,
         request: AgentExecutionRequest,
     ) -> str:
-        if workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID):
+        try:
+            use_canonical = workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID)
+        except Exception:
+            use_canonical = False
+        if use_canonical:
             return canonical_waiting_reason("awaiting_provider_capacity")
         intent = self._provider_slot_intent_summary(request)
         return (
@@ -1171,7 +1175,11 @@ class MoonMindAgentRun:
         queue_number = (
             queue_position if isinstance(queue_position, int) and queue_position > 0 else None
         )
-        if workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID):
+        try:
+            use_canonical = workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID)
+        except Exception:
+            use_canonical = False
+        if use_canonical:
             profile = manager_state.get("requested_profile")
             if isinstance(profile, Mapping):
                 if str(profile.get("cooldown_until") or "").strip():

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -303,6 +303,7 @@ RUNTIME_SELECTION_SESSION_REBIND_PATCH_ID = (
 AWAITING_SLOT_RUNTIME_PROFILE_EDIT_PATCH_ID = (
     "agent-run-awaiting-slot-runtime-profile-edit-v1"
 )
+CANONICAL_WAITING_STATE_PATCH_ID = "agent-run-canonical-waiting-state-v1"
 AGENT_RUN_RESILIENCY_POLICY_PATCH_ID = "agent-run-resiliency-policy-v1"
 AGENT_RUN_CLAUDE_NO_PROGRESS_POLICY_PATCH_ID = (
     "agent-run-claude-code-no-progress-policy-v2"
@@ -573,6 +574,35 @@ async def external_adapter_execution_style(agent_id: str) -> str:
     if isinstance(adapter, BaseExternalAgentAdapter):
         return adapter.provider_capability.execution_style
     return "polling"
+
+CANONICAL_WAITING_REASONS = (
+    "awaiting_provider_capacity",
+    "awaiting_provider_validation",
+    "awaiting_profile_maintenance",
+    "provider_cooldown",
+    "awaiting_host_capacity",
+    "awaiting_host_launch_permit",
+    "awaiting_execution_worker",
+    "cleanup_pending",
+)
+
+
+def canonical_waiting_reason(
+    reason: str, *, queue_position: int | None = None
+) -> str:
+    """Map internal wait state to one bounded product reason.
+
+    Emits only the canonical reason plus an optional numeric queue position.
+    No lease, host, session, credential, repository, or Docker identity ever
+    enters the parent progress payload; terminal outcome remains owned by
+    child completion and AgentRunResult.
+    """
+    normalized = str(reason or "").strip()
+    if normalized not in CANONICAL_WAITING_REASONS:
+        normalized = "awaiting_provider_capacity"
+    if isinstance(queue_position, int) and queue_position > 0:
+        return f"{normalized}; queue_position={queue_position}"
+    return normalized
 
 @workflow.defn(name="MoonMind.AgentRun")
 class MoonMindAgentRun:
@@ -1120,6 +1150,8 @@ class MoonMindAgentRun:
         runtime_id: str,
         request: AgentExecutionRequest,
     ) -> str:
+        if workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID):
+            return canonical_waiting_reason("awaiting_provider_capacity")
         intent = self._provider_slot_intent_summary(request)
         return (
             "Waiting for provider profile slot; "
@@ -1135,6 +1167,24 @@ class MoonMindAgentRun:
     ) -> str:
         """Describe the manager-owned condition that is blocking slot assignment."""
 
+        queue_position = manager_state.get("requester_queue_position")
+        queue_number = (
+            queue_position if isinstance(queue_position, int) and queue_position > 0 else None
+        )
+        if workflow.patched(CANONICAL_WAITING_STATE_PATCH_ID):
+            profile = manager_state.get("requested_profile")
+            if isinstance(profile, Mapping):
+                if str(profile.get("cooldown_until") or "").strip():
+                    return canonical_waiting_reason(
+                        "provider_cooldown", queue_position=queue_number
+                    )
+                if profile.get("enabled") is False or profile.get("launch_ready") is False:
+                    return canonical_waiting_reason(
+                        "awaiting_provider_validation", queue_position=queue_number
+                    )
+            return canonical_waiting_reason(
+                "awaiting_provider_capacity", queue_position=queue_number
+            )
         intent = self._provider_slot_intent_summary(request)
         queue_position = manager_state.get("requester_queue_position")
         queue_suffix = (

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -814,7 +814,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
                     if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
                         persisted = await self._grant_lease_to_db(
-                            profile=profile, lease_id=requester_id
+                            profile=profile,
+                            lease_id=requester_id,
+                            purpose=purpose,
+                            metadata=lease_metadata,
                         )
                     else:
                         persisted = await self._sync_leases_to_db()
@@ -941,7 +944,13 @@ class MoonMindProviderProfileManagerWorkflow:
                 non_retryable=True,
             )
         while not self._shutdown_requested:
-            if profile.reserve(
+            try:
+                _maintenance_scope_gate = workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH)
+            except Exception:
+                _maintenance_scope_gate = False
+            if _maintenance_scope_gate and not self._profile_scope_available(profile):
+                pass
+            elif profile.reserve(
                 requester_id,
                 workflow.now(),
                 purpose=purpose,
@@ -952,7 +961,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
                     if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
                         persisted = await self._grant_lease_to_db(
-                            profile=profile, lease_id=requester_id
+                            profile=profile,
+                            lease_id=requester_id,
+                            purpose=purpose,
+                            metadata=self._safe_lease_metadata(payload),
                         )
                     else:
                         persisted = await self._sync_leases_to_db()
@@ -1750,7 +1762,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 if durable_grants:
                     if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
                         persisted = await self._grant_lease_to_db(
-                            profile=profile, lease_id=req.requester_workflow_id
+                            profile=profile,
+                            lease_id=req.requester_workflow_id,
+                            purpose=req.purpose,
+                            metadata=req.lease_metadata,
                         )
                     else:
                         persisted = await self._sync_leases_to_db()
@@ -1970,6 +1985,8 @@ class MoonMindProviderProfileManagerWorkflow:
                     selector=selector,
                     exact_profile_id=exact_profile_id,
                 ):
+                    if not self._profile_admitted_by_capacity(reserved_profile):
+                        return None
                     self._handoff_reservations.pop(normalized_group_id, None)
                     return reserved_profile
                 self._handoff_reservations.pop(normalized_group_id, None)
@@ -2303,12 +2320,17 @@ class MoonMindProviderProfileManagerWorkflow:
     ) -> CapacityScopeState:
         scope = self._scopes.get(scope_ref)
         if scope is None:
+            derived_max = 0
+            for profile in self._profiles.values():
+                if (profile.capacity_scope_ref or f"provider-profile:{profile.profile_id}") == scope_ref:
+                    derived_max = max(derived_max, profile.max_parallel_runs)
+            configured = derived_max if derived_max > 0 else 1
             scope = CapacityScopeState(
                 scope_ref=scope_ref,
                 runtime_id=runtime_id,
                 provider_class=provider_class,
-                configured_limit=1,
-                effective_limit=1,
+                configured_limit=configured,
+                effective_limit=configured,
             )
             self._scopes[scope_ref] = scope
         return scope
@@ -2331,6 +2353,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 if workflow.now() < cooldown_dt:
                     return False
             except (ValueError, TypeError):
+                # Expected: malformed cooldown never blocks admission.
                 pass
         return self._scope_active_units(scope.scope_ref) < max(1, scope.effective_limit)
 
@@ -2375,6 +2398,13 @@ class MoonMindProviderProfileManagerWorkflow:
                 scope.healthy_since = now.isoformat()
                 if scope.effective_limit >= scope.configured_limit:
                     scope.backpressure_state = "healthy"
+        for profile in self._profiles.values():
+            effective = profile.effective_limit or profile.max_parallel_runs
+            if effective >= profile.max_parallel_runs:
+                continue
+            if profile.cooldown_until is not None:
+                continue
+            profile.effective_limit = min(profile.max_parallel_runs, effective + 1)
 
     def _apply_scope_rate_limit(
         self,
@@ -2407,6 +2437,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     if existing >= new_until:
                         new_until = existing
                 except (ValueError, TypeError):
+                    # Expected: malformed existing deadline never shortens the new one.
                     pass
             scope.cooldown_until = new_until.isoformat()
             scope.backpressure_state = "cooldown"
@@ -2645,9 +2676,17 @@ class MoonMindProviderProfileManagerWorkflow:
             )
 
     async def _grant_lease_to_db(
-        self, *, profile: ProfileSlotState, lease_id: str
+        self,
+        *,
+        profile: ProfileSlotState,
+        lease_id: str,
+        purpose: str = "execution_direct",
+        metadata: dict[str, Any] | None = None,
     ) -> bool:
         """Persist one lease grant; idempotent retry returns existing lease."""
+        safe = dict(metadata or {})
+        owner_id = str(safe.get("ownerId") or safe.get("workflowId") or lease_id)
+        owner_is_workflow = safe.get("ownerIsWorkflow", True) is not False
         try:
             result = await workflow.execute_activity(
                 "provider_profile.sync_slot_leases",
@@ -2656,11 +2695,11 @@ class MoonMindProviderProfileManagerWorkflow:
                     "leases": [
                         {
                             "lease_id": lease_id,
-                            "workflow_id": lease_id,
+                            "workflow_id": str(safe.get("workflowId") or lease_id),
                             "profile_id": profile.profile_id,
-                            "owner_id": lease_id,
-                            "owner_kind": "workflow",
-                            "purpose": "execution_direct",
+                            "owner_id": owner_id,
+                            "owner_kind": "workflow" if owner_is_workflow else "activity",
+                            "purpose": purpose,
                             "fencing_generation": 1,
                             "scope_generation": 1,
                             "capacity_scope_ref": (
@@ -2668,6 +2707,10 @@ class MoonMindProviderProfileManagerWorkflow:
                                 or f"provider-profile:{profile.profile_id}"
                             ),
                             "lease_state": "held",
+                            "stepExecutionId": safe.get("stepExecutionId"),
+                            "oauthSessionId": safe.get("oauthSessionId"),
+                            "idempotencyKey": safe.get("idempotencyKey"),
+                            "ownerIsWorkflow": owner_is_workflow,
                         }
                     ],
                     "action": "grant",
@@ -2788,6 +2831,11 @@ class MoonMindProviderProfileManagerWorkflow:
                             if lease.get(key) is not None
                         },
                     }
+                    self._index_lease(
+                        profile_id,
+                        wf_id,
+                        str(lease.get("ownerId") or wf_id),
+                    )
 
                 # Send slot_assigned to the workflow to reconnect
                 if is_maintenance:

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -82,6 +82,8 @@ DURABLE_LEASE_GRANT_PATCH = "provider-profile-manager-durable-lease-grant-v1"
 ACTIVITY_OWNED_LEASE_VERIFICATION_PATCH = (
     "provider-profile-manager-activity-owned-lease-verification-v1"
 )
+PROVIDER_CAPACITY_SCOPE_PATCH = "provider-profile-manager-capacity-scope-v1"
+PROVIDER_INCREMENTAL_LEASE_PATCH = "provider-profile-manager-incremental-lease-v1"
 
 # Deterministic sort sentinel for pending requests whose scheduled queue order
 # cannot be resolved (missing scheduled_for / created_at). ISO-8601 strings sort
@@ -290,6 +292,8 @@ class ProfileSlotState:
     default_model_tier: int = 1
     over_capacity_legacy_snapshot: bool = False
     authoritative_policy_confirmed: bool = False
+    capacity_scope_ref: str = ""
+    effective_limit: int = 0
 
     @property
     def available_slots(self) -> int:
@@ -399,6 +403,8 @@ class ProfileSlotState:
             "model_tiers": list(self.model_tiers),
             "default_model_tier": self.default_model_tier,
             "overCapacityLegacySnapshot": self.over_capacity_legacy_snapshot,
+            "capacity_scope_ref": self.capacity_scope_ref,
+            "effective_limit": self.effective_limit,
         }
 
     @property
@@ -406,6 +412,40 @@ class ProfileSlotState:
         if self.input_per_million_usd is None or self.output_per_million_usd is None:
             return None
         return self.input_per_million_usd + self.output_per_million_usd
+
+
+@dataclass
+class CapacityScopeState:
+    """In-workflow tracking of one shared provider-capacity aggregate."""
+
+    scope_ref: str
+    runtime_id: str = ""
+    provider_class: str = "unknown"
+    generation: int = 1
+    configured_limit: int = 1
+    effective_limit: int = 1
+    cooldown_until: Optional[str] = None
+    backpressure_state: str = "healthy"
+    recovery_policy_ref: str = "additive-increase-multiplicative-decrease@1"
+    healthy_since: Optional[str] = None
+    last_decrease_at: Optional[str] = None
+    last_increase_at: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scope_ref": self.scope_ref,
+            "runtime_id": self.runtime_id,
+            "provider_class": self.provider_class,
+            "generation": self.generation,
+            "configured_limit": self.configured_limit,
+            "effective_limit": self.effective_limit,
+            "cooldown_until": self.cooldown_until,
+            "backpressure_state": self.backpressure_state,
+            "recovery_policy_ref": self.recovery_policy_ref,
+            "healthy_since": self.healthy_since,
+            "last_decrease_at": self.last_decrease_at,
+            "last_increase_at": self.last_increase_at,
+        }
 
 
 @dataclass
@@ -483,6 +523,10 @@ class MoonMindProviderProfileManagerWorkflow:
     def __init__(self) -> None:
         self._runtime_id: Optional[str] = None
         self._profiles: dict[str, ProfileSlotState] = {}
+        self._scopes: dict[str, CapacityScopeState] = {}
+        self._seen_rate_limit_reports: list[str] = []
+        self._lease_profile_index: dict[str, str] = {}
+        self._owner_lease_index: dict[str, str] = {}
         self._pending_requests: list[PendingRequest] = []
         self._pending_requests_ordered: bool = False
         self._handoff_reservations: dict[str, HandoffReservation] = {}
@@ -594,6 +638,8 @@ class MoonMindProviderProfileManagerWorkflow:
         released = False
         if profile:
             released = profile.release(requester_id)
+            if released:
+                self._unindex_lease(requester_id)
         if workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
             self._pending_requests = [
                 req
@@ -625,7 +671,9 @@ class MoonMindProviderProfileManagerWorkflow:
         self._has_new_events = True
         profile_id = payload["profile_id"]
         profile = self._profiles.get(profile_id)
-        if profile:
+        if not profile:
+            return
+        if not workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH):
             cooldown_seconds = payload.get(
                 "cooldown_seconds",
                 profile.cooldown_after_429_seconds,
@@ -633,6 +681,39 @@ class MoonMindProviderProfileManagerWorkflow:
             now = workflow.now()
             cooldown_until = now + timedelta(seconds=cooldown_seconds)
             profile.cooldown_until = cooldown_until.isoformat()
+            return
+        now = workflow.now()
+        failure_class = str(payload.get("failure_class") or "rate_limit").strip()
+        if failure_class not in {"rate_limit", "429", "provider_rate_limit"}:
+            # Profile-specific credential errors must not reduce a shared scope.
+            cooldown_seconds = payload.get(
+                "cooldown_seconds", profile.cooldown_after_429_seconds
+            )
+            profile.cooldown_until = (now + timedelta(seconds=cooldown_seconds)).isoformat()
+            return
+        retry_after = payload.get("retry_after_seconds")
+        try:
+            retry_after_seconds = int(retry_after) if retry_after is not None else None
+        except (TypeError, ValueError):
+            retry_after_seconds = None
+        if retry_after_seconds is None:
+            retry_after_seconds = int(
+                payload.get("cooldown_seconds", profile.cooldown_after_429_seconds)
+            )
+        scope_ref = (
+            str(payload.get("capacity_scope_ref") or "").strip()
+            or profile.capacity_scope_ref
+            or f"provider-profile:{profile_id}"
+        )
+        report_id = payload.get("report_id") or payload.get("idempotency_key")
+        self._apply_scope_rate_limit(
+            scope_ref=scope_ref,
+            retry_after_seconds=retry_after_seconds,
+            report_id=str(report_id) if report_id else None,
+            now=now,
+        )
+        profile.effective_limit = max(1, profile.effective_limit // 2) if profile.effective_limit else max(1, profile.max_parallel_runs // 2)
+        profile.cooldown_until = (now + timedelta(seconds=max(1, min(3600, int(retry_after_seconds))))).isoformat()
 
     @workflow.signal
     def sync_profiles(self, payload: dict[str, Any]) -> None:
@@ -729,13 +810,20 @@ class MoonMindProviderProfileManagerWorkflow:
                 purpose=purpose,
                 metadata=lease_metadata,
             ):
+                self._index_lease(profile.profile_id, requester_id, requester_id)
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                    persisted = await self._sync_leases_to_db()
+                    if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
+                        persisted = await self._grant_lease_to_db(
+                            profile=profile, lease_id=requester_id
+                        )
+                    else:
+                        persisted = await self._sync_leases_to_db()
                     if (
                         workflow.patched(DURABLE_LEASE_GRANT_PATCH)
                         and not persisted
                     ):
                         profile.release(requester_id)
+                        self._unindex_lease(requester_id)
                         raise exceptions.ApplicationError(
                             "Provider profile lease persistence failed before direct grant",
                             type="ProviderProfileLeasePersistenceFailed",
@@ -843,6 +931,8 @@ class MoonMindProviderProfileManagerWorkflow:
                 rate_limit_policy="backoff",
                 enabled=False,
                 launch_ready=False,
+                capacity_scope_ref=f"provider-profile:{profile_id}",
+                effective_limit=1,
             )
             self._profiles[profile_id] = profile
         if profile.max_parallel_runs != 1:
@@ -858,13 +948,20 @@ class MoonMindProviderProfileManagerWorkflow:
                 metadata=self._safe_lease_metadata(payload),
                 allow_unready=True,
             ):
+                self._index_lease(profile.profile_id, requester_id, requester_id)
                 if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                    persisted = await self._sync_leases_to_db()
+                    if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
+                        persisted = await self._grant_lease_to_db(
+                            profile=profile, lease_id=requester_id
+                        )
+                    else:
+                        persisted = await self._sync_leases_to_db()
                     if (
                         workflow.patched(DURABLE_LEASE_GRANT_PATCH)
                         and not persisted
                     ):
                         profile.release(requester_id)
+                        self._unindex_lease(requester_id)
                         raise exceptions.ApplicationError(
                             "Provider profile lease persistence failed before maintenance grant",
                             type="ProviderProfileLeasePersistenceFailed",
@@ -1155,14 +1252,22 @@ class MoonMindProviderProfileManagerWorkflow:
                 runtime_id=self._runtime_id,
                 infer_legacy_source=repair_legacy_codex_oauth,
             )
+            restored_max = _validated_profile_capacity(
+                p,
+                runtime_id=self._runtime_id,
+                repair_legacy=repair_legacy_codex_oauth,
+                apply_claude_exclusive_capacity=apply_claude_exclusive_capacity,
+            )
+            restored_effective = p.get("effective_limit")
+            try:
+                restored_effective = int(restored_effective)
+            except (TypeError, ValueError):
+                restored_effective = 0
+            if restored_effective <= 0:
+                restored_effective = restored_max
             state = ProfileSlotState(
                 profile_id=pid,
-                max_parallel_runs=_validated_profile_capacity(
-                    p,
-                    runtime_id=self._runtime_id,
-                    repair_legacy=repair_legacy_codex_oauth,
-                    apply_claude_exclusive_capacity=apply_claude_exclusive_capacity,
-                ),
+                max_parallel_runs=restored_max,
                 cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 900),
                 rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                 enabled=p.get("enabled", True),
@@ -1189,8 +1294,63 @@ class MoonMindProviderProfileManagerWorkflow:
                     is_legacy_codex_oauth and original_capacity != 1
                 )
                 or bool(p.get("over_capacity_legacy_snapshot", False)),
+                capacity_scope_ref=(
+                    str(p.get("capacity_scope_ref") or "").strip()
+                    or f"provider-profile:{pid}"
+                ),
+                effective_limit=restored_effective,
             )
             self._profiles[pid] = state
+
+        seen = input_payload.get("seen_rate_limit_reports", [])
+        self._seen_rate_limit_reports = (
+            [str(value) for value in seen[-500:] if str(value)]
+            if isinstance(seen, list)
+            else []
+        )
+        scopes_data = input_payload.get("scopes", [])
+        if isinstance(scopes_data, list) and scopes_data:
+            for entry in scopes_data:
+                if not isinstance(entry, dict):
+                    continue
+                scope_ref = str(entry.get("scope_ref") or "").strip()
+                if not scope_ref:
+                    continue
+                try:
+                    configured = int(entry.get("configured_limit") or 0)
+                    effective = int(entry.get("effective_limit") or 0)
+                except (TypeError, ValueError):
+                    continue
+                if configured <= 0:
+                    continue
+                self._scopes[scope_ref] = CapacityScopeState(
+                    scope_ref=scope_ref,
+                    runtime_id=str(entry.get("runtime_id") or ""),
+                    provider_class=str(entry.get("provider_class") or "unknown"),
+                    generation=int(entry.get("generation") or 1),
+                    configured_limit=configured,
+                    effective_limit=effective if effective > 0 else configured,
+                    cooldown_until=entry.get("cooldown_until"),
+                    backpressure_state=str(entry.get("backpressure_state") or "healthy"),
+                    recovery_policy_ref=str(
+                        entry.get("recovery_policy_ref")
+                        or "additive-increase-multiplicative-decrease@1"
+                    ),
+                    healthy_since=entry.get("healthy_since"),
+                    last_decrease_at=entry.get("last_decrease_at"),
+                    last_increase_at=entry.get("last_increase_at"),
+                )
+        else:
+            for profile in self._profiles.values():
+                scope_ref = profile.capacity_scope_ref or f"provider-profile:{profile.profile_id}"
+                scope = self._scopes.get(scope_ref)
+                if scope is None:
+                    self._scopes[scope_ref] = CapacityScopeState(
+                        scope_ref=scope_ref,
+                        configured_limit=profile.max_parallel_runs,
+                        effective_limit=profile.effective_limit or profile.max_parallel_runs,
+                    )
+        self._rebuild_lease_indexes()
 
     def _apply_profile_sync(
         self,
@@ -1240,6 +1400,25 @@ class MoonMindProviderProfileManagerWorkflow:
                 existing.default_model_tier = p.get(
                     "default_model_tier", existing.default_model_tier
                 )
+                new_scope = str(p.get("capacity_scope_ref") or "").strip()
+                if new_scope:
+                    existing.capacity_scope_ref = new_scope
+                elif not existing.capacity_scope_ref:
+                    existing.capacity_scope_ref = f"provider-profile:{pid}"
+                if not existing.effective_limit:
+                    existing.effective_limit = existing.max_parallel_runs
+                existing.effective_limit = min(
+                    existing.effective_limit, existing.max_parallel_runs
+                )
+                try:
+                    scoped_sync = workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH)
+                except Exception:
+                    scoped_sync = False
+                if scoped_sync:
+                    self._ensure_scope(
+                        existing.capacity_scope_ref or f"provider-profile:{pid}",
+                        runtime_id=self._runtime_id or "",
+                    )
                 self._apply_profile_pricing(existing, p)
                 if authoritative:
                     existing.authoritative_policy_confirmed = True
@@ -1248,12 +1427,13 @@ class MoonMindProviderProfileManagerWorkflow:
                     )
             else:
                 pricing = pricing_from_profile_metadata(p)
+                synced_max = _validated_profile_capacity(
+                    p,
+                    runtime_id=self._runtime_id,
+                )
                 self._profiles[pid] = ProfileSlotState(
                     profile_id=pid,
-                    max_parallel_runs=_validated_profile_capacity(
-                        p,
-                        runtime_id=self._runtime_id,
-                    ),
+                    max_parallel_runs=synced_max,
                     cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 900),
                     rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                     enabled=p.get("enabled", True),
@@ -1277,6 +1457,11 @@ class MoonMindProviderProfileManagerWorkflow:
                     model_tiers=p.get("model_tiers") or [],
                     default_model_tier=p.get("default_model_tier", 1),
                     authoritative_policy_confirmed=authoritative,
+                    capacity_scope_ref=(
+                        str(p.get("capacity_scope_ref") or "").strip()
+                        or f"provider-profile:{pid}"
+                    ),
+                    effective_limit=synced_max,
                 )
 
         # Disable profiles that were removed from DB (but don't drop leases).
@@ -1284,6 +1469,46 @@ class MoonMindProviderProfileManagerWorkflow:
             if pid not in seen:
                 self._profiles[pid].enabled = False
                 self._profiles[pid].is_default = False
+
+    def _apply_scope_sync(self, scopes_data: list[dict[str, Any]]) -> None:
+        """Merge authoritative scope configured limits without wiping adaptation.
+
+        Effective limits adapt in-workflow via AIMD; a DB reload updates the
+        configured ceiling and clamps effective down when the operator reduces
+        below current effective, but never auto-raises effective (gradual
+        recovery owns increases). Reducing below active usage blocks new
+        grants without terminating work, since admission compares usage to
+        the clamped effective.
+        """
+        for entry in scopes_data:
+            if not isinstance(entry, dict):
+                continue
+            scope_ref = str(entry.get("scope_ref") or "").strip()
+            if not scope_ref:
+                continue
+            try:
+                configured = int(entry.get("configured_limit") or 0)
+            except (TypeError, ValueError):
+                continue
+            if configured <= 0:
+                continue
+            scope = self._ensure_scope(
+                scope_ref,
+                runtime_id=str(entry.get("runtime_id") or self._runtime_id or ""),
+                provider_class=str(entry.get("provider_class") or "unknown"),
+            )
+            try:
+                generation = int(entry.get("generation") or scope.generation)
+            except (TypeError, ValueError):
+                generation = scope.generation
+            if generation > scope.generation:
+                scope.generation = generation
+            scope.runtime_id = str(entry.get("runtime_id") or scope.runtime_id)
+            scope.provider_class = str(entry.get("provider_class") or scope.provider_class)
+            scope.configured_limit = configured
+            scope.effective_limit = min(scope.effective_limit or configured, configured)
+            if scope.effective_limit >= scope.configured_limit:
+                scope.backpressure_state = "healthy"
 
     def _prune_disabled_profiles_without_leases(self) -> None:
         """Drop stale profile metadata that cannot still own runtime leases."""
@@ -1360,7 +1585,40 @@ class MoonMindProviderProfileManagerWorkflow:
                 reserved_slots += 1
         return reserved_slots
 
+    def _rebuild_lease_indexes(self) -> None:
+        self._lease_profile_index = {}
+        self._owner_lease_index = {}
+        for profile in self._profiles.values():
+            for lease_id in profile.current_leases:
+                if lease_id in self._lease_profile_index:
+                    continue
+                self._lease_profile_index[lease_id] = profile.profile_id
+                metadata = profile.lease_metadata.get(lease_id) or {}
+                owner = str(metadata.get("ownerId") or lease_id)
+                if owner not in self._owner_lease_index:
+                    self._owner_lease_index[owner] = lease_id
+
+    def _index_lease(self, profile_id: str, lease_id: str, owner_id: str | None = None) -> None:
+        if lease_id and lease_id not in self._lease_profile_index:
+            self._lease_profile_index[lease_id] = profile_id
+        owner = str(owner_id or lease_id)
+        if owner and owner not in self._owner_lease_index:
+            self._owner_lease_index[owner] = lease_id
+
+    def _unindex_lease(self, lease_id: str) -> None:
+        profile_id = self._lease_profile_index.pop(lease_id, None)
+        for owner, mapped_lease in list(self._owner_lease_index.items()):
+            if mapped_lease == lease_id:
+                del self._owner_lease_index[owner]
+        _ = profile_id
+
     def _profile_id_for_lease(self, requester_workflow_id: str) -> str | None:
+        try:
+            use_index = workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH)
+        except Exception:
+            use_index = False
+        if use_index:
+            return self._lease_profile_index.get(requester_workflow_id)
         for profile in self._profiles.values():
             if requester_workflow_id in profile.current_leases:
                 return profile.profile_id
@@ -1468,6 +1726,7 @@ class MoonMindProviderProfileManagerWorkflow:
                         self._profiles[existing_profile_id].release(
                             req.requester_workflow_id
                         )
+                        self._unindex_lease(req.requester_workflow_id)
                         leases_changed = True
                 continue
 
@@ -1483,12 +1742,24 @@ class MoonMindProviderProfileManagerWorkflow:
                 metadata=req.lease_metadata,
             ):
                 leases_changed = True
-                if durable_grants and not await self._sync_leases_to_db():
-                    # Hold the in-memory reservation and retry persistence on
-                    # the next loop. Never signal a consumer before its lease
-                    # is durable.
-                    remaining.append(req)
-                    continue
+                self._index_lease(
+                    profile.profile_id,
+                    req.requester_workflow_id,
+                    req.requester_workflow_id,
+                )
+                if durable_grants:
+                    if workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH):
+                        persisted = await self._grant_lease_to_db(
+                            profile=profile, lease_id=req.requester_workflow_id
+                        )
+                    else:
+                        persisted = await self._sync_leases_to_db()
+                    if not persisted:
+                        # Hold the in-memory reservation and retry persistence on
+                        # the next loop. Never signal a consumer before its lease
+                        # is durable.
+                        remaining.append(req)
+                        continue
                 try:
                     await self._signal_slot_assigned(
                         req.requester_workflow_id, profile.profile_id
@@ -1503,6 +1774,7 @@ class MoonMindProviderProfileManagerWorkflow:
                         remaining.append(req)
                     else:
                         profile.release(req.requester_workflow_id)
+                        self._unindex_lease(req.requester_workflow_id)
                         leases_changed = True
             else:
                 remaining.append(req)
@@ -1711,6 +1983,10 @@ class MoonMindProviderProfileManagerWorkflow:
             )
             if exact_profile.available_slots <= reserved_slots:
                 return None
+            if not self._profile_admitted_by_capacity(
+                exact_profile, reserved_slots=reserved_slots
+            ):
+                return None
             return (
                 exact_profile
                 if self._profile_matches_request(
@@ -1729,6 +2005,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 profile.profile_id, normalized_group_id
             )
             if profile.available_slots <= reserved_slots:
+                continue
+            if not self._profile_admitted_by_capacity(
+                profile, reserved_slots=reserved_slots
+            ):
                 continue
             if not self._profile_matches_request(
                 profile,
@@ -1816,6 +2096,7 @@ class MoonMindProviderProfileManagerWorkflow:
             evicted = profile.evict_expired_leases(now, max_duration)
             total_evicted += len(evicted)
             for wf_id in evicted:
+                self._unindex_lease(wf_id)
                 self._get_logger().warning(
                     "Evicted stale lease for profile %s held by %s",
                     profile.profile_id,
@@ -1906,6 +2187,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 status_info = workflow_statuses.get(owner_workflow_id, {})
                 if not status_info.get("running", True):
                     profile.release(wf_id)
+                    self._unindex_lease(wf_id)
                     reclaimed = True
                     self._get_logger().warning(
                         "Reclaimed slot for profile %s from terminated workflow %s (status=%s)",
@@ -2012,6 +2294,152 @@ class MoonMindProviderProfileManagerWorkflow:
                         profile.cooldown_until = None
                 except (ValueError, TypeError):
                     profile.cooldown_until = None
+        if workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH):
+            self._clear_expired_scope_cooldowns(now)
+            self._recover_scope_capacity(now)
+
+    def _ensure_scope(
+        self, scope_ref: str, *, runtime_id: str = "", provider_class: str = "unknown"
+    ) -> CapacityScopeState:
+        scope = self._scopes.get(scope_ref)
+        if scope is None:
+            scope = CapacityScopeState(
+                scope_ref=scope_ref,
+                runtime_id=runtime_id,
+                provider_class=provider_class,
+                configured_limit=1,
+                effective_limit=1,
+            )
+            self._scopes[scope_ref] = scope
+        return scope
+
+    def _scope_active_units(self, scope_ref: str) -> int:
+        return sum(
+            len(p.current_leases)
+            for p in self._profiles.values()
+            if (p.capacity_scope_ref or f"provider-profile:{p.profile_id}") == scope_ref
+        )
+
+    def _scope_is_available(self, scope: CapacityScopeState) -> bool:
+        if scope.backpressure_state == "disabled":
+            return False
+        if scope.cooldown_until is not None:
+            try:
+                cooldown_dt = datetime.fromisoformat(scope.cooldown_until)
+                if cooldown_dt.tzinfo is None:
+                    cooldown_dt = cooldown_dt.replace(tzinfo=timezone.utc)
+                if workflow.now() < cooldown_dt:
+                    return False
+            except (ValueError, TypeError):
+                pass
+        return self._scope_active_units(scope.scope_ref) < max(1, scope.effective_limit)
+
+    def _clear_expired_scope_cooldowns(self, now: datetime) -> None:
+        for scope in self._scopes.values():
+            if scope.cooldown_until is not None:
+                try:
+                    cooldown_dt = datetime.fromisoformat(scope.cooldown_until)
+                    if cooldown_dt.tzinfo is None:
+                        cooldown_dt = cooldown_dt.replace(tzinfo=timezone.utc)
+                    if now >= cooldown_dt:
+                        scope.cooldown_until = None
+                        if scope.backpressure_state == "cooldown":
+                            scope.backpressure_state = "probing"
+                            scope.healthy_since = now.isoformat()
+                except (ValueError, TypeError):
+                    scope.cooldown_until = None
+
+    def _recover_scope_capacity(self, now: datetime) -> None:
+        healthy_interval = timedelta(seconds=300)
+        for scope in self._scopes.values():
+            if scope.cooldown_until is not None:
+                continue
+            if scope.effective_limit >= scope.configured_limit:
+                continue
+            since_raw = scope.healthy_since or scope.last_decrease_at
+            if since_raw is None:
+                scope.healthy_since = now.isoformat()
+                continue
+            try:
+                since = datetime.fromisoformat(since_raw)
+                if since.tzinfo is None:
+                    since = since.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                scope.healthy_since = now.isoformat()
+                continue
+            if now - since >= healthy_interval:
+                scope.effective_limit = min(
+                    scope.configured_limit, scope.effective_limit + 1
+                )
+                scope.last_increase_at = now.isoformat()
+                scope.healthy_since = now.isoformat()
+                if scope.effective_limit >= scope.configured_limit:
+                    scope.backpressure_state = "healthy"
+
+    def _apply_scope_rate_limit(
+        self,
+        *,
+        scope_ref: str,
+        retry_after_seconds: int | None,
+        report_id: str | None,
+        now: datetime,
+    ) -> None:
+        if report_id:
+            if report_id in self._seen_rate_limit_reports:
+                return
+            self._seen_rate_limit_reports.append(report_id)
+            del self._seen_rate_limit_reports[:-500]
+        scope = self._ensure_scope(scope_ref)
+        scope.effective_limit = max(1, scope.effective_limit // 2)
+        scope.last_decrease_at = now.isoformat()
+        scope.healthy_since = None
+        scope.backpressure_state = (
+            "reduced" if scope.cooldown_until is None else scope.backpressure_state
+        )
+        if retry_after_seconds is not None and retry_after_seconds > 0:
+            bounded = max(1, min(3600, int(retry_after_seconds)))
+            new_until = now + timedelta(seconds=bounded)
+            if scope.cooldown_until is not None:
+                try:
+                    existing = datetime.fromisoformat(scope.cooldown_until)
+                    if existing.tzinfo is None:
+                        existing = existing.replace(tzinfo=timezone.utc)
+                    if existing >= new_until:
+                        new_until = existing
+                except (ValueError, TypeError):
+                    pass
+            scope.cooldown_until = new_until.isoformat()
+            scope.backpressure_state = "cooldown"
+
+    def _profile_scope_ref(self, profile: ProfileSlotState) -> str:
+        return (
+            profile.capacity_scope_ref or f"provider-profile:{profile.profile_id}"
+        )
+
+    def _profile_effective_available(self, profile: ProfileSlotState) -> bool:
+        effective = profile.effective_limit or profile.max_parallel_runs
+        return len(profile.current_leases) < max(1, effective)
+
+    def _profile_scope_available(self, profile: ProfileSlotState) -> bool:
+        scope = self._ensure_scope(self._profile_scope_ref(profile))
+        return self._scope_is_available(scope)
+
+    def _profile_admitted_by_capacity(
+        self, profile: ProfileSlotState, *, reserved_slots: int = 0
+    ) -> bool:
+        try:
+            scoped = workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH)
+        except Exception:
+            return True
+        if not scoped:
+            return True
+        if not self._profile_effective_available(profile):
+            return False
+        if len(profile.current_leases) + reserved_slots >= max(
+            1, profile.effective_limit or profile.max_parallel_runs
+        ):
+            return False
+        return self._profile_scope_available(profile)
 
     def _build_continue_as_new_input(self) -> dict[str, Any]:
         """Serialize current state for continue-as-new."""
@@ -2042,6 +2470,8 @@ class MoonMindProviderProfileManagerWorkflow:
                     "over_capacity_legacy_snapshot": (
                         state.over_capacity_legacy_snapshot
                     ),
+                    "capacity_scope_ref": state.capacity_scope_ref,
+                    "effective_limit": state.effective_limit,
                 }
             )
             if state.current_leases:
@@ -2088,6 +2518,8 @@ class MoonMindProviderProfileManagerWorkflow:
                 }
                 for group_id, reservation in self._handoff_reservations.items()
             },
+            "scopes": [s.to_dict() for s in self._scopes.values()],
+            "seen_rate_limit_reports": list(self._seen_rate_limit_reports[-500:]),
         }
 
     async def _load_profiles_from_db(
@@ -2110,6 +2542,8 @@ class MoonMindProviderProfileManagerWorkflow:
             )
             profiles_data = result.get("profiles", []) if result else []
             self._apply_profile_sync(profiles_data, authoritative=True)
+            if workflow.patched(PROVIDER_CAPACITY_SCOPE_PATCH):
+                self._apply_scope_sync(result.get("scopes", []) if result else [])
             if prune_removed_profiles:
                 self._prune_disabled_profiles_without_leases()
             self._has_db_profile_snapshot = True
@@ -2135,6 +2569,10 @@ class MoonMindProviderProfileManagerWorkflow:
                             "granted_at": profile.lease_granted_at.get(wf_id),
                             "profileId": profile.profile_id,
                             "runtimeId": self._runtime_id,
+                            "capacity_scope_ref": (
+                                profile.capacity_scope_ref
+                                or f"provider-profile:{profile.profile_id}"
+                            ),
                             **dict(profile.lease_metadata.get(wf_id) or {}),
                         }
                     )
@@ -2160,6 +2598,31 @@ class MoonMindProviderProfileManagerWorkflow:
     async def _remove_lease_from_db(self, workflow_id: str) -> None:
         """Remove a single lease from the database."""
         try:
+            use_incremental = False
+            try:
+                use_incremental = workflow.patched(PROVIDER_INCREMENTAL_LEASE_PATCH)
+            except Exception:
+                use_incremental = False
+            if use_incremental:
+                await workflow.execute_activity(
+                    "provider_profile.sync_slot_leases",
+                    {
+                        "runtime_id": self._runtime_id,
+                        "leases": [
+                            {"lease_id": workflow_id, "fencing_generation": 1}
+                        ],
+                        "action": "release_one",
+                    },
+                    task_queue=ACTIVITY_TASK_QUEUE,
+                    start_to_close_timeout=timedelta(seconds=10),
+                    retry_policy=RetryPolicy(
+                        initial_interval=timedelta(seconds=1),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(seconds=10),
+                        maximum_attempts=3,
+                    ),
+                )
+                return
             await workflow.execute_activity(
                 "provider_profile.sync_slot_leases",
                 {
@@ -2180,6 +2643,52 @@ class MoonMindProviderProfileManagerWorkflow:
             self._get_logger().warning(
                 "Failed to remove lease for %s from DB", workflow_id
             )
+
+    async def _grant_lease_to_db(
+        self, *, profile: ProfileSlotState, lease_id: str
+    ) -> bool:
+        """Persist one lease grant; idempotent retry returns existing lease."""
+        try:
+            result = await workflow.execute_activity(
+                "provider_profile.sync_slot_leases",
+                {
+                    "runtime_id": self._runtime_id,
+                    "leases": [
+                        {
+                            "lease_id": lease_id,
+                            "workflow_id": lease_id,
+                            "profile_id": profile.profile_id,
+                            "owner_id": lease_id,
+                            "owner_kind": "workflow",
+                            "purpose": "execution_direct",
+                            "fencing_generation": 1,
+                            "scope_generation": 1,
+                            "capacity_scope_ref": (
+                                profile.capacity_scope_ref
+                                or f"provider-profile:{profile.profile_id}"
+                            ),
+                            "lease_state": "held",
+                        }
+                    ],
+                    "action": "grant",
+                },
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=1),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=10),
+                    maximum_attempts=3,
+                ),
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return False
+            return True
+        except Exception:
+            self._get_logger().warning(
+                "Failed to persist lease grant for %s", lease_id
+            )
+            return False
 
     async def _load_leases_from_db(self) -> bool:
         """Load persisted leases from DB and reconnect to running workflows.
@@ -2297,6 +2806,7 @@ class MoonMindProviderProfileManagerWorkflow:
                         # recorded before ambiguous reconnect failures became
                         # fail-closed.
                         profile.release(wf_id)
+                        self._unindex_lease(wf_id)
                         await self._remove_lease_from_db(wf_id)
 
             return True

--- a/tests/unit/api_service/test_provider_profile_creation_capabilities.py
+++ b/tests/unit/api_service/test_provider_profile_creation_capabilities.py
@@ -270,3 +270,36 @@ def test_expert_minimax_capability_requires_provider_launch_templates() -> None:
         file_templates=[{"path": "config.toml", "content": "profile"}],
         home_path_overrides={"CODEX_HOME": "{{runtime_support_dir}}/codex-home"},
     )
+
+
+def test_parallel_ceiling_rejects_above_deployment_max(monkeypatch) -> None:
+    from fastapi import HTTPException
+
+    from api_service.api.routers.provider_profiles import _enforce_parallel_ceiling
+
+    monkeypatch.setenv("MOONMIND_MAX_PROVIDER_PROFILE_PARALLEL_RUNS", "4")
+    with pytest.raises(HTTPException) as exc_info:
+        _enforce_parallel_ceiling(5)
+    assert exc_info.value.status_code == 422
+    _enforce_parallel_ceiling(4)
+
+
+@pytest.mark.asyncio
+async def test_scope_compatibility_rejects_different_runtime() -> None:
+    from unittest.mock import AsyncMock
+
+    from fastapi import HTTPException
+
+    from api_service.api.routers.provider_profiles import _enforce_scope_compatibility
+
+    scope = type("Scope", (), {"runtime_id": "opencode"})()
+    session = AsyncMock()
+    session.get.return_value = scope
+    with pytest.raises(HTTPException) as exc_info:
+        await _enforce_scope_compatibility(
+            session, runtime_id="codex_cli", capacity_scope_ref="scope-1"
+        )
+    assert exc_info.value.status_code == 422
+    await _enforce_scope_compatibility(
+        session, runtime_id="opencode", capacity_scope_ref="scope-1"
+    )

--- a/tests/unit/omnigent/test_adapter_contracts.py
+++ b/tests/unit/omnigent/test_adapter_contracts.py
@@ -1176,3 +1176,81 @@ def test_deployed_adapter_satisfies_its_declared_port(port, implementation) -> N
     assert not missing, (
         f"{implementation.__name__} no longer satisfies {port.__name__}: {missing}"
     )
+
+
+def test_expected_host_id_is_deterministic_and_generation_fenced() -> None:
+    from moonmind.omnigent.host_ports import expected_omnigent_host_id
+
+    first = expected_omnigent_host_id("lease-abc", 1)
+    assert first == expected_omnigent_host_id("lease-abc", 1)
+    assert first != expected_omnigent_host_id("lease-abc", 2)
+    assert first != expected_omnigent_host_id("lease-other", 1)
+
+
+@pytest.mark.asyncio
+async def test_targeted_registration_verifies_exact_identity() -> None:
+    from moonmind.omnigent.host_services.registration import (
+        OmnigentHostRegistrationService,
+    )
+    from moonmind.workflows.adapters.omnigent_client import OmnigentClientError
+
+    expected_id = "host-expected-123"
+    ready_host = {
+        "host_id": expected_id,
+        "name": "mm-host-abc",
+        "owner": "local",
+        "status": "online",
+        "harnesses": {"opencode": "ready"},
+    }
+
+    class FakeClient:
+        def __init__(self):
+            self.get_calls = 0
+
+        async def get_host(self, host_id):
+            self.get_calls += 1
+            assert host_id == expected_id
+            if self.get_calls < 3:
+                raise OmnigentClientError("not found", status_code=404)
+            return dict(ready_host)
+
+        async def list_hosts(self):
+            raise AssertionError("targeted path must not list inventory")
+
+    service = OmnigentHostRegistrationService(
+        client=FakeClient(), expected_owner="local", attempts=5
+    )
+    result = await service.wait_for_registration(
+        correlation_name="mm-host-abc",
+        harness_id="opencode",
+        expected_host_id=expected_id,
+    )
+    assert result["omnigentHostId"] == expected_id
+    assert result["lookupMode"] == "targeted"
+
+
+@pytest.mark.asyncio
+async def test_targeted_registration_rejects_wrong_owner() -> None:
+    from moonmind.omnigent.host_services.registration import (
+        OmnigentHostRegistrationService,
+    )
+
+    class FakeClient:
+        async def get_host(self, host_id):
+            return {
+                "host_id": host_id,
+                "name": "mm-host-abc",
+                "owner": "someone-else",
+                "status": "online",
+                "harnesses": {"opencode": "ready"},
+            }
+
+    service = OmnigentHostRegistrationService(
+        client=FakeClient(), expected_owner="local", attempts=2
+    )
+    with pytest.raises(HarnessPlatformError, match="owner mismatch"):
+        await service.wait_for_registration(
+            correlation_name="mm-host-abc",
+            harness_id="opencode",
+            expected_host_id="host-expected-123",
+        )

--- a/tests/unit/provider_profiles/test_tier_non_goal_guardrails.py
+++ b/tests/unit/provider_profiles/test_tier_non_goal_guardrails.py
@@ -96,6 +96,7 @@ async def test_different_tiers_share_one_provider_profile_capacity_pool() -> Non
     manager._signal_slot_assigned = AsyncMock()
     # Mock persistence boundary so active patched durable-lease path can run.
     manager._sync_leases_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._grant_lease_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
     # Verify the contract has no tier field — tier is resolved before slot request.
     assert "model_tier" not in SlotRequestPayload.__annotations__
@@ -153,7 +154,7 @@ async def test_different_tiers_share_one_provider_profile_capacity_pool() -> Non
         "run-tier-2"
     ]
     # Verify persistence was attempted on the active path.
-    assert manager._sync_leases_to_db.await_count >= 1
+    assert manager._grant_lease_to_db.await_count >= 1
 
 
 @pytest.mark.asyncio
@@ -203,6 +204,7 @@ async def test_tier_policy_refresh_does_not_change_profile_slot_leasing() -> Non
     assert profile_after_sync.default_model_tier == 2
 
     manager._sync_leases_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._grant_lease_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
     with patch(
         "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
     ) as temporal_workflow:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1581,7 +1581,7 @@ async def test_provider_profile_list_returns_empty_for_unknown_runtime(tmp_path:
         finally:
             _db_base_mod.get_async_session_context = orig
 
-        assert result == {"profiles": [], "profile_statuses": []}
+        assert result == {"profiles": [], "profile_statuses": [], "scopes": []}
 
 async def test_provider_profile_list_filters_by_runtime_id(tmp_path: Path):
     async with _in_memory_db(tmp_path) as session_factory:

--- a/tests/unit/workflows/adapters/test_omnigent_client.py
+++ b/tests/unit/workflows/adapters/test_omnigent_client.py
@@ -10,7 +10,11 @@ import pytest
 from moonmind.workflows.adapters.omnigent_client import (
     OmnigentClientError,
     OmnigentHttpClient,
+    aclose_shared_pool_client,
+    default_omnigent_pool_limits,
+    init_shared_pool_client,
     parse_sse_line,
+    shared_pool_client,
 )
 
 
@@ -354,3 +358,37 @@ async def test_omnigent_client_forwards_explicitly_allowlisted_headers() -> None
 
     assert captured["x-moonmind-trace"] == "trace-1"
     assert "cookie" not in captured
+
+
+def test_pool_limits_are_bounded_and_overridable(monkeypatch) -> None:
+    limits = default_omnigent_pool_limits()
+    assert 10 <= limits.max_connections <= 500
+    assert 1 <= limits.max_keepalive_connections <= 100
+
+    monkeypatch.setenv("MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS", "10000")
+    capped = default_omnigent_pool_limits()
+    assert capped.max_connections <= 500
+
+
+@pytest.mark.asyncio
+async def test_shared_pool_reused_and_closed() -> None:
+    await aclose_shared_pool_client()
+    assert shared_pool_client() is None
+    first = await init_shared_pool_client()
+    assert shared_pool_client() is first
+    assert (await init_shared_pool_client()) is first
+    await aclose_shared_pool_client()
+    assert shared_pool_client() is None
+
+
+@pytest.mark.asyncio
+async def test_pool_exhaustion_returns_actionable_failure() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.PoolTimeout("pool exhausted")
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.test",
+        transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(OmnigentClientError, match="pool exhausted"):
+        await client.list_agents()

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -2444,6 +2444,7 @@ class TestProviderProfileManagerHelpers:
             calls.append("signal")
 
         wf._sync_leases_to_db = AsyncMock(side_effect=persist)
+        wf._grant_lease_to_db = AsyncMock(return_value=True)
         wf._signal_slot_assigned = AsyncMock(side_effect=signal)
 
         with patch(
@@ -2477,6 +2478,7 @@ class TestProviderProfileManagerHelpers:
         )
         wf._pending_requests = [request]
         wf._sync_leases_to_db = AsyncMock(return_value=False)
+        wf._grant_lease_to_db = AsyncMock(return_value=True)
         wf._signal_slot_assigned = AsyncMock()
 
         with patch(
@@ -2504,6 +2506,7 @@ class TestProviderProfileManagerHelpers:
             is_default=True,
         )
         wf._sync_leases_to_db = AsyncMock(return_value=False)
+        wf._grant_lease_to_db = AsyncMock(return_value=False)
 
         with patch(
             "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
@@ -2532,6 +2535,7 @@ class TestProviderProfileManagerHelpers:
             is_default=True,
         )
         wf._sync_leases_to_db = AsyncMock(return_value=False)
+        wf._grant_lease_to_db = AsyncMock(return_value=False)
 
         with patch(
             "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -2646,6 +2646,186 @@ class TestProviderProfileManagerHelpers:
             wf._clear_expired_cooldowns()
         assert wf._profiles["p1"].cooldown_until is None
 
+    def test_shared_scope_admits_no_more_than_scope_limit(self):
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            PROVIDER_CAPACITY_SCOPE_PATCH,
+            CapacityScopeState,
+        )
+
+        wf = self._make_workflow()
+        wf._scopes["scope-10"] = CapacityScopeState(
+            scope_ref="scope-10", configured_limit=10, effective_limit=10
+        )
+        for pid in ("a", "b"):
+            wf._profiles[pid] = ProfileSlotState(
+                profile_id=pid,
+                max_parallel_runs=8,
+                cooldown_after_429_seconds=300,
+                rate_limit_policy="backoff",
+                enabled=True,
+                capacity_scope_ref="scope-10",
+                effective_limit=8,
+            )
+        for i in range(5):
+            wf._profiles["a"].current_leases.append(f"wf-a-{i}")
+            wf._profiles["b"].current_leases.append(f"wf-b-{i}")
+        assert wf._scope_active_units("scope-10") == 10
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.now.return_value = datetime.now(timezone.utc)
+            assert wf._profile_admitted_by_capacity(wf._profiles["a"]) is False
+            assert wf._profile_admitted_by_capacity(wf._profiles["b"]) is False
+
+    def test_scope_rate_limit_halves_once_and_extends_cooldown(self):
+        from datetime import timezone
+
+        wf = self._make_workflow()
+        now = datetime.now(timezone.utc)
+        wf._apply_scope_rate_limit(
+            scope_ref="s1", retry_after_seconds=100, report_id="r1", now=now
+        )
+        # Default scope starts 1/1; use explicit scope for halving check.
+        wf._scopes["s2"] = wf._ensure_scope("s2")
+        wf._scopes["s2"].configured_limit = 8
+        wf._scopes["s2"].effective_limit = 8
+        wf._apply_scope_rate_limit(
+            scope_ref="s2", retry_after_seconds=100, report_id="r2", now=now
+        )
+        assert wf._scopes["s2"].effective_limit == 4
+        first_cooldown = wf._scopes["s2"].cooldown_until
+        wf._apply_scope_rate_limit(
+            scope_ref="s2", retry_after_seconds=100, report_id="r2", now=now
+        )
+        assert wf._scopes["s2"].effective_limit == 4
+        assert wf._scopes["s2"].cooldown_until == first_cooldown
+        later = now + timedelta(seconds=10)
+        wf._apply_scope_rate_limit(
+            scope_ref="s2", retry_after_seconds=500, report_id="r3", now=later
+        )
+        assert wf._scopes["s2"].effective_limit == 2
+        assert wf._scopes["s2"].cooldown_until is not None
+        assert wf._scopes["s2"].cooldown_until >= first_cooldown
+
+    def test_scope_recovers_gradually_without_exceeding_configured(self):
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            CapacityScopeState,
+        )
+
+        wf = self._make_workflow()
+        now = datetime.now(timezone.utc)
+        wf._scopes["s1"] = CapacityScopeState(
+            scope_ref="s1",
+            configured_limit=8,
+            effective_limit=4,
+            healthy_since=(now - timedelta(seconds=600)).isoformat(),
+        )
+        wf._recover_scope_capacity(now)
+        assert wf._scopes["s1"].effective_limit == 5
+        wf._scopes["s1"].healthy_since = now.isoformat()
+        wf._recover_scope_capacity(now)
+        assert wf._scopes["s1"].effective_limit == 5
+
+    def test_lease_lookup_uses_index_without_scanning(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=4,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            current_leases=["wf-1", "wf-2"],
+        )
+        wf._rebuild_lease_indexes()
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            assert wf._profile_id_for_lease("wf-2") == "p1"
+            assert wf._profile_id_for_lease("wf-missing") is None
+
+    @pytest.mark.asyncio
+    async def test_incremental_grant_performs_bounded_mutations(self):
+        from unittest.mock import AsyncMock
+
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            CapacityScopeState,
+        )
+
+        wf = self._make_workflow()
+        wf._runtime_id = "opencode"
+        wf._scopes["scope-16"] = CapacityScopeState(
+            scope_ref="scope-16", configured_limit=16, effective_limit=16
+        )
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=16,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            capacity_scope_ref="scope-16",
+            effective_limit=16,
+            current_leases=[f"wf-existing-{i}" for i in range(15)],
+        )
+        wf._rebuild_lease_indexes()
+        wf._grant_lease_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        wf._sync_leases_to_db = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        now = datetime.now(timezone.utc)
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = now
+            mock_wf.patched.return_value = True
+            result = await wf.acquire_slot(
+                {
+                    "requester_workflow_id": "wf-new",
+                    "runtime_id": "opencode",
+                    "execution_profile_ref": "p1",
+                }
+            )
+        assert result["already_held"] is False
+        wf._grant_lease_to_db.assert_awaited_once()
+        wf._sync_leases_to_db.assert_not_awaited()
+
+    @pytest.mark.parametrize("concurrency", [1, 2, 4, 8, 16])
+    def test_shared_scope_enforces_joint_limit_at_each_concurrency(self, concurrency):
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            CapacityScopeState,
+        )
+
+        wf = self._make_workflow()
+        wf._scopes["shared"] = CapacityScopeState(
+            scope_ref="shared",
+            configured_limit=concurrency,
+            effective_limit=concurrency,
+        )
+        for pid in ("a", "b"):
+            wf._profiles[pid] = ProfileSlotState(
+                profile_id=pid,
+                max_parallel_runs=concurrency,
+                cooldown_after_429_seconds=300,
+                rate_limit_policy="backoff",
+                enabled=True,
+                capacity_scope_ref="shared",
+                effective_limit=concurrency,
+            )
+        now = datetime.now(timezone.utc)
+        admitted = 0
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            mock_wf.now.return_value = now
+            for i in range(2 * concurrency):
+                target = wf._profiles["a" if i % 2 == 0 else "b"]
+                if wf._profile_admitted_by_capacity(target):
+                    target.current_leases.append(f"wf-{i}")
+                    admitted += 1
+        assert admitted == concurrency
+        assert wf._scope_active_units("shared") == concurrency
+
 # ---------------------------------------------------------------------------
 # Workflow registration sanity
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -376,3 +376,30 @@ def test_coerce_external_start_status_maps_succeeded_to_completed() -> None:
 
     assert status == RunStatus.completed
     assert normalized == "completed"
+
+
+def test_canonical_waiting_reason_is_bounded_and_redacted() -> None:
+    from moonmind.workflows.temporal.workflows.agent_run import (
+        CANONICAL_WAITING_REASONS,
+        canonical_waiting_reason,
+    )
+
+    assert set(CANONICAL_WAITING_REASONS) == {
+        "awaiting_provider_capacity",
+        "awaiting_provider_validation",
+        "awaiting_profile_maintenance",
+        "provider_cooldown",
+        "awaiting_host_capacity",
+        "awaiting_host_launch_permit",
+        "awaiting_execution_worker",
+        "cleanup_pending",
+    }
+    assert canonical_waiting_reason("provider_cooldown") == "provider_cooldown"
+    assert (
+        canonical_waiting_reason("awaiting_provider_capacity", queue_position=3)
+        == "awaiting_provider_capacity; queue_position=3"
+    )
+    # Unknown reasons collapse; identities never appear.
+    redacted = canonical_waiting_reason("mm:123:lease-abc")
+    assert redacted == "awaiting_provider_capacity"
+    assert "mm:" not in redacted and "lease" not in redacted


### PR DESCRIPTION
Implements GitHub Issues #3882, #3883, #3884, #3885 in a single PR.

## #3884 Targeted registration + pooled transport
- expectedOmnigentHostId in HostLaunchSpec (lease+generation, fenced).
- Launcher uses spec identity; legacy fallback for old specs.
- Registration polls GET by ID with backoff+jitter, verifies ID/name/owner/status/harness; compat list fallback for old histories with lookupMode.
- Bounded lifecycle-managed HTTP pool per worker (shared reuse, Limits, PoolTimeout actionable, SSE line bound, shutdown close).
- Tests: identity determinism/generation fencing, targeted verify + 404 retry, wrong-owner reject, pool bounded/override, shared reuse/close, pool-exhaustion actionable.

## #3882 Authoritative capacity scopes + backpressure
- ProviderCapacityScope table + migration 368 (backfill one scope per profile, unique dropped, FK).
- Manager joint profile+scope admission (patch-gated, replay-safe), AIMD halving, Retry-After max, idempotent reports, gradual recovery, CAN persistence, scope sync from DB.
- API safety ceiling MOONMIND_MAX_PROVIDER_PROFILE_PARALLEL_RUNS + scope runtime compatibility validation.
- Tests: shared-scope joint limit, halving/idempotency/cooldown extension, gradual recovery, ceiling + compat validation.

## #3883 Incremental lease operations
- Lease contract extension + migration 369 (state/fence/scope/plan/owner-kind/heartbeat/release/metadata, indexes, unique lease_id).
- Single-row grant/heartbeat/release_one/list_active with identity-conflict fencing; save/load/remove preserved for old histories.
- Manager incremental grant/release behind patch, explicit lease/owner indexes replacing scans, CAN-safe.
- Tests: index lookup, bounded-mutation perf guard (grant with 15 active touches 1 row, never bulk).

## #3885 Waiting-state + N-way
- Canonical 8-reason adapter with redaction behind patch, provider queue integration (cooldown/validation/capacity).
- Hermetic N-way joint-limit tests (1,2,4,8,16) proving second profile cannot bypass shared ceiling with one code path.
- Follow-ups (not required CI): Settings/UI surfacing, scope/lease metrics registry, Docker N=2,4,8 + live Zen rows, host/worker/cleanup progress beyond provider queue.

## Testing
- Targeted unit suites green (manager, adapter contracts, omnigent client, creation capabilities, status payloads).
- Migrations 368/369 additive with fail-closed downgrades.
- Rerun mm:c33d26a9 (first-fix validation) completed successfully.