### PR TITLE
Fix stale Omnigent catalog admission

### DIFF
--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -177,7 +177,9 @@ async def _try_load_real_harness_config(
             else "default"
         )
         repo = DbHarnessCatalogRepository(session_factory)
-        # Try catalogRef first, then latest
+        # Load the immutable profile authority first. A separate latest
+        # observation supplies freshness/liveness evidence; it must never
+        # replace the catalog ref pinned by the Agent Profile.
         catalog_result = None
         if catalog_ref:
             catalog_result = await repo.load(catalog_ref)
@@ -185,6 +187,7 @@ async def _try_load_real_harness_config(
             catalog_result = await repo.latest(endpoint_ref)
         if catalog_result is None:
             return None
+        latest_catalog_result = await repo.latest(endpoint_ref)
         harness_record = next(
             (h for h in catalog_result.snapshot.harnesses if h.id == harness_id),
             None,
@@ -207,6 +210,11 @@ async def _try_load_real_harness_config(
             "authModel": auth_model,
             "integrationMode": integration_mode,
             "_catalogSnapshot": catalog_result.snapshot,
+            "_freshnessCatalogSnapshot": (
+                latest_catalog_result.snapshot
+                if latest_catalog_result is not None
+                else catalog_result.snapshot
+            ),
             "_harnessRecord": harness_record,
         }
     except Exception:
@@ -632,6 +640,9 @@ async def compile_and_persist_execution_plan(
     if config is None:
         raise ValueError(f"unsupported trusted Omnigent harness: {harness_id!r}")
     exact_catalog = real_config.get("_catalogSnapshot") if real_config else None
+    freshness_catalog = (
+        real_config.get("_freshnessCatalogSnapshot") if real_config else None
+    )
     exact_harness = real_config.get("_harnessRecord") if real_config else None
     # Production uses the exact catalog pinned by the Agent Profile. The
     # latest lookup only supplies a version to hermetic/legacy profiles that do
@@ -1034,6 +1045,7 @@ async def compile_and_persist_execution_plan(
             additional_tools=mounted_skill_tools,
         ),
         harness_catalog=catalog,
+        freshness_catalog=freshness_catalog,
         trust_record=trust,
         resolved_skills=resolved_skills,
         credential_binding_set=binding_set,

--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -25,6 +25,7 @@ from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfil
 from moonmind.omnigent.harness_platform.catalog import (
     HarnessImplementationIdentity,
     HarnessRecord,
+    HarnessTrustRecord,
     TrustState,
     classify_harness_trust,
     create_catalog_snapshot,
@@ -188,12 +189,31 @@ async def _try_load_real_harness_config(
         if catalog_result is None:
             return None
         latest_catalog_result = await repo.latest(endpoint_ref)
+        if latest_catalog_result is None:
+            raise HarnessPlatformError(
+                "fresh harness catalog observation is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HARNESS_CATALOG_UNAVAILABLE,
+            )
         harness_record = next(
             (h for h in catalog_result.snapshot.harnesses if h.id == harness_id),
             None,
         )
         if harness_record is None:
             return None
+        freshness_trust_record = next(
+            (
+                record
+                for record in latest_catalog_result.trust_records
+                if record.implementationRef
+                == harness_record.implementation.implementation_ref()
+            ),
+            None,
+        )
+        if freshness_trust_record is None:
+            raise HarnessPlatformError(
+                "fresh harness trust decision is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HARNESS_UNTRUSTED,
+            )
         implementation_digest = harness_record.implementation.digest
         # Derive materializer/auth/integration from catalog capabilities
         registration = harness_registration(harness_id)
@@ -210,14 +230,18 @@ async def _try_load_real_harness_config(
             "authModel": auth_model,
             "integrationMode": integration_mode,
             "_catalogSnapshot": catalog_result.snapshot,
-            "_freshnessCatalogSnapshot": (
-                latest_catalog_result.snapshot
-                if latest_catalog_result is not None
-                else catalog_result.snapshot
-            ),
+            "_freshnessCatalogSnapshot": latest_catalog_result.snapshot,
+            "_freshnessTrustRecord": freshness_trust_record,
             "_harnessRecord": harness_record,
         }
-    except Exception:
+    except HarnessPlatformError:
+        raise
+    except Exception as exc:
+        if callable(session_factory):
+            raise HarnessPlatformError(
+                "harness catalog authority could not be loaded",
+                code=HarnessPlatformFailure.OMNIGENT_HARNESS_CATALOG_UNAVAILABLE,
+            ) from exc
         return None
 
 
@@ -964,11 +988,19 @@ async def compile_and_persist_execution_plan(
             }
         },
     )
-    trust = classify_harness_trust(
-        harnessId=harness_id,
-        implementation=implementation,
-        trustState=TrustState.core_trusted,
-    )
+    if real_config is not None:
+        trust = real_config.get("_freshnessTrustRecord")
+        if not isinstance(trust, HarnessTrustRecord):
+            raise HarnessPlatformError(
+                "fresh harness trust decision is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HARNESS_UNTRUSTED,
+            )
+    else:
+        trust = classify_harness_trust(
+            harnessId=harness_id,
+            implementation=implementation,
+            trustState=TrustState.core_trusted,
+        )
     # The plan pins this exact catalog snapshot; persist it as durable
     # observation authority so launch-time host resolution can load it.
     # Hermetic callers may pass a non-callable session factory placeholder;

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -349,7 +349,7 @@ Trust is bound to implementation identity. A plugin name or canonical harness id
 
 ### 7.4 Freshness
 
-Catalog snapshots are immutable. New plans require a snapshot inside the configured freshness bound unless the selected policy explicitly permits a previously verified offline snapshot. Historical plans retain their original snapshot ref.
+Catalog snapshots are immutable. New plans retain the Agent Profile's pinned catalog as authority and require a current observation that attests the same endpoint, Omnigent build, and harness implementation. The current observation supplies freshness only; it never replaces the pinned authority. Historical plans retain their original snapshot ref.
 
 An endpoint outage may retain the last known catalog for diagnostics. It does not silently make stale harnesses launchable.
 

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -16,8 +16,15 @@ from moonmind.omnigent.execution_support_evidence import (
     EXECUTION_SUPPORT_EVIDENCE_ISSUER,
     EXECUTION_SUPPORT_EVIDENCE_VERSION,
 )
-from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
-from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.harness_platform.catalog import (
+    TrustState,
+    classify_harness_trust,
+    create_catalog_snapshot,
+)
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
 from moonmind.omnigent.policies import compile_policy_snapshot
 from moonmind.omnigent.session_supervisor_rollback import (
     SUPERVISOR_ROLLBACK_POLICY_VERSION,
@@ -580,6 +587,11 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
             for item in authority_catalog.harnesses
         ],
     )
+    freshness_trust = classify_harness_trust(
+        harnessId=harness.id,
+        implementation=harness.implementation,
+        trustState=TrustState.core_trusted,
+    )
 
     async def load_authority(**_kwargs):
         return {
@@ -590,6 +602,7 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
             "integrationMode": "native-server",
             "_catalogSnapshot": authority_catalog,
             "_freshnessCatalogSnapshot": freshness_catalog,
+            "_freshnessTrustRecord": freshness_trust,
             "_harnessRecord": harness,
         }
 
@@ -650,6 +663,110 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
         result.envelope.payload.harnessCatalogRef == authority_catalog.catalogRef
     )
     assert result.envelope.payload.harnessCatalogRef != freshness_catalog.catalogRef
+
+
+@pytest.mark.asyncio
+async def test_product_boundary_rejects_revoked_freshness_trust(
+    monkeypatch,
+) -> None:
+    """A matching fresh implementation cannot override its current denial."""
+
+    catalog = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="0.11.0",
+        omnigentBuildDigest="sha256:" + "b" * 64,
+        sourceDigest="sha256:" + "d" * 64,
+        observedAt=datetime.now(UTC),
+        harnesses=[
+            {
+                "id": "opencode-native",
+                "aliases": [],
+                "label": "OpenCode",
+                "implementation": {
+                    "sourceKind": "core",
+                    "package": "omnigent",
+                    "version": "0.11.0",
+                    "digest": "sha256:" + "c" * 64,
+                    "pluginEntryPoint": None,
+                },
+                "runtimeRequirements": {},
+                "capabilities": {
+                    "integrationMode": "native-server",
+                    "authModel": "own-auth",
+                    "interrupt": True,
+                    "streaming": True,
+                },
+                "setupSteps": [],
+            }
+        ],
+    )
+    harness = catalog.harnesses[0]
+
+    async def load_authority(**_kwargs):
+        return {
+            "hostClassRef": "omnigent-opencode@1",
+            "implementationDigest": harness.implementation.digest,
+            "materializerRef": "opencode-auth-json@1",
+            "authModel": "own-auth",
+            "integrationMode": "native-server",
+            "_catalogSnapshot": catalog,
+            "_freshnessCatalogSnapshot": catalog,
+            "_freshnessTrustRecord": classify_harness_trust(
+                harnessId=harness.id,
+                implementation=harness.implementation,
+                trustState=TrustState.blocked,
+            ),
+            "_harnessRecord": harness,
+        }
+
+    monkeypatch.setattr(service, "_try_load_real_harness_config", load_authority)
+    with pytest.raises(HarnessPlatformError) as exc_info:
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref="opencode-on-demand@1",
+            plan_store=_PlanStore(object()),
+        )
+
+    assert exc_info.value.code == HarnessPlatformFailure.OMNIGENT_HARNESS_UNTRUSTED
+
+
+@pytest.mark.asyncio
+async def test_real_harness_config_fails_closed_when_freshness_read_errors(
+    monkeypatch,
+) -> None:
+    class Repository:
+        def __init__(self, _session_factory):
+            pass
+
+        async def load(self, _catalog_ref):
+            return SimpleNamespace(snapshot=object())
+
+        async def latest(self, _endpoint_ref):
+            raise RuntimeError("database unavailable")
+
+    from moonmind.omnigent.harness_platform import catalog_service
+
+    monkeypatch.setattr(catalog_service, "DbHarnessCatalogRepository", Repository)
+
+    with pytest.raises(HarnessPlatformError) as exc_info:
+        await service._try_load_real_harness_config(
+            harness_id="opencode-native",
+            agent_profile_snapshot={
+                "document": {
+                    "endpointRef": "default",
+                    "harness": {
+                        "catalogRef": "omnigent-harness-catalog:sha256:" + "1" * 64
+                    },
+                }
+            },
+            session_factory=lambda: None,
+        )
+
+    assert (
+        exc_info.value.code
+        == HarnessPlatformFailure.OMNIGENT_HARNESS_CATALOG_UNAVAILABLE
+    )
 
 
 async def _compile_opencode_plan(

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -535,16 +535,16 @@ async def test_product_boundary_uses_exact_arm64_architecture_for_support_identi
 async def test_product_boundary_uses_profile_catalog_build_identity(
     monkeypatch,
 ) -> None:
-    """A server image manifest digest must not replace the shared build ref."""
+    """Fresh observation attests old profile authority without replacing it."""
 
     build_identity = "sha256:" + "b" * 64
     implementation_digest = "sha256:" + "c" * 64
-    catalog = create_catalog_snapshot(
+    authority_catalog = create_catalog_snapshot(
         endpointRef="default",
         omnigentVersion="0.11.0",
         omnigentBuildDigest=build_identity,
         sourceDigest="sha256:" + "d" * 64,
-        observedAt=datetime.now(UTC),
+        observedAt=datetime.now(UTC) - timedelta(seconds=106_285),
         harnesses=[
             {
                 "id": "opencode-native",
@@ -568,7 +568,18 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
             }
         ],
     )
-    harness = catalog.harnesses[0]
+    harness = authority_catalog.harnesses[0]
+    freshness_catalog = create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion=authority_catalog.omnigentVersion,
+        omnigentBuildDigest=authority_catalog.omnigentBuildDigest,
+        sourceDigest="sha256:" + "e" * 64,
+        observedAt=datetime.now(UTC),
+        harnesses=[
+            item.model_dump(mode="json", by_alias=True)
+            for item in authority_catalog.harnesses
+        ],
+    )
 
     async def load_authority(**_kwargs):
         return {
@@ -577,7 +588,8 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
             "materializerRef": "opencode-auth-json@1",
             "authModel": "own-auth",
             "integrationMode": "native-server",
-            "_catalogSnapshot": catalog,
+            "_catalogSnapshot": authority_catalog,
+            "_freshnessCatalogSnapshot": freshness_catalog,
             "_harnessRecord": harness,
         }
 
@@ -634,7 +646,10 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
     support = result.envelope.payload.supportIdentity
     assert support.omnigentServerBuildRef == build_identity
     assert support.omnigentHostBuildRef == build_identity
-    assert result.envelope.payload.harnessCatalogRef == catalog.catalogRef
+    assert (
+        result.envelope.payload.harnessCatalogRef == authority_catalog.catalogRef
+    )
+    assert result.envelope.payload.harnessCatalogRef != freshness_catalog.catalogRef
 
 
 async def _compile_opencode_plan(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep the Agent Profile immutable catalog snapshot as execution authority while validating freshness against the latest synchronized observation.
- Prevent profiles older than 24 hours from blocking OpenCode Go admission when a fresh observation attests the same endpoint, Omnigent build, and harness implementation.
- Add regression coverage reproducing the reported 106,285-second catalog age.

## Test Plan

```bash
docker compose --project-name moonmind-test -f docker-compose.test.yaml run --rm pytest bash -lc "python -m pytest tests/unit/services/test_omnigent_execution_plan_service.py -q --tb=short"
```

Result: 20 passed.

## Demo

N/A - no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Risk notes

The fix does not relax catalog identity checks: endpoint, Omnigent build digest, and harness implementation must still match. It only uses the latest observation for freshness instead of requiring the immutable profile-pinned authority itself to be recent. No credential, billing, migration, or Temporal payload contract changes.

## Coverage notes

Verified the API plan-compilation authority handoff with the exact reported stale age and confirmed the plan continues to pin the original catalog reference.

## Changelog

Fixed OpenCode Go workflow admission failures caused by stale profile-pinned catalog timestamps.
