### PR TITLE
Fix Omnigent host registration across UUID encodings

### DIFF
--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -98,12 +98,13 @@ def expected_omnigent_host_id(host_lease_ref: str, host_lease_generation: int) -
     Deterministic from the exact host lease and generation before container
     creation, so Activity retry and host reconciliation derive the same value
     and a replacement generation receives a distinct identity. Contains no
-    provider, repository, credential, or secret material.
+    provider, repository, credential, or secret material. Omnigent's host
+    identity loader and HTTP inventory use bare hexadecimal UUIDs.
     """
     import uuid as _uuid
 
     seed = f"{host_lease_ref}:{int(host_lease_generation)}"
-    return str(_uuid.uuid5(_uuid.NAMESPACE_URL, seed))
+    return _uuid.uuid5(_uuid.NAMESPACE_URL, seed).hex
 
 @runtime_checkable
 class OmnigentWorkspaceMaterializationPort(Protocol):

--- a/moonmind/omnigent/host_services/registration.py
+++ b/moonmind/omnigent/host_services/registration.py
@@ -6,6 +6,7 @@ import asyncio
 import random
 from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID
 
 from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformError,
@@ -161,7 +162,17 @@ class OmnigentHostRegistrationService:
     ) -> dict[str, Any] | None:
         observed_at = datetime.now(UTC)
         host_id = str(host.get("host_id") or host.get("id") or "").strip()
-        if host_id != expected_host_id:
+        identity_matches = host_id == expected_host_id
+        if not identity_matches:
+            # Persisted launch specs may carry the dashed UUID emitted before
+            # canonical host-ID generation. Omnigent registers that same UUID
+            # as bare hex. Compare UUID values without accepting another host
+            # or changing the persisted spec; retain the server ID as evidence.
+            try:
+                identity_matches = UUID(host_id) == UUID(expected_host_id)
+            except ValueError:
+                pass
+        if not identity_matches:
             raise HarnessPlatformError(
                 "launched host identity mismatch",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_REGISTRATION_TIMEOUT,

--- a/tests/integration/reliability/replays/omnigent-targeted-host-uuid/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-targeted-host-uuid/manifest.json
@@ -1,0 +1,14 @@
+{
+  "incidentWorkflowId": "mm:9556a9c0-f461-40a0-852b-6fdb388b6f78",
+  "failureShape": "Exact host lookup returned HTTP 200 after registration, but the dashed launch UUID was compared literally against Omnigent's bare hexadecimal UUID.",
+  "boundary": "lease-derived launch identity to HTTP host registration and attestation handoff",
+  "persistedExpectedHostId": "d4ad2354-2db9-5413-9d35-92eff5f026bb",
+  "host": {
+    "host_id": "d4ad23542db954139d3592eff5f026bb",
+    "name": "mm-host-registration-replay",
+    "owner": "local",
+    "status": "online",
+    "configured_harnesses": {"opencode-native": "ready"},
+    "runners": []
+  }
+}

--- a/tests/integration/reliability/test_omnigent_host_registration.py
+++ b/tests/integration/reliability/test_omnigent_host_registration.py
@@ -1,0 +1,103 @@
+"""Replay the stock host UUID wire contract without provider calls or credentials."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import httpx
+import pytest
+
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.host_ports import expected_omnigent_host_id
+from moonmind.omnigent.host_services.registration import OmnigentHostRegistrationService
+from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.reliability_journey,
+]
+
+
+@pytest.mark.parametrize(
+    "persisted", [False, True], ids=["new-launch", "in-flight-launch"]
+)
+@pytest.mark.parametrize("harness", ["opencode-native", "codex-native", "claude-native"])
+async def test_targeted_registration_stock_uuid_handoff(
+    monkeypatch: pytest.MonkeyPatch, persisted: bool, harness: str
+) -> None:
+    manifest = load_replay("omnigent-targeted-host-uuid", "manifest.json")
+    expected_id = (
+        manifest["persistedExpectedHostId"]
+        if persisted
+        else expected_omnigent_host_id("registration-replay-lease", 1)
+    )
+    host = dict(manifest["host"], host_id=UUID(expected_id).hex)
+    host["configured_harnesses"] = {harness: "ready"}
+    calls = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        assert request.url.path == f"/v1/hosts/{expected_id}"
+        if len(calls) == 1:
+            return httpx.Response(404, json={"detail": "host not found"})
+        if len(calls) == 2:
+            return httpx.Response(200, json=dict(host, status="offline"))
+        return httpx.Response(200, json=host)
+
+    client = OmnigentHttpClient(
+        base_url="https://omnigent.test", transport=httpx.MockTransport(handler)
+    )
+    registration = OmnigentHostRegistrationService(
+        client=client, expected_owner=host["owner"], attempts=3
+    )
+    monkeypatch.setattr(registration, "_registration_delay", lambda _attempt: 0)
+    result = await registration.wait_for_registration(
+        correlation_name=host["name"], harness_id=harness, expected_host_id=expected_id
+    )
+    assert len(calls) == 3
+    assert result["lookupMode"] == "targeted"
+    assert result["harnessReady"] is True
+    # Attestation and subsequent session creation consume the server's exact ID.
+    assert result["omnigentHostId"] == host["host_id"]
+    assert result["host"] == host
+    if not persisted:
+        assert expected_id == host["host_id"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("host_id", "00000000000000000000000000000000", "identity mismatch"),
+        ("host_id", "invalid-host-id", "identity mismatch"),
+        ("host_id", "", "identity mismatch"),
+        ("name", "another-host", "name mismatch"),
+        ("owner", "another-owner", "owner mismatch"),
+    ],
+)
+async def test_targeted_registration_rejects_foreign_or_malformed_identity(
+    field: str, value: str, error: str
+) -> None:
+    manifest = load_replay("omnigent-targeted-host-uuid", "manifest.json")
+    host = dict(manifest["host"], **{field: value})
+    calls = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(200, json=host)
+
+    registration = OmnigentHostRegistrationService(
+        client=OmnigentHttpClient(
+            base_url="https://omnigent.test", transport=httpx.MockTransport(handler)
+        ),
+        expected_owner="local",
+        attempts=3,
+    )
+    with pytest.raises(HarnessPlatformError, match=error):
+        await registration.wait_for_registration(
+            correlation_name=manifest["host"]["name"],
+            harness_id="opencode-native",
+            expected_host_id=manifest["persistedExpectedHostId"],
+        )
+    assert len(calls) == 1  # Identity failures never retry against another host.

--- a/tests/unit/omnigent/test_adapter_contracts.py
+++ b/tests/unit/omnigent/test_adapter_contracts.py
@@ -1179,9 +1179,12 @@ def test_deployed_adapter_satisfies_its_declared_port(port, implementation) -> N
 
 
 def test_expected_host_id_is_deterministic_and_generation_fenced() -> None:
+    from uuid import UUID
+
     from moonmind.omnigent.host_ports import expected_omnigent_host_id
 
     first = expected_omnigent_host_id("lease-abc", 1)
+    assert first == UUID(first).hex
     assert first == expected_omnigent_host_id("lease-abc", 1)
     assert first != expected_omnigent_host_id("lease-abc", 2)
     assert first != expected_omnigent_host_id("lease-other", 1)

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -64,7 +64,7 @@ from moonmind.omnigent.host_services.github_credentials import (
     OmnigentGithubCredentialService,
     github_repository_from_request,
 )
-from moonmind.omnigent.host_ports import HostLaunchSpec
+from moonmind.omnigent.host_ports import HostLaunchSpec, expected_omnigent_host_id
 from moonmind.omnigent.host_services.launcher import DockerOmnigentHostLauncher
 from moonmind.omnigent.host_services.mounted_tools import (
     OmnigentMountedToolService,
@@ -990,6 +990,15 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "expected_host_id",
+    [
+        None,
+        expected_omnigent_host_id("host-lease:one", 1),
+        "d4ad2354-2db9-5413-9d35-92eff5f026bb",
+    ],
+    ids=["legacy-spec", "canonical-spec", "persisted-dashed-spec"],
+)
+@pytest.mark.parametrize(
     ("host_api_token", "expected_secret_payloads"),
     [
         (
@@ -1002,6 +1011,7 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
 async def test_host_volume_initializers_use_setup_authority(
     host_api_token: str,
     expected_secret_payloads: list[bytes],
+    expected_host_id: str | None,
 ) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -1048,6 +1058,7 @@ async def test_host_volume_initializers_use_setup_authority(
                 "runtimeBindingId": "binding-1",
                 "hostLeaseRef": owner_ref,
                 "hostLeaseGeneration": 1,
+                "expectedOmnigentHostId": expected_host_id,
                 "hostClassRef": host_class.ref,
                 "imageRef": host_class.imageRef,
                 "serverEndpointRef": "default",
@@ -1103,6 +1114,11 @@ async def test_host_volume_initializers_use_setup_authority(
         assert argv[argv.index("--user") + 1] == "0:0"
     workload_create = next(argv for argv, _kwargs in calls if argv[:2] == ["docker", "create"])
     assert workload_create[workload_create.index("--user") + 1] == "1000:1000"
+    from uuid import NAMESPACE_URL, uuid5
+
+    launched_id = expected_host_id or str(uuid5(NAMESPACE_URL, owner_ref))
+    assert f"OMNIGENT_HOST_ID={launched_id}" in workload_create
+    assert "OMNIGENT_HOST_NAME=mm-host-test" in workload_create
     assert "scoped-fanout-token" not in json.dumps(
         [argv for argv, _kwargs in calls]
     )


### PR DESCRIPTION
Omnigent normalizes host UUIDs to bare hexadecimal strings, but targeted registration compared them literally against MoonMind's dashed launch UUIDs. This rejected correctly registered hosts before agent execution, including workflow `mm:9556a9c0-f461-40a0-852b-6fdb388b6f78`.

Generate canonical host IDs for new launches and compare UUID values for persisted launch specs. Preserve the server's exact ID for attestation, along with the existing name and owner checks. Add a required-CI HTTP-boundary replay of the escaped failure across OpenCode, Codex, and Claude, including delayed registration, in-flight payloads, and foreign/malformed identities. Launcher tests also cover both persisted and newly generated IDs. These regression tests require no LLM compute or provider credentials.

Validation: 121 targeted unit tests and 11 regression replay cases passed. Deployed commit `970b64bcb`; live retry `mm:e3c2269f-533f-502e-8ac2-e414887bdc63` completed with a verified terminal contract, two queued children, and no errors. Both children retain the original provider, model, and effort. The successful retry uses the refreshed deployment Agent Profile; the initial exact rerun retained an unavailable upstream agent version and was canceled.

The full Compose-backed `integration_ci` suite passed: 629 passed, 1 skipped.
