### PR TITLE
Unify Profile selection and make model discovery non-blocking

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -237,7 +237,6 @@ from moonmind.workflows.temporal.hard_switch_cutover import (
 from moonmind.workflows.executions.model_resolver import (
     RequestedModelTierUnavailableError,
     ResolvedModelEffort,
-    resolve_effective_model,
     resolve_model_effort,
 )
 from moonmind.workflows.executions.preset_goal_scheduler import (
@@ -7722,13 +7721,15 @@ def _resolve_runtime_model_effort(
             _model_tier_resolution_payload(resolved, profile=profile),
         )
 
-    resolved_model, model_source = resolve_effective_model(
+    resolved = resolve_model_effort(
         runtime_id=runtime_id,
         profile=profile,
         requested_model=requested_model,
+        requested_effort=requested_effort,
+        require_launch_ready=False,
         workflow_settings=settings.workflow,
     )
-    return resolved_model, model_source, requested_effort, None
+    return resolved.model, resolved.model_source, resolved.effort, None
 
 
 def _require_provider_profile_runtime(
@@ -11365,6 +11366,28 @@ async def _create_execution_from_workflow_request(
                 "omnigent.executionTargetRef must match the selected "
                 "Agent Profile executionProfileRef."
             )
+        selected_provider_profile = await session.get(
+            ManagedAgentProviderProfile,
+            str(profile_snapshot["providerProfileRef"]),
+        )
+        if selected_provider_profile is None:
+            raise _invalid_workflow_request(
+                "Selected Provider Profile disappeared before plan compilation."
+            )
+        if not explicit_agent_profile:
+            resolved_model, model_source, resolved_effort, model_tier_resolution = (
+                _resolve_runtime_model_effort(
+                    runtime_id=selected_provider_profile.runtime_id,
+                    profile=selected_provider_profile,
+                    runtime_payload=runtime_payload,
+                    requested_model=runtime_payload.get("model"),
+                )
+            )
+            initial_parameters.update(
+                model=resolved_model, effort=resolved_effort, modelSource=model_source,
+            )
+            if model_tier_resolution is not None:
+                initial_parameters["modelTierResolution"] = model_tier_resolution
         initial_parameters = compile_agent_profile_snapshot_parameters(
             initial_parameters,
             snapshot=profile_snapshot,
@@ -11394,14 +11417,6 @@ async def _create_execution_from_workflow_request(
             or effort_source in provider_authority_sources
         ):
             initial_parameters["effort"] = resolved_effort
-        selected_provider_profile = await session.get(
-            ManagedAgentProviderProfile,
-            str(profile_snapshot["providerProfileRef"]),
-        )
-        if selected_provider_profile is None:
-            raise _invalid_workflow_request(
-                "Selected Provider Profile disappeared before plan compilation."
-            )
 
     persisted_omnigent_plan = None
     prelaunch_task_input_snapshot_ref = ""

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -13419,6 +13419,11 @@ async def create_remediation_checkpoint_branch(
             consumer_id=branch_id,
             user=user,
         )
+    if payload.agent_profile is None and payload.provider_profile_ref:
+        agent_profile_snapshot = await resolve_default_agent_profile_snapshot(
+            session, provider_profile_ref=payload.provider_profile_ref,
+            launch_policy_ref=None, consumer_type="checkpoint", consumer_id=branch_id, user=user,
+        )
     await _prepare_checkpoint_branch_launch(
         session=session,
         record=target_record,
@@ -15057,6 +15062,11 @@ async def create_checkpoint_branch(
             consumer_type="checkpoint",
             consumer_id=branch_id,
             user=user,
+        )
+    if payload.agent_profile is None and payload.provider_profile_ref:
+        agent_profile_snapshot = await resolve_default_agent_profile_snapshot(
+            session, provider_profile_ref=payload.provider_profile_ref,
+            launch_policy_ref=None, consumer_type="checkpoint", consumer_id=branch_id, user=user,
         )
     await _prepare_checkpoint_branch_launch(
         session=session,

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -384,11 +384,6 @@ _REASONS: dict[str, tuple[str, str]] = {
         "Connect and validate a compatible Provider Profile.",
         "/settings#provider-profiles",
     ),
-    "provider_runtime_revalidation_pending": (
-        "MoonMind is re-validating this Provider Profile against the updated "
-        "pinned host image. This finishes automatically; retry shortly.",
-        "/settings#provider-profiles",
-    ),
     "model_catalog_unavailable": (
         "Run runtime-backed Provider Profile validation to discover models.",
         "/settings#provider-profiles",
@@ -403,25 +398,6 @@ _REASONS: dict[str, tuple[str, str]] = {
 def _reason(code: str) -> GateReason:
     message, href = _REASONS[code]
     return GateReason(code=code, message=message, remediationHref=href)
-
-
-def _revalidation_is_exhausted(provider: Any, selected_classes: Any) -> bool:
-    """Report whether re-validation gave up on this credential and image.
-
-    Re-validation preserves the enrolled credential and its prior evidence when
-    the pinned runtime rejects it, so a revoked or incompatible credential looks
-    exactly like an attempt in flight. The reconciler records its bounded
-    outcome, and reading it here is what keeps readiness from promising forever
-    that the wait "finishes automatically".
-    """
-
-    from moonmind.omnigent.bootstrap.provider_revalidation import (
-        revalidation_is_exhausted,
-    )
-
-    return revalidation_is_exhausted(
-        provider, image_refs={item.imageRef for item in selected_classes}
-    )
 
 
 def _valid_server_url(value: str) -> bool:
@@ -1536,9 +1512,6 @@ async def get_omnigent_execution_readiness(
 
     from api_service.db.base import async_session_maker
     from api_service.db.models import OmnigentAgentProfile, OmnigentAgentProfileVersion
-    from moonmind.omnigent.bootstrap.provider_revalidation import (
-        evidence_observation_is_current,
-    )
     from moonmind.omnigent.harness_platform.agent_profile import validate_agent_profile
     from moonmind.omnigent.harness_platform.catalog import (
         TrustState,
@@ -1662,7 +1635,6 @@ async def get_omnigent_execution_readiness(
         compatible: list[dict[str, Any]] = []
         host_classes: set[str] = set()
         models: set[str] = set()
-        revalidating: list[str] = []
         for provider in visible_providers:
             state = getattr(provider.auth_state, "value", provider.auth_state)
             if (
@@ -1694,31 +1666,8 @@ async def get_omnigent_execution_readiness(
             except Exception:
                 continue
             evidence = provider.model_catalog_evidence_json or {}
-            try:
-                evidence_generation = int(evidence.get("credentialGeneration") or 0)
-            except (TypeError, ValueError):
-                evidence_generation = 0
-            if (
-                evidence_generation != int(provider.credential_generation)
-                or str(evidence.get("imageRef") or "")
-                not in {item.imageRef for item in selected_classes}
-                # An observation older than the configured catalog interval no
-                # longer describes the provider's current models, so it cannot
-                # advertise a target either. The reconciler re-probes it on the
-                # same bounded schedule as image and credential staleness.
-                or not evidence_observation_is_current(evidence)
-            ):
-                if evidence and not _revalidation_is_exhausted(
-                    provider, selected_classes
-                ):
-                    # The credential is enrolled and connected; only its
-                    # runtime-backed evidence trails the currently pinned host
-                    # image, the credential generation, or the catalog
-                    # interval. The bootstrap reconciler re-validates it
-                    # against the exact selected image, so this is a bounded
-                    # wait rather than a reconnect.
-                    revalidating.append(provider.profile_id)
-                continue
+            # Catalog snapshots aid discovery only. Credential and exact-host
+            # model authority are verified on the execution host before use.
             observed_models = {
                 model
                 for model in _catalog_model_ids(evidence)
@@ -1735,17 +1684,9 @@ async def get_omnigent_execution_readiness(
             host_classes.update(item.ref for item in selected_classes)
             models.update(observed_models)
         if not compatible:
-            reasons.append(
-                _reason(
-                    "provider_runtime_revalidation_pending"
-                    if revalidating
-                    else "compatible_provider_profile_unavailable"
-                )
-            )
+            reasons.append(_reason("compatible_provider_profile_unavailable"))
         if not host_classes:
             reasons.append(_reason("host_class_unavailable"))
-        if not models:
-            reasons.append(_reason("model_catalog_unavailable"))
         targets.append(
             GenericExecutionTargetReadiness(
                 ref=f"{profile_row.profile_id}@{version.version}",

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -30,6 +30,9 @@ from api_service.db.models import (
     SecretStatus,
     User,
 )
+from api_service.services.profile_execution_selection import (
+    ProfileExecutionConfiguration,
+)
 from api_service.services.provider_profile_creation import (
     ProviderApiKeyStrategy,
     authentication_method_launch_ready_after_setup,
@@ -215,6 +218,7 @@ def _validate_profile_tier_policy(row: ManagedAgentProviderProfile) -> None:
 
 
 class ProviderProfileCreate(BaseModel):
+    execution_configuration: ProfileExecutionConfiguration | None = None
     profile_id: str = Field(..., max_length=128)
     runtime_id: str = Field(..., max_length=64)
     provider_id: str = Field(default="unknown", max_length=64)
@@ -347,6 +351,7 @@ class ProviderProfileCreate(BaseModel):
 
 
 class ProviderProfileUpdate(BaseModel):
+    execution_configuration: ProfileExecutionConfiguration | None = None
     provider_id: Optional[str] = Field(default=None, max_length=64)
     provider_label: Optional[str] = None
     default_model: Optional[str] = None
@@ -478,6 +483,9 @@ class ProviderProfileCreationCapabilitiesResponse(BaseModel):
 
 class ProviderProfileResponse(BaseModel):
     profile_id: str
+    execution_configuration: ProfileExecutionConfiguration | None = None
+    execution_selection: dict[str, Any] | None = None
+    execution_selection_error: dict[str, Any] | None = None
     runtime_id: str
     provider_id: str
     provider_label: Optional[str]
@@ -993,6 +1001,7 @@ async def _reconcile_imported_credential_generation(
 async def list_profiles(
     runtime_id: Optional[str] = None,
     enabled_only: bool = False,
+    include_execution: bool = False,
     session: AsyncSession = Depends(_get_session()),  # type: ignore[assignment]
     current_user: User = Depends(get_current_user()),
 ) -> list[dict[str, Any]]:
@@ -1017,7 +1026,7 @@ async def list_profiles(
         visible_rows,
         secret_ref_results=secret_ref_results,
     )
-    return [
+    payloads = [
         _row_to_dict(
             r,
             managed_secret_statuses=secret_statuses,
@@ -1025,6 +1034,18 @@ async def list_profiles(
         )
         for r in visible_rows
     ]
+    if include_execution:
+        from api_service.services.profile_execution_selection import (
+            load_execution_configurations,
+            select_execution_configuration,
+        )
+        configurations = await load_execution_configurations(session, current_user, visible_rows)
+        for row, payload in zip(visible_rows, payloads):
+            try:
+                payload["execution_selection"] = select_execution_configuration(row, configurations)
+            except HTTPException as exc:
+                payload["execution_selection_error"] = exc.detail
+    return payloads
 
 
 @router.get(
@@ -1343,6 +1364,7 @@ async def create_profile(
 
     profile = ManagedAgentProviderProfile(
         profile_id=body.profile_id,
+        execution_configuration=(body.execution_configuration.model_dump() if body.execution_configuration else None),
         runtime_id=values["runtime_id"],
         provider_id=values["provider_id"],
         provider_label=body.provider_label,
@@ -1388,6 +1410,11 @@ async def create_profile(
         ),
     )
     _validate_profile_tier_policy(profile)
+    if body.execution_configuration:
+        from api_service.services.profile_execution_selection import (
+            profile_execution_selection,
+        )
+        await profile_execution_selection(session, profile, current_user)
     incomplete_preset_oauth = (
         body.authentication_method == ProviderProfileAuthenticationMethod.OAUTH
         and not profile.enabled
@@ -1451,6 +1478,22 @@ async def update_profile(
     _require_profile_management(profile, current_user)
 
     update_data = body.model_dump(exclude_unset=True)
+    if update_data.get("execution_configuration"):
+        from types import SimpleNamespace
+
+        from api_service.services.profile_execution_selection import (
+            profile_execution_selection,
+        )
+
+        prospective = SimpleNamespace(
+            profile_id=profile.profile_id,
+            runtime_id=profile.runtime_id,
+            provider_id=update_data.get("provider_id") or profile.provider_id,
+            credential_source=update_data.get("credential_source", profile.credential_source),
+            runtime_materialization_mode=update_data.get("runtime_materialization_mode", profile.runtime_materialization_mode),
+            execution_configuration=update_data["execution_configuration"],
+        )
+        await profile_execution_selection(session, prospective, current_user)
     import_existing_credential_volume = bool(
         update_data.pop("import_existing_credential_volume", False)
     )
@@ -1583,6 +1626,8 @@ async def update_profile(
                         try:
                             from moonmind.provider_profiles.isolation_policy import (
                                 classify_existing_policy as _classify_repair_policy,
+                            )
+                            from moonmind.provider_profiles.isolation_policy import (
                                 derive_isolation_policy as _derive_repair_policy,
                             )
 
@@ -1937,7 +1982,9 @@ async def update_profile(
                 if (profile.capacity_scope_ref or _default_scope) == _default_scope:
                     from sqlalchemy import select as _select_scope_count
 
-                    from api_service.db.models import ManagedAgentProviderProfile as _Profile
+                    from api_service.db.models import (
+                        ManagedAgentProviderProfile as _Profile,
+                    )
 
                     _count_result = await session.execute(
                         _select_scope_count(_Profile.profile_id).where(
@@ -2338,9 +2385,15 @@ async def commit_claude_manual_auth(
         "anthropic_api_key": secret_ref,
     }
     # #3821: credential enrollment reuses the isolation authority.
-    from moonmind.provider_profiles.isolation_policy import derive_isolation_policy as _derive_manual_policy
-    from moonmind.provider_profiles.isolation_policy import merge_enrollment_policy as _merge_manual_policy
-    from moonmind.provider_profiles.isolation_policy import IsolationPolicyError as _ManualMergeError
+    from moonmind.provider_profiles.isolation_policy import (
+        IsolationPolicyError as _ManualMergeError,
+    )
+    from moonmind.provider_profiles.isolation_policy import (
+        derive_isolation_policy as _derive_manual_policy,
+    )
+    from moonmind.provider_profiles.isolation_policy import (
+        merge_enrollment_policy as _merge_manual_policy,
+    )
 
     try:
         profile.clear_env_keys = _merge_manual_policy(
@@ -2740,13 +2793,13 @@ def _apply_api_key_setup_to_profile(
     # #3821: enrollment reuses the single isolation authority and preserves
     # unknown legacy custom keys instead of silently discarding them.
     from moonmind.provider_profiles.isolation_policy import (
+        IsolationPolicyError as _EnrollmentMergeError,
+    )
+    from moonmind.provider_profiles.isolation_policy import (
         derive_isolation_policy as _derive_enrollment_policy,
     )
     from moonmind.provider_profiles.isolation_policy import (
         merge_enrollment_policy as _merge_enrollment_policy,
-    )
-    from moonmind.provider_profiles.isolation_policy import (
-        IsolationPolicyError as _EnrollmentMergeError,
     )
 
     _enrollment_derived = _derive_enrollment_policy(
@@ -3551,6 +3604,7 @@ def _row_to_dict(
     )
     payload = {
         "profile_id": row.profile_id,
+        "execution_configuration": getattr(row, "execution_configuration", None),
         "runtime_id": row.runtime_id,
         "provider_id": row.provider_id,
         "provider_label": row.provider_label,

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -1037,10 +1037,13 @@ async def list_profiles(
     if include_execution:
         from api_service.services.profile_execution_selection import (
             load_execution_configurations,
+            profile_has_native_inventory_route,
             select_execution_configuration,
         )
         configurations = await load_execution_configurations(session, current_user, visible_rows)
         for row, payload in zip(visible_rows, payloads):
+            if profile_has_native_inventory_route(row, configurations):
+                continue
             try:
                 payload["execution_selection"] = select_execution_configuration(row, configurations)
             except HTTPException as exc:
@@ -1478,7 +1481,17 @@ async def update_profile(
     _require_profile_management(profile, current_user)
 
     update_data = body.model_dump(exclude_unset=True)
-    if update_data.get("execution_configuration"):
+    execution_configuration = update_data.get(
+        "execution_configuration", profile.execution_configuration
+    )
+    execution_contract_supplied = bool(
+        {"provider_id", "credential_source", "runtime_materialization_mode"}
+        .intersection(update_data)
+        or update_data.get("import_existing_credential_volume")
+    )
+    if execution_configuration and (
+        "execution_configuration" in update_data or execution_contract_supplied
+    ):
         from types import SimpleNamespace
 
         from api_service.services.profile_execution_selection import (
@@ -1489,9 +1502,19 @@ async def update_profile(
             profile_id=profile.profile_id,
             runtime_id=profile.runtime_id,
             provider_id=update_data.get("provider_id") or profile.provider_id,
-            credential_source=update_data.get("credential_source", profile.credential_source),
-            runtime_materialization_mode=update_data.get("runtime_materialization_mode", profile.runtime_materialization_mode),
-            execution_configuration=update_data["execution_configuration"],
+            credential_source=(
+                ProviderCredentialSource.OAUTH_VOLUME
+                if update_data.get("import_existing_credential_volume")
+                else update_data.get("credential_source", profile.credential_source)
+            ),
+            runtime_materialization_mode=(
+                RuntimeMaterializationMode.OAUTH_HOME
+                if update_data.get("import_existing_credential_volume")
+                else update_data.get(
+                    "runtime_materialization_mode", profile.runtime_materialization_mode
+                )
+            ),
+            execution_configuration=execution_configuration,
         )
         await profile_execution_selection(session, prospective, current_user)
     import_existing_credential_volume = bool(

--- a/api_service/api/routers/recurring_workflows.py
+++ b/api_service/api/routers/recurring_workflows.py
@@ -520,6 +520,8 @@ def _recurring_sort_value(
     return definition.updated_at or _MIN_AWARE_DATETIME
 
 def _map_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, HTTPException):
+        return exc
     if isinstance(exc, ProviderProfileRuntimeMismatchError):
         # Provider Profiles are runtime-owned launch contracts; the shared
         # invariant raises one error contract for every authoring boundary.

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3404,6 +3404,9 @@ class ManagedAgentProviderProfile(Base):
         String(64), nullable=False, default="unknown", server_default=text("'unknown'")
     )
     provider_label: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    execution_configuration: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
     default_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     default_effort: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     model_tiers: Mapped[list[dict[str, Any]]] = mapped_column(

--- a/api_service/migrations/versions/371_profile_execution_config.py
+++ b/api_service/migrations/versions/371_profile_execution_config.py
@@ -1,0 +1,56 @@
+"""Bind reusable execution behavior to the existing Profile identity.
+
+Null preserves automatic resolution. Existing immutable consumer snapshots
+remain authoritative; migration never guesses among customized combinations.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "371_profile_execution_config"
+down_revision = "370_provider_default_authority"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "execution_configuration",
+            sa.JSON(),
+            nullable=True,
+        ),
+    )
+    profiles = sa.table(
+        "managed_agent_provider_profiles",
+        sa.column("profile_id", sa.String()),
+        sa.column("auth_state", sa.String()),
+        sa.column("command_behavior", sa.JSON()),
+    )
+    connection = op.get_bind()
+    for row in connection.execute(sa.select(profiles)).mappings():
+        behavior = dict(row["command_behavior"] or {})
+        readiness = dict(behavior.get("auth_readiness") or {})
+        # One-time cutover of the two discovery-owned flags written by the
+        # previous reconciler. Credential failures and explicit disables remain.
+        if str(row["auth_state"]).lower() == "connected" and readiness.get(
+            "failure_reason"
+        ) in {
+            "Pinned OpenCode runtime validation failed.",
+            "The selected model was not observed by the pinned OpenCode runtime.",
+        }:
+            readiness.pop("failure_reason", None)
+            readiness.pop("launch_ready", None)
+            behavior["auth_readiness"] = readiness
+            connection.execute(
+                profiles.update()
+                .where(
+                    profiles.c.profile_id == row["profile_id"],
+                )
+                .values(command_behavior=behavior)
+            )
+
+
+def downgrade():
+    op.drop_column("managed_agent_provider_profiles", "execution_configuration")

--- a/api_service/services/checkpoint_branch_turn_execution.py
+++ b/api_service/services/checkpoint_branch_turn_execution.py
@@ -1179,6 +1179,20 @@ class CheckpointBranchTurnExecutionOwner:
             kind="runtime.branch_turn.context_bundle.json",
             branch_turn_id=branch_turn_id,
         )
+        # The complete immutable configuration stays in the verified branch
+        # usage and context artifact. AgentRun carries only selection metadata;
+        # providerRequirements and arbitrary configuration sections are not a
+        # compact runtime contract (and can contain credential metadata keys).
+        compact_runtime_selection = {
+            key: runtime_selection[key]
+            for key in (
+                "providerProfileRef", "executionProfileRef", "profileId",
+                "agentProfile", "runtimeId", "model", "effort", "maxBudgetUsd",
+                "runtimeContextPolicy", "publishMode", "gitWorkBranch",
+                "launchPolicyRef", "executionPlanRef",
+            )
+            if key in runtime_selection
+        }
         step_launch = {
             "schemaVersion": "v1",
             "workflowId": identity.workflow_id,
@@ -1203,7 +1217,7 @@ class CheckpointBranchTurnExecutionOwner:
                     ]
                 )
             ),
-            "runtimeSelection": runtime_selection,
+            "runtimeSelection": compact_runtime_selection,
             "runtimeSessionReset": {
                 "mode": "new_agent_run",
                 "sourceProviderSessionReused": False,
@@ -1260,7 +1274,7 @@ class CheckpointBranchTurnExecutionOwner:
                 "checkoutCommit": binding.base_commit,
             },
             parameters={
-                **runtime_selection,
+                **compact_runtime_selection,
                 "repository": binding.repository,
                 "startingBranch": binding.base_branch,
                 "targetBranch": binding.work_branch,

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -638,23 +638,18 @@ async def resolve_default_agent_profile_snapshot(
         if provider is None:
             raise HTTPException(404, "Profile not found")
         selection = await profile_execution_selection(session, provider, user)
-        from moonmind.workflows.executions.model_resolver import resolve_model_effort
-
-        resolved_model = resolve_model_effort(
-            runtime_id=provider.runtime_id, profile=provider, require_launch_ready=False,
-        )
         configurations = await session.scalar(
             select(OmnigentAgentProfileVersion).where(
                 OmnigentAgentProfileVersion.profile_id == selection["profileId"],
                 OmnigentAgentProfileVersion.version == selection["version"],
             )
         )
-        model_key = (
-            "qualifiedId" if configurations.document.get("schemaVersion")
-            == "moonmind.omnigent-agent-profile.v2" else "model"
-        )
+        # Profile model authority belongs to execution parameters. Clear legacy
+        # configuration defaults without sending provider values through the
+        # legacy model schema (whose validation is intentionally narrower).
         selection["overrides"] = {"model": {
-            model_key: resolved_model.model, "effort": resolved_model.effort,
+            key: None for key in ("model", "qualifiedId", "effort")
+            if key in (configurations.document.get("model") or {})
         }}
         if launch_policy_ref:
             selection["launchPolicyRef"] = launch_policy_ref

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -623,6 +623,46 @@ async def resolve_default_agent_profile_snapshot(
     Agent Profile, so workers never repeat default/profile resolution.
     """
 
+    if provider_profile_ref:
+        from api_service.services.profile_execution_selection import (
+            profile_execution_selection,
+        )
+
+        query = select(ManagedAgentProviderProfile).where(
+            ManagedAgentProviderProfile.profile_id == provider_profile_ref
+        )
+        visibility_filter = _provider_profile_visibility_filter(user)
+        if visibility_filter is not None:
+            query = query.where(visibility_filter)
+        provider = await session.scalar(query)
+        if provider is None:
+            raise HTTPException(404, "Profile not found")
+        selection = await profile_execution_selection(session, provider, user)
+        from moonmind.workflows.executions.model_resolver import resolve_model_effort
+
+        resolved_model = resolve_model_effort(
+            runtime_id=provider.runtime_id, profile=provider, require_launch_ready=False,
+        )
+        configurations = await session.scalar(
+            select(OmnigentAgentProfileVersion).where(
+                OmnigentAgentProfileVersion.profile_id == selection["profileId"],
+                OmnigentAgentProfileVersion.version == selection["version"],
+            )
+        )
+        model_key = (
+            "qualifiedId" if configurations.document.get("schemaVersion")
+            == "moonmind.omnigent-agent-profile.v2" else "model"
+        )
+        selection["overrides"] = {"model": {
+            model_key: resolved_model.model, "effort": resolved_model.effort,
+        }}
+        if launch_policy_ref:
+            selection["launchPolicyRef"] = launch_policy_ref
+        return await resolve_agent_profile_snapshot(
+            session, selection=selection, consumer_type=consumer_type,
+            consumer_id=consumer_id, user=user,
+        )
+
     profile = await session.scalar(
         select(OmnigentAgentProfile)
         .where(OmnigentAgentProfile.default_for_runtime.is_(True))
@@ -723,22 +763,10 @@ async def resolve_default_agent_profile_snapshot(
                 "Agent Profile",
             )
         selected_provider_ref = selected.profile_id
-    selection = {
-        "profileId": profile.profile_id,
-        "version": profile.active_version,
-        "providerProfileRef": selected_provider_ref,
-        **(
-            {"launchPolicyRef": str(launch_policy_ref).strip()}
-            if str(launch_policy_ref or "").strip()
-            else {}
-        ),
-    }
-    return await resolve_agent_profile_snapshot(
-        session,
-        selection=selection,
-        consumer_type=consumer_type,
-        consumer_id=consumer_id,
-        user=user,
+    return await resolve_default_agent_profile_snapshot(
+        session, provider_profile_ref=selected_provider_ref,
+        launch_policy_ref=launch_policy_ref, consumer_type=consumer_type,
+        consumer_id=consumer_id, user=user,
     )
 
 

--- a/api_service/services/omnigent_agent_smoke_service.py
+++ b/api_service/services/omnigent_agent_smoke_service.py
@@ -249,20 +249,6 @@ def _profile_snapshot_digest(value: Mapping[str, Any]) -> str:
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
-def _profile_model_ids(value: Any) -> set[str]:
-    if isinstance(value, str):
-        return {value} if "/" in value else set()
-    if isinstance(value, Mapping):
-        return {
-            model
-            for item in value.values()
-            for model in _profile_model_ids(item)
-        }
-    if isinstance(value, list):
-        return {model for item in value for model in _profile_model_ids(item)}
-    return set()
-
-
 async def _run_v2_profile_readiness_checks(
     session: AsyncSession,
     *,
@@ -275,9 +261,6 @@ async def _run_v2_profile_readiness_checks(
     from api_service.db.models import (
         OmnigentHarnessCatalogSnapshotRecord,
         OmnigentHarnessTrustRecord,
-    )
-    from moonmind.omnigent.bootstrap.provider_revalidation import (
-        evidence_observation_is_current,
     )
     from moonmind.omnigent.harness_platform.agent_profile import (
         BundleSource,
@@ -480,7 +463,7 @@ async def _run_v2_profile_readiness_checks(
             materializer_ref = materializer_ref_for_provider(
                 provider.runtime_id, provider.provider_id
             )
-            selected_classes = [
+            for policy_ref in profile.allowedLaunchPolicyRefs:
                 OmnigentHostClassSelector().select(
                     harness=harness,
                     omnigent_version=authority.omnigentVersion,
@@ -490,22 +473,8 @@ async def _run_v2_profile_readiness_checks(
                     materializer_refs=[materializer_ref],
                     requested_host_mode=get_launch_policy(policy_ref).hostMode,
                 )
-                for policy_ref in profile.allowedLaunchPolicyRefs
-            ]
-            evidence = dict(provider.model_catalog_evidence_json or {})
-            model = str(profile.model.get("qualifiedId") or "").strip()
-            if (
-                int(evidence.get("credentialGeneration") or 0)
-                != int(provider.credential_generation)
-                or str(evidence.get("imageRef") or "")
-                not in {item.imageRef for item in selected_classes}
-                # Smoke launches the real host, so it must not admit a catalog
-                # the provider may have changed since it was observed.
-                or not evidence_observation_is_current(evidence)
-                or not model
-                or model not in _profile_model_ids(evidence.get("models", []))
-            ):
-                continue
+            # Smoke attests model availability on its actual host. Discovery
+            # cache age or identity does not establish launch authority.
             compatible_provider = True
             break
         except Exception:

--- a/api_service/services/profile_execution_selection.py
+++ b/api_service/services/profile_execution_selection.py
@@ -1,8 +1,8 @@
 """Resolve a Profile's subordinate execution configuration at API boundaries.
 
 Inventory and selection never depend on model discovery or temporary runtime
-health. The existing immutable configuration and credential authorities are
-validated when a consumer snapshot is committed and on the actual host.
+health. Executable selections require a ready immutable configuration; credential
+authorities are validated when a consumer snapshot is committed and on the host.
 """
 
 from __future__ import annotations
@@ -53,6 +53,30 @@ def configuration_accepts_profile(document: Mapping[str, Any], provider: Any) ->
     )
 
 
+def profile_has_native_inventory_route(
+    provider: Any,
+    configurations: list[tuple[Any, Any]],
+) -> bool:
+    """Identify direct-runtime inventory without bypassing configured authority.
+
+    An unvalidated compatible configuration still owns the Profile's route. This
+    projection must not reinterpret that configuration's failure as permission
+    to execute through a different runtime.
+    """
+    from moonmind.workflows.executions.execution_contract import (
+        SUPPORTED_EXECUTION_RUNTIMES,
+    )
+
+    return (
+        not getattr(provider, "execution_configuration", None)
+        and provider.runtime_id in SUPPORTED_EXECUTION_RUNTIMES
+        and not any(
+            configuration_accepts_profile(version.document, provider)
+            for _, version in configurations
+        )
+    )
+
+
 async def load_execution_configurations(
     session: Any,
     user: Any,
@@ -91,11 +115,14 @@ def select_execution_configuration(
     configurations: list[tuple[Any, Any]],
 ) -> dict[str, Any]:
     authored = getattr(provider, "execution_configuration", None)
-    candidates = [
+    compatible_configurations = [
         (row, version)
         for row, version in configurations
-        if configuration_accepts_profile(version.document, provider)
+        if isinstance(getattr(version, "validation_result", None), Mapping)
+        and version.validation_result.get("ready") is True
+        and configuration_accepts_profile(version.document, provider)
     ]
+    candidates = compatible_configurations
     if authored:
         candidates = [
             (row, version)
@@ -123,7 +150,7 @@ def select_execution_configuration(
                 "message": (
                     "Choose an execution configuration in Profile settings."
                     if candidates
-                    else "This Profile's execution configuration is unavailable or incompatible."
+                    else "This Profile's execution configuration is unavailable, unvalidated, or incompatible."
                 ),
                 "profileId": provider.profile_id,
             },
@@ -144,8 +171,7 @@ def select_execution_configuration(
         "defaultForRuntime": any(
             candidate.default_for_runtime
             and candidate_version.version == candidate.active_version
-            and configuration_accepts_profile(candidate_version.document, provider)
-            for candidate, candidate_version in configurations
+            for candidate, candidate_version in compatible_configurations
         ),
     }
 

--- a/api_service/services/profile_execution_selection.py
+++ b/api_service/services/profile_execution_selection.py
@@ -1,0 +1,159 @@
+"""Resolve a Profile's subordinate execution configuration at API boundaries.
+
+Inventory and selection never depend on model discovery or temporary runtime
+health. The existing immutable configuration and credential authorities are
+validated when a consumer snapshot is committed and on the actual host.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import and_, or_, select
+
+from api_service.db.models import OmnigentAgentProfile, OmnigentAgentProfileVersion
+
+
+class ProfileExecutionConfiguration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profileId: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    digest: str = Field(pattern=r"^sha256:[a-f0-9]{64}$")
+
+
+def configuration_accepts_profile(document: Mapping[str, Any], provider: Any) -> bool:
+    from api_service.services.omnigent_agent_profile_selection import (
+        _accepted_provider_ids,
+        _provider_materializer_error,
+    )
+
+    if document.get("schemaVersion") == "moonmind.omnigent-agent-profile.v2":
+        accepted = _accepted_provider_ids(document)
+        return (not accepted or provider.provider_id in accepted) and (
+            _provider_materializer_error(document, provider) is None
+        )
+    requirements = document.get("providerRequirements") or {}
+
+    def value(raw: Any) -> Any:
+        return getattr(raw, "value", raw)
+
+    return bool(requirements) and all(
+        (
+            provider.runtime_id == requirements.get("runtimeId"),
+            value(provider.credential_source) == requirements.get("credentialSource"),
+            value(provider.runtime_materialization_mode)
+            == requirements.get("materializationMode"),
+            not requirements.get("providerIds")
+            or provider.provider_id in requirements["providerIds"],
+        )
+    )
+
+
+async def load_execution_configurations(
+    session: Any,
+    user: Any,
+    providers: list[Any],
+) -> list[tuple[Any, Any]]:
+    selected_versions = [
+        OmnigentAgentProfileVersion.version == OmnigentAgentProfile.active_version,
+    ]
+    for provider in providers:
+        pinned = getattr(provider, "execution_configuration", None)
+        if pinned:
+            selected_versions.append(
+                and_(
+                    OmnigentAgentProfileVersion.profile_id == pinned.get("profileId"),
+                    OmnigentAgentProfileVersion.version == pinned.get("version"),
+                    OmnigentAgentProfileVersion.digest == pinned.get("digest"),
+                )
+            )
+    statement = (
+        select(OmnigentAgentProfile, OmnigentAgentProfileVersion)
+        .join(
+            OmnigentAgentProfileVersion,
+            OmnigentAgentProfileVersion.profile_id == OmnigentAgentProfile.profile_id,
+        )
+        .where(OmnigentAgentProfile.state == "active", or_(*selected_versions))
+    )
+    return [
+        (row, version)
+        for row, version in (await session.execute(statement)).all()
+        if row.visibility != "private" or row.owner_id == getattr(user, "id", None)
+    ]
+
+
+def select_execution_configuration(
+    provider: Any,
+    configurations: list[tuple[Any, Any]],
+) -> dict[str, Any]:
+    authored = getattr(provider, "execution_configuration", None)
+    candidates = [
+        (row, version)
+        for row, version in configurations
+        if configuration_accepts_profile(version.document, provider)
+    ]
+    if authored:
+        candidates = [
+            (row, version)
+            for row, version in candidates
+            if row.profile_id == authored.get("profileId")
+            and version.version == authored.get("version")
+            and version.digest == authored.get("digest")
+        ]
+    else:
+        candidates = [
+            (row, version)
+            for row, version in candidates
+            if version.version == row.active_version
+        ]
+        preferred = [
+            (row, version) for row, version in candidates if row.default_for_runtime
+        ]
+        if preferred:
+            candidates = preferred
+    if len(candidates) != 1:
+        raise HTTPException(
+            409,
+            {
+                "code": "profile_execution_configuration_required",
+                "message": (
+                    "Choose an execution configuration in Profile settings."
+                    if candidates
+                    else "This Profile's execution configuration is unavailable or incompatible."
+                ),
+                "profileId": provider.profile_id,
+            },
+        )
+    row, version = candidates[0]
+    document = version.document
+    policies = (
+        document.get("allowedLaunchPolicyRefs")
+        or (document.get("execution") or {}).get("allowedLaunchPolicyRefs")
+        or []
+    )
+    return {
+        "profileId": row.profile_id,
+        "version": version.version,
+        "digest": version.digest,
+        "providerProfileRef": provider.profile_id,
+        "launchPolicyRef": policies[0] if policies else None,
+        "defaultForRuntime": any(
+            candidate.default_for_runtime
+            and candidate_version.version == candidate.active_version
+            and configuration_accepts_profile(candidate_version.document, provider)
+            for candidate, candidate_version in configurations
+        ),
+    }
+
+
+async def profile_execution_selection(
+    session: Any, provider: Any, user: Any
+) -> dict[str, Any]:
+    return select_execution_configuration(
+        provider,
+        await load_execution_configurations(session, user, [provider]),
+    )

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -30,9 +30,11 @@ from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
     refresh_managed_bootstrap_snapshot,
     resolve_agent_profile_snapshot,
+    resolve_default_agent_profile_snapshot,
 )
 from api_service.services.provider_profile_runtime import (
     require_launch_target_provider_profile_runtime,
+    resolve_launch_target_profile_selection,
 )
 from moonmind.workflows.recurring.cron import (
     compute_next_occurrence,
@@ -980,23 +982,40 @@ class RecurringWorkflowsService:
         self._session.add(definition)
         await self._session.flush()
 
-        if agent_profile_selection is not None:
+        initial_parameters = dict(definition.target.get("initialParameters") or {})
+        authored_profile = resolve_launch_target_profile_selection(definition.target)
+        needs_profile_snapshot = (
+            "omnigent" in authored_profile.runtime_ids
+            and not initial_parameters.get("agentProfileSnapshot")
+            and not initial_parameters.get("omnigentExecutionPlan")
+        )
+        if agent_profile_selection is not None or needs_profile_snapshot:
             if actor is None:
                 raise RecurringWorkflowValidationError(
                     "an authenticated actor is required for agent profile selection"
                 )
-            snapshot = await resolve_agent_profile_snapshot(
-                self._session,
-                selection=agent_profile_selection,
-                consumer_type="schedule",
-                consumer_id=str(definition_id),
-                user=actor,
-            )
+            if agent_profile_selection is not None:
+                snapshot = await resolve_agent_profile_snapshot(
+                    self._session, selection=agent_profile_selection,
+                    consumer_type="schedule", consumer_id=str(definition_id), user=actor,
+                )
+            else:
+                snapshot = await resolve_default_agent_profile_snapshot(
+                    self._session,
+                    provider_profile_ref=authored_profile.profile_id,
+                    launch_policy_ref=(initial_parameters.get("omnigent") or {}).get("launchPolicyRef"),
+                    consumer_type="schedule", consumer_id=str(definition_id), user=actor,
+                )
             initial_parameters = dict(definition.target.get("initialParameters") or {})
             initial_parameters = compile_agent_profile_snapshot_parameters(
                 initial_parameters,
                 snapshot=snapshot,
             )
+            if needs_profile_snapshot and agent_profile_selection is None:
+                authored_parameters = definition.target.get("initialParameters") or {}
+                for key in ("model", "effort"):
+                    if authored_parameters.get(key) is not None:
+                        initial_parameters[key] = authored_parameters[key]
             target_runtime = str(
                 initial_parameters.get("targetRuntime") or ""
             ).strip().lower()

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -1011,11 +1011,6 @@ class RecurringWorkflowsService:
                 initial_parameters,
                 snapshot=snapshot,
             )
-            if needs_profile_snapshot and agent_profile_selection is None:
-                authored_parameters = definition.target.get("initialParameters") or {}
-                for key in ("model", "effort"):
-                    if authored_parameters.get(key) is not None:
-                        initial_parameters[key] = authored_parameters[key]
             target_runtime = str(
                 initial_parameters.get("targetRuntime") or ""
             ).strip().lower()
@@ -1043,6 +1038,23 @@ class RecurringWorkflowsService:
                 raise RecurringWorkflowValidationError(
                     "selected Provider Profile disappeared before plan compilation"
                 )
+            if needs_profile_snapshot and agent_profile_selection is None:
+                from moonmind.workflows.executions.model_resolver import (
+                    resolve_model_effort,
+                )
+
+                authored_parameters = definition.target.get("initialParameters") or {}
+                task_intent = authored_parameters.get("workflow") or authored_parameters.get("task") or {}
+                runtime_intent = task_intent.get("runtime") or {}
+                resolved = resolve_model_effort(
+                    runtime_id=provider_profile.runtime_id, profile=provider_profile,
+                    requested_model=runtime_intent.get("model", authored_parameters.get("model")),
+                    requested_effort=runtime_intent.get("effort", authored_parameters.get("effort")),
+                    requested_model_tier=runtime_intent.get("modelTier", authored_parameters.get("modelTier")),
+                    tier_fallback=runtime_intent.get("tierFallback", authored_parameters.get("tierFallback", "clamp")),
+                    require_launch_ready=False,
+                )
+                initial_parameters.update(model=resolved.model, effort=resolved.effort, modelSource=resolved.model_source)
             principal = str(getattr(actor, "id", "") or "system")
             artifact_service = self._artifact_service or TemporalArtifactService(
                 TemporalArtifactRepository(self._session)

--- a/docs/Omnigent/AgentProfiles.md
+++ b/docs/Omnigent/AgentProfiles.md
@@ -1,4 +1,4 @@
-# Omnigent Agent Profiles
+# Omnigent Execution Configurations
 
 Status: **Desired-State Design**  
 Document Class: System / Feature Design View
@@ -22,7 +22,7 @@ Every execution resolves these references into a secret-free immutable snapshot 
 
 A stable `profileId` owns monotonically numbered immutable versions. Each version stores canonical JSON, a SHA-256 digest, parent/clone/supersedes lineage, upstream metadata at selection time, validation results, rollout metadata, actor, and timestamp. Editing always creates a version. Activation only moves the stable profile's active pointer. Disablement and deprecation block new selection without deleting versions or historical snapshots. Deletion is permitted only for an unused draft; referenced profiles and versions are retained.
 
-The version document includes endpoint and bridge-mode refs; stable upstream or artifact-backed bundle identity; harness and capabilities; execution and allowed launch policies; credential-free Provider Profile compatibility requirements; model and effort settings; workspace mutation and capability constraints; Skills and tools; capture, retention, evidence, and RAG defaults and ceilings; continuation compatibility; publish default; and versioned policy ref.
+The version document includes endpoint and bridge-mode refs; stable upstream or artifact-backed bundle identity; harness and capabilities; execution and allowed launch policies; credential-free Provider Profile compatibility requirements; legacy model and effort settings (new Profile launches resolve these from Profile tiers and explicit overrides); workspace mutation and capability constraints; Skills and tools; capture, retention, evidence, and RAG defaults and ceilings; continuation compatibility; publish default; and versioned policy ref.
 
 Profiles never contain credentials, OAuth homes, registration secrets, Dockerfiles, host paths, volume names, host ids, or privileged launch settings.
 
@@ -30,7 +30,14 @@ Profiles never contain credentials, OAuth homes, registration secrets, Dockerfil
 
 MoonMind synchronizes the stock `/v1/agents` built-in catalog through its authenticated bridge boundary into a bounded last-known projection keyed by endpoint plus stable upstream id and version. The stock catalog's session bindability is projected as the canonical `session.start` capability. MoonMind records harness, capabilities, health, provenance, compatibility, successful-sync time, attempt time, and redacted error state. An outage retains the prior snapshot but marks it stale. Missing or incompatible agents block new launches; historical snapshots remain readable.
 
-The selector shown by workflow, schedule, checkpoint-branch, and remediation authoring lists active versions and fresh readiness diagnostics. Submission persists the profile id/version/digest, upstream snapshot, Provider Profile id, execution and policy refs, and effective model/workspace/capture/RAG values. Overrides are accepted only after policy validation.
+Workflow, schedule, checkpoint-branch, and remediation authoring select one
+Profile. The existing Provider Profile identity owns account, model tiers and
+capacity, and optionally pins an immutable execution configuration. Configuration
+versions remain an advanced implementation contract, not a second required
+profile selector. Automatic resolution selects the compatible deployment default
+or the sole compatible configuration; ambiguity requires an explicit choice in
+Profile settings. A pinned version remains selected after the active version
+changes. Discovery freshness never filters Profile inventory. Submission persists the profile id/version/digest, upstream snapshot, Provider Profile id, execution and policy refs, and effective model/workspace/capture/RAG values. Overrides are accepted only after policy validation.
 
 ## Native Workflow Chat capability authority
 

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -423,7 +423,7 @@ OpenCode model-catalog evidence binds:
 
 `OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS` bounds observation age and defaults to `6`. A value of `0` revalidates only when image or credential identity changes.
 
-Evidence is invalid when:
+Discovery needs refresh when:
 
 - the host image changes
 - the OpenCode runtime identity changes
@@ -434,12 +434,16 @@ Evidence is invalid when:
 
 The bootstrap reconciler revalidates connected profiles through their selected
 materializer: the existing SecretRef for OpenCode Go and no credential for
-OpenCode Zen. It does not request a new key. While a valid revalidation is
-pending, authoring reports `provider_runtime_revalidation_pending`.
+OpenCode Zen. It does not request a new key. Discovery freshness is advisory for connected Profiles. A refresh, image change,
+or failed background probe never removes a configured Profile from authoring or
+revokes previously established credential readiness. The existing durable launch
+phase reports preparation progress while the actual host verifies the selected
+model and credential materialization. Missing models produce an actionable failure
+without substituting a model or account.
 
 Revalidation attempts are bounded per image and credential generation. Failure to acquire the maintenance lease does not spend a provider probe attempt because no probe occurred.
 
-## 10. Agent Profile
+## 10. Advanced execution configuration
 
 A representative OpenCode Agent Profile remains:
 

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -31,6 +31,18 @@ Last Updated: 2026-06-23
 
 ---
 
+## Unified Profile selection
+
+The user-facing Profile is this existing credential and capacity identity. It also
+owns model tiers and an optional `execution_configuration` reference containing
+an immutable configuration id, version and digest. New workflow and schedule
+submissions supply the Profile id; API admission resolves compatible execution
+behavior and records the immutable snapshot transactionally. Existing consumer
+snapshots remain authoritative for continuations. Profile selection never changes
+because model discovery expires or a host image changes. Disabled and disconnected
+Profiles remain visible with an actionable setup state. Credentials, trust,
+capability compatibility and actual-host model verification remain launch gates.
+
 ## 1. Summary
 
 MoonMind-managed runtimes such as Claude Code and Codex CLI do not map one-to-one to a single upstream company or a single authentication method.

--- a/docs/UI/ProviderProfileCreation.md
+++ b/docs/UI/ProviderProfileCreation.md
@@ -13,6 +13,16 @@ Canonical for: the create and edit experience for Provider Profiles on the **Pro
 
 ---
 
+## Profile identity and advanced behavior
+
+Settings and workflow authoring use the label **Profile**. Workflow creation,
+schedules, step overrides and replacement selections use the same persisted
+Profile id. Runtime and host details are progressively disclosed. Advanced Profile
+settings may pin an immutable execution configuration; the ordinary path resolves
+compatible deployment behavior automatically. Model discovery is an advisory cache:
+cached choices and explicit custom entries remain usable during refresh, while
+the execution host validates the actual selected model before work starts.
+
 ## 1. Purpose
 
 Creating a Provider Profile should ask users for decisions they understand and are likely to change. It should not require them to review every launch-contract field before they can create a normal profile.

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -267,7 +267,7 @@ describe('backend creation presets', () => {
     expect(screen.getByText('Materialization mode: api_key_env')).toBeTruthy();
     expect(screen.queryByLabelText('Enabled')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() => {
       expect(
@@ -439,7 +439,7 @@ describe('backend creation presets', () => {
     fireEvent.change(screen.getByLabelText('Command behavior'), {
       target: { value: '{"auth_strategy":"manual"}' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() => {
       expect(fetchSpy.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true);
@@ -578,7 +578,7 @@ describe('backend creation presets', () => {
     fireEvent.click(await screen.findByLabelText('API key'));
 
     await screen.findByText(/provider-profile-create-v1-old loaded/);
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await screen.findByText(/provider-profile-create-v1-current loaded/);
     expect(presetRequests).toBe(2);
@@ -1090,7 +1090,7 @@ describe('ProviderProfilesManager form controls', () => {
     expect(payload).not.toHaveProperty('default_effort');
   });
 
-  it('disables stale catalog choices while preserving backend-authorized custom entry', async () => {
+  it('preserves cached model choices and backend-authorized custom entry during refresh', async () => {
     const staleCapabilities = { version: 'tier-cap-v1-stale', profile_id: profile.profile_id, runtime_id: profile.runtime_id, provider_id: profile.provider_id, evidence: { source: 'profile_catalog_evidence', credential_generation: 1, image_ref: null, observed_at: null, stale: true }, tier_constraints: { min_count: 1, max_count: null }, model: { runtime_default: 'gpt-5.5', allow_custom: true, options: [{ value: 'gpt-5.5', label: 'GPT-5.5', description: null, status: 'available' }, { value: 'gpt-4o', label: 'GPT-4o', description: null, status: 'available', compatible_models: null }] }, effort: { supported: true, runtime_default: 'medium', allow_custom: false, application: 'native', options: [{ value: 'medium', label: 'Medium', description: null, status: 'available', compatible_models: null }] }, diagnostics: [] };
     vi.spyOn(window, 'fetch').mockImplementation(async (input) => {
       const url = String(input);
@@ -1108,13 +1108,13 @@ describe('ProviderProfilesManager form controls', () => {
     renderProviderProfilesManager([staleProfile]);
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
-    await screen.findByText(/observed catalog choices are disabled/);
+    await screen.findByText(/Model discovery is refreshing/);
     const modelSelect = screen.getByLabelText('Tier 1 model') as HTMLSelectElement;
     expect(modelSelect.value).toBe('gpt-4o');
     const options = within(modelSelect).getAllByRole('option') as HTMLOptionElement[];
     const byValue = new Map(options.map((o) => [o.value, o]));
     expect(byValue.get('__runtime_default__')?.disabled).toBe(false);
-    expect(byValue.get('gpt-5.5')?.disabled).toBe(true);
+    expect(byValue.get('gpt-5.5')?.disabled).toBe(false);
     expect(byValue.get('gpt-4o')?.disabled).toBe(false);
     expect(within(modelSelect).getByRole('option', { name: 'Custom value…' })).toBeTruthy();
     fireEvent.change(modelSelect, { target: { value: '__custom__' } });
@@ -1178,7 +1178,7 @@ describe('ProviderProfilesManager form controls', () => {
       target: { value: 'unknown-provider' },
     });
     await screen.findByText('No validated creation preset exists for this runtime and provider.');
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() => {
       expect(onNotice).toHaveBeenCalledWith({
@@ -1186,7 +1186,7 @@ describe('ProviderProfilesManager form controls', () => {
         text: 'Choose a supported authentication method.',
       });
     });
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(0);
   });
 
   it('starts a Codex OAuth session from the profile OAuth action', async () => {
@@ -1900,7 +1900,7 @@ describe('ProviderProfilesManager form controls', () => {
     expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Disable' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Create provider profile' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Create profile' })).toBeNull();
     expect(screen.queryByText('Create Provider Profile')).toBeNull();
   });
 });
@@ -2167,7 +2167,7 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     });
     await selectOpenAiApiKeyCreation();
     await screen.findByText(/Backend preset provider-profile-creation-v1 loaded/);
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     expect(
       await screen.findByRole('dialog', { name: 'OpenAI API key enrollment for codex-guided-key' }),
@@ -2223,9 +2223,9 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     fireEvent.change(screen.getByLabelText('OpenAI API key (required)'), {
       target: { value: 'db://OPENAI_API_KEY' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(fetchSpy.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(true));
     expect(
       screen.queryByRole('dialog', {
         name: 'OpenAI API key enrollment for codex-guided-existing-key',
@@ -2300,7 +2300,7 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     });
     fireEvent.click(await screen.findByLabelText('OAuth'));
     await screen.findByText(/Backend preset provider-profile-creation-v1 loaded/);
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() => expect(openSpy).toHaveBeenCalledTimes(1));
     expect(fetchSpy).toHaveBeenCalledTimes(5);
@@ -2735,7 +2735,7 @@ describe('MoonLadderStudios/MoonMind#3815 cross-boundary verification (#3822 cov
     fireEvent.click(await screen.findByLabelText('API key'));
     await screen.findByText(/Backend preset provider-profile-create-v1-test loaded/);
     fireEvent.click(screen.getByLabelText('Runtime default'));
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     // Guided API-key setup opens automatically; the checked default intent
     // must survive creation (which stores is_default=false) and apply after

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { QueryClient, useMutation } from '@tanstack/react-query';
+import { QueryClient, useMutation, useQuery } from '@tanstack/react-query';
 
 import type { components } from '../../generated/openapi';
 import { formatRuntimeLabel, formatStatusLabel } from '../../utils/formatters';
@@ -19,6 +19,7 @@ type ProviderProfileCreationPreset =
   components['schemas']['ProviderProfileCreationPresetResponse'];
 
 export interface ProviderProfile {
+  execution_configuration?: { profileId: string; version: number; digest: string } | null;
   profile_id: string;
   runtime_id: string;
   provider_id: string;
@@ -176,6 +177,7 @@ interface ProviderProfilesManagerProps {
 }
 
 interface ProviderProfileFormState {
+  executionConfiguration?: string;
   profileId: string;
   runtimeId: string;
   providerId: string;
@@ -201,6 +203,7 @@ interface ProviderProfileFormState {
 }
 
 interface ProviderProfileSavePayload {
+  execution_configuration?: { profileId: string; version: number; digest: string } | null;
   profile_id: string;
   runtime_id?: string;
   provider_id?: string;
@@ -346,6 +349,7 @@ export function defaultFormState(runtimeId = ''): ProviderProfileFormState {
 
 export function toFormState(profile: ProviderProfile): ProviderProfileFormState {
   return {
+    executionConfiguration: JSON.stringify(profile.execution_configuration || null),
     profileId: profile.profile_id,
     runtimeId: profile.runtime_id,
     providerId: profile.provider_id,
@@ -996,6 +1000,7 @@ function buildSavePayload(
       Number(baseline.cooldownAfter429Seconds),
     );
     setChanged('rate_limit_policy', form.rateLimitPolicy, baseline.rateLimitPolicy);
+    setChanged('execution_configuration', JSON.parse(form.executionConfiguration || 'null'), JSON.parse(baseline.executionConfiguration || 'null'));
     setChanged('enabled', form.enabled, baseline.enabled);
     setChanged('is_default', form.isDefault, baseline.isDefault);
     setChanged(
@@ -1020,6 +1025,7 @@ function buildSavePayload(
     return payload;
   }
 
+  if (form.executionConfiguration) payload.execution_configuration = JSON.parse(form.executionConfiguration);
   payload.runtime_id = form.runtimeId.trim();
   payload.provider_id = form.providerId.trim();
   payload.provider_label = form.providerLabel.trim() || null;
@@ -1157,6 +1163,16 @@ export function ProviderProfilesManager({
     useState<ProviderProfileCreationCapabilities | null>(null);
   const [creationCapabilitiesError, setCreationCapabilitiesError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const executionConfigurations = useQuery({
+    queryKey: ['settings', 'profile-execution-configurations'],
+    enabled: showAdvanced,
+    queryFn: async (): Promise<Array<{profileId: string; displayName: string; activeVersion: number; versions: Array<{version: number; digest: string}>}>> => {
+      const response = await fetch('/api/omnigent/agent-profiles', { credentials: 'same-origin' });
+      if (!response.ok) throw new Error('Execution configurations could not be loaded.');
+      const value = await response.json();
+      return Array.isArray(value) ? value : [];
+    },
+  });
   const [advancedFocusRequest, setAdvancedFocusRequest] = useState<
     { field: string; nonce: number } | null
   >(null);
@@ -1192,7 +1208,7 @@ export function ProviderProfilesManager({
         );
       }
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
-      onNotice({ level: 'ok', text: `Provider profile "${profileId}" is now the runtime default.` });
+      onNotice({ level: 'ok', text: `Profile "${profileId}" is now the runtime default.` });
     } catch (error) {
       onNotice({
         level: 'error',
@@ -2270,8 +2286,8 @@ export function ProviderProfilesManager({
       onNotice({
         level: 'ok',
         text: isEditing
-          ? `Provider profile "${editingProfileId}" updated.`
-          : `Provider profile "${submittedForm.profileId.trim()}" created.`,
+          ? `Profile "${editingProfileId}" updated.`
+          : `Profile "${submittedForm.profileId.trim()}" created.`,
       });
       setEditingProfileId(null);
       const nextForm = defaultFormState(createFormRuntimeSeed);
@@ -2412,7 +2428,7 @@ export function ProviderProfilesManager({
       }
     },
     onSuccess: (_data, profileId) => {
-      onNotice({ level: 'ok', text: `Provider profile "${profileId}" deleted.` });
+      onNotice({ level: 'ok', text: `Profile "${profileId}" deleted.` });
       if (editingProfileId === profileId) {
         setEditingProfileId(null);
         const nextForm = defaultFormState(createFormRuntimeSeed);
@@ -2457,7 +2473,7 @@ export function ProviderProfilesManager({
     onSuccess: (_data, variables) => {
       onNotice({
         level: 'ok',
-        text: `Provider profile "${variables.profileId}" ${
+        text: `Profile "${variables.profileId}" ${
           variables.enabled ? 'enabled' : 'disabled'
         }.`,
       });
@@ -2770,7 +2786,7 @@ export function ProviderProfilesManager({
     <section className="rounded-3xl border border-mm-border/80 bg-transparent p-6 shadow-sm">
       <div className="flex flex-col gap-3 border-b border-slate-200 dark:border-slate-800 pb-4 md:flex-row md:items-end md:justify-between">
         <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Provider Profiles</h3>
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Profiles</h3>
           <p className="max-w-3xl text-sm text-slate-600 dark:text-slate-400">
             Manage your configured provider profiles. Select a profile below to edit, or scroll down to create a new one.
           </p>
@@ -2783,7 +2799,7 @@ export function ProviderProfilesManager({
             className="font-medium text-slate-700 dark:text-slate-300"
             htmlFor={RUNTIME_FILTER_CONTROL_ID}
           >
-            Provider Profile runtime filter
+            Profile runtime filter
           </label>
           <select
             id={RUNTIME_FILTER_CONTROL_ID}
@@ -3741,7 +3757,7 @@ export function ProviderProfilesManager({
         <div className="flex flex-col gap-1 mb-6 md:flex-row md:items-end md:justify-between">
           <div>
             <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
-              {isEditing ? `Edit Profile: ${editingProfileId}` : 'Create Provider Profile'}
+              {isEditing ? `Edit Profile: ${editingProfileId}` : 'Create Profile'}
             </h3>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Fields marked <span className="text-amber-600 dark:text-amber-400 font-semibold">*</span> are
@@ -3934,7 +3950,7 @@ export function ProviderProfilesManager({
             ) : null}
             {tierCapabilities?.evidence?.stale ? (
               <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-3 text-xs text-amber-800 dark:text-amber-300">
-                Model catalog evidence is stale; observed catalog choices are disabled until the profile is revalidated. Runtime default and custom model entry remain available.
+                Model discovery is refreshing. Cached choices remain available; the runtime verifies your selected model before execution.
               </div>
             ) : null}
             {tierCapabilities?.diagnostics?.length ? (
@@ -3981,7 +3997,6 @@ export function ProviderProfilesManager({
                               <span>Model</span>
                               {(() => {
                                 const catalogOptions = tierCapabilities?.model?.options ?? [];
-                                const staleCatalog = tierCapabilities?.evidence?.stale === true;
                                 const allowCustomModel = tierCapabilities?.model?.allow_custom === true;
                                 const knownValues = new Set([
                                   '__runtime_default__',
@@ -4014,7 +4029,7 @@ export function ProviderProfilesManager({
                                     }} aria-label={`Tier ${tierNumber} model`}>
                                       <option value="__runtime_default__">Runtime default{tierCapabilities?.model?.runtime_default ? ` — ${tierCapabilities.model.runtime_default}` : ''}</option>
                                       {catalogOptions.map((opt) => (
-                                        <option key={opt.value} value={opt.value} disabled={staleCatalog && opt.value !== tier.model}>
+                                        <option key={opt.value} value={opt.value}>
                                           {opt.label}
                                           {opt.status === 'deprecated' ? ' (Deprecated)' : ''}
                                           {opt.recommended ? ' · Recommended' : ''}
@@ -4437,6 +4452,18 @@ export function ProviderProfilesManager({
 
               <fieldset className="rounded-2xl border border-slate-200 dark:border-slate-700 p-5 space-y-4">
                 <legend className="px-2 text-sm font-semibold text-slate-700 dark:text-slate-300">Advanced profile policy</legend>
+                <label>
+                  Execution configuration
+                  <select value={form.executionConfiguration || 'null'} onChange={(event) => setForm((current) => ({ ...current, executionConfiguration: event.target.value }))}>
+                    <option value="null">Automatic compatible configuration</option>
+                    {form.executionConfiguration && form.executionConfiguration !== 'null' ? <option value={form.executionConfiguration}>Saved configuration</option> : null}
+                    {(executionConfigurations.data || []).flatMap((configuration) => configuration.versions.filter((version) => version.version === configuration.activeVersion).map((version) => (
+                      <option key={configuration.profileId} value={JSON.stringify({profileId: configuration.profileId, version: version.version, digest: version.digest})}>{configuration.displayName}</option>
+                    )))}
+                  </select>
+                </label>
+                {executionConfigurations.isError ? <p role="status">Execution configurations could not be loaded. Your saved selection is preserved.</p> : null}
+                <a href="/omnigent/agents">Manage execution configurations</a>
                 <div className="grid gap-4 md:grid-cols-2">
                   <label data-advanced-field="provider_label" className="flex flex-col gap-1.5 text-sm font-medium text-slate-700 dark:text-slate-300">
                     <span>Provider label override</span>
@@ -4631,7 +4658,7 @@ export function ProviderProfilesManager({
                 ? 'Saving...'
                 : isEditing
                   ? 'Update provider profile'
-                  : 'Create provider profile'}
+                  : 'Create profile'}
             </button>
             <button
               type="button"

--- a/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
+++ b/frontend/src/components/settings/providerProfileRedesignConformance.test.tsx
@@ -460,7 +460,7 @@ describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation mat
       expect(screen.getByLabelText('Runtime default')).toBeTruthy();
       expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(false);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
       await waitFor(() =>
         expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
       );
@@ -498,7 +498,7 @@ describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation mat
     const fetchSpy = creationFetch(creationClass, profileId);
     renderManager();
     await startStandardCreation(creationClass, profileId);
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     fireEvent.click(await screen.findByRole('button', { name: 'Continue to API key paste' }));
     const keyInput = screen.getByLabelText('Anthropic API key') as HTMLInputElement;
@@ -529,7 +529,7 @@ describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation mat
     const fetchSpy = creationFetch(creationClass, profileId);
     renderManager();
     await startStandardCreation(creationClass, profileId);
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     fireEvent.click(await screen.findByRole('button', { name: 'Continue to API key paste' }));
     fireEvent.change(screen.getByLabelText('OpenCode API key'), {
@@ -560,7 +560,7 @@ describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation mat
     await startStandardCreation(creationClass, profileId);
 
     expect(screen.queryByLabelText(/Volume/)).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect(fetchSpy.mock.calls.some(([url]) => url === '/api/v1/oauth-sessions')).toBe(true),
@@ -687,7 +687,7 @@ describe('MoonLadderStudios/MoonMind#3822 Provider Profile standard-creation mat
     fireEvent.change(screen.getByLabelText('Provider API key (required)'), {
       target: { value: 'db://OPENAI_API_KEY' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),
@@ -764,7 +764,7 @@ describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts
     await startStandardCreation(creationClass, 'conformance-hidden-error');
     expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(false);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
@@ -828,7 +828,7 @@ describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts
     expect(toggle.checked).toBe(false);
     expect(document.getElementById('provider-profile-advanced-region')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
@@ -874,7 +874,7 @@ describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts
 
     renderManager();
     await startStandardCreation(creationClass, 'conformance-clear-env');
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect((screen.getByLabelText('Show advanced options') as HTMLInputElement).checked).toBe(true),
@@ -931,7 +931,7 @@ describe('MoonLadderStudios/MoonMind#3822 progressive disclosure and tier drafts
     fireEvent.change(screen.getByLabelText('Tier 2 model'), { target: { value: 'gpt-4o' } });
     fireEvent.change(screen.getByLabelText('Tier 2 effort'), { target: { value: 'high' } });
     fireEvent.click(screen.getByRole('radio', { name: 'Use Tier 2 as default' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Create provider profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     await waitFor(() =>
       expect(fetchSpy.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'POST')).toBe(true),

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -257,7 +257,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
     enabled: enabled && kind === 'agents',
     queryFn: async (): Promise<AgentProfile[]> => {
       const response = await fetch('/api/omnigent/agent-profiles', { credentials: 'same-origin' });
-      if (!response.ok) throw new Error(`Agent profiles request failed (${response.status})`);
+      if (!response.ok) throw new Error(`Execution configurations request failed (${response.status})`);
       const data: unknown = await response.json();
       return Array.isArray(data) ? data as AgentProfile[] : [];
     },
@@ -324,7 +324,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
         body = { profileId: draft.id, displayName: draft.name, version: draft.source!.activeVersion || draft.source!.versions[0]?.version };
       }
       const response = await fetch(url, { method: 'POST', credentials: 'same-origin', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-      if (!response.ok) throw new Error(`Agent profile save failed (${response.status})`);
+      if (!response.ok) throw new Error(`Execution configuration save failed (${response.status})`);
       return response.json();
     },
     onSuccess: async () => { setAgentEditor(null); await profiles.refetch(); },
@@ -533,15 +533,15 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
     </section>
     {kind === 'agents' ? <section aria-labelledby="omnigent-profiles-heading">
       <div className="omnigent-inventory__toolbar">
-        <div><p className="eyebrow">Reusable configuration</p><h2 id="omnigent-profiles-heading">Agent profiles</h2></div>
+        <div><p className="eyebrow">Reusable configuration</p><h2 id="omnigent-profiles-heading">Execution configurations</h2></div>
         <div className="actions"><button type="button" onClick={() => setAgentEditor({ mode: 'create', id: 'omnigent-opencode-default', name: 'OpenCode via Omnigent', description: '', document: '{}', preset: 'opencode', sourceRef: '', defaultModel: '', launchPolicyRef: 'omnigent-on-demand@1', workspaceMutation: 'allowed', skillsText: '', toolsText: '', captureStream: true, captureEvidence: true, continuationCheckpoint: true, continuationBranch: true, publicationMode: 'none' })}>Create Omnigent agent</button><button type="button" onClick={() => void profiles.refetch()} disabled={profiles.isFetching}>Refresh profiles</button></div>
       </div>
       <p>Immutable, validated selections used by workflows and continuations.</p>
-      {profiles.isPending ? <p role="status">Loading agent profiles…</p> : null}
+      {profiles.isPending ? <p role="status">Loading execution configurations…</p> : null}
       {profiles.isError ? <p role="alert">{profiles.error.message}</p> : null}
       {profileAction.isError ? <p role="alert">{profileAction.error.message}</p> : null}
       {agentEditor ? <form className="omnigent-policy-editor" onSubmit={(event) => { event.preventDefault(); saveAgentProfile.mutate(agentEditor); }}>
-        <h3>{agentEditor.mode === 'version' ? 'Edit as immutable new version' : agentEditor.mode === 'clone' ? 'Clone agent profile' : 'Create agent profile'}</h3>
+        <h3>{agentEditor.mode === 'version' ? 'Edit as immutable new version' : agentEditor.mode === 'clone' ? 'Clone execution configuration' : 'Create execution configuration'}</h3>
         <label><span>Profile id</span><input value={agentEditor.id} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, id: event.target.value })} required /></label>
         <label><span>Display name</span><input value={agentEditor.name} disabled={agentEditor.mode === 'version'} onChange={(event) => setAgentEditor({ ...agentEditor, name: event.target.value })} required /></label>
         <label><span>Description</span><input value={agentEditor.description} disabled={agentEditor.mode !== 'create'} onChange={(event) => setAgentEditor({ ...agentEditor, description: event.target.value })} /></label>
@@ -565,7 +565,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
         {saveAgentProfile.isError ? <p role="alert">{saveAgentProfile.error.message}</p> : null}
         <button type="submit" disabled={saveAgentProfile.isPending}>Save immutable profile version</button><button type="button" onClick={() => setAgentEditor(null)}>Cancel</button>
       </form> : null}
-      {profiles.data?.length === 0 ? <p>No persistent agent profiles are available.</p> : null}
+      {profiles.data?.length === 0 ? <p>No persistent execution configurations are available.</p> : null}
       {profiles.data?.length ? <div className="omnigent-inventory__table-wrap"><table>
         <thead><tr><th>Profile</th><th>Lifecycle</th><th>Version history</th><th>Readiness</th><th>Actions</th></tr></thead>
         <tbody>{profiles.data.map((profile) => {
@@ -573,7 +573,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
           const ready = latest?.validationResult?.ready === true;
           return <tr key={profile.profileId}>
             <td><strong>{profile.displayName}</strong><small>{profile.profileId}</small>{profile.description ? <small>{profile.description}</small> : null}</td>
-            <td>{profile.state}{profile.defaultForRuntime ? ' · Default' : ''}</td>
+            <td>{profile.state}{profile.defaultForRuntime ? ' · Deployment default' : ''}</td>
             <td>{latest ? <><span>Version {latest.version}</span><small title={latest.digest}>{latest.digest.slice(0, 18)}…</small><small>{profile.versions.length} immutable version{profile.versions.length === 1 ? '' : 's'}</small></> : 'No versions'}</td>
             <td>{ready ? 'Ready' : 'Validation required'}</td>
             <td>
@@ -584,7 +584,6 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
               <button type="button" disabled={profileAction.isPending || !ready} onClick={() => profileAction.mutate({ profile, action: 'smoke' })}>Smoke test {profile.displayName}</button>
               {latest?.document && (latest.document.source as { bundleArtifactRef?: unknown } | undefined)?.bundleArtifactRef ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'import-bundle' })}>Import bundle for {profile.displayName}</button> : null}
               {ready && (profile.state !== 'active' || latest.version !== profile.activeVersion) ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'activate' })}>Activate {profile.displayName}</button> : null}
-              {profile.state === 'active' && !profile.defaultForRuntime ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'default' })}>Make {profile.displayName} default</button> : null}
               {profile.state === 'active' ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'disable' })}>Disable {profile.displayName}</button> : null}
               {profile.state !== 'deprecated' ? <button type="button" disabled={profileAction.isPending} onClick={() => profileAction.mutate({ profile, action: 'deprecate' })}>Deprecate {profile.displayName}</button> : null}
               {profile.state === 'draft' ? <button type="button" className="destructive" disabled={profileAction.isPending} onClick={() => { if (window.confirm(`Delete unused draft ${profile.displayName}? This cannot be undone.`)) profileAction.mutate({ profile, action: 'delete' }); }}>Delete unused draft {profile.displayName}</button> : null}

--- a/frontend/src/entrypoints/settings.test.tsx
+++ b/frontend/src/entrypoints/settings.test.tsx
@@ -69,7 +69,7 @@ describe('Settings Entrypoint', () => {
   });
 });
 
-describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filter', () => {
+describe('MoonLadderStudios/MoonMind#3788 Settings Profile runtime filter', () => {
   const codexProfile = {
     profile_id: 'codex_minimax_team',
     runtime_id: 'codex_cli',
@@ -134,7 +134,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
 
   function runtimeFilterControl(): HTMLSelectElement {
     return screen.getByLabelText(
-      'Provider Profile runtime filter',
+      'Profile runtime filter',
     ) as HTMLSelectElement;
   }
 
@@ -146,7 +146,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   // assertions are scoped to the Provider Profiles table.
   function providerProfilesTable(): HTMLElement {
     const section = screen
-      .getByRole('heading', { name: 'Provider Profiles' })
+      .getByRole('heading', { name: 'Profiles' })
       .closest('section');
     expect(section).not.toBeNull();
     return within(section as HTMLElement).getByRole('table');
@@ -155,7 +155,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('fetches the complete Provider Profile collection and defaults to All runtimes', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
 
     // Settings is the administrative view, so it never scopes the request by
     // runtime the way an execution surface does.
@@ -173,7 +173,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('offers one option per available runtime using canonical IDs and formatted labels', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
 
     const control = runtimeFilterControl();
     const options = within(control)
@@ -195,7 +195,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('shows only matching rows while the global health summary keeps every loaded profile', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
 
     const healthSummary = screen.getByLabelText('Configuration health summary');
     expect(within(healthSummary).getByText('2')).toBeTruthy();
@@ -222,7 +222,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('prefills the create form runtime from the active filter without touching an existing runtime', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
 
     const runtimeIdInput = () => screen.getByLabelText(/Runtime ID/) as HTMLInputElement;
     expect(runtimeIdInput().value).toBe('');
@@ -242,7 +242,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('names the active runtime in the empty state instead of the global message', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
     expect(screen.queryByText('No provider profiles configured yet.')).toBeNull();
 
     selectRuntimeFilter('codex_cloud');
@@ -256,7 +256,7 @@ describe('MoonLadderStudios/MoonMind#3788 Settings Provider Profile runtime filt
   it('keeps runtime_id immutable while editing an existing profile', async () => {
     renderProvidersPage(payloadWithRuntimes);
 
-    await screen.findByRole('heading', { name: 'Provider Profiles' });
+    await screen.findByRole('heading', { name: 'Profiles' });
 
     selectRuntimeFilter('claude_code');
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));

--- a/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
+++ b/frontend/src/entrypoints/settingsDraftNavigation.test.tsx
@@ -165,7 +165,7 @@ describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', ()
 
     const profileId = await screen.findByLabelText(/Profile ID/) as HTMLInputElement;
     fireEvent.change(profileId, { target: { value: 'draft-profile' } });
-    fireEvent.change(screen.getByLabelText('Provider Profile runtime filter'), {
+    fireEvent.change(screen.getByLabelText('Profile runtime filter'), {
       target: { value: 'codex_cli' },
     });
     expect(screen.getByRole('dialog', { name: 'Unsaved changes' })).toBeTruthy();
@@ -310,7 +310,7 @@ describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', ()
     await waitFor(() => expect(window.location.pathname).toBe('/settings/user-workspace'));
   });
 
-  it('restores the Provider Profile runtime filter across Back and Forward navigation', async () => {
+  it('restores the Profile runtime filter across Back and Forward navigation', async () => {
     window.history.replaceState({}, '', '/settings/providers-secrets');
     renderWithClient(
       <BrowserRouter>
@@ -327,7 +327,7 @@ describe('MoonLadderStudios/MoonMind#3818 Settings draft departure contract', ()
       </BrowserRouter>,
     );
 
-    const filter = await screen.findByLabelText('Provider Profile runtime filter') as HTMLSelectElement;
+    const filter = await screen.findByLabelText('Profile runtime filter') as HTMLSelectElement;
     fireEvent.change(filter, { target: { value: 'codex_cli' } });
     await waitFor(() => expect(window.location.search).toBe('?runtime=codex_cli'));
     fireEvent.change(filter, { target: { value: 'claude_code' } });

--- a/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
+++ b/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
@@ -11,7 +11,7 @@
  * Run it on its own with `npm run ui:test:settings-redesign`.
  */
 import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import { BrowserRouter } from 'react-router-dom';
 import {
@@ -580,7 +580,7 @@ describe('MoonLadderStudios/MoonMind#3822 Settings redesign conformance', () => 
       const selected = frontendSourceTestFiles(join(process.cwd(), 'frontend', 'src')).filter(
         (file) => new RegExp(filter).test(file),
       );
-      expect(selected.map((file) => file.split('/').pop()).sort()).toEqual([
+      expect(selected.map((file) => basename(file)).sort()).toEqual([
         'providerProfileRedesignConformance.test.tsx',
         'settingsRedesignConformance.test.tsx',
       ]);

--- a/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
+++ b/frontend/src/entrypoints/settingsRedesignConformance.test.tsx
@@ -11,7 +11,7 @@
  * Run it on its own with `npm run ui:test:settings-redesign`.
  */
 import { readFileSync, readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 
 import { BrowserRouter } from 'react-router-dom';
 import {
@@ -580,7 +580,7 @@ describe('MoonLadderStudios/MoonMind#3822 Settings redesign conformance', () => 
       const selected = frontendSourceTestFiles(join(process.cwd(), 'frontend', 'src')).filter(
         (file) => new RegExp(filter).test(file),
       );
-      expect(selected.map((file) => basename(file)).sort()).toEqual([
+      expect(selected.map((file) => file.split(/[\\/]/).pop()).sort()).toEqual([
         'providerProfileRedesignConformance.test.tsx',
         'settingsRedesignConformance.test.tsx',
       ]);

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -2080,9 +2080,14 @@ describe('Workflow Detail Entrypoint', () => {
       return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
     });
 
+    // The same inventory endpoint populates workflow and branch selection.
+    const existingFetch = fetchSpy.getMockImplementation()!;
+    fetchSpy.mockImplementation((input, init) => String(input).includes('/v1/provider-profiles')
+      ? Promise.resolve({ ok: true, json: async () => [{ profile_id: 'profile-oauth-2', account_label: 'Team Profile' }] } as Response)
+      : existingFetch(input, init));
     renderWithClient(<WorkflowDetailPage payload={actionsPayload} />);
-
-    fireEvent.change(await screen.findByLabelText('Provider profile'), { target: { value: 'profile-oauth-2' } });
+    await screen.findByRole('option', { name: 'Team Profile' });
+    fireEvent.change(await screen.findByLabelText('Profile'), { target: { value: 'profile-oauth-2' } });
     fireEvent.change(screen.getByLabelText('Execution profile / launch policy'), { target: { value: 'omnigent-isolated' } });
     fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5.6-sol' } });
     fireEvent.change(screen.getByLabelText('Effort'), { target: { value: 'high' } });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -4802,17 +4802,6 @@ type BranchCreateDraft = {
   effort: string;
 };
 
-type CheckpointAgentProfileOption = {
-  profileId: string;
-  displayName: string;
-  state: string;
-  activeVersion: number | null;
-  versions: Array<{
-    version: number;
-    validationResult?: { ready?: boolean } | null;
-  }>;
-};
-
 type BranchMutationKind = 'create' | 'continue' | 'fork' | 'promote' | 'publish' | 'archive' | 'compare';
 
 type BranchMutationRequest =
@@ -5075,18 +5064,15 @@ function BranchExplorerPanel({
   onBranchAction: (request: BranchMutationRequest) => void;
   retrievalCeilings: ReturnType<typeof retrievalCeilingsFromRuntimeConfig>;
 }) {
-  const agentProfilesQuery = useQuery({
-    queryKey: ['workflow-detail', 'omnigent-agent-profiles'],
-    queryFn: async (): Promise<CheckpointAgentProfileOption[]> => {
-      const response = await fetch(`${apiBase}/omnigent/agent-profiles`, { credentials: 'include' });
-      if (!response.ok) throw new Error(await response.text() || 'Failed to load agent profiles.');
+  const profilesQuery = useQuery({
+    queryKey: ['checkpoint-branch', 'profiles'],
+    enabled: actionsEnabled,
+    queryFn: async (): Promise<Array<{ profile_id: string; account_label?: string; enabled?: boolean; launch_ready?: boolean }>> => {
+      const response = await fetch(`${apiBase}/v1/provider-profiles?include_execution=true`, { credentials: 'same-origin' });
+      if (!response.ok) throw new Error('Profiles could not be loaded.');
       const value: unknown = await response.json();
-      return Array.isArray(value) ? value as CheckpointAgentProfileOption[] : [];
+      return Array.isArray(value) ? value : [];
     },
-  });
-  const readyAgentProfiles = (agentProfilesQuery.data || []).filter((profile) => {
-    const active = (profile.versions || []).find((version) => version.version === profile.activeVersion);
-    return profile.state === 'active' && active?.validationResult?.ready === true;
   });
   const checkpointRows = rows.filter((row) => isSupportedCheckpointRef(stepCheckpointRef(row)));
   const branchGroups = useMemo(() => buildBranchGroups(branches), [branches]);
@@ -5285,31 +5271,13 @@ function BranchExplorerPanel({
             </select>
           </label>
           <label>
-            Agent profile
-            <select
-              value={draft.agentProfileId}
-              disabled={busy || agentProfilesQuery.isFetching}
-              onChange={(event) => {
-                const selected = readyAgentProfiles.find((profile) => profile.profileId === event.target.value);
-                setDraft((current) => ({
-                  ...current,
-                  agentProfileId: event.target.value,
-                  agentProfileVersion: selected?.activeVersion ?? null,
-                }));
-              }}
-            >
-              <option value="">Inherit no agent profile</option>
-              {readyAgentProfiles.map((profile) => (
-                <option key={profile.profileId} value={profile.profileId}>
-                  {profile.displayName} · v{profile.activeVersion}
-                </option>
-              ))}
+            Profile
+            <select value={draft.providerProfileRef} disabled={busy} onChange={(event) => setDraft((current) => ({ ...current, providerProfileRef: event.target.value }))}>
+              <option value="">Inherit execution Profile</option>
+              {draft.providerProfileRef && !(profilesQuery.data || []).some((profile) => profile.profile_id === draft.providerProfileRef) ? <option value={draft.providerProfileRef}>{draft.providerProfileRef} · Unavailable</option> : null}
+              {(profilesQuery.data || []).map((profile) => <option key={profile.profile_id} value={profile.profile_id}>{profile.account_label || profile.profile_id}{profile.enabled === false ? ' · Disabled' : profile.launch_ready === false ? ' · Needs setup' : ''}</option>)}
             </select>
-            {agentProfilesQuery.isError ? <span className="small" role="alert">Agent-profile readiness is unavailable.</span> : null}
-          </label>
-          <label>
-            Provider profile
-            <input value={draft.providerProfileRef} disabled={busy} placeholder="Automatic authorized profile" onChange={(event) => setDraft((current) => ({ ...current, providerProfileRef: event.target.value }))} />
+            {profilesQuery.isError ? <span role="status">Profiles could not be loaded. Your selection is preserved.</span> : null}
           </label>
           <label>
             Execution profile / launch policy

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -889,12 +889,11 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     await waitFor(() => expect(readinessRequests).toBe(2));
   });
 
-  it("MoonLadderStudios/MoonMind#3788 reports an Omnigent readiness failure instead of an empty provider-profile state", async () => {
+  it("keeps Zen and Go Profiles visible during a readiness service outage", async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "/api/omnigent/codex-catalog-readiness") {
-        // The readiness projection is the only source of Omnigent-eligible
-        // Provider Profiles, so its failure is what empties the selector.
+        // Runtime readiness is independent of configured Profile inventory.
         return Promise.resolve({
           ok: false,
           status: 503,
@@ -905,7 +904,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       if (url.startsWith("/api/v1/provider-profiles")) {
         // The ordinary profile request still succeeds, so it cannot be the
         // query that reports the failure.
-        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "zen", account_label: "OpenCode Zen", is_default: true },
+          { profile_id: "go", account_label: "OpenCode Go" },
+        ] } as Response);
       }
       if (url === "/api/omnigent/agent-profiles") {
         return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
@@ -921,11 +923,9 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       target: { value: "omnigent" },
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Failed to load provider profiles.")).toBeTruthy();
-    });
-    // Directing the operator to Settings would hide a transient outage behind a
-    // configuration error.
+    expect(await screen.findByRole("option", { name: "OpenCode Zen (Default)" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "OpenCode Go" })).toBeTruthy();
+    expect(screen.queryByText("Failed to load provider profiles.")).toBeNull();
     expect(
       screen.queryByText(/No launch-ready Provider Profiles are configured/),
     ).toBeNull();
@@ -982,7 +982,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
 
     renderWorkflowStartPage(payload);
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
 
     expect(await screen.findByText(/busy and does not support queued waiting/)).toBeTruthy();
     expect((screen.getByRole("button", { name: "Start Workflow" }) as HTMLButtonElement).disabled).toBe(true);
@@ -1022,7 +1022,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(document.activeElement).toBe(runtime);
     fireEvent.change(runtime, { target: { value: "omnigent" } });
     expect((runtime as HTMLSelectElement).value).toBe("omnigent");
-    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Exercise the Omnigent submit boundary." } });
 
     expect(await screen.findByText("Runtime: Codex via Omnigent")).toBeTruthy();
@@ -1037,28 +1037,14 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
     expect(request.payload).toMatchObject({
       targetRuntime: "omnigent",
-      agentProfile: {
-        profileId: "team-codex",
-        providerProfileRef: "oauth-1",
-        launchPolicyRef: "on-demand-v1",
-      },
-      omnigent: { executionTargetRef: "omnigent-codex-default", launchPolicyRef: "on-demand-v1" },
-      task: {
-        runtime: {
-          mode: "omnigent",
-          profileId: "oauth-1",
-          agentProfile: {
-            profileId: "team-codex",
-            providerProfileRef: "oauth-1",
-            launchPolicyRef: "on-demand-v1",
-          },
-        },
-      },
+      task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
     });
+    expect(request.payload.agentProfile).toBeUndefined();
+    expect(request.payload.omnigent).toBeUndefined();
     expect(JSON.stringify(request)).not.toMatch(/hostId|volume|credential|registrationToken|image|network|mount/i);
   });
 
-  it("follows current generic v2 readiness and submits its latest refresh", async () => {
+  it("submits the selected Profile without waiting for another catalog refresh", async () => {
     vi.mocked(navigateTo).mockClear();
     const staleDigest = `sha256:${"c".repeat(64)}`;
     const currentDigest = `sha256:${"d".repeat(64)}`;
@@ -1161,7 +1147,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(await screen.findByLabelText("Runtime"), {
       target: { value: "omnigent" },
     });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), {
+    fireEvent.change(await screen.findByLabelText("Profile"), {
       target: { value: "opencode-1" },
     });
     fireEvent.change(screen.getByLabelText("Instructions"), {
@@ -1182,18 +1168,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       (options as RequestInit | undefined)?.method === "POST",
     );
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
-    expect(request.payload.agentProfile).toEqual({
-      profileId: "omnigent-opencode-default",
-      version: 202,
-      digest: submitDigest,
-      providerProfileRef: "opencode-1",
-      launchPolicyRef: "omnigent-on-demand@1",
-    });
-    expect(request.payload.task.runtime.agentProfile).toEqual(request.payload.agentProfile);
-    expect(request.payload.omnigent).toEqual({
-      executionTargetRef: "omnigent-opencode-default@202",
-      launchPolicyRef: "omnigent-on-demand@1",
-    });
+    expect(request.payload.task.runtime.profileId).toBe("opencode-1");
+    expect(request.payload.agentProfile).toBeUndefined();
+    expect(request.payload.omnigent).toBeUndefined();
+    expect(genericReadinessRequests).toBe(1);
   });
 
   it("names the selected generic Omnigent agent when no provider profile is ready", async () => {
@@ -1268,12 +1246,12 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     });
 
     expect(await screen.findByText(
-      "No launch-ready Provider Profiles are configured for OpenCode via Omnigent. Configure one in Settings before starting this workflow.",
+      "No Profiles are configured for OpenCode via Omnigent. Configure one in Settings before starting this workflow.",
     )).toBeTruthy();
     expect(screen.queryByText(/configured for Codex CLI/)).toBeNull();
   });
 
-  it("synchronizes the execution target when the Agent Profile changes", async () => {
+  it("resolves advanced execution from the selected Profile", async () => {
     const payload = omnigentPayload();
     const initialData = payload.initialData as {
       dashboardConfig: { system: Record<string, unknown> };
@@ -1353,7 +1331,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         return Promise.resolve({ ok: true, json: async () => profiles } as Response);
       }
       if (url.startsWith("/api/v1/provider-profiles")) {
-        return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "oauth-1", account_label: "Codex", is_default: true, execution_selection: { profileId: "team-codex", launchPolicyRef: "on-demand-v1" } },
+          { profile_id: "claude-1", account_label: "Claude", execution_selection: { profileId: "team-claude", launchPolicyRef: "claude-on-demand-v1" } },
+        ] } as Response);
       }
       if (url.startsWith("/api/github/branches")) {
         return Promise.resolve(defaultBranchOptionsResponse());
@@ -1366,14 +1347,14 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       target: { value: "omnigent" },
     });
     await waitFor(() => {
-      expect((screen.getByLabelText("Agent profile") as HTMLSelectElement).value)
-        .toBe("team-codex");
+      expect((screen.getByLabelText("Profile") as HTMLSelectElement).value)
+        .toBe("oauth-1");
       expect((screen.getByLabelText("Execution target") as HTMLSelectElement).value)
         .toBe("omnigent-codex-default");
     });
 
-    fireEvent.change(screen.getByLabelText("Agent profile"), {
-      target: { value: "team-claude" },
+    fireEvent.change(screen.getByLabelText("Profile"), {
+      target: { value: "claude-1" },
     });
 
     await waitFor(() => {
@@ -1589,7 +1570,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
 
     renderWorkflowStartPage(omnigentPayload());
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
 
     const hostPolicy = await screen.findByLabelText("Host policy");
     await waitFor(() => expect((hostPolicy as HTMLSelectElement).value).toBe("on-demand-v2"));
@@ -1606,14 +1587,8 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
       String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST",
     );
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
-    expect(request.payload.omnigent).toEqual({
-      executionTargetRef: "omnigent-codex-default",
-      launchPolicyRef: "on-demand-v2",
-    });
-    expect(request.payload.agentProfile.launchPolicyRef).toBe("on-demand-v2");
-    expect(request.payload.task.runtime.agentProfile.launchPolicyRef).toBe(
-      "on-demand-v2",
-    );
+    expect(request.payload.task.runtime.profileId).toBe("oauth-1");
+    expect(request.payload.agentProfile).toBeUndefined();
   });
 
   it("keeps a historical profile version compatible for an Omnigent rerun", async () => {
@@ -1785,7 +1760,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     });
   });
 
-  it("filters mixed Provider Profiles by execution target and resets an incompatible selection", async () => {
+  it("keeps all configured Profiles visible without changing the selected account", async () => {
     const payload = omnigentPayload();
     const initialData = payload.initialData as {
       dashboardConfig: { system: Record<string, unknown> };
@@ -1821,23 +1796,23 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         return Promise.resolve({ ok: true, json: async () => [{ profile_id: "claude-oauth", account_label: "Anthropic subscription", provider_id: "anthropic" }] } as Response);
       }
       if (url.startsWith("/api/v1/provider-profiles")) {
-        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "codex-oauth", account_label: "OpenAI subscription", provider_id: "openai" }] } as Response);
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "codex-oauth", is_default: true, account_label: "OpenAI subscription", provider_id: "openai" }, { profile_id: "claude-oauth", account_label: "Anthropic subscription", provider_id: "anthropic" }] } as Response);
       }
       return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
     });
 
     renderWorkflowStartPage(payload);
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
-    const profileSelect = await screen.findByLabelText("Provider profile");
+    const profileSelect = await screen.findByLabelText("Profile");
     await waitFor(() => expect((profileSelect as HTMLSelectElement).value).toBe("codex-oauth"));
-    expect(within(profileSelect).queryByRole("option", { name: /Anthropic subscription/ })).toBeNull();
+    expect(within(profileSelect).queryByRole("option", { name: /Anthropic subscription/ })).toBeTruthy();
 
     fireEvent.change(screen.getByLabelText("Execution target"), {
       target: { value: "omnigent-claude@1" },
     });
 
-    await waitFor(() => expect((profileSelect as HTMLSelectElement).value).toBe("claude-oauth"));
-    expect(within(profileSelect).queryByRole("option", { name: /OpenAI subscription/ })).toBeNull();
+    await waitFor(() => expect((profileSelect as HTMLSelectElement).value).toBe("codex-oauth"));
+    expect(within(profileSelect).queryByRole("option", { name: /OpenAI subscription/ })).toBeTruthy();
     expect(within(profileSelect).getByRole("option", { name: /Anthropic subscription/ })).toBeTruthy();
   });
 
@@ -1845,7 +1820,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     ["deferred", "deferred_minutes", "Minutes from now", "5", { mode: "once" }],
     ["once", "once", "Scheduled For", "2099-01-01T12:00", { mode: "once", scheduledFor: new Date("2099-01-01T12:00").toISOString() }],
     ["recurring", "recurring", "Cron Expression", "0 4 * * *", { mode: "recurring", cron: "0 4 * * *", timezone: "UTC" }],
-  ])("preserves canonical Omnigent refs in %s schedule submissions", async (_label, mode, fieldLabel, fieldValue, expectedSchedule) => {
+  ])("submits one Profile identity in %s schedule submissions", async (_label, mode, fieldLabel, fieldValue, expectedSchedule) => {
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "/api/omnigent/codex-catalog-readiness") {
@@ -1869,7 +1844,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
 
     renderWorkflowStartPage(omnigentPayload());
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: `Exercise ${mode} scheduling.` } });
     fireEvent.change(screen.getByLabelText("Schedule Mode"), { target: { value: mode } });
     fireEvent.change(screen.getByLabelText(fieldLabel), { target: { value: fieldValue } });
@@ -1880,7 +1855,6 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
     expect(request.payload).toMatchObject({
       targetRuntime: "omnigent",
-      omnigent: { executionTargetRef: "omnigent-codex-default", launchPolicyRef: "on-demand-v1" },
       task: { runtime: { mode: "omnigent", profileId: "oauth-1" } },
       schedule: expectedSchedule,
     });
@@ -1910,13 +1884,13 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
 
     renderWorkflowStartPage(omnigentPayload());
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), { target: { value: "oauth-1" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Do not launch stale authority." } });
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
 
     expect(await screen.findByText("Omnigent deployment became unavailable.")).toBeTruthy();
     expect(fetchSpy.mock.calls.some(([url, options]) => String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST")).toBe(false);
-    expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe("oauth-1");
+    expect((screen.getByLabelText("Profile") as HTMLSelectElement).value).toBe("oauth-1");
     const readinessCalls = fetchSpy.mock.calls.filter(
       ([url]) => String(url) === "/api/omnigent/codex-catalog-readiness",
     );
@@ -1969,7 +1943,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(await screen.findByLabelText("Runtime"), {
       target: { value: "omnigent" },
     });
-    fireEvent.change(await screen.findByLabelText("Provider profile"), {
+    fireEvent.change(await screen.findByLabelText("Profile"), {
       target: { value: "oauth-1" },
     });
     fireEvent.change(screen.getByLabelText("Instructions"), {
@@ -5692,7 +5666,7 @@ describe.skip("Task Create Entrypoint", () => {
         "claude_code",
       );
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:claude-default");
       expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe(
         "claude-sonnet-test",
@@ -5848,7 +5822,7 @@ describe.skip("Task Create Entrypoint", () => {
         (screen.getByLabelText("Instructions") as HTMLTextAreaElement).value,
       ).toBe("Rerun from artifact-backed instructions.");
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:codex-secondary");
     });
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -6682,7 +6656,7 @@ describe.skip("Task Create Entrypoint", () => {
     expect(await screen.findByRole("heading", { name: "Edit Workflow" })).toBeTruthy();
     await waitFor(() => {
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:claude-default");
     });
 
@@ -6692,7 +6666,7 @@ describe.skip("Task Create Entrypoint", () => {
 
     await waitFor(() => {
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:codex-default");
     });
     fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -9917,7 +9891,7 @@ describe.skip("Task Create Entrypoint", () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
     expect(await screen.findByPlaceholderText("owner/repo")).not.toBeNull();
-    expect(await screen.findByLabelText("Provider profile")).not.toBeNull();
+    expect(await screen.findByLabelText("Profile")).not.toBeNull();
     expect(
       await screen.findByLabelText("Instructions"),
     ).not.toBeNull();
@@ -11544,7 +11518,7 @@ describe.skip("Task Create Entrypoint", () => {
   it("updates provider-profile options when the selected runtime changes", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
-    const providerSelect = await screen.findByLabelText("Provider profile");
+    const providerSelect = await screen.findByLabelText("Profile");
     await waitFor(() => {
       const labels = Array.from(
         (providerSelect as HTMLSelectElement).options,
@@ -21856,26 +21830,12 @@ describe("resolveDefaultProviderProfileId", () => {
 
 describe("Task Create runtime switch layout stability", () => {
   let fetchSpy: MockInstance;
-  let resolveClaudeProfiles:
-    | ((profiles: Array<Record<string, unknown>>) => void)
-    | null;
-
-  // The Runtime/Provider-profile row container is the parent of the wrapping
-  // <label> around the Runtime <select>. Its class toggles between "grid-2"
-  // (two columns / half width) and "stack" (single column / full width).
-  function runtimeRowContainer(): HTMLElement {
-    const container = screen.getByLabelText("Runtime").closest("label")
-      ?.parentElement;
-    expect(container).not.toBeNull();
-    return container as HTMLElement;
-  }
 
   beforeEach(() => {
     window.history.pushState({}, "Task Create", "/workflows/new");
     window.sessionStorage.clear();
     window.localStorage.clear();
     vi.mocked(navigateTo).mockReset();
-    resolveClaudeProfiles = null;
     fetchSpy = vi
       .spyOn(window, "fetch")
       .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -21930,20 +21890,6 @@ describe("Task Create runtime switch layout stability", () => {
           } as Response);
         }
         if (url.startsWith("/api/v1/provider-profiles")) {
-          const runtimeId = new URL(`http://localhost${url}`).searchParams.get(
-            "runtime_id",
-          );
-          if (runtimeId === "claude_code") {
-            // Hold the switched-to runtime's profiles in-flight so the test
-            // can observe the layout while the refetch is still pending.
-            return new Promise<Response>((resolve) => {
-              resolveClaudeProfiles = (profiles) =>
-                resolve({
-                  ok: true,
-                  json: async () => profiles,
-                } as Response);
-            });
-          }
           return Promise.resolve({
             ok: true,
             json: async () => [
@@ -22000,136 +21946,25 @@ describe("Task Create runtime switch layout stability", () => {
     fetchSpy.mockRestore();
   });
 
-  it("keeps the Runtime/Provider-profile row at half width while a runtime switch refetches profiles", async () => {
+  it("keeps Profile inventory and explicit selection stable when advanced runtime changes", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
-
-    // The initial runtime (codex_cli) loads two provider profiles, so the row
-    // renders as the two-column grid (half width each).
-    await screen.findByLabelText("Provider profile");
-    expect(runtimeRowContainer().className).toContain("grid-2");
-
-    // Switch to a runtime whose provider profiles are still in-flight.
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText("Runtime"), {
-        target: { value: "claude_code" },
-      });
-    });
-
-    // Regression (MM runtime-dropdown width flicker): the row must stay
-    // grid-2 during the refetch instead of collapsing to the full-width
-    // "stack" layout that hid the Provider profile field until the new
-    // profiles arrived.
-    expect(runtimeRowContainer().className).toContain("grid-2");
-    expect(runtimeRowContainer().className).not.toContain("stack");
-    expect(screen.getByLabelText("Provider profile")).toBeTruthy();
-
-    // Resolving the in-flight fetch swaps in the new runtime's profiles while
-    // the row stays at half width throughout.
-    await act(async () => {
-      resolveClaudeProfiles?.([
-        {
-          profile_id: "profile:claude-default",
-          account_label: "Claude Default",
-          is_default: true,
-        },
-      ]);
-    });
-
-    await waitFor(() => {
-      expect(runtimeRowContainer().className).toContain("grid-2");
-    });
-    expect(screen.getByLabelText("Provider profile")).toBeTruthy();
-  });
-
-  it("withholds the previous runtime's profiles while a runtime switch refetches", async () => {
-    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
-
-    // The initial runtime exposes its (Codex) profiles as selectable options.
-    await screen.findByLabelText("Provider profile");
-    expect(
-      (screen.getByLabelText("Provider profile") as HTMLSelectElement).disabled,
-    ).toBe(false);
+    const profile = await screen.findByLabelText("Profile") as HTMLSelectElement;
+    fireEvent.change(profile, { target: { value: "profile:codex-secondary" } });
+    const requests = fetchSpy.mock.calls.filter(([url]) => String(url).startsWith("/api/v1/provider-profiles")).length;
+    fireEvent.change(screen.getByLabelText("Runtime"), { target: { value: "claude_code" } });
+    expect(profile.disabled).toBe(false);
+    expect(profile.value).toBe("profile:codex-secondary");
     expect(screen.getByRole("option", { name: /Codex Default/ })).toBeTruthy();
-
-    // Switch to a runtime whose provider profiles are still in-flight.
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText("Runtime"), {
-        target: { value: "claude_code" },
-      });
-    });
-
-    // Regression (codex r3463139233): keepPreviousData keeps the previous
-    // runtime's profiles in `data` only to stabilize layout. The control must
-    // not expose those stale profiles as selectable/submittable while the new
-    // runtime's profiles are still loading.
-    const switchingSelect = screen.getByLabelText(
-      "Provider profile",
-    ) as HTMLSelectElement;
-    expect(switchingSelect.disabled).toBe(true);
-    expect(screen.queryByRole("option", { name: /Codex Default/ })).toBeNull();
-    expect(
-      screen.queryByRole("option", { name: /Codex Secondary/ }),
-    ).toBeNull();
-
-    // Once the new runtime's profiles arrive, the control re-enables with its
-    // own options.
-    await act(async () => {
-      resolveClaudeProfiles?.([
-        {
-          profile_id: "profile:claude-default",
-          account_label: "Claude Default",
-          is_default: true,
-        },
-      ]);
-    });
-
-    await waitFor(() => {
-      expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement)
-          .disabled,
-      ).toBe(false);
-    });
-    expect(screen.getByRole("option", { name: /Claude Default/ })).toBeTruthy();
-    expect(screen.queryByRole("option", { name: /Codex Default/ })).toBeNull();
-  });
-
-  it("MoonLadderStudios/MoonMind#3788 names the runtime in the empty state when it has no launch-ready profiles", async () => {
-    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
-
-    await screen.findByLabelText("Provider profile");
-
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText("Runtime"), {
-        target: { value: "claude_code" },
-      });
-    });
-
-    // The runtime-scoped refetch is still in flight, so the surface must not
-    // yet claim the runtime has no profiles.
-    expect(
-      screen.queryByText(/No launch-ready Provider Profiles are configured/),
-    ).toBeNull();
-
-    await act(async () => {
-      resolveClaudeProfiles?.([]);
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /No launch-ready Provider Profiles are configured for Claude Code\. Configure one in Settings before starting this workflow\./,
-        ),
-      ).toBeTruthy();
-    });
-    // No selector means no way to submit an incompatible profile.
-    expect(screen.queryByLabelText("Provider profile")).toBeNull();
+    expect(fetchSpy.mock.calls.filter(([url]) => String(url).startsWith("/api/v1/provider-profiles"))).toHaveLength(requests);
+    expect(screen.queryByLabelText("Agent profile")).toBeNull();
+    expect(screen.getByLabelText("Runtime").closest("details")?.open).toBe(false);
   });
 
   it("omits task effort when the selected provider profile defines a default effort", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
     const providerProfileSelect = (await screen.findByLabelText(
-      "Provider profile",
+      "Profile",
     )) as HTMLSelectElement;
     await waitFor(() => {
       expect(providerProfileSelect.value).toBe("profile:codex-default");
@@ -22166,7 +22001,7 @@ describe("Task Create runtime switch layout stability", () => {
 
     await waitFor(() => {
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:codex-default");
     });
 
@@ -22255,7 +22090,7 @@ describe("Task Create runtime switch layout stability", () => {
 
     await waitFor(() => {
       expect(
-        (screen.getByLabelText("Provider profile") as HTMLSelectElement).value,
+        (screen.getByLabelText("Profile") as HTMLSelectElement).value,
       ).toBe("profile:codex-default");
     });
 
@@ -22356,7 +22191,7 @@ describe("Task Create runtime switch layout stability", () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 
     await waitFor(() => {
-      expect((screen.getByLabelText("Provider profile") as HTMLSelectElement).value).toBe(
+      expect((screen.getByLabelText("Profile") as HTMLSelectElement).value).toBe(
         "profile:codex-default",
       );
       expect((screen.getByLabelText("Hard override model") as HTMLInputElement).value).toBe(

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -21960,6 +21960,86 @@ describe("Task Create runtime switch layout stability", () => {
     expect(screen.getByLabelText("Runtime").closest("details")?.open).toBe(false);
   });
 
+  it("submits the native runtime of the selected Profile when switching from Codex to Claude", async () => {
+    const fallback = fetchSpy.getMockImplementation()!;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "native-codex", account_label: "Native Codex", runtime_id: "codex_cli", is_default: true },
+          { profile_id: "native-claude", account_label: "Native Claude", runtime_id: "claude_code" },
+        ] } as Response);
+      }
+      return fallback(input, init);
+    });
+    const { queryClient } = renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const profile = await screen.findByLabelText("Profile") as HTMLSelectElement;
+    await waitFor(() => expect(profile.value).toBe("native-codex"));
+    expect((screen.getByLabelText("Runtime") as HTMLSelectElement).value).toBe("codex_cli");
+
+    fireEvent.change(profile, { target: { value: "native-claude" } });
+    await waitFor(() => expect((screen.getByLabelText("Runtime") as HTMLSelectElement).value).toBe("claude_code"));
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["workflow-start", "provider-profiles"] });
+    });
+    expect(profile.value).toBe("native-claude");
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Use the selected native Claude profile." } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith("/api/executions", expect.objectContaining({ method: "POST" })));
+    const request = JSON.parse(String(fetchSpy.mock.calls.find(([url]) => String(url) === "/api/executions")?.[1]?.body));
+    expect(request.payload.task.runtime).toMatchObject({ mode: "claude_code", profileId: "native-claude" });
+    expect(request).not.toHaveProperty("agentProfile");
+  });
+
+  it.each([false, true])("preserves an explicit runtime override after Profile inventory refetch (Omnigent configuration: %s)", async (configured) => {
+    const fallback = fetchSpy.getMockImplementation()!;
+    let inventoryVersion = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("/api/v1/provider-profiles")) {
+        inventoryVersion += 1;
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "runtime-profile", account_label: `Profile ${inventoryVersion}`, runtime_id: "codex_cli", is_default: true,
+            ...(configured ? { execution_selection: { profileId: "team-codex" } } : {}),
+          },
+        ] } as Response);
+      }
+      return fallback(input, init);
+    });
+    const { queryClient } = renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const profile = await screen.findByLabelText("Profile") as HTMLSelectElement;
+    await waitFor(() => expect(profile.value).toBe("runtime-profile"));
+    fireEvent.change(screen.getByLabelText("Runtime"), { target: { value: "claude_code" } });
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["workflow-start", "provider-profiles"] });
+    });
+    expect(inventoryVersion).toBe(2);
+    expect(profile.value).toBe("runtime-profile");
+    expect((screen.getByLabelText("Runtime") as HTMLSelectElement).value).toBe("claude_code");
+  });
+
+  it("keeps a Profile configuration error blocking instead of silently selecting its native runtime", async () => {
+    const fallback = fetchSpy.getMockImplementation()!;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "native-codex", account_label: "Native Codex", runtime_id: "codex_cli", is_default: true },
+          { profile_id: "pinned-claude", account_label: "Pinned Claude", runtime_id: "claude_code",
+            execution_selection_error: { message: "The pinned execution configuration is incompatible with this Profile." },
+          },
+        ] } as Response);
+      }
+      return fallback(input, init);
+    });
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    const profile = await screen.findByLabelText("Profile") as HTMLSelectElement;
+    await waitFor(() => expect(profile.value).toBe("native-codex"));
+    fireEvent.change(profile, { target: { value: "pinned-claude" } });
+    expect((screen.getByLabelText("Runtime") as HTMLSelectElement).value).toBe("codex_cli");
+    expect(await screen.findByText(/Profile cannot be submitted: The pinned execution configuration is incompatible/)).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Do not bypass the pinned configuration." } });
+    expect((screen.getByRole("button", { name: "Start Workflow" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(fetchSpy.mock.calls.some(([url]) => String(url) === "/api/executions")).toBe(false);
+  });
+
   it("omits task effort when the selected provider profile defines a default effort", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent, ReactElement } from "react";
 import { createPortal } from "react-dom";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useInRouterContext, useLocation } from "react-router-dom";
 
 import type { BootPayload } from "../boot/parseBootPayload";
@@ -547,6 +547,13 @@ interface JiraImportProvenance {
 
 interface ProviderProfile {
   profile_id: string;
+  runtime_id?: string;
+  execution_selection?: {
+    profileId: string; version: number; digest: string;
+    providerProfileRef: string; launchPolicyRef: string | null;
+    defaultForRuntime: boolean;
+  } | null;
+  execution_selection_error?: { message: string } | null;
   account_label?: string | null;
   provider_id?: string | null;
   provider_label?: string | null;
@@ -947,7 +954,9 @@ export function resolveDefaultProviderProfileId(
       return configured.profile_id;
     }
   }
-  const explicitDefault = launchableProfiles.find((profile) => profile.is_default);
+  const explicitDefault = launchableProfiles.find((profile) =>
+    profile.is_default && profile.execution_selection?.defaultForRuntime,
+  ) || launchableProfiles.find((profile) => profile.is_default);
   if (explicitDefault) {
     return explicitDefault.profile_id;
   }
@@ -6545,12 +6554,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     runtime === "omnigent" ? selectedOmnigentProviderRuntime : runtime;
   const providerProfilesQuery = useQuery({
     ...configQueryDefaults,
-    queryKey: ["workflow-start", "provider-profiles", providerProfileRuntime],
+    queryKey: ["workflow-start", "provider-profiles"],
     queryFn: async (): Promise<ProviderProfile[]> => {
       const separator = providerProfilesEndpoint.includes("?") ? "&" : "?";
-      const providerUrl = runtime === "omnigent"
-        ? providerProfilesEndpoint
-        : `${providerProfilesEndpoint}${separator}runtime_id=${encodeURIComponent(providerProfileRuntime)}`;
+      const providerUrl = `${providerProfilesEndpoint}${separator}include_execution=true`;
       const response = await fetch(
         providerUrl,
         {
@@ -6567,15 +6574,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       }
       return (await response.json()) as ProviderProfile[];
     },
-    // Omnigent eligibility comes exclusively from the readiness catalog, but
-    // the normal profile response remains the authority for model/effort
-    // capabilities. Load it for Codex and intersect the two below.
+    // Inventory is shared across runtimes and independent of discovery health.
     enabled: Boolean(runtime),
-    // Keep the previously loaded profiles visible while a runtime switch
-    // refetches. Without this, the query key change empties `data`, which
-    // collapses the Runtime/Provider-profile row from `grid-2` to `stack`
-    // (full width) until the fetch resolves and it snaps back to half width.
-    placeholderData: keepPreviousData,
   });
   const agentProfilesQuery = useQuery({
     queryKey: ["workflow-start", "omnigent-agent-profiles"],
@@ -6600,7 +6600,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       : pageMode.mode !== "create" &&
           temporalDraftQuery.data?.draft.agentProfile?.profileId === agentProfile
         ? temporalDraftQuery.data.draft.agentProfile.version || undefined
-        : undefined;
+        : providerProfilesQuery.data?.find((profile) => profile.profile_id === providerProfile)?.execution_selection?.version;
   const selectedOmnigentAgentProfileVersion =
     selectedOmnigentAgentProfile?.versions.find(
       (version) =>
@@ -6670,6 +6670,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     },
     staleTime: 0,
     refetchOnWindowFocus: true,
+    refetchInterval: 5000,
   });
   const selectedGenericOmnigentTarget = omnigentExecutionReadinessQuery.data?.executionTargets?.find(
     (target) =>
@@ -6686,37 +6687,21 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     ? selectedGenericOmnigentTarget?.agentProfileRef.digest ||
       selectedOmnigentAgentProfileVersion?.digest
     : undefined;
-  const activeProviderProfiles: ProviderProfile[] = runtime === "omnigent"
-    ? selectedProfileIsGenericV2
-      ? (selectedGenericOmnigentTarget?.compatibleProviderProfiles || []).map((profile) => {
-          const capabilityProfile = (providerProfilesQuery.data || []).find(
-            (candidate) => candidate.profile_id === profile.profileId,
-          );
-          return {
-            ...capabilityProfile,
-            profile_id: profile.profileId,
-            account_label: profile.label,
-            provider_id: profile.providerId,
-            enabled: true,
-            launch_ready: true,
-          };
-        })
-      : (omnigentCatalogQuery.data?.eligibleProviderProfiles || [])
-      .filter((profile) => profile.runtimeId === selectedOmnigentProviderRuntime)
-      .map((profile) => {
-        const capabilityProfile = (providerProfilesQuery.data || []).find(
-          (candidate) => candidate.profile_id === profile.profileId,
-        );
-        return {
-          ...capabilityProfile,
-          profile_id: profile.profileId,
-          account_label: profile.label,
-          provider_id: profile.providerId,
-          enabled: true,
-          launch_ready: true,
-        };
-      })
-    : (providerProfilesQuery.data || []);
+  // Profile inventory is independent of transient host/catalog readiness.
+  const activeProviderProfiles: ProviderProfile[] = providerProfilesQuery.data || [];
+
+  useEffect(() => {
+    const selected = activeProviderProfiles.find((profile) => profile.profile_id === providerProfile);
+    if (!selected || pageMode.mode !== "create" || remediationDraft) return;
+    const configuration = selected.execution_selection;
+    if (configuration) {
+      setRuntime("omnigent");
+      setAgentProfile(configuration.profileId);
+      if (!omnigentLaunchPolicyAuthored) {
+        setOmnigentLaunchPolicyRef(configuration.launchPolicyRef || "");
+      }
+    }
+  }, [providerProfilesQuery.data, providerProfile, pageMode.mode, remediationDraft, omnigentLaunchPolicyAuthored]);
 
   const modelTierPreviewSelections = useMemo<ModelTierPreviewSelection[]>(() => {
     if (providerProfilesQuery.isPlaceholderData) {
@@ -6839,21 +6824,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 
   useEffect(() => {
     const profiles = activeProviderProfiles;
-    if (
-      (runtime === "omnigent" && (
-        omnigentCatalogQuery.isFetching ||
-        (selectedProfileIsGenericV2 && omnigentExecutionReadinessQuery.isFetching)
-      )) ||
-      (runtime !== "omnigent" && (providerProfilesQuery.isLoading || providerProfilesQuery.isFetching))
-    ) {
-      return;
-    }
+    if (providerProfilesQuery.isPending) return;
     const resolvedProfileId = resolveLoadedProviderProfileId({
       profiles,
       providerProfile,
       configuredDefaultRef: configuredDefaultProviderProfileRef,
-      preserveUnavailableProfile:
-        pageMode.mode !== "create" && Boolean(temporalDraftAppliedRef.current),
+      preserveUnavailableProfile: Boolean(providerProfile),
     });
     if (providerProfile !== resolvedProfileId) {
       setProviderProfile(resolvedProfileId);
@@ -6885,7 +6861,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
 
     if (runtimeChanged) {
-      setProviderProfile("");
       prevRuntimeRef.current = runtime;
     }
 
@@ -8500,11 +8475,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   // placeholder data counts as unresolved too.
   const providerProfilesUnresolvedForRuntime =
     runtime === "omnigent"
-      ? omnigentCatalogQuery.isPending ||
-        omnigentCatalogQuery.isFetching ||
-        (selectedProfileIsGenericV2 &&
-          (omnigentExecutionReadinessQuery.isPending ||
-            omnigentExecutionReadinessQuery.isFetching))
+      ? providerProfilesQuery.isPending
       : providerProfilesQuery.isPending ||
         providerProfilesQuery.isPlaceholderData ||
         providerProfilesQuery.isFetching;
@@ -8513,12 +8484,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   // load failure, not an empty result. For Omnigent the list comes from the
   // readiness projections, so the ordinary profile request can succeed while
   // the user still has no profiles to choose from.
-  const providerProfilesLoadFailedForRuntime =
-    providerProfilesQuery.isError ||
-    (runtime === "omnigent" &&
-      (omnigentCatalogQuery.isError ||
-        (selectedProfileIsGenericV2 &&
-          omnigentExecutionReadinessQuery.isError)));
+  const providerProfilesLoadFailedForRuntime = providerProfilesQuery.isError;
 
   const providerOptions = [...activeProviderProfiles]
     .sort((left, right) => {
@@ -8541,6 +8507,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? profile.provider_label
           : profile.account_label || profile.profile_id,
       isDefault: Boolean(profile.is_default),
+      status: profile.enabled === false ? "Disabled" : profile.launch_ready === false ? "Needs setup" : "",
     }));
   const providerProfileScopeLabel =
     runtime === "omnigent" && selectedProfileIsGenericV2
@@ -8622,34 +8589,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           : !selectedOmnigentPolicyAvailable
             ? "Choose a compatible Omnigent host policy."
             : null);
-  const omnigentSelectionEligible =
-    runtime !== "omnigent" ||
-    ((selectedProfileIsGenericV2
-        ? selectedGenericOmnigentTarget?.available === true
-        : omnigentCatalogQuery.data?.available === true) &&
-      effectiveOmnigentReadiness?.available === true &&
-      Boolean(selectedEligibleOmnigentProfile) &&
-      selectedOmnigentPolicyAvailable &&
-      !(
-        selectedEligibleOmnigentProfile?.busy === true &&
-        selectedEligibleOmnigentProfile.queueWhenBusy !== true
-      ));
-
-  useEffect(() => {
-    if (
-      runtime !== "omnigent" || !selectedProfileIsGenericV2 ||
-      modelManualOverride || !selectedGenericOmnigentTarget?.models.length
-    ) return;
-    if (!selectedGenericOmnigentTarget.models.includes(model)) {
-      setModel(selectedGenericOmnigentTarget.models[0] || "");
-    }
-  }, [
-    model,
-    modelManualOverride,
-    runtime,
-    selectedGenericOmnigentTarget,
-    selectedProfileIsGenericV2,
-  ]);
+  const selectedConfiguredProfile = activeProviderProfiles.find((profile) => profile.profile_id === providerProfile);
+  const profileSelectionError = selectedConfiguredProfile?.execution_selection_error?.message || (
+    selectedConfiguredProfile?.enabled === false || selectedConfiguredProfile?.launch_ready === false
+      ? "Connect and enable this Profile in Settings."
+      : omnigentSelectionGateReason
+  );
+  const omnigentSelectionEligible = runtime !== "omnigent" || (
+    Boolean(selectedConfiguredProfile) && selectedConfiguredProfile?.enabled !== false &&
+    selectedConfiguredProfile?.launch_ready !== false && !selectedConfiguredProfile?.execution_selection_error &&
+    (selectedProfileIsGenericV2 || !(selectedEligibleOmnigentProfile?.busy && !selectedEligibleOmnigentProfile?.queueWhenBusy))
+  );
 
   const selectedProviderProfileForPreview = providerProfilesQuery.isPlaceholderData
     ? undefined
@@ -10428,10 +10378,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
 
     const normalizedRuntime = runtime.trim().toLowerCase();
     let submittedOmnigentLaunchPolicyRef = omnigentLaunchPolicyRef;
-    let effectiveOmnigentAgentProfileVersion =
+    const effectiveOmnigentAgentProfileVersion =
       submittedOmnigentAgentProfileVersion;
-    let effectiveOmnigentAgentProfileDigest = submittedOmnigentAgentProfileDigest;
-    let effectiveOmnigentExecutionTargetRef = omnigentExecutionTargetRef;
+    const effectiveOmnigentAgentProfileDigest = submittedOmnigentAgentProfileDigest;
+    const effectiveOmnigentExecutionTargetRef = omnigentExecutionTargetRef;
     const supportedAgentRuntimeIds = runtimeOptions.map((item) =>
       item.trim().toLowerCase(),
     );
@@ -10444,48 +10394,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (normalizedRuntime === "omnigent") {
       if (selectedProfileIsGenericV2) {
-        const refreshed = await omnigentExecutionReadinessQuery.refetch();
-        const target = refreshed.data?.executionTargets?.find(
-          (item) =>
-            item.agentProfileRef.profileId === agentProfile &&
-            (authoredOmnigentAgentProfileVersion === undefined ||
-              (item.agentProfileRef.version === selectedOmnigentAgentProfileVersion?.version &&
-                item.agentProfileRef.digest === selectedOmnigentAgentProfileVersion?.digest)),
-        );
-        if (refreshed.isError || !target?.available) {
-          setSubmitMessage(
-            target?.gateReasons[0]?.message ||
-              "Generic Omnigent readiness could not be verified.",
-          );
+        const selected = activeProviderProfiles.find((profile) => profile.profile_id === providerProfile);
+        if (!selected || selected.enabled === false || selected.launch_ready === false || selected.execution_selection_error) {
+          setSubmitMessage(selected?.execution_selection_error?.message || "Connect and enable this Profile in Settings.");
           clearSubmitBusy();
           return;
-        }
-        effectiveOmnigentAgentProfileVersion = target.agentProfileRef.version;
-        effectiveOmnigentAgentProfileDigest = target.agentProfileRef.digest;
-        effectiveOmnigentExecutionTargetRef = target.ref;
-        if (target.ref !== omnigentExecutionTargetRef) {
-          setOmnigentExecutionTargetRef(target.ref);
-        }
-        if (!target.compatibleProviderProfiles.some(
-          (profile) => profile.profileId === providerProfile,
-        )) {
-          setSubmitMessage(
-            "The selected Provider Profile is not compatible with this Agent Profile.",
-          );
-          clearSubmitBusy();
-          return;
-        }
-        if (!target.policies.includes(submittedOmnigentLaunchPolicyRef)) {
-          if (!omnigentLaunchPolicyAuthored && target.policies[0]) {
-            submittedOmnigentLaunchPolicyRef = target.policies[0];
-            setOmnigentLaunchPolicyRef(target.policies[0]);
-          } else {
-            setSubmitMessage(
-              "The selected Omnigent host policy is no longer compatible.",
-            );
-            clearSubmitBusy();
-            return;
-          }
         }
       } else {
       const refreshed = await omnigentCatalogQuery.refetch();
@@ -11636,7 +11549,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         ...(submittedModel ? { model: submittedModel } : {}),
         ...(submittedEffort ? { effort: submittedEffort } : {}),
         ...(providerProfile ? { profileId: providerProfile } : {}),
-        ...(runtime === "omnigent" && agentProfile
+        ...(runtime === "omnigent" && agentProfile && (pageMode.mode !== "create" || remediationDraft)
           ? {
               agentProfile: {
                 profileId: agentProfile,
@@ -11712,7 +11625,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           ? { requiredCapabilities: mergedCapabilities }
           : {}),
         targetRuntime: normalizedRuntime,
-        ...(normalizedRuntime === "omnigent" && agentProfile
+        ...(normalizedRuntime === "omnigent" && agentProfile && (pageMode.mode !== "create" || remediationDraft)
           ? {
               agentProfile: {
                 profileId: agentProfile,
@@ -11730,7 +11643,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               },
             }
           : {}),
-        ...(normalizedRuntime === "omnigent" && effectiveOmnigentExecutionTargetRef
+        ...(normalizedRuntime === "omnigent" && effectiveOmnigentExecutionTargetRef && (pageMode.mode !== "create" || remediationDraft)
           ? {
               omnigent: {
                 executionTargetRef: effectiveOmnigentExecutionTargetRef,
@@ -11739,7 +11652,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   : {}),
               },
             }
-          : {}),
+          : normalizedRuntime === "omnigent" && omnigentLaunchPolicyAuthored
+            ? { omnigent: { launchPolicyRef: submittedOmnigentLaunchPolicyRef } }
+            : {}),
         publishMode: effectivePublishMode,
         ...(produceReport || pageMode.mode !== "create"
           ? {
@@ -13815,7 +13730,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                         </select>
                       </label>
                       <label>
-                        {`Step ${index + 1} Provider profile`}
+                        {`Step ${index + 1} Profile`}
                         <input
                           data-step-field="runtimeProviderProfile"
                           data-step-index={String(index)}
@@ -14100,7 +14015,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           aria-label="Execution context"
         >
         <div className={providerOptions.length > 0 ? "grid-2" : "stack"}>
-          <label>
+          <details><summary>Advanced runtime</summary><label>
             Runtime
             <select
               name="runtime"
@@ -14130,44 +14045,25 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             ) : null}
           </label>
 
-          {runtime === "omnigent" ? (
-            <label>
-              Agent profile
-              <select
-                name="agentProfile"
-                value={agentProfile}
-                onChange={(event) => setAgentProfile(event.target.value)}
-                disabled={agentProfilesQuery.isFetching}
-                required
-              >
-                <option value="">Select a launch-ready agent profile</option>
-                {readyAgentProfiles.map((profile) => (
-                  <option key={profile.profileId} value={profile.profileId}>
-                    {profile.displayName}{profile.defaultForRuntime ? " (Default)" : ""} · v{profile.activeVersion}
-                  </option>
-                ))}
-              </select>
-              {agentProfilesQuery.isError ? <span className="small" role="alert">Failed to load agent profiles.</span> : null}
-              {!agentProfilesQuery.isPending && !agentProfilesQuery.isError && readyAgentProfiles.length === 0 ? (
-                <span className="small" role="alert">No launch-ready agent profile is available.</span>
-              ) : null}
-            </label>
-          ) : null}
+          </details>
 
           {providerOptions.length > 0 ? (
             <div id="queue-provider-profile-wrap">
               <label>
-                Provider profile
+                Profile
                 <select
                   name="providerProfile"
                   value={providerProfile}
-                  onChange={(event) => setProviderProfile(event.target.value)}
+                  onChange={(event) => {
+                    setProviderProfile(event.target.value);
+                    setOmnigentLaunchPolicyAuthored(false);
+                  }}
                   // While a runtime switch refetch is in flight, `keepPreviousData`
                   // keeps the previous runtime's profiles in `data` only so the row
                   // layout stays stable. Those profiles do not belong to the newly
                   // selected runtime, so the control is disabled and the stale
                   // options are withheld to prevent selecting/submitting them.
-                  disabled={runtime === "omnigent" ? omnigentCatalogQuery.isFetching || (selectedProfileIsGenericV2 && omnigentExecutionReadinessQuery.isFetching) : providerProfilesQuery.isPlaceholderData}
+                  disabled={providerProfilesQuery.isPending}
                 >
                   {runtime !== "omnigent" && providerProfilesQuery.isPlaceholderData ? (
                     <option value="">Loading profiles…</option>
@@ -14182,7 +14078,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                         <option key={option.id} value={option.id}>
                           {option.isDefault
                             ? `${option.label} (Default)`
-                            : option.label}
+                            : option.label}{option.status ? ` · ${option.status}` : ""}
                         </option>
                       ))}
                     </>
@@ -14203,7 +14099,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 </p>
               ) : (
                 <p className="small" role="alert" id="queue-provider-profile-empty">
-                  No launch-ready Provider Profiles are configured for{" "}
+                  No Profiles are configured for{" "}
                   {providerProfileScopeLabel}. Configure one in
                   Settings before starting this workflow.
                 </p>
@@ -14213,11 +14109,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         </div>
 
         {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) ? (
-          <div className="grid-2" aria-label="Omnigent execution target">
+          <details><summary>Advanced execution</summary><div className="grid-2" aria-label="Omnigent execution target">
             <label>
               Execution target
               <select
                 name="omnigentExecutionTargetRef"
+                disabled={pageMode.mode === "create" && !remediationDraft}
                 value={omnigentExecutionTargetRef}
                 onChange={(event) => {
                   const ref = event.target.value;
@@ -14264,23 +14161,23 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 ))}
               </select>
             </label>
-          </div>
+          </div></details>
         ) : null}
 
         {runtime.trim().toLowerCase() === "omnigent" ? (
           <>
-            {!omnigentSelectionEligible && omnigentSelectionGateReason ? (
+            {!omnigentSelectionEligible && profileSelectionError ? (
               <div className="notice error small" role="alert">
-                Omnigent cannot be submitted: {omnigentSelectionGateReason}
+                Omnigent cannot be submitted: {profileSelectionError}
               </div>
             ) : null}
-            <div className="notice small" aria-label="Effective Omnigent selection">
+            <details className="notice small" aria-label="Effective Omnigent selection"><summary>Execution details</summary>
               <div>Runtime: {selectedProfileIsGenericV2 ? selectedOmnigentAgentProfile?.displayName || "Omnigent" : "Codex via Omnigent"}</div>
-              <div>Provider Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || historicalOmnigentProviderProfile?.label || providerProfile || "Not selected"}</div>
+              <div>Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || historicalOmnigentProviderProfile?.label || providerProfile || "Not selected"}</div>
               <div>Host mode: {selectedOmnigentLaunchPolicy?.hostMode === "on_demand_docker" ? "On-demand Docker" : selectedOmnigentLaunchPolicy?.hostMode === "static_compose" ? "Static Compose" : "Not selected"}</div>
               <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>
               <div>Repository: {repository.trim() || "Not selected"}</div>
-            </div>
+            </details>
           </>
         ) : null}
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -6695,13 +6695,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     if (!selected || pageMode.mode !== "create" || remediationDraft) return;
     const configuration = selected.execution_selection;
     if (configuration) {
-      setRuntime("omnigent");
+      if (!runtimeAuthored) setRuntime("omnigent");
       setAgentProfile(configuration.profileId);
       if (!omnigentLaunchPolicyAuthored) {
         setOmnigentLaunchPolicyRef(configuration.launchPolicyRef || "");
       }
+    } else if (!runtimeAuthored && !selected.execution_selection_error && selected.runtime_id) {
+      setRuntime(selected.runtime_id);
     }
-  }, [providerProfilesQuery.data, providerProfile, pageMode.mode, remediationDraft, omnigentLaunchPolicyAuthored]);
+  }, [providerProfilesQuery.data, providerProfile, pageMode.mode, remediationDraft, omnigentLaunchPolicyAuthored, runtimeAuthored]);
 
   const modelTierPreviewSelections = useMemo<ModelTierPreviewSelection[]>(() => {
     if (providerProfilesQuery.isPlaceholderData) {
@@ -10377,6 +10379,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     setAttachmentTargetErrors({});
 
     const normalizedRuntime = runtime.trim().toLowerCase();
+    if (selectedConfiguredProfile?.execution_selection_error) {
+      setSubmitMessage(selectedConfiguredProfile.execution_selection_error.message);
+      clearSubmitBusy();
+      return;
+    }
     let submittedOmnigentLaunchPolicyRef = omnigentLaunchPolicyRef;
     const effectiveOmnigentAgentProfileVersion =
       submittedOmnigentAgentProfileVersion;
@@ -12050,7 +12057,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     pageMode.mode !== "create" &&
     (temporalDraftQuery.isLoading || Boolean(modeLoadError));
   const isSubmitBlocked =
-    isTemporalFormBlocked || (runtime === "omnigent" && !omnigentSelectionEligible);
+    isTemporalFormBlocked || Boolean(selectedConfiguredProfile?.execution_selection_error) ||
+    (runtime === "omnigent" && !omnigentSelectionEligible);
 
   useEffect(() => {
     if (!showPrimaryCtaArrow || isTemporalFormBlocked) {
@@ -14056,13 +14064,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   value={providerProfile}
                   onChange={(event) => {
                     setProviderProfile(event.target.value);
+                    setRuntimeAuthored(false);
                     setOmnigentLaunchPolicyAuthored(false);
                   }}
-                  // While a runtime switch refetch is in flight, `keepPreviousData`
-                  // keeps the previous runtime's profiles in `data` only so the row
-                  // layout stays stable. Those profiles do not belong to the newly
-                  // selected runtime, so the control is disabled and the stale
-                  // options are withheld to prevent selecting/submitting them.
                   disabled={providerProfilesQuery.isPending}
                 >
                   {runtime !== "omnigent" && providerProfilesQuery.isPlaceholderData ? (
@@ -14164,6 +14168,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           </div></details>
         ) : null}
 
+        {runtime !== "omnigent" && selectedConfiguredProfile?.execution_selection_error ? (
+          <div className="notice error small" role="alert">
+            Profile cannot be submitted: {selectedConfiguredProfile.execution_selection_error.message}
+          </div>
+        ) : null}
         {runtime.trim().toLowerCase() === "omnigent" ? (
           <>
             {!omnigentSelectionEligible && profileSelectionError ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -10905,6 +10905,15 @@ export interface components {
             visibility: "private" | "workspace" | "public";
             document: components["schemas"]["AgentProfileDocument"];
         };
+        /** ProfileExecutionConfiguration */
+        ProfileExecutionConfiguration: {
+            /** Profileid */
+            profileId: string;
+            /** Version */
+            version: number;
+            /** Digest */
+            digest: string;
+        };
         /** ProviderApiKeySetupRequest */
         ProviderApiKeySetupRequest: {
             /** Api Key */
@@ -11002,6 +11011,7 @@ export interface components {
         };
         /** ProviderProfileCreate */
         ProviderProfileCreate: {
+            execution_configuration?: components["schemas"]["ProfileExecutionConfiguration"] | null;
             /** Profile Id */
             profile_id: string;
             /** Runtime Id */
@@ -11202,6 +11212,15 @@ export interface components {
         ProviderProfileResponse: {
             /** Profile Id */
             profile_id: string;
+            execution_configuration?: components["schemas"]["ProfileExecutionConfiguration"] | null;
+            /** Execution Selection */
+            execution_selection?: {
+                [key: string]: unknown;
+            } | null;
+            /** Execution Selection Error */
+            execution_selection_error?: {
+                [key: string]: unknown;
+            } | null;
             /** Runtime Id */
             runtime_id: string;
             /** Provider Id */
@@ -11389,6 +11408,7 @@ export interface components {
         };
         /** ProviderProfileUpdate */
         ProviderProfileUpdate: {
+            execution_configuration?: components["schemas"]["ProfileExecutionConfiguration"] | null;
             /** Provider Id */
             provider_id?: string | null;
             /** Provider Label */
@@ -15728,6 +15748,7 @@ export interface operations {
             query?: {
                 runtime_id?: string | null;
                 enabled_only?: boolean;
+                include_execution?: boolean;
             };
             header?: never;
             path?: never;

--- a/moonmind/omnigent/bootstrap/provider_revalidation.py
+++ b/moonmind/omnigent/bootstrap/provider_revalidation.py
@@ -104,12 +104,8 @@ def evidence_observation_is_current(
     publishes afterwards -- contributor tiers included -- would never reach
     selection, readiness, or admission on an otherwise unchanged deployment.
 
-    Every boundary that admits an OpenCode target answers this same question:
-    the bootstrap reconciler, the execution-readiness catalog, pre-session
-    planning, and smoke admission. Enforcing the interval in the reconciler
-    alone would leave the other three advertising and launching from a catalog
-    the provider has since changed -- including a model it has removed --
-    whenever a refresh has not yet succeeded.
+    This interval schedules discovery refreshes. It does not authorize or block
+    execution: the actual host verifies the selected model before session start.
     """
 
     from moonmind.omnigent.settings import opencode_model_catalog_max_age
@@ -574,15 +570,19 @@ async def _revalidate_stale_evidence(
         OpenCodeProviderRuntimeValidationService,
     )
     from moonmind.omnigent.production import build_omnigent_secret_resolver
+    from moonmind.omnigent.settings import opencode_model_catalog_max_age
     from moonmind.provider_profiles.lease_client import CredentialLeasePurpose
     from moonmind.provider_profiles.maintenance import (
         acquire_credential_maintenance_guard,
     )
 
+    interval = opencode_model_catalog_max_age()
+    refresh_lead = min(timedelta(minutes=5), interval / 10) if interval else timedelta(0)
+    refresh_at = datetime.now(UTC) + refresh_lead
     stale = [
         profile
         for profile in profiles
-        if not evidence_is_current(profile, image_ref=image_ref)
+        if not evidence_is_current(profile, image_ref=image_ref, now=refresh_at)
     ]
     if not stale:
         return ProviderReconcileOutcome(ready=True, checked=checked)
@@ -786,6 +786,13 @@ async def _persist_evidence(
             == "none@1"
         )
         readiness = dict(behavior.get("auth_readiness") or {})
+        previously_connected = profile.auth_state == ProviderProfileAuthState.CONNECTED
+        if previously_connected and not launchable:
+            # Discovery is advisory for an enrolled credential. A missing model
+            # in a refresh must not revoke credential authority or hide a Profile.
+            profile.command_behavior = behavior
+            await session.commit()
+            return launchable
         readiness.update(
             {
                 "connected": launchable,
@@ -851,14 +858,8 @@ async def _record_revalidation_failure(
             "exhausted": attempts + 1 >= MAX_REVALIDATION_ATTEMPTS,
             "lastAttemptAt": datetime.now(UTC).isoformat(),
         }
-        readiness = dict(behavior.get("auth_readiness") or {})
-        readiness.update(
-            {
-                "launch_ready": False,
-                "failure_reason": "Pinned OpenCode runtime validation failed.",
-            }
-        )
-        behavior["auth_readiness"] = readiness
+        # A failed catalog probe is not evidence that the credential is invalid.
+        # Keep the last authenticated state; the execution host validates again.
         profile.command_behavior = behavior
         await session.commit()
 

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -412,11 +412,9 @@ class OmnigentExecutionPlanningService:
                 requested_host_mode=policy.hostMode,
                 requested_host_class_ref=self._requested_host_class_ref(request),
             )
-            self._verify_model_evidence(
-                provider_profile,
-                model,
-                expected_image_ref=host_class.imageRef,
-            )
+            # Discovery is advisory. The actual host attests the selected model
+            # before session creation; a cached observation cannot grant or
+            # revoke that authority, including after an image update.
             if str(effective_launch.get("hostImageRef") or "") != (
                 host_class.imageRef
             ):
@@ -715,23 +713,15 @@ class OmnigentExecutionPlanningService:
         explicit_effort = (
             omnigent.get("effort") if isinstance(omnigent, Mapping) else None
         )
-        profile_model = profile.model
-        profile_default = str(
-            profile_model.get("qualifiedId") or profile_model.get("model") or ""
-        ).strip()
-        profile_effort = str(profile_model.get("effort") or "").strip() or None
         try:
             resolved = resolve_model_effort(
                 runtime_id=provider.runtime_id,
                 profile=provider,
-                # Supplying the Agent Profile value as the requested value
-                # gives the product-defined precedence while retaining the
-                # canonical Provider Profile tier/default/runtime resolver.
-                requested_model=explicit_model or profile_default or None,
+                requested_model=explicit_model or None,
                 requested_effort=(
                     str(explicit_effort).strip()
                     if explicit_effort is not None
-                    else profile_effort
+                    else request.parameters.get("effort")
                 ),
             )
         except ValueError as exc:
@@ -753,70 +743,6 @@ class OmnigentExecutionPlanningService:
             )
         effort = str(resolved.effort or "").strip() or None
         return qualified, effort, provider.provider_id
-
-    @staticmethod
-    def _verify_model_evidence(
-        provider: Any,
-        qualified_model: str,
-        *,
-        expected_image_ref: str,
-    ) -> None:
-        from moonmind.omnigent.bootstrap.provider_revalidation import (
-            evidence_observation_is_current,
-        )
-
-        evidence = provider.model_catalog_evidence_json
-        if not isinstance(evidence, Mapping):
-            raise HarnessPlatformError(
-                "Provider Profile has no runtime-backed model catalog evidence",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
-        try:
-            evidence_generation = int(evidence.get("credentialGeneration") or 0)
-        except (TypeError, ValueError):
-            evidence_generation = 0
-        if evidence_generation != int(provider.credential_generation):
-            raise HarnessPlatformError(
-                "Provider Profile model evidence belongs to a stale credential generation",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
-        if str(evidence.get("imageRef") or "") != expected_image_ref:
-            raise HarnessPlatformError(
-                "Provider Profile model evidence belongs to a different host image",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
-        if not evidence_observation_is_current(evidence):
-            # The credential generation and image digest of a healthy
-            # deployment never change on their own, so identity alone would let
-            # this boundary launch from the first catalog it ever observed --
-            # including a model the provider has since removed. The bootstrap
-            # reconciler re-probes on the same interval; refusing here is what
-            # makes that refresh authoritative instead of advisory.
-            raise HarnessPlatformError(
-                "Provider Profile model evidence is older than the configured "
-                "model catalog refresh interval",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
-        raw_models = evidence.get("models")
-        if not isinstance(raw_models, list):
-            raise HarnessPlatformError(
-                "Provider Profile model catalog evidence is invalid",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
-        available = {
-            str(
-                item.get("qualifiedId") or item.get("id") or ""
-                if isinstance(item, Mapping)
-                else item
-            ).strip()
-            for item in raw_models
-            if isinstance(item, (str, Mapping))
-        }
-        if qualified_model not in available:
-            raise HarnessPlatformError(
-                f"selected model {qualified_model} is absent from runtime-backed evidence",
-                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
-            )
 
     @staticmethod
     def _require_durable_legacy_authority(document: Mapping[str, Any]) -> None:

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -227,7 +227,7 @@ class GenericOmnigentHostRealizer:
             await self._notify_execution_state(
                 workflow_id,
                 "launching",
-                "Provider Profile capacity acquired.",
+                "Preparing runtime: validating the execution host and selected model.",
             )
             materializers = {
                 slot: value.materializerRef

--- a/tests/integration/api/test_profile_configuration_migration.py
+++ b/tests/integration/api/test_profile_configuration_migration.py
@@ -1,0 +1,87 @@
+"""Replay the persisted discovery regression through the real Alembic migration."""
+
+import importlib
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def test_profile_cutover_preserves_identity_credentials_and_operator_state(tmp_path):
+    module = importlib.import_module(
+        "api_service.migrations.versions.371_profile_execution_config"
+    )
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'profiles.db'}")
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "managed_agent_provider_profiles",
+        metadata,
+        sa.Column("profile_id", sa.String(), primary_key=True),
+        sa.Column("auth_state", sa.String()),
+        sa.Column("enabled", sa.Boolean()),
+        sa.Column("command_behavior", sa.JSON()),
+        sa.Column("secret_refs", sa.JSON()),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        for name, state, enabled, reason in (
+            ("zen", "connected", True, "Pinned OpenCode runtime validation failed."),
+            (
+                "go",
+                "connected",
+                True,
+                "The selected model was not observed by the pinned OpenCode runtime.",
+            ),
+            (
+                "disabled",
+                "connected",
+                False,
+                "Pinned OpenCode runtime validation failed.",
+            ),
+            ("invalid", "error", True, "Authentication rejected."),
+        ):
+            connection.execute(
+                table.insert().values(
+                    profile_id=name,
+                    auth_state=state,
+                    enabled=enabled,
+                    command_behavior={
+                        "auth_readiness": {
+                            "launch_ready": False,
+                            "failure_reason": reason,
+                        }
+                    },
+                    secret_refs={"api_key": "db://existing-binding"},
+                )
+            )
+        with Operations.context(MigrationContext.configure(connection)):
+            module.upgrade()
+        migrated = sa.Table(table.name, sa.MetaData(), autoload_with=connection)
+        rows = {
+            row["profile_id"]: row
+            for row in connection.execute(sa.select(migrated)).mappings()
+        }
+        assert set(rows) == {"zen", "go", "disabled", "invalid"}
+        for name in ("zen", "go", "disabled"):
+            assert (
+                "launch_ready" not in rows[name]["command_behavior"]["auth_readiness"]
+            )
+        assert rows["disabled"]["enabled"] is False
+        assert (
+            rows["invalid"]["command_behavior"]["auth_readiness"]["launch_ready"]
+            is False
+        )
+        assert all(row["execution_configuration"] is None for row in rows.values())
+        assert all(
+            row["secret_refs"] == {"api_key": "db://existing-binding"}
+            for row in rows.values()
+        )
+        with Operations.context(MigrationContext.configure(connection)):
+            module.downgrade()
+        assert "execution_configuration" not in {
+            column["name"] for column in sa.inspect(connection).get_columns(table.name)
+        }
+    engine.dispose()

--- a/tests/integration/reliability_journey/test_omnigent_cumulative_remediation_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_cumulative_remediation_journey.py
@@ -143,7 +143,11 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
     app.dependency_overrides[_get_service] = lambda: service
     app.dependency_overrides[get_temporal_client] = AsyncMock
     provider_profile = SimpleNamespace(
-        profile_id="omnigent-codex", provider_id="openai"
+        profile_id="omnigent-codex",
+        provider_id="openai",
+        runtime_id="codex_cli",
+        default_model="gpt-5",
+        default_effort="high",
     )
     db_session = SimpleNamespace(
         get=AsyncMock(return_value=provider_profile),
@@ -227,6 +231,9 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
     assert authored["targetRuntime"] == "omnigent"
     assert authored["omnigent"]["executionTargetRef"] == "omnigent-host-codex"
     assert authored["workflow"]["runtime"]["executionProfileRef"] == "omnigent-codex"
+    assert authored["model"] == "gpt-5"
+    assert authored["effort"] == "high"
+    assert authored["modelSource"] == "provider_profile_default"
     assert authored["agentProfileSnapshot"]["profileId"] == (
         "omnigent-bootstrap-default"
     )
@@ -268,6 +275,8 @@ async def test_normal_create_c0_c1_c2_survives_destroyed_attempts_and_restarts(
     assert compiled.agent_kind == "external"
     assert compiled.agent_id == "omnigent"
     assert compiled.execution_profile_ref == "omnigent-codex"
+    assert compiled.parameters["model"] == "gpt-5"
+    assert compiled.parameters["effort"] == "high"
     assert "executionPlanRef" not in compiled.parameters
     assert compiled.parameters["omnigent"]["executionTargetRef"] == (
         "omnigent-host-codex"

--- a/tests/integration/workflows/temporal/test_checkpoint_branch_turn_execution.py
+++ b/tests/integration/workflows/temporal/test_checkpoint_branch_turn_execution.py
@@ -32,6 +32,9 @@ from api_service.db.base import get_async_session
 from api_service.db.models import (
     Base,
     ManagedAgentProviderProfile,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileUsage,
+    OmnigentAgentProfileVersion,
     OmnigentPolicy,
     OmnigentPolicyVersion,
     ProviderCredentialSource,
@@ -918,10 +921,61 @@ async def test_public_root_continue_and_fork_cross_the_real_execution_owner(
         created_at=now,
         updated_at=now,
     )
+    from api_service.api.routers.omnigent_agent_profiles import AgentProfileDocument
+    from moonmind.provider_profiles.isolation_policy import derive_isolation_policy
+
+    configuration_document = AgentProfileDocument.model_validate({
+        "endpointRef": "default",
+        "bridgeMode": "proxy",
+        "source": {
+            "bundleArtifactRef": "artifact://checkpoint-owner-agent-bundle",
+            "bundleDigest": "sha256:" + "b" * 64,
+        },
+        "harness": "codex-native",
+        "requiredCapabilities": ["session.start"],
+        "execution": {
+            "defaultExecutionProfileRef": "omnigent-codex@1",
+            "allowedLaunchPolicyRefs": ["codex-on-demand@1"],
+        },
+        "providerRequirements": {
+            "runtimeId": "codex_cli",
+            "providerIds": ["openai"],
+            "credentialSource": "oauth_volume",
+            "materializationMode": "oauth_home",
+        },
+        "policyRef": policy["policyRef"],
+    }).model_dump(mode="json", by_alias=True, exclude_none=True)
+    configuration_digest = "sha256:" + hashlib.sha256(
+        json.dumps(configuration_document, sort_keys=True).encode()
+    ).hexdigest()
+    isolation = derive_isolation_policy(
+        runtime_id="codex_cli", provider_id="openai", authentication_method="oauth",
+        credential_source="oauth_volume", runtime_materialization_mode="oauth_home",
+    )
+    assert isolation is not None
     async with sessions() as session:
         session.add_all(
             [
                 record,
+                OmnigentAgentProfile(
+                    profile_id="checkpoint-owner-configuration",
+                    display_name="Checkpoint owner execution configuration",
+                    visibility="workspace",
+                    state="active",
+                    active_version=1,
+                    default_for_runtime=True,
+                ),
+                OmnigentAgentProfileVersion(
+                    profile_id="checkpoint-owner-configuration",
+                    version=1,
+                    digest=configuration_digest,
+                    document=configuration_document,
+                    validation_result={"ready": True},
+                    rollout_metadata={"bundleImport": {
+                        "status": "succeeded",
+                        "upstreamAgent": {"id": "checkpoint-owner-agent"},
+                    }},
+                ),
                 ManagedAgentProviderProfile(
                     profile_id="profile-1",
                     runtime_id="codex_cli",
@@ -937,6 +991,7 @@ async def test_public_root_continue_and_fork_cross_the_real_execution_owner(
                     last_auth_method=ProviderProfileAuthMethod.OAUTH_VOLUME,
                     default_model="gpt-test",
                     default_effort="high",
+                    clear_env_keys=list(isolation.keys),
                 ),
                 OmnigentPolicy(
                     policy_id=policy["policyId"],
@@ -1551,6 +1606,36 @@ async def test_public_root_continue_and_fork_cross_the_real_execution_owner(
     requests_by_turn = {
         request.correlation_id: request for request in ledger.requests
     }
+    async with sessions() as session:
+        artifacts = artifact_service(session)
+        for request in ledger.requests:
+            step = request.step_execution
+            assert step is not None
+            assert "agentProfileSnapshot" not in step.runtime_selection
+            assert "agentProfileSnapshot" not in request.parameters
+            assert step.runtime_selection["agentProfile"] == {
+                "profileId": "checkpoint-owner-configuration",
+                "version": 1,
+                "digest": configuration_digest,
+            }
+            assert step.runtime_selection["providerProfileRef"] == "profile-1"
+            assert step.runtime_selection["model"] == "gpt-test"
+            assert step.runtime_selection["effort"] == "high"
+            _artifact, context_bytes = await artifacts.read(
+                artifact_id=step.context_bundle_ref.removeprefix("artifact://"),
+                principal=principal,
+                allow_restricted_raw=True,
+            )
+            assert "sha256:" + hashlib.sha256(context_bytes).hexdigest() == step.context_bundle_digest
+            context = json.loads(context_bytes)
+            snapshot = context["runtimeSelection"]["agentProfileSnapshot"]
+            assert snapshot["document"]["providerRequirements"]["credentialSource"] == "oauth_volume"
+            usage = await session.scalar(select(OmnigentAgentProfileUsage).where(
+                OmnigentAgentProfileUsage.consumer_type == "checkpoint",
+                OmnigentAgentProfileUsage.consumer_id == context["branchId"],
+            ))
+            assert usage is not None
+            assert usage.effective_snapshot == snapshot
     assert set(requests_by_turn) == {
         root_turn_id,
         continue_turn_id,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -6925,7 +6925,9 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
     test_client, service, _user = client
     service.create_execution.return_value = _build_execution_record()
     provider_profile = SimpleNamespace(
-        profile_id="codex-openai-oauth", provider_id="openai"
+        profile_id="codex-openai-oauth", provider_id="openai", runtime_id="codex_cli",
+        default_model="vendor/" + "future-model-" * 16,
+        default_effort="future-provider-effort",
     )
     db_session = SimpleNamespace(
         get=AsyncMock(side_effect=[provider_profile, None]),
@@ -7011,6 +7013,8 @@ def test_create_workflow_omnigent_browser_payload_persists_canonical_intent(
     ]
     assert initial_parameters["targetRuntime"] == "omnigent"
     assert initial_parameters["requestType"] == "task"
+    assert initial_parameters["model"] == provider_profile.default_model
+    assert initial_parameters["effort"] == provider_profile.default_effort
     assert initial_parameters["omnigent"] == {
         "executionTargetRef": "omnigent-codex@1",
         "launchPolicyRef": "codex-on-demand@1",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -18195,7 +18195,12 @@ def _mm3788_client(profile: SimpleNamespace) -> Iterator[tuple[TestClient, Async
         async def scalar(self, _stmt: object) -> object | None:
             # No Omnigent Agent Profile authority is seeded, so the Omnigent
             # selection service is the one that rejects an Omnigent submission.
+            if _stmt.column_descriptions[0].get("entity") is ManagedAgentProviderProfile:
+                return profile
             return None
+
+        async def execute(self, _stmt):
+            return SimpleNamespace(all=lambda: [])
 
     app.dependency_overrides[get_async_session] = lambda: _Session()
     _override_temporal_client(app)
@@ -18316,7 +18321,7 @@ def test_mm3788_create_execution_leaves_omnigent_compatibility_to_the_selection_
     # mismatch: the submission proceeds into the Omnigent selection service,
     # which owns compatibility against the selected execution target.
     assert response.status_code == 409
-    assert response.json()["detail"] == "default Omnigent Agent Profile is unavailable"
+    assert response.json()["detail"]["code"] == "profile_execution_configuration_required"
     service.create_execution.assert_not_awaited()
 
 

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -424,10 +424,7 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
     assert enabled_target.compatible_host_classes == ["omnigent-opencode@1"]
     assert enabled_target.models == ["opencode-go/test-model"]
 
-    # The pinned host image refreshes its catalog from the provider at probe
-    # time, so an observation older than the configured interval no longer
-    # describes the provider's current models. Advertising a target from it
-    # would keep offering a model the provider may have removed.
+    # Expiry updates discovery, never profile inventory or launch authority.
     provider.model_catalog_evidence_json["validatedAt"] = (
         datetime.now(UTC) - timedelta(hours=9)
     ).isoformat()
@@ -435,12 +432,12 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
         session=Session(), current_user=current_user
     )
     expired_target = expired.execution_targets[0]
-    assert expired_target.available is False
-    assert expired_target.models == []
+    assert expired_target.available is True
+    assert expired_target.models == ["opencode-go/test-model"]
     expired_codes = {reason.code for reason in expired_target.gate_reasons}
     # Connected and enrolled: this is a bounded re-validation wait, not a
     # request to reconnect a profile that is already connected.
-    assert "provider_runtime_revalidation_pending" in expired_codes
+    assert "provider_runtime_revalidation_pending" not in expired_codes
     assert "compatible_provider_profile_unavailable" not in expired_codes
 
     # ``0`` disables the interval and restores identity-only staleness.
@@ -452,7 +449,7 @@ async def test_generic_readiness_requires_both_feature_gates_and_real_launch_dat
 
 
 @pytest.mark.asyncio
-async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconnect(
+async def test_catalog_identity_changes_do_not_hide_configured_profiles(
     monkeypatch,
 ):
     """A connected profile awaiting re-validation must not read as unconnected."""
@@ -581,9 +578,9 @@ async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconne
         session=Session(stale_provider), current_user=current_user
     )
     stale_target = stale.execution_targets[0]
-    assert stale_target.available is False
+    assert stale_target.available is True
     codes = {reason.code for reason in stale_target.gate_reasons}
-    assert "provider_runtime_revalidation_pending" in codes
+    assert "provider_runtime_revalidation_pending" not in codes
     assert "compatible_provider_profile_unavailable" not in codes
 
     # A profile that was never runtime-validated still needs an operator action.
@@ -601,7 +598,7 @@ async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconne
         session=Session(never_validated), current_user=current_user
     )
     fresh_codes = {reason.code for reason in fresh.execution_targets[0].gate_reasons}
-    assert "compatible_provider_profile_unavailable" in fresh_codes
+    assert "compatible_provider_profile_unavailable" not in fresh_codes
     assert "provider_runtime_revalidation_pending" not in fresh_codes
 
     # A credential the pinned runtime keeps rejecting needs an operator, so the
@@ -638,7 +635,7 @@ async def test_stale_host_image_evidence_reports_revalidation_instead_of_reconne
     exhausted_codes = {
         reason.code for reason in exhausted.execution_targets[0].gate_reasons
     }
-    assert "compatible_provider_profile_unavailable" in exhausted_codes
+    assert "compatible_provider_profile_unavailable" not in exhausted_codes
     assert "provider_runtime_revalidation_pending" not in exhausted_codes
 
 

--- a/tests/unit/api/routers/test_recurring_workflows.py
+++ b/tests/unit/api/routers/test_recurring_workflows.py
@@ -575,25 +575,36 @@ async def test_mm3788_create_route_accepts_a_profile_owned_by_the_target_runtime
 
 
 @pytest.mark.asyncio
-async def test_mm3788_create_route_defers_omnigent_compatibility_to_selection(
+async def test_create_route_preserves_missing_execution_configuration_error(
     tmp_path: Path,
 ) -> None:
-    """An Omnigent target is not a runtime mismatch; selection owns that check."""
+    """Omnigent selection rejects missing authority before schedule persistence."""
 
     user = SimpleNamespace(id=uuid4(), is_superuser=False)
 
     async with _mm3788_session(tmp_path) as session:
-        created = await recurring_router.create_recurring_workflow(
-            payload=_mm3788_create_payload(
-                _mm3788_route_target(
-                    target_runtime="omnigent", profile_id="codex_minimax_team"
-                )
-            ),
-            service=_mm3788_service(session),
-            user=user,
-        )
+        service = _mm3788_service(session)
+        with pytest.raises(HTTPException) as excinfo:
+            await recurring_router.create_recurring_workflow(
+                payload=_mm3788_create_payload(
+                    _mm3788_route_target(
+                        target_runtime="omnigent", profile_id="codex_minimax_team"
+                    )
+                ),
+                service=service,
+                user=user,
+            )
 
-        assert created.target["initialParameters"]["targetRuntime"] == "omnigent"
+        assert excinfo.value.status_code == status.HTTP_409_CONFLICT
+        assert excinfo.value.detail["code"] == "profile_execution_configuration_required"
+        assert excinfo.value.detail["profileId"] == "codex_minimax_team"
+        service._adapter.create_schedule.assert_not_awaited()
+        # Match the failed request's session cleanup before reading durable state.
+        await session.rollback()
+        stored = (
+            await session.execute(select(RecurringWorkflowDefinition))
+        ).scalars().all()
+        assert stored == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -19,6 +19,8 @@ from api_service.db.models import (
     ManagedAgentProviderProfile,
     ManagedAgentRateLimitPolicy,
     ManagedSecret,
+    OmnigentAgentProfile,
+    OmnigentAgentProfileVersion,
     ProviderCredentialSource,
     ProviderProfileAuthMethod,
     ProviderProfileAuthState,
@@ -3381,6 +3383,136 @@ async def test_update_profile(client_app: AsyncClient, _module_db):
     data = response.json()
     assert data["max_parallel_runs"] == 10
     assert data["enabled"] is False
+
+
+async def _seed_profile_with_execution_configuration() -> tuple[str, dict, dict]:
+    profile_id = f"pinned-update-{uuid4().hex}"
+    pins = []
+    async with db_base.async_session_maker() as session:
+        for index, (provider_id, source, mode) in enumerate(
+            (("original", "secret_ref", "api_key_env"), ("replacement", "oauth_volume", "oauth_home"))
+        ):
+            configuration_id = f"{profile_id}-configuration-{index}"
+            digest = "sha256:" + str(index + 1) * 64
+            session.add(OmnigentAgentProfile(
+                profile_id=configuration_id,
+                display_name=configuration_id,
+                visibility="shared",
+                state="active",
+                active_version=1,
+            ))
+            session.add(OmnigentAgentProfileVersion(
+                profile_id=configuration_id,
+                version=1,
+                digest=digest,
+                validation_result={"ready": True},
+                document={
+                    "providerRequirements": {
+                        "runtimeId": "pin_update_runtime",
+                        "providerIds": [provider_id],
+                        "credentialSource": source,
+                        "materializationMode": mode,
+                    },
+                },
+            ))
+            pins.append({"profileId": configuration_id, "version": 1, "digest": digest})
+        session.add(ManagedAgentProviderProfile(
+            profile_id=profile_id,
+            runtime_id="pin_update_runtime",
+            provider_id="original",
+            credential_source=ProviderCredentialSource.SECRET_REF,
+            runtime_materialization_mode=RuntimeMaterializationMode.API_KEY_ENV,
+            execution_configuration=pins[0],
+            enabled=False,
+        ))
+        await session.commit()
+    return profile_id, pins[0], pins[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("contract_update", [
+    {"provider_id": "replacement"},
+    {"credential_source": "oauth_volume"},
+    {"runtime_materialization_mode": "oauth_home"},
+])
+async def test_update_profile_rejects_retained_incompatible_configuration_before_mutation(
+    client_app: AsyncClient, _module_db, contract_update: dict
+) -> None:
+    _override_current_user()
+    profile_id, original_pin, _ = await _seed_profile_with_execution_configuration()
+
+    async with client_app as client:
+        response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={**contract_update, "provider_label": "must not persist"},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "profile_execution_configuration_required"
+    async with db_base.async_session_maker() as session:
+        stored = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert stored.provider_id == "original"
+        assert stored.credential_source == ProviderCredentialSource.SECRET_REF
+        assert stored.runtime_materialization_mode == RuntimeMaterializationMode.API_KEY_ENV
+        assert stored.execution_configuration == original_pin
+        assert stored.provider_label is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clear_configuration", [False, True])
+async def test_update_profile_can_replace_or_clear_pin_with_changed_contract(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch,
+    clear_configuration: bool,
+) -> None:
+    _override_current_user()
+    _advertise_expert_manual_contracts(
+        monkeypatch,
+        ("pin_update_runtime", "replacement", "oauth_volume", "oauth_home"),
+    )
+    profile_id, _, replacement_pin = await _seed_profile_with_execution_configuration()
+    requested_pin = None if clear_configuration else replacement_pin
+
+    async with client_app as client:
+        response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={
+                "provider_id": "replacement",
+                "credential_source": "oauth_volume",
+                "runtime_materialization_mode": "oauth_home",
+                "execution_configuration": requested_pin,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["execution_configuration"] == requested_pin
+    async with db_base.async_session_maker() as session:
+        stored = await session.get(ManagedAgentProviderProfile, profile_id)
+        assert stored.provider_id == "replacement"
+        assert stored.credential_source == ProviderCredentialSource.OAUTH_VOLUME
+        assert stored.runtime_materialization_mode == RuntimeMaterializationMode.OAUTH_HOME
+        assert stored.execution_configuration == requested_pin
+
+
+@pytest.mark.asyncio
+async def test_update_profile_unrelated_edit_does_not_revalidate_saved_pin(
+    client_app: AsyncClient, _module_db,
+) -> None:
+    _override_current_user()
+    profile_id, original_pin, _ = await _seed_profile_with_execution_configuration()
+    async with db_base.async_session_maker() as session:
+        configuration = await session.get(OmnigentAgentProfile, original_pin["profileId"])
+        configuration.state = "retired"
+        await session.commit()
+
+    async with client_app as client:
+        response = await client.patch(
+            f"/api/v1/provider-profiles/{profile_id}",
+            json={"provider_label": "Renamed profile"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["provider_label"] == "Renamed profile"
+    assert response.json()["execution_configuration"] == original_pin
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_profile_execution_selection.py
+++ b/tests/unit/api_service/test_profile_execution_selection.py
@@ -4,8 +4,9 @@ import pytest
 from fastapi import HTTPException
 
 from api_service.services.profile_execution_selection import (
-    select_execution_configuration,
     configuration_accepts_profile,
+    profile_has_native_inventory_route,
+    select_execution_configuration,
 )
 
 
@@ -29,6 +30,7 @@ def configuration(name="behavior", *, default=False, providers=None):
         Row(
             version=1,
             digest="sha256:" + "a" * 64,
+            validation_result={"ready": True},
             document={
                 "providerRequirements": {
                     "runtimeId": "opencode",
@@ -63,6 +65,85 @@ def test_authentication_contract_cannot_cross_zen_and_go():
             credential_source="secret_ref",
         ),
     )
+
+
+@pytest.mark.parametrize("validation_result", [None, {}, {"ready": False}, {"ready": 1}])
+def test_unvalidated_configuration_cannot_be_selected(validation_result):
+    candidate = configuration()
+    candidate[1].validation_result = validation_result
+    with pytest.raises(HTTPException) as error:
+        select_execution_configuration(provider(), [candidate])
+    assert error.value.status_code == 409
+    assert error.value.detail["code"] == "profile_execution_configuration_required"
+
+
+def test_configuration_without_validation_result_cannot_be_selected():
+    candidate = configuration()
+    del candidate[1].validation_result
+    with pytest.raises(HTTPException) as error:
+        select_execution_configuration(provider(), [candidate])
+    assert error.value.status_code == 409
+
+
+@pytest.mark.parametrize("runtime", ["codex", "codex_cli", "claude", "claude_code", "jules"])
+def test_direct_runtime_inventory_does_not_require_omnigent_configuration(runtime):
+    native = provider(runtime_id=runtime)
+    assert profile_has_native_inventory_route(native, [configuration()]) is True
+    # Explicit Omnigent admission retains the configuration requirement.
+    with pytest.raises(HTTPException):
+        select_execution_configuration(native, [configuration()])
+
+
+@pytest.mark.parametrize("runtime", ["opencode", "omnigent", "codex_cloud", "unknown"])
+def test_unsupported_direct_runtime_keeps_configuration_requirement(runtime):
+    assert profile_has_native_inventory_route(provider(runtime_id=runtime), []) is False
+
+
+@pytest.mark.parametrize("validation_result", [None, {}, {"ready": False}, {"ready": True}])
+def test_compatible_configuration_prevents_native_route(validation_result):
+    native = provider(runtime_id="codex_cli")
+    candidate = configuration()
+    candidate[1].document["providerRequirements"]["runtimeId"] = native.runtime_id
+    candidate[1].validation_result = validation_result
+    assert profile_has_native_inventory_route(native, [candidate]) is False
+
+
+def test_explicit_configuration_pin_prevents_native_route_when_missing():
+    native = provider(
+        runtime_id="codex_cli",
+        execution_configuration={
+            "profileId": "missing", "version": 1, "digest": "sha256:" + "a" * 64,
+        },
+    )
+    assert profile_has_native_inventory_route(native, []) is False
+
+
+def test_unready_pinned_configuration_does_not_substitute_ready_default():
+    custom = configuration("custom")
+    custom[1].validation_result = {"ready": False}
+    with pytest.raises(HTTPException) as error:
+        select_execution_configuration(
+            provider(
+                execution_configuration={
+                    "profileId": "custom",
+                    "version": 1,
+                    "digest": custom[1].digest,
+                }
+            ),
+            [configuration("stock", default=True), custom],
+        )
+    assert error.value.status_code == 409
+    assert error.value.detail["profileId"] == "zen"
+
+
+def test_unready_default_cannot_make_ready_custom_configuration_default():
+    stock = configuration("stock", default=True)
+    stock[1].validation_result = {"ready": False}
+    selected = select_execution_configuration(
+        provider(), [stock, configuration("custom")]
+    )
+    assert selected["profileId"] == "custom"
+    assert selected["defaultForRuntime"] is False
 
 
 def test_explicit_configuration_wins_over_deployment_default():
@@ -120,7 +201,12 @@ def test_automatic_and_explicit_configuration_resolve_same_identity():
 def test_pinned_configuration_survives_active_version_advancement():
     row, old = configuration()
     row.active_version = 2
-    latest = Row(version=2, digest="sha256:" + "b" * 64, document=old.document)
+    latest = Row(
+        version=2,
+        digest="sha256:" + "b" * 64,
+        document=old.document,
+        validation_result={"ready": True},
+    )
     selected = select_execution_configuration(
         provider(
             execution_configuration={

--- a/tests/unit/api_service/test_profile_execution_selection.py
+++ b/tests/unit/api_service/test_profile_execution_selection.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace as Row
+
+import pytest
+from fastapi import HTTPException
+
+from api_service.services.profile_execution_selection import (
+    select_execution_configuration,
+    configuration_accepts_profile,
+)
+
+
+def provider(**changes):
+    return Row(
+        **{
+            "profile_id": "zen",
+            "runtime_id": "opencode",
+            "provider_id": "opencode",
+            "credential_source": "none",
+            "runtime_materialization_mode": "config_bundle",
+            "execution_configuration": None,
+            **changes,
+        }
+    )
+
+
+def configuration(name="behavior", *, default=False, providers=None):
+    return (
+        Row(profile_id=name, default_for_runtime=default, active_version=1),
+        Row(
+            version=1,
+            digest="sha256:" + "a" * 64,
+            document={
+                "providerRequirements": {
+                    "runtimeId": "opencode",
+                    "credentialSource": "none",
+                    "materializationMode": "config_bundle",
+                    "providerIds": providers or ["opencode"],
+                },
+                "execution": {"allowedLaunchPolicyRefs": ["isolated@1"]},
+            },
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "catalog", [None, {}, {"validatedAt": "2000-01-01", "imageRef": "old"}]
+)
+def test_profile_configuration_is_independent_of_discovery(catalog):
+    selected = select_execution_configuration(
+        provider(model_catalog_evidence_json=catalog),
+        [configuration()],
+    )
+    assert selected["providerProfileRef"] == "zen"
+    assert selected["profileId"] == "behavior"
+    assert selected["launchPolicyRef"] == "isolated@1"
+
+
+def test_authentication_contract_cannot_cross_zen_and_go():
+    assert not configuration_accepts_profile(
+        configuration()[1].document,
+        provider(
+            provider_id="opencode-go",
+            credential_source="secret_ref",
+        ),
+    )
+
+
+def test_explicit_configuration_wins_over_deployment_default():
+    selected = select_execution_configuration(
+        provider(
+            execution_configuration={
+                "profileId": "custom",
+                "version": 1,
+                "digest": "sha256:" + "a" * 64,
+            }
+        ),
+        [configuration("stock", default=True), configuration("custom")],
+    )
+    assert selected["profileId"] == "custom"
+
+
+def test_missing_pinned_version_does_not_substitute_default():
+    with pytest.raises(HTTPException) as error:
+        select_execution_configuration(
+            provider(
+                execution_configuration={
+                    "profileId": "custom",
+                    "version": 2,
+                    "digest": "sha256:" + "b" * 64,
+                }
+            ),
+            [configuration("stock", default=True), configuration("custom")],
+        )
+    assert error.value.status_code == 409
+
+
+def test_ambiguous_custom_configuration_is_actionable():
+    with pytest.raises(HTTPException) as error:
+        select_execution_configuration(
+            provider(), [configuration("one"), configuration("two")]
+        )
+    assert error.value.detail["code"] == "profile_execution_configuration_required"
+
+
+def test_automatic_and_explicit_configuration_resolve_same_identity():
+    automatic = select_execution_configuration(
+        provider(), [configuration(default=True)]
+    )
+    explicit = select_execution_configuration(
+        provider(
+            execution_configuration={
+                key: automatic[key] for key in ("profileId", "version", "digest")
+            }
+        ),
+        [configuration(default=True)],
+    )
+    assert explicit == automatic
+
+
+def test_pinned_configuration_survives_active_version_advancement():
+    row, old = configuration()
+    row.active_version = 2
+    latest = Row(version=2, digest="sha256:" + "b" * 64, document=old.document)
+    selected = select_execution_configuration(
+        provider(
+            execution_configuration={
+                "profileId": row.profile_id,
+                "version": 1,
+                "digest": old.digest,
+            }
+        ),
+        [(row, old), (row, latest)],
+    )
+    assert selected["version"] == 1
+    assert (
+        select_execution_configuration(provider(), [(row, old), (row, latest)])[
+            "version"
+        ]
+        == 2
+    )

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -313,92 +313,19 @@ async def test_opencode_exact_host_model_options_fail_closed_without_diagnostics
     assert "sensitive context" not in str(exc.value)
 
 
-def _evidence_provider(*, validated_at: datetime | None = None) -> SimpleNamespace:
-    image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
-    return SimpleNamespace(
-        credential_generation=4,
-        model_catalog_evidence_json={
-            "credentialGeneration": 4,
-            "imageRef": image_ref,
-            "models": [{"qualifiedId": "opencode-go/model"}],
-            "validatedAt": (validated_at or datetime.now(UTC)).isoformat(),
-        },
+@pytest.mark.parametrize("evidence", [None, {}, {"validatedAt": "2000-01-01", "imageRef": "old"}])
+def test_profile_model_intent_does_not_depend_on_discovery(evidence):
+    service = object.__new__(OmnigentExecutionPlanningService)
+    service._deployment_default_model = ""
+    provider = SimpleNamespace(
+        runtime_id="opencode", provider_id="opencode", default_model="opencode/selected",
+        default_effort="high", model_tiers=None, default_model_tier=1,
+        model_catalog_evidence_json=evidence,
     )
-
-
-def test_planning_model_evidence_is_bound_to_generation_and_host_image() -> None:
-    image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
-    provider = _evidence_provider()
-    OmnigentExecutionPlanningService._verify_model_evidence(
-        provider,
-        "opencode-go/model",
-        expected_image_ref=image_ref,
-    )
-
-    provider.model_catalog_evidence_json["credentialGeneration"] = 3
-    with pytest.raises(HarnessPlatformError) as stale:
-        OmnigentExecutionPlanningService._verify_model_evidence(
-            provider,
-            "opencode-go/model",
-            expected_image_ref=image_ref,
-        )
-    assert stale.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
-
-    provider.model_catalog_evidence_json["credentialGeneration"] = 4
-    with pytest.raises(HarnessPlatformError) as wrong_image:
-        OmnigentExecutionPlanningService._verify_model_evidence(
-            provider,
-            "opencode-go/model",
-            expected_image_ref="ghcr.io/moonmind/opencode@sha256:" + "b" * 64,
-        )
-    assert wrong_image.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
-
-
-def test_planning_rejects_a_model_catalog_older_than_the_refresh_interval(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Identity alone would launch from the first catalog ever observed.
-
-    A healthy deployment never changes its credential generation or host image
-    digest on its own, so pre-session planning has to enforce the same
-    observation interval the bootstrap reconciler refreshes on. Otherwise it
-    keeps admitting -- and launching -- a model the provider may have removed.
-    """
-
-    # Exercise the documented default: the interval applies with no env value.
-    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", raising=False)
-    image_ref = "ghcr.io/moonmind/opencode@sha256:" + "a" * 64
-    expired = _evidence_provider(validated_at=datetime.now(UTC) - timedelta(hours=9))
-
-    with pytest.raises(HarnessPlatformError) as stale:
-        OmnigentExecutionPlanningService._verify_model_evidence(
-            expired,
-            "opencode-go/model",
-            expected_image_ref=image_ref,
-        )
-    assert stale.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
-    assert "refresh interval" in str(stale.value)
-
-    # The interval is deployment-configurable, and ``0`` restores identity-only
-    # staleness at this boundary exactly as it does at the reconciler.
-    monkeypatch.setenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS", "0")
-    OmnigentExecutionPlanningService._verify_model_evidence(
-        expired,
-        "opencode-go/model",
-        expected_image_ref=image_ref,
-    )
-
-    # An observation that cannot say when it was taken is never admitted.
-    monkeypatch.delenv("OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS")
-    undated = _evidence_provider()
-    undated.model_catalog_evidence_json.pop("validatedAt")
-    with pytest.raises(HarnessPlatformError) as undatable:
-        OmnigentExecutionPlanningService._verify_model_evidence(
-            undated,
-            "opencode-go/model",
-            expected_image_ref=image_ref,
-        )
-    assert undatable.value.code == HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE
+    request = _request()
+    profile = SimpleNamespace(model={"qualifiedId": "opencode-go/different", "effort": "low"})
+    model, effort, route = service._resolve_model(request, profile, provider)
+    assert (model, effort, route) == ("opencode/selected", "high", "opencode")
 
 
 class _Session:
@@ -2150,7 +2077,7 @@ async def test_generic_realizer_projects_provider_capacity_wait() -> None:
         (
             "workflow-1",
             "launching",
-            "Provider Profile capacity acquired.",
+            "Preparing runtime: validating the execution host and selected model.",
         ),
         ("workflow-1", "running", "Agent is running."),
     ]

--- a/tests/unit/omnigent/test_provider_revalidation.py
+++ b/tests/unit/omnigent/test_provider_revalidation.py
@@ -31,7 +31,8 @@ _UNSET_VALIDATED_AT = "__unset__"
 
 
 @pytest.fixture(autouse=True)
-def _clear_enrollment_latch():
+def _clear_enrollment_latch(monkeypatch):
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
     reset_enrollment_attempts()
     yield
     reset_enrollment_attempts()
@@ -122,6 +123,21 @@ class _Session:
 
 def _session_factory(rows):
     return lambda: _Session(rows)
+
+
+@pytest.mark.asyncio
+async def test_failed_discovery_preserves_enrolled_credential_readiness():
+    from moonmind.omnigent.bootstrap.provider_revalidation import _record_revalidation_failure
+
+    profile = _profile(command_behavior={"auth_readiness": {
+        "connected": True, "launch_ready": True, "backing_secret_exists": True,
+    }})
+    await _record_revalidation_failure(
+        session_factory=_session_factory([profile]), profile_id=profile.profile_id,
+        image_ref=CURRENT_IMAGE,
+    )
+    assert profile.command_behavior["auth_readiness"]["launch_ready"] is True
+    assert profile.auth_state == "connected"
 
 
 def _install_stubs(

--- a/tests/unit/services/test_default_omnigent_launch_authority.py
+++ b/tests/unit/services/test_default_omnigent_launch_authority.py
@@ -44,6 +44,53 @@ from api_service.services.omnigent_agent_profile_service import (
 pytestmark = [pytest.mark.asyncio]
 
 
+@pytest.mark.parametrize("configuration_state", ["absent", "pinned_missing", "unready"])
+async def test_native_profile_inventory_distinguishes_missing_and_unready_configuration(
+    session, configuration_state
+):
+    from api_service.api.routers.provider_profiles import list_profiles
+
+    native = ManagedAgentProviderProfile(
+        profile_id="native-codex",
+        runtime_id="codex_cli",
+        provider_id="openai",
+        enabled=False,
+    )
+    session.add(native)
+    if configuration_state == "pinned_missing":
+        native.execution_configuration = {
+            "profileId": "missing", "version": 1, "digest": "sha256:" + "a" * 64,
+        }
+    elif configuration_state == "unready":
+        session.add(OmnigentAgentProfile(
+            profile_id="codex-config", display_name="Codex configuration",
+            state="active", visibility="shared", active_version=1,
+        ))
+        await session.flush()
+        session.add(OmnigentAgentProfileVersion(
+            profile_id="codex-config", version=1, digest="sha256:" + "b" * 64,
+            document={"providerRequirements": {
+                "runtimeId": "codex_cli", "providerIds": ["openai"],
+                "credentialSource": "none", "materializationMode": "composite",
+            }},
+            validation_result={"ready": False},
+        ))
+    await session.commit()
+
+    rows = await list_profiles(
+        include_execution=True, session=session,
+        current_user=SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    selected = next(item for item in rows if item["profile_id"] == native.profile_id)
+    assert selected["runtime_id"] == "codex_cli"
+    assert selected["launch_ready"] is False
+    assert selected.get("execution_selection") is None
+    if configuration_state == "absent":
+        assert selected.get("execution_selection_error") is None
+    else:
+        assert selected["execution_selection_error"]["code"] == "profile_execution_configuration_required"
+
+
 async def test_profile_inventory_and_default_resolution_survive_catalog_expiry(session, monkeypatch):
     from api_service.api.routers.provider_profiles import list_profiles
 
@@ -91,7 +138,9 @@ async def test_disabled_profile_remains_in_inventory_without_gaining_launch_auth
 
 
 async def test_inventory_loads_active_and_explicitly_pinned_versions_only(session, monkeypatch):
-    from api_service.services.profile_execution_selection import load_execution_configurations
+    from api_service.services.profile_execution_selection import (
+        load_execution_configurations,
+    )
 
     await _seed_default_deployment(session, monkeypatch)
     profile = await session.get(OmnigentAgentProfile, OPENCODE_BUILTIN_PROFILE_ID)

--- a/tests/unit/services/test_default_omnigent_launch_authority.py
+++ b/tests/unit/services/test_default_omnigent_launch_authority.py
@@ -43,6 +43,82 @@ from api_service.services.omnigent_agent_profile_service import (
 
 pytestmark = [pytest.mark.asyncio]
 
+
+async def test_profile_inventory_and_default_resolution_survive_catalog_expiry(session, monkeypatch):
+    from api_service.api.routers.provider_profiles import list_profiles
+
+    await _seed_default_deployment(session, monkeypatch)
+    row = await session.get(ManagedAgentProviderProfile, "opencode-zen-free")
+    row.model_catalog_evidence_json = {
+        "validatedAt": "2000-01-01T00:00:00+00:00", "imageRef": "previous-image",
+        "credentialGeneration": 0, "models": [],
+    }
+    await session.commit()
+    user = SimpleNamespace(id=uuid4(), is_superuser=True)
+    rows = await list_profiles(include_execution=True, session=session, current_user=user)
+    selected = next(item for item in rows if item["profile_id"] == row.profile_id)
+    assert selected["execution_selection"]["providerProfileRef"] == row.profile_id
+    assert selected["launch_ready"] is True
+    automatic = await resolve_default_agent_profile_snapshot(
+        session, provider_profile_ref=None, launch_policy_ref=None,
+        consumer_type="workflow", consumer_id="default-expired", user=user,
+    )
+    explicit = await resolve_default_agent_profile_snapshot(
+        session, provider_profile_ref=row.profile_id, launch_policy_ref=None,
+        consumer_type="workflow", consumer_id="explicit-expired", user=user,
+    )
+    assert automatic == explicit
+
+
+async def test_disabled_profile_remains_in_inventory_without_gaining_launch_authority(session, monkeypatch):
+    from api_service.api.routers.provider_profiles import list_profiles
+
+    await _seed_default_deployment(session, monkeypatch)
+    row = await session.get(ManagedAgentProviderProfile, "opencode-zen-free")
+    row.enabled = False
+    row.disabled_reason = ProviderProfileDisabledReason.USER_DISABLED
+    await session.commit()
+    user = SimpleNamespace(id=uuid4(), is_superuser=True)
+    rows = await list_profiles(include_execution=True, session=session, current_user=user)
+    selected = next(item for item in rows if item["profile_id"] == row.profile_id)
+    assert selected["launch_ready"] is False
+    assert selected["execution_selection"]["providerProfileRef"] == row.profile_id
+    with pytest.raises(HTTPException):
+        await resolve_default_agent_profile_snapshot(
+            session, provider_profile_ref=row.profile_id, launch_policy_ref=None,
+            consumer_type="workflow", consumer_id="disabled", user=user,
+        )
+
+
+async def test_inventory_loads_active_and_explicitly_pinned_versions_only(session, monkeypatch):
+    from api_service.services.profile_execution_selection import load_execution_configurations
+
+    await _seed_default_deployment(session, monkeypatch)
+    profile = await session.get(OmnigentAgentProfile, OPENCODE_BUILTIN_PROFILE_ID)
+    old = await session.scalar(select(OmnigentAgentProfileVersion).where(
+        OmnigentAgentProfileVersion.profile_id == profile.profile_id,
+        OmnigentAgentProfileVersion.version == profile.active_version,
+    ))
+    provider = await session.get(ManagedAgentProviderProfile, "opencode-zen-free")
+    for number in (2, 3):
+        session.add(OmnigentAgentProfileVersion(
+            profile_id=profile.profile_id, version=number,
+            digest="sha256:" + str(number) * 64,
+            document={**old.document, "version": number},
+            validation_result=old.validation_result,
+        ))
+    profile.active_version = 3
+    provider.execution_configuration = {
+        "profileId": profile.profile_id, "version": 1, "digest": old.digest,
+    }
+    await session.flush()
+    user = SimpleNamespace(id=uuid4(), is_superuser=True)
+    pinned = await load_execution_configurations(session, user, [provider])
+    assert {version.version for row, version in pinned if row.profile_id == profile.profile_id} == {1, 3}
+    provider.execution_configuration = None
+    automatic = await load_execution_configurations(session, user, [provider])
+    assert {version.version for row, version in automatic if row.profile_id == profile.profile_id} == {3}
+
 _SERVER_IMAGE_REF = "registry.test/server@sha256:" + "1" * 64
 _OPENCODE_HOST_IMAGE_REF = "registry.test/opencode@sha256:" + "6" * 64
 
@@ -417,9 +493,7 @@ async def test_selection_rejects_a_provider_the_slot_auth_model_forbids(
     assert caught.value.status_code == 409
     # The incompatibility is the slot auth-model contract, not readiness: an
     # unenforced contract would fall through to the launch-ready check instead.
-    assert "not compatible with the selected Omnigent execution target" in str(
-        caught.value.detail
-    )
+    assert caught.value.detail["code"] == "profile_execution_configuration_required"
 
     # The automatic default still resolves the credentialless route the slot
     # does accept.

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -35,6 +35,7 @@ class _Session:
             visibility="workspace",
             owner_id=uuid4(),
             active_version=2,
+            default_for_runtime=True,
         )
         self.version = SimpleNamespace(
             version=2,
@@ -54,8 +55,8 @@ class _Session:
                 },
                 "providerRequirements": {
                     "runtimeId": "codex_cli",
-                    "credentialSource": "oauth",
-                    "materializationMode": "host",
+                    "credentialSource": "oauth_volume",
+                    "materializationMode": "oauth_home",
                     "providerIds": ["openai"],
                 },
                 "model": {"model": "gpt-5.4"},
@@ -106,6 +107,9 @@ class _Session:
 
     async def get(self, model, key):
         return self.profile if model is OmnigentAgentProfile else None
+
+    async def execute(self, statement):
+        return SimpleNamespace(all=lambda: [(self.profile, self.version)])
 
     async def scalar(self, statement):
         self.statements.append(statement)

--- a/tests/unit/services/test_omnigent_agent_profile_selection.py
+++ b/tests/unit/services/test_omnigent_agent_profile_selection.py
@@ -111,6 +111,9 @@ class _Session:
     async def execute(self, statement):
         return SimpleNamespace(all=lambda: [(self.profile, self.version)])
 
+    async def scalars(self, statement):
+        return SimpleNamespace(all=lambda: [self.provider])
+
     async def scalar(self, statement):
         self.statements.append(statement)
         entity = statement.column_descriptions[0].get("entity")
@@ -129,6 +132,33 @@ class _Session:
 
     async def flush(self):
         return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_ref", [None, "oauth-team"])
+async def test_profile_model_authority_bypasses_legacy_configuration_constraints(provider_ref):
+    from moonmind.workflows.executions.model_resolver import resolve_model_effort
+
+    session = _Session()
+    model = "vendor/" + "future-model-" * 16
+    effort = "future-provider-effort"
+    session.provider.default_model = model
+    session.provider.default_effort = effort
+    snapshot = await resolve_default_agent_profile_snapshot(
+        session, provider_profile_ref=provider_ref, launch_policy_ref=None,
+        consumer_type="workflow", consumer_id="pass-through", user=SimpleNamespace(id=uuid4()),
+    )
+    resolved = resolve_model_effort(
+        runtime_id=session.provider.runtime_id, profile=session.provider,
+        require_launch_ready=False,
+    )
+    compiled = compile_agent_profile_snapshot_parameters(
+        {"model": resolved.model, "effort": resolved.effort}, snapshot=snapshot,
+    )
+    assert compiled["model"] == model
+    assert compiled["effort"] == effort
+    assert not snapshot["document"]["model"].get("model")
+    assert not snapshot["document"]["model"].get("effort")
 
 
 def test_snapshot_parameter_compiler_keeps_authority_out_of_authored_omnigent() -> None:

--- a/tests/unit/services/test_omnigent_agent_smoke_service.py
+++ b/tests/unit/services/test_omnigent_agent_smoke_service.py
@@ -446,7 +446,7 @@ async def _provider_check(session, document):
     return {check["name"]: check for check in outcome.checks}["provider_profile"]
 
 
-async def test_smoke_admission_rejects_an_expired_model_catalog(session, monkeypatch):
+async def test_smoke_admission_uses_actual_host_instead_of_expired_catalog(session, monkeypatch):
     """Smoke launches the real host, so it must not admit an expired catalog.
 
     The pinned host image refreshes its catalog from the provider at probe
@@ -495,7 +495,7 @@ async def test_smoke_admission_rejects_an_expired_model_catalog(session, monkeyp
     }
     await session.commit()
 
-    assert (await _provider_check(session, document))["ready"] is False
+    assert (await _provider_check(session, document))["ready"] is True
 
     # The interval is deployment-configurable; ``0`` restores identity-only
     # staleness at this boundary exactly as it does at the reconciler.

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -131,7 +131,9 @@ async def test_create_definition_creates_temporal_schedule(
             }
 
 
+@pytest.mark.parametrize("explicit_configuration", [False, True])
 async def test_create_definition_compiles_agent_profile_snapshot_separately(
+    explicit_configuration,
     tmp_path: Path,
     mock_temporal_adapter,
     monkeypatch: pytest.MonkeyPatch,
@@ -156,6 +158,11 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
     monkeypatch.setattr(
         "api_service.services.recurring_workflows_service.resolve_agent_profile_snapshot",
         resolver,
+    )
+    default_resolver = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr(
+        "api_service.services.recurring_workflows_service.resolve_default_agent_profile_snapshot",
+        default_resolver,
     )
     plan_binding = {
         "planRef": "omnigent-execution-plan:sha256:" + "b" * 64,
@@ -218,7 +225,7 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
                     },
                     "workflow": {
                         "instructions": "Run the selected profile.",
-                        "runtime": {"mode": "omnigent"},
+                        "runtime": {"mode": "omnigent", "profileId": "codex-openai-oauth"},
                     },
                 },
             },
@@ -226,7 +233,7 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
             agent_profile_selection={
                 "profileId": "omnigent-bootstrap-default",
                 "providerProfileRef": "codex-openai-oauth",
-            },
+            } if explicit_configuration else None,
             actor=SimpleNamespace(id=uuid4()),
         )
 
@@ -241,6 +248,9 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
     assert initial_parameters["omnigentExecutionPlan"] == plan_binding
     assert initial_parameters["resolvedSkillsetRef"] == "art_skills"
     assert compile_plan.await_count == 1
+    if not explicit_configuration:
+        assert default_resolver.await_args.kwargs["provider_profile_ref"] == "codex-openai-oauth"
+        resolver.assert_not_awaited()
     scheduled_parameters = mock_temporal_adapter.create_schedule.await_args.kwargs[
         "workflow_input"
     ]["initial_parameters"]
@@ -1529,16 +1539,15 @@ async def test_mm3788_create_definition_leaves_omnigent_compatibility_to_selecti
             session, temporal_client_adapter=mock_temporal_adapter
         )
 
-        definition = await _mm3788_create(
-            service,
-            target=_mm3788_target(
-                target_runtime="omnigent", profile_id="codex_minimax_team"
-            ),
-            owner_user_id=uuid4(),
-        )
-
-        assert definition.target["initialParameters"]["targetRuntime"] == "omnigent"
-        mock_temporal_adapter.create_schedule.assert_awaited_once()
+        with pytest.raises(RecurringWorkflowValidationError, match="authenticated actor"):
+            await _mm3788_create(
+                service,
+                target=_mm3788_target(
+                    target_runtime="omnigent", profile_id="codex_minimax_team"
+                ),
+                owner_user_id=uuid4(),
+            )
+        mock_temporal_adapter.create_schedule.assert_not_awaited()
 
 
 async def test_mm3788_update_definition_rejects_a_cross_runtime_target(

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -138,6 +138,8 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
     mock_temporal_adapter,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    provider_model = "vendor/" + "future-model-" * 16
+    provider_effort = "future-provider-effort"
     snapshot = {
         "schemaVersion": "moonmind.omnigent-agent-profile-snapshot.v1",
         "profileId": "omnigent-bootstrap-default",
@@ -197,6 +199,8 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
                 profile_id="codex-openai-oauth",
                 runtime_id="codex_cli",
                 provider_id="openai",
+                default_model=provider_model,
+                default_effort=provider_effort,
             )
         )
         await session.flush()
@@ -251,6 +255,9 @@ async def test_create_definition_compiles_agent_profile_snapshot_separately(
     if not explicit_configuration:
         assert default_resolver.await_args.kwargs["provider_profile_ref"] == "codex-openai-oauth"
         resolver.assert_not_awaited()
+        assert initial_parameters["model"] == provider_model
+        assert initial_parameters["effort"] == provider_effort
+        assert compile_plan.await_args.kwargs["initial_parameters"]["model"] == provider_model
     scheduled_parameters = mock_temporal_adapter.create_schedule.await_args.kwargs[
         "workflow_input"
     ]["initial_parameters"]


### PR DESCRIPTION
Workflow creation could hide configured OpenCode Zen/Go profiles and block submission whenever cached model discovery expired or the pinned host image changed. This change keeps Profile inventory stable, makes discovery advisory, and retains credential, trust, capability, and model validation on the actual execution host.

The UI now selects one Profile. Advanced settings can pin its immutable execution configuration, and workflow creation, schedules, checkpoint branches, and remediation use the shared selection path. Native Profiles derive the matching runtime automatically. Existing execution snapshots remain authoritative. Configuration queries load only active and explicitly pinned versions, and explicit model/account choices survive refreshes. Structural configuration readiness and prospective credential compatibility are checked before execution; provider model and effort values pass through without legacy configuration schema restrictions.

Migration `371_profile_execution_config` adds the optional configuration reference and clears legacy discovery-owned readiness failures without changing credentials or explicit disables. Canonical docs and generated API types are updated. This PR has not been deployed.

Validation:
- 729 backend selection/API/schedule/checkpoint unit tests passed across the final targeted runs.
- 1,424 frontend tests passed across the full suite and corrected Windows path assertion; 238 existing skipped tests remain.
- 3 migration/startup integration tests passed.
- 70 checkpoint integration tests passed, including the public root/continue/fork journey and historical replay cases.
- TypeScript, targeted frontend ESLint, production build, and whitespace checks passed.
- Desktop/mobile light/dark harness checks passed with the production stylesheet.
- New Python modules pass Ruff; comparison against HEAD found no added production-code lint findings. Existing broader Ruff findings remain.

Live provider qualification was not run. Tests preserve the existing exact-host model-verification and execution-lifecycle boundaries.
