### PR TITLE
Align workflow UI runtime admission with provider profiles

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -7193,7 +7193,6 @@ describe.skip("Task Create Entrypoint", () => {
       },
     });
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "git",
       "gh",
     ]);
@@ -7376,7 +7375,6 @@ describe.skip("Task Create Entrypoint", () => {
       };
     };
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "git",
       "gh",
       "jira",
@@ -7450,8 +7448,6 @@ describe.skip("Task Create Entrypoint", () => {
       };
     };
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
-      "claude_code",
       "git",
       "gh",
     ]);
@@ -7464,6 +7460,7 @@ describe.skip("Task Create Entrypoint", () => {
       effort: "high",
     });
   });
+
 
   it("reveals per-step advanced skill options from the bottom toggle", async () => {
     renderWithClient(<WorkflowStartPage payload={mockPayload} />);
@@ -7538,7 +7535,6 @@ describe.skip("Task Create Entrypoint", () => {
       "qdrant",
     ]);
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "git",
       "gh",
       "docker",
@@ -7673,7 +7669,6 @@ describe.skip("Task Create Entrypoint", () => {
       name: "auto",
     });
     expect(payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "git",
       "gh",
     ]);
@@ -20396,7 +20391,6 @@ describe("Task Create governed Tool authoring", () => {
     };
     expect(request.payload.repository).toBeUndefined();
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "gh",
       "jira",
     ]);
@@ -20462,7 +20456,6 @@ describe("Task Create governed Tool authoring", () => {
     };
     expect(request.payload.repository).toBeUndefined();
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "gh",
       "jira",
     ]);
@@ -20526,7 +20519,6 @@ describe("Task Create governed Tool authoring", () => {
       };
     };
     expect(request.payload.requiredCapabilities).toEqual([
-      "codex_cli",
       "git",
       "gh",
       "jira",
@@ -21988,6 +21980,71 @@ describe("Task Create runtime switch layout stability", () => {
     const request = JSON.parse(String(fetchSpy.mock.calls.find(([url]) => String(url) === "/api/executions")?.[1]?.body));
     expect(request.payload.task.runtime).toMatchObject({ mode: "claude_code", profileId: "native-claude" });
     expect(request).not.toHaveProperty("agentProfile");
+    expect(request.payload.requiredCapabilities).toEqual(["git", "gh"]);
+  });
+
+  it("uses the canonical runtime catalog ahead of legacy boot metadata", async () => {
+    const payload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: {
+        ...mockDashboardConfig,
+        system: { ...mockDashboardConfig.system, supportedRuntimes: ["codex_cli", "claude_code", "jules"] },
+      } },
+    } as BootPayload;
+    renderWithClient(<WorkflowStartPage payload={payload} />);
+    const runtime = await screen.findByLabelText("Runtime");
+    expect(within(runtime).getByRole("option", { name: "Jules" })).toBeTruthy();
+    expect(within(runtime).queryByRole("option", { name: "Codex via Omnigent" })).toBeNull();
+  });
+
+  it.each(["codex", "claude"])("submits a Profile's %s runtime for API validation despite a stale boot catalog", async (runtimeId) => {
+    const fallback = fetchSpy.getMockImplementation()!;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [
+          { profile_id: "selected-profile", runtime_id: runtimeId, is_default: true },
+        ] } as Response);
+      }
+      return fallback(input, init);
+    });
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    await waitFor(() => expect((screen.getByLabelText("Profile") as HTMLSelectElement).value).toBe("selected-profile"));
+    await waitFor(() => expect((screen.getByLabelText("Runtime") as HTMLSelectElement).value).toBe(runtimeId));
+    fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Preserve the selected Profile's runtime intent." } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith("/api/executions", expect.objectContaining({ method: "POST" })));
+    const request = JSON.parse(String(fetchSpy.mock.calls.find(([url]) => String(url) === "/api/executions")?.[1]?.body));
+    expect(request.payload.task.runtime).toMatchObject({ mode: runtimeId, profileId: "selected-profile" });
+    expect(request.payload.requiredCapabilities).toEqual(["git", "gh"]);
+  });
+
+  it.each(["omnigent", "claude_code"])("submits a %s step selection without deriving host capability claims", async (runtimeId) => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    fireEvent.click(screen.getByLabelText("Advanced mode"));
+    fireEvent.change(await screen.findByLabelText("Instructions"), { target: { value: "Validate the step runtime at API admission." } });
+    fireEvent.change(screen.getByLabelText("Step 1 Runtime"), { target: { value: runtimeId } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith("/api/executions", expect.objectContaining({ method: "POST" })));
+    const request = JSON.parse(String(fetchSpy.mock.calls.find(([url]) => String(url) === "/api/executions")?.[1]?.body));
+    expect(request.payload.task.steps[0].runtime.mode).toBe(runtimeId);
+    expect(request.payload.requiredCapabilities).toEqual(["git", "gh"]);
+  });
+
+  it("surfaces authoritative capability admission errors from the API", async () => {
+    const fallback = fetchSpy.getMockImplementation()!;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: false, status: 409, text: async () => JSON.stringify({
+          detail: { message: "required capabilities unknown: ['custom-tool']" },
+        }) } as Response);
+      }
+      return fallback(input, init);
+    });
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+    fireEvent.change(await screen.findByLabelText("Instructions"), { target: { value: "Check capability admission." } });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+    expect(await screen.findByText(/required capabilities unknown/)).toBeTruthy();
+    expect(navigateTo).not.toHaveBeenCalled();
   });
 
   it.each([false, true])("preserves an explicit runtime override after Profile inventory refetch (Omnigent configuration: %s)", async (configured) => {
@@ -22355,11 +22412,10 @@ describe("MM-936/MM-941 capability registry and chip computation", () => {
 
   it("keeps derived capabilities non-removable with provenance", () => {
     const chips = buildCapabilityChips({
-      skill: ["git"],
+      skill: ["git", "codex_cli"],
       tool: ["gh"],
       generatedTool: ["docker"],
       preset: ["jira"],
-      runtime: ["codex_cli"],
       publish: ["gh"],
       template: ["unity"],
     });
@@ -22377,7 +22433,7 @@ describe("MM-936/MM-941 capability registry and chip computation", () => {
       "from preset",
     );
     expect(capabilityChipProvenanceLabel(requireChip(chips, "codex_cli"))).toBe(
-      "from runtime",
+      "from skill",
     );
     expect(requireChip(chips, "gh").readiness.sourceLabels).toEqual([
       "from tool",

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -2814,7 +2814,6 @@ export type CapabilitySourceKind =
   | "preset"
   | "skill"
   | "tool"
-  | "runtime"
   | "publish"
   | "template";
 
@@ -2823,7 +2822,6 @@ const CAPABILITY_SOURCE_LABELS: Record<CapabilitySourceKind, string> = {
   preset: "from preset",
   skill: "from skill",
   tool: "from tool",
-  runtime: "from runtime",
   publish: "from publish mode",
   template: "from template",
 };
@@ -2862,7 +2860,6 @@ interface BuildCapabilityChipsArgs {
   generatedSkill?: string[] | null | undefined;
   generatedTool?: string[] | null | undefined;
   preset?: string[] | null | undefined;
-  runtime?: string[] | null | undefined;
   publish?: string[] | null | undefined;
   template?: string[] | null | undefined;
 }
@@ -2870,7 +2867,7 @@ interface BuildCapabilityChipsArgs {
 // Compute the display chips for a step's required capabilities. Sources are
 // additive and backend normalization is authoritative, so a capability chip is
 // only removable when the sole contribution is the explicit step authoring
-// field. Derived contributions (preset, skill, tool, runtime, publish mode,
+// field. Derived contributions (preset, skill, tool, publish mode,
 // template) keep the chip non-removable and carry provenance plus readiness
 // semantics for display without implying the UI grants backend access.
 export function buildCapabilityChips(
@@ -2887,7 +2884,6 @@ export function buildCapabilityChips(
     { tokens: args.generatedTool, sourceKind: "tool" },
     { tokens: args.preset, sourceKind: "preset" },
     { tokens: args.template, sourceKind: "template" },
-    { tokens: args.runtime, sourceKind: "runtime" },
     { tokens: args.publish, sourceKind: "publish" },
   ];
 
@@ -3519,8 +3515,6 @@ function validateJiraImageAttachment(
 }
 
 function deriveRequiredCapabilities(args: {
-  runtimeMode: string;
-  stepRuntimeModes: string[];
   publishMode: string;
   repositoryBacked: boolean;
   taskSkillRequiredCapabilities: string[];
@@ -3532,8 +3526,6 @@ function deriveRequiredCapabilities(args: {
   return Array.from(
     new Set(
       [
-        args.runtimeMode,
-        ...args.stepRuntimeModes,
         ...(args.repositoryBacked ? ["git"] : []),
         ...(args.publishMode === "pr" ? ["gh"] : []),
         ...args.taskSkillRequiredCapabilities,
@@ -6139,8 +6131,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     dashboardConfig.system?.defaultTaskEffortByRuntime ||
     {};
   const supportedAgentRuntimes = dashboardConfig.system
-    ?.supportedAgentRuntimes ||
-    dashboardConfig.system?.supportedRuntimes || ["omnigent", "codex_cli", "claude_code"];
+    ?.supportedRuntimes ||
+    dashboardConfig.system?.supportedAgentRuntimes || ["omnigent", "codex_cli", "claude_code"];
   const runtimeOptions = Array.from(new Set(supportedAgentRuntimes));
 
   const [steps, setSteps] = useState<StepState[]>([createStepStateEntry(1)]);
@@ -10389,16 +10381,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       submittedOmnigentAgentProfileVersion;
     const effectiveOmnigentAgentProfileDigest = submittedOmnigentAgentProfileDigest;
     const effectiveOmnigentExecutionTargetRef = omnigentExecutionTargetRef;
-    const supportedAgentRuntimeIds = runtimeOptions.map((item) =>
-      item.trim().toLowerCase(),
-    );
-    if (!supportedAgentRuntimeIds.includes(normalizedRuntime)) {
-      setSubmitMessage(
-        `Runtime must be one of: ${runtimeOptions.join(", ")}.`,
-      );
-      clearSubmitBusy();
-      return;
-    }
+    // The boot catalog supplies choices, not admission authority. Profiles,
+    // presets and persisted drafts may carry runtime selections beyond that
+    // snapshot. The API validates them against the selected execution profile.
     if (normalizedRuntime === "omnigent") {
       if (selectedProfileIsGenericV2) {
         const selected = activeProviderProfiles.find((profile) => profile.profile_id === providerProfile);
@@ -10483,23 +10468,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       (!Number.isInteger(submittedModelTier) || submittedModelTier < 1)
     ) {
       setSubmitMessage("Model tier must be a positive number.");
-      clearSubmitBusy();
-      return;
-    }
-    const invalidStepRuntime = submissionSteps.find((step) => {
-      const stepRuntime = (step.runtimeMode || "").trim().toLowerCase();
-      return (
-        stepRuntime === "omnigent" ||
-        (stepRuntime && !supportedAgentRuntimeIds.includes(stepRuntime))
-      );
-    });
-    if (invalidStepRuntime) {
-      const stepIndex = submissionSteps.indexOf(invalidStepRuntime) + 1;
-      setSubmitMessage(
-        (invalidStepRuntime.runtimeMode || "").trim().toLowerCase() === "omnigent"
-          ? `Step ${stepIndex} cannot use Codex via Omnigent; select it as the workflow runtime instead.`
-          : `Step ${stepIndex} runtime must be one of: ${supportedAgentRuntimes.join(", ")}.`,
-      );
       clearSubmitBusy();
       return;
     }
@@ -11461,15 +11429,10 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       primaryToolRequiredCapabilities,
       ...parsedAdditionalStepInputs.map((entry) => entry.toolCaps),
     );
+    // Runtime identity is compiled by API admission from the selected Profile
+    // and runtime fields. Sending UI-derived runtime tokens as independent
+    // requirements can leave stale harness names in Omnigent host admission.
     const mergedCapabilities = deriveRequiredCapabilities({
-      runtimeMode: normalizedRuntime,
-      stepRuntimeModes: normalizedSteps
-        .map((step) =>
-          String(
-            (step as { runtime?: { mode?: unknown } }).runtime?.mode || "",
-          ).trim(),
-        )
-        .filter(Boolean),
       publishMode: effectivePublishMode,
       taskSkillRequiredCapabilities,
       stepSkillRequiredCapabilities,
@@ -12953,7 +12916,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 step,
               );
               // MM-936: derive the capability chip row for this step. Explicit
-              // chips are removable; preset/skill/tool/runtime/publish/template
+              // chips are removable; preset/skill/tool/publish/template
               // derived chips are non-removable and carry provenance.
               const stepCapabilityChips = buildCapabilityChips({
                 explicit: step.explicitRequiredCapabilities,
@@ -12963,7 +12926,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 generatedTool: step.generatedTool?.requiredCapabilities,
                 preset: selectedPresetCapabilities,
                 template: stepTemplateCapabilities,
-                runtime: step.runtimeMode ? [step.runtimeMode] : [],
                 publish:
                   isPrimaryStep && stepPublishModeRequiresGh ? ["gh"] : [],
               });
@@ -13730,6 +13692,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                           }
                         >
                           <option value="">Inherit agent runtime</option>
+                          {step.runtimeMode && !runtimeOptions.includes(step.runtimeMode) ? (
+                            <option value={step.runtimeMode}>{formatRuntimeLabel(step.runtimeMode)} (Current selection)</option>
+                          ) : null}
                           {supportedAgentRuntimes.map((runtimeOption) => (
                             <option key={runtimeOption} value={runtimeOption}>
                               {formatRuntimeLabel(runtimeOption)}
@@ -14033,6 +13998,9 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 setRuntimeAuthored(true);
               }}
             >
+              {runtime && !runtimeOptions.includes(runtime) ? (
+                <option value={runtime}>{formatRuntimeLabel(runtime)} (Current selection)</option>
+              ) : null}
               {runtimeOptions.map((runtimeOption) => (
                 <option key={runtimeOption} value={runtimeOption}>
                   {formatRuntimeLabel(runtimeOption)}


### PR DESCRIPTION
Workflow Create could reject profile, preset, and saved runtime selections against a stale browser runtime catalog. It also duplicated workflow and step runtime identities into requiredCapabilities, where profile-bound Omnigent admission can interpret those names as unsupported host requirements.

Use the canonical supportedRuntimes catalog for choices, preserve current selections missing from that catalog, and leave runtime admission to the API. Stop synthesizing runtime capability tokens and chips; retain explicit, Skill, Tool, preset, repository, and publishing requirements. Profile configuration and backend admission errors still block submission.

Validation:
- Targeted workflow-start and step-type suites through tools/test_unit.sh: 173 passed; 238 pre-existing skipped tests.
- TypeScript typecheck and targeted ESLint passed.
- Production Vite build and manifest verification passed.

Inspected the local Profile inventory: OpenCode profiles resolve to an Omnigent execution configuration. No deployment or live workflow launch was performed.
