### PR TITLE
Fix Omnigent Host Class admission diagnostics and readiness

### DIFF
--- a/api_service/api/routers/omnigent_agent_profiles.py
+++ b/api_service/api/routers/omnigent_agent_profiles.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from moonmind.omnigent.harness_platform.harness_registry import harness_registration
+
 import hashlib
 import json
 import re
@@ -439,6 +441,7 @@ async def ensure_builtin_opencode_agent_profile(
             integration_mode=harness.capabilities.integrationMode or "native-server",
             materializer_refs=["opencode-auth-json@1", "none@1"],
             requested_host_mode="on-demand",
+            requested_host_class_ref=harness_registration(harness.id).hostClassRef,
         )
     except Exception:
         host_ready = False
@@ -892,6 +895,7 @@ async def create_guided_profile(
             integration_mode=harness.capabilities.integrationMode or "native-server",
             materializer_refs=[str(preset["materializerRef"])],
             requested_host_mode=policy.hostMode,
+            requested_host_class_ref=harness_registration(harness.id).hostClassRef,
         )
     except Exception as exc:
         raise HTTPException(409, "selected_harness_host_class_unavailable") from exc

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -171,8 +171,8 @@ class OmnigentCodexCatalogReadiness(BaseModel):
         _SCHEMA_VERSION, alias="schemaVersion"
     )
     runtime_id: Literal["omnigent"] = Field("omnigent", alias="runtimeId")
-    display_name: Literal["Codex via Omnigent"] = Field(
-        "Codex via Omnigent", alias="displayName"
+    display_name: Literal["Omnigent"] = Field(
+        "Omnigent", alias="displayName"
     )
     agent_kind: Literal["external"] = Field("external", alias="agentKind")
     agent_id: Literal["omnigent"] = Field("omnigent", alias="agentId")

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -6,6 +6,8 @@ selection data, never launch authority or provider/host secret material.
 
 from __future__ import annotations
 
+from moonmind.omnigent.harness_platform.harness_registry import harness_registration
+
 import json
 import os
 import re
@@ -1660,6 +1662,7 @@ async def get_omnigent_execution_readiness(
                         or "native-server",
                         materializer_refs=[materializer],
                         requested_host_mode=get_launch_policy(policy_ref).hostMode,
+                        requested_host_class_ref=harness_registration(harness.id).hostClassRef,
                     )
                     for policy_ref in policy_refs
                 ]

--- a/api_service/services/omnigent_agent_smoke_service.py
+++ b/api_service/services/omnigent_agent_smoke_service.py
@@ -15,6 +15,8 @@ lease cleanup) is specific to smoke validation.
 """
 from __future__ import annotations
 
+from moonmind.omnigent.harness_platform.harness_registry import harness_registration
+
 import asyncio
 import hashlib
 import json
@@ -472,6 +474,7 @@ async def _run_v2_profile_readiness_checks(
                     or "native-server",
                     materializer_refs=[materializer_ref],
                     requested_host_mode=get_launch_policy(policy_ref).hostMode,
+                    requested_host_class_ref=harness_registration(harness.id).hostClassRef,
                 )
             # Smoke attests model availability on its actual host. Discovery
             # cache age or identity does not establish launch authority.

--- a/api_service/services/settings_catalog.py
+++ b/api_service/services/settings_catalog.py
@@ -533,7 +533,7 @@ _REGISTRY: tuple[SettingRegistryEntry, ...] = (
         env_aliases=("WORKFLOW_DEFAULT_RUNTIME", "MOONMIND_DEFAULT_RUNTIME"),
         apply_mode="next_workflow",
         options=(
-            ("omnigent", "Codex via Omnigent"),
+            ("omnigent", "Omnigent"),
             ("codex", "Codex"),
             ("codex_cli", "Codex CLI"),
             ("claude_code", "Claude Code"),

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -64,7 +64,7 @@ claude
 opencode
 ```
 
-An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF` or image/tag override remains authoritative for specialized deployments. It must pass the same bootstrap checks. An incompatible pin is quarantined rather than silently replaced. Existing environment files selecting the old image repository must be updated explicitly.
+An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF` or image/tag override remains authoritative for specialized deployments. It must pass the same bootstrap checks. An incompatible pin is quarantined rather than silently replaced. Existing environment files selecting the old image repository must be updated explicitly. A rejected Host Class reports the underlying reason, including missing or placeholder digests, mismatched compatibility evidence, build/version mismatch, and a missing offline bootstrap contract. A valid digest alone does not prove launch readiness. For an obsolete image, select a qualified shared host and its matching server build, then restart the API and runtime workers so reconciliation and launch use the same image pair. A rejected Host Class reports the underlying reason, including missing or placeholder digests, mismatched compatibility evidence, build/version mismatch, and a missing offline bootstrap contract. A valid digest alone does not prove launch readiness. For an obsolete image, select a qualified shared host and its matching server build, then restart the API and runtime workers so reconciliation and launch use the same image pair.
 
 The image migration does not by itself move Codex or Claude execution to the generic realizer. Those changes require their own runtime-pack, credential-materializer, conformance, rollout, and replay-safe retirement work.
 

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -12,6 +12,8 @@ The Create page lets a user describe work, choose how MoonMind should execute it
 
 The page should support simple one-step workflows while also scaling to advanced workflows that use skills, scripts, managed agents, external agents, presets, Jira issue context, dependencies, publishing, and merge automation.
 
+The runtime selector labels the generic runtime **Omnigent**. The selected Agent Profile identifies its harness; the runtime label does not imply Codex when the profile uses OpenCode or another supported harness.
+
 ## Design Principles
 
 - The Create page is a composition surface, not a catalog of hard-coded workflows.
@@ -426,7 +428,7 @@ The visible **Remediation Draft** section separates:
 - **Pinned target identity (immutable):** target Workflow, exact run, original
   outcome, and selected failed Step Execution/checkpoint evidence.
 - **Editable repair intent:** instructions, repository, starting and isolated
-  work branches, publish mode, Codex via Omnigent runtime, Agent Profile,
+  work branches, publish mode, Omnigent runtime, Agent Profile,
   Provider Profile, execution target and launch policy, model, effort, retrieval
   controls, remediation mode/authority, and the action, evidence, approval,
   lock, verification, and Checkpoint Branch policies.

--- a/frontend/src/browser/remediationJourney.browser.test.tsx
+++ b/frontend/src/browser/remediationJourney.browser.test.tsx
@@ -174,7 +174,7 @@ const createdRelationship = {
 const readyOmnigentCatalog = {
   schemaVersion: 'moonmind.omnigent-codex-readiness.v2',
   runtimeId: 'omnigent',
-  displayName: 'Codex via Omnigent',
+  displayName: 'Omnigent',
   available: true,
   defaultExecutionProfileRef: 'omnigent-codex-default',
   executionProfiles: [

--- a/frontend/src/entrypoints/workflow-detail.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail.test.tsx
@@ -8972,7 +8972,7 @@ describe('Workflow Detail Entrypoint', () => {
       // the demoted diagnostic surface. Wait on durable event content before asserting.
       expect((await screen.findAllByText('Previously approved by operator.')).length).toBeGreaterThan(0);
       const identity = screen.getByRole('region', { name: 'Omnigent runtime identity' });
-      expect(identity.textContent).toContain('Codex via Omnigent');
+      expect(identity.textContent).toContain('Omnigent');
       expect(identity.textContent).toContain('codex-profile');
       expect(identity.textContent).toContain('omnigent-launch:sha256:safe-ref');
       const compatibility = screen.getByRole('region', { name: 'Omnigent compatibility diagnostics' });

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -6552,7 +6552,7 @@ function BridgeSessionLogsPanel({
         error={followUpRetrievalQuery.error}
       />
       <section className="card stack" aria-label="Omnigent runtime identity">
-        <h3>Codex via Omnigent</h3>
+        <h3>Omnigent</h3>
         <dl className="details-grid">
           {([
             ['Provider Profile', projection.providerProfileId],

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -626,7 +626,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
           json: async () => ({
             schemaVersion: "moonmind.omnigent-codex-readiness.v2",
             runtimeId: "omnigent",
-            displayName: "Codex via Omnigent",
+            displayName: "Omnigent",
             available: false,
             eligibleProviderProfiles: [],
             gateReasons: [{
@@ -671,7 +671,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
   const readyOmnigentCatalog = {
     schemaVersion: "moonmind.omnigent-codex-readiness.v2",
     runtimeId: "omnigent",
-    displayName: "Codex via Omnigent",
+    displayName: "Omnigent",
     agentKind: "external",
     agentId: "omnigent",
     harness: "codex-native",
@@ -868,7 +868,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     await waitFor(() => {
       expect(screen.queryAllByText(/endpoint is starting/)).toHaveLength(0);
       expect(
-        screen.queryByText(/Codex via Omnigent cannot be submitted/),
+        screen.queryByText(/Omnigent cannot be submitted/),
       ).toBeNull();
     });
   });
@@ -876,7 +876,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
   it("keeps an unready runtime selectable and explicitly revalidates stale readiness", async () => {
     renderWorkflowStartPage(mockPayload);
 
-    const option = await screen.findByRole("option", { name: "Codex via Omnigent" });
+    const option = await screen.findByRole("option", { name: "Omnigent" });
     expect((option as HTMLOptionElement).disabled).toBe(false);
     fireEvent.change(screen.getByLabelText("Runtime"), {
       target: { value: "omnigent" },
@@ -955,7 +955,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
           json: async () => ({
             schemaVersion: "moonmind.omnigent-codex-readiness.v2",
             runtimeId: "omnigent",
-            displayName: "Codex via Omnigent",
+            displayName: "Omnigent",
             available: true,
             defaultExecutionProfileRef: "omnigent-codex-default",
             executionProfiles: [{
@@ -1025,7 +1025,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Exercise the Omnigent submit boundary." } });
 
-    expect(await screen.findByText("Runtime: Codex via Omnigent")).toBeTruthy();
+    expect(await screen.findByText("Runtime: Omnigent")).toBeTruthy();
     expect(screen.getByText("Host mode: On-demand Docker")).toBeTruthy();
     expect(screen.getByLabelText("Execution target").getAttribute("name")).toBe("omnigentExecutionTargetRef");
     expect(screen.getByLabelText("Execution target").closest(".grid-2")).toBeTruthy();
@@ -21994,7 +21994,7 @@ describe("Task Create runtime switch layout stability", () => {
     renderWithClient(<WorkflowStartPage payload={payload} />);
     const runtime = await screen.findByLabelText("Runtime");
     expect(within(runtime).getByRole("option", { name: "Jules" })).toBeTruthy();
-    expect(within(runtime).queryByRole("option", { name: "Codex via Omnigent" })).toBeNull();
+    expect(within(runtime).queryByRole("option", { name: "Omnigent" })).toBeNull();
   });
 
   it.each(["codex", "claude"])("submits a Profile's %s runtime for API validation despite a stale boot catalog", async (runtimeId) => {

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -3376,7 +3376,7 @@ const RUNTIME_DISPLAY_LABELS: Record<string, string> = {
   claude_code: "Claude Code",
   codex_cli: "Codex CLI",
   codex_cloud: "Codex Cloud",
-  omnigent: "Codex via Omnigent",
+  omnigent: "Omnigent",
 };
 
 function formatRuntimeLabel(runtimeId: string): string {
@@ -14149,7 +14149,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
               </div>
             ) : null}
             <details className="notice small" aria-label="Effective Omnigent selection"><summary>Execution details</summary>
-              <div>Runtime: {selectedProfileIsGenericV2 ? selectedOmnigentAgentProfile?.displayName || "Omnigent" : "Codex via Omnigent"}</div>
+              <div>Runtime: {selectedProfileIsGenericV2 ? selectedOmnigentAgentProfile?.displayName || "Omnigent" : "Omnigent"}</div>
               <div>Profile: {providerOptions.find((option) => option.id === providerProfile)?.label || historicalOmnigentProviderProfile?.label || providerProfile || "Not selected"}</div>
               <div>Host mode: {selectedOmnigentLaunchPolicy?.hostMode === "on_demand_docker" ? "On-demand Docker" : selectedOmnigentLaunchPolicy?.hostMode === "static_compose" ? "Static Compose" : "Not selected"}</div>
               <div>Policy: {omnigentLaunchPolicyRef || "Not selected"}</div>

--- a/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
+++ b/frontend/src/features/workflow-native-chat/WorkflowNativeChatRoute.test.tsx
@@ -60,7 +60,7 @@ function renderRoute(onNavigate = vi.fn(), workflowTerminal = false) {
       routeWorkflowId="wf-1"
       search={new URLSearchParams('source=temporal')}
       workflowTitle="Ship the thing"
-      runtimeLabel="Codex via Omnigent"
+      runtimeLabel="Omnigent"
       workflowTerminal={workflowTerminal}
       pollIntervalMs={5000}
       onNavigate={onNavigate}
@@ -92,7 +92,7 @@ describe('WorkflowNativeChatRoute', () => {
     expect(screen.queryByTestId('chat-session-blocks')).toBeNull();
     // Context bar exposes bounded workflow context + actions.
     expect(screen.getByText('Ship the thing')).toBeTruthy();
-    expect(screen.getByText('Codex via Omnigent')).toBeTruthy();
+    expect(screen.getByText('Omnigent')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Back to Overview' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'View captured evidence' })).toBeTruthy();
   });

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -10169,10 +10169,10 @@ export interface components {
             runtimeId: "omnigent";
             /**
              * Displayname
-             * @default Codex via Omnigent
+             * @default Omnigent
              * @constant
              */
-            displayName: "Codex via Omnigent";
+            displayName: "Omnigent";
             /**
              * Agentkind
              * @default external

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from moonmind.omnigent.harness_platform.harness_registry import harness_registration
+
 import logging
 import os
 from datetime import UTC, datetime
@@ -1438,6 +1440,7 @@ class BootstrapController:
                 integration_mode="native-server",
                 materializer_refs=[materializer_ref],
                 requested_host_mode="on-demand",
+                requested_host_class_ref=harness_registration(harness.id).hostClassRef,
             )
         except Exception as exc:
             raise RuntimeError(f"host class selection failed: {exc}") from exc

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -324,10 +324,11 @@ class OmnigentHostClassSelector:
                 continue
             try:
                 image_ref = _require_image_ref(self._environment, template.image_env)
-            except HarnessPlatformError:
-                reasons.append(
-                    f"{template.ref}: {template.image_env} is not digest-pinned"
-                )
+            except HarnessPlatformError as exc:
+                # Image validation also checks exact-pair compatibility and
+                # bootstrap qualification. Preserve that actionable cause;
+                # a quarantined, valid digest is not a missing image pin.
+                reasons.append(f"{template.ref}: {exc}")
                 continue
             if integration_mode not in template.integration_modes:
                 reasons.append(

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -256,8 +256,9 @@ async def _qualify(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("shared_image", [False, True])
 async def test_qualification_attests_the_launch_policy_admission_selects(
-    qualification_boundary,
+    qualification_boundary, monkeypatch, shared_image,
 ) -> None:
     """Qualification derives the launch policy from the Agent Profile.
 
@@ -265,7 +266,10 @@ async def test_qualification_attests_the_launch_policy_admission_selects(
     ever compiles, and every OpenCode launch then fails evidence admission.
     """
 
+    if shared_image:
+        monkeypatch.setenv("OMNIGENT_SHARED_HOST_IMAGE_REF", _HOST_IMAGE_REF)
     evidence = await _qualify(qualification_boundary)
+    assert evidence["supportIdentity"]["hostClassRef"] == "omnigent-opencode@1"
 
     expected = default_launch_policy_ref(_ALLOWED_LAUNCH_POLICIES)
     assert expected == "omnigent-on-demand@1"

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -757,3 +757,89 @@ async def test_publication_never_clears_an_operator_pinned_ref(
     import os
 
     assert os.environ["OMNIGENT_PI_HOST_IMAGE_REF"] == pinned_pi
+
+
+@pytest.mark.parametrize("explicit_pin", [False, True])
+@pytest.mark.parametrize(
+    "failure_code",
+    [
+        "omnigent_host_bootstrap_contract_missing",
+        "omnigent_server_host_build_mismatch",
+        "omnigent_server_host_version_mismatch",
+        "omnigent_server_host_version_probe_failed",
+    ],
+)
+def test_host_selection_preserves_quarantine_reason(
+    monkeypatch, explicit_pin, failure_code
+):
+    """Replay Create's escaped misleading digest error through selection."""
+    from types import SimpleNamespace
+
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform.host_classes import (
+        OmnigentHostClassSelector,
+    )
+    from moonmind.omnigent.harness_platform.failures import (
+        HarnessPlatformError,
+        HarnessPlatformFailure,
+    )
+
+    state = _state(
+        details={
+            "opencodeHostCompatibility": {
+                "status": "blocked",
+                "failureCode": failure_code,
+                "serverImageRef": SERVER_REF,
+                "hostImageRef": HOST_REF,
+            }
+        }
+    )
+    monkeypatch.setattr(store, "load_resolved_state", lambda: state)
+    environment = {"OMNIGENT_OPENCODE_HOST_IMAGE_REF": HOST_REF} if explicit_pin else {}
+    with pytest.raises(HarnessPlatformError) as caught:
+        OmnigentHostClassSelector(environment=environment).select(
+            harness=SimpleNamespace(id="opencode-native"),
+            omnigent_version="0.12.0",
+            omnigent_build_digest=BUILD_DIGEST,
+            integration_mode="native-server",
+            materializer_refs=["opencode-auth-json@1"],
+            requested_host_class_ref="omnigent-opencode@1",
+        )
+    assert caught.value.code == HarnessPlatformFailure.OMNIGENT_HOST_CLASS_UNAVAILABLE
+    assert failure_code in str(caught.value)
+    assert "quarantined" in str(caught.value)
+    assert "not digest-pinned" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "image_ref, expected",
+    [
+        ("", "must be set to a digest-pinned image ref"),
+        ("ghcr.io/example/host:latest", "must be set to a digest-pinned image ref"),
+        ("ghcr.io/example/host@sha256:" + "0" * 64, "digest must not be a placeholder"),
+        (HOST_REF, "compatibility evidence does not match"),
+    ],
+)
+def test_host_selection_preserves_adjacent_image_failures(
+    monkeypatch, image_ref, expected
+):
+    from types import SimpleNamespace
+
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform.host_classes import (
+        OmnigentHostClassSelector,
+    )
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+
+    monkeypatch.setattr(store, "load_resolved_state", lambda: None)
+    with pytest.raises(HarnessPlatformError, match=expected):
+        OmnigentHostClassSelector(
+            environment={"OMNIGENT_OPENCODE_HOST_IMAGE_REF": image_ref}
+        ).select(
+            harness=SimpleNamespace(id="opencode-native"),
+            omnigent_version="0.12.0",
+            omnigent_build_digest=BUILD_DIGEST,
+            integration_mode="native-server",
+            materializer_refs=["opencode-auth-json@1"],
+            requested_host_class_ref="omnigent-opencode@1",
+        )

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -1260,3 +1260,28 @@ async def test_untrusted_evidence_values_are_redacted_from_admission_errors(
     assert "launchPolicyRef differs" in message
     assert untrusted_value not in message
     assert "/api/omnigent/bootstrap/opencode/retry" not in message
+
+
+@pytest.mark.asyncio
+async def test_create_plan_reports_bootstrap_quarantine_instead_of_invalid_digest(monkeypatch):
+    """A pinned pre-cache image must expose its real rejection at Create."""
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+
+    host_ref = "ghcr.io/example/omnigent-host@sha256:" + "7" * 64
+    state = SimpleNamespace(
+        server_image_ref=_SERVER_IMAGE_REF,
+        opencode_host_image_ref=host_ref,
+        details={"opencodeHostCompatibility": {
+            "status": "blocked",
+            "failureCode": "omnigent_host_bootstrap_contract_missing",
+            "serverImageRef": _SERVER_IMAGE_REF,
+            "hostImageRef": host_ref,
+        }},
+    )
+    monkeypatch.setattr(store, "load_resolved_state", lambda: state)
+    with pytest.raises(HarnessPlatformError, match="omnigent_host_bootstrap_contract_missing"):
+        await _compile_opencode_plan(
+            monkeypatch, artifacts=_ArtifactService(),
+            launch_policy_ref="opencode-on-demand@1", plan_store=_PlanStore(object()),
+        )


### PR DESCRIPTION
Workflow creation reported that a digest-pinned OpenCode image was unpinned because Host Class selection discarded the underlying bootstrap-qualification error. Preserve the actual rejection reason, and make bootstrap qualification, profile readiness, and catalog checks select the same registered Host Class as workflow admission when both OpenCode classes are installed. Label the generic runtime Omnigent across Create, Detail, and the settings catalog.

Validation:
- Canonical tools/test_unit.sh from a clean tracked checkout: both repository guards and all 182 selected backend tests passed.
- 379 frontend tests passed (238 existing skips).
- 13 startup and admission integration tests passed.
- Complete application image built and deployed; deployed dashboard asset verification passed.
- Live Create submission accepted and launched OpenCode Go with opencode-go/muse-spark-1.3-contributor, xhigh, MoonLadderStudios/MoonMind, and PR with Merge Automation. Runtime heartbeat confirmed first-message delivery and active work; the workflow published the requested UI removal as PR #3996 and entered merge automation.

Deployment diagnosis: the ignored local configuration pinned an obsolete OpenCode image without the offline plugin cache. Updated it to the verified shared host image and matching Omnigent 0.12.0 server build. The code retains digest and compatibility enforcement. The optional static Codex host also reports a missing active Skill manifest; the requested on-demand OpenCode workflow uses its own resolved manifest.

