### PR TITLE
Fix Claude Profile admission and direct fan-out repository context

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11067,6 +11067,27 @@ async def _create_execution_from_workflow_request(
     if derived_task_title:
         normalized_task_for_planner["title"] = derived_task_title
 
+    raw_profile_id = str(
+        runtime_payload.get("providerProfileRef")
+        or runtime_payload.get("profileId")
+        or runtime_payload.get("providerProfile")
+        or task_payload.get("providerProfileRef")
+        or task_payload.get("profileId")
+        or task_payload.get("providerProfile")
+        or payload.get("providerProfileRef")
+        or payload.get("profileId")
+        or payload.get("providerProfile")
+        or ""
+    ).strip() or None
+    _provider_profile = None
+    if raw_profile_id and session is not None:
+        _provider_profile = await _load_provider_profile_for_runtime(
+            session=session,
+            profile_id=raw_profile_id,
+            selected_runtime=None,
+            not_found_message=f"Provider profile not found: {raw_profile_id!r}.",
+        )
+
     # --- Model resolution ---
     runtime_was_authored = runtime_payload.get("authored") is not False
     authored_runtime = (
@@ -11074,6 +11095,23 @@ async def _create_execution_from_workflow_request(
         if runtime_was_authored
         else None
     )
+    if not authored_runtime and _provider_profile is not None:
+        # Profile selection is execution authority even when the advanced
+        # runtime control was untouched. Use the same route as inventory; an
+        # unready or pinned Omnigent configuration must never fall back direct.
+        from api_service.services.profile_execution_selection import (
+            load_execution_configurations,
+            profile_has_native_inventory_route,
+        )
+
+        configurations = await load_execution_configurations(
+            session, user, [_provider_profile]
+        )
+        authored_runtime = (
+            _provider_profile.runtime_id
+            if profile_has_native_inventory_route(_provider_profile, configurations)
+            else "omnigent"
+        )
     try:
         cutover_status = effective_phase()
         cutover_selection = select_runtime(
@@ -11090,18 +11128,6 @@ async def _create_execution_from_workflow_request(
     except ValueError as exc:
         raise _invalid_workflow_request(str(exc)) from exc
     raw_target_runtime = cutover_selection.runtime_id
-    raw_profile_id = str(
-        runtime_payload.get("providerProfileRef")
-        or runtime_payload.get("profileId")
-        or runtime_payload.get("providerProfile")
-        or task_payload.get("providerProfileRef")
-        or task_payload.get("profileId")
-        or task_payload.get("providerProfile")
-        or payload.get("providerProfileRef")
-        or payload.get("profileId")
-        or payload.get("providerProfile")
-        or ""
-    ).strip() or None
     # Preserve the original requested model byte-for-byte (Compatibility Policy:
     # codex.model and codex.effort inputs must not be modified).
     raw_requested_model: str | None = runtime_payload.get("model") or None
@@ -11133,13 +11159,11 @@ async def _create_execution_from_workflow_request(
     # Load provider profile when a profileId is supplied. For tier-aware
     # submissions without an exact profile, use the same runtime default profile
     # selection order as the ProviderProfileManager.
-    _provider_profile = None
-    if raw_profile_id and session is not None:
-        _provider_profile = await _load_provider_profile_for_runtime(
-            session=session,
+    if _provider_profile is not None:
+        _require_provider_profile_runtime(
+            profile=_provider_profile,
             profile_id=raw_profile_id,
             selected_runtime=canonical_target_runtime,
-            not_found_message=f"Provider profile not found: {raw_profile_id!r}.",
         )
     elif _runtime_model_tier(runtime_payload) is not None:
         _provider_profile = await _load_default_provider_profile_for_runtime(

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -43,6 +43,14 @@ because model discovery expires or a host image changes. Disabled and disconnect
 Profiles remain visible with an actionable setup state. Credentials, trust,
 capability compatibility and actual-host model verification remain launch gates.
 
+When the advanced runtime control is untouched or omitted, the selected Profile
+owns runtime selection before deployment defaults apply. A supported direct
+runtime Profile without a compatible Omnigent configuration uses its owning
+runtime. A pinned or compatible Omnigent configuration keeps Omnigent authority,
+including when validation is incomplete; it cannot silently fall back to direct
+execution. Explicit runtime overrides remain subject to compatibility checks.
+The selected model and effort are preserved through this admission decision.
+
 ## 1. Summary
 
 MoonMind-managed runtimes such as Claude Code and Codex CLI do not map one-to-one to a single upstream company or a single authentication method.

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -468,6 +468,13 @@ requests with `runtimeInheritance="caller"`, rejects schedule and direct-create
 shapes, records the authoritative `parentWorkflowId`, and limits describe calls
 to children of that parent. Restricted Omnigent egress additionally requires
 the fan-out marker and bearer on the exact create and child-describe paths.
+
+Fan-out launch context also carries `MOONMIND_REPOSITORY_CONNECTION_REF` when
+the parent request declares repository connection authority. Direct managed
+processes and Omnigent hosts derive this value from the canonical workspace
+request, including supported in-flight payload shapes. Ambient or Provider
+Profile environment values cannot substitute a different connection. Portable
+Skills use that exported reference when constructing child repository targets.
 Profile-bound Omnigent hosts expose the bearer through a lease-owned read-only
 file and pass only its non-secret selector into runner and login-shell
 environments. Hosts without the requirement receive neither the bearer nor the

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -929,6 +929,7 @@ class ManagedRuntimeLauncher:
 
         environment.pop("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", None)
         environment.pop("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE", None)
+        environment.pop("MOONMIND_REPOSITORY_CONNECTION_REF", None)
         raw_capabilities = request.parameters.get("requiredCapabilities")
         if raw_capabilities is None:
             required_capabilities: tuple[str, ...] = ()
@@ -950,6 +951,16 @@ class ManagedRuntimeLauncher:
             required_capabilities,
             authorization,
         )
+        # Share the canonical request reader with Omnigent: portable fan-out
+        # Skills need the parent's connection authority in every runtime host.
+        # Never substitute ambient or profile-provided repository authority.
+        from moonmind.omnigent.workspace_intent import authored_connection_ref
+
+        repository_connection_ref = authored_connection_ref(request)
+        if repository_connection_ref:
+            environment["MOONMIND_REPOSITORY_CONNECTION_REF"] = (
+                repository_connection_ref
+            )
         step_execution = request.step_execution
         request_workflow_id = (
             str(step_execution.workflow_id or "").strip()

--- a/tests/integration/reliability/replays/direct-managed-fanout-repository-context/expected-outcome.json
+++ b/tests/integration/reliability/replays/direct-managed-fanout-repository-context/expected-outcome.json
@@ -1,0 +1,13 @@
+{
+  "invariant": "The direct runtime hands the authorized parent repository connection to the portable fan-out Skill without ambient authority substitution",
+  "repositoryCapabilityOwner": "runtime",
+  "capabilitySourceKind": "managed_process",
+  "requiredClaimBindings": [
+    "parentWorkflowId",
+    "agentRunId",
+    "stepId",
+    "runtimeId"
+  ],
+  "staleCapabilityFileSelectorRemoved": true,
+  "unknownCapabilitiesRemainFailClosed": true
+}

--- a/tests/integration/reliability/replays/direct-managed-fanout-repository-context/manifest.json
+++ b/tests/integration/reliability/replays/direct-managed-fanout-repository-context/manifest.json
@@ -1,0 +1,65 @@
+{
+  "incidentWorkflowId": "mm:c9e85a81-581a-4cc5-9f63-469a7f287d41",
+  "agentRunId": "76279da5-dbfe-46b9-87e5-dda1eff0a861",
+  "logicalStepId": "tpl:batch-github-workflows:01:998a52f5",
+  "targetRuntime": "claude_code",
+  "repository": "MoonLadderStudios/MoonMind",
+  "preparedCommitSha": "01f12e5b65e0601b6606a898e0a4ac1567d9f0a5",
+  "terminalFailureCode": "BATCH_FANOUT_INPUT_INVALID",
+  "failureShape": "Direct Claude launched with a canonical repository target but omitted MOONMIND_REPOSITORY_CONNECTION_REF, so batch GitHub discovery failed before queuing children",
+  "request": {
+    "agentKind": "managed",
+    "agentId": "claude_code",
+    "executionProfileRef": "claude_anthropic_oauth",
+    "correlationId": "replay-mm-c9e85a81",
+    "idempotencyKey": "mm:c9e85a81:76279da5-dbfe-46b9-87e5-dda1eff0a861",
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "repositoryTarget": {
+        "provider": "git",
+        "connectionRef": "repository-connection:git-default",
+        "repository": {
+          "name": "MoonLadderStudios/MoonMind"
+        },
+        "branch": {
+          "name": "main"
+        }
+      }
+    },
+    "parameters": {
+      "publishMode": "none",
+      "requiredCapabilities": [
+        "claude_code",
+        "git",
+        "gh",
+        "execution.fanout"
+      ],
+      "model": "claude-opus-5",
+      "effort": "xhigh"
+    },
+    "skill": {
+      "name": "batch-workflows",
+      "requiredCapabilities": [
+        "git",
+        "gh",
+        "execution.fanout"
+      ]
+    },
+    "stepExecution": {
+      "workflowId": "mm:c9e85a81-581a-4cc5-9f63-469a7f287d41",
+      "runId": "01a07046-5795-71e3-814a-f5ab08272eb9",
+      "logicalStepId": "tpl:batch-github-workflows:01:998a52f5",
+      "executionOrdinal": 1,
+      "stepExecutionId": "mm:c9e85a81-581a-4cc5-9f63-469a7f287d41:01a07046-5795-71e3-814a-f5ab08272eb9:tpl:batch-github-workflows:01:998a52f5:execution:1",
+      "runtimeContextPolicy": "fresh_agent_run",
+      "skillSourcePolicy": {
+        "executionFanout": {
+          "authorized": true,
+          "selectedSkill": "batch-workflows",
+          "sourceKind": "built_in",
+          "reasonCode": "trusted_resolved_skill_requirement"
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -280,13 +280,17 @@ pytestmark = [
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+@pytest.mark.parametrize("replay_id", [
+    "direct-managed-fanout-readiness",
+    "direct-managed-fanout-repository-context",
+])
 async def test_direct_managed_fanout_crosses_repository_and_launch_readiness(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    replay_id: str,
 ) -> None:
-    """Replay mm:91c47b8e across both pre-launch authority handoffs."""
+    """Replay direct fan-out failures across repository and runtime authority."""
 
-    replay_id = "direct-managed-fanout-readiness"
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
     evidence = RepositoryClientEvidence(
@@ -325,6 +329,7 @@ async def test_direct_managed_fanout_crosses_repository_and_launch_readiness(
         "MOONMIND_URL": "http://api:8000",
         "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "stale-token",
         "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "/stale/token-file",
+        "MOONMIND_REPOSITORY_CONNECTION_REF": "repository-connection:stale",
     }
     launcher._materialize_execution_fanout_environment(
         environment=environment,
@@ -348,6 +353,10 @@ async def test_direct_managed_fanout_crosses_repository_and_launch_readiness(
     assert capability.agent_run_id == manifest["agentRunId"]
     assert capability.step_id == manifest["logicalStepId"]
     assert capability.runtime_id == manifest["targetRuntime"]
+    assert (
+        environment["MOONMIND_REPOSITORY_CONNECTION_REF"]
+        == resolved_repository.connection_ref
+    )
     assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE" not in environment
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -18280,6 +18280,61 @@ def test_mm3788_create_execution_accepts_provider_profile_owned_by_selected_runt
     assert initial_parameters["profileId"] == "claude_minimax_team"
 
 
+@pytest.mark.parametrize("runtime", ["claude_code", "codex_cli"])
+@pytest.mark.parametrize("selection", ["profile_inferred", "omitted", "explicit"])
+def test_profile_selected_runtime_survives_deployment_default(
+    monkeypatch, runtime, selection
+) -> None:
+    """Replay the UI's untouched advanced-runtime control at Temporal admission."""
+    monkeypatch.setattr(settings.workflow, "default_runtime", "omnigent")
+    profile = _mm3788_provider_profile(profile_id="subscription", runtime_id=runtime)
+    profile.provider_id = "anthropic" if runtime == "claude_code" else "openai"
+    body = _mm3788_task_request(target_runtime=runtime, profile_id=profile.profile_id)
+    authored = body["payload"]["workflow"]["runtime"]
+    model = "claude-opus-5" if runtime == "claude_code" else "gpt-5"
+    authored.update(model=model, effort="xhigh")
+    if selection == "profile_inferred":
+        authored["authored"] = False
+    elif selection == "omitted":
+        del body["payload"]["targetRuntime"]
+        del authored["mode"]
+
+    for test_client, service in _mm3788_client(profile):
+        response = test_client.post("/api/executions", json=body)
+
+    assert response.status_code == 201, response.text
+    parameters = service.create_execution.await_args.kwargs["initial_parameters"]
+    assert parameters["targetRuntime"] == runtime
+    assert parameters["profileId"] == profile.profile_id
+    assert parameters["model"] == model
+    assert parameters["effort"] == "xhigh"
+    assert parameters["workflow"]["runtime"]["mode"] == runtime
+
+
+@pytest.mark.parametrize("explicit_omnigent", [False, True])
+def test_profile_runtime_inference_does_not_bypass_omnigent_authority(
+    monkeypatch, explicit_omnigent
+) -> None:
+    monkeypatch.setattr(settings.workflow, "default_runtime", "claude_code")
+    profile = _mm3788_provider_profile(
+        profile_id="subscription", runtime_id="claude_code"
+    )
+    profile.execution_configuration = {
+        "profileId": "missing", "version": 1, "digest": "sha256:" + "a" * 64,
+    }
+    body = _mm3788_task_request(
+        target_runtime="omnigent" if explicit_omnigent else "claude_code",
+        profile_id=profile.profile_id,
+    )
+    body["payload"]["workflow"]["runtime"]["authored"] = explicit_omnigent
+    for test_client, service in _mm3788_client(profile):
+        response = test_client.post("/api/executions", json=body)
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "profile_execution_configuration_required"
+    service.create_execution.assert_not_awaited()
+
+
 def test_mm3788_create_execution_rejects_legacy_runtime_alias_mismatch() -> None:
     """Canonical runtime IDs decide the comparison, not the submitted spelling."""
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -18280,19 +18280,25 @@ def test_mm3788_create_execution_accepts_provider_profile_owned_by_selected_runt
     assert initial_parameters["profileId"] == "claude_minimax_team"
 
 
-@pytest.mark.parametrize("runtime", ["claude_code", "codex_cli"])
+@pytest.mark.parametrize(
+    "runtime,provider_id,model,effort",
+    [
+        ("claude_code", "anthropic", "claude-opus-5", "xhigh"),
+        ("codex_cli", "openai", "gpt-5", "xhigh"),
+        ("jules", "google", "provider-selected-model", None),
+    ],
+)
 @pytest.mark.parametrize("selection", ["profile_inferred", "omitted", "explicit"])
 def test_profile_selected_runtime_survives_deployment_default(
-    monkeypatch, runtime, selection
+    monkeypatch, runtime, provider_id, model, effort, selection
 ) -> None:
     """Replay the UI's untouched advanced-runtime control at Temporal admission."""
     monkeypatch.setattr(settings.workflow, "default_runtime", "omnigent")
     profile = _mm3788_provider_profile(profile_id="subscription", runtime_id=runtime)
-    profile.provider_id = "anthropic" if runtime == "claude_code" else "openai"
+    profile.provider_id = provider_id
     body = _mm3788_task_request(target_runtime=runtime, profile_id=profile.profile_id)
     authored = body["payload"]["workflow"]["runtime"]
-    model = "claude-opus-5" if runtime == "claude_code" else "gpt-5"
-    authored.update(model=model, effort="xhigh")
+    authored.update(model=model, effort=effort)
     if selection == "profile_inferred":
         authored["authored"] = False
     elif selection == "omitted":
@@ -18307,7 +18313,7 @@ def test_profile_selected_runtime_survives_deployment_default(
     assert parameters["targetRuntime"] == runtime
     assert parameters["profileId"] == profile.profile_id
     assert parameters["model"] == model
-    assert parameters["effort"] == "xhigh"
+    assert parameters["effort"] == effort
     assert parameters["workflow"]["runtime"]["mode"] == runtime
 
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -4804,8 +4804,10 @@ async def test_launch_generic_env_uses_logical_step_id_for_artifacts_dir(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_id", ["claude_code", "codex_cli"])
+@pytest.mark.parametrize("repository_shape", ["current", "in_flight", "absent"])
 async def test_direct_managed_launch_materializes_scoped_execution_fanout(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, runtime_id, repository_shape
 ):
     """Replay mm:91c47b8e through the direct Claude launch environment."""
 
@@ -4815,7 +4817,15 @@ async def test_direct_managed_launch_materializes_scoped_execution_fanout(
     workspace = tmp_path / "workspaces" / "agent-run-1" / "repo"
     workspace.mkdir(parents=True)
     launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+    connection_ref = "repository-connection:operator-selected"
+    workspace_spec = {
+        "current": {"repositoryTarget": {"connectionRef": connection_ref}},
+        "in_flight": {"connectionRef": connection_ref},
+        "absent": {},
+    }[repository_shape]
+    launcher._repository_readiness_boundary = AsyncMock(return_value=None)
     request = _make_request(
+        workspace_spec=workspace_spec,
         parameters={"requiredCapabilities": ["execution.fanout"]},
         timeout_policy={"timeout_seconds": 300},
         step_execution={
@@ -4843,8 +4853,9 @@ async def test_direct_managed_launch_materializes_scoped_execution_fanout(
         workflow_id="mm:parent",
         request=request,
         profile=_make_profile(
-            runtime_id="claude_code",
+            runtime_id=runtime_id,
             command_template=["echo", "hello"],
+            env_overrides={"MOONMIND_REPOSITORY_CONNECTION_REF": "repository-connection:stale"},
         ),
         workspace_path=str(workspace),
     )
@@ -4858,12 +4869,16 @@ async def test_direct_managed_launch_materializes_scoped_execution_fanout(
     assert capability.agent_run_id == "agent-run-1"
     assert capability.step_id == "batch-workflows"
     assert capability.session_id == "agent-run-1"
-    assert capability.runtime_id == "claude_code"
+    assert capability.runtime_id == runtime_id
     assert capability.source_kind == "managed_process"
     assert captured_env["MOONMIND_TASK_WORKFLOW_ID"] == "mm:parent"
     assert captured_env["MOONMIND_AGENT_RUN_ID"] == "agent-run-1"
-    assert captured_env["MOONMIND_RUNTIME_ID"] == "claude_code"
+    assert captured_env["MOONMIND_RUNTIME_ID"] == runtime_id
     assert captured_env["MOONMIND_STEP_ID"] == "batch-workflows"
+    if repository_shape == "absent":
+        assert "MOONMIND_REPOSITORY_CONNECTION_REF" not in captured_env
+    else:
+        assert captured_env["MOONMIND_REPOSITORY_CONNECTION_REF"] == connection_ref
     # The capability must still be valid at the execution ceiling. It is minted
     # before the broker, workspace ownership changes, and process creation that
     # precede the supervisor starting its clock, so a lifetime of exactly the
@@ -4878,6 +4893,7 @@ def test_direct_managed_launch_removes_unrequested_ambient_fanout_authority() ->
     environment = {
         "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "stale-inline-token",
         "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "/stale/token-file",
+        "MOONMIND_REPOSITORY_CONNECTION_REF": "repository-connection:stale",
     }
 
     ManagedRuntimeLauncher._materialize_execution_fanout_environment(
@@ -4890,6 +4906,7 @@ def test_direct_managed_launch_removes_unrequested_ambient_fanout_authority() ->
 
     assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
     assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE" not in environment
+    assert "MOONMIND_REPOSITORY_CONNECTION_REF" not in environment
 
 
 def test_direct_managed_launch_rejects_denied_fanout_authorization() -> None:


### PR DESCRIPTION
Selecting a Claude OAuth Profile in Create inferred `claude_code` in the UI but sent `runtime.authored=false`. API admission discarded that selection and applied the deployment's Omnigent default, returning HTTP 409 because the Claude Profile had no Omnigent execution configuration.

Resolve the selected Profile's route before deployment defaults, using the same native-route rule as Profile inventory. Explicit runtime overrides remain authoritative, and missing or unvalidated Omnigent configurations cannot fall back to direct execution. Model and effort values remain unchanged.

Live verification also exposed missing repository connection context in the direct-process fan-out environment. Export the parent's canonical connection reference using the same request reader as Omnigent, clearing stale ambient values. Current and in-flight request shapes remain supported; no workflow payload shape changes are introduced.

Validation: 524 targeted API/configuration/cutover tests, an expanded 9-case direct-runtime admission matrix, 114 launcher tests, and all 165 reliability journey tests passed. A minimized replay captures the missing connection context. The deployed UI-shaped submission returned HTTP 201, and its Claude Opus 5/xhigh batch completed with 8 children and zero final errors after the agent recovered the missing context. All eight durable child snapshots retain the selected OAuth Profile and PR publication with merge automation enabled. The launcher regression fix removes the need for that recovery on future runs.
