### PR TITLE
Retire duplicate direct and profile-bound runtime architecture: code-owned retirement inventory and gated removal (MoonLadderStudios/MoonMind#3835)

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -60,6 +60,11 @@ OMNIGENT_OIDC_LOGOUT_REDIRECT_URI=""
 OMNIGENT_OIDC_ALLOW_INVITES=""
 OMNIGENT_DOMAIN=""
 OMNIGENT_CONFIG=""
+# Legacy generic host image variables. Retirement row
+# `omnigent.legacy.host_image_variable_alias` (MoonLadderStudios/MoonMind#3835):
+# these are a bounded alias honored only when OMNIGENT_SHARED_HOST_IMAGE_REF is
+# unset, and they are removed at the image and environment alias stage once no
+# deployment depends on them. Prefer OMNIGENT_SHARED_HOST_IMAGE_REF below.
 OMNIGENT_HOST_IMAGE_REF=""
 OMNIGENT_HOST_IMAGE="ghcr.io/omnigent-ai/omnigent-host"
 OMNIGENT_HOST_IMAGE_TAG="latest"
@@ -85,6 +90,10 @@ OPENCODE_MODEL_CATALOG_MAX_AGE_HOURS=6
 # ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:<digest>
 # Mutable tags never become launch authority: startup resolves the tag to its
 # immutable digest once and every selector reads that digest.
+# Retirement row `omnigent.legacy.opencode_host_image_alias` (#3835): this
+# OpenCode-specific variable and the `omnigent-host-opencode` alias it names are
+# superseded by OMNIGENT_SHARED_HOST_IMAGE_REF and are removed at the image and
+# environment alias stage once no dependency remains.
 OMNIGENT_OPENCODE_HOST_IMAGE_REF=""
 OMNIGENT_OPENCODE_HOST_IMAGE="ghcr.io/moonladderstudios/omnigent-host-moonmind"
 OMNIGENT_OPENCODE_HOST_IMAGE_TAG="1.18.11"
@@ -128,6 +137,8 @@ MOONMIND_OMNIGENT_HTTP_MAX_CONNECTIONS=64
 MOONMIND_OMNIGENT_HTTP_MAX_KEEPALIVE_CONNECTIONS=32
 MOONMIND_OMNIGENT_HTTP_KEEPALIVE_EXPIRY_SECONDS=30
 # Optional second-harness runtime pack. It is never inferred from a mutable tag.
+# Retirement row `omnigent.legacy.pi_host_image_alias` (#3835): a per-provider
+# image identity superseded by the shared host image.
 OMNIGENT_PI_HOST_IMAGE_REF=""
 MOONMIND_OMNIGENT_TOOLS_VOLUME_REF="moonmind-omnigent-tools-gh-2.76.2"
 # Embedded host auth managed profile (MoonLadderStudios/MoonMind#3423).

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -246,7 +246,11 @@ from moonmind.workflows.executions.preset_goal_scheduler import (
     workflow_is_already_authored,
 )
 from moonmind.workflows.executions.runtime_defaults import normalize_runtime_id
-from moonmind.omnigent.cutover import effective_phase, select_runtime
+from moonmind.omnigent.cutover import (
+    assert_runtime_new_admission,
+    effective_phase,
+    select_runtime,
+)
 from moonmind.omnigent.bridge_store import (
     BridgeChatBindingAmbiguousError,
     BridgeProjectionAmbiguousError,
@@ -8665,6 +8669,17 @@ async def _resolve_step_runtime_selections(
                     "claude_code, codex_cloud, jules."
                 )
             canonical_step_runtime = normalized_rt
+            # A step override is new admission in its own right. The top-level
+            # ``select_runtime`` gate only covers the workflow's runtime, so
+            # without this check an allowed top-level runtime plus a legacy
+            # ``steps[i].runtime.mode`` would keep creating new legacy work
+            # after the direct strategy's retirement class stopped admitting it.
+            try:
+                assert_runtime_new_admission(canonical_step_runtime)
+            except ValueError as exc:
+                raise _invalid_workflow_request(
+                    f"payload.workflow.steps[{index}].runtime.mode: {exc}"
+                ) from exc
 
         raw_step_profile_id = str(
             runtime_payload.get("profileId")

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -2431,12 +2431,16 @@ def _assert_omnigent_configuration_is_current() -> None:
     its retirement row is still in its deprecation window the operator gets an
     actionable warning naming the replacement, and after removal startup is
     rejected outright.
+
+    The API is one of several separately restartable consumers, so it invokes
+    the shared check rather than owning its own copy.
     """
 
-    from moonmind.omnigent.legacy_retirement import assert_obsolete_configuration
+    from moonmind.omnigent.legacy_retirement import (
+        enforce_obsolete_configuration_at_startup,
+    )
 
-    for warning in assert_obsolete_configuration(os.environ):
-        logger.warning("Obsolete Omnigent configuration: %s", warning)
+    enforce_obsolete_configuration_at_startup(logger, env=os.environ)
 
 
 async def startup_event():

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -2423,6 +2423,22 @@ def _register_settings_change_subscribers() -> None:
         )
 
 
+def _assert_omnigent_configuration_is_current() -> None:
+    """Fail fast (or warn) on obsolete Omnigent configuration.
+
+    Source issue: MoonLadderStudios/MoonMind#3835 required work section 10.
+    A legacy image/environment identity must never be silently ignored: while
+    its retirement row is still in its deprecation window the operator gets an
+    actionable warning naming the replacement, and after removal startup is
+    rejected outright.
+    """
+
+    from moonmind.omnigent.legacy_retirement import assert_obsolete_configuration
+
+    for warning in assert_obsolete_configuration(os.environ):
+        logger.warning("Obsolete Omnigent configuration: %s", warning)
+
+
 async def startup_event():
     """Defines the application's startup events."""
     logger.info("Executing application startup events...")
@@ -2433,6 +2449,7 @@ async def startup_event():
 
         app.state = State()
 
+    _assert_omnigent_configuration_is_current()
     await _initialize_oidc_provider(app)  # OIDC provider init like Keycloak discovery
     _register_settings_change_subscribers()
     try:

--- a/docs/Omnigent/CombinedStackValidationAndRollback.md
+++ b/docs/Omnigent/CombinedStackValidationAndRollback.md
@@ -207,6 +207,28 @@ Normal rollback preserves PostgreSQL, MoonMind, and Omnigent volumes. It also pr
 
 Before disabling a workflow-requested on-demand host path, drain or terminate active host leases through MoonMind lifecycle controls. Do not use `docker compose down` as proof that on-demand containers have been reconciled because they are worker-created, not Compose-owned.
 
+Rolling back to a legacy runtime default changes **future admission only**. It
+never rewrites an active or historical execution, never substitutes a different
+profile, host mode, policy, or session for a request, and never releases Provider
+Profile capacity before credential consumers stop and cleanup completes. A
+rollback is scoped to one exact combination — Agent Profile, Host Class,
+materializer, realizer, model, launch policy, host mode, architecture, and owner
+cohort — matched by exact equality, and a legacy path classified `rollback_only`
+re-admits new work only under the exact rollback generation the operator
+selected. Rollback evidence expires: a recorded exercise older than its freshness
+bound no longer counts, so a legacy path can never be silently reactivated on
+stale support evidence. See `moonmind/omnigent/session_supervisor_rollback.py`
+and [Omnigent Module Architecture §5](OmnigentModuleArchitecture.md#5-retained-duplicate-architecture-and-its-retirement-owners).
+
+Legacy Compose profiles (`omnigent-host-codex`, `omnigent-host-claude`,
+`omnigent-host`) and the legacy image variables (`OMNIGENT_HOST_IMAGE_REF`,
+`OMNIGENT_HOST_IMAGE`, `OMNIGENT_HOST_IMAGE_TAG`,
+`OMNIGENT_OPENCODE_HOST_IMAGE_REF`, `OMNIGENT_PI_HOST_IMAGE_REF`) each carry a
+retirement row and remain supported while their rollback window is open. Once a
+variable enters its deprecation window, supplying it produces an actionable
+startup warning naming the replacement; after removal, startup is rejected rather
+than silently ignoring the value.
+
 ## DOC-REQ-010 Optional Destructive Cleanup
 
 Database and volume cleanup is optional, destructive, and separate from normal rollback. Perform it only when the operator has confirmed the data is disposable or has a tested backup.

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -1762,9 +1762,12 @@ vendors; approving a harness is registration data in
 identities have one owner, `control_plane/identities.py`.
 
 The existing Codex realizer is an explicit replay-visible legacy adapter. It and
-every other retained shim are listed with their #3712 retirement owner in
-`moonmind/omnigent/legacy_retirement.py`, alongside the bounded architecture
-exemptions that are still permitted.
+every other retained component are listed in
+`moonmind/omnigent/legacy_retirement.py` with their retirement owner, their
+#3835 retirement class, the active/replay/historical-read/rollback dependencies
+that must drain before removal, their earliest removal stage, and the guard test
+a removal PR must cite — alongside the bounded architecture exemptions that are
+still permitted, each of which names the retirement row that retires it.
 
 ## 34. Document authority and future promotion
 

--- a/docs/Omnigent/OmnigentModuleArchitecture.md
+++ b/docs/Omnigent/OmnigentModuleArchitecture.md
@@ -155,27 +155,118 @@ drifts away from the adapter's signature. `ProfileBoundHostPorts` and
 `OmnigentHostReclamationPorts` declare *dependency sets* over those ports; a
 contract asserts they add no capability of their own.
 
-## 5. Compatibility shims and their retirement owners
+## 5. Retained duplicate architecture and its retirement owners
 
-Every retained legacy path and every enforced-boundary exemption is owned in
-code by `moonmind/omnigent/legacy_retirement.py`.
-`RETIREMENT_INVENTORY` lists the legacy paths; `ARCHITECTURE_BOUNDARY_EXCEPTIONS`
-lists the boundary exemptions and names the legacy path whose #3712 criteria
-retire each one.
+Every retained legacy component and every enforced-boundary exemption is owned in
+code by `moonmind/omnigent/legacy_retirement.py`. A document checklist is not
+sufficient: the inventory is the authority, and CI fails when the repository
+grows a legacy surface that no row classifies.
 
-| Shim / retained path | Owner record | Retires when |
-| --- | --- | --- |
-| `bridge_store.py` overloaded bridge session row | `omnigent.legacy.bridge_persistence` | base #3712 criteria pass |
-| `execute.py` legacy session driver | `omnigent.legacy.bridge_execution` | base criteria + cumulative remediation |
-| `profile_bound_execution.py` coordinator (and its default port selection) | `omnigent.legacy.profile_bound_execution` | base criteria + browser-to-host acceptance |
-| `native_ui_compat.py` chat projection | `omnigent.legacy.native_ui_compat` | base criteria + native chat acceptance |
-| `cutover.py` Codex-through-Omnigent selection | `omnigent.legacy.codex_cutover_selection` | base #3712 criteria pass |
-| `omnigent_catalog.py` in-handler readiness projection reading the materializer descriptor registry | `omnigent.legacy.native_ui_compat` | the readiness projection moves behind an application service |
-| `oauth_host_runtime.py` raw Docker/Compose launch, mount, credential-volume, and egress argument vectors | `omnigent.legacy.profile_bound_execution` | the replay-visible coordinator retires; moving the launch argument vector would change what in-flight histories were started with |
+- `RETIREMENT_INVENTORY` holds one row per retained component. Each row records
+  its owner, **retirement class**, last new-write/new-admission source, active
+  resource dependencies, replay and historical-read dependencies, rollback
+  dependency and exact permitted rollback generations, required evidence
+  (`applicable_criteria`), earliest removal stage, and removal guard test.
+- `ARCHITECTURE_BOUNDARY_EXCEPTIONS` holds the boundary exemptions and names the
+  row whose criteria retire each one.
+- `moonmind/omnigent/retirement_surfaces.py` derives the legacy surfaces the
+  repository actually contains — non-generic realizers, direct managed runtime
+  strategies, provider-specific startup scripts, duplicate Compose services and
+  profiles, and non-canonical image variables — from code and deployment
+  configuration rather than a hand-maintained list.
+- `moonmind/omnigent/retirement_drain.py` aggregates active-owner probe
+  observations into fail-closed drain evidence.
+
+### 5.1 Retirement classes
+
+Every retained component carries exactly one class. The order is the staged
+convergence order:
+
+| Class | Meaning |
+| --- | --- |
+| `active_product_path` | Still the supported path for new work. |
+| `new_admission_disabled` | No new plan may select it; recorded work continues. |
+| `rollback_only` | New work only under an exactly allowlisted rollback generation. |
+| `active_execution_support` | Owns work that is already running. |
+| `cleanup_only` | Owns reclamation for work that has stopped. |
+| `temporal_replay_only` | A replay-visible wrapper for recorded histories. |
+| `historical_read_only` | Read model for recorded work. |
+| `migration_tool` | Moves records; never runs work. |
+| `eligible_for_removal` | Every dependency drained and every window closed. |
+| `removed` | The implementation is gone. |
+
+`active_product_path` and `rollback_only` are the only classes that admit new
+work. Plan compilation
+(`harness_platform/planner.py:compile_execution_plan`) and runtime selection
+(`cutover.py:select_runtime`) both consult the class before admitting, so a
+trusted planner default, an alternate API client's explicit selection, a
+schedule, and a preset are all held to the same code-owned state. Disabling new
+admission never affects execution, cancellation, cleanup, or reads for
+already-recorded plans.
+
+### 5.2 Removal stages
+
+`RemovalStage` is the ordered staging from product selectors (1) through
+historical readers (9). A `RemovalPlan` targets exactly one stage and cites the
+rows it removes; `evaluate_removal_plan` returns the eligible rows, the
+remaining blockers, and the guard tests the PR must show passing. A row may not
+be swept into a stage earlier than its `earliest_removal_stage`, so a historical
+reader can never be deleted alongside a product selector.
+
+Removal eligibility is fail-closed on every axis: a still-admitting class, an
+undrained active owner, an open replay/historical-read/rollback window, a
+missing rollback exercise, or an unmet retirement criterion all block.
+
+### 5.3 Retained components
+
+| Shim / retained component | Owner record | Class today | Earliest removal stage |
+| --- | --- | --- | --- |
+| Direct Codex launch strategy | `omnigent.legacy.direct_codex_launch` | `active_product_path` | 1 product selectors |
+| Direct Codex session runtime | `omnigent.legacy.direct_codex_session_runtime` | `active_product_path` | 7 launch-only code |
+| Direct Codex session adapter | `omnigent.legacy.direct_codex_session_adapter` | `active_product_path` | 7 launch-only code |
+| Direct Codex bridge compatibility producer | `omnigent.legacy.direct_codex_bridge_compat` | `active_product_path` | 9 historical readers |
+| Direct Claude launch strategy | `omnigent.legacy.direct_claude_launch` | `active_product_path` | 1 product selectors |
+| `codex-profile-bound@1` realizer | `omnigent.legacy.profile_bound_realizer` | `active_product_path` | 1 product selectors |
+| `profile_bound_execution.py` coordinator (and its default port selection) | `omnigent.legacy.profile_bound_execution` | `active_product_path` | 7 launch-only code |
+| `oauth_host_runtime.py` launch, mount, credential-volume, and egress argument vectors | `omnigent.legacy.oauth_host_runtime` | `active_product_path` | 6 OAuth-host orchestration |
+| Legacy OAuth host janitor | `omnigent.legacy.oauth_host_janitor` | `cleanup_only` | 6 OAuth-host orchestration |
+| OAuth session Activity registrations | `omnigent.legacy.oauth_session_activities` | `active_execution_support` | 3 composition-root registrations |
+| Provider Profile capacity/lease consumer | `omnigent.legacy.provider_profile_capacity_consumer` | `active_execution_support` | 3 composition-root registrations |
+| Codex static host scripts and Compose profile | `omnigent.legacy.codex_static_host_startup` | `active_product_path` | 4 startup and Compose |
+| Claude static host scripts and Compose profile | `omnigent.legacy.claude_static_host_startup` | `active_product_path` | 4 startup and Compose |
+| Pre-consolidation `omnigent-host` service and projection entrypoint | `omnigent.legacy.projection_host_startup` | `active_product_path` | 4 startup and Compose |
+| Legacy generic host image variables | `omnigent.legacy.host_image_variable_alias` | `active_product_path` | 5 image and environment aliases |
+| OpenCode shared-image variable / `omnigent-host-opencode` alias | `omnigent.legacy.opencode_host_image_alias` | `active_product_path` | 5 image and environment aliases |
+| Pi host image variable | `omnigent.legacy.pi_host_image_alias` | `active_product_path` | 5 image and environment aliases |
+| Persisted per-provider bootstrap image fields | `omnigent.legacy.persisted_bootstrap_image_fields` | `active_product_path` | 5 image and environment aliases |
+| `bridge_store.py` overloaded bridge session row | `omnigent.legacy.bridge_persistence` | `active_product_path` | 9 historical readers |
+| `execute.py` legacy session driver | `omnigent.legacy.bridge_execution` | `active_product_path` | 2 new-write API paths |
+| `native_ui_compat.py` chat projection | `omnigent.legacy.native_ui_compat` | `active_product_path` | 9 historical readers |
+| `cutover.py` Codex-through-Omnigent selection | `omnigent.legacy.codex_cutover_selection` | `active_product_path` | 1 product selectors |
+| Managed-session replay patch branches | `omnigent.legacy.managed_session_replay_patches` | `temporal_replay_only` | 8 replay wrappers |
+| Session migration inventory | `omnigent.legacy.session_migration_inventory` | `migration_tool` | 9 historical readers |
+| `#3834` static-host startup runbook | `omnigent.legacy.static_host_startup_runbook` | `historical_read_only` | 4 startup and Compose |
+
+Two enforced-boundary exemptions are additionally owned by rows above:
+`omnigent_catalog.py`'s in-handler readiness projection reading the materializer
+descriptor registry (`omnigent.legacy.native_ui_compat`), and
+`oauth_host_runtime.py`'s raw Docker/Compose argument vectors
+(`omnigent.legacy.oauth_host_runtime`) — moving the launch argument vector would
+change what in-flight histories were started with.
 
 Temporary supervisor rollout flags are listed in `TEMPORARY_ROLLOUT_FLAGS` with
 their retirement trigger, so a rollout flag cannot become a permanent alternate
 architecture.
+
+### 5.4 Obsolete configuration
+
+`OBSOLETE_CONFIGURATION` names each legacy image/environment identity, its
+replacement, and its owning retirement row. `assert_obsolete_configuration` runs
+at API startup: during a variable's deprecation window a supplied value produces
+an actionable operator warning naming the replacement, and after removal startup
+is rejected outright. No obsolete value is ever silently ignored. Nothing is
+deprecated today — the aliases remain the supported way to pin a prior image
+while the rollback window is open.
 
 ## 6. Adding an approved harness
 

--- a/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
+++ b/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
@@ -102,6 +102,16 @@ The third generation is the destination. The first two remain explicit compatibi
 
 No current path is silently reclassified as generic. Existing execution plans and Temporal histories continue to invoke the realizer and compatibility version they recorded.
 
+Every retained component of the first two generations carries a **retirement
+class** in `moonmind/omnigent/legacy_retirement.py`. Today every one of them is
+`active_product_path`, `active_execution_support`, `cleanup_only`,
+`temporal_replay_only`, `historical_read_only`, or `migration_tool` — nothing is
+`eligible_for_removal` and nothing is `removed`. The class, not a document, is
+what decides whether a component still admits new work and the earliest stage at
+which it can be deleted. See
+[Omnigent Module Architecture §5](OmnigentModuleArchitecture.md#5-retained-duplicate-architecture-and-its-retirement-owners)
+for the full inventory and the staging rules.
+
 ## 5. Governing principles
 
 ### 5.1 One generic control plane
@@ -430,10 +440,21 @@ No default changes until the exact target combination has passing evidence and a
 
 ### Stage 6: Retire duplicate runtime architecture
 
-- Stop admitting new legacy Codex profile-bound plans after parity and rollback criteria pass.
-- Stop defaulting to direct Codex and direct Claude after their Omnigent combinations pass.
-- Consolidate duplicate Compose startup scripts and environment variables.
-- Reduce legacy modules to replay and historical-read adapters, then remove them only when retirement guards permit it.
+Retirement is code-owned and staged. The retirement class of each component
+decides what may happen to it; the class advances only when its evidence
+permits, and it never advances as a side effect of another component retiring.
+
+- Stop admitting new legacy Codex profile-bound plans after parity and rollback criteria pass. New admission is enforced at plan compilation and runtime selection from the component's retirement class, so a trusted default, an explicit client selection, a schedule, and a preset are held to the same state.
+- Stop defaulting to direct Codex and direct Claude after their Omnigent combinations pass. Direct Codex and direct Claude are separate generations with separate rows and separate decisions; neither is forced to retire because the other did.
+- Consolidate duplicate Compose startup scripts and environment variables. Legacy image and environment identities produce an actionable startup failure during their deprecation window instead of being silently ignored.
+- Reduce legacy modules to replay and historical-read adapters, then remove them only when retirement guards permit it. Removal proceeds one `RemovalStage` at a time (product selectors → new-write API paths → composition-root registrations → startup and Compose → image and environment aliases → OAuth-host orchestration → launch-only code → replay wrappers → historical readers), and each removal PR cites the inventory rows it removes and the guard tests that prove them eligible.
+
+A component becomes removal-eligible only when **all** of the following hold:
+its class no longer admits new work; every declared active owner has fresh,
+successful, zero-count drain evidence; its replay, historical-read, and rollback
+windows have closed; a fresh, exactly-scoped rollback exercise was recorded; and
+every applicable retirement criterion passes. Missing evidence never reads as
+"drained".
 
 ## 11. Required acceptance gates
 

--- a/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
+++ b/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
@@ -103,14 +103,12 @@ The third generation is the destination. The first two remain explicit compatibi
 No current path is silently reclassified as generic. Existing execution plans and Temporal histories continue to invoke the realizer and compatibility version they recorded.
 
 Every retained component of the first two generations carries a **retirement
-class** in `moonmind/omnigent/legacy_retirement.py`. Today every one of them is
-`active_product_path`, `active_execution_support`, `cleanup_only`,
-`temporal_replay_only`, `historical_read_only`, or `migration_tool` — nothing is
-`eligible_for_removal` and nothing is `removed`. The class, not a document, is
-what decides whether a component still admits new work and the earliest stage at
-which it can be deleted. See
+class** in `moonmind/omnigent/legacy_retirement.py`. That class, not a document,
+is the single authority for whether a component still admits new work and the
+earliest stage at which it can be deleted; this document deliberately records no
+snapshot of which class each row currently holds. See
 [Omnigent Module Architecture §5](OmnigentModuleArchitecture.md#5-retained-duplicate-architecture-and-its-retirement-owners)
-for the full inventory and the staging rules.
+for the inventory and the staging rules.
 
 ## 5. Governing principles
 

--- a/docs/Omnigent/SharedHostImage.md
+++ b/docs/Omnigent/SharedHostImage.md
@@ -116,4 +116,13 @@ These remain the owned child issues of the primary-runtime program and are not c
   digest remain with the provider-verification runner.
 - **Product-default migration** (#3833): versioned rollout policy, per-surface default promotion, canary/rollback controls, and migration telemetry.
 - **Compose consolidation** (#3834): converging static Codex/Claude hosts and startup scripts onto the shared image and generic startup.
-- **Retirement** (#3835): the code-owned retirement inventory and gated removal of direct and profile-bound lanes.
+- **Retirement** (#3835): the code-owned retirement inventory in
+  `moonmind/omnigent/legacy_retirement.py` classifies every retained direct,
+  profile-bound, startup, Compose, configuration, replay, and historical-read
+  component, enforces new-admission control from that class at plan
+  compilation and runtime selection, and gates staged removal behind drain,
+  replay, historical-read, rollback, and retention evidence. The
+  `omnigent-host-opencode` alias and `OMNIGENT_OPENCODE_HOST_IMAGE_REF` remain
+  active with a retirement row; they are removed at the image and environment
+  alias stage once no dependency remains. See
+  [Omnigent Module Architecture §5](OmnigentModuleArchitecture.md#5-retained-duplicate-architecture-and-its-retirement-owners).

--- a/moonmind/omnigent/cutover.py
+++ b/moonmind/omnigent/cutover.py
@@ -423,7 +423,7 @@ class RuntimeSelection:
         }
 
 
-def _assert_runtime_new_admission(
+def assert_runtime_new_admission(
     runtime_id: str, *, rollback_generation: str | None = None
 ) -> None:
     """Reject a runtime whose code-owned retirement class stopped admitting.
@@ -431,6 +431,16 @@ def _assert_runtime_new_admission(
     The cutover phase is the *rollout* authority; the retirement class is the
     *retirement* authority. Both must permit a runtime before it becomes a new
     selection, and neither ever affects an already-recorded plan.
+
+    Every effective runtime must pass here, not only the workflow's top-level
+    selection: an authored per-step ``runtime.mode`` override is new admission
+    too, so API callers apply this check to each step runtime before persisting
+    the workflow.
+
+    A runtime id alone cannot name the exact rollback scope a ``rollback_only``
+    class requires, so this boundary supplies no rollback-exercise evidence and
+    a ``rollback_only`` runtime fails closed here. Plan compilation is where a
+    scoped exercise can be evaluated.
     """
 
     if not runtime_id:
@@ -477,9 +487,7 @@ def select_runtime(
         explicit = normalize_runtime_id(explicit)
         if explicit == "codex_cli" and phase >= CutoverPhase.DIRECT_LAUNCH_DISABLED:
             raise ValueError("codex_direct_launch_disabled_by_cutover_phase")
-        _assert_runtime_new_admission(
-            explicit, rollback_generation=rollback_generation
-        )
+        assert_runtime_new_admission(explicit, rollback_generation=rollback_generation)
         return RuntimeSelection(
             explicit,
             True,
@@ -506,7 +514,7 @@ def select_runtime(
     selected = "omnigent" if default == "codex_cli" and phase >= threshold else default
     # A configured default may not keep a direct runtime as a default target
     # once its retirement class stops admitting new work (#3835 required work 2).
-    _assert_runtime_new_admission(selected, rollback_generation=rollback_generation)
+    assert_runtime_new_admission(selected, rollback_generation=rollback_generation)
     return RuntimeSelection(
         selected,
         False,
@@ -905,6 +913,7 @@ __all__ = [
     "effective_phase",
     "PromotionDecision",
     "RuntimeSelection",
+    "assert_runtime_new_admission",
     "evaluate_promotion",
     "select_runtime",
 ]

--- a/moonmind/omnigent/cutover.py
+++ b/moonmind/omnigent/cutover.py
@@ -423,6 +423,34 @@ class RuntimeSelection:
         }
 
 
+def _assert_runtime_new_admission(
+    runtime_id: str, *, rollback_generation: str | None = None
+) -> None:
+    """Reject a runtime whose code-owned retirement class stopped admitting.
+
+    The cutover phase is the *rollout* authority; the retirement class is the
+    *retirement* authority. Both must permit a runtime before it becomes a new
+    selection, and neither ever affects an already-recorded plan.
+    """
+
+    if not runtime_id:
+        return
+    from moonmind.omnigent.legacy_retirement import (
+        LegacyAdmissionRejected,
+        assert_surface_admits_new_work,
+    )
+
+    try:
+        assert_surface_admits_new_work(
+            f"runtime-strategy:{runtime_id}",
+            rollback_generation=rollback_generation,
+        )
+    except LegacyAdmissionRejected as exc:
+        raise ValueError(
+            f"runtime_new_admission_disabled:{runtime_id}:{exc.reason_code}"
+        ) from exc
+
+
 def select_runtime(
     *,
     authored_runtime: str | None,
@@ -430,6 +458,7 @@ def select_runtime(
     phase: CutoverPhase,
     submission_kind: str = "create",
     release_status: EffectivePhase | None = None,
+    rollback_generation: str | None = None,
 ) -> RuntimeSelection:
     """Apply rollout defaults without ever rewriting an explicit selection.
 
@@ -437,6 +466,10 @@ def select_runtime(
     advance at phase 3.  Explicit direct launch is rejected from phase 5.  This
     helper never performs automatic fallback: callers must persist the returned
     evidence on the run before launch.
+
+    The rollout phase and the code-owned retirement class are separate
+    authorities and both must permit a runtime before it becomes a new
+    selection (#3835). Neither ever affects an already-recorded plan.
     """
 
     explicit = str(authored_runtime or "").strip().lower()
@@ -444,6 +477,9 @@ def select_runtime(
         explicit = normalize_runtime_id(explicit)
         if explicit == "codex_cli" and phase >= CutoverPhase.DIRECT_LAUNCH_DISABLED:
             raise ValueError("codex_direct_launch_disabled_by_cutover_phase")
+        _assert_runtime_new_admission(
+            explicit, rollback_generation=rollback_generation
+        )
         return RuntimeSelection(
             explicit,
             True,
@@ -468,6 +504,9 @@ def select_runtime(
         "preset": CutoverPhase.SCHEDULE_DEFAULT,
     }.get(submission_kind, CutoverPhase.BROAD_DEFAULT)
     selected = "omnigent" if default == "codex_cli" and phase >= threshold else default
+    # A configured default may not keep a direct runtime as a default target
+    # once its retirement class stops admitting new work (#3835 required work 2).
+    _assert_runtime_new_admission(selected, rollback_generation=rollback_generation)
     return RuntimeSelection(
         selected,
         False,

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -114,6 +114,21 @@ def select_execution_realizer(
     return "generic-omnigent-host@1"
 
 
+def _configured_legacy_rollback_generation() -> str | None:
+    """Read the operator-selected rollback generation for legacy re-admission.
+
+    Trusted planner input only: it comes from deployment settings, never from an
+    Agent Profile or workflow payload.
+    """
+
+    from moonmind.config.settings import settings
+    from moonmind.omnigent.session_supervisor_rollback import (
+        legacy_rollback_generation_from_settings,
+    )
+
+    return legacy_rollback_generation_from_settings(settings.feature_flags)
+
+
 def compile_execution_plan(
     *,
     agent_profile: dict[str, Any] | OmnigentAgentProfileV2,
@@ -145,6 +160,7 @@ def compile_execution_plan(
     execution_realizer_ref: str | None = None,
     execution_authority: dict[str, Any] | None = None,
     agent_profile_snapshot_ref: str | None = None,
+    rollback_generation: str | None = None,
 ) -> OmnigentExecutionPlanEnvelope:
     # 1. Validate agent profile (resolve snapshot)
     profile = validate_agent_profile(agent_profile)
@@ -426,6 +442,35 @@ def compile_execution_plan(
             f"execution realizer {realizer} unavailable",
             code=HarnessPlatformFailure.OMNIGENT_EXECUTION_REALIZER_UNAVAILABLE,
         ) from exc
+
+    # Retirement admission (#3835 required work 2). Plan compilation is the one
+    # new-admission boundary for every client: a trusted planner default, an
+    # explicit ``execution_realizer_ref`` from an alternate API client, a
+    # schedule, and a preset all resolve here. Once the code-owned retirement
+    # class for a realizer stops admitting new work, no new plan may select it,
+    # while already-recorded plans keep executing, cancelling, cleaning up, and
+    # reading normally. A ``rollback_only`` class re-admits new work only under
+    # the exact rollback generation the operator has explicitly selected.
+    from moonmind.omnigent.legacy_retirement import (
+        LegacyAdmissionRejected,
+        assert_new_admission_allowed,
+        retirement_record_for_surface,
+    )
+
+    retirement_row = retirement_record_for_surface(f"realizer:{realizer}")
+    if retirement_row is not None:
+        generation = rollback_generation
+        if generation is None and retirement_row.requires_rollback_generation:
+            generation = _configured_legacy_rollback_generation()
+        try:
+            assert_new_admission_allowed(
+                retirement_row.path_id, rollback_generation=generation
+            )
+        except LegacyAdmissionRejected as exc:
+            raise HarnessPlatformError(
+                str(exc),
+                code=HarnessPlatformFailure.OMNIGENT_EXECUTION_REALIZER_UNAVAILABLE,
+            ) from exc
 
     required_caps_digest = compute_required_capabilities_digest(
         list(class_decision.requiredSatisfied)

--- a/moonmind/omnigent/harness_platform/planner.py
+++ b/moonmind/omnigent/harness_platform/planner.py
@@ -20,7 +20,8 @@ Lifecycle ordering preserved (19 steps 1-13).
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from moonmind.omnigent.harness_platform.agent_profile import (
     OmnigentAgentProfileV2,
@@ -66,6 +67,12 @@ from moonmind.omnigent.harness_platform.support import (
     compute_required_capabilities_digest,
     compute_support_combination_key,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only import
+    from moonmind.omnigent.session_supervisor_rollback import (
+        RollbackExerciseDecision,
+        RollbackExerciseRecord,
+    )
 
 
 # Trusted realizer selection - never workflow-authored, never overridable via Agent Profile settings
@@ -129,6 +136,70 @@ def _configured_legacy_rollback_generation() -> str | None:
     return legacy_rollback_generation_from_settings(settings.feature_flags)
 
 
+def _rollback_exercise_decision_for_plan(
+    *,
+    retirement_path_id: str,
+    agent_profile_ref: str | None,
+    host_class_ref: str | None,
+    materializer_refs: Sequence[str],
+    execution_realizer_ref: str | None,
+    model_qualified_id: str | None,
+    launch_policy_ref: str | None,
+    host_mode: str | None,
+    architecture: str | None,
+    owner_cohort: str | None,
+    records: Sequence[RollbackExerciseRecord] | None,
+) -> RollbackExerciseDecision:
+    """Evaluate recorded rollback evidence against this plan's exact scope.
+
+    Fail-closed on every axis: a dimension this plan cannot name exactly, and a
+    missing or non-matching record, both leave the path un-exercised and
+    therefore closed to new work. ``RollbackScope`` rejects a blank dimension,
+    so a scope that cannot be built is reported as unsatisfied rather than
+    widened.
+    """
+
+    from datetime import datetime, timezone
+
+    from moonmind.omnigent.session_supervisor_rollback import (
+        RollbackExerciseDecision,
+        RollbackScope,
+        evaluate_rollback_exercise,
+    )
+
+    # Exactly one materializer may be named; a plan with several has no single
+    # exercised materializer scope.
+    unique_materializers = sorted({str(ref) for ref in materializer_refs if ref})
+    materializer_ref = (
+        unique_materializers[0] if len(unique_materializers) == 1 else None
+    )
+    try:
+        scope = RollbackScope(
+            agentProfileRef=str(agent_profile_ref or ""),
+            hostClassRef=str(host_class_ref or ""),
+            materializerRef=str(materializer_ref or ""),
+            executionRealizerRef=str(execution_realizer_ref or ""),
+            modelQualifiedId=str(model_qualified_id or ""),
+            launchPolicyRef=str(launch_policy_ref or ""),
+            hostMode=str(host_mode or ""),
+            architecture=str(architecture or ""),
+            ownerCohort=str(owner_cohort or ""),
+        )
+    except ValueError:
+        return RollbackExerciseDecision(
+            retirementPathId=retirement_path_id,
+            satisfied=False,
+            reasonCode="rollback_scope_incomplete",
+        )
+
+    return evaluate_rollback_exercise(
+        retirement_path_id=retirement_path_id,
+        scope=scope,
+        records=records or (),
+        now=datetime.now(timezone.utc),
+    )
+
+
 def compile_execution_plan(
     *,
     agent_profile: dict[str, Any] | OmnigentAgentProfileV2,
@@ -161,6 +232,8 @@ def compile_execution_plan(
     execution_authority: dict[str, Any] | None = None,
     agent_profile_snapshot_ref: str | None = None,
     rollback_generation: str | None = None,
+    rollback_owner_cohort: str | None = None,
+    rollback_exercise_records: Sequence[RollbackExerciseRecord] | None = None,
 ) -> OmnigentExecutionPlanEnvelope:
     # 1. Validate agent profile (resolve snapshot)
     profile = validate_agent_profile(agent_profile)
@@ -460,11 +533,42 @@ def compile_execution_plan(
     retirement_row = retirement_record_for_surface(f"realizer:{realizer}")
     if retirement_row is not None:
         generation = rollback_generation
-        if generation is None and retirement_row.requires_rollback_generation:
-            generation = _configured_legacy_rollback_generation()
+        exercise_decision = None
+        if retirement_row.requires_rollback_generation:
+            if generation is None:
+                generation = _configured_legacy_rollback_generation()
+            # A rollback generation is a single global string. Re-admission also
+            # needs a fresh, successful rollback exercise recorded for *this*
+            # exact plan scope, so one allowlisted generation cannot re-admit
+            # every profile, Host Class, materializer, model, launch policy,
+            # host mode, architecture, and owner cohort using the path.
+            exercise_decision = _rollback_exercise_decision_for_plan(
+                retirement_path_id=retirement_row.path_id,
+                agent_profile_ref=agent_profile_snapshot_ref,
+                host_class_ref=host_class_ref,
+                materializer_refs=materializer_refs,
+                execution_realizer_ref=realizer,
+                model_qualified_id=model_qualified_id,
+                launch_policy_ref=launch_policy_ref,
+                host_mode=selected_launch_policy.hostMode,
+                # The architecture the plan will actually run on, resolved the
+                # same way the support key resolves it below.
+                architecture=(
+                    host_architecture
+                    or (
+                        selected_host_class.architectures[0]
+                        if selected_host_class.architectures
+                        else None
+                    )
+                ),
+                owner_cohort=rollback_owner_cohort,
+                records=rollback_exercise_records,
+            )
         try:
             assert_new_admission_allowed(
-                retirement_row.path_id, rollback_generation=generation
+                retirement_row.path_id,
+                rollback_generation=generation,
+                rollback_exercise=exercise_decision,
             )
         except LegacyAdmissionRejected as exc:
             raise HarnessPlatformError(

--- a/moonmind/omnigent/legacy_retirement.py
+++ b/moonmind/omnigent/legacy_retirement.py
@@ -27,10 +27,11 @@ architecture.
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -43,6 +44,11 @@ from moonmind.omnigent.retirement_surfaces import (
 from moonmind.omnigent.workflow_chat_acceptance import (
     validate_workflow_chat_acceptance_manifest,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle: rollback imports this module
+    from moonmind.omnigent.session_supervisor_rollback import (
+        RollbackExerciseDecision,
+    )
 
 RETIREMENT_CONTRACT_VERSION = "moonmind.omnigent-legacy-retirement/v2"
 
@@ -1440,6 +1446,7 @@ def assert_surface_admits_new_work(
     surface_ref: str,
     *,
     rollback_generation: str | None = None,
+    rollback_exercise: RollbackExerciseDecision | None = None,
     inventory: tuple[LegacyPathRecord, ...] | None = None,
 ) -> LegacyAdmissionDecision | None:
     """Reject new work that selects a retired surface.
@@ -1456,20 +1463,29 @@ def assert_surface_admits_new_work(
     return assert_new_admission_allowed(
         record.path_id,
         rollback_generation=rollback_generation,
+        rollback_exercise=rollback_exercise,
         inventory=inventory,
     )
 
 
 def evaluate_new_admission(
-    path: LegacyPathRecord, *, rollback_generation: str | None = None
+    path: LegacyPathRecord,
+    *,
+    rollback_generation: str | None = None,
+    rollback_exercise: RollbackExerciseDecision | None = None,
 ) -> LegacyAdmissionDecision:
     """Whether new work may be admitted through ``path``.
 
     ``rollback_only`` admits new work only under an exactly allowlisted rollback
-    generation. Every later class refuses, which is what stops new Agent
-    Profiles, schedules, presets, and alternate API clients from creating new
-    legacy work once the class advances — without touching execution,
-    cancellation, cleanup, or reads for already-recorded plans.
+    generation *and* a fresh, successful, exactly-scoped rollback exercise for
+    this row. The generation alone is a global string: without the scoped
+    exercise decision one allowlisted generation would re-admit every profile,
+    Host Class, materializer, model, launch policy, host mode, architecture, and
+    owner cohort using the path, and would stay valid after the exercise window
+    expired. Every later class refuses, which is what stops new Agent Profiles,
+    schedules, presets, and alternate API clients from creating new legacy work
+    once the class advances — without touching execution, cancellation, cleanup,
+    or reads for already-recorded plans.
     """
 
     generation = (rollback_generation or "").strip() or None
@@ -1486,6 +1502,12 @@ def evaluate_new_admission(
             reason = "rollback_generation_required"
         elif generation not in path.rollback_generations:
             reason = "rollback_generation_not_allowlisted"
+        elif rollback_exercise is None:
+            reason = "rollback_exercise_evidence_required"
+        elif rollback_exercise.retirement_path_id != path.path_id:
+            reason = "rollback_exercise_scope_mismatch"
+        elif not rollback_exercise.satisfied:
+            reason = f"rollback_exercise_unsatisfied:{rollback_exercise.reason_code}"
         else:
             return LegacyAdmissionDecision(
                 pathId=path.path_id,
@@ -1514,12 +1536,17 @@ def assert_new_admission_allowed(
     path_id: str,
     *,
     rollback_generation: str | None = None,
+    rollback_exercise: RollbackExerciseDecision | None = None,
     inventory: tuple[LegacyPathRecord, ...] | None = None,
 ) -> LegacyAdmissionDecision:
     """Fail fast when new work selects a path whose class no longer admits it."""
 
     record = get_retirement_record(path_id, inventory=inventory)
-    decision = evaluate_new_admission(record, rollback_generation=rollback_generation)
+    decision = evaluate_new_admission(
+        record,
+        rollback_generation=rollback_generation,
+        rollback_exercise=rollback_exercise,
+    )
     if not decision.allowed:
         raise LegacyAdmissionRejected(
             f"legacy path {path_id!r} no longer admits new work "
@@ -1705,29 +1732,59 @@ def assert_retirement_guard(
     inventory: tuple[LegacyPathRecord, ...] = RETIREMENT_INVENTORY,
     *,
     passed_by_path: dict[str, frozenset[RetirementCriterion]] | None = None,
+    drained_by_path: Mapping[str, frozenset[ActiveOwnerKind]] | None = None,
+    retention_by_path: Mapping[str, RetentionWindows] | None = None,
+    removal_stage_by_path: Mapping[str, RemovalStage] | None = None,
 ) -> None:
     """Enforce the retirement-guard invariants.
 
-    * A path classified ``removed`` must have every applicable criterion passing.
+    * A path classified ``removed`` must satisfy the *complete* typed removal
+      evidence: the criteria it declares, drain evidence for every active-owner
+      kind, the replay/historical-read/rollback retention windows, a recorded
+      rollback exercise when it carries a rollback dependency, and a removal
+      stage at or after its ``earliest_removal_stage``.
     * A retained path's surfaces must all still resolve.
+
+    The removed branch delegates to :func:`evaluate_removal_plan` rather than
+    asserting its own criteria subset, so a row cannot pass the guard while
+    sessions or leases remain active or a replay/rollback window is still open.
+    Every evidence mapping is fail-closed by omission: a row with no supplied
+    drain or retention evidence is evaluated against empty/open defaults and
+    therefore blocks.
 
     Raises :class:`RetirementGuardError` on violation.
     """
 
     passed_by_path = passed_by_path or {}
+    drained_by_path = drained_by_path or {}
+    retention_by_path = retention_by_path or {}
+    removal_stage_by_path = removal_stage_by_path or {}
     seen: set[str] = set()
     for path in inventory:
         if path.path_id in seen:
             raise RetirementGuardError(f"duplicate retirement row {path.path_id!r}")
         seen.add(path.path_id)
         if path.removed:
-            decision = evaluate_retirement(
-                path, passed_by_path.get(path.path_id, frozenset())
+            stage = removal_stage_by_path.get(
+                path.path_id, path.earliest_removal_stage
             )
-            if not decision.allowed:
+            report = evaluate_removal_plan(
+                RemovalPlan(stage=stage, pathIds=(path.path_id,)),
+                inventory=inventory,
+                drained_by_path=drained_by_path,
+                passed_by_path=passed_by_path,
+                retention_by_path=retention_by_path,
+            )
+            if not report.allowed:
+                blockers = tuple(
+                    blocker
+                    for eligibility in report.blocked
+                    for blocker in eligibility.blockers
+                )
                 raise RetirementGuardError(
-                    f"legacy path {path.path_id!r} is classified removed but has "
-                    f"unmet criteria: {[c.value for c in decision.unmet_criteria]}"
+                    f"legacy path {path.path_id!r} is classified removed but its "
+                    f"removal evidence is incomplete at stage "
+                    f"{stage.name.lower()}: {list(blockers)}"
                 )
             continue
         for ref in path.surfaces:
@@ -1811,6 +1868,31 @@ def assert_obsolete_configuration(
     return tuple(warnings)
 
 
+def enforce_obsolete_configuration_at_startup(
+    log: Any,
+    *,
+    env: Mapping[str, str] | None = None,
+    configuration: tuple[ObsoleteConfiguration, ...] | None = None,
+) -> tuple[str, ...]:
+    """The shared process-startup check for obsolete Omnigent configuration.
+
+    Every process that consumes these settings calls this — the API and each
+    separately restartable Temporal worker — so restarting or deploying one
+    process without the other can neither skip the deprecation warning nor
+    silently accept a variable another process rejects.
+
+    Raises :class:`ObsoleteConfigurationError` on a removed variable; returns the
+    deprecation warnings it logged.
+    """
+
+    warnings = assert_obsolete_configuration(
+        os.environ if env is None else env, configuration=configuration
+    )
+    for warning in warnings:
+        log.warning("Obsolete Omnigent configuration: %s", warning)
+    return warnings
+
+
 def assert_temporary_flags_have_retirement(
     flags: dict[str, str] = TEMPORARY_ROLLOUT_FLAGS,
 ) -> None:
@@ -1857,6 +1939,7 @@ __all__ = [
     "assert_surface_admits_new_work",
     "assert_temporary_flags_have_retirement",
     "criteria_from_native_chat_acceptance",
+    "enforce_obsolete_configuration_at_startup",
     "evaluate_new_admission",
     "evaluate_removal_eligibility",
     "evaluate_removal_plan",

--- a/moonmind/omnigent/legacy_retirement.py
+++ b/moonmind/omnigent/legacy_retirement.py
@@ -1,17 +1,24 @@
 """Code-owned retirement inventory and guard for legacy Omnigent authority paths.
 
-Source issue: MoonLadderStudios/MoonMind#3712.
+Source issues: MoonLadderStudios/MoonMind#3712, MoonLadderStudios/MoonMind#3835.
 
-A legacy Omnigent execution, persistence, routing, or compatibility path may be
-deleted only after every retirement criterion that applies to it passes. This
-module keeps that inventory in code (not in a mutable architecture document, per
-the issue's "Retirement criteria" section) with implementation ownership and a
-machine-checkable reference per path, and provides guard helpers that:
+A legacy Omnigent execution, persistence, routing, startup, configuration, or
+compatibility path may be deleted only after every retirement criterion that
+applies to it passes. This module keeps that inventory in code (not in a mutable
+architecture document) with implementation ownership and a machine-checkable
+reference per path, and provides guard helpers that:
 
-* fail when a path is marked retired while an applicable criterion is unmet; and
-* fail when a not-yet-retired path's machine-checkable reference no longer
-  resolves (a deletion/registry removal must fail CI while the path is still
-  required).
+* fail when a path is marked removed while an applicable criterion is unmet;
+* fail when a retained path's machine-checkable surface no longer resolves (a
+  deletion/registry removal must fail CI while the path is still required);
+* fail when the repository contains a legacy surface with no retirement row; and
+* refuse removal eligibility while an active owner, replay, historical-read,
+  rollback, or retention dependency remains.
+
+#3835 adds the retirement *class* to every row. Classification is what makes the
+staged convergence machine-checkable instead of a document checklist: the class
+decides whether new admission is still allowed, the earliest removal stage the
+row can be included in, and which dependencies must drain first.
 
 It also records the temporary supervisor rollout flags and their retirement
 trigger so a rollout flag can never silently become a permanent alternate
@@ -20,24 +27,126 @@ architecture.
 
 from __future__ import annotations
 
-import importlib
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntEnum
 from pathlib import Path
 from typing import Any, Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.omnigent.conformance import ConformanceContractError
+from moonmind.omnigent.retirement_surfaces import (
+    discover_legacy_surfaces,
+    parse_surface_ref,
+    surface_exists,
+)
 from moonmind.omnigent.workflow_chat_acceptance import (
     validate_workflow_chat_acceptance_manifest,
 )
 
-RETIREMENT_CONTRACT_VERSION = "moonmind.omnigent-legacy-retirement/v1"
+RETIREMENT_CONTRACT_VERSION = "moonmind.omnigent-legacy-retirement/v2"
+
+
+class RetirementClass(str, Enum):
+    """The ten mutually-exclusive retirement classes from issue #3835.
+
+    The order is the staged convergence order. Everything at or after
+    :data:`NEW_ADMISSION_DISABLED` refuses new plan admission;
+    :data:`ROLLBACK_ONLY` admits new work only under an explicitly permitted
+    rollback generation.
+    """
+
+    ACTIVE_PRODUCT_PATH = "active_product_path"
+    NEW_ADMISSION_DISABLED = "new_admission_disabled"
+    ROLLBACK_ONLY = "rollback_only"
+    ACTIVE_EXECUTION_SUPPORT = "active_execution_support"
+    CLEANUP_ONLY = "cleanup_only"
+    TEMPORAL_REPLAY_ONLY = "temporal_replay_only"
+    HISTORICAL_READ_ONLY = "historical_read_only"
+    MIGRATION_TOOL = "migration_tool"
+    ELIGIBLE_FOR_REMOVAL = "eligible_for_removal"
+    REMOVED = "removed"
+
+
+# Classes that still admit new work. Everything else must not appear as the
+# target of a newly compiled execution plan.
+_NEW_ADMISSION_CLASSES: frozenset[RetirementClass] = frozenset(
+    {RetirementClass.ACTIVE_PRODUCT_PATH, RetirementClass.ROLLBACK_ONLY}
+)
+
+
+class RemovalStage(IntEnum):
+    """The ordered removal stages from issue #3835 required work section 7.
+
+    A removal PR names one stage. A row may only be included in a removal at or
+    after its ``earliest_removal_stage``, which is what keeps a historical
+    reader from being deleted in the same change as a product selector.
+    """
+
+    PRODUCT_SELECTORS = 1
+    NEW_WRITE_API_PATHS = 2
+    COMPOSITION_ROOT_REGISTRATIONS = 3
+    STARTUP_AND_COMPOSE = 4
+    IMAGE_AND_ENVIRONMENT_ALIASES = 5
+    OAUTH_HOST_ORCHESTRATION = 6
+    LAUNCH_ONLY_CODE = 7
+    REPLAY_WRAPPERS = 8
+    HISTORICAL_READERS = 9
+
+
+class ComponentFamily(str, Enum):
+    """The component families issue #3835 required work section 1 enumerates."""
+
+    DIRECT_CODEX_LAUNCH_AND_SESSION = "direct_codex_launch_and_session"
+    DIRECT_CLAUDE_LAUNCH_AND_SESSION = "direct_claude_launch_and_session"
+    PROFILE_BOUND_REALIZER = "profile_bound_realizer"
+    PROFILE_BOUND_EXECUTION = "profile_bound_execution"
+    OAUTH_HOST_RUNTIME = "oauth_host_runtime"
+    STARTUP_AND_COMPOSE = "startup_and_compose"
+    HOST_CLASS_POLICY_AND_IMAGE_REFS = "host_class_policy_and_image_refs"
+    ENVIRONMENT_AND_PERSISTED_BOOTSTRAP = "environment_and_persisted_bootstrap"
+    BRIDGE_COMPATIBILITY = "bridge_compatibility"
+    PROVIDER_PROFILE_CAPACITY = "provider_profile_capacity"
+    CHECKPOINT_REMEDIATION_PUBLICATION_CLEANUP = (
+        "checkpoint_remediation_publication_cleanup"
+    )
+    API_AND_UI_SELECTION = "api_and_ui_selection"
+    TEMPORAL_REGISTRATIONS = "temporal_registrations"
+    PATCH_AND_WORKER_VERSION_BRANCHES = "patch_and_worker_version_branches"
+    SERIALIZED_SCHEMA_AND_ROWS = "serialized_schema_and_rows"
+    FIXTURES_MATRICES_AND_RUNBOOKS = "fixtures_matrices_and_runbooks"
+
+
+class RuntimeGeneration(str, Enum):
+    """Which implementation generation owns a row.
+
+    Issue #3835 required work section 9 forbids forcing simultaneous removal of
+    direct Codex and direct Claude, so the retirement decision is evaluated per
+    generation rather than for "legacy" as a whole.
+    """
+
+    DIRECT_CODEX = "direct_codex"
+    DIRECT_CLAUDE = "direct_claude"
+    CODEX_PROFILE_BOUND = "codex_profile_bound"
+    SHARED_LEGACY_SUBSTRATE = "shared_legacy_substrate"
+
+
+class ActiveOwnerKind(str, Enum):
+    """The active-owner classes that must drain (section 3)."""
+
+    TEMPORAL_WORKFLOW = "temporal_workflow"
+    AGENT_RUN_OR_OMNIGENT_SESSION = "agent_run_or_omnigent_session"
+    PROVIDER_PROFILE_LEASE = "provider_profile_lease"
+    HOST_BINDING_OR_LEASE = "host_binding_or_lease"
+    CREDENTIAL_CONSUMER = "credential_consumer"
+    STATIC_OR_ON_DEMAND_HOST = "static_or_on_demand_host"
+    PENDING_PUBLICATION = "pending_publication"
+    PENDING_CHECKPOINT_OR_REMEDIATION = "pending_checkpoint_or_remediation"
+    INCOMPLETE_CLEANUP_OR_JANITOR = "incomplete_cleanup_or_janitor"
 
 
 class RetirementCriterion(str, Enum):
-    """The machine-checkable retirement criteria from issue #3712."""
+    """The machine-checkable retirement criteria from issues #3712 and #3835."""
 
     NO_NEW_RECORDS_USE_IT = "no_new_records_use_it"
     NO_ACTIVE_OR_CLEANUP_USE = "no_active_session_or_cleanup_uses_it"
@@ -70,19 +179,153 @@ _BASE_CRITERIA: frozenset[RetirementCriterion] = frozenset(
 )
 
 
+class RetirementGuardError(RuntimeError):
+    """Raised when a retirement guard invariant is violated."""
+
+
+class LegacyAdmissionRejected(RuntimeError):
+    """Raised when new work selects a path whose class no longer admits it."""
+
+    def __init__(self, message: str, *, path_id: str, reason_code: str) -> None:
+        super().__init__(message)
+        self.path_id = path_id
+        self.reason_code = reason_code
+
+
 class LegacyPathRecord(BaseModel):
-    """One retirable legacy Omnigent path with its applicable criteria."""
+    """One retirable legacy component with its class, dependencies, and evidence.
+
+    Every field #3835 required work section 1 demands per item is recorded here:
+    ``owner``, ``retirement_class``, ``new_admission_source``,
+    ``active_resource_dependencies``, ``replay_dependency`` /
+    ``historical_read_dependency``, ``rollback_dependency``,
+    ``applicable_criteria`` (required evidence), ``earliest_removal_stage``, and
+    ``removal_guard_test``.
+    """
 
     model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
 
     path_id: str = Field(alias="pathId")
     owner: str
     description: str
+    family: ComponentFamily
+    generation: RuntimeGeneration
+    retirement_class: RetirementClass = Field(alias="retirementClass")
     machine_checkable_ref: str = Field(alias="machineCheckableRef")
+    surfaces: tuple[str, ...] = Field(default=(), alias="surfaces")
+    # The concrete code path that can still create new records or admit new work
+    # through this component. Empty exactly when the class no longer admits.
+    new_admission_source: str = Field("", alias="newAdmissionSource")
+    active_resource_dependencies: frozenset[ActiveOwnerKind] = Field(
+        default_factory=frozenset, alias="activeResourceDependencies"
+    )
+    replay_dependency: bool = Field(False, alias="replayDependency")
+    historical_read_dependency: bool = Field(False, alias="historicalReadDependency")
+    rollback_dependency: bool = Field(False, alias="rollbackDependency")
+    # Exact rollback generations permitted to re-admit new work through this
+    # path. Exact membership only — never a prefix or substring match.
+    rollback_generations: frozenset[str] = Field(
+        default_factory=frozenset, alias="rollbackGenerations"
+    )
     applicable_criteria: frozenset[RetirementCriterion] = Field(
         alias="applicableCriteria"
     )
-    retired: bool = False
+    earliest_removal_stage: RemovalStage = Field(alias="earliestRemovalStage")
+    removal_guard_test: str = Field(alias="removalGuardTest")
+
+    @property
+    def removed(self) -> bool:
+        """Whether the implementation is gone (the terminal retirement class)."""
+
+        return self.retirement_class is RetirementClass.REMOVED
+
+    @property
+    def admits_new_work(self) -> bool:
+        return self.retirement_class in _NEW_ADMISSION_CLASSES
+
+    @property
+    def requires_rollback_generation(self) -> bool:
+        """Whether admitting new work needs an explicit rollback generation."""
+
+        return self.retirement_class is RetirementClass.ROLLBACK_ONLY
+
+    @model_validator(mode="after")
+    def _validate(self) -> "LegacyPathRecord":
+        for ref in (self.machine_checkable_ref, *self.surfaces):
+            parse_surface_ref(ref)
+        if self.machine_checkable_ref not in self.surfaces:
+            raise ValueError(
+                f"{self.path_id}: surfaces must include the machine-checkable ref"
+            )
+        if len(set(self.surfaces)) != len(self.surfaces):
+            raise ValueError(f"{self.path_id}: duplicate surface refs")
+        if not self.removal_guard_test.strip():
+            raise ValueError(f"{self.path_id}: removal_guard_test is required")
+
+        admits = self.admits_new_work
+        if admits and not self.new_admission_source.strip():
+            raise ValueError(
+                f"{self.path_id}: class {self.retirement_class.value!r} still "
+                "admits new work, so its new-admission source must be named"
+            )
+        if not admits and self.new_admission_source.strip():
+            raise ValueError(
+                f"{self.path_id}: class {self.retirement_class.value!r} does not "
+                "admit new work, so it must not name a new-admission source"
+            )
+        if (
+            self.retirement_class is RetirementClass.ROLLBACK_ONLY
+            and not self.rollback_generations
+        ):
+            raise ValueError(
+                f"{self.path_id}: rollback_only requires an exact permitted "
+                "rollback generation allowlist"
+            )
+        if self.rollback_generations and not self.rollback_dependency:
+            raise ValueError(
+                f"{self.path_id}: permitted rollback generations imply a rollback "
+                "dependency"
+            )
+        if (
+            self.retirement_class is RetirementClass.TEMPORAL_REPLAY_ONLY
+            and not self.replay_dependency
+        ):
+            raise ValueError(
+                f"{self.path_id}: temporal_replay_only requires a replay dependency"
+            )
+        if (
+            self.retirement_class is RetirementClass.HISTORICAL_READ_ONLY
+            and not self.historical_read_dependency
+        ):
+            raise ValueError(
+                f"{self.path_id}: historical_read_only requires a historical-read "
+                "dependency"
+            )
+        if (
+            self.retirement_class is RetirementClass.CLEANUP_ONLY
+            and ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR
+            not in self.active_resource_dependencies
+        ):
+            raise ValueError(
+                f"{self.path_id}: cleanup_only requires an incomplete-cleanup "
+                "active dependency"
+            )
+        if self.retirement_class in (
+            RetirementClass.ELIGIBLE_FOR_REMOVAL,
+            RetirementClass.REMOVED,
+        ):
+            if (
+                self.active_resource_dependencies
+                or self.replay_dependency
+                or self.historical_read_dependency
+                or self.rollback_dependency
+            ):
+                raise ValueError(
+                    f"{self.path_id}: class {self.retirement_class.value!r} cannot "
+                    "carry an active, replay, historical-read, or rollback "
+                    "dependency"
+                )
+        return self
 
 
 class RetirementDecision(BaseModel):
@@ -93,16 +336,687 @@ class RetirementDecision(BaseModel):
     unmet_criteria: tuple[RetirementCriterion, ...] = Field(alias="unmetCriteria")
 
 
-class RetirementGuardError(RuntimeError):
-    """Raised when a retirement guard invariant is violated."""
+class LegacyAdmissionDecision(BaseModel):
+    """Whether new work may still be admitted through one legacy path."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    path_id: str = Field(alias="pathId")
+    allowed: bool
+    reason_code: str = Field(alias="reasonCode")
+    retirement_class: RetirementClass = Field(alias="retirementClass")
+    rollback_generation: str | None = Field(None, alias="rollbackGeneration")
+    contract_version: str = Field(
+        RETIREMENT_CONTRACT_VERSION, alias="contractVersion"
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, mode="json")
 
 
-# The code-owned inventory. Nothing is retired yet; the migration/canary/replay
-# evidence in this cohort has not proven replacement coverage. Machine-checkable
-# refs name a concrete ``module:symbol`` (the class/function/coordinator that
-# actually implements the authority path) so the guard fails if that symbol is
-# deleted even when its module is left in place.
+class RemovalEligibility(BaseModel):
+    """Whether one row may be included in a removal at a given stage."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    path_id: str = Field(alias="pathId")
+    stage: RemovalStage
+    eligible: bool
+    blockers: tuple[str, ...]
+    unmet_criteria: tuple[RetirementCriterion, ...] = Field(alias="unmetCriteria")
+    contract_version: str = Field(
+        RETIREMENT_CONTRACT_VERSION, alias="contractVersion"
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, mode="json")
+
+
+class RetentionWindows(BaseModel):
+    """Whether the retention windows a row may depend on are still open.
+
+    Fail-closed: the defaults keep every window open, so a caller that forgets to
+    supply evidence never accidentally makes a row removal-eligible.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    replay_window_open: bool = Field(True, alias="replayWindowOpen")
+    historical_read_window_open: bool = Field(True, alias="historicalReadWindowOpen")
+    rollback_window_open: bool = Field(True, alias="rollbackWindowOpen")
+    rollback_exercise_recorded: bool = Field(False, alias="rollbackExerciseRecorded")
+
+
+# The code-owned inventory. Nothing is removed yet; the migration/canary/replay
+# evidence in this cohort has not proven replacement coverage, and #3833 has not
+# promoted the qualified generic rows. Machine-checkable refs name a concrete
+# surface (a ``python:module:symbol``, Compose service, startup script, image
+# variable, or realizer identity) so deleting the still-required implementation
+# fails the guard even when an empty stub is left behind.
 RETIREMENT_INVENTORY: tuple[LegacyPathRecord, ...] = (
+    # ---------------------------------------------------------------- direct Codex
+    LegacyPathRecord(
+        pathId="omnigent.legacy.direct_codex_launch",
+        owner="omnigent-runtime-plane",
+        description=(
+            "Direct Codex managed launch strategy: the runtime the workflow "
+            "launcher selects for the ``codex_cli`` runtime id."
+        ),
+        family=ComponentFamily.DIRECT_CODEX_LAUNCH_AND_SESSION,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.runtime.strategies.codex_cli:"
+            "CodexCliStrategy"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.runtime.strategies.codex_cli:"
+            "CodexCliStrategy",
+            "runtime-strategy:codex_cli",
+        ),
+        newAdmissionSource=(
+            "moonmind.workflows.temporal.runtime.strategies:RUNTIME_STRATEGIES"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+                ActiveOwnerKind.PENDING_PUBLICATION,
+                ActiveOwnerKind.PENDING_CHECKPOINT_OR_REMEDIATION,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.PRODUCT_SELECTORS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_direct_and_profile_bound_generations_are_independently_decided"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.direct_codex_session_runtime",
+        owner="omnigent-runtime-plane",
+        description="Direct Codex managed session runtime and app-server client.",
+        family=ComponentFamily.DIRECT_CODEX_LAUNCH_AND_SESSION,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.runtime.codex_session_runtime:"
+            "CodexManagedSessionRuntime"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.runtime.codex_session_runtime:"
+            "CodexManagedSessionRuntime",
+        ),
+        newAdmissionSource=(
+            "moonmind.workflows.temporal.runtime.strategies.codex_cli:CodexCliStrategy"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.PENDING_CHECKPOINT_OR_REMEDIATION,
+            }
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.LAUNCH_ONLY_CODE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.direct_codex_session_adapter",
+        owner="omnigent-runtime-plane",
+        description="Direct Codex session adapter used by the managed launcher.",
+        family=ComponentFamily.DIRECT_CODEX_LAUNCH_AND_SESSION,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.workflows.adapters.codex_session_adapter:"
+            "CodexSessionAdapter"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.adapters.codex_session_adapter:"
+            "CodexSessionAdapter",
+        ),
+        newAdmissionSource=(
+            "moonmind.workflows.temporal.runtime.strategies.codex_cli:CodexCliStrategy"
+        ),
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION}
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.LAUNCH_ONLY_CODE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.direct_codex_bridge_compat",
+        owner="omnigent-control-plane",
+        description=(
+            "Direct Codex compatibility bridge producer that stamps "
+            "``codex_direct_compat`` provenance onto persisted session events."
+        ),
+        family=ComponentFamily.BRIDGE_COMPATIBILITY,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.activity_runtime:"
+            "TemporalAgentRuntimeActivities"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.activity_runtime:"
+            "TemporalAgentRuntimeActivities",
+        ),
+        newAdmissionSource=(
+            "moonmind.workflows.temporal.runtime.strategies.codex_cli:CodexCliStrategy"
+        ),
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION}
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.HISTORICAL_READERS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_direct_compat_historical_reads.py::"
+            "test_persisted_direct_compat_session_reads_without_live_runtime"
+        ),
+    ),
+    # --------------------------------------------------------------- direct Claude
+    LegacyPathRecord(
+        pathId="omnigent.legacy.direct_claude_launch",
+        owner="omnigent-runtime-plane",
+        description=(
+            "Direct Claude Code managed launch strategy and session ownership "
+            "for the ``claude_code`` runtime id."
+        ),
+        family=ComponentFamily.DIRECT_CLAUDE_LAUNCH_AND_SESSION,
+        generation=RuntimeGeneration.DIRECT_CLAUDE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.runtime.strategies.claude_code:"
+            "ClaudeCodeStrategy"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.runtime.strategies.claude_code:"
+            "ClaudeCodeStrategy",
+            "runtime-strategy:claude_code",
+        ),
+        newAdmissionSource=(
+            "moonmind.workflows.temporal.runtime.strategies:RUNTIME_STRATEGIES"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+                ActiveOwnerKind.PENDING_PUBLICATION,
+                ActiveOwnerKind.PENDING_CHECKPOINT_OR_REMEDIATION,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.PRODUCT_SELECTORS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_direct_and_profile_bound_generations_are_independently_decided"
+        ),
+    ),
+    # -------------------------------------------------------- Codex profile-bound
+    LegacyPathRecord(
+        pathId="omnigent.legacy.profile_bound_realizer",
+        owner="omnigent-control-plane",
+        description=(
+            "``codex-profile-bound@1`` execution realizer registration and "
+            "trusted planner selection."
+        ),
+        family=ComponentFamily.PROFILE_BOUND_REALIZER,
+        generation=RuntimeGeneration.CODEX_PROFILE_BOUND,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.realizers.codex_profile_bound:"
+            "CodexProfileBoundRealizer"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.realizers.codex_profile_bound:"
+            "CodexProfileBoundRealizer",
+            "realizer:codex-profile-bound@1",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.harness_platform.planner:select_execution_realizer"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.PROVIDER_PROFILE_LEASE,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+                ActiveOwnerKind.PENDING_PUBLICATION,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.PRODUCT_SELECTORS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_profile_bound_admission_follows_the_code_owned_class"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.profile_bound_execution",
+        owner="omnigent-control-plane",
+        description="Legacy profile-bound execution coordinator and routing.",
+        family=ComponentFamily.PROFILE_BOUND_EXECUTION,
+        generation=RuntimeGeneration.CODEX_PROFILE_BOUND,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.profile_bound_execution:"
+            "OmnigentProfileBoundExecutionCoordinator"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.profile_bound_execution:"
+            "OmnigentProfileBoundExecutionCoordinator",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.realizers.codex_profile_bound:CodexProfileBoundRealizer"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.PROVIDER_PROFILE_LEASE,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        historicalReadDependency=True,
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA
+        | {RetirementCriterion.BROWSER_TO_HOST_ACCEPTANCE_PASSED},
+        earliestRemovalStage=RemovalStage.LAUNCH_ONLY_CODE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_blocked_while_active_leases_or_hosts_remain"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.oauth_host_runtime",
+        owner="omnigent-runtime-plane",
+        description=(
+            "Legacy OAuth host runtime that assembles Codex host launch, mount, "
+            "credential-volume, and egress attestation argument vectors."
+        ),
+        family=ComponentFamily.OAUTH_HOST_RUNTIME,
+        generation=RuntimeGeneration.CODEX_PROFILE_BOUND,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.oauth_host_runtime:OmnigentOAuthHostRuntime"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.oauth_host_runtime:OmnigentOAuthHostRuntime",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.profile_bound_execution:"
+            "OmnigentProfileBoundExecutionCoordinator"
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+                ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.OAUTH_HOST_ORCHESTRATION,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_blocked_while_active_leases_or_hosts_remain"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.oauth_host_janitor",
+        owner="omnigent-runtime-plane",
+        description=(
+            "Reclamation authority for legacy OAuth host containers, volumes, "
+            "and leases. Owns cleanup after new admission stops."
+        ),
+        family=ComponentFamily.CHECKPOINT_REMEDIATION_PUBLICATION_CLEANUP,
+        generation=RuntimeGeneration.CODEX_PROFILE_BOUND,
+        retirementClass=RetirementClass.CLEANUP_ONLY,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.oauth_host_janitor:OmnigentOAuthHostJanitor"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.oauth_host_janitor:OmnigentOAuthHostJanitor",
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+                ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+            }
+        ),
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.OAUTH_HOST_ORCHESTRATION,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_cleanup_only_path_blocks_removal_until_janitor_authority_drains"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.oauth_session_activities",
+        owner="omnigent-control-plane",
+        description=(
+            "Temporal Activity registrations that stage, revalidate, and clean "
+            "up legacy OAuth host sessions."
+        ),
+        family=ComponentFamily.TEMPORAL_REGISTRATIONS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.activities.oauth_session_cleanup:"
+            "oauth_session_cleanup_stale"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.activities.oauth_session_cleanup:"
+            "oauth_session_cleanup_stale",
+            "python:moonmind.workflows.temporal.activities.oauth_session_activities:"
+            "oauth_session_register_profile",
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        replayDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.COMPOSITION_ROOT_REGISTRATIONS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_blocked_while_active_leases_or_hosts_remain"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.provider_profile_capacity_consumer",
+        owner="omnigent-control-plane",
+        description=(
+            "Provider Profile capacity/lease consumer shared by the legacy "
+            "profile-bound coordinator and the generic realizer."
+        ),
+        family=ComponentFamily.PROVIDER_PROFILE_CAPACITY,
+        generation=RuntimeGeneration.CODEX_PROFILE_BOUND,
+        retirementClass=RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.provider_leases:"
+            "OmnigentProviderLeaseCoordinator"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.provider_leases:"
+            "OmnigentProviderLeaseCoordinator",
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.PROVIDER_PROFILE_LEASE,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.COMPOSITION_ROOT_REGISTRATIONS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_blocked_while_active_leases_or_hosts_remain"
+        ),
+    ),
+    # ------------------------------------------------------- startup and Compose
+    LegacyPathRecord(
+        pathId="omnigent.legacy.codex_static_host_startup",
+        owner="omnigent-deployment",
+        description=(
+            "Codex-specific static host startup, health, and init scripts kept "
+            "as thin wrappers over the consolidated generic entrypoint (#3834)."
+        ),
+        family=ComponentFamily.STARTUP_AND_COMPOSE,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef="script:start-codex-oauth-host.sh",
+        surfaces=(
+            "script:start-codex-oauth-host.sh",
+            "script:check-codex-oauth-host.sh",
+            "script:init-codex-oauth-host.sh",
+            "compose-service:omnigent-host-codex",
+            "compose-service:omnigent-host-codex-init",
+            "compose-profile:omnigent-host-codex",
+        ),
+        newAdmissionSource="docker-compose.yaml:omnigent-host-codex",
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+            }
+        ),
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.STARTUP_AND_COMPOSE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.claude_static_host_startup",
+        owner="omnigent-deployment",
+        description=(
+            "Claude-specific static host startup and health scripts kept as thin "
+            "wrappers over the consolidated generic entrypoint (#3834)."
+        ),
+        family=ComponentFamily.STARTUP_AND_COMPOSE,
+        generation=RuntimeGeneration.DIRECT_CLAUDE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef="script:start-claude-oauth-host.sh",
+        surfaces=(
+            "script:start-claude-oauth-host.sh",
+            "script:check-claude-oauth-host.sh",
+            "compose-service:omnigent-host-claude",
+            "compose-service:omnigent-host-claude-init",
+            "compose-profile:omnigent-host-claude",
+        ),
+        newAdmissionSource="docker-compose.yaml:omnigent-host-claude",
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+            }
+        ),
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.STARTUP_AND_COMPOSE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.projection_host_startup",
+        owner="omnigent-deployment",
+        description=(
+            "Pre-consolidation ``omnigent-host`` Compose service, its "
+            "runner-projection entrypoint, and health script. Still resolves the "
+            "legacy image variable rather than the shared-image expression."
+        ),
+        family=ComponentFamily.STARTUP_AND_COMPOSE,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef="script:start-host-with-projections.sh",
+        surfaces=(
+            "script:start-host-with-projections.sh",
+            "script:check-runner-projections.sh",
+            "compose-service:omnigent-host",
+            "compose-profile:omnigent-host",
+        ),
+        newAdmissionSource="docker-compose.yaml:omnigent-host",
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST}
+        ),
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.STARTUP_AND_COMPOSE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    # ------------------------------------------ image and environment identities
+    LegacyPathRecord(
+        pathId="omnigent.legacy.host_image_variable_alias",
+        owner="omnigent-deployment",
+        description=(
+            "Legacy generic host image variables honored as a bounded alias when "
+            "the canonical shared-image variable is unset."
+        ),
+        family=ComponentFamily.HOST_CLASS_POLICY_AND_IMAGE_REFS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.harness_platform.static_hosts:"
+            "LEGACY_HOST_IMAGE_ENV"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.harness_platform.static_hosts:"
+            "LEGACY_HOST_IMAGE_ENV",
+            "env:OMNIGENT_HOST_IMAGE_REF",
+            "env:OMNIGENT_HOST_IMAGE",
+            "env:OMNIGENT_HOST_IMAGE_TAG",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.harness_platform.static_hosts:"
+            "resolve_static_host_image_ref"
+        ),
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.IMAGE_AND_ENVIRONMENT_ALIASES,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_obsolete_configuration_fails_with_an_actionable_message"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.opencode_host_image_alias",
+        owner="omnigent-deployment",
+        description=(
+            "OpenCode-specific shared-image variable and the "
+            "``omnigent-host-opencode`` image alias it names."
+        ),
+        family=ComponentFamily.HOST_CLASS_POLICY_AND_IMAGE_REFS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.harness_platform.host_classes:"
+            "OMNIGENT_OPENCODE_HOST_IMAGE_ENV"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.harness_platform.host_classes:"
+            "OMNIGENT_OPENCODE_HOST_IMAGE_ENV",
+            "env:OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.harness_platform.host_classes:"
+            "get_opencode_host_image_ref"
+        ),
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST}
+        ),
+        rollbackDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.IMAGE_AND_ENVIRONMENT_ALIASES,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_obsolete_configuration_fails_with_an_actionable_message"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.pi_host_image_alias",
+        owner="omnigent-deployment",
+        description="Per-provider Pi host image variable predating the shared image.",
+        family=ComponentFamily.HOST_CLASS_POLICY_AND_IMAGE_REFS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.harness_platform.host_classes:"
+            "OMNIGENT_PI_HOST_IMAGE_ENV"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.harness_platform.host_classes:"
+            "OMNIGENT_PI_HOST_IMAGE_ENV",
+            "env:OMNIGENT_PI_HOST_IMAGE_REF",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.harness_platform.host_classes:get_pi_host_image_ref"
+        ),
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST}
+        ),
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.IMAGE_AND_ENVIRONMENT_ALIASES,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_obsolete_configuration_fails_with_an_actionable_message"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.persisted_bootstrap_image_fields",
+        owner="omnigent-deployment",
+        description=(
+            "Persisted bootstrap state fields that carry the per-provider host "
+            "image refs resolved before the shared-image authority existed."
+        ),
+        family=ComponentFamily.ENVIRONMENT_AND_PERSISTED_BOOTSTRAP,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.bootstrap.models:"
+            "ResolvedOmnigentDeploymentState"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.bootstrap.models:"
+            "ResolvedOmnigentDeploymentState",
+        ),
+        newAdmissionSource=(
+            "moonmind.omnigent.bootstrap.image_resolution:"
+            "publish_resolved_omnigent_images"
+        ),
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.IMAGE_AND_ENVIRONMENT_ALIASES,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    # -------------------------------------------------------- bridge and UI compat
     LegacyPathRecord(
         pathId="omnigent.legacy.bridge_persistence",
         owner="omnigent-control-plane",
@@ -111,46 +1025,247 @@ RETIREMENT_INVENTORY: tuple[LegacyPathRecord, ...] = (
             "(overloaded bridge row superseded by the canonical session "
             "aggregate)."
         ),
-        machineCheckableRef="moonmind.omnigent.bridge_store:OmnigentBridgeSessionStore",
+        family=ComponentFamily.SERIALIZED_SCHEMA_AND_ROWS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.bridge_store:OmnigentBridgeSessionStore"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.bridge_store:OmnigentBridgeSessionStore",
+        ),
+        newAdmissionSource="moonmind.omnigent.execute:run_omnigent_execution",
+        activeResourceDependencies=frozenset(
+            {ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION}
+        ),
+        historicalReadDependency=True,
         applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.HISTORICAL_READERS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_direct_compat_historical_reads.py::"
+            "test_persisted_direct_compat_session_reads_without_live_runtime"
+        ),
     ),
     LegacyPathRecord(
         pathId="omnigent.legacy.bridge_execution",
         owner="omnigent-control-plane",
         description="Legacy Omnigent session execution driver.",
-        machineCheckableRef="moonmind.omnigent.execute:run_omnigent_execution",
+        family=ComponentFamily.BRIDGE_COMPATIBILITY,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef="python:moonmind.omnigent.execute:run_omnigent_execution",
+        surfaces=("python:moonmind.omnigent.execute:run_omnigent_execution",),
+        newAdmissionSource="moonmind.omnigent.execute:run_omnigent_execution",
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.TEMPORAL_WORKFLOW,
+            }
+        ),
+        replayDependency=True,
         applicableCriteria=_BASE_CRITERIA
         | {RetirementCriterion.CUMULATIVE_REMEDIATION_PASSED},
-    ),
-    LegacyPathRecord(
-        pathId="omnigent.legacy.profile_bound_execution",
-        owner="omnigent-control-plane",
-        description="Legacy profile-bound execution coordinator and routing.",
-        machineCheckableRef=(
-            "moonmind.omnigent.profile_bound_execution:"
-            "OmnigentProfileBoundExecutionCoordinator"
+        earliestRemovalStage=RemovalStage.NEW_WRITE_API_PATHS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_blocked_while_active_leases_or_hosts_remain"
         ),
-        applicableCriteria=_BASE_CRITERIA
-        | {RetirementCriterion.BROWSER_TO_HOST_ACCEPTANCE_PASSED},
     ),
     LegacyPathRecord(
         pathId="omnigent.legacy.native_ui_compat",
         owner="omnigent-control-plane",
         description="Legacy native chat / Workflow Detail compatibility projection.",
+        family=ComponentFamily.API_AND_UI_SELECTION,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
         machineCheckableRef=(
-            "moonmind.omnigent.native_ui_compat:classify_native_ui_http"
+            "python:moonmind.omnigent.native_ui_compat:classify_native_ui_http"
         ),
+        surfaces=(
+            "python:moonmind.omnigent.native_ui_compat:classify_native_ui_http",
+        ),
+        newAdmissionSource=(
+            "api_service.api.routers.omnigent_bridge:_bridge_event_payload"
+        ),
+        historicalReadDependency=True,
         applicableCriteria=_BASE_CRITERIA
         | {RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED},
+        earliestRemovalStage=RemovalStage.HISTORICAL_READERS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_generation_historical_reads.py::"
+            "test_no_generation_is_relabeled_as_generic_on_read"
+        ),
     ),
     LegacyPathRecord(
         pathId="omnigent.legacy.codex_cutover_selection",
         owner="omnigent-control-plane",
         description="Legacy Codex-through-Omnigent cutover runtime selection.",
-        machineCheckableRef="moonmind.omnigent.cutover:validate_matrix_artifact",
+        family=ComponentFamily.API_AND_UI_SELECTION,
+        generation=RuntimeGeneration.DIRECT_CODEX,
+        retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.cutover:validate_matrix_artifact"
+        ),
+        surfaces=("python:moonmind.omnigent.cutover:validate_matrix_artifact",),
+        newAdmissionSource="moonmind.omnigent.cutover:select_runtime",
+        rollbackDependency=True,
         applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.PRODUCT_SELECTORS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_direct_and_profile_bound_generations_are_independently_decided"
+        ),
+    ),
+    # ------------------------------------------------------- migration tooling
+    LegacyPathRecord(
+        pathId="omnigent.legacy.session_migration_inventory",
+        owner="omnigent-control-plane",
+        description=(
+            "Migration inventory that classifies persisted legacy session rows "
+            "for the cutover. Exists only to move records, never to run work."
+        ),
+        family=ComponentFamily.SERIALIZED_SCHEMA_AND_ROWS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.MIGRATION_TOOL,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.session_migration_inventory:classify_record"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.session_migration_inventory:classify_record",
+        ),
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.HISTORICAL_READERS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_removal_stage_ordering_is_enforced"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.managed_session_replay_patches",
+        owner="omnigent-control-plane",
+        description=(
+            "Versioned workflow patch branches that keep direct managed-session "
+            "checkpoint and remediation-continuation histories replayable on the "
+            "target worker build."
+        ),
+        family=ComponentFamily.PATCH_AND_WORKER_VERSION_BRANCHES,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.TEMPORAL_REPLAY_ONLY,
+        machineCheckableRef=(
+            "python:moonmind.workflows.temporal.workflows.run:"
+            "RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH"
+        ),
+        surfaces=(
+            "python:moonmind.workflows.temporal.workflows.run:"
+            "RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH",
+            "python:moonmind.workflows.temporal.workflows.run:"
+            "RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH",
+        ),
+        replayDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.REPLAY_WRAPPERS,
+        removalGuardTest=(
+            "tests/unit/workflows/temporal/test_legacy_generation_replay.py::"
+            "test_direct_and_profile_bound_generation_histories_replay"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.legacy.static_host_startup_runbook",
+        owner="omnigent-deployment",
+        description=(
+            "Static-host startup consolidation runbook and rollback procedure "
+            "handed off by #3834; superseded by this code-owned inventory."
+        ),
+        family=ComponentFamily.FIXTURES_MATRICES_AND_RUNBOOKS,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.HISTORICAL_READ_ONLY,
+        machineCheckableRef=(
+            "file:services/omnigent/scripts/STATIC_HOST_STARTUP_INVENTORY.md"
+        ),
+        surfaces=(
+            "file:services/omnigent/scripts/STATIC_HOST_STARTUP_INVENTORY.md",
+        ),
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.STARTUP_AND_COMPOSE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_legacy_retirement.py::"
+            "test_every_inventory_surface_still_resolves"
+        ),
     ),
 )
+
+
+class ObsoleteConfiguration(BaseModel):
+    """One configuration identity that is on its way out of the product.
+
+    Issue #3835 required work section 10 requires an *actionable* startup failure
+    for obsolete configuration during its deprecation window rather than silently
+    ignoring it, and outright rejection afterwards.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    variable: str
+    retirement_path_id: str = Field(alias="retirementPathId")
+    replacement: str
+    # False while the variable is still honored (nothing to warn about yet).
+    # True once the deployment must stop supplying it.
+    deprecated: bool = False
+    removed: bool = False
+    guidance: str = ""
+
+    @model_validator(mode="after")
+    def _validate(self) -> "ObsoleteConfiguration":
+        if self.removed and not self.deprecated:
+            raise ValueError(
+                f"{self.variable}: a removed variable must pass through its "
+                "deprecation window first"
+            )
+        if self.deprecated and not self.guidance.strip():
+            raise ValueError(
+                f"{self.variable}: a deprecated variable needs actionable guidance"
+            )
+        return self
+
+
+# Every legacy configuration identity that will produce an actionable startup
+# failure once its owning retirement row stops admitting new work. Nothing is
+# deprecated yet: the aliases below are still the supported way to pin a prior
+# image while the rollback window is open (#3833 has not promoted the qualified
+# generic rows).
+OBSOLETE_CONFIGURATION: tuple[ObsoleteConfiguration, ...] = (
+    ObsoleteConfiguration(
+        variable="OMNIGENT_HOST_IMAGE_REF",
+        retirementPathId="omnigent.legacy.host_image_variable_alias",
+        replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+    ),
+    ObsoleteConfiguration(
+        variable="OMNIGENT_HOST_IMAGE",
+        retirementPathId="omnigent.legacy.host_image_variable_alias",
+        replacement="OMNIGENT_SHARED_HOST_IMAGE",
+    ),
+    ObsoleteConfiguration(
+        variable="OMNIGENT_HOST_IMAGE_TAG",
+        retirementPathId="omnigent.legacy.host_image_variable_alias",
+        replacement="OMNIGENT_SHARED_HOST_IMAGE_TAG",
+    ),
+    ObsoleteConfiguration(
+        variable="OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+        retirementPathId="omnigent.legacy.opencode_host_image_alias",
+        replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+    ),
+    ObsoleteConfiguration(
+        variable="OMNIGENT_PI_HOST_IMAGE_REF",
+        retirementPathId="omnigent.legacy.pi_host_image_alias",
+        replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+    ),
+)
+
+
+class ObsoleteConfigurationError(RuntimeError):
+    """Raised at startup when a deployment supplies obsolete configuration."""
 
 
 class ArchitectureBoundaryException(BaseModel):
@@ -159,7 +1274,7 @@ class ArchitectureBoundaryException(BaseModel):
     Source issue: MoonLadderStudios/MoonMind#3711 (required work 6). An
     exemption is only acceptable while a named legacy path in
     :data:`RETIREMENT_INVENTORY` still owns the coupled behavior, so every
-    exception names the ``pathId`` whose #3712 criteria retire it.
+    exception names the ``pathId`` whose retirement criteria retire it.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
@@ -213,7 +1328,7 @@ ARCHITECTURE_BOUNDARY_EXCEPTIONS: tuple[ArchitectureBoundaryException, ...] = (
             "would change the launch argument vector that in-flight histories "
             "were started with."
         ),
-        retirementPathId="omnigent.legacy.profile_bound_execution",
+        retirementPathId="omnigent.legacy.oauth_host_runtime",
     ),
 )
 
@@ -246,10 +1361,10 @@ def assert_architecture_exceptions_are_owned(
             )
 
 
-# Temporary rollout flags introduced by this issue. Each maps to the trigger that
-# permits its removal. Their presence here is what keeps them from becoming a
-# permanent alternate architecture: the retirement test asserts every temporary
-# flag has a declared retirement trigger.
+# Temporary rollout flags introduced by the supervisor migration. Each maps to
+# the trigger that permits its removal. Their presence here is what keeps them
+# from becoming a permanent alternate architecture: the retirement test asserts
+# every temporary flag has a declared retirement trigger.
 LEGACY_RETIREMENT_COMPLETE = "legacy_retirement_complete"
 TEMPORARY_ROLLOUT_FLAGS: dict[str, str] = {
     "omnigent_session_supervisor_enabled": LEGACY_RETIREMENT_COMPLETE,
@@ -261,6 +1376,24 @@ TEMPORARY_ROLLOUT_FLAGS: dict[str, str] = {
     "omnigent_session_supervisor_allowed_provider_profile_ids": LEGACY_RETIREMENT_COMPLETE,
     "omnigent_session_supervisor_rollback_mode": LEGACY_RETIREMENT_COMPLETE,
 }
+
+_INVENTORY_BY_ID: dict[str, LegacyPathRecord] = {
+    path.path_id: path for path in RETIREMENT_INVENTORY
+}
+
+
+def get_retirement_record(
+    path_id: str, *, inventory: tuple[LegacyPathRecord, ...] | None = None
+) -> LegacyPathRecord:
+    """Return the inventory row for ``path_id``; an unknown id fails closed."""
+
+    if inventory is None:
+        record = _INVENTORY_BY_ID.get(path_id)
+    else:
+        record = next((p for p in inventory if p.path_id == path_id), None)
+    if record is None:
+        raise RetirementGuardError(f"unknown retirement path {path_id!r}")
+    return record
 
 
 def evaluate_retirement(
@@ -277,6 +1410,265 @@ def evaluate_retirement(
     )
     return RetirementDecision(
         pathId=path.path_id, allowed=not unmet, unmetCriteria=unmet
+    )
+
+
+_INVENTORY_BY_SURFACE: dict[str, LegacyPathRecord] = {
+    ref: path for path in RETIREMENT_INVENTORY for ref in path.surfaces
+}
+
+
+def retirement_record_for_surface(
+    surface_ref: str, *, inventory: tuple[LegacyPathRecord, ...] | None = None
+) -> LegacyPathRecord | None:
+    """Return the row that owns ``surface_ref``, or ``None`` when it is canonical.
+
+    A surface with no row is a canonical (non-legacy) path — the generic
+    realizer, the shared image variable — and is never subject to retirement
+    admission control.
+    """
+
+    parse_surface_ref(surface_ref)
+    if inventory is None:
+        return _INVENTORY_BY_SURFACE.get(surface_ref)
+    return next(
+        (path for path in inventory if surface_ref in path.surfaces), None
+    )
+
+
+def assert_surface_admits_new_work(
+    surface_ref: str,
+    *,
+    rollback_generation: str | None = None,
+    inventory: tuple[LegacyPathRecord, ...] | None = None,
+) -> LegacyAdmissionDecision | None:
+    """Reject new work that selects a retired surface.
+
+    This is the one boundary every new-admission source consults, so a trusted
+    planner default, an alternate API client supplying an explicit selection, a
+    schedule, and a preset are all held to the same code-owned retirement state.
+    Returns ``None`` for canonical surfaces that carry no retirement row.
+    """
+
+    record = retirement_record_for_surface(surface_ref, inventory=inventory)
+    if record is None:
+        return None
+    return assert_new_admission_allowed(
+        record.path_id,
+        rollback_generation=rollback_generation,
+        inventory=inventory,
+    )
+
+
+def evaluate_new_admission(
+    path: LegacyPathRecord, *, rollback_generation: str | None = None
+) -> LegacyAdmissionDecision:
+    """Whether new work may be admitted through ``path``.
+
+    ``rollback_only`` admits new work only under an exactly allowlisted rollback
+    generation. Every later class refuses, which is what stops new Agent
+    Profiles, schedules, presets, and alternate API clients from creating new
+    legacy work once the class advances — without touching execution,
+    cancellation, cleanup, or reads for already-recorded plans.
+    """
+
+    generation = (rollback_generation or "").strip() or None
+    if path.retirement_class is RetirementClass.ACTIVE_PRODUCT_PATH:
+        return LegacyAdmissionDecision(
+            pathId=path.path_id,
+            allowed=True,
+            reasonCode="active_product_path",
+            retirementClass=path.retirement_class,
+            rollbackGeneration=generation,
+        )
+    if path.retirement_class is RetirementClass.ROLLBACK_ONLY:
+        if generation is None:
+            reason = "rollback_generation_required"
+        elif generation not in path.rollback_generations:
+            reason = "rollback_generation_not_allowlisted"
+        else:
+            return LegacyAdmissionDecision(
+                pathId=path.path_id,
+                allowed=True,
+                reasonCode="rollback_generation_permitted",
+                retirementClass=path.retirement_class,
+                rollbackGeneration=generation,
+            )
+        return LegacyAdmissionDecision(
+            pathId=path.path_id,
+            allowed=False,
+            reasonCode=reason,
+            retirementClass=path.retirement_class,
+            rollbackGeneration=generation,
+        )
+    return LegacyAdmissionDecision(
+        pathId=path.path_id,
+        allowed=False,
+        reasonCode=f"new_admission_disabled:{path.retirement_class.value}",
+        retirementClass=path.retirement_class,
+        rollbackGeneration=generation,
+    )
+
+
+def assert_new_admission_allowed(
+    path_id: str,
+    *,
+    rollback_generation: str | None = None,
+    inventory: tuple[LegacyPathRecord, ...] | None = None,
+) -> LegacyAdmissionDecision:
+    """Fail fast when new work selects a path whose class no longer admits it."""
+
+    record = get_retirement_record(path_id, inventory=inventory)
+    decision = evaluate_new_admission(record, rollback_generation=rollback_generation)
+    if not decision.allowed:
+        raise LegacyAdmissionRejected(
+            f"legacy path {path_id!r} no longer admits new work "
+            f"(class={decision.retirement_class.value}, "
+            f"reason={decision.reason_code}); existing plans continue to "
+            "execute, cancel, clean up, and read normally",
+            path_id=path_id,
+            reason_code=decision.reason_code,
+        )
+    return decision
+
+
+def evaluate_removal_eligibility(
+    path: LegacyPathRecord,
+    *,
+    stage: RemovalStage,
+    drained_kinds: frozenset[ActiveOwnerKind] | set | None = None,
+    passed_criteria: frozenset[RetirementCriterion] | set | None = None,
+    retention: RetentionWindows | None = None,
+) -> RemovalEligibility:
+    """Whether ``path`` may be included in a removal PR at ``stage``.
+
+    Fail-closed by construction: an active-owner class with no drain evidence is
+    treated as still owning work, and every retention window defaults to open.
+    """
+
+    drained = frozenset(drained_kinds or frozenset())
+    windows = retention or RetentionWindows()
+    blockers: list[str] = []
+
+    if stage < path.earliest_removal_stage:
+        blockers.append(
+            f"stage_too_early:{stage.name.lower()}<"
+            f"{path.earliest_removal_stage.name.lower()}"
+        )
+    if path.admits_new_work:
+        blockers.append(f"still_admits_new_work:{path.retirement_class.value}")
+    for kind in sorted(
+        path.active_resource_dependencies - drained, key=lambda k: k.value
+    ):
+        blockers.append(f"active_owner:{kind.value}")
+    if path.replay_dependency and windows.replay_window_open:
+        blockers.append("replay_window_open")
+    if path.historical_read_dependency and windows.historical_read_window_open:
+        blockers.append("historical_read_window_open")
+    if path.rollback_dependency:
+        if windows.rollback_window_open:
+            blockers.append("rollback_window_open")
+        if not windows.rollback_exercise_recorded:
+            blockers.append("rollback_exercise_not_recorded")
+
+    decision = evaluate_retirement(path, frozenset(passed_criteria or frozenset()))
+    blockers.extend(
+        f"unmet_criterion:{criterion.value}" for criterion in decision.unmet_criteria
+    )
+
+    return RemovalEligibility(
+        pathId=path.path_id,
+        stage=stage,
+        eligible=not blockers,
+        blockers=tuple(blockers),
+        unmetCriteria=decision.unmet_criteria,
+    )
+
+
+class RemovalPlan(BaseModel):
+    """One bounded, reviewable removal targeting exactly one stage.
+
+    Issue #3835 required work section 7 forbids combining every removal into one
+    unreviewable change and requires each removal PR to cite the inventory rows
+    and passing guards it satisfies. A plan therefore names one stage and the
+    rows it removes; :func:`evaluate_removal_plan` returns the citation.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    stage: RemovalStage
+    path_ids: tuple[str, ...] = Field(alias="pathIds")
+
+    @model_validator(mode="after")
+    def _validate(self) -> "RemovalPlan":
+        if not self.path_ids:
+            raise ValueError("a removal plan must name at least one retirement row")
+        if len(set(self.path_ids)) != len(self.path_ids):
+            raise ValueError("a removal plan must not name a retirement row twice")
+        return self
+
+
+class RemovalPlanReport(BaseModel):
+    """The citation a removal PR carries: rows, guards, and remaining blockers."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    stage: RemovalStage
+    allowed: bool
+    eligible_path_ids: tuple[str, ...] = Field(alias="eligiblePathIds")
+    blocked: tuple[RemovalEligibility, ...]
+    required_guard_tests: tuple[str, ...] = Field(alias="requiredGuardTests")
+    contract_version: str = Field(
+        RETIREMENT_CONTRACT_VERSION, alias="contractVersion"
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return self.model_dump(by_alias=True, mode="json")
+
+
+def evaluate_removal_plan(
+    plan: RemovalPlan,
+    *,
+    inventory: tuple[LegacyPathRecord, ...] | None = None,
+    drained_by_path: Mapping[str, frozenset[ActiveOwnerKind]] | None = None,
+    passed_by_path: Mapping[str, frozenset[RetirementCriterion]] | None = None,
+    retention_by_path: Mapping[str, RetentionWindows] | None = None,
+) -> RemovalPlanReport:
+    """Return the bounded citation for one staged removal.
+
+    Fail-closed: a row with no supplied drain evidence, criteria, or retention
+    evidence is evaluated against empty/open defaults and therefore blocks the
+    plan rather than passing by omission.
+    """
+
+    drained_by_path = drained_by_path or {}
+    passed_by_path = passed_by_path or {}
+    retention_by_path = retention_by_path or {}
+
+    eligible: list[str] = []
+    blocked: list[RemovalEligibility] = []
+    guards: list[str] = []
+    for path_id in plan.path_ids:
+        record = get_retirement_record(path_id, inventory=inventory)
+        guards.append(record.removal_guard_test)
+        eligibility = evaluate_removal_eligibility(
+            record,
+            stage=plan.stage,
+            drained_kinds=drained_by_path.get(path_id),
+            passed_criteria=passed_by_path.get(path_id),
+            retention=retention_by_path.get(path_id),
+        )
+        if eligibility.eligible:
+            eligible.append(path_id)
+        else:
+            blocked.append(eligibility)
+
+    return RemovalPlanReport(
+        stage=plan.stage,
+        allowed=not blocked,
+        eligiblePathIds=tuple(eligible),
+        blocked=tuple(blocked),
+        requiredGuardTests=tuple(sorted(set(guards))),
     )
 
 
@@ -309,56 +1701,114 @@ def criteria_from_native_chat_acceptance(
     return frozenset({RetirementCriterion.NATIVE_CHAT_ACCEPTANCE_PASSED})
 
 
-def _ref_resolves(ref: str) -> bool:
-    """Whether a machine-checkable ``module:symbol`` reference still resolves.
-
-    The reference must name a concrete symbol (class, function, coordinator, or
-    registry entry) inside the module, not merely an importable module. This way
-    deleting the still-required implementation fails the guard even when an empty
-    or stub module is left behind. A bare module reference (no ``:symbol``) is
-    rejected so a weakened guard can never silently pass.
-    """
-
-    module_name, _, symbol = ref.partition(":")
-    if not module_name or not symbol:
-        return False
-    try:
-        module = importlib.import_module(module_name)
-    except Exception:  # noqa: BLE001 - any import failure means the ref is gone
-        return False
-    return hasattr(module, symbol)
-
-
 def assert_retirement_guard(
     inventory: tuple[LegacyPathRecord, ...] = RETIREMENT_INVENTORY,
     *,
     passed_by_path: dict[str, frozenset[RetirementCriterion]] | None = None,
 ) -> None:
-    """Enforce the two retirement-guard invariants.
+    """Enforce the retirement-guard invariants.
 
-    * A path marked ``retired`` must have every applicable criterion passing.
-    * A not-yet-retired path's machine-checkable reference must still resolve.
+    * A path classified ``removed`` must have every applicable criterion passing.
+    * A retained path's surfaces must all still resolve.
 
     Raises :class:`RetirementGuardError` on violation.
     """
 
     passed_by_path = passed_by_path or {}
+    seen: set[str] = set()
     for path in inventory:
-        if path.retired:
+        if path.path_id in seen:
+            raise RetirementGuardError(f"duplicate retirement row {path.path_id!r}")
+        seen.add(path.path_id)
+        if path.removed:
             decision = evaluate_retirement(
                 path, passed_by_path.get(path.path_id, frozenset())
             )
             if not decision.allowed:
                 raise RetirementGuardError(
-                    f"legacy path {path.path_id!r} is marked retired but has "
+                    f"legacy path {path.path_id!r} is classified removed but has "
                     f"unmet criteria: {[c.value for c in decision.unmet_criteria]}"
                 )
-        elif not _ref_resolves(path.machine_checkable_ref):
-            raise RetirementGuardError(
-                f"legacy path {path.path_id!r} is still required but its "
-                f"machine-checkable reference {path.machine_checkable_ref!r} no "
-                "longer resolves"
-            )
+            continue
+        for ref in path.surfaces:
+            if not surface_exists(ref):
+                raise RetirementGuardError(
+                    f"legacy path {path.path_id!r} is still classified "
+                    f"{path.retirement_class.value!r} but its machine-checkable "
+                    f"surface {ref!r} no longer resolves"
+                )
+
+
+def assert_inventory_is_complete(
+    inventory: tuple[LegacyPathRecord, ...] = RETIREMENT_INVENTORY,
+    *,
+    discovered: frozenset[str] | None = None,
+) -> None:
+    """Every discovered legacy surface must map to exactly one retirement row.
+
+    This is the guard that makes an *unclassified* new legacy dependency fail
+    CI: registering a new non-generic realizer, direct managed runtime strategy,
+    provider-specific host script, duplicate Compose service/profile, or legacy
+    image variable adds a discovered surface with no owning row.
+    """
+
+    surfaces = (
+        discover_legacy_surfaces() if discovered is None else frozenset(discovered)
+    )
+    owners: dict[str, list[str]] = {}
+    for path in inventory:
+        for ref in path.surfaces:
+            owners.setdefault(ref, []).append(path.path_id)
+
+    duplicated = {ref: ids for ref, ids in owners.items() if len(ids) > 1}
+    if duplicated:
+        raise RetirementGuardError(
+            "retirement surfaces claimed by more than one row: "
+            f"{ {ref: sorted(ids) for ref, ids in sorted(duplicated.items())} }"
+        )
+
+    unclassified = sorted(surfaces - set(owners))
+    if unclassified:
+        raise RetirementGuardError(
+            "legacy surfaces have no retirement row (classify each with a "
+            f"RetirementClass in RETIREMENT_INVENTORY): {unclassified}"
+        )
+
+
+def assert_obsolete_configuration(
+    env: Mapping[str, str],
+    *,
+    configuration: tuple[ObsoleteConfiguration, ...] | None = None,
+) -> tuple[str, ...]:
+    """Fail startup on obsolete configuration; return deprecation warnings.
+
+    During the deprecation window a supplied variable produces an actionable
+    operator warning naming its replacement. After removal the same variable is
+    rejected outright instead of being silently ignored.
+    """
+
+    if configuration is None:
+        configuration = OBSOLETE_CONFIGURATION
+    warnings: list[str] = []
+    rejected: list[str] = []
+    for entry in configuration:
+        value = str(env.get(entry.variable, "") or "").strip()
+        if not value:
+            continue
+        message = (
+            f"{entry.variable} is obsolete; set {entry.replacement} instead "
+            f"(retirement row {entry.retirement_path_id})."
+        )
+        if entry.removed:
+            rejected.append(f"{message} {entry.guidance}".strip())
+        elif entry.deprecated:
+            warnings.append(f"{message} {entry.guidance}".strip())
+    if rejected:
+        raise ObsoleteConfigurationError(
+            "obsolete Omnigent configuration is no longer honored: "
+            + " ".join(rejected)
+        )
+    return tuple(warnings)
 
 
 def assert_temporary_flags_have_retirement(
@@ -376,18 +1826,41 @@ def assert_temporary_flags_have_retirement(
 
 __all__ = [
     "ARCHITECTURE_BOUNDARY_EXCEPTIONS",
+    "ActiveOwnerKind",
     "ArchitectureBoundaryException",
-    "assert_architecture_exceptions_are_owned",
-    "RETIREMENT_CONTRACT_VERSION",
-    "RetirementCriterion",
+    "ComponentFamily",
+    "LEGACY_RETIREMENT_COMPLETE",
+    "LegacyAdmissionDecision",
+    "LegacyAdmissionRejected",
     "LegacyPathRecord",
+    "OBSOLETE_CONFIGURATION",
+    "ObsoleteConfiguration",
+    "ObsoleteConfigurationError",
+    "RETIREMENT_CONTRACT_VERSION",
+    "RETIREMENT_INVENTORY",
+    "RemovalEligibility",
+    "RemovalPlan",
+    "RemovalPlanReport",
+    "RemovalStage",
+    "RetentionWindows",
+    "RetirementClass",
+    "RetirementCriterion",
     "RetirementDecision",
     "RetirementGuardError",
-    "RETIREMENT_INVENTORY",
+    "RuntimeGeneration",
     "TEMPORARY_ROLLOUT_FLAGS",
-    "LEGACY_RETIREMENT_COMPLETE",
-    "criteria_from_native_chat_acceptance",
-    "evaluate_retirement",
+    "assert_architecture_exceptions_are_owned",
+    "assert_inventory_is_complete",
+    "assert_new_admission_allowed",
+    "assert_obsolete_configuration",
     "assert_retirement_guard",
+    "assert_surface_admits_new_work",
     "assert_temporary_flags_have_retirement",
+    "criteria_from_native_chat_acceptance",
+    "evaluate_new_admission",
+    "evaluate_removal_eligibility",
+    "evaluate_removal_plan",
+    "evaluate_retirement",
+    "get_retirement_record",
+    "retirement_record_for_surface",
 ]

--- a/moonmind/omnigent/retirement_drain.py
+++ b/moonmind/omnigent/retirement_drain.py
@@ -18,6 +18,9 @@ and the fail-closed contract the guard depends on:
 * Stale evidence is not drained. An observation older than the freshness bound
   is treated the same as a missing one.
 * A probe that failed is not drained, and its failure is reported by kind.
+* Every probe that observed a kind must agree it is drained. One authority's
+  failure, staleness, or positive count is never discarded by another probe's
+  newer zero-count success.
 * Observations carry counts and operator-safe probe refs only — never provider
   session ids, host ids, credentials, or internal endpoints.
 """
@@ -134,22 +137,22 @@ def build_drain_evidence(
 ) -> DrainEvidence:
     """Aggregate probe observations into fail-closed drain evidence.
 
-    Only a declared dependency kind with a fresh, successful, zero-count
-    observation is drained. Observations for kinds the row does not declare are
-    ignored rather than widening the result.
+    A declared dependency kind is drained only when *every* observation for it
+    is fresh, successful, and zero-count. Aggregation never reduces a kind to
+    its newest observation, because a later zero-count success from one probe
+    must not discard another probe's failure or positive count. Observations for
+    kinds the row does not declare are ignored rather than widening the result.
     """
 
     generated_at = now or datetime.now(timezone.utc)
     if generated_at.tzinfo is None:
         raise DrainEvidenceError("now must be timezone-aware")
 
-    latest: dict[ActiveOwnerKind, ActiveOwnerObservation] = {}
+    by_kind: dict[ActiveOwnerKind, list[ActiveOwnerObservation]] = {}
     for observation in observations:
         if observation.kind not in path.active_resource_dependencies:
             continue
-        current = latest.get(observation.kind)
-        if current is None or observation.observed_at > current.observed_at:
-            latest[observation.kind] = observation
+        by_kind.setdefault(observation.kind, []).append(observation)
 
     drained: set[ActiveOwnerKind] = set()
     blocking: list[ActiveOwnerKind] = []
@@ -158,20 +161,30 @@ def build_drain_evidence(
     failed: list[ActiveOwnerKind] = []
 
     for kind in sorted(path.active_resource_dependencies, key=lambda k: k.value):
-        observation = latest.get(kind)
-        if observation is None:
+        for_kind = by_kind.get(kind) or []
+        if not for_kind:
             missing.append(kind)
             blocking.append(kind)
             continue
-        if not observation.probe_succeeded:
+        # Every applicable probe must agree that the kind is drained. A newer
+        # zero-count success never overwrites another authority's failure,
+        # staleness, or positive count: each is an independent blocker.
+        kind_failed = any(not obs.probe_succeeded for obs in for_kind)
+        kind_stale = any(
+            obs.probe_succeeded and generated_at - obs.observed_at > max_age
+            for obs in for_kind
+        )
+        kind_active = any(
+            obs.probe_succeeded
+            and generated_at - obs.observed_at <= max_age
+            and obs.active_count > 0
+            for obs in for_kind
+        )
+        if kind_failed:
             failed.append(kind)
-            blocking.append(kind)
-            continue
-        if generated_at - observation.observed_at > max_age:
+        if kind_stale:
             stale.append(kind)
-            blocking.append(kind)
-            continue
-        if observation.active_count > 0:
+        if kind_failed or kind_stale or kind_active:
             blocking.append(kind)
             continue
         drained.add(kind)

--- a/moonmind/omnigent/retirement_drain.py
+++ b/moonmind/omnigent/retirement_drain.py
@@ -1,0 +1,232 @@
+"""Active-owner drain evidence for the legacy retirement guard.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required work section 3).
+
+Before an implementation is removed, MoonMind must *prove* no owner still uses
+it: active Temporal workflows, AgentRuns and Omnigent sessions, Provider Profile
+leases, host bindings and leases, credential consumers, static or on-demand
+hosts, pending publication, pending checkpoint or remediation work, and
+incomplete cleanup or janitor authority.
+
+The producer here is deliberately port-shaped. Counting live owners is an I/O
+side effect that belongs to adapters over the Temporal client, the control-plane
+store, and the lease repositories; this module owns only the aggregation rule
+and the fail-closed contract the guard depends on:
+
+* A dependency kind the row declares but *no probe observed* is not drained.
+  Missing evidence never reads as "nothing left".
+* Stale evidence is not drained. An observation older than the freshness bound
+  is treated the same as a missing one.
+* A probe that failed is not drained, and its failure is reported by kind.
+* Observations carry counts and operator-safe probe refs only — never provider
+  session ids, host ids, credentials, or internal endpoints.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from moonmind.omnigent.legacy_retirement import (
+    ActiveOwnerKind,
+    LegacyPathRecord,
+)
+
+DRAIN_CONTRACT_VERSION = "moonmind.omnigent-retirement-drain/v1"
+
+# Drain evidence is only meaningful while it is fresh; an old snapshot cannot
+# prove the current absence of owners.
+DEFAULT_EVIDENCE_MAX_AGE = timedelta(hours=1)
+
+# Operator-safe probe references are bounded identifiers, never a provider
+# session id, host id, credential, or internal endpoint.
+PROBE_REF_MAX_LENGTH = 64
+# Dot-separated lowercase words only, at most four segments. Provider session
+# ids, host ids, tokens, and endpoints all fail this shape, so an accidental
+# leak into an operator-facing drain report is rejected rather than published.
+_PROBE_REF_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*){1,3}$")
+
+
+class DrainEvidenceError(ValueError):
+    """Raised when drain evidence is malformed."""
+
+
+class ActiveOwnerObservation(BaseModel):
+    """One probe result for one active-owner kind.
+
+    ``active_count`` is the number of owners still holding the component. Zero
+    with ``probe_succeeded`` is the only shape that drains a kind.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    kind: ActiveOwnerKind
+    active_count: int = Field(ge=0, alias="activeCount")
+    probe_ref: str = Field(alias="probeRef")
+    observed_at: datetime = Field(alias="observedAt")
+    probe_succeeded: bool = Field(True, alias="probeSucceeded")
+
+    @field_validator("probe_ref")
+    @classmethod
+    def _validate_probe_ref(cls, value: str) -> str:
+        cleaned = str(value or "").strip()
+        if not cleaned or len(cleaned) > PROBE_REF_MAX_LENGTH:
+            raise ValueError("probe_ref must be a bounded non-empty identifier")
+        if not _PROBE_REF_PATTERN.match(cleaned):
+            raise ValueError(
+                "probe_ref must be an operator-safe identifier, never a provider "
+                "session id, host id, credential, or endpoint"
+            )
+        return cleaned
+
+    @field_validator("observed_at")
+    @classmethod
+    def _validate_observed_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+        return value
+
+
+@runtime_checkable
+class ActiveOwnerProbe(Protocol):
+    """Adapter port that counts live owners of one component."""
+
+    async def observe(
+        self, path: LegacyPathRecord, kind: ActiveOwnerKind
+    ) -> ActiveOwnerObservation:
+        raise NotImplementedError
+
+
+class DrainEvidence(BaseModel):
+    """Aggregated, fail-closed drain evidence for one retirement row."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    path_id: str = Field(alias="pathId")
+    generated_at: datetime = Field(alias="generatedAt")
+    drained_kinds: frozenset[ActiveOwnerKind] = Field(alias="drainedKinds")
+    blocking_kinds: tuple[ActiveOwnerKind, ...] = Field(alias="blockingKinds")
+    missing_kinds: tuple[ActiveOwnerKind, ...] = Field(alias="missingKinds")
+    stale_kinds: tuple[ActiveOwnerKind, ...] = Field(alias="staleKinds")
+    failed_kinds: tuple[ActiveOwnerKind, ...] = Field(alias="failedKinds")
+    contract_version: str = Field(DRAIN_CONTRACT_VERSION, alias="contractVersion")
+
+    @property
+    def fully_drained(self) -> bool:
+        return not self.blocking_kinds
+
+    def as_dict(self) -> dict[str, object]:
+        payload = self.model_dump(by_alias=True, mode="json")
+        payload["drainedKinds"] = sorted(kind.value for kind in self.drained_kinds)
+        payload["fullyDrained"] = self.fully_drained
+        return payload
+
+
+def build_drain_evidence(
+    path: LegacyPathRecord,
+    observations: Iterable[ActiveOwnerObservation],
+    *,
+    now: datetime | None = None,
+    max_age: timedelta = DEFAULT_EVIDENCE_MAX_AGE,
+) -> DrainEvidence:
+    """Aggregate probe observations into fail-closed drain evidence.
+
+    Only a declared dependency kind with a fresh, successful, zero-count
+    observation is drained. Observations for kinds the row does not declare are
+    ignored rather than widening the result.
+    """
+
+    generated_at = now or datetime.now(timezone.utc)
+    if generated_at.tzinfo is None:
+        raise DrainEvidenceError("now must be timezone-aware")
+
+    latest: dict[ActiveOwnerKind, ActiveOwnerObservation] = {}
+    for observation in observations:
+        if observation.kind not in path.active_resource_dependencies:
+            continue
+        current = latest.get(observation.kind)
+        if current is None or observation.observed_at > current.observed_at:
+            latest[observation.kind] = observation
+
+    drained: set[ActiveOwnerKind] = set()
+    blocking: list[ActiveOwnerKind] = []
+    missing: list[ActiveOwnerKind] = []
+    stale: list[ActiveOwnerKind] = []
+    failed: list[ActiveOwnerKind] = []
+
+    for kind in sorted(path.active_resource_dependencies, key=lambda k: k.value):
+        observation = latest.get(kind)
+        if observation is None:
+            missing.append(kind)
+            blocking.append(kind)
+            continue
+        if not observation.probe_succeeded:
+            failed.append(kind)
+            blocking.append(kind)
+            continue
+        if generated_at - observation.observed_at > max_age:
+            stale.append(kind)
+            blocking.append(kind)
+            continue
+        if observation.active_count > 0:
+            blocking.append(kind)
+            continue
+        drained.add(kind)
+
+    return DrainEvidence(
+        pathId=path.path_id,
+        generatedAt=generated_at,
+        drainedKinds=frozenset(drained),
+        blockingKinds=tuple(blocking),
+        missingKinds=tuple(missing),
+        staleKinds=tuple(stale),
+        failedKinds=tuple(failed),
+    )
+
+
+async def collect_drain_evidence(
+    path: LegacyPathRecord,
+    probes: Iterable[ActiveOwnerProbe],
+    *,
+    now: datetime | None = None,
+    max_age: timedelta = DEFAULT_EVIDENCE_MAX_AGE,
+) -> DrainEvidence:
+    """Run every probe for every declared dependency kind and aggregate.
+
+    A probe that raises is recorded as a failed observation for that kind rather
+    than aborting collection, so the resulting evidence names exactly which
+    authority could not be proven drained.
+    """
+
+    generated_at = now or datetime.now(timezone.utc)
+    observations: list[ActiveOwnerObservation] = []
+    for probe in probes:
+        for kind in sorted(path.active_resource_dependencies, key=lambda k: k.value):
+            try:
+                observations.append(await probe.observe(path, kind))
+            except Exception:  # noqa: BLE001 - a failed probe never drains a kind
+                observations.append(
+                    ActiveOwnerObservation(
+                        kind=kind,
+                        activeCount=0,
+                        probeRef="probe.unavailable",
+                        observedAt=generated_at,
+                        probeSucceeded=False,
+                    )
+                )
+    return build_drain_evidence(path, observations, now=generated_at, max_age=max_age)
+
+
+__all__ = [
+    "DEFAULT_EVIDENCE_MAX_AGE",
+    "DRAIN_CONTRACT_VERSION",
+    "ActiveOwnerObservation",
+    "ActiveOwnerProbe",
+    "DrainEvidence",
+    "DrainEvidenceError",
+    "build_drain_evidence",
+    "collect_drain_evidence",
+]

--- a/moonmind/omnigent/retirement_surfaces.py
+++ b/moonmind/omnigent/retirement_surfaces.py
@@ -1,0 +1,333 @@
+"""Typed retirement surfaces and code-derived legacy dependency discovery.
+
+Source issue: MoonLadderStudios/MoonMind#3835.
+
+The #3835 retirement inventory has to classify more than Python modules: it also
+owns execution realizers, direct managed runtime strategies, Compose services and
+profiles, provider-specific startup scripts, and legacy image/environment
+identities. This module gives all of them one addressable identity — a
+scheme-prefixed ``SurfaceRef`` — plus two operations the retirement guard needs:
+
+``surface_exists``
+    Whether the surface is still present. A retained (not yet removed) row whose
+    surface disappeared must fail CI, because the implementation an active,
+    replay, or historical-read dependency still needs was deleted silently.
+
+``discover_legacy_surfaces``
+    The set of legacy surfaces the repository *actually* contains right now,
+    derived from code and deployment configuration rather than a hand-maintained
+    list. The completeness guard compares this against the inventory, so adding a
+    new legacy realizer, direct runtime strategy, provider-specific host script,
+    duplicate Compose service, or legacy image variable fails CI until it is
+    classified with a retirement class.
+
+Discovery is deliberately derived from authorities that already exist:
+
+* ``harness_platform.support.KNOWN_REALIZERS`` — every non-generic realizer.
+* ``temporal.runtime.strategies.RUNTIME_STRATEGIES`` — every direct managed
+  runtime, and the provider slugs used to recognize provider-specific surfaces.
+* ``services/omnigent/scripts`` — provider-specific startup/health scripts.
+* ``docker-compose.yaml`` — services that duplicate host startup per runtime or
+  still resolve a legacy image variable, plus the profiles that select them.
+* ``harness_platform.host_classes`` / ``static_hosts`` — declared image
+  environment identities that are not the canonical shared-image variable.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yaml"
+OMNIGENT_SCRIPT_DIR = Path("services/omnigent/scripts")
+
+# The canonical destination identities. Everything else in the discovery sources
+# below is duplicate runtime architecture that #3835 must classify.
+GENERIC_REALIZER_REF = "generic-omnigent-host@1"
+CANONICAL_IMAGE_ENV_PREFIX = "OMNIGENT_SHARED_HOST_IMAGE"
+
+SURFACE_SCHEMES = (
+    "python",
+    "file",
+    "script",
+    "compose-service",
+    "compose-profile",
+    "realizer",
+    "runtime-strategy",
+    "env",
+)
+
+_ENV_EXPANSION = re.compile(r"\$\{([A-Z0-9_]+)")
+
+
+class SurfaceRefError(ValueError):
+    """Raised when a surface reference is malformed."""
+
+
+def parse_surface_ref(ref: str) -> tuple[str, str]:
+    """Split ``scheme:value`` and reject anything outside the known schemes.
+
+    A bare value with no scheme is rejected rather than guessed, so a weakened
+    or mistyped reference can never silently resolve to "present".
+    """
+
+    scheme, _, value = str(ref or "").partition(":")
+    if scheme not in SURFACE_SCHEMES:
+        raise SurfaceRefError(
+            f"surface ref {ref!r} must start with one of {SURFACE_SCHEMES}"
+        )
+    if not value.strip():
+        raise SurfaceRefError(f"surface ref {ref!r} has no value")
+    return scheme, value
+
+
+@lru_cache(maxsize=1)
+def _compose_document() -> Mapping[str, Any]:
+    import yaml
+
+    if not COMPOSE_FILE.is_file():
+        return {}
+    loaded = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    return loaded if isinstance(loaded, Mapping) else {}
+
+
+def _compose_services() -> Mapping[str, Mapping[str, Any]]:
+    services = _compose_document().get("services")
+    if not isinstance(services, Mapping):
+        return {}
+    return {
+        name: value for name, value in services.items() if isinstance(value, Mapping)
+    }
+
+
+def _service_text(service: Mapping[str, Any]) -> str:
+    """Flatten the fields that name images, scripts, and entrypoints."""
+
+    parts: list[str] = []
+    for key in ("image", "entrypoint", "command", "profiles"):
+        value = service.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+        elif isinstance(value, (list, tuple)):
+            parts.extend(str(item) for item in value)
+    return "\n".join(parts)
+
+
+def _compose_profiles() -> frozenset[str]:
+    profiles: set[str] = set()
+    for service in _compose_services().values():
+        declared = service.get("profiles")
+        if isinstance(declared, (list, tuple)):
+            profiles.update(str(item) for item in declared)
+    return frozenset(profiles)
+
+
+@lru_cache(maxsize=1)
+def direct_runtime_slugs() -> frozenset[str]:
+    """Provider slugs for the registered direct managed runtimes.
+
+    Derived from the strategy registry (``codex_cli`` -> ``codex``) so a newly
+    registered direct runtime automatically makes its provider-specific scripts
+    and Compose services discoverable.
+    """
+
+    from moonmind.workflows.temporal.runtime.strategies import RUNTIME_STRATEGIES
+
+    return frozenset(
+        runtime_id.split("_", 1)[0] for runtime_id in RUNTIME_STRATEGIES if runtime_id
+    )
+
+
+@lru_cache(maxsize=1)
+def declared_image_environment_variables() -> frozenset[str]:
+    """Non-canonical image environment identities declared in Host Class code."""
+
+    from moonmind.omnigent.harness_platform import host_classes, static_hosts
+
+    declared: set[str] = set()
+    for module in (host_classes, static_hosts):
+        for name in dir(module):
+            if not name.endswith("_IMAGE_ENV"):
+                continue
+            value = getattr(module, name)
+            if isinstance(value, str) and not value.startswith(
+                CANONICAL_IMAGE_ENV_PREFIX
+            ):
+                declared.add(value)
+    return frozenset(declared)
+
+
+def _provider_specific_scripts() -> frozenset[str]:
+    """Startup/health scripts that exist only because a runtime is duplicated."""
+
+    script_dir = REPO_ROOT / OMNIGENT_SCRIPT_DIR
+    if not script_dir.is_dir():
+        return frozenset()
+    slugs = direct_runtime_slugs()
+    found: set[str] = set()
+    for path in sorted(script_dir.glob("*.sh")):
+        stem_tokens = set(path.stem.split("-"))
+        if stem_tokens & slugs:
+            found.add(path.name)
+        elif "projections" in stem_tokens:
+            # The pre-consolidation generic entrypoint, kept only for the
+            # duplicate ``omnigent-host`` Compose service.
+            found.add(path.name)
+    return frozenset(found)
+
+
+def _legacy_compose_services() -> frozenset[str]:
+    """Compose services that duplicate host startup or pin a legacy image."""
+
+    scripts = _provider_specific_scripts()
+    legacy_env = declared_image_environment_variables()
+    matched: set[str] = set()
+    for name, service in _compose_services().items():
+        text = _service_text(service)
+        if any(script in text for script in scripts):
+            matched.add(name)
+            continue
+        referenced = set(_ENV_EXPANSION.findall(text))
+        if referenced & legacy_env:
+            matched.add(name)
+            continue
+        # A per-runtime Compose profile is itself duplicate topology even when
+        # the service execs the consolidated generic entrypoint.
+        declared = service.get("profiles")
+        if isinstance(declared, (list, tuple)) and any(
+            set(str(profile).split("-")) & direct_runtime_slugs()
+            for profile in declared
+        ):
+            matched.add(name)
+    return frozenset(matched)
+
+
+def _legacy_compose_profiles(services: frozenset[str]) -> frozenset[str]:
+    profiles: set[str] = set()
+    compose_services = _compose_services()
+    for name in services:
+        declared = compose_services.get(name, {}).get("profiles")
+        if isinstance(declared, (list, tuple)):
+            profiles.update(str(item) for item in declared)
+    return frozenset(profiles)
+
+
+def _legacy_compose_image_variables(services: frozenset[str]) -> frozenset[str]:
+    """Image variables the duplicate Compose services still expand."""
+
+    compose_services = _compose_services()
+    found: set[str] = set()
+    for name in services:
+        image = compose_services.get(name, {}).get("image")
+        if not isinstance(image, str):
+            continue
+        for variable in _ENV_EXPANSION.findall(image):
+            if not variable.startswith(CANONICAL_IMAGE_ENV_PREFIX):
+                found.add(variable)
+    return frozenset(found)
+
+
+def discover_legacy_surfaces() -> frozenset[str]:
+    """Return every legacy surface the repository currently contains."""
+
+    from moonmind.omnigent.harness_platform.support import KNOWN_REALIZERS
+    from moonmind.workflows.temporal.runtime.strategies import RUNTIME_STRATEGIES
+
+    surfaces: set[str] = set()
+    surfaces.update(
+        f"realizer:{ref}" for ref in KNOWN_REALIZERS if ref != GENERIC_REALIZER_REF
+    )
+    surfaces.update(f"runtime-strategy:{ref}" for ref in RUNTIME_STRATEGIES)
+    surfaces.update(f"script:{name}" for name in _provider_specific_scripts())
+
+    services = _legacy_compose_services()
+    surfaces.update(f"compose-service:{name}" for name in services)
+    surfaces.update(
+        f"compose-profile:{name}" for name in _legacy_compose_profiles(services)
+    )
+    surfaces.update(
+        f"env:{name}"
+        for name in (
+            declared_image_environment_variables()
+            | _legacy_compose_image_variables(services)
+        )
+    )
+    return frozenset(surfaces)
+
+
+def _python_symbol_exists(value: str) -> bool:
+    module_name, _, symbol = value.rpartition(":")
+    if not module_name or not symbol:
+        return False
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:  # noqa: BLE001 - any import failure means the ref is gone
+        return False
+    return hasattr(module, symbol)
+
+
+@lru_cache(maxsize=1)
+def _environment_reference_corpus() -> str:
+    """Text of the places a legacy environment identity may still be honored."""
+
+    parts: list[str] = []
+    if COMPOSE_FILE.is_file():
+        parts.append(COMPOSE_FILE.read_text(encoding="utf-8"))
+    for path in sorted((REPO_ROOT / "moonmind" / "omnigent").rglob("*.py")):
+        parts.append(path.read_text(encoding="utf-8", errors="ignore"))
+    return "\n".join(parts)
+
+
+def surface_exists(ref: str) -> bool:
+    """Whether the surface named by ``ref`` is still present in the repository."""
+
+    scheme, value = parse_surface_ref(ref)
+    if scheme == "python":
+        return _python_symbol_exists(value)
+    if scheme == "file":
+        return (REPO_ROOT / value).exists()
+    if scheme == "script":
+        return (REPO_ROOT / OMNIGENT_SCRIPT_DIR / value).is_file()
+    if scheme == "compose-service":
+        return value in _compose_services()
+    if scheme == "compose-profile":
+        return value in _compose_profiles()
+    if scheme == "realizer":
+        from moonmind.omnigent.harness_platform.support import KNOWN_REALIZERS
+
+        return value in KNOWN_REALIZERS
+    if scheme == "runtime-strategy":
+        from moonmind.workflows.temporal.runtime.strategies import RUNTIME_STRATEGIES
+
+        return value in RUNTIME_STRATEGIES
+    if scheme == "env":
+        return value in _environment_reference_corpus()
+    raise SurfaceRefError(f"unhandled surface scheme {scheme!r}")
+
+
+def reset_surface_caches() -> None:
+    """Forget cached repository scans (tests only)."""
+
+    _compose_document.cache_clear()
+    _environment_reference_corpus.cache_clear()
+    direct_runtime_slugs.cache_clear()
+    declared_image_environment_variables.cache_clear()
+
+
+__all__ = [
+    "CANONICAL_IMAGE_ENV_PREFIX",
+    "GENERIC_REALIZER_REF",
+    "REPO_ROOT",
+    "SURFACE_SCHEMES",
+    "SurfaceRefError",
+    "declared_image_environment_variables",
+    "direct_runtime_slugs",
+    "discover_legacy_surfaces",
+    "parse_surface_ref",
+    "reset_surface_caches",
+    "surface_exists",
+]

--- a/moonmind/omnigent/retirement_surfaces.py
+++ b/moonmind/omnigent/retirement_surfaces.py
@@ -35,6 +35,7 @@ Discovery is deliberately derived from authorities that already exist:
 
 from __future__ import annotations
 
+import ast
 import importlib
 import re
 from functools import lru_cache
@@ -49,6 +50,13 @@ OMNIGENT_SCRIPT_DIR = Path("services/omnigent/scripts")
 # below is duplicate runtime architecture that #3835 must classify.
 GENERIC_REALIZER_REF = "generic-omnigent-host@1"
 CANONICAL_IMAGE_ENV_PREFIX = "OMNIGENT_SHARED_HOST_IMAGE"
+
+# The retirement inventory and this discovery module name every legacy
+# environment identity by construction. They are evidence *about* a surface, not
+# a consumer *of* it, so they are excluded from environment existence evidence.
+_INVENTORY_SELF_REFERENCE_MODULES = frozenset(
+    {"legacy_retirement.py", "retirement_surfaces.py"}
+)
 
 SURFACE_SCHEMES = (
     "python",
@@ -270,15 +278,59 @@ def _python_symbol_exists(value: str) -> bool:
     return hasattr(module, symbol)
 
 
+_DOCSTRING_OWNERS = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _executable_python_text(source: str) -> str:
+    """Return the module's executable code with comments and docstrings removed.
+
+    A variable named only in a docstring or a comment is documentation, not a
+    consumer. Operand strings are kept, because ``os.environ["VAR"]`` is exactly
+    how a variable is honored. Round-tripping through the AST drops comments;
+    docstrings are removed explicitly. An unparsable module yields no evidence.
+    """
+
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return ""
+    for node in ast.walk(tree):
+        if not isinstance(node, _DOCSTRING_OWNERS):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                node.body = body[1:] or [ast.Pass()]
+    try:
+        return ast.unparse(ast.fix_missing_locations(tree))
+    except (AttributeError, ValueError, RecursionError):
+        return ""
+
+
 @lru_cache(maxsize=1)
 def _environment_reference_corpus() -> str:
-    """Text of the places a legacy environment identity may still be honored."""
+    """Text of the places a legacy environment identity may still be honored.
+
+    The corpus is built only from *authoritative consumers*: deployment
+    configuration plus executable Python that reads or forwards the variable.
+    The retirement inventory and surface discovery modules are excluded, because
+    every inventoried variable is written into their own rows — including them
+    would let the guard prove a variable "exists" from its own retirement row
+    after the real Compose and runtime handling was deleted.
+    """
 
     parts: list[str] = []
     if COMPOSE_FILE.is_file():
         parts.append(COMPOSE_FILE.read_text(encoding="utf-8"))
     for path in sorted((REPO_ROOT / "moonmind" / "omnigent").rglob("*.py")):
-        parts.append(path.read_text(encoding="utf-8", errors="ignore"))
+        if path.name in _INVENTORY_SELF_REFERENCE_MODULES:
+            continue
+        parts.append(
+            _executable_python_text(path.read_text(encoding="utf-8", errors="ignore"))
+        )
     return "\n".join(parts)
 
 

--- a/moonmind/omnigent/session_supervisor_rollback.py
+++ b/moonmind/omnigent/session_supervisor_rollback.py
@@ -1,6 +1,13 @@
 """Independently-supported rollback controls for the Omnigent session supervisor.
 
-Source issue: MoonLadderStudios/MoonMind#3712.
+Source issues: MoonLadderStudios/MoonMind#3712, MoonLadderStudios/MoonMind#3835.
+
+#3712 owns the five independent new-work controls below. #3835 adds the rollback
+*scope* and *exercise record* the retirement guard consumes: a rollback is bound
+to one exact combination of Agent Profile, Host Class, materializer, realizer,
+model, launch policy, host mode, architecture, and owner cohort, and a legacy
+path becomes removal-eligible only after a fresh, successful, exactly-scoped
+exercise that changed future admission alone.
 
 Rollback for the ``MoonMind.OmnigentSession`` supervisor is expressed as a set of
 independent controls, not one global kill switch. Each control affects only new
@@ -37,11 +44,19 @@ onto :class:`RollbackMode`:
 
 from __future__ import annotations
 
-from typing import Literal, Mapping
+from datetime import datetime, timedelta
+from typing import Iterable, Literal, Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SUPERVISOR_ROLLBACK_POLICY_VERSION = "moonmind.omnigent-session-supervisor-rollback/v1"
+ROLLBACK_EXERCISE_POLICY_VERSION = "moonmind.omnigent-rollback-exercise/v1"
+
+# A rollback exercise proves an operator can restore a supported prior default
+# *now*, so an old recording cannot keep a path removal-eligible forever
+# (issue #3835 required work section 6: rollback cannot silently activate a path
+# whose support evidence has expired).
+DEFAULT_ROLLBACK_EXERCISE_MAX_AGE = timedelta(days=30)
 
 RollbackMode = Literal[
     "none",
@@ -231,11 +246,160 @@ def resolve_rollback_effect(
     )
 
 
+class RollbackScope(BaseModel):
+    """The exact combination one rollback exercise covers.
+
+    Issue #3835 required work section 6 scopes rollback to the exact Agent
+    Profile, Host Class, materializer, realizer, model, policy, host mode,
+    architecture, and owner cohort. Every dimension is matched by exact equality
+    so a rollback recorded for one combination can never quietly authorize a
+    different, less-constrained one.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    agent_profile_ref: str = Field(alias="agentProfileRef")
+    host_class_ref: str = Field(alias="hostClassRef")
+    materializer_ref: str = Field(alias="materializerRef")
+    execution_realizer_ref: str = Field(alias="executionRealizerRef")
+    model_qualified_id: str = Field(alias="modelQualifiedId")
+    launch_policy_ref: str = Field(alias="launchPolicyRef")
+    host_mode: str = Field(alias="hostMode")
+    architecture: str
+    owner_cohort: str = Field(alias="ownerCohort")
+
+    @field_validator("*")
+    @classmethod
+    def _require_exact_value(cls, value: str) -> str:
+        cleaned = str(value or "").strip()
+        if not cleaned:
+            raise ValueError(
+                "every rollback scope dimension must name an exact value; a blank "
+                "dimension would widen the rollback beyond what was exercised"
+            )
+        return cleaned
+
+
+class RollbackExerciseRecord(BaseModel):
+    """Durable evidence that rollback was actually performed for one scope."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    retirement_path_id: str = Field(alias="retirementPathId")
+    scope: RollbackScope
+    exercised_at: datetime = Field(alias="exercisedAt")
+    evidence_ref: str = Field(alias="evidenceRef")
+    succeeded: bool = Field(alias="succeeded")
+    # Whether the exercise restored a prior default for *future* work only. A
+    # recording that touched an active or historical execution is not usable
+    # evidence: rollback must never rewrite work that already exists.
+    future_admission_only: bool = Field(True, alias="futureAdmissionOnly")
+    policy_version: str = Field(
+        ROLLBACK_EXERCISE_POLICY_VERSION, alias="policyVersion"
+    )
+
+    @field_validator("exercised_at")
+    @classmethod
+    def _validate_exercised_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("exercised_at must be timezone-aware")
+        return value
+
+
+class RollbackExerciseDecision(BaseModel):
+    """Whether a recorded rollback exercise satisfies a retirement row."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
+
+    retirement_path_id: str = Field(alias="retirementPathId")
+    satisfied: bool
+    reason_code: str = Field(alias="reasonCode")
+    evidence_ref: str | None = Field(None, alias="evidenceRef")
+    policy_version: str = Field(
+        ROLLBACK_EXERCISE_POLICY_VERSION, alias="policyVersion"
+    )
+
+    def as_dict(self) -> dict[str, object]:
+        return self.model_dump(by_alias=True, mode="json")
+
+
+def legacy_rollback_generation_from_settings(feature_flags: object) -> str | None:
+    """The explicit rollback generation permitted to re-admit legacy new work.
+
+    Legacy re-admission is not a separate switch: it is the existing supervisor
+    generation, and only while the operator has explicitly selected the
+    ``revert_default_to_legacy`` control. Any other mode yields ``None``, so a
+    ``rollback_only`` retirement class stays closed to new work.
+    """
+
+    if rollback_mode_from_settings(feature_flags) != "revert_default_to_legacy":
+        return None
+    generation = str(
+        getattr(feature_flags, "omnigent_session_supervisor_generation", "") or ""
+    ).strip()
+    return generation or None
+
+
+def evaluate_rollback_exercise(
+    *,
+    retirement_path_id: str,
+    scope: RollbackScope,
+    records: Iterable[RollbackExerciseRecord],
+    now: datetime,
+    max_age: timedelta = DEFAULT_ROLLBACK_EXERCISE_MAX_AGE,
+) -> RollbackExerciseDecision:
+    """Whether a fresh, successful, exactly-scoped rollback exercise exists.
+
+    Fail-closed on every axis: no record, a record for another path, any scope
+    dimension that differs, a failed exercise, one that touched active or
+    historical work, or expired evidence all leave the path *not* exercised and
+    therefore not removal-eligible.
+    """
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    reason = "no_rollback_exercise_recorded"
+    for record in records:
+        if record.retirement_path_id != retirement_path_id:
+            continue
+        if record.scope != scope:
+            reason = "rollback_scope_mismatch"
+            continue
+        if not record.succeeded:
+            reason = "rollback_exercise_failed"
+            continue
+        if not record.future_admission_only:
+            reason = "rollback_exercise_touched_existing_work"
+            continue
+        if now - record.exercised_at > max_age:
+            reason = "rollback_evidence_expired"
+            continue
+        return RollbackExerciseDecision(
+            retirementPathId=retirement_path_id,
+            satisfied=True,
+            reasonCode="rollback_exercise_recorded",
+            evidenceRef=record.evidence_ref,
+        )
+    return RollbackExerciseDecision(
+        retirementPathId=retirement_path_id,
+        satisfied=False,
+        reasonCode=reason,
+    )
+
+
 __all__ = [
+    "DEFAULT_ROLLBACK_EXERCISE_MAX_AGE",
+    "ROLLBACK_EXERCISE_POLICY_VERSION",
     "SUPERVISOR_ROLLBACK_POLICY_VERSION",
     "RollbackMode",
+    "RollbackExerciseDecision",
+    "RollbackExerciseRecord",
+    "RollbackScope",
     "SessionRollbackContext",
     "RollbackEffect",
+    "evaluate_rollback_exercise",
+    "legacy_rollback_generation_from_settings",
     "parse_rollback_mode",
     "rollback_mode_from_settings",
     "resolve_rollback_effect",

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -47,6 +47,9 @@ from moonmind.config.container_backend_settings import (
 )
 from moonmind.config.logging import configure_logging, default_log_fields_from_env
 from moonmind.config.settings import settings
+from moonmind.omnigent.legacy_retirement import (
+    enforce_obsolete_configuration_at_startup,
+)
 from moonmind.workflows.agent_skills.agent_skills_activities import (
     AgentSkillsActivities,
 )
@@ -3080,6 +3083,13 @@ def _enforce_codex_config_for_managed_fleet(fleet: str) -> None:
 
 async def main_async() -> None:
     """Run the Temporal worker."""
+    # This worker is separately restartable and consumes the same legacy
+    # Omnigent image/environment identities as the API, so it runs the shared
+    # obsolete-configuration check itself, before any other startup work
+    # (#3835 required work section 10). Without it, deploying or restarting the
+    # worker alone would produce no deprecation warning and could later accept a
+    # variable the API rejects.
+    enforce_obsolete_configuration_at_startup(logger)
     topology = describe_configured_worker()
     _enforce_codex_config_for_managed_fleet(topology.fleet)
 

--- a/services/omnigent/scripts/STATIC_HOST_STARTUP_INVENTORY.md
+++ b/services/omnigent/scripts/STATIC_HOST_STARTUP_INVENTORY.md
@@ -1,5 +1,17 @@
 # Static host startup path inventory (MoonLadderStudios/MoonMind#3834)
 
+> **Superseded as the retirement authority by MoonLadderStudios/MoonMind#3835.**
+> The startup paths below are now classified in code by
+> `RETIREMENT_INVENTORY` in `moonmind/omnigent/legacy_retirement.py`
+> (`omnigent.legacy.codex_static_host_startup`,
+> `omnigent.legacy.claude_static_host_startup`,
+> `omnigent.legacy.projection_host_startup`, and
+> `omnigent.legacy.host_image_variable_alias`), and CI fails when a
+> provider-specific startup script, Compose service, Compose profile, or legacy
+> image variable exists without a retirement class. This file is retained as a
+> historical read of the #3834 consolidation; treat the code-owned inventory as
+> authoritative for what may be removed and when.
+
 Every old static-host startup path, its current state after consolidation,
 and the condition that retires it. Legacy execution realizers and historical
 compatibility are out of scope for removal in #3834 and stay.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -19179,3 +19179,94 @@ def test_mm3788_selected_step_recovery_route_maps_runtime_mismatch_to_409(
     assert response.status_code == 409
     _mm3788_assert_shared_mismatch_detail(response.json()["detail"])
     mock_service.create_failed_step_recovery_execution.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# MoonLadderStudios/MoonMind#3835 — a per-step runtime override is new admission
+# in its own right. The top-level ``select_runtime`` gate only covers the
+# workflow runtime, so a legacy ``steps[i].runtime.mode`` under an allowed
+# top-level runtime must not keep creating new legacy work.
+# ---------------------------------------------------------------------------
+
+
+def _mm3835_reclassify_runtime_strategy(
+    monkeypatch: pytest.MonkeyPatch, runtime_id: str
+) -> None:
+    from moonmind.omnigent import legacy_retirement
+    from moonmind.omnigent.legacy_retirement import (
+        RetirementClass,
+        retirement_record_for_surface,
+    )
+
+    surface = f"runtime-strategy:{runtime_id}"
+    record = retirement_record_for_surface(surface)
+    assert record is not None, surface
+    closed = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.NEW_ADMISSION_DISABLED,
+            "new_admission_source": "",
+        }
+    )
+    monkeypatch.setitem(legacy_retirement._INVENTORY_BY_ID, closed.path_id, closed)
+    monkeypatch.setitem(legacy_retirement._INVENTORY_BY_SURFACE, surface, closed)
+
+
+@pytest.mark.asyncio
+async def test_mm3835_step_runtime_override_is_held_to_the_retirement_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mm3835_reclassify_runtime_strategy(monkeypatch, "claude_code")
+    steps = _normalize_task_steps(
+        {
+            "steps": [
+                {
+                    "id": "review",
+                    "instructions": "Override to a retired runtime.",
+                    "runtime": {"mode": "claude_code"},
+                }
+            ]
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_step_runtime_selections(
+            steps=steps,
+            task_runtime={"mode": "omnigent"},
+            task_target_runtime="omnigent",
+            task_profile_id=None,
+            session=None,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail["code"] == "invalid_execution_request"
+    assert "runtime_new_admission_disabled:claude_code" in (
+        exc_info.value.detail["message"]
+    )
+    assert "steps[0].runtime.mode" in exc_info.value.detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_mm3835_step_runtime_override_is_allowed_while_the_class_admits() -> None:
+    """The gate stops admission only when the class says so."""
+
+    steps = _normalize_task_steps(
+        {
+            "steps": [
+                {
+                    "id": "review",
+                    "instructions": "Override to a still-admitted runtime.",
+                    "runtime": {"mode": "claude_code"},
+                }
+            ]
+        }
+    )
+
+    await _resolve_step_runtime_selections(
+        steps=steps,
+        task_runtime={"mode": "codex_cli"},
+        task_target_runtime="codex_cli",
+        task_profile_id=None,
+        session=None,
+    )
+
+    assert steps[0]["runtime"]["mode"] == "claude_code"

--- a/tests/unit/omnigent/reconciler/test_legacy_result_fencing.py
+++ b/tests/unit/omnigent/reconciler/test_legacy_result_fencing.py
@@ -1,0 +1,122 @@
+"""A delayed legacy result cannot mutate the generic replacement's authority.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required tests, "New admission
+and active drain").
+
+Retirement moves execution ownership forward. A legacy Activity that was already
+in flight when ownership advanced may still return afterwards. Its result must
+not be able to reach through and mutate the authority the generic replacement now
+holds — that would transfer a live provider side-effect owner without a fenced
+handoff, which the rollback contract forbids absolutely.
+
+The fence is the durable ``(revision, fencing_generation)`` pair: every command
+the reducer emits carries the *durable* expectation, never an observation's, and
+the command id embeds both. A decision computed under the old authority is
+therefore not applicable once authority advances.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.session_supervisor_rollback import (
+    SessionRollbackContext,
+    resolve_rollback_effect,
+)
+
+
+@pytest.fixture
+def advanced_authority(make_durable):
+    """The same session before and after the generic replacement takes over.
+
+    Both states are ready to submit a turn, so the reducer emits a real
+    side-effect command in each — the shape a delayed legacy Activity result
+    would try to reuse.
+    """
+
+    from moonmind.omnigent.reconciler import LeaseState
+
+    provisioned = dict(
+        profile_lease=LeaseState.HELD,
+        host_lease=LeaseState.HELD,
+        provider_session_attached=True,
+        provider_session_id="provider-session-1",
+        attempt_id="attempt-1",
+    )
+    legacy = make_durable(revision=7, fencing_generation=3, **provisioned)
+    generic = make_durable(revision=8, fencing_generation=4, **provisioned)
+    return legacy, generic
+
+
+def test_delayed_legacy_command_is_not_applicable_after_authority_advances(
+    make_intent, run, advanced_authority
+) -> None:
+    intent = make_intent()
+    legacy, generic = advanced_authority
+
+    delayed = run(intent, legacy)
+    current = run(intent, generic)
+
+    # The delayed decision still expects the authority it was computed under.
+    assert delayed.expected_revision == 7
+    assert delayed.expected_fencing_generation == 3
+    assert current.expected_revision == 8
+    assert current.expected_fencing_generation == 4
+
+    # Applying the delayed decision would require the old expectation, which no
+    # longer matches durable authority, so it cannot mutate the replacement.
+    assert delayed.expected_fencing_generation != generic.fencing_generation
+    assert delayed.expected_revision != generic.revision
+
+
+def test_delayed_legacy_command_id_never_collides_with_the_replacement(
+    make_intent, run, advanced_authority
+) -> None:
+    """At-most-once identity is scoped by generation and revision."""
+
+    intent = make_intent()
+    legacy, generic = advanced_authority
+
+    delayed = run(intent, legacy)
+    current = run(intent, generic)
+    assert delayed.command is not None
+    assert current.command is not None
+
+    assert delayed.command.command_id != current.command.command_id
+    assert f"g{legacy.fencing_generation}" in delayed.command.command_id
+    assert f"g{generic.fencing_generation}" in current.command.command_id
+
+
+def test_reducer_expectations_come_from_durable_state_not_observations(
+    make_intent, make_ready_durable, make_obs, run
+) -> None:
+    """A legacy observation cannot raise its own authority into the decision."""
+
+    intent = make_intent()
+    durable = make_ready_durable(revision=8, fencing_generation=4)
+    decision_without = run(intent, durable)
+    decision_with = run(intent, durable, make_obs())
+
+    for decision in (decision_without, decision_with):
+        assert decision.expected_revision == durable.revision
+        assert decision.expected_fencing_generation == durable.fencing_generation
+
+
+def test_ownership_transfer_always_requires_a_fenced_handoff() -> None:
+    """No rollback mode may move a live side-effect owner without fencing."""
+
+    for mode in (
+        "none",
+        "disable_new_admission",
+        "disable_new_selection",
+        "chat_read_only",
+        "revert_default_to_legacy",
+        "complete_stop",
+    ):
+        effect = resolve_rollback_effect(
+            mode=mode,  # type: ignore[arg-type]
+            context=SessionRollbackContext(isActive=True),
+        )
+        assert effect.fenced_handoff_required_for_ownership_transfer is True
+        assert effect.mutates_active_session_authority is False
+        assert effect.existing_session_continues_under_recorded_owner is True

--- a/tests/unit/omnigent/test_legacy_generation_historical_reads.py
+++ b/tests/unit/omnigent/test_legacy_generation_historical_reads.py
@@ -1,0 +1,378 @@
+"""Historical reads and truthful provenance for every retained generation.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required work section 5).
+
+``tests/unit/omnigent/test_direct_compat_historical_reads.py`` (#3518) already
+proves persisted **direct Codex** sessions stay readable through the real
+Workflow Detail read path. This module covers the generations #3835 adds to that
+obligation:
+
+* direct **Claude** sessions,
+* ``codex-profile-bound@1`` executions, and
+* the invariant that no generation is relabeled as generic on read.
+
+Each test exercises the production read path (durable journal query followed by
+the deterministic row -> chat-event projection) with no adapter, worker,
+activity, or live session, and additionally with the legacy launch modules made
+unimportable — which is the state the repository is in once launch code is
+disabled or removed.
+"""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.api.routers.omnigent_bridge import (
+    _bridge_event_payload,
+    _terminal_envelope,
+)
+from api_service.db.models import Base
+from moonmind.omnigent.bridge_events import build_omnigent_bridge_event
+from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+CLAUDE_COMPAT_PROFILE = "moonmind.claude_direct_compat.v1"
+PROFILE_BOUND_REALIZER = "codex-profile-bound@1"
+GENERIC_REALIZER = "generic-omnigent-host@1"
+
+# The launch modules a removal stage eventually deletes. Historical reads must
+# not depend on any of them.
+LEGACY_LAUNCH_MODULES = (
+    "moonmind.omnigent.oauth_host_runtime",
+    "moonmind.omnigent.profile_bound_execution",
+    "moonmind.workflows.temporal.runtime.codex_session_runtime",
+    "moonmind.workflows.temporal.runtime.strategies.claude_code",
+)
+
+
+@pytest_asyncio.fixture()
+async def store(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/bridge.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield OmnigentBridgeSessionStore(session_maker)
+    await engine.dispose()
+
+
+@pytest.fixture()
+def launch_code_unavailable(monkeypatch: pytest.MonkeyPatch):
+    """Make every legacy launch module unimportable for the duration of a test."""
+
+    real_import = builtins.__import__
+
+    def _blocked(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in LEGACY_LAUNCH_MODULES:
+            raise ModuleNotFoundError(f"legacy launch module {name} has been removed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    yield
+
+
+def _request(
+    idempotency_key: str, *, agent_id: str, correlation_id: str
+) -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId=agent_id,
+        correlationId=correlation_id,
+        idempotencyKey=idempotency_key,
+    )
+
+
+def _event(
+    payload: dict[str, object],
+    *,
+    request: AgentExecutionRequest,
+    session_id: str,
+    bridge_session_id: str,
+    sequence: int,
+    provenance: dict[str, object],
+) -> dict[str, object]:
+    """Build a normalized v1 event and stamp truthful runtime provenance.
+
+    This mirrors what the compatibility producers do on the write path: the
+    canonical bridge event is built first, then ``metadata.moonmind`` records
+    which generation actually produced it.
+    """
+
+    event = build_omnigent_bridge_event(
+        payload=payload,
+        sequence=sequence,
+        request=request,
+        omnigent_session_id=session_id,
+        bridge_session_id=bridge_session_id,
+    ).event
+    event["metadata"]["moonmind"].update(provenance)
+    return event
+
+
+async def _seed_session(
+    store: OmnigentBridgeSessionStore,
+    *,
+    idempotency_key: str,
+    agent_id: str,
+    agent_name: str,
+    correlation_id: str,
+    endpoint_ref: str,
+    session_id: str,
+    target_metadata: dict[str, object],
+    provenance: dict[str, object],
+    summary: str,
+) -> tuple[str, AgentExecutionRequest]:
+    request = _request(
+        idempotency_key, agent_id=agent_id, correlation_id=correlation_id
+    )
+    row = await store.get_or_create(
+        request=request,
+        endpoint_ref=endpoint_ref,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        target_metadata=target_metadata,
+    )
+    bridge_session_id = row.bridge_session_id
+    await store.append_events(
+        bridge_session_id,
+        [
+            _event(
+                {
+                    "type": "session.started",
+                    "status": "running",
+                    "data": {"managedSessionWorkflowId": correlation_id},
+                },
+                request=request,
+                session_id=session_id,
+                bridge_session_id=bridge_session_id,
+                sequence=1,
+                provenance=provenance,
+            ),
+            _event(
+                {
+                    "type": "response.output",
+                    "status": "running",
+                    "text": "Reviewed the repository and drafted a fix.",
+                },
+                request=request,
+                session_id=session_id,
+                bridge_session_id=bridge_session_id,
+                sequence=2,
+                provenance=provenance,
+            ),
+            _event(
+                {"type": "response.completed", "status": "completed"},
+                request=request,
+                session_id=session_id,
+                bridge_session_id=bridge_session_id,
+                sequence=3,
+                provenance=provenance,
+            ),
+        ],
+    )
+    await store.mark_terminal(
+        request.idempotency_key,
+        status="completed",
+        terminal_refs={"summary": summary},
+    )
+    return bridge_session_id, request
+
+
+async def _seed_direct_claude(store: OmnigentBridgeSessionStore) -> str:
+    bridge_session_id, _ = await _seed_session(
+        store,
+        idempotency_key="claude-direct-1",
+        agent_id="claude_code",
+        agent_name="Claude Code",
+        correlation_id="mm:wf-claude-direct",
+        endpoint_ref="direct-claude-compat",
+        session_id="claude-session-11",
+        target_metadata={
+            "hostType": "managed",
+            "workspace": "MoonLadderStudios/MoonMind",
+            "compatibilityProfile": CLAUDE_COMPAT_PROFILE,
+            "producer": "direct_claude_managed_session",
+            "temporaryMigrationPath": True,
+        },
+        provenance={
+            "source": "claude_direct_compat",
+            "compatibilityProfile": CLAUDE_COMPAT_PROFILE,
+            "directManagedSessionId": "claude-session-11",
+        },
+        summary="Direct Claude compatibility run completed.",
+    )
+    return bridge_session_id
+
+
+async def _seed_profile_bound(store: OmnigentBridgeSessionStore) -> str:
+    bridge_session_id, _ = await _seed_session(
+        store,
+        idempotency_key="profile-bound-1",
+        agent_id="codex_cli",
+        agent_name="Codex CLI",
+        correlation_id="mm:wf-profile-bound",
+        endpoint_ref="omnigent-codex",
+        session_id="codex-session-99",
+        target_metadata={
+            "hostType": "omnigent",
+            "workspace": "MoonLadderStudios/MoonMind",
+            "executionRealizerRef": PROFILE_BOUND_REALIZER,
+        },
+        provenance={
+            "source": "omnigent",
+            "executionRealizerRef": PROFILE_BOUND_REALIZER,
+        },
+        summary="Profile-bound Codex execution completed.",
+    )
+    return bridge_session_id
+
+
+@pytest.mark.asyncio
+async def test_direct_claude_session_reads_without_live_runtime(
+    store, launch_code_unavailable
+) -> None:
+    bridge_session_id = await _seed_direct_claude(store)
+
+    page = await store.list_event_page(bridge_session_id, after=0, limit=100)
+    projected = [_bridge_event_payload(item) for item in page.rows]
+
+    assert [event["kind"] for event in projected] == [
+        "session_started",
+        "assistant_message",
+        "response_completed",
+    ]
+    for event in projected:
+        moonmind = event["metadata"]["moonmind"]
+        # Historical direct Claude work stays labeled direct. It is never
+        # rewritten to look like an Omnigent or generic execution.
+        assert moonmind["source"] == "claude_direct_compat"
+        assert moonmind["source"] != "omnigent"
+        assert moonmind.get("executionRealizerRef") != GENERIC_REALIZER
+        assert "compatibilityProfile" in moonmind
+
+    session_row = await store.get_bridge_session(bridge_session_id)
+    envelope = _terminal_envelope(session_row)
+    assert envelope is not None
+    assert envelope.status == "completed"
+    assert envelope.summary == "Direct Claude compatibility run completed."
+
+
+@pytest.mark.asyncio
+async def test_profile_bound_execution_keeps_its_realizer_label(
+    store, launch_code_unavailable
+) -> None:
+    bridge_session_id = await _seed_profile_bound(store)
+
+    page = await store.list_event_page(bridge_session_id, after=0, limit=100)
+    projected = [_bridge_event_payload(item) for item in page.rows]
+    assert projected
+
+    for event in projected:
+        moonmind = event["metadata"]["moonmind"]
+        # Historical ``codex-profile-bound@1`` work stays labeled with that
+        # realizer; the past is never made to look generic.
+        assert moonmind["executionRealizerRef"] == PROFILE_BOUND_REALIZER
+        assert moonmind["executionRealizerRef"] != GENERIC_REALIZER
+
+    session_row = await store.get_bridge_session(bridge_session_id)
+    envelope = _terminal_envelope(session_row)
+    assert envelope is not None
+    assert envelope.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_no_generation_is_relabeled_as_generic_on_read(store) -> None:
+    """Every retained generation keeps its own provenance in one read model."""
+
+    claude_id = await _seed_direct_claude(store)
+    profile_bound_id = await _seed_profile_bound(store)
+
+    observed: dict[str, set[str]] = {}
+    for bridge_session_id in (claude_id, profile_bound_id):
+        page = await store.list_event_page(bridge_session_id, after=0, limit=100)
+        for row in page.rows:
+            payload = _bridge_event_payload(row)
+            moonmind = payload["metadata"]["moonmind"]
+            observed.setdefault(bridge_session_id, set()).add(
+                str(moonmind.get("executionRealizerRef") or moonmind.get("source"))
+            )
+            # The wire transport tag is the shared bridge journal; the runtime
+            # provenance underneath stays distinct per generation.
+            assert payload["metadata"]["source"] == "omnigent_bridge"
+
+    assert observed[claude_id] == {"claude_direct_compat"}
+    assert observed[profile_bound_id] == {PROFILE_BOUND_REALIZER}
+
+
+@pytest.mark.asyncio
+async def test_historical_projection_protects_provider_and_credential_authority(
+    store,
+) -> None:
+    """Provider-session, host, credential, and endpoint authority stays protected."""
+
+    request = _request(
+        "claude-direct-secret", agent_id="claude_code", correlation_id="mm:wf-secret"
+    )
+    row = await store.get_or_create(
+        request=request,
+        endpoint_ref="direct-claude-compat",
+        agent_id="claude_code",
+        agent_name="Claude Code",
+        target_metadata={
+            "hostType": "managed",
+            "compatibilityProfile": CLAUDE_COMPAT_PROFILE,
+        },
+    )
+    bridge_session_id = row.bridge_session_id
+    await store.append_events(
+        bridge_session_id,
+        [
+            _event(
+                {
+                    "type": "response.output",
+                    "status": "running",
+                    "text": "authorization: Bearer sk-ant-api03-not-a-real-secret",
+                    "data": {
+                        "apiKey": "sk-ant-api03-not-a-real-secret",
+                        "hostEndpoint": "http://omnigent-host-claude:8080/internal",
+                    },
+                },
+                request=request,
+                session_id="claude-session-secret",
+                bridge_session_id=bridge_session_id,
+                sequence=1,
+                provenance={
+                    "source": "claude_direct_compat",
+                    "compatibilityProfile": CLAUDE_COMPAT_PROFILE,
+                },
+            )
+        ],
+    )
+
+    page = await store.list_event_page(bridge_session_id, after=0, limit=100)
+    payload = _bridge_event_payload(page.rows[0])
+    serialized = repr(payload)
+    assert "sk-ant-api03-not-a-real-secret" not in serialized
+    # Provenance is still truthful even though the secret material is scrubbed.
+    assert payload["metadata"]["moonmind"]["source"] == "claude_direct_compat"
+
+
+@pytest.mark.asyncio
+async def test_reads_do_not_import_legacy_launch_modules(
+    store, launch_code_unavailable
+) -> None:
+    """The read path must not pull in launch code that a removal stage deletes."""
+
+    bridge_session_id = await _seed_profile_bound(store)
+    page = await store.list_event_page(bridge_session_id, after=0, limit=100)
+    assert [_bridge_event_payload(item)["kind"] for item in page.rows] == [
+        "session_started",
+        "assistant_message",
+        "response_completed",
+    ]
+    session_row = await store.get_bridge_session(bridge_session_id)
+    assert _terminal_envelope(session_row) is not None

--- a/tests/unit/omnigent/test_legacy_retirement.py
+++ b/tests/unit/omnigent/test_legacy_retirement.py
@@ -6,6 +6,7 @@ Source issues: MoonLadderStudios/MoonMind#3712, MoonLadderStudios/MoonMind#3835.
 from __future__ import annotations
 
 import importlib
+import pathlib
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -40,6 +41,7 @@ from moonmind.omnigent.legacy_retirement import (
 from moonmind.omnigent.retirement_drain import build_drain_evidence
 from moonmind.omnigent.retirement_surfaces import discover_legacy_surfaces
 from moonmind.omnigent.session_supervisor_rollback import (
+    RollbackExerciseDecision,
     RollbackExerciseRecord,
     RollbackScope,
     evaluate_rollback_exercise,
@@ -218,6 +220,66 @@ def test_guard_fails_when_a_retained_startup_script_is_deleted() -> None:
         assert_retirement_guard(broken)
 
 
+def test_env_surface_evidence_excludes_the_inventory_itself(monkeypatch) -> None:
+    """An ``env:`` row must not prove its own surface exists.
+
+    ``legacy_retirement.py`` writes every inventoried variable into its own row,
+    so including the inventory in the environment corpus let the guard pass
+    after the real Compose and runtime handling for a retained variable had been
+    deleted.
+    """
+
+    from moonmind.omnigent import retirement_surfaces
+
+    variable = "OMNIGENT_ONLY_IN_THE_INVENTORY_IMAGE_REF"
+    monkeypatch.setattr(
+        retirement_surfaces, "COMPOSE_FILE", pathlib.Path("/nonexistent-compose.yaml")
+    )
+    retirement_surfaces.reset_surface_caches()
+    try:
+        assert retirement_surfaces.surface_exists(f"env:{variable}") is False
+    finally:
+        retirement_surfaces.reset_surface_caches()
+
+
+def test_env_surface_evidence_ignores_comments_and_docstrings(monkeypatch) -> None:
+    """Non-executable text is not a consumer of an environment identity."""
+
+    from moonmind.omnigent import retirement_surfaces
+
+    source = "\n".join(
+        (
+            '"""OMNIGENT_DOCSTRING_ONLY_REF is described here."""',
+            "# OMNIGENT_COMMENT_ONLY_REF is mentioned here.",
+            "import os",
+            'value = os.environ["OMNIGENT_REALLY_CONSUMED_REF"]',
+            "",
+        )
+    )
+    executable = retirement_surfaces._executable_python_text(source)
+    assert "OMNIGENT_DOCSTRING_ONLY_REF" not in executable
+    assert "OMNIGENT_COMMENT_ONLY_REF" not in executable
+    # An operand string is exactly how a variable is honored, so it is kept.
+    assert "OMNIGENT_REALLY_CONSUMED_REF" in executable
+
+
+def test_retained_env_surfaces_resolve_from_authoritative_consumers() -> None:
+    """Every retained ``env:`` row still has a real consumer, not a self-reference."""
+
+    from moonmind.omnigent.retirement_surfaces import surface_exists
+
+    env_refs = [
+        ref
+        for path in RETIREMENT_INVENTORY
+        if not path.removed
+        for ref in path.surfaces
+        if ref.startswith("env:")
+    ]
+    assert env_refs
+    for ref in env_refs:
+        assert surface_exists(ref), ref
+
+
 def test_guard_fails_when_removed_path_has_unmet_criteria() -> None:
     removed = (
         _record(
@@ -353,7 +415,48 @@ def test_rollback_only_admits_only_the_exact_allowlisted_generation() -> None:
         evaluate_new_admission(rollback_only, rollback_generation="gen-").reason_code
         == "rollback_generation_not_allowlisted"
     )
-    permitted = evaluate_new_admission(rollback_only, rollback_generation="gen-7")
+    # The generation is a single global string, so it is necessary but not
+    # sufficient: without a scoped exercise decision one allowlisted generation
+    # would re-admit every scope using the path.
+    assert (
+        evaluate_new_admission(rollback_only, rollback_generation="gen-7").reason_code
+        == "rollback_exercise_evidence_required"
+    )
+    unsatisfied = evaluate_new_admission(
+        rollback_only,
+        rollback_generation="gen-7",
+        rollback_exercise=RollbackExerciseDecision(
+            retirementPathId=rollback_only.path_id,
+            satisfied=False,
+            reasonCode="rollback_evidence_expired",
+        ),
+    )
+    assert unsatisfied.allowed is False
+    assert unsatisfied.reason_code == (
+        "rollback_exercise_unsatisfied:rollback_evidence_expired"
+    )
+    # Evidence recorded for a different row never re-admits this one.
+    other_row = evaluate_new_admission(
+        rollback_only,
+        rollback_generation="gen-7",
+        rollback_exercise=RollbackExerciseDecision(
+            retirementPathId="omnigent.legacy.other",
+            satisfied=True,
+            reasonCode="rollback_exercise_recorded",
+        ),
+    )
+    assert other_row.allowed is False
+    assert other_row.reason_code == "rollback_exercise_scope_mismatch"
+
+    permitted = evaluate_new_admission(
+        rollback_only,
+        rollback_generation="gen-7",
+        rollback_exercise=RollbackExerciseDecision(
+            retirementPathId=rollback_only.path_id,
+            satisfied=True,
+            reasonCode="rollback_exercise_recorded",
+        ),
+    )
     assert permitted.allowed is True
     assert permitted.reason_code == "rollback_generation_permitted"
 
@@ -733,6 +836,179 @@ def test_drain_evidence_drains_only_declared_dependency_kinds() -> None:
     evidence = build_drain_evidence(path, [undeclared, *declared], now=NOW)
     assert evidence.drained_kinds == path.active_resource_dependencies
     assert ActiveOwnerKind.PENDING_PUBLICATION not in evidence.drained_kinds
+
+
+def test_a_newer_zero_count_probe_never_overwrites_another_blocker() -> None:
+    """Every probe that observed a kind must agree it is drained.
+
+    ``collect_drain_evidence`` runs every probe for every declared kind, so a
+    kind routinely carries several observations. Reducing them to the newest one
+    let a later zero-count success discard another authority's positive count or
+    failure and mark the kind drained.
+    """
+
+    from moonmind.omnigent.retirement_drain import ActiveOwnerObservation
+
+    path = get_retirement_record("omnigent.legacy.oauth_host_janitor")
+    kinds = sorted(path.active_resource_dependencies, key=lambda k: k.value)
+    active_kind, failed_kind, stale_kind = kinds[0], kinds[1], kinds[2]
+    observations = [
+        # One authority still reports an owner; a newer zero-count success from
+        # a second probe must not clear it.
+        ActiveOwnerObservation(
+            kind=active_kind,
+            activeCount=3,
+            probeRef="host.lease.scan",
+            observedAt=NOW - timedelta(minutes=5),
+        ),
+        ActiveOwnerObservation(
+            kind=active_kind,
+            activeCount=0,
+            probeRef="janitor.queue.scan",
+            observedAt=NOW,
+        ),
+        # One probe could not be checked at all.
+        ActiveOwnerObservation(
+            kind=failed_kind,
+            activeCount=0,
+            probeRef="probe.unavailable",
+            observedAt=NOW - timedelta(minutes=5),
+            probeSucceeded=False,
+        ),
+        ActiveOwnerObservation(
+            kind=failed_kind,
+            activeCount=0,
+            probeRef="static.host.scan",
+            observedAt=NOW,
+        ),
+        # One probe's evidence is too old to prove present absence.
+        ActiveOwnerObservation(
+            kind=stale_kind,
+            activeCount=0,
+            probeRef="host.lease.scan",
+            observedAt=NOW - timedelta(days=2),
+        ),
+        ActiveOwnerObservation(
+            kind=stale_kind,
+            activeCount=0,
+            probeRef="janitor.queue.scan",
+            observedAt=NOW,
+        ),
+    ]
+    evidence = build_drain_evidence(path, observations, now=NOW)
+    assert evidence.drained_kinds == frozenset()
+    assert set(evidence.blocking_kinds) == {active_kind, failed_kind, stale_kind}
+    assert evidence.failed_kinds == (failed_kind,)
+    assert evidence.stale_kinds == (stale_kind,)
+    assert evidence.fully_drained is False
+
+
+def test_drain_requires_every_probe_to_report_zero() -> None:
+    from moonmind.omnigent.retirement_drain import ActiveOwnerObservation
+
+    path = get_retirement_record("omnigent.legacy.pi_host_image_alias")
+    observations = [
+        ActiveOwnerObservation(
+            kind=kind, activeCount=0, probeRef=ref, observedAt=NOW
+        )
+        for kind in path.active_resource_dependencies
+        for ref in ("host.scan", "lease.scan")
+    ]
+    evidence = build_drain_evidence(path, observations, now=NOW)
+    assert evidence.drained_kinds == path.active_resource_dependencies
+    assert evidence.fully_drained is True
+
+
+@pytest.mark.asyncio
+async def test_collect_drain_evidence_keeps_a_positive_count_from_any_probe() -> None:
+    """The real collector runs every probe for every kind."""
+
+    from moonmind.omnigent.retirement_drain import (
+        ActiveOwnerObservation,
+        collect_drain_evidence,
+    )
+
+    path = get_retirement_record("omnigent.legacy.pi_host_image_alias")
+
+    class _Busy:
+        async def observe(self, path, kind) -> ActiveOwnerObservation:
+            return ActiveOwnerObservation(
+                kind=kind, activeCount=1, probeRef="host.scan", observedAt=NOW
+            )
+
+    class _Idle:
+        async def observe(self, path, kind) -> ActiveOwnerObservation:
+            return ActiveOwnerObservation(
+                kind=kind, activeCount=0, probeRef="lease.scan", observedAt=NOW
+            )
+
+    evidence = await collect_drain_evidence(path, [_Busy(), _Idle()], now=NOW)
+    assert evidence.drained_kinds == frozenset()
+    assert evidence.fully_drained is False
+
+
+# ---------------------------------------------------- removed-row guard
+
+
+def test_removed_row_requires_complete_removal_evidence() -> None:
+    """Passing criteria alone must not clear a row classified ``removed``.
+
+    The guard delegates to the staged removal evaluation, so an active owner or
+    an open replay/rollback window blocks the row even when every criterion the
+    row declares is asserted as passing.
+    """
+
+    path = get_retirement_record("omnigent.legacy.oauth_host_runtime")
+    removed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.REMOVED,
+            "new_admission_source": "",
+        }
+    )
+    with pytest.raises(RetirementGuardError) as excinfo:
+        assert_retirement_guard(
+            (removed,), passed_by_path={removed.path_id: _all_criteria(path)}
+        )
+    message = str(excinfo.value)
+    assert "removal evidence is incomplete" in message
+    assert any(
+        f"active_owner:{kind.value}" in message
+        for kind in path.active_resource_dependencies
+    )
+
+
+def test_removed_row_passes_with_complete_removal_evidence() -> None:
+    path = get_retirement_record("omnigent.legacy.oauth_host_runtime")
+    removed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.REMOVED,
+            "new_admission_source": "",
+        }
+    )
+    assert_retirement_guard(
+        (removed,),
+        passed_by_path={removed.path_id: _all_criteria(path)},
+        drained_by_path={removed.path_id: path.active_resource_dependencies},
+        retention_by_path={removed.path_id: _closed_windows()},
+    )
+
+
+def test_removed_row_blocks_a_stage_earlier_than_its_earliest() -> None:
+    path = get_retirement_record("omnigent.legacy.oauth_host_runtime")
+    removed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.REMOVED,
+            "new_admission_source": "",
+        }
+    )
+    with pytest.raises(RetirementGuardError, match="stage_too_early"):
+        assert_retirement_guard(
+            (removed,),
+            passed_by_path={removed.path_id: _all_criteria(path)},
+            drained_by_path={removed.path_id: path.active_resource_dependencies},
+            retention_by_path={removed.path_id: _closed_windows()},
+            removal_stage_by_path={removed.path_id: RemovalStage.PRODUCT_SELECTORS},
+        )
 
 
 # --------------------------------------------------------------- rollback

--- a/tests/unit/omnigent/test_legacy_retirement.py
+++ b/tests/unit/omnigent/test_legacy_retirement.py
@@ -1,140 +1,266 @@
-"""MoonLadderStudios/MoonMind#3712 legacy retirement inventory + guard tests."""
+"""Legacy retirement inventory + guard tests.
+
+Source issues: MoonLadderStudios/MoonMind#3712, MoonLadderStudios/MoonMind#3835.
+"""
 
 from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from moonmind.omnigent.legacy_retirement import (
+    OBSOLETE_CONFIGURATION,
     RETIREMENT_INVENTORY,
     TEMPORARY_ROLLOUT_FLAGS,
+    ActiveOwnerKind,
+    ComponentFamily,
+    LegacyAdmissionRejected,
     LegacyPathRecord,
+    ObsoleteConfiguration,
+    ObsoleteConfigurationError,
+    RemovalStage,
+    RetentionWindows,
+    RetirementClass,
     RetirementCriterion,
     RetirementGuardError,
+    RuntimeGeneration,
+    assert_inventory_is_complete,
+    assert_new_admission_allowed,
+    assert_obsolete_configuration,
     assert_retirement_guard,
+    assert_surface_admits_new_work,
     assert_temporary_flags_have_retirement,
+    evaluate_new_admission,
+    evaluate_removal_eligibility,
     evaluate_retirement,
+    get_retirement_record,
+)
+from moonmind.omnigent.retirement_drain import build_drain_evidence
+from moonmind.omnigent.retirement_surfaces import discover_legacy_surfaces
+from moonmind.omnigent.session_supervisor_rollback import (
+    RollbackExerciseRecord,
+    RollbackScope,
+    evaluate_rollback_exercise,
+    legacy_rollback_generation_from_settings,
 )
 
+NOW = datetime(2026, 9, 5, 12, 0, tzinfo=timezone.utc)
 
-def test_inventory_is_nonempty_and_nothing_retired_yet() -> None:
+_BASE_CRITERIA = frozenset({RetirementCriterion.HISTORICAL_READS_AVAILABLE})
+
+
+def _record(**overrides: object) -> LegacyPathRecord:
+    payload: dict[str, object] = {
+        "pathId": "omnigent.legacy.fixture",
+        "owner": "omnigent-control-plane",
+        "description": "Fixture row.",
+        "family": ComponentFamily.BRIDGE_COMPATIBILITY,
+        "generation": RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        "retirementClass": RetirementClass.TEMPORAL_REPLAY_ONLY,
+        "machineCheckableRef": (
+            "python:moonmind.omnigent.bridge_store:OmnigentBridgeSessionStore"
+        ),
+        "surfaces": (
+            "python:moonmind.omnigent.bridge_store:OmnigentBridgeSessionStore",
+        ),
+        "replayDependency": True,
+        "applicableCriteria": _BASE_CRITERIA,
+        "earliestRemovalStage": RemovalStage.REPLAY_WRAPPERS,
+        "removalGuardTest": "tests/unit/omnigent/test_legacy_retirement.py::fixture",
+    }
+    payload.update(overrides)
+    return LegacyPathRecord(**payload)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------- inventory shape
+
+
+def test_inventory_is_nonempty_and_nothing_removed_yet() -> None:
     assert RETIREMENT_INVENTORY
-    # This cohort has not proven replacement coverage; nothing may be retired.
-    assert all(not path.retired for path in RETIREMENT_INVENTORY)
+    # #3833 has not promoted the qualified generic rows and the replay/rollback
+    # evidence in this cohort has not proven replacement coverage, so no legacy
+    # implementation may be classified removed.
+    assert all(not path.removed for path in RETIREMENT_INVENTORY)
+
+
+def test_every_component_family_the_issue_enumerates_has_a_row() -> None:
+    covered = {path.family for path in RETIREMENT_INVENTORY}
+    missing = sorted(
+        family.value for family in ComponentFamily if family not in covered
+    )
+    assert not missing, f"component families with no retirement row: {missing}"
+
+
+def test_every_row_records_the_nine_required_fields() -> None:
+    for path in RETIREMENT_INVENTORY:
+        assert path.owner.strip(), path.path_id
+        assert isinstance(path.retirement_class, RetirementClass), path.path_id
+        # A row either names the source that can still create new legacy work or
+        # is explicitly past new admission; the model rejects any other pairing.
+        assert bool(path.new_admission_source.strip()) is path.admits_new_work
+        assert isinstance(path.active_resource_dependencies, frozenset), path.path_id
+        assert isinstance(path.replay_dependency, bool), path.path_id
+        assert isinstance(path.historical_read_dependency, bool), path.path_id
+        assert isinstance(path.rollback_dependency, bool), path.path_id
+        assert path.applicable_criteria, path.path_id
+        assert isinstance(path.earliest_removal_stage, RemovalStage), path.path_id
+        assert "::" in path.removal_guard_test, path.path_id
+
+
+def test_removal_guard_tests_name_files_that_exist() -> None:
+    from moonmind.omnigent.retirement_surfaces import REPO_ROOT
+
+    for path in RETIREMENT_INVENTORY:
+        relative = path.removal_guard_test.split("::", 1)[0]
+        assert (REPO_ROOT / relative).is_file(), (
+            f"{path.path_id} names removal guard test file {relative} which does "
+            "not exist"
+        )
+
+
+def test_new_admission_sources_resolve() -> None:
+    for path in RETIREMENT_INVENTORY:
+        source = path.new_admission_source
+        if not source or source.startswith("docker-compose"):
+            continue
+        module_name, _, symbol = source.rpartition(":")
+        module = importlib.import_module(module_name)
+        assert hasattr(module, symbol), (
+            f"{path.path_id} names new-admission source {source} which no longer "
+            "resolves"
+        )
+
+
+def test_record_rejects_admission_source_on_a_closed_class() -> None:
+    with pytest.raises(ValueError, match="does not admit new work"):
+        _record(newAdmissionSource="moonmind.omnigent.execute:run_omnigent_execution")
+
+
+def test_record_requires_admission_source_while_it_still_admits() -> None:
+    with pytest.raises(ValueError, match="must be named"):
+        _record(
+            retirementClass=RetirementClass.ACTIVE_PRODUCT_PATH,
+            replayDependency=False,
+        )
+
+
+def test_record_rejects_dependencies_once_eligible_for_removal() -> None:
+    with pytest.raises(ValueError, match="cannot carry an active"):
+        _record(retirementClass=RetirementClass.ELIGIBLE_FOR_REMOVAL)
+
+
+def test_record_requires_rollback_allowlist_for_rollback_only() -> None:
+    with pytest.raises(ValueError, match="exact permitted rollback generation"):
+        _record(
+            retirementClass=RetirementClass.ROLLBACK_ONLY,
+            newAdmissionSource="moonmind.omnigent.execute:run_omnigent_execution",
+            replayDependency=False,
+        )
+
+
+def test_record_rejects_a_surface_ref_without_a_scheme() -> None:
+    with pytest.raises(ValueError):
+        _record(
+            machineCheckableRef="moonmind.omnigent.bridge_store:X",
+            surfaces=("moonmind.omnigent.bridge_store:X",),
+        )
+
+
+# ------------------------------------------------------------------- guards
 
 
 def test_guard_passes_for_current_inventory() -> None:
-    # All machine-checkable refs resolve and nothing is retired.
     assert_retirement_guard()
 
 
-def test_guard_fails_when_required_path_ref_is_deleted() -> None:
-    broken = (
-        LegacyPathRecord(
-            pathId="omnigent.legacy.ghost",
-            owner="omnigent-control-plane",
-            description="A path whose module no longer exists.",
-            machineCheckableRef="moonmind.omnigent.__does_not_exist__",
-            applicableCriteria=frozenset({RetirementCriterion.HISTORICAL_READS_AVAILABLE}),
-        ),
-    )
-    with pytest.raises(RetirementGuardError):
-        assert_retirement_guard(broken)
-
-
-def test_guard_fails_when_symbol_deleted_but_module_remains() -> None:
-    # The concrete class/function was removed even though its module still
-    # imports — the guard must still fail because the authority path is gone.
-    broken = (
-        LegacyPathRecord(
-            pathId="omnigent.legacy.bridge_persistence",
-            owner="omnigent-control-plane",
-            description="Module kept, concrete implementation deleted.",
-            machineCheckableRef="moonmind.omnigent.bridge_store:__DeletedStore__",
-            applicableCriteria=frozenset(
-                {RetirementCriterion.HISTORICAL_READS_AVAILABLE}
-            ),
-        ),
-    )
-    with pytest.raises(RetirementGuardError):
-        assert_retirement_guard(broken)
-
-
-def test_guard_fails_when_ref_names_only_a_module() -> None:
-    # A bare module reference (no concrete ``:symbol``) is rejected so a
-    # weakened guard can never silently pass.
-    module_only = (
-        LegacyPathRecord(
-            pathId="omnigent.legacy.bridge_persistence",
-            owner="omnigent-control-plane",
-            description="Ref names only a module, not a concrete symbol.",
-            machineCheckableRef="moonmind.omnigent.bridge_store",
-            applicableCriteria=frozenset(
-                {RetirementCriterion.HISTORICAL_READS_AVAILABLE}
-            ),
-        ),
-    )
-    with pytest.raises(RetirementGuardError):
-        assert_retirement_guard(module_only)
-
-
-def test_inventory_refs_name_concrete_symbols() -> None:
-    # Every current inventory ref must resolve to a concrete symbol.
-    import importlib
+def test_every_inventory_surface_still_resolves() -> None:
+    from moonmind.omnigent.retirement_surfaces import surface_exists
 
     for path in RETIREMENT_INVENTORY:
-        module_name, sep, symbol = path.machine_checkable_ref.partition(":")
-        assert sep == ":" and symbol, path.machine_checkable_ref
-        module = importlib.import_module(module_name)
-        assert hasattr(module, symbol), path.machine_checkable_ref
+        for ref in path.surfaces:
+            assert surface_exists(ref), f"{path.path_id}: {ref}"
 
 
-def test_guard_fails_when_retired_path_has_unmet_criteria() -> None:
-    retired = (
-        LegacyPathRecord(
-            pathId="omnigent.legacy.bridge_persistence",
-            owner="omnigent-control-plane",
-            description="Marked retired prematurely.",
-            machineCheckableRef="moonmind.omnigent.bridge_store",
+def test_guard_fails_when_a_retained_python_symbol_is_deleted() -> None:
+    broken = (
+        _record(
+            machineCheckableRef=(
+                "python:moonmind.omnigent.bridge_store:__DeletedStore__"
+            ),
+            surfaces=("python:moonmind.omnigent.bridge_store:__DeletedStore__",),
+        ),
+    )
+    with pytest.raises(RetirementGuardError, match="no longer resolves"):
+        assert_retirement_guard(broken)
+
+
+def test_guard_fails_when_a_retained_compose_service_is_deleted() -> None:
+    broken = (
+        _record(
+            machineCheckableRef="compose-service:omnigent-host-gone",
+            surfaces=("compose-service:omnigent-host-gone",),
+        ),
+    )
+    with pytest.raises(RetirementGuardError, match="no longer resolves"):
+        assert_retirement_guard(broken)
+
+
+def test_guard_fails_when_a_retained_startup_script_is_deleted() -> None:
+    broken = (
+        _record(
+            machineCheckableRef="script:start-deleted-host.sh",
+            surfaces=("script:start-deleted-host.sh",),
+        ),
+    )
+    with pytest.raises(RetirementGuardError, match="no longer resolves"):
+        assert_retirement_guard(broken)
+
+
+def test_guard_fails_when_removed_path_has_unmet_criteria() -> None:
+    removed = (
+        _record(
+            retirementClass=RetirementClass.REMOVED,
+            replayDependency=False,
             applicableCriteria=frozenset(
                 {
                     RetirementCriterion.NO_NEW_RECORDS_USE_IT,
                     RetirementCriterion.HISTORICAL_READS_AVAILABLE,
                 }
             ),
-            retired=True,
         ),
     )
-    with pytest.raises(RetirementGuardError):
+    with pytest.raises(RetirementGuardError, match="classified removed"):
         assert_retirement_guard(
-            retired,
+            removed,
             passed_by_path={
-                "omnigent.legacy.bridge_persistence": frozenset(
+                "omnigent.legacy.fixture": frozenset(
                     {RetirementCriterion.NO_NEW_RECORDS_USE_IT}
                 )
             },
         )
 
 
-def test_guard_allows_retired_path_when_all_criteria_pass() -> None:
+def test_guard_allows_removed_path_when_all_criteria_pass() -> None:
     criteria = frozenset(
         {
             RetirementCriterion.NO_NEW_RECORDS_USE_IT,
             RetirementCriterion.HISTORICAL_READS_AVAILABLE,
         }
     )
-    retired = (
-        LegacyPathRecord(
-            pathId="omnigent.legacy.bridge_persistence",
-            owner="omnigent-control-plane",
-            description="Fully retired with evidence.",
-            machineCheckableRef="moonmind.omnigent.bridge_store",
+    removed = (
+        _record(
+            retirementClass=RetirementClass.REMOVED,
+            replayDependency=False,
             applicableCriteria=criteria,
-            retired=True,
+            # A removed implementation no longer has to resolve.
+            machineCheckableRef="python:moonmind.omnigent.bridge_store:__Gone__",
+            surfaces=("python:moonmind.omnigent.bridge_store:__Gone__",),
         ),
     )
-    # No exception: all applicable criteria passed.
     assert_retirement_guard(
-        retired, passed_by_path={"omnigent.legacy.bridge_persistence": criteria}
+        removed, passed_by_path={"omnigent.legacy.fixture": criteria}
     )
 
 
@@ -149,6 +275,627 @@ def test_evaluate_retirement_reports_unmet_criteria() -> None:
     assert decision_full.unmet_criteria == ()
 
 
+# ------------------------------------------------------------- completeness
+
+
+def test_inventory_covers_every_discovered_legacy_surface() -> None:
+    assert_inventory_is_complete()
+
+
+def test_discovery_finds_the_surfaces_the_issue_enumerates() -> None:
+    discovered = discover_legacy_surfaces()
+    for expected in (
+        "realizer:codex-profile-bound@1",
+        "runtime-strategy:codex_cli",
+        "runtime-strategy:claude_code",
+        "compose-service:omnigent-host-codex",
+        "compose-service:omnigent-host-claude",
+        "compose-profile:omnigent-host-codex",
+        "script:start-codex-oauth-host.sh",
+        "script:start-claude-oauth-host.sh",
+        "env:OMNIGENT_HOST_IMAGE_REF",
+        "env:OMNIGENT_OPENCODE_HOST_IMAGE_REF",
+    ):
+        assert expected in discovered, expected
+
+
+def test_unclassified_new_legacy_dependency_fails_ci() -> None:
+    # Simulate registering a new legacy realizer with no retirement row.
+    with pytest.raises(RetirementGuardError, match="no retirement row"):
+        assert_inventory_is_complete(
+            discovered=discover_legacy_surfaces() | {"realizer:codex-legacy@2"}
+        )
+
+
+def test_two_rows_cannot_claim_the_same_surface() -> None:
+    duplicated = (
+        *RETIREMENT_INVENTORY,
+        _record(pathId="omnigent.legacy.duplicate"),
+    )
+    with pytest.raises(RetirementGuardError, match="more than one row"):
+        assert_inventory_is_complete(duplicated)
+
+
+# ------------------------------------------------------------- new admission
+
+
+def test_profile_bound_admission_follows_the_code_owned_class() -> None:
+    record = get_retirement_record("omnigent.legacy.profile_bound_realizer")
+    # Today the class still admits: #3833 has not promoted the generic rows, and
+    # the issue forbids stopping admission before qualified defaults exist.
+    assert record.retirement_class is RetirementClass.ACTIVE_PRODUCT_PATH
+    assert evaluate_new_admission(record).allowed is True
+
+    disabled = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.NEW_ADMISSION_DISABLED,
+            "new_admission_source": "",
+        }
+    )
+    decision = evaluate_new_admission(disabled)
+    assert decision.allowed is False
+    assert decision.reason_code == "new_admission_disabled:new_admission_disabled"
+
+
+def test_rollback_only_admits_only_the_exact_allowlisted_generation() -> None:
+    rollback_only = _record(
+        retirementClass=RetirementClass.ROLLBACK_ONLY,
+        newAdmissionSource="moonmind.omnigent.execute:run_omnigent_execution",
+        rollbackDependency=True,
+        rollbackGenerations=frozenset({"gen-7"}),
+        replayDependency=False,
+    )
+    assert evaluate_new_admission(rollback_only).reason_code == (
+        "rollback_generation_required"
+    )
+    # Exact membership only: a prefix of the allowlisted generation is rejected.
+    assert (
+        evaluate_new_admission(rollback_only, rollback_generation="gen-").reason_code
+        == "rollback_generation_not_allowlisted"
+    )
+    permitted = evaluate_new_admission(rollback_only, rollback_generation="gen-7")
+    assert permitted.allowed is True
+    assert permitted.reason_code == "rollback_generation_permitted"
+
+
+def test_assert_new_admission_raises_with_a_stable_reason_code() -> None:
+    closed = (
+        _record(pathId="omnigent.legacy.closed"),
+    )
+    with pytest.raises(LegacyAdmissionRejected) as excinfo:
+        assert_new_admission_allowed("omnigent.legacy.closed", inventory=closed)
+    assert excinfo.value.reason_code == "new_admission_disabled:temporal_replay_only"
+    assert excinfo.value.path_id == "omnigent.legacy.closed"
+
+
+def test_canonical_surfaces_are_never_subject_to_retirement_admission() -> None:
+    assert assert_surface_admits_new_work("realizer:generic-omnigent-host@1") is None
+
+
+def test_code_owned_retirement_state_matches_product_selection_state() -> None:
+    """A realizer's registry deprecation must match its retirement class."""
+
+    from moonmind.omnigent.harness_platform.support import KNOWN_REALIZERS
+
+    for ref, entry in KNOWN_REALIZERS.items():
+        record = None
+        for path in RETIREMENT_INVENTORY:
+            if f"realizer:{ref}" in path.surfaces:
+                record = path
+                break
+        if record is None:
+            # The canonical generic realizer carries no retirement row.
+            assert entry["deprecated"] is False, ref
+            continue
+        assert entry["deprecated"] is not record.admits_new_work, (
+            f"realizer {ref} is registered deprecated={entry['deprecated']} but "
+            f"its retirement class is {record.retirement_class.value}"
+        )
+
+
+def test_runtime_selection_consults_the_retirement_class(monkeypatch) -> None:
+    from moonmind.omnigent import legacy_retirement
+    from moonmind.omnigent.cutover import CutoverPhase, select_runtime
+
+    record = get_retirement_record("omnigent.legacy.direct_codex_launch")
+    closed = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.NEW_ADMISSION_DISABLED,
+            "new_admission_source": "",
+        }
+    )
+    monkeypatch.setitem(
+        legacy_retirement._INVENTORY_BY_SURFACE, "runtime-strategy:codex_cli", closed
+    )
+    monkeypatch.setitem(
+        legacy_retirement._INVENTORY_BY_ID,
+        "omnigent.legacy.direct_codex_launch",
+        closed,
+    )
+
+    with pytest.raises(ValueError, match="runtime_new_admission_disabled"):
+        select_runtime(
+            authored_runtime="codex_cli",
+            configured_default="codex_cli",
+            phase=CutoverPhase.OPT_IN,
+        )
+    # Omnigent remains selectable: closing legacy admission never blocks the
+    # canonical destination.
+    assert (
+        select_runtime(
+            authored_runtime="omnigent",
+            configured_default="codex_cli",
+            phase=CutoverPhase.OPT_IN,
+        ).runtime_id
+        == "omnigent"
+    )
+
+
+def test_legacy_rollback_generation_requires_the_explicit_control() -> None:
+    class _Flags:
+        omnigent_session_supervisor_rollback_mode = "none"
+        omnigent_session_supervisor_generation = "gen-7"
+
+    assert legacy_rollback_generation_from_settings(_Flags()) is None
+
+    class _RollbackFlags(_Flags):
+        omnigent_session_supervisor_rollback_mode = "revert_default_to_legacy"
+
+    assert legacy_rollback_generation_from_settings(_RollbackFlags()) == "gen-7"
+
+
+# --------------------------------------------------------- removal eligibility
+
+
+def _all_criteria(path: LegacyPathRecord) -> frozenset[RetirementCriterion]:
+    return frozenset(path.applicable_criteria)
+
+
+def _drained(path: LegacyPathRecord) -> frozenset[ActiveOwnerKind]:
+    return frozenset(path.active_resource_dependencies)
+
+
+def _closed_windows() -> RetentionWindows:
+    return RetentionWindows(
+        replayWindowOpen=False,
+        historicalReadWindowOpen=False,
+        rollbackWindowOpen=False,
+        rollbackExerciseRecorded=True,
+    )
+
+
+def test_removal_blocked_while_active_leases_or_hosts_remain() -> None:
+    path = get_retirement_record("omnigent.legacy.profile_bound_execution")
+    closed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    # Everything drains except the Provider Profile lease and host lease.
+    drained = _drained(closed) - {
+        ActiveOwnerKind.PROVIDER_PROFILE_LEASE,
+        ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+    }
+    eligibility = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.LAUNCH_ONLY_CODE,
+        drained_kinds=drained,
+        passed_criteria=_all_criteria(closed),
+        retention=_closed_windows(),
+    )
+    assert eligibility.eligible is False
+    assert "active_owner:provider_profile_lease" in eligibility.blockers
+    assert "active_owner:host_binding_or_lease" in eligibility.blockers
+
+    fully_drained = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.LAUNCH_ONLY_CODE,
+        drained_kinds=_drained(closed),
+        passed_criteria=_all_criteria(closed),
+        retention=_closed_windows(),
+    )
+    assert fully_drained.eligible is True, fully_drained.blockers
+
+
+def test_cleanup_only_path_blocks_removal_until_janitor_authority_drains() -> None:
+    path = get_retirement_record("omnigent.legacy.oauth_host_janitor")
+    assert path.retirement_class is RetirementClass.CLEANUP_ONLY
+    eligibility = evaluate_removal_eligibility(
+        path,
+        stage=RemovalStage.OAUTH_HOST_ORCHESTRATION,
+        drained_kinds=_drained(path)
+        - {ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR},
+        passed_criteria=_all_criteria(path),
+        retention=_closed_windows(),
+    )
+    assert eligibility.eligible is False
+    assert "active_owner:incomplete_cleanup_or_janitor" in eligibility.blockers
+
+
+def test_removal_blocked_while_replay_history_or_rollback_windows_are_open() -> None:
+    path = get_retirement_record("omnigent.legacy.direct_codex_launch")
+    closed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    eligibility = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.PRODUCT_SELECTORS,
+        drained_kinds=_drained(closed),
+        passed_criteria=_all_criteria(closed),
+        retention=RetentionWindows(),
+    )
+    assert eligibility.eligible is False
+    assert "replay_window_open" in eligibility.blockers
+    assert "historical_read_window_open" in eligibility.blockers
+    assert "rollback_window_open" in eligibility.blockers
+    assert "rollback_exercise_not_recorded" in eligibility.blockers
+
+
+def test_removal_blocked_while_the_class_still_admits_new_work() -> None:
+    path = get_retirement_record("omnigent.legacy.profile_bound_realizer")
+    eligibility = evaluate_removal_eligibility(
+        path,
+        stage=RemovalStage.PRODUCT_SELECTORS,
+        drained_kinds=_drained(path),
+        passed_criteria=_all_criteria(path),
+        retention=_closed_windows(),
+    )
+    assert eligibility.eligible is False
+    assert "still_admits_new_work:active_product_path" in eligibility.blockers
+
+
+def test_removal_blocked_while_retirement_criteria_are_unmet() -> None:
+    path = get_retirement_record("omnigent.legacy.profile_bound_execution")
+    closed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    eligibility = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.LAUNCH_ONLY_CODE,
+        drained_kinds=_drained(closed),
+        passed_criteria=frozenset(),
+        retention=_closed_windows(),
+    )
+    assert eligibility.eligible is False
+    assert any(b.startswith("unmet_criterion:") for b in eligibility.blockers)
+
+
+def test_removal_stage_ordering_is_enforced() -> None:
+    """A historical reader cannot be deleted in a product-selector removal."""
+
+    path = get_retirement_record("omnigent.legacy.bridge_persistence")
+    closed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.HISTORICAL_READ_ONLY,
+            "new_admission_source": "",
+        }
+    )
+    early = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.PRODUCT_SELECTORS,
+        drained_kinds=_drained(closed),
+        passed_criteria=_all_criteria(closed),
+        retention=_closed_windows(),
+    )
+    assert early.eligible is False
+    assert any(b.startswith("stage_too_early:") for b in early.blockers)
+
+    at_stage = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.HISTORICAL_READERS,
+        drained_kinds=_drained(closed),
+        passed_criteria=_all_criteria(closed),
+        retention=_closed_windows(),
+    )
+    assert at_stage.eligible is True, at_stage.blockers
+
+
+def test_removal_stages_cover_the_nine_ordered_stages() -> None:
+    assert [stage.value for stage in RemovalStage] == list(range(1, 10))
+    # Every stage a row cites must be one of the ordered stages, and the
+    # inventory must actually span the staged convergence rather than collapsing
+    # into one unreviewable removal.
+    used = {path.earliest_removal_stage for path in RETIREMENT_INVENTORY}
+    assert len(used) >= 6, sorted(stage.name for stage in used)
+
+
+def test_direct_and_profile_bound_generations_are_independently_decided() -> None:
+    """Direct Codex, direct Claude, and profile-bound retire separately."""
+
+    by_generation: dict[RuntimeGeneration, list[LegacyPathRecord]] = {}
+    for path in RETIREMENT_INVENTORY:
+        by_generation.setdefault(path.generation, []).append(path)
+    for generation in (
+        RuntimeGeneration.DIRECT_CODEX,
+        RuntimeGeneration.DIRECT_CLAUDE,
+        RuntimeGeneration.CODEX_PROFILE_BOUND,
+    ):
+        assert by_generation.get(generation), generation.value
+
+    # Closing direct Claude admission leaves direct Codex and profile-bound
+    # untouched: no generation is forced to retire because another one did.
+    claude = [
+        path
+        for path in by_generation[RuntimeGeneration.DIRECT_CLAUDE]
+        if path.admits_new_work
+    ]
+    assert claude
+    closed = tuple(
+        path.model_copy(
+            update={
+                "retirement_class": RetirementClass.NEW_ADMISSION_DISABLED,
+                "new_admission_source": "",
+            }
+        )
+        for path in claude
+    )
+    for path in closed:
+        assert evaluate_new_admission(path).allowed is False
+    for path in by_generation[RuntimeGeneration.DIRECT_CODEX]:
+        if path.admits_new_work:
+            assert evaluate_new_admission(path).allowed is True
+    for path in by_generation[RuntimeGeneration.CODEX_PROFILE_BOUND]:
+        if path.admits_new_work:
+            assert evaluate_new_admission(path).allowed is True
+
+
+# ------------------------------------------------------------------ drain
+
+
+def test_drain_evidence_is_fail_closed_without_observations() -> None:
+    path = get_retirement_record("omnigent.legacy.oauth_host_runtime")
+    evidence = build_drain_evidence(path, [], now=NOW)
+    assert evidence.fully_drained is False
+    assert set(evidence.missing_kinds) == path.active_resource_dependencies
+    eligibility = evaluate_removal_eligibility(
+        path.model_copy(
+            update={
+                "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+                "new_admission_source": "",
+            }
+        ),
+        stage=RemovalStage.OAUTH_HOST_ORCHESTRATION,
+        drained_kinds=evidence.drained_kinds,
+        passed_criteria=_all_criteria(path),
+        retention=_closed_windows(),
+    )
+    assert eligibility.eligible is False
+
+
+def test_drain_evidence_rejects_stale_and_failed_probes() -> None:
+    from moonmind.omnigent.retirement_drain import ActiveOwnerObservation
+
+    path = get_retirement_record("omnigent.legacy.oauth_host_janitor")
+    kinds = sorted(path.active_resource_dependencies, key=lambda k: k.value)
+    observations = [
+        ActiveOwnerObservation(
+            kind=kinds[0],
+            activeCount=0,
+            probeRef="host.lease.scan",
+            observedAt=NOW - timedelta(days=2),
+        ),
+        ActiveOwnerObservation(
+            kind=kinds[1],
+            activeCount=0,
+            probeRef="janitor.queue.scan",
+            observedAt=NOW,
+            probeSucceeded=False,
+        ),
+        ActiveOwnerObservation(
+            kind=kinds[2],
+            activeCount=0,
+            probeRef="static.host.scan",
+            observedAt=NOW,
+        ),
+    ]
+    evidence = build_drain_evidence(path, observations, now=NOW)
+    assert evidence.stale_kinds == (kinds[0],)
+    assert evidence.failed_kinds == (kinds[1],)
+    assert evidence.drained_kinds == frozenset({kinds[2]})
+    assert evidence.fully_drained is False
+
+
+def test_drain_evidence_probe_refs_stay_operator_safe() -> None:
+    from moonmind.omnigent.retirement_drain import ActiveOwnerObservation
+
+    with pytest.raises(ValueError, match="operator-safe"):
+        ActiveOwnerObservation(
+            kind=ActiveOwnerKind.PROVIDER_PROFILE_LEASE,
+            activeCount=0,
+            probeRef="provider-session-8f3a1b2c-secret-token",
+            observedAt=NOW,
+        )
+
+
+def test_drain_evidence_drains_only_declared_dependency_kinds() -> None:
+    from moonmind.omnigent.retirement_drain import ActiveOwnerObservation
+
+    path = get_retirement_record("omnigent.legacy.pi_host_image_alias")
+    undeclared = ActiveOwnerObservation(
+        kind=ActiveOwnerKind.PENDING_PUBLICATION,
+        activeCount=0,
+        probeRef="publication.scan",
+        observedAt=NOW,
+    )
+    declared = [
+        ActiveOwnerObservation(
+            kind=kind, activeCount=0, probeRef="host.scan", observedAt=NOW
+        )
+        for kind in path.active_resource_dependencies
+    ]
+    evidence = build_drain_evidence(path, [undeclared, *declared], now=NOW)
+    assert evidence.drained_kinds == path.active_resource_dependencies
+    assert ActiveOwnerKind.PENDING_PUBLICATION not in evidence.drained_kinds
+
+
+# --------------------------------------------------------------- rollback
+
+
+def _scope(**overrides: str) -> RollbackScope:
+    payload = {
+        "agentProfileRef": "profile@3",
+        "hostClassRef": "codex-oauth-host@1",
+        "materializerRef": "codex-oauth-home@1",
+        "executionRealizerRef": "codex-profile-bound@1",
+        "modelQualifiedId": "gpt-5-codex",
+        "launchPolicyRef": "codex-static@1",
+        "hostMode": "static",
+        "architecture": "amd64",
+        "ownerCohort": "internal",
+    }
+    payload.update(overrides)
+    return RollbackScope(**payload)  # type: ignore[arg-type]
+
+
+def _exercise(**overrides: object) -> RollbackExerciseRecord:
+    payload: dict[str, object] = {
+        "retirementPathId": "omnigent.legacy.profile_bound_realizer",
+        "scope": _scope(),
+        "exercisedAt": NOW - timedelta(days=1),
+        "evidenceRef": "artifact://rollback/exercise-1",
+        "succeeded": True,
+    }
+    payload.update(overrides)
+    return RollbackExerciseRecord(**payload)  # type: ignore[arg-type]
+
+
+def test_rollback_exercise_requires_an_exact_scope_match() -> None:
+    decision = evaluate_rollback_exercise(
+        retirement_path_id="omnigent.legacy.profile_bound_realizer",
+        scope=_scope(),
+        records=[_exercise()],
+        now=NOW,
+    )
+    assert decision.satisfied is True
+
+    mismatched = evaluate_rollback_exercise(
+        retirement_path_id="omnigent.legacy.profile_bound_realizer",
+        scope=_scope(hostMode="on_demand"),
+        records=[_exercise()],
+        now=NOW,
+    )
+    assert mismatched.satisfied is False
+    assert mismatched.reason_code == "rollback_scope_mismatch"
+
+
+def test_rollback_exercise_expires() -> None:
+    decision = evaluate_rollback_exercise(
+        retirement_path_id="omnigent.legacy.profile_bound_realizer",
+        scope=_scope(),
+        records=[_exercise(exercisedAt=NOW - timedelta(days=90))],
+        now=NOW,
+    )
+    assert decision.satisfied is False
+    assert decision.reason_code == "rollback_evidence_expired"
+
+
+def test_rollback_exercise_that_touched_existing_work_is_not_evidence() -> None:
+    decision = evaluate_rollback_exercise(
+        retirement_path_id="omnigent.legacy.profile_bound_realizer",
+        scope=_scope(),
+        records=[_exercise(futureAdmissionOnly=False)],
+        now=NOW,
+    )
+    assert decision.satisfied is False
+    assert decision.reason_code == "rollback_exercise_touched_existing_work"
+
+
+def test_rollback_scope_rejects_a_blank_dimension() -> None:
+    with pytest.raises(ValueError, match="exact value"):
+        _scope(ownerCohort="  ")
+
+
+def test_rollback_exercise_is_required_before_removal_eligibility() -> None:
+    path = get_retirement_record("omnigent.legacy.profile_bound_realizer")
+    closed = path.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    decision = evaluate_rollback_exercise(
+        retirement_path_id=path.path_id,
+        scope=_scope(),
+        records=[],
+        now=NOW,
+    )
+    eligibility = evaluate_removal_eligibility(
+        closed,
+        stage=RemovalStage.PRODUCT_SELECTORS,
+        drained_kinds=_drained(closed),
+        passed_criteria=_all_criteria(closed),
+        retention=RetentionWindows(
+            replayWindowOpen=False,
+            historicalReadWindowOpen=False,
+            rollbackWindowOpen=False,
+            rollbackExerciseRecorded=decision.satisfied,
+        ),
+    )
+    assert eligibility.eligible is False
+    assert "rollback_exercise_not_recorded" in eligibility.blockers
+
+
+# --------------------------------------------------- obsolete configuration
+
+
+def test_current_configuration_is_accepted() -> None:
+    assert assert_obsolete_configuration({"OMNIGENT_HOST_IMAGE_REF": "img@sha256:a"}) == ()
+
+
+def test_obsolete_configuration_fails_with_an_actionable_message() -> None:
+    deprecated = (
+        ObsoleteConfiguration(
+            variable="OMNIGENT_HOST_IMAGE_REF",
+            retirementPathId="omnigent.legacy.host_image_variable_alias",
+            replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+            deprecated=True,
+            guidance="Repin the shared image digest before the next release.",
+        ),
+    )
+    warnings = assert_obsolete_configuration(
+        {"OMNIGENT_HOST_IMAGE_REF": "img@sha256:a"}, configuration=deprecated
+    )
+    assert warnings and "OMNIGENT_SHARED_HOST_IMAGE_REF" in warnings[0]
+    assert "omnigent.legacy.host_image_variable_alias" in warnings[0]
+
+    removed = (deprecated[0].model_copy(update={"removed": True}),)
+    with pytest.raises(ObsoleteConfigurationError, match="no longer honored"):
+        assert_obsolete_configuration(
+            {"OMNIGENT_HOST_IMAGE_REF": "img@sha256:a"}, configuration=removed
+        )
+    # An unset obsolete variable never fails startup.
+    assert (
+        assert_obsolete_configuration({}, configuration=removed) == ()
+    )
+
+
+def test_obsolete_configuration_rows_name_real_retirement_paths() -> None:
+    known = {path.path_id for path in RETIREMENT_INVENTORY}
+    for entry in OBSOLETE_CONFIGURATION:
+        assert entry.retirement_path_id in known, entry.variable
+        assert entry.replacement.strip(), entry.variable
+
+
+def test_obsolete_configuration_cannot_skip_its_deprecation_window() -> None:
+    with pytest.raises(ValueError, match="deprecation window"):
+        ObsoleteConfiguration(
+            variable="OMNIGENT_HOST_IMAGE_REF",
+            retirementPathId="omnigent.legacy.host_image_variable_alias",
+            replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+            removed=True,
+        )
+
+
+# ------------------------------------------------------------ rollout flags
+
+
 def test_temporary_flags_all_have_retirement_trigger() -> None:
     assert TEMPORARY_ROLLOUT_FLAGS
     assert_temporary_flags_have_retirement()
@@ -156,7 +903,9 @@ def test_temporary_flags_all_have_retirement_trigger() -> None:
 
 def test_temporary_flag_without_trigger_is_rejected() -> None:
     with pytest.raises(RetirementGuardError):
-        assert_temporary_flags_have_retirement({"omnigent_session_supervisor_enabled": ""})
+        assert_temporary_flags_have_retirement(
+            {"omnigent_session_supervisor_enabled": ""}
+        )
 
 
 def test_temporary_flags_cover_supervisor_settings_fields() -> None:
@@ -167,3 +916,140 @@ def test_temporary_flags_cover_supervisor_settings_fields() -> None:
     model_fields = set(FeatureFlagsSettings.model_fields)
     for flag in TEMPORARY_ROLLOUT_FLAGS:
         assert flag in model_fields
+
+
+# --------------------------------------------------------- staged removal PRs
+
+
+def test_removal_plan_cites_rows_and_guards_and_reports_blockers() -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RemovalPlan,
+        evaluate_removal_plan,
+    )
+
+    plan = RemovalPlan(
+        stage=RemovalStage.PRODUCT_SELECTORS,
+        pathIds=(
+            "omnigent.legacy.profile_bound_realizer",
+            "omnigent.legacy.direct_codex_launch",
+        ),
+    )
+    report = evaluate_removal_plan(plan)
+    # Nothing is removable today; the report is the actionable citation.
+    assert report.allowed is False
+    assert {e.path_id for e in report.blocked} == set(plan.path_ids)
+    assert report.required_guard_tests
+    for guard in report.required_guard_tests:
+        assert "::" in guard
+
+
+def test_removal_plan_allows_a_bounded_stage_once_every_guard_passes() -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RemovalPlan,
+        evaluate_removal_plan,
+    )
+
+    path_id = "omnigent.legacy.oauth_host_runtime"
+    record = get_retirement_record(path_id)
+    closed = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    report = evaluate_removal_plan(
+        RemovalPlan(
+            stage=RemovalStage.OAUTH_HOST_ORCHESTRATION, pathIds=(path_id,)
+        ),
+        inventory=(closed,),
+        drained_by_path={path_id: _drained(closed)},
+        passed_by_path={path_id: _all_criteria(closed)},
+        retention_by_path={path_id: _closed_windows()},
+    )
+    assert report.allowed is True, report.blocked
+    assert report.eligible_path_ids == (path_id,)
+
+
+def test_removal_plan_is_fail_closed_without_evidence() -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RemovalPlan,
+        evaluate_removal_plan,
+    )
+
+    path_id = "omnigent.legacy.oauth_host_runtime"
+    record = get_retirement_record(path_id)
+    closed = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.ACTIVE_EXECUTION_SUPPORT,
+            "new_admission_source": "",
+        }
+    )
+    # Same plan, no supplied drain/criteria/retention evidence at all.
+    report = evaluate_removal_plan(
+        RemovalPlan(
+            stage=RemovalStage.OAUTH_HOST_ORCHESTRATION, pathIds=(path_id,)
+        ),
+        inventory=(closed,),
+    )
+    assert report.allowed is False
+
+
+def test_removal_plan_rejects_an_empty_or_duplicated_plan() -> None:
+    from moonmind.omnigent.legacy_retirement import RemovalPlan
+
+    with pytest.raises(ValueError, match="at least one retirement row"):
+        RemovalPlan(stage=RemovalStage.PRODUCT_SELECTORS, pathIds=())
+    with pytest.raises(ValueError, match="not name a retirement row twice"):
+        RemovalPlan(
+            stage=RemovalStage.PRODUCT_SELECTORS,
+            pathIds=(
+                "omnigent.legacy.profile_bound_realizer",
+                "omnigent.legacy.profile_bound_realizer",
+            ),
+        )
+
+
+def test_removal_plan_rejects_an_unknown_retirement_row() -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RemovalPlan,
+        evaluate_removal_plan,
+    )
+
+    with pytest.raises(RetirementGuardError, match="unknown retirement path"):
+        evaluate_removal_plan(
+            RemovalPlan(
+                stage=RemovalStage.PRODUCT_SELECTORS,
+                pathIds=("omnigent.legacy.not_a_row",),
+            )
+        )
+
+
+def test_removal_plan_will_not_delete_a_later_stage_row_early() -> None:
+    from moonmind.omnigent.legacy_retirement import (
+        RemovalPlan,
+        evaluate_removal_plan,
+    )
+
+    # ``bridge_persistence`` is a historical reader (stage 9). A stage-1
+    # product-selector removal may not sweep it up.
+    path_id = "omnigent.legacy.bridge_persistence"
+    record = get_retirement_record(path_id)
+    closed = record.model_copy(
+        update={
+            "retirement_class": RetirementClass.HISTORICAL_READ_ONLY,
+            "new_admission_source": "",
+        }
+    )
+    report = evaluate_removal_plan(
+        RemovalPlan(stage=RemovalStage.PRODUCT_SELECTORS, pathIds=(path_id,)),
+        inventory=(closed,),
+        drained_by_path={path_id: _drained(closed)},
+        passed_by_path={path_id: _all_criteria(closed)},
+        retention_by_path={path_id: _closed_windows()},
+    )
+    assert report.allowed is False
+    assert any(
+        blocker.startswith("stage_too_early:")
+        for eligibility in report.blocked
+        for blocker in eligibility.blockers
+    )

--- a/tests/unit/omnigent/test_module_architecture.py
+++ b/tests/unit/omnigent/test_module_architecture.py
@@ -915,3 +915,400 @@ def test_environment_read_negative_fixtures(source: str, tmp_path) -> None:
         and node.attr in {"getenv", "environ"}
         for node in ast.walk(tree)
     )
+
+
+# ---------------------------------------------------------------------------
+# Permanent retirement guards (MoonLadderStudios/MoonMind#3835 required work 11)
+#
+# After retirement, CI must reject reintroduction of the duplicate architecture.
+# Each rule below is derived from the code-owned retirement inventory rather
+# than a hand-maintained list, so a *new* duplicate path fails these tests until
+# it is either removed or explicitly classified with a retirement class.
+# ---------------------------------------------------------------------------
+
+# The one module allowed to hold the versioned direct-vs-generic rollout
+# decision, and the one module allowed to hold the deployment runtime default.
+VERSIONED_ROLLOUT_AUTHORITY_MODULES = (
+    "moonmind/omnigent/cutover.py",
+    "moonmind/workflows/executions/runtime_defaults.py",
+)
+
+# Credential materialization handles are registered in exactly these modules.
+# A new credential path anywhere else bypasses runtime-pack and materializer
+# registration.
+CREDENTIAL_REGISTRATION_MODULES = (
+    "moonmind/omnigent/harness_platform/materializers.py",
+    "moonmind/omnigent/harness_platform/runtime_packs.py",
+    "moonmind/omnigent/credential_materializers.py",
+)
+_MATERIALIZER_REF_PATTERN = __import__("re").compile(
+    r"^[a-z0-9]+(?:-[a-z0-9]+)*-(?:oauth-home|auth-json|api-key)@\d+$"
+)
+
+# Shared-image resolution has one authority. A provider-specific resolver would
+# reintroduce per-provider image identity behind the shared image.
+SHARED_IMAGE_AUTHORITY_MODULES = (
+    "moonmind/omnigent/harness_platform/host_classes.py",
+    "moonmind/omnigent/harness_platform/static_hosts.py",
+    "moonmind/omnigent/bootstrap/image_resolution.py",
+    "moonmind/omnigent/bootstrap/store.py",
+)
+SHARED_IMAGE_ENV = "OMNIGENT_SHARED_HOST_IMAGE_REF"
+
+# Compose topology is one file plus the test-only project file.
+ALLOWED_COMPOSE_FILES = ("docker-compose.yaml", "docker-compose.test.yaml")
+
+_PROVIDER_LIFECYCLE_SUFFIXES = ("Coordinator", "Runtime", "Lifecycle", "Launcher")
+_PROVIDER_NAMES = ("Codex", "Claude", "OpenCode")
+
+
+def _inventory_surfaces() -> frozenset[str]:
+    from moonmind.omnigent.legacy_retirement import RETIREMENT_INVENTORY
+
+    return frozenset(ref for path in RETIREMENT_INVENTORY for ref in path.surfaces)
+
+
+def _provider_lifecycle_classes(tree: ast.AST) -> tuple[str, ...]:
+    """Top-level classes that own a provider-named lifecycle."""
+
+    return tuple(
+        node.name
+        for node in getattr(tree, "body", [])
+        if isinstance(node, ast.ClassDef)
+        and node.name.endswith(_PROVIDER_LIFECYCLE_SUFFIXES)
+        and any(provider in node.name for provider in _PROVIDER_NAMES)
+    )
+
+
+def _direct_default_assignments(
+    tree: ast.AST, direct_ids: frozenset[str]
+) -> tuple[str, ...]:
+    """Module-level ``*DEFAULT*`` constants bound to a direct runtime id."""
+
+    found: list[str] = []
+    for node in getattr(tree, "body", []):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [t.id for t in targets if isinstance(t, ast.Name)]
+        if not any("DEFAULT" in name for name in names):
+            continue
+        value = node.value
+        if isinstance(value, ast.Constant) and value.value in direct_ids:
+            found.append(names[0])
+    return tuple(found)
+
+
+def _legacy_fallback_constants(
+    tree: ast.AST, legacy_values: frozenset[str]
+) -> tuple[str, ...]:
+    """Legacy realizer/runtime literals produced inside an exception handler."""
+
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Constant) and inner.value in legacy_values:
+                found.append(str(inner.value))
+    return tuple(found)
+
+
+def test_no_new_top_level_provider_lifecycle_coordinator() -> None:
+    """A provider-named lifecycle owner must be an inventoried legacy path."""
+
+    surfaces = _inventory_surfaces()
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "moonmind/omnigent").rglob("*.py")):
+        relative = str(path.relative_to(REPO_ROOT))
+        module = relative.removesuffix(".py").replace("/", ".")
+        for name in _provider_lifecycle_classes(
+            ast.parse(path.read_text(encoding="utf-8"))
+        ):
+            if f"python:{module}:{name}" in surfaces:
+                continue
+            offenders.append(f"{relative}:{name}")
+    assert not offenders, (
+        "new top-level provider lifecycle coordinators must not be introduced; "
+        "the generic host owns the lifecycle and every retained provider "
+        f"coordinator carries a retirement row: {offenders}"
+    )
+
+
+def test_direct_default_selection_stays_in_versioned_rollout_authority() -> None:
+    """Only the rollout authority may name a direct runtime as a default."""
+
+    from moonmind.workflows.temporal.runtime.strategies import RUNTIME_STRATEGIES
+
+    direct_ids = frozenset(RUNTIME_STRATEGIES)
+    offenders: list[str] = []
+    for root in ("moonmind", "api_service"):
+        for path in sorted((REPO_ROOT / root).rglob("*.py")):
+            relative = str(path.relative_to(REPO_ROOT))
+            if relative in VERSIONED_ROLLOUT_AUTHORITY_MODULES:
+                continue
+            for name in _direct_default_assignments(
+                ast.parse(path.read_text(encoding="utf-8")), direct_ids
+            ):
+                offenders.append(f"{relative}:{name}")
+    assert not offenders, (
+        "a direct runtime may only become a default through the versioned "
+        f"rollout authority {VERSIONED_ROLLOUT_AUTHORITY_MODULES}: {offenders}"
+    )
+
+
+def test_no_implicit_fallback_from_generic_omnigent() -> None:
+    """A generic failure may never substitute a legacy realizer or runtime."""
+
+    from moonmind.omnigent.harness_platform.support import KNOWN_REALIZERS
+    from moonmind.omnigent.retirement_surfaces import GENERIC_REALIZER_REF
+    from moonmind.workflows.temporal.runtime.strategies import RUNTIME_STRATEGIES
+
+    legacy_values = frozenset(
+        {ref for ref in KNOWN_REALIZERS if ref != GENERIC_REALIZER_REF}
+        | set(RUNTIME_STRATEGIES)
+    )
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "moonmind/omnigent").rglob("*.py")):
+        relative = str(path.relative_to(REPO_ROOT))
+        for value in _legacy_fallback_constants(
+            ast.parse(path.read_text(encoding="utf-8")), legacy_values
+        ):
+            offenders.append(f"{relative}: {value}")
+    assert not offenders, (
+        "an except handler that yields a legacy realizer or direct runtime is "
+        f"an implicit fallback from generic Omnigent: {offenders}"
+    )
+
+
+def test_provider_profile_capacity_ownership_is_singular() -> None:
+    names = {
+        "acquire_provider_lease",
+        "release_provider_lease",
+        "evaluate_generic_host_capacity",
+    }
+    definitions: dict[str, list[str]] = {name: [] for name in names}
+    for root in (REPO_ROOT / "moonmind/omnigent", REPO_ROOT / "api_service"):
+        for path in sorted(root.rglob("*.py")):
+            relative = str(path.relative_to(REPO_ROOT))
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.name in definitions:
+                        definitions[node.name].append(relative)
+    for name, owners in definitions.items():
+        assert len(owners) <= 1, (
+            f"Provider Profile capacity function {name!r} has duplicate owners: "
+            f"{owners}"
+        )
+
+
+def _reads_environment_key(tree: ast.AST, key: str) -> bool:
+    """Whether a module resolves ``key`` from the environment.
+
+    Naming the key (as documentation, a replacement hint, or a value passed into
+    a launched host) is not resolution. Reading it to decide an image is.
+    """
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Subscript):
+            index = node.slice
+            if isinstance(index, ast.Constant) and index.value == key:
+                return True
+        elif isinstance(node, ast.Call):
+            func = node.func
+            attr = func.attr if isinstance(func, ast.Attribute) else None
+            name = func.id if isinstance(func, ast.Name) else None
+            if attr in {"getenv", "get"} or (name and "image_ref" in name):
+                if any(
+                    isinstance(arg, ast.Constant) and arg.value == key
+                    for arg in node.args
+                ):
+                    return True
+    return False
+
+
+def test_shared_image_resolution_is_not_provider_specific() -> None:
+    """Only the image authority may resolve the shared host image.
+
+    A provider-specific resolver would reintroduce per-provider image identity
+    behind the one shared image. A module that still resolves it because it owns
+    a retained legacy path is exempt only while it carries a retirement row, so
+    the exemption disappears with the code.
+    """
+
+    surfaces = _inventory_surfaces()
+    offenders: list[str] = []
+    for root in ("moonmind", "api_service"):
+        for path in sorted((REPO_ROOT / root).rglob("*.py")):
+            relative = str(path.relative_to(REPO_ROOT))
+            if relative in SHARED_IMAGE_AUTHORITY_MODULES:
+                continue
+            module = relative.removesuffix(".py").replace("/", ".")
+            if any(ref.startswith(f"python:{module}:") for ref in surfaces):
+                continue
+            if _reads_environment_key(
+                ast.parse(path.read_text(encoding="utf-8")), SHARED_IMAGE_ENV
+            ):
+                offenders.append(relative)
+    assert not offenders, (
+        "shared host image resolution has one authority "
+        f"{SHARED_IMAGE_AUTHORITY_MODULES}: {offenders}"
+    )
+
+
+def test_every_provider_specific_image_variable_is_inventoried() -> None:
+    """A per-provider image identity must carry a retirement class."""
+
+    from moonmind.omnigent.legacy_retirement import assert_inventory_is_complete
+    from moonmind.omnigent.retirement_surfaces import (
+        declared_image_environment_variables,
+    )
+
+    surfaces = _inventory_surfaces()
+    for variable in declared_image_environment_variables():
+        assert f"env:{variable}" in surfaces, (
+            f"per-provider image variable {variable} has no retirement row"
+        )
+    assert_inventory_is_complete()
+
+
+def test_credential_paths_stay_in_runtime_pack_and_materializer_registration() -> None:
+    """A credential handle must come from the materializer registry.
+
+    Consuming a registered materializer ref is ordinary Host Class, runtime-pack,
+    and conformance work. Naming a materializer-shaped ref that the registry
+    never registered is a new credential path outside registration.
+    """
+
+    from moonmind.omnigent.harness_platform.materializers import (
+        BUILTIN_MATERIALIZERS,
+    )
+
+    offenders: list[str] = []
+    for path in sorted((REPO_ROOT / "moonmind/omnigent").rglob("*.py")):
+        relative = str(path.relative_to(REPO_ROOT))
+        if relative in CREDENTIAL_REGISTRATION_MODULES:
+            continue
+        for literal in _string_literals(relative):
+            if (
+                _MATERIALIZER_REF_PATTERN.match(literal)
+                and literal not in BUILTIN_MATERIALIZERS
+            ):
+                offenders.append(f"{relative}: {literal}")
+    assert not offenders, (
+        "credential materialization handles are registered only in "
+        f"{CREDENTIAL_REGISTRATION_MODULES}: {offenders}"
+    )
+
+
+def test_no_hidden_legacy_compose_overlay_or_startup_script() -> None:
+    """Compose topology and provider startup scripts stay discoverable."""
+
+    from moonmind.omnigent.legacy_retirement import assert_inventory_is_complete
+
+    compose_files = sorted(
+        path.name
+        for path in REPO_ROOT.glob("docker-compose*.y*ml")
+    )
+    assert compose_files == sorted(ALLOWED_COMPOSE_FILES), (
+        "a new Compose file is hidden deployment topology; consolidate it or "
+        f"declare it: {compose_files}"
+    )
+    # Any provider-specific Compose service, profile, or startup script that is
+    # not classified with a retirement class fails here.
+    assert_inventory_is_complete()
+
+
+def test_architecture_exception_modules_are_inventoried_legacy_paths() -> None:
+    """A boundary exemption may only shelter a classified legacy component."""
+
+    from moonmind.omnigent.legacy_retirement import (
+        ARCHITECTURE_BOUNDARY_EXCEPTIONS,
+        RetirementClass,
+        get_retirement_record,
+    )
+
+    for exception in ARCHITECTURE_BOUNDARY_EXCEPTIONS:
+        record = get_retirement_record(exception.retirement_path_id)
+        assert record.retirement_class is not RetirementClass.REMOVED, (
+            f"architecture exception {exception.exception_id} is owned by a "
+            "removed retirement row; delete the exemption with the code"
+        )
+
+
+# Negative fixtures: each retirement guard must actually reject the shape it
+# forbids, so a future refactor cannot leave it vacuously passing.
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "class ClaudeSessionCoordinator:\n    pass\n",
+        "class OpenCodeHostLifecycle:\n    pass\n",
+        "class CodexManagedRuntime:\n    pass\n",
+    ),
+)
+def test_provider_lifecycle_coordinator_negative_fixtures(source: str) -> None:
+    assert _provider_lifecycle_classes(ast.parse(source))
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "DEFAULT_WORKFLOW_RUNTIME = 'codex_cli'",
+        "SOME_DEFAULT_RUNTIME = 'claude_code'",
+    ),
+)
+def test_direct_default_selection_negative_fixtures(source: str) -> None:
+    assert _direct_default_assignments(
+        ast.parse(source), frozenset({"codex_cli", "claude_code"})
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "try:\n    generic()\nexcept Exception:\n    realizer = 'codex-profile-bound@1'\n",
+        "try:\n    generic()\nexcept Exception:\n    return 'codex_cli'\n",
+    ),
+)
+def test_implicit_fallback_negative_fixtures(source: str) -> None:
+    assert _legacy_fallback_constants(
+        ast.parse(source),
+        frozenset({"codex-profile-bound@1", "codex_cli"}),
+    )
+
+
+def test_implicit_fallback_detector_ignores_non_handler_literals() -> None:
+    # Recording the realizer a plan already selected is not a fallback.
+    source = "recorded = 'codex-profile-bound@1'\n"
+    assert not _legacy_fallback_constants(
+        ast.parse(source), frozenset({"codex-profile-bound@1"})
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "IMAGE = os.getenv('OMNIGENT_SHARED_HOST_IMAGE_REF')",
+        "IMAGE = os.environ['OMNIGENT_SHARED_HOST_IMAGE_REF']",
+        "IMAGE = environment.get('OMNIGENT_SHARED_HOST_IMAGE_REF', '')",
+    ),
+)
+def test_shared_image_resolution_negative_fixtures(source: str) -> None:
+    assert _reads_environment_key(ast.parse(source), SHARED_IMAGE_ENV)
+
+
+def test_shared_image_detector_ignores_a_named_replacement_hint() -> None:
+    # Naming the canonical variable as an operator hint is not resolution.
+    source = "HINT = Obsolete(replacement='OMNIGENT_SHARED_HOST_IMAGE_REF')"
+    assert not _reads_environment_key(ast.parse(source), SHARED_IMAGE_ENV)
+
+
+def test_unregistered_materializer_ref_is_a_new_credential_path() -> None:
+    from moonmind.omnigent.harness_platform.materializers import (
+        BUILTIN_MATERIALIZERS,
+    )
+
+    assert _MATERIALIZER_REF_PATTERN.match("gemini-oauth-home@1")
+    assert "gemini-oauth-home@1" not in BUILTIN_MATERIALIZERS

--- a/tests/unit/omnigent/test_obsolete_configuration_startup.py
+++ b/tests/unit/omnigent/test_obsolete_configuration_startup.py
@@ -1,0 +1,80 @@
+"""Obsolete Omnigent configuration is never silently ignored at startup.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required work section 10).
+
+Before an image or environment alias is removed, a deployment that still supplies
+it must get an actionable failure naming the replacement; after removal the value
+is rejected outright. These tests drive the real API startup helper rather than
+the pure guard so the wiring at the startup boundary is proven, not assumed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from moonmind.omnigent import legacy_retirement
+from moonmind.omnigent.legacy_retirement import (
+    ObsoleteConfiguration,
+    ObsoleteConfigurationError,
+)
+
+VARIABLE = "OMNIGENT_HOST_IMAGE_REF"
+ROW = "omnigent.legacy.host_image_variable_alias"
+
+
+def _startup_guard():
+    from api_service.main import _assert_omnigent_configuration_is_current
+
+    return _assert_omnigent_configuration_is_current
+
+
+def _deprecated() -> tuple[ObsoleteConfiguration, ...]:
+    return (
+        ObsoleteConfiguration(
+            variable=VARIABLE,
+            retirementPathId=ROW,
+            replacement="OMNIGENT_SHARED_HOST_IMAGE_REF",
+            deprecated=True,
+            guidance="Repin the shared image digest before the next release.",
+        ),
+    )
+
+
+def test_startup_accepts_the_current_configuration(monkeypatch) -> None:
+    monkeypatch.setenv(VARIABLE, "ghcr.io/example/host@sha256:" + "a" * 64)
+    # Nothing is deprecated today: the alias is still the supported way to pin a
+    # prior image while the rollback window is open.
+    _startup_guard()()
+
+
+def test_startup_warns_actionably_during_the_deprecation_window(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", _deprecated())
+    monkeypatch.setenv(VARIABLE, "ghcr.io/example/host@sha256:" + "a" * 64)
+    with caplog.at_level(logging.WARNING):
+        _startup_guard()()
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        VARIABLE in message
+        and "OMNIGENT_SHARED_HOST_IMAGE_REF" in message
+        and ROW in message
+        for message in messages
+    ), messages
+
+
+def test_startup_is_rejected_after_the_variable_is_removed(monkeypatch) -> None:
+    removed = (_deprecated()[0].model_copy(update={"removed": True}),)
+    monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", removed)
+    monkeypatch.setenv(VARIABLE, "ghcr.io/example/host@sha256:" + "a" * 64)
+    with pytest.raises(ObsoleteConfigurationError, match="no longer honored"):
+        _startup_guard()()
+
+
+def test_startup_ignores_an_unset_obsolete_variable(monkeypatch) -> None:
+    removed = (_deprecated()[0].model_copy(update={"removed": True}),)
+    monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", removed)
+    monkeypatch.delenv(VARIABLE, raising=False)
+    _startup_guard()()

--- a/tests/unit/omnigent/test_obsolete_configuration_startup.py
+++ b/tests/unit/omnigent/test_obsolete_configuration_startup.py
@@ -10,6 +10,7 @@ the pure guard so the wiring at the startup boundary is proven, not assumed.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import pytest
@@ -78,3 +79,55 @@ def test_startup_ignores_an_unset_obsolete_variable(monkeypatch) -> None:
     monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", removed)
     monkeypatch.delenv(VARIABLE, raising=False)
     _startup_guard()()
+
+
+# ---------------------------------------------- every consuming process
+
+
+def test_agent_runtime_worker_startup_enforces_the_same_check(monkeypatch) -> None:
+    """The worker is separately restartable and consumes the same variables.
+
+    Installing the check only in the API lifespan means restarting or deploying
+    ``temporal-worker-agent-runtime`` without the API produces no deprecation
+    warning during the window, and after removal the worker would silently
+    accept a variable the API rejects.
+    """
+
+    from moonmind.workflows.temporal import worker_runtime
+
+    removed = (_deprecated()[0].model_copy(update={"removed": True}),)
+    monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", removed)
+    monkeypatch.setenv(VARIABLE, "ghcr.io/example/host@sha256:" + "a" * 64)
+
+    called: list[str] = []
+    monkeypatch.setattr(
+        worker_runtime,
+        "describe_configured_worker",
+        lambda: called.append("topology") or _unreachable_topology(),
+    )
+    with pytest.raises(ObsoleteConfigurationError, match="no longer honored"):
+        asyncio.run(worker_runtime.main_async())
+
+
+def test_agent_runtime_worker_startup_warns_during_deprecation(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from moonmind.workflows.temporal import worker_runtime
+
+    monkeypatch.setattr(legacy_retirement, "OBSOLETE_CONFIGURATION", _deprecated())
+    monkeypatch.setenv(VARIABLE, "ghcr.io/example/host@sha256:" + "a" * 64)
+    with caplog.at_level(logging.WARNING):
+        legacy_retirement.enforce_obsolete_configuration_at_startup(
+            worker_runtime.logger
+        )
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        VARIABLE in message and "OMNIGENT_SHARED_HOST_IMAGE_REF" in message
+        for message in messages
+    ), messages
+
+
+def _unreachable_topology():
+    raise AssertionError(
+        "worker startup must reject obsolete configuration before topology use"
+    )

--- a/tests/unit/omnigent/test_retirement_admission_boundary.py
+++ b/tests/unit/omnigent/test_retirement_admission_boundary.py
@@ -1,0 +1,298 @@
+"""New-admission enforcement at the real plan-compilation boundary.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required work section 2).
+
+Plan compilation is the single new-admission boundary for every client: the
+trusted planner default, an alternate API client supplying an explicit
+``execution_realizer_ref``, a schedule, and a preset all resolve here. These
+tests drive :func:`compile_execution_plan` itself — not a nearby helper — so the
+code-owned retirement class is proven to gate real Codex plan admission.
+
+They also prove the two ordering rules the issue insists on:
+
+* new admission stops *only* when the class says so — today every legacy row is
+  ``active_product_path`` because #3833 has not promoted the qualified generic
+  rows, so Codex plan compilation still succeeds; and
+* disabling new admission never touches execution, cancellation, cleanup, or
+  reads for an already-recorded plan.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from moonmind.omnigent import legacy_retirement
+from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfileV2
+from moonmind.omnigent.harness_platform.catalog import (
+    HarnessImplementationIdentity,
+    TrustState,
+    classify_harness_trust,
+    create_catalog_snapshot,
+)
+from moonmind.omnigent.harness_platform.credential_bindings import create_binding_set
+from moonmind.omnigent.harness_platform.failures import (
+    HarnessPlatformError,
+    HarnessPlatformFailure,
+)
+from moonmind.omnigent.harness_platform.host_classes import HostClass
+from moonmind.omnigent.harness_platform.planner import compile_execution_plan
+from moonmind.omnigent.harness_platform.skills import ResolvedSkillSet
+from moonmind.omnigent.legacy_retirement import (
+    RetirementClass,
+    get_retirement_record,
+)
+
+PROFILE_BOUND_REALIZER = "codex-profile-bound@1"
+PROFILE_BOUND_PATH_ID = "omnigent.legacy.profile_bound_realizer"
+_IMPL_DIGEST = "sha256:" + "e" * 64
+
+
+def _catalog():
+    return create_catalog_snapshot(
+        endpointRef="default",
+        omnigentVersion="1.0.0",
+        omnigentBuildDigest="sha256:" + "b" * 64,
+        sourceDigest="sha256:" + "c" * 64,
+        harnesses=[
+            {
+                "id": "codex-native",
+                "aliases": [],
+                "label": "codex-native",
+                "implementation": {
+                    "sourceKind": "core",
+                    "package": "omnigent",
+                    "version": "1.0.0",
+                    "digest": _IMPL_DIGEST,
+                    "pluginEntryPoint": None,
+                },
+                "runtimeRequirements": {},
+                "capabilities": {
+                    "integrationMode": "native-server",
+                    "authModel": "own-auth",
+                    "interrupt": True,
+                    "streaming": True,
+                },
+                "setupSteps": [],
+            }
+        ],
+        observedAt=datetime.now(UTC),
+    )
+
+
+def _host_class(implementation_ref: str) -> HostClass:
+    return HostClass.model_validate(
+        {
+            "hostClassId": "omnigent-codex-current",
+            "version": 1,
+            "imageRef": "ghcr.io/example/codex-host@sha256:" + "d" * 64,
+            "omnigentVersion": "1.0.0",
+            "omnigentBuildDigest": "sha256:" + "b" * 64,
+            "architectures": ["linux/amd64"],
+            "declaredHarnessImplementations": [
+                {
+                    "harnessId": "codex-native",
+                    "implementationRef": implementation_ref,
+                    "runtimeDependencies": [],
+                }
+            ],
+            "integrationModes": ["native-server"],
+            "materializerRefs": ["codex-oauth-home@1"],
+            "features": {
+                "readOnlyRoot": True,
+                "restrictedEgress": True,
+                "workspaceBind": True,
+            },
+            "runtime": {"uid": 1000, "gid": 1000, "home": "/home/app"},
+        }
+    )
+
+
+@pytest.fixture()
+def codex_plan_inputs() -> dict[str, object]:
+    catalog = _catalog()
+    impl = HarnessImplementationIdentity.model_validate(
+        {
+            "sourceKind": "core",
+            "package": "omnigent",
+            "version": "1.0.0",
+            "digest": _IMPL_DIGEST,
+            "pluginEntryPoint": None,
+        }
+    )
+    trust = classify_harness_trust(
+        harnessId="codex-native",
+        implementation=impl,
+        trustState=TrustState.core_trusted,
+    )
+    profile = OmnigentAgentProfileV2.model_validate(
+        {
+            "schemaVersion": "moonmind.omnigent-agent-profile.v2",
+            "endpointRef": "default",
+            "source": {
+                "kind": "upstream",
+                "upstreamId": "codex-native-ui",
+                "upstreamVersion": "1.0.0",
+                "upstreamSnapshotDigest": "sha256:" + "d" * 64,
+            },
+            "harness": {
+                "id": "codex-native",
+                "catalogRef": catalog.catalogRef,
+                "implementationRef": impl.implementation_ref(),
+            },
+            "requirements": {
+                "harness": {"required": []},
+                "moonmind": {"required": []},
+                "host": {"required": []},
+            },
+            "credentialSlots": [
+                {
+                    "id": "primary-model",
+                    "optional": False,
+                    "acceptedAuthModels": ["oauth_volume"],
+                    "acceptedProviderIds": ["openai"],
+                }
+            ],
+            "model": {},
+            "workspace": {},
+            "skills": [],
+            "tools": [],
+            "capture": {},
+            "continuations": {},
+            "publish": {},
+            "allowedLaunchPolicyRefs": ["codex-on-demand@1"],
+        }
+    )
+    skills = ResolvedSkillSet.model_validate(
+        {
+            "resolvedSkillSetRef": "artifact:test",
+            "resolvedSkillSetDigest": "sha256:" + "a" * 64,
+            "skillDeliveryRef": "skill-delivery:sha256:" + "b" * 64,
+        }
+    )
+    binding_set = create_binding_set(
+        bindingSetId="codex",
+        version=1,
+        bindings={
+            "primary-model": {
+                "providerProfileRef": "p1",
+                "materializerRef": "codex-oauth-home@1",
+            }
+        },
+    )
+    return dict(
+        agent_profile=profile,
+        harness_catalog=catalog,
+        trust_record=trust,
+        resolved_skills=skills,
+        credential_binding_set=binding_set,
+        host_class_ref="omnigent-codex-current@1",
+        host_class=_host_class(impl.implementation_ref()),
+        launch_policy_ref="codex-on-demand@1",
+        model_qualified_id="gpt-5",
+        model_effort=None,
+        model_route_ref="openai",
+        model_normalized_options={},
+    )
+
+
+def _reclassify(monkeypatch: pytest.MonkeyPatch, **updates: object) -> None:
+    record = get_retirement_record(PROFILE_BOUND_PATH_ID)
+    changed = record.model_copy(update=updates)
+    monkeypatch.setitem(
+        legacy_retirement._INVENTORY_BY_ID, PROFILE_BOUND_PATH_ID, changed
+    )
+    monkeypatch.setitem(
+        legacy_retirement._INVENTORY_BY_SURFACE,
+        f"realizer:{PROFILE_BOUND_REALIZER}",
+        changed,
+    )
+
+
+def test_active_product_path_still_compiles_codex_plans(codex_plan_inputs) -> None:
+    # #3833 has not promoted the qualified generic rows, so the legacy realizer
+    # is still the trusted Codex selection and new admission must not stop.
+    assert (
+        get_retirement_record(PROFILE_BOUND_PATH_ID).retirement_class
+        is RetirementClass.ACTIVE_PRODUCT_PATH
+    )
+    envelope = compile_execution_plan(**codex_plan_inputs)
+    assert envelope.payload.executionRealizerRef == PROFILE_BOUND_REALIZER
+
+
+def test_new_admission_disabled_rejects_the_trusted_planner_default(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reclassify(
+        monkeypatch,
+        retirement_class=RetirementClass.NEW_ADMISSION_DISABLED,
+        new_admission_source="",
+    )
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(**codex_plan_inputs)
+    assert (
+        excinfo.value.code
+        == HarnessPlatformFailure.OMNIGENT_EXECUTION_REALIZER_UNAVAILABLE.value
+    )
+    assert "no longer admits new work" in str(excinfo.value)
+
+
+def test_alternate_client_cannot_bypass_the_retirement_state(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit client-supplied realizer is held to the same class."""
+
+    _reclassify(
+        monkeypatch,
+        retirement_class=RetirementClass.NEW_ADMISSION_DISABLED,
+        new_admission_source="",
+    )
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(
+            **codex_plan_inputs,
+            execution_realizer_ref=PROFILE_BOUND_REALIZER,
+        )
+    assert "no longer admits new work" in str(excinfo.value)
+
+
+def test_rollback_only_admits_only_the_allowlisted_generation(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reclassify(
+        monkeypatch,
+        retirement_class=RetirementClass.ROLLBACK_ONLY,
+        new_admission_source="operator rollback generation",
+        rollback_dependency=True,
+        rollback_generations=frozenset({"gen-rollback-1"}),
+    )
+    with pytest.raises(HarnessPlatformError):
+        compile_execution_plan(**codex_plan_inputs)
+
+    with pytest.raises(HarnessPlatformError):
+        compile_execution_plan(**codex_plan_inputs, rollback_generation="gen-rollback")
+
+    envelope = compile_execution_plan(
+        **codex_plan_inputs, rollback_generation="gen-rollback-1"
+    )
+    assert envelope.payload.executionRealizerRef == PROFILE_BOUND_REALIZER
+
+
+def test_disabled_admission_does_not_change_recorded_plans(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An already-compiled plan keeps its recorded realizer and digest."""
+
+    recorded = compile_execution_plan(**codex_plan_inputs)
+    _reclassify(
+        monkeypatch,
+        retirement_class=RetirementClass.TEMPORAL_REPLAY_ONLY,
+        new_admission_source="",
+        replay_dependency=True,
+    )
+    assert recorded.payload.executionRealizerRef == PROFILE_BOUND_REALIZER
+    # The realizer stays registered and resolvable for the recorded plan even
+    # though no new plan may select it.
+    from moonmind.omnigent.harness_platform.support import validate_realizer
+
+    validate_realizer(recorded.payload.executionRealizerRef)

--- a/tests/unit/omnigent/test_retirement_admission_boundary.py
+++ b/tests/unit/omnigent/test_retirement_admission_boundary.py
@@ -19,7 +19,7 @@ They also prove the two ordering rules the issue insists on:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -42,6 +42,10 @@ from moonmind.omnigent.harness_platform.skills import ResolvedSkillSet
 from moonmind.omnigent.legacy_retirement import (
     RetirementClass,
     get_retirement_record,
+)
+from moonmind.omnigent.session_supervisor_rollback import (
+    DEFAULT_ROLLBACK_EXERCISE_MAX_AGE,
+    RollbackExerciseRecord,
 )
 
 PROFILE_BOUND_REALIZER = "codex-profile-bound@1"
@@ -256,9 +260,43 @@ def test_alternate_client_cannot_bypass_the_retirement_state(
     assert "no longer admits new work" in str(excinfo.value)
 
 
-def test_rollback_only_admits_only_the_allowlisted_generation(
-    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
-) -> None:
+# ``host_architecture`` is deliberately omitted: it belongs to the atomic
+# launch-authority set, and the rollback scope must resolve the effective
+# architecture the plan actually runs on (the Host Class default here).
+ROLLBACK_SCOPE_INPUTS: dict[str, object] = {
+    "agent_profile_snapshot_ref": "agent-profile-snapshot:rollback",
+    "rollback_owner_cohort": "internal",
+}
+
+
+def _exercise_record(**overrides: object) -> RollbackExerciseRecord:
+    """A fresh, successful exercise for exactly the compiled plan's scope."""
+
+    scope = {
+        "agentProfileRef": ROLLBACK_SCOPE_INPUTS["agent_profile_snapshot_ref"],
+        "hostClassRef": "omnigent-codex-current@1",
+        "materializerRef": "codex-oauth-home@1",
+        "executionRealizerRef": PROFILE_BOUND_REALIZER,
+        "modelQualifiedId": "gpt-5",
+        "launchPolicyRef": "codex-on-demand@1",
+        "hostMode": "on-demand",
+        "architecture": "linux/amd64",
+        "ownerCohort": ROLLBACK_SCOPE_INPUTS["rollback_owner_cohort"],
+    }
+    scope.update(overrides.pop("scope", {}))  # type: ignore[arg-type]
+    payload: dict[str, object] = {
+        "retirementPathId": PROFILE_BOUND_PATH_ID,
+        "scope": scope,
+        "exercisedAt": datetime.now(UTC),
+        "evidenceRef": "artifact://rollback-exercise",
+        "succeeded": True,
+        "futureAdmissionOnly": True,
+    }
+    payload.update(overrides)
+    return RollbackExerciseRecord.model_validate(payload)
+
+
+def _reclassify_rollback_only(monkeypatch: pytest.MonkeyPatch) -> None:
     _reclassify(
         monkeypatch,
         retirement_class=RetirementClass.ROLLBACK_ONLY,
@@ -266,16 +304,112 @@ def test_rollback_only_admits_only_the_allowlisted_generation(
         rollback_dependency=True,
         rollback_generations=frozenset({"gen-rollback-1"}),
     )
+
+
+def test_rollback_only_admits_only_the_allowlisted_generation(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reclassify_rollback_only(monkeypatch)
     with pytest.raises(HarnessPlatformError):
         compile_execution_plan(**codex_plan_inputs)
 
     with pytest.raises(HarnessPlatformError):
-        compile_execution_plan(**codex_plan_inputs, rollback_generation="gen-rollback")
+        compile_execution_plan(
+            **codex_plan_inputs,
+            **ROLLBACK_SCOPE_INPUTS,
+            rollback_generation="gen-rollback",
+            rollback_exercise_records=[_exercise_record()],
+        )
 
     envelope = compile_execution_plan(
-        **codex_plan_inputs, rollback_generation="gen-rollback-1"
+        **codex_plan_inputs,
+        **ROLLBACK_SCOPE_INPUTS,
+        rollback_generation="gen-rollback-1",
+        rollback_exercise_records=[_exercise_record()],
     )
     assert envelope.payload.executionRealizerRef == PROFILE_BOUND_REALIZER
+
+
+def test_rollback_only_refuses_a_generation_with_no_exercise_evidence(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The allowlisted generation alone is a global string, not scoped evidence."""
+
+    _reclassify_rollback_only(monkeypatch)
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(
+            **codex_plan_inputs,
+            **ROLLBACK_SCOPE_INPUTS,
+            rollback_generation="gen-rollback-1",
+        )
+    assert "rollback_exercise" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "dimension, value",
+    [
+        ("hostClassRef", "omnigent-codex-other@1"),
+        ("materializerRef", "codex-api-key@1"),
+        ("modelQualifiedId", "gpt-5-codex"),
+        ("launchPolicyRef", "codex-static@1"),
+        ("hostMode", "static-connected"),
+        ("architecture", "linux/arm64"),
+        ("ownerCohort", "external"),
+        ("agentProfileRef", "agent-profile-snapshot:other"),
+    ],
+)
+def test_rollback_exercise_does_not_widen_beyond_its_exact_scope(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch, dimension: str, value: str
+) -> None:
+    """One exercised combination never re-admits a different one."""
+
+    _reclassify_rollback_only(monkeypatch)
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(
+            **codex_plan_inputs,
+            **ROLLBACK_SCOPE_INPUTS,
+            rollback_generation="gen-rollback-1",
+            rollback_exercise_records=[_exercise_record(scope={dimension: value})],
+        )
+    assert "rollback_exercise" in str(excinfo.value)
+
+
+def test_rollback_exercise_expires_with_its_window(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evidence older than the exercise window no longer re-admits new work."""
+
+    _reclassify_rollback_only(monkeypatch)
+    expired = _exercise_record(
+        exercisedAt=datetime.now(UTC)
+        - (DEFAULT_ROLLBACK_EXERCISE_MAX_AGE + timedelta(minutes=1))
+    )
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(
+            **codex_plan_inputs,
+            **ROLLBACK_SCOPE_INPUTS,
+            rollback_generation="gen-rollback-1",
+            rollback_exercise_records=[expired],
+        )
+    assert "rollback_exercise" in str(excinfo.value)
+
+
+def test_rollback_only_requires_every_scope_dimension(
+    codex_plan_inputs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plan that cannot name its exact scope fails closed."""
+
+    _reclassify_rollback_only(monkeypatch)
+    incomplete = dict(ROLLBACK_SCOPE_INPUTS)
+    incomplete["rollback_owner_cohort"] = None
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        compile_execution_plan(
+            **codex_plan_inputs,
+            **incomplete,
+            rollback_generation="gen-rollback-1",
+            rollback_exercise_records=[_exercise_record()],
+        )
+    assert "rollback_scope_incomplete" in str(excinfo.value)
 
 
 def test_disabled_admission_does_not_change_recorded_plans(

--- a/tests/unit/workflows/temporal/test_legacy_generation_replay.py
+++ b/tests/unit/workflows/temporal/test_legacy_generation_replay.py
@@ -1,0 +1,253 @@
+"""Representative Temporal histories for every retained runtime generation.
+
+Source issue: MoonLadderStudios/MoonMind#3835 (required work section 4).
+
+Retirement may not proceed until the target worker build can replay a
+representative history for each retained implementation generation. This module
+records those histories on a time-skipping server and replays every one of them
+against the *current* worker build, covering the generations the issue
+enumerates:
+
+* direct Codex workflows and sessions
+* direct Claude workflows and sessions
+* ``codex-profile-bound@1`` executions
+* continuation and checkpoint histories
+* cancellation and cleanup histories
+* janitor and Provider Profile manager histories
+* migration and rollback generations
+
+Each generation is recorded twice — once as a pre-patch (legacy) history and once
+through the versioned patch branch the retirement introduces — so a source file
+may become a thin replay-visible wrapper without changing the recorded command
+semantics. The replay assertions check the recorded payloads, not just that
+replay did not raise: a history that replays but reports a different realizer,
+runtime, or command would silently rewrite provenance.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from temporalio import workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
+
+with workflow.unsafe.imports_passed_through():
+    from moonmind.omnigent.legacy_retirement import (
+        RETIREMENT_INVENTORY,
+        RetirementClass,
+        RuntimeGeneration,
+    )
+
+# The patch that gates the retirement-era branch. Versioned so every legacy
+# branch stays registered for the supported history window.
+LEGACY_GENERATION_RETIREMENT_PATCH = "omnigent-legacy-generation-retirement-v1"
+
+# One representative recorded command payload per generation. These are the
+# semantics a replay must preserve exactly; the retirement may re-home the code
+# that produces them but may never change what an old history means.
+GENERATION_COMMANDS: dict[str, dict[str, Any]] = {
+    "direct_codex_session": {
+        "generation": "direct_codex",
+        "runtimeId": "codex_cli",
+        "executionRealizerRef": None,
+        "command": "managed_session.start",
+        "provenance": "codex_direct_compat",
+    },
+    "direct_claude_session": {
+        "generation": "direct_claude",
+        "runtimeId": "claude_code",
+        "executionRealizerRef": None,
+        "command": "managed_session.start",
+        "provenance": "claude_direct",
+    },
+    "codex_profile_bound_execution": {
+        "generation": "codex_profile_bound",
+        "runtimeId": "omnigent",
+        "executionRealizerRef": "codex-profile-bound@1",
+        "command": "omnigent.execute",
+        "provenance": "codex-profile-bound@1",
+    },
+    "continuation_checkpoint": {
+        "generation": "codex_profile_bound",
+        "runtimeId": "omnigent",
+        "executionRealizerRef": "codex-profile-bound@1",
+        "command": "omnigent.continue_from_checkpoint",
+        "provenance": "codex-profile-bound@1",
+    },
+    "cancellation_cleanup": {
+        "generation": "direct_codex",
+        "runtimeId": "codex_cli",
+        "executionRealizerRef": None,
+        "command": "managed_session.cancel_and_cleanup",
+        "provenance": "codex_direct_compat",
+    },
+    "janitor_provider_profile_manager": {
+        "generation": "shared_legacy_substrate",
+        "runtimeId": "omnigent",
+        "executionRealizerRef": None,
+        "command": "oauth_host_janitor.reclaim",
+        "provenance": "provider_profile_manager",
+    },
+    "migration_rollback": {
+        "generation": "shared_legacy_substrate",
+        "runtimeId": "omnigent",
+        "executionRealizerRef": "codex-profile-bound@1",
+        "command": "migration.rollback_to_recorded_default",
+        "provenance": "rollback_generation:gen-1",
+    },
+}
+
+
+@workflow.defn(name="MM3835LegacyGenerationReplayFixture")
+class _LegacyGenerationReplayFixture:
+    """Pre-patch history: the generation's command with no retirement gating."""
+
+    @workflow.run
+    async def run(self, generation_key: str) -> dict[str, Any]:
+        return dict(GENERATION_COMMANDS[generation_key], patched=False)
+
+
+@workflow.defn(name="MM3835LegacyGenerationReplayFixture")
+class _CurrentGenerationReplayFixture:
+    """Post-patch history: the same recorded command behind a versioned patch."""
+
+    @workflow.run
+    async def run(self, generation_key: str) -> dict[str, Any]:
+        # Snapshot the patch decision before any branch reads it so replay stays
+        # stable (mirrors the run.py patch-snapshot convention).
+        retirement_gated = workflow.patched(LEGACY_GENERATION_RETIREMENT_PATCH)
+        command = dict(GENERATION_COMMANDS[generation_key])
+        # The retirement branch may only add non-semantic retirement metadata.
+        # The recorded realizer, runtime, command, and provenance are unchanged.
+        command["patched"] = retirement_gated
+        return command
+
+
+@pytest.mark.asyncio
+async def test_direct_and_profile_bound_generation_histories_replay() -> None:
+    recorded: dict[str, list[Any]] = {}
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-mm3835-legacy",
+            workflows=[_LegacyGenerationReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            for key in GENERATION_COMMANDS:
+                handle = await env.client.start_workflow(
+                    _LegacyGenerationReplayFixture.run,
+                    key,
+                    id=f"test-mm3835-legacy-{key}",
+                    task_queue="test-mm3835-legacy",
+                )
+                result = await handle.result()
+                assert result == dict(GENERATION_COMMANDS[key], patched=False)
+                recorded.setdefault(key, []).append(await handle.fetch_history())
+
+        async with Worker(
+            env.client,
+            task_queue="test-mm3835-current",
+            workflows=[_CurrentGenerationReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            for key in GENERATION_COMMANDS:
+                handle = await env.client.start_workflow(
+                    _CurrentGenerationReplayFixture.run,
+                    key,
+                    id=f"test-mm3835-current-{key}",
+                    task_queue="test-mm3835-current",
+                )
+                result = await handle.result()
+                assert result == dict(GENERATION_COMMANDS[key], patched=True)
+                recorded.setdefault(key, []).append(await handle.fetch_history())
+
+    # One target worker build replays every retained generation, pre- and
+    # post-patch, without the legacy launch path being available.
+    replayer = Replayer(
+        workflows=[_CurrentGenerationReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    for key, histories in recorded.items():
+        assert len(histories) == 2, key
+        for history in histories:
+            await replayer.replay_workflow(history)
+
+
+@pytest.mark.asyncio
+async def test_nonterminal_history_preserves_recorded_command_semantics() -> None:
+    """An in-flight (nonterminal) history replays with unchanged semantics."""
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-mm3835-nonterminal",
+            workflows=[_LegacyGenerationReplayFixture],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                _LegacyGenerationReplayFixture.run,
+                "codex_profile_bound_execution",
+                id="test-mm3835-nonterminal",
+                task_queue="test-mm3835-nonterminal",
+            )
+            # Capture the history before the workflow result is consumed, then
+            # let it complete; both shapes must remain replayable.
+            nonterminal = await handle.fetch_history()
+            await handle.result()
+            terminal = await handle.fetch_history()
+
+    replayer = Replayer(
+        workflows=[_CurrentGenerationReplayFixture],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+    await replayer.replay_workflow(nonterminal)
+    await replayer.replay_workflow(terminal)
+
+
+def test_retirement_patch_is_versioned_and_snapshotted() -> None:
+    assert LEGACY_GENERATION_RETIREMENT_PATCH.endswith("-v1")
+    source = inspect.getsource(_CurrentGenerationReplayFixture.run)
+    assert source.count("LEGACY_GENERATION_RETIREMENT_PATCH") == 1
+    assert source.index("workflow.patched(") < source.index("command = dict(")
+
+
+def test_every_replay_dependent_generation_has_a_representative_history() -> None:
+    """A row that declares a replay dependency must be covered by this corpus."""
+
+    covered = {command["generation"] for command in GENERATION_COMMANDS.values()}
+    for path in RETIREMENT_INVENTORY:
+        if not path.replay_dependency:
+            continue
+        assert path.generation.value in covered, (
+            f"{path.path_id} declares a replay dependency but generation "
+            f"{path.generation.value} has no representative history"
+        )
+    # Every generation the issue names is represented, including the ones with
+    # no direct-launch code of their own.
+    assert {
+        RuntimeGeneration.DIRECT_CODEX.value,
+        RuntimeGeneration.DIRECT_CLAUDE.value,
+        RuntimeGeneration.CODEX_PROFILE_BOUND.value,
+        RuntimeGeneration.SHARED_LEGACY_SUBSTRATE.value,
+    } <= covered
+
+
+def test_recorded_histories_are_never_relabeled_as_generic() -> None:
+    """Replay must not rewrite provenance to make the past look generic."""
+
+    for key, command in GENERATION_COMMANDS.items():
+        assert command["provenance"] != "generic-omnigent-host@1", key
+        if command["executionRealizerRef"] is not None:
+            assert command["executionRealizerRef"] != "generic-omnigent-host@1", key
+
+
+def test_replay_only_rows_never_admit_new_work() -> None:
+    """A replay wrapper must be closed to new admission, not a parallel default."""
+
+    for path in RETIREMENT_INVENTORY:
+        if path.retirement_class is RetirementClass.TEMPORAL_REPLAY_ONLY:
+            assert path.admits_new_work is False, path.path_id
+            assert path.replay_dependency is True, path.path_id


### PR DESCRIPTION
## Issue

- Issue: [MoonLadderStudios/MoonMind#3835](https://github.com/MoonLadderStudios/MoonMind/issues/3835) — *[Omnigent retirement] Retire duplicate direct and profile-bound runtime architecture after generic cutover*
- Parent: #3825 · Design source: #3823 and `docs/Omnigent/PrimaryRuntimeProviderStrategy.md` §5.9, §5.10, §10–12

Closes MoonLadderStudios/MoonMind#3835

## Summary

The recorded assessment verdict was `PARTIALLY_IMPLEMENTED`, so this change completes the unmet and partially-met acceptance criteria only.

**No legacy implementation is deleted.** The issue is explicit that it is not permission to delete legacy code immediately, and blocking dependency #3833 (product-default migration and rollback controls) is still open. Every retained component stays in a class that admits new work or supports existing work; nothing is `eligible_for_removal` or `removed`. What lands here is the code-owned inventory, the class-driven admission control, and the evidence-gated staged-removal machinery that #3835 owns.

### Retirement inventory (AC1, AC8)
- Adds the ten-value `RetirementClass` taxonomy and grows `RETIREMENT_INVENTORY` to 25 rows spanning every component family the issue enumerates. Each row records owner, class, last new-admission source, active resource dependencies, replay/historical-read/rollback dependencies, required evidence, earliest removal stage, and removal guard test. `RuntimeGeneration` keeps direct Codex, direct Claude, and `codex-profile-bound@1` independently decidable.
- Adds `moonmind/omnigent/retirement_surfaces.py`: typed scheme-prefixed surface refs plus discovery derived from `KNOWN_REALIZERS`, `RUNTIME_STRATEGIES`, `services/omnigent/scripts`, `docker-compose.yaml`, and declared image environment constants. `assert_inventory_is_complete` fails CI on an unclassified surface, so a document checklist is no longer the source of truth.

### New-admission control (AC2, AC3)
- Enforces the code-owned class at the real boundaries: `compile_execution_plan` (`harness_platform/planner.py`) and `cutover.select_runtime`. A trusted planner default, an alternate client's explicit `executionRealizerRef`, a schedule, and a preset are all held to the same state.
- `rollback_only` re-admits only under an exactly allowlisted rollback generation resolved from the existing `revert_default_to_legacy` control.
- Disabling admission never touches recorded plans — a recorded plan keeps its realizer and stays resolvable, executable, cancellable, and readable.

### Drain, replay, historical reads, rollback (AC4–AC7)
- `moonmind/omnigent/retirement_drain.py` adds an `ActiveOwnerProbe` port with fail-closed aggregation: missing, stale, and failed probes never drain a kind, and probe refs are constrained to operator-safe identifiers.
- Adds a representative Temporal history corpus for every retained generation and replays all of them, pre- and post-patch, on one target worker build.
- Adds historical-read and provenance coverage for direct Claude and `codex-profile-bound@1` with every legacy launch module made unimportable. Historical work stays labeled with its own generation; provenance is not rewritten to look generic.
- Adds `RollbackScope`, `RollbackExerciseRecord`, and `evaluate_rollback_exercise` with exact nine-dimension matching and evidence expiry; a rollback-dependent row cannot become removal-eligible without a fresh recorded exercise.

### Staged removal and permanent guards (AC9–AC11)
- Adds the nine ordered `RemovalStage` values, `RemovalPlan`, and `evaluate_removal_plan` so each future removal PR must cite its rows, blockers, and guard tests — and a historical reader can never be swept into a product-selector removal.
- Adds `OBSOLETE_CONFIGURATION` and wires `assert_obsolete_configuration` into API startup: a deprecated variable warns actionably with its replacement, a removed variable rejects startup, and no obsolete value is silently ignored.
- Adds the seven missing architecture guards with negative fixtures: no new top-level provider lifecycle coordinator, direct defaults confined to the versioned rollout authority, no implicit fallback from generic Omnigent, one Provider Profile capacity owner, no provider-specific shared-image resolution, credential handles confined to registered materializers, and no hidden Compose overlay or unclassified startup script.

### Documentation (AC12)
- Reconciles `OmnigentModuleArchitecture.md`, `PrimaryRuntimeProviderStrategy.md`, `SharedHostImage.md`, `CombinedStackValidationAndRollback.md`, `OmnigentHarnessPlatformDesign.md`, `.env-template`, and the #3834 static-host startup runbook with the actual current state.

## Tests

| Suite | Command | Result |
|---|---|---|
| Retirement inventory + admission + obsolete configuration | `./tools/test_unit.sh --python-only --no-xdist -- tests/unit/omnigent/test_legacy_retirement.py tests/unit/omnigent/test_retirement_admission_boundary.py tests/unit/omnigent/test_obsolete_configuration_startup.py` | **PASS** — 68 passed |
| Architecture guards + historical reads + fencing + Temporal replay | `./tools/test_unit.sh --python-only --no-xdist -- tests/unit/omnigent/test_module_architecture.py tests/unit/omnigent/test_legacy_generation_historical_reads.py tests/unit/omnigent/reconciler/test_legacy_result_fencing.py tests/unit/workflows/temporal/test_legacy_generation_replay.py` | **PASS** — 530 passed (includes time-skipping record/replay for every retained generation) |
| Impacted neighbours (run replayer, docs guards, legacy API retirement) | `./tools/test_unit.sh --python-only -- tests/unit/workflows/temporal/test_run_replayer.py tests/unit/docs tests/unit/api/test_legacy_api_retirement.py` | **PASS** — 105 passed |
| Full changed-area suite | `./tools/test_unit.sh --python-only -- tests/unit/omnigent` | **PASS (no new failures)** — 2693 passed, 67 failed, 2 skipped. The same 67 node ids fail identically at baseline `01f12e5b6` (verified in a clean clone; sorted-FAILED-node-id diff is empty). Zero regressions attributable to this change. |
| Baseline regression control | clean clone at `HEAD~1`, same 8 affected files | Baseline reproduces the same 67 failures |
| Hermetic integration (`integration_ci`) | `./tools/test_integration.sh` | **NOT RUN** — not selected by impact; the change touches no Docker, compose, database, migration, or integration-boundary surface. |

Pre-existing environment failures are the vendored upstream `omnigent` package being absent, no Docker daemon, and a commit-pinned source digest.

## Remaining risks

- **R1 (pre-existing, non-blocking):** `moonmind/omnigent/cutover.py:select_runtime` still has no production caller, so the admission gate added there is dormant. If a direct-runtime row's class later advances, direct Codex/Claude new admission would not be refused at a live boundary until the rollout authority is wired.
- **R2:** No concrete `ActiveOwnerProbe` adapter exists yet, and `retirement_drain.collect_drain_evidence`'s probe-failure path is uncovered. Fail-closed by construction, so the absence of probes blocks removal rather than permitting it.
- **R3:** Representative histories are recorded from fixture workflows rather than captured production `MoonMind.AgentSession` / `OmnigentSession` histories. This matches the repo's existing replay-test convention but is a weaker proxy; the `ALL_SUPPORTED_HISTORIES_REPLAY` criterion remains unmet in the guard, so no removal can rely on it.
- **R4:** Historical-read coverage under launch-code-unavailable conditions is proven on the bridge journal read model; artifact, checkpoint, publication, and usage projections rely on their own pre-existing suites.
- **R5:** `OBSOLETE_CONFIGURATION` covers `OMNIGENT_OPENCODE_HOST_IMAGE_REF` and `OMNIGENT_PI_HOST_IMAGE_REF` but not their `_IMAGE` / `_IMAGE_TAG` companions, which `docker-compose.yaml` still expands. If those aliases later enter a deprecation window, the tag form would be honored without a warning.

**Out of scope (by the issue's own text):** live drain of real active Temporal workflows, AgentRuns, Provider Profile leases, host leases, and credential consumers requires a deployed control plane; and execution of any removal stage is forbidden until evidence permits and #3833 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
