### PR TITLE
Fix remediation crash from verifier-supplied progress digests

### DIFF
--- a/docs/Workflows/RemediationVerificationCadence.md
+++ b/docs/Workflows/RemediationVerificationCadence.md
@@ -81,6 +81,16 @@ The attempt number is the retry-cycle number, not the individual gap number. A s
 10. **Optional tooling never gates the verdict.** Unavailable or misconfigured optional enrichment tooling (for example MoonMind RAG retrieval failing with `embedding_provider_not_configured`) is recorded as a `NOT RUN` environment note. `NO_DETERMINATION` is reserved for verification targets that cannot be established at all: a missing or unreadable authoritative input, unrecoverably truncated acceptance criteria, or repository evidence for visible in-scope requirements that cannot be inspected.
 11. **Every attempt preserves one authoritative candidate source.** A remediation loop should carry a workflow-owned cumulative workspace head so each attempt continues from the prior candidate checkpoint. That head is supplied by the capture/persistence boundary and, when present, remains the single authority: an attempt or verifier bound to a different head version or attempt ordinal is rejected, and the head crosses Continue-As-New with the loop state. When a runtime cannot capture that checkpoint, MoonMind may admit a checkpointless attempt only from the same repository branch and exact head SHA that the admitting verifier proved was publication-authorized, uncontaminated, and remote-verified after either a push or a verified no-change result. The remediation request is pinned to that admitted SHA; its verifier follows the resulting head of the same candidate branch, and both preserve the verified base branch separately for publication. Missing, advanced, or mismatched checkpoint and remote-branch evidence stops the attempt before dispatch; a managed runtime must never select another run's checkout or an unverified branch tip as an implicit fallback. An admitted checkpointless attempt still advances the loop out of remediation so its verifier's evidence can be evaluated.
 
+For additional-work verdicts with structured `remainingWork`, the artifact
+publisher owns the compact progress identity. It computes
+`validatedRefs.authoritativeEvidenceDigest` from the published remaining-work
+entries, independent of entry order, and stamps
+`progressEvidenceSchemaVersion=remediation-progress-evidence/v1`. Supplied values
+for these two fields are replaced, including syntactically valid stale digests;
+the verifier continues to own the gaps and verdict. Workflow history carries the
+computed digest and artifact references, while the full evidence stays in the
+artifact.
+
 ---
 
 ## 5. When immediate verification is still required

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -7959,13 +7959,14 @@ class TemporalAgentRuntimeActivities:
                     if isinstance(validated_refs_value, Mapping)
                     else {}
                 )
-                validated_refs.setdefault(
-                    "progressEvidenceSchemaVersion",
-                    "remediation-progress-evidence/v1",
+                # These fields attest to the evidence published here. Agent
+                # supplied placeholders or stale digests cannot own progress
+                # identity, even when they are syntactically valid hashes.
+                validated_refs["progressEvidenceSchemaVersion"] = (
+                    "remediation-progress-evidence/v1"
                 )
-                validated_refs.setdefault(
-                    "authoritativeEvidenceDigest",
-                    _unordered_json_list_digest(remaining_work),
+                validated_refs["authoritativeEvidenceDigest"] = (
+                    _unordered_json_list_digest(remaining_work)
                 )
                 gate_payload["validatedRefs"] = validated_refs
                 gate_payload.pop("validated_refs", None)

--- a/tests/fixtures/reliability/remediation-progress-digest.json
+++ b/tests/fixtures/reliability/remediation-progress-digest.json
@@ -1,0 +1,23 @@
+{
+  "incidentWorkflowId": "mm:e2ed01e4-ffb1-45e3-b3b6-3eebb2994773",
+  "boundary": "agent_runtime.publish_artifacts to dynamic remediation verification",
+  "escapedFailure": "progressSignature must be a sha256 digest",
+  "verifierPayload": {
+    "schemaVersion": "moonspec-verify.issue_brief.v1",
+    "verdict": "ADDITIONAL_WORK_NEEDED",
+    "recommendedNextAction": "reattempt_current_step",
+    "recoverableInCurrentRuntime": false,
+    "remainingWork": [
+      {
+        "gapType": "verification",
+        "recoverableInCurrentRuntime": false,
+        "requirement": "CLI contract unit evidence + default admission authority suite + required hermetic journey + selector regression (execution)",
+        "remainingWork": "Execute the required tests in a runner with pytest or the managed container backend and attach PASS evidence."
+      }
+    ],
+    "validatedRefs": {
+      "authoritativeEvidenceDigest": "sha256:recomputed-by-publisher-from-remainingWork",
+      "progressEvidenceSchemaVersion": "remediation-progress-evidence/v1"
+    }
+  }
+}

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -49,6 +50,7 @@ from moonmind.workflows.skills.deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_VERSION,
 )
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
+from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.activity_catalog import (
     AGENT_RUNTIME_FLEET,
     ARTIFACTS_FLEET,
@@ -3133,44 +3135,71 @@ async def test_remaining_work_digest_is_independent_of_entry_order() -> None:
     )
 
 
+@pytest.mark.parametrize("runtime", ["codex_cli", "claude_code", "omnigent"])
+@pytest.mark.parametrize(
+    "supplied_digest",
+    ["incident", "absent", None, "", "unknown", "sha256:" + "0" * 64],
+)
 async def test_agent_runtime_publish_artifacts_links_remediation_verification_attempt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    runtime: str,
+    supplied_digest: str | None,
 ) -> None:
     async with temporal_db(tmp_path) as session_maker:
         async with session_maker() as session:
             workspace = tmp_path / "workspace"
             verify_path = workspace / "var/artifacts/moonspec-verify/final.json"
             verify_path.parent.mkdir(parents=True)
-            verify_path.write_text(
-                json.dumps(
-                    {
-                        "schemaVersion": "moonspec-verify.issue_brief.v1",
-                        "moonSpecVerdict": "ADDITIONAL_WORK_NEEDED",
-                        "recommendedNextAction": "reattempt_current_step",
-                        "recoverableInCurrentRuntime": True,
-                        "remainingWork": [
-                            {
-                                "requirement": "artifact linkage",
-                                "gapType": "implementation",
-                                "remainingWork": "link verification to attempt",
-                            }
-                        ],
-                    }
-                ),
-                encoding="utf-8",
+            fixture = json.loads(
+                (
+                    Path(__file__).resolve().parents[3]
+                    / "fixtures/reliability/remediation-progress-digest.json"
+                ).read_text(encoding="utf-8")
             )
+            payload = fixture["verifierPayload"]
+            refs = payload["validatedRefs"]
+            if supplied_digest == "absent":
+                # Historical verifier payloads omitted publisher metadata.
+                payload.pop("validatedRefs")
+            elif supplied_digest != "incident":
+                refs["authoritativeEvidenceDigest"] = supplied_digest
+                refs["progressEvidenceSchemaVersion"] = "untrusted-schema"
+            verify_path.write_text(json.dumps(payload), encoding="utf-8")
             run_store = ManagedRunStore(tmp_path / "runs")
             run_store.save(
                 ManagedRunRecord(
                     runId="verify-run-2",
-                    agentId="codex_cli",
-                    runtimeId="codex_cli",
+                    agentId=runtime,
+                    runtimeId=runtime,
                     status="completed",
                     startedAt=datetime.now(timezone.utc),
                     workspacePath=workspace.as_posix(),
                 )
             )
+            workspace_metadata = {"agentRunId": "verify-run-2"}
+            if runtime == "omnigent":
+                workspace = tmp_path / "temporal_sandbox" / "verify-workspace" / "repo"
+                sandbox_verify = workspace / "var/artifacts/moonspec-verify/final.json"
+                sandbox_verify.parent.mkdir(parents=True)
+                sandbox_verify.write_text(verify_path.read_text(), encoding="utf-8")
+                SandboxWorkspaceRecordStore(tmp_path).ensure(
+                    SandboxWorkspaceRecord(
+                        workspace_id="verify-workspace",
+                        workflow_id="parent-wf",
+                        step_execution_id="parent-wf:run:verify:execution:1",
+                        relative_path="repo",
+                    )
+                )
+                workspace_metadata = {
+                    "correlationId": "parent-wf",
+                    "idempotencyKey": "parent-wf:run:verify:execution:1:agent_execute",
+                    "workspaceLocator": {
+                        "kind": "sandbox",
+                        "workspaceId": "verify-workspace",
+                        "relativePath": "repo",
+                    },
+                }
             service = TemporalArtifactService(
                 TemporalArtifactRepository(session),
                 store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
@@ -3178,6 +3207,7 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
             activities = TemporalAgentRuntimeActivities(
                 artifact_service=service,
                 run_store=run_store,
+                workspace_root=tmp_path,
             )
 
             async def _skip_notify(*_args: Any, **_kwargs: Any) -> dict[str, str]:
@@ -3202,7 +3232,7 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
                 AgentRunResult(
                     summary="Completed.",
                     metadata={
-                        "agentRunId": "verify-run-2",
+                        **workspace_metadata,
                         "verify_artifact_path": (
                             "var/artifacts/moonspec-verify/final.json"
                         ),
@@ -3237,7 +3267,10 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
             assert evidence["progressEvidenceSchemaVersion"] == (
                 "remediation-progress-evidence/v1"
             )
-            assert evidence["authoritativeEvidenceDigest"].startswith("sha256:")
+            expected_digest = activity_runtime_module._unordered_json_list_digest(
+                payload["remainingWork"]
+            )
+            assert evidence["authoritativeEvidenceDigest"] == expected_digest
             artifact, artifact_path = await service.read_path(
                 artifact_id=verification_ref,
                 principal="system:agent_runtime",
@@ -3255,10 +3288,75 @@ async def test_agent_runtime_publish_artifacts_links_remediation_verification_at
                 "moonSpecVerifyArtifactRef"
             ] == result.metadata["sourceMoonSpecVerifyArtifactRef"]
             assert persisted_payload["remainingGaps"][0]["requirement"] == (
-                "artifact linkage"
+                payload["remainingWork"][0]["requirement"]
             )
             assert persisted_payload["moonSpecVerify"]["remainingWorkRef"] == (
                 result.metadata["sourceMoonSpecVerifyArtifactRef"]
+            )
+
+            assert persisted_payload["moonSpecVerify"]["validatedRefs"] == evidence
+
+            # Cross the production workflow gate with the published compact
+            # result, so the publisher and controller cannot drift independently.
+            monkeypatch.setattr(
+                run_module.workflow,
+                "info",
+                lambda: SimpleNamespace(workflow_id="parent-wf", run_id="run"),
+            )
+            monkeypatch.setattr(
+                run_module.workflow,
+                "patched",
+                lambda patch_id: (
+                    patch_id == run_module.RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH
+                ),
+            )
+            monkeypatch.setattr(
+                run_module.workflow,
+                "now",
+                lambda: datetime(2026, 9, 5, tzinfo=timezone.utc),
+            )
+            parent = run_module.MoonMindRunWorkflow()
+            parent._initialize_remediation_loop_controller(
+                ordered_nodes=[{
+                    "id": "controller",
+                    "inputs": {"runtime": {"mode": runtime}},
+                    "annotations": {"remediationLoop": {
+                        "loopId": "issue-implementation-remediation",
+                        "remediationTool": {
+                            "name": "remediate-issue",
+                            "inputs": {"instructions": "Remediate the verified gaps."},
+                        },
+                        "verificationTool": {
+                            "name": "moonspec-verify",
+                            "inputs": {"instructions": "Verify the candidate."},
+                        },
+                        "workspacePolicy": "continue_from_loop_head",
+                        "budgets": {"hardMaxAttempts": 6},
+                        "terminalPolicy": {
+                            "fullyImplemented": "advance",
+                            "additionalWorkNeeded": "continue_when_allowed",
+                            "blocked": "stop",
+                            "noDetermination": "retry_evidence_or_stop",
+                            "failedUnrecoverable": "stop",
+                        },
+                        "sideEffectPolicy": "workflow_owned",
+                        "publicationPolicy": "evaluate_after_terminal",
+                    }},
+                }]
+            )
+            parent._write_json_artifact = AsyncMock(return_value="artifact://decision")
+            gate_payload = result.metadata["moonSpecVerify"]
+            gate = parent._moonspec_verify_gate_result({"moonSpecVerify": gate_payload})
+            admitted = await parent._evaluate_dynamic_remediation_verification(
+                ordered_nodes=[],
+                verdict=gate.verdict,
+                gate_result_ref="artifact://" + verification_ref,
+                remaining_work_ref="artifact://" + gate.remaining_work_ref,
+                progress_signature=gate.validated_refs["authoritativeEvidenceDigest"],
+            )
+            assert admitted is True
+            assert parent._remediation_loop_state.latest_progress_signature == (
+                expected_digest
             )
 
 


### PR DESCRIPTION
Workflow `mm:e2ed01e4-ffb1-45e3-b3b6-3eebb2994773` failed after verification because the published report retained the agent-supplied placeholder `sha256:recomputed-by-publisher-from-remainingWork`. The artifact publisher used `setdefault`, so the remediation controller rejected the value with `progressSignature must be a sha256 digest`.

Compute the progress digest and schema marker at publication from the structured remaining-work evidence, replacing supplied placeholders and stale hashes. The verifier still owns the gaps and verdict. Activity payload shapes and workflow commands remain unchanged; existing recorded activity results are not rewritten.

Validation:
- 388 targeted unit tests passed across artifact publication, remediation contracts, and workflow gates.
- The minimized incident fixture exercises publication through Codex, Claude Code, and Omnigent workspace boundaries, then enters the real remediation gate; 18 cases cover the placeholder, omitted metadata, null/blank/unknown values, and stale hashes.
- Confirmed the incident regression fails against the original publisher and passes with the fix.
- Isolated Compose integration suite: 630 passed, 1 skipped.
