### PR TITLE
Fix provider profile manager replay before lease cleanup

### DIFF
--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1418,8 +1418,11 @@ themselves:
 - the narrowed drain set that exempts a credentialless profile, so a pre-marker
   manager still drains every lease;
 - the per-purpose scope exemption, so a pre-marker manager still gates credential
-  repair and revocation on shared-scope availability; and
-- withdrawing a pending request when its owner releases.
+  repair and revocation on shared-scope availability;
+- withdrawing a pending request when its owner releases; and
+- scheduling periodic released-lease tombstone cleanup. DB lease persistence
+  alone does not enable this activity: older histories proceed directly to
+  lease verification at that boundary and must preserve that command order.
 
 A grant that moved under a recorded history would emit a reservation — and, under
 DB lease persistence, a `provider_profile.sync_slot_leases` activity — where the

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1419,10 +1419,24 @@ themselves:
   manager still drains every lease;
 - the per-purpose scope exemption, so a pre-marker manager still gates credential
   repair and revocation on shared-scope availability;
-- withdrawing a pending request when its owner releases; and
-- scheduling periodic released-lease tombstone cleanup. DB lease persistence
-  alone does not enable this activity: older histories proceed directly to
-  lease verification at that boundary and must preserve that command order.
+- withdrawing a pending request when its owner releases.
+
+Periodic released-lease tombstone cleanup has its own workflow marker,
+`provider-profile-manager-lease-tombstone-purge-v1`. Both DB lease persistence and
+maintenance durability predate cleanup; neither may enable the purge activity
+on replay. Histories without cleanup proceed directly to lease verification at
+that boundary. New executions record the cleanup marker and perform periodic
+cleanup, with failures contained so lease verification and admission can proceed.
+
+Deployment requires replaying every active singleton manager history against the
+candidate worker. Histories that already contain an unmarked `purge_released`
+activity cannot be distinguished from the older generation by its maintenance
+marker. Those histories require a controlled cutover: retain their compatible
+worker until its state-preserving Continue-As-New handoff, then route the new run
+to the patched worker before it starts. The handoff must retain held leases,
+fencing counters, pending slot requests and maintenance queue order. A direct
+worker replacement, termination, or reset is not a safe substitute. Managers
+whose histories contain no purge can upgrade directly after successful replay.
 
 A grant that moved under a recorded history would emit a reservation — and, under
 DB lease persistence, a `provider_profile.sync_slot_leases` activity — where the

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -2137,8 +2137,13 @@ class MoonMindProviderProfileManagerWorkflow:
 
             # Reap release tombstones on a deterministic cadence so the lease
             # table stays bounded while the high-water mark outlives them.
-            if workflow.patched(DB_LEASE_PERSISTENCE_PATCH) and (
-                self._event_count % _LEASE_TOMBSTONE_PURGE_EVENT_INTERVAL == 0
+            # Cleanup was introduced with maintenance durability. Older
+            # histories already have DB persistence but go straight to lease
+            # verification here; inserting an activity breaks their replay.
+            if (
+                self._durable_maintenance_queue
+                and workflow.patched(DB_LEASE_PERSISTENCE_PATCH)
+                and self._event_count % _LEASE_TOMBSTONE_PURGE_EVENT_INTERVAL == 0
             ):
                 await self._purge_released_lease_rows()
 

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -49,6 +49,7 @@ WORKFLOW_ID_PREFIX = "provider-profile-manager"
 # "auth-profile" spellings in identifiers until a deliberate workflow migration.
 VERIFY_LEASE_HOLDERS_PATCH = "auth-profile-manager-verify-leases-v1"
 DB_LEASE_PERSISTENCE_PATCH = "provider-profile-manager-db-lease-persistence-v1"
+LEASE_TOMBSTONE_PURGE_PATCH = "provider-profile-manager-lease-tombstone-purge-v1"
 SLOT_HANDOFF_RESERVATION_PATCH = "provider-profile-manager-slot-handoff-v1"
 REFRESH_RESTORED_PROFILES_PATCH = (
     "provider-profile-manager-refresh-restored-profiles-v1"
@@ -2137,11 +2138,11 @@ class MoonMindProviderProfileManagerWorkflow:
 
             # Reap release tombstones on a deterministic cadence so the lease
             # table stays bounded while the high-water mark outlives them.
-            # Cleanup was introduced with maintenance durability. Older
-            # histories already have DB persistence but go straight to lease
-            # verification here; inserting an activity breaks their replay.
+            # Maintenance durability predates cleanup, so neither its marker
+            # nor DB persistence identifies a history that scheduled a purge.
+            # Preserve older histories' direct transition to lease verification.
             if (
-                self._durable_maintenance_queue
+                workflow.patched(LEASE_TOMBSTONE_PURGE_PATCH)
                 and workflow.patched(DB_LEASE_PERSISTENCE_PATCH)
                 and self._event_count % _LEASE_TOMBSTONE_PURGE_EVENT_INTERVAL == 0
             ):

--- a/tests/unit/workflows/temporal/fixtures/provider_profile_manager_maintenance_before_purge.json
+++ b/tests/unit/workflows/temporal/fixtures/provider_profile_manager_maintenance_before_purge.json
@@ -1,0 +1,1146 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-09-05T21:29:25.460Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "MoonMind.ProviderProfileManager"
+        },
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJsZWFzZV9ncmFudGVkX2F0Ijp7InRlc3QtZGVmYXVsdCI6eyJ0ZXN0LWFjdGl2ZS1hZ2VudCI6IjIwMjYtMDktMDVUMjE6Mjk6MjUuNDUxMDAwKzAwOjAwIn19LCJsZWFzZXMiOnsidGVzdC1kZWZhdWx0IjpbInRlc3QtYWN0aXZlLWFnZW50Il19LCJwcm9maWxlcyI6W3siY3JlZGVudGlhbF9zb3VyY2UiOiJhcGlfa2V5IiwiZW5hYmxlZCI6dHJ1ZSwiaXNfZGVmYXVsdCI6dHJ1ZSwibWF4X3BhcmFsbGVsX3J1bnMiOjEsInByb2ZpbGVfaWQiOiJ0ZXN0LWRlZmF1bHQiLCJydW50aW1lX2lkIjoib3BlbmNvZGUiLCJydW50aW1lX21hdGVyaWFsaXphdGlvbl9tb2RlIjoiZW52In1dLCJydW50aW1lX2lkIjoib3BlbmNvZGUifQ=="
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "315360000s",
+        "workflowRunTimeout": "315360000s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "2a468932-ef1d-4e45-9668-03fff63948e8",
+        "identity": "1@6dacb904ad45",
+        "firstExecutionRunId": "2a468932-ef1d-4e45-9668-03fff63948e8",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-09-05T21:29:25.460Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-09-05T21:29:25.460Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "1@6dacb904ad45",
+        "historySizeBytes": "640"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "1@6dacb904ad45",
+        "binaryChecksum": "899b74c50f6d29e3339528f4c383b564",
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            2,
+            1,
+            3
+          ],
+          "sdkName": "temporal-python",
+          "sdkVersion": "1.32.0"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY29kZXgtb2F1dGgtbGVnYWN5LXJlc3RvcmUtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1tYWludGVuYW5jZS1xdWV1ZS1kdXJhYmlsaXR5LXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1tYWludGVuYW5jZS1xdWV1ZS1kdXJhYmlsaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1tYWludGVuYW5jZS1xdWV1ZS1kdXJhYmlsaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "3"
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "3",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLW1haW50ZW5hbmNlLXF1ZXVlLWR1cmFiaWxpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "provider_profile.sync_slot_leases"
+        },
+        "taskQueue": {
+          "name": "mm.activity.artifacts",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJhY3Rpb24iOiJsb2FkIiwicnVudGltZV9pZCI6Im9wZW5jb2RlIn0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "30s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "3",
+        "retryPolicy": {
+          "initialInterval": "2s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "30s",
+          "maximumAttempts": 3
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-09-05T21:29:25.474Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "19",
+        "identity": "1@6dacb904ad45",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-09-05T21:29:25.477Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJsZWFzZXMiOltdLCJzeW5jZWQiOjB9"
+            }
+          ]
+        },
+        "scheduledEventId": "19",
+        "startedEventId": "20",
+        "identity": "1@6dacb904ad45"
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-09-05T21:29:25.477Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-09-05T21:29:25.477Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "22",
+        "identity": "1@6dacb904ad45",
+        "historySizeBytes": "4713"
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-09-05T21:29:25.481Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "22",
+        "identity": "1@6dacb904ad45",
+        "binaryChecksum": "899b74c50f6d29e3339528f4c383b564",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2026-09-05T21:29:25.481Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "23"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2026-09-05T21:29:25.481Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "23",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLW1haW50ZW5hbmNlLXF1ZXVlLWR1cmFiaWxpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2026-09-05T21:29:25.481Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "provider_profile.list"
+        },
+        "taskQueue": {
+          "name": "mm.activity.artifacts",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJydW50aW1lX2lkIjoib3BlbmNvZGUifQ=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "30s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "23",
+        "retryPolicy": {
+          "initialInterval": "2s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "30s",
+          "maximumAttempts": 5
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2026-09-05T21:29:25.481Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "27",
+        "identity": "1@6dacb904ad45",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2026-09-05T21:29:25.483Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJwcm9maWxlcyI6W3siY3JlZGVudGlhbF9zb3VyY2UiOiJhcGlfa2V5IiwiZW5hYmxlZCI6dHJ1ZSwiaXNfZGVmYXVsdCI6dHJ1ZSwibGF1bmNoX3JlYWR5Ijp0cnVlLCJtYXhfcGFyYWxsZWxfcnVucyI6MSwicHJvZmlsZV9pZCI6InRlc3QtZGVmYXVsdCIsInJ1bnRpbWVfaWQiOiJvcGVuY29kZSIsInJ1bnRpbWVfbWF0ZXJpYWxpemF0aW9uX21vZGUiOiJlbnYifV19"
+            }
+          ]
+        },
+        "scheduledEventId": "27",
+        "startedEventId": "28",
+        "identity": "1@6dacb904ad45"
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2026-09-05T21:29:25.483Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": "2026-09-05T21:29:25.483Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "30",
+        "identity": "1@6dacb904ad45",
+        "historySizeBytes": "6117"
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "30",
+        "identity": "1@6dacb904ad45",
+        "binaryChecksum": "899b74c50f6d29e3339528f4c383b564",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLW1haW50ZW5hbmNlLXF1ZXVlLWR1cmFiaWxpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLW1haW50ZW5hbmNlLXF1ZXVlLWR1cmFiaWxpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItbWFpbnRlbmFuY2UtcXVldWUtZHVyYWJpbGl0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcmVmcmVzaC1yZXN0b3JlZC1wcm9maWxlcy12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItbWFpbnRlbmFuY2UtcXVldWUtZHVyYWJpbGl0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "42",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItbWFpbnRlbmFuY2UtcXVldWUtZHVyYWJpbGl0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "43",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1zY2hlZHVsZWQtcGVuZGluZy1yZXF1ZXN0cy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "44",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItbWFpbnRlbmFuY2UtcXVldWUtZHVyYWJpbGl0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItc2NoZWR1bGVkLXBlbmRpbmctcmVxdWVzdHMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "45",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6ImF1dGgtcHJvZmlsZS1tYW5hZ2VyLXZlcmlmeS1sZWFzZXMtdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "46",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNhcGFjaXR5LXNjb3BlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNsYXVkZS1vYXV0aC1leGNsdXNpdmUtY2FwYWNpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY29kZXgtb2F1dGgtbGVnYWN5LXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZGItYXV0aG9yaXRhdGl2ZS1wcm9maWxlLXN5bmMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZGItbGVhc2UtcGVyc2lzdGVuY2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZHVyYWJsZS1sZWFzZS1ncmFudC12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLW1haW50ZW5hbmNlLXF1ZXVlLWR1cmFiaWxpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHJpb3JpdHktcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcXVldWUtb3JkZXItcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXNjaGVkdWxlZC1wZW5kaW5nLXJlcXVlc3RzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "47",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1hY3Rpdml0eS1vd25lZC1sZWFzZS12ZXJpZmljYXRpb24tdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "48",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWFjdGl2aXR5LW93bmVkLWxlYXNlLXZlcmlmaWNhdGlvbi12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNvZGV4LW9hdXRoLWxlZ2FjeS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWF1dGhvcml0YXRpdmUtcHJvZmlsZS1zeW5jLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWxlYXNlLXBlcnNpc3RlbmNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWR1cmFibGUtbGVhc2UtZ3JhbnQtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZnJlc2gtc3RhcnQtZGItbGVhc2UtcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1tYWludGVuYW5jZS1xdWV1ZS1kdXJhYmlsaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXByaW9yaXR5LXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXF1ZXVlLW9yZGVyLXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcmVmcmVzaC1yZXN0b3JlZC1wcm9maWxlcy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1zY2hlZHVsZWQtcGVuZGluZy1yZXF1ZXN0cy12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "49",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktcGVuZGluZy1yZXF1ZXN0cy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "31"
+      }
+    },
+    {
+      "eventId": "50",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "31",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "type": "S2V5d29yZExpc3Q=",
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWFjdGl2aXR5LW93bmVkLWxlYXNlLXZlcmlmaWNhdGlvbi12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNvZGV4LW9hdXRoLWxlZ2FjeS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWF1dGhvcml0YXRpdmUtcHJvZmlsZS1zeW5jLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWxlYXNlLXBlcnNpc3RlbmNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWR1cmFibGUtbGVhc2UtZ3JhbnQtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZnJlc2gtc3RhcnQtZGItbGVhc2UtcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1tYWludGVuYW5jZS1xdWV1ZS1kdXJhYmlsaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXByaW9yaXR5LXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXF1ZXVlLW9yZGVyLXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcmVmcmVzaC1yZXN0b3JlZC1wcm9maWxlcy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1zY2hlZHVsZWQtcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktcGVuZGluZy1yZXF1ZXN0cy12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "51",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "provider_profile.verify_lease_holders"
+        },
+        "taskQueue": {
+          "name": "mm.activity.artifacts",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ3b3JrZmxvd19pZHMiOlsidGVzdC1hY3RpdmUtYWdlbnQiXX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "315360000s",
+        "scheduleToStartTimeout": "315360000s",
+        "startToCloseTimeout": "30s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "31",
+        "retryPolicy": {
+          "initialInterval": "2s",
+          "backoffCoefficient": 2.0,
+          "maximumInterval": "30s",
+          "maximumAttempts": 3
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "52",
+      "eventTime": "2026-09-05T21:29:25.486Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "51",
+        "identity": "1@6dacb904ad45",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "53",
+      "eventTime": "2026-09-05T21:29:25.488Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ0ZXN0LWFjdGl2ZS1hZ2VudCI6eyJydW5uaW5nIjp0cnVlLCJzdGF0dXMiOiJORVdfU1RBVFVTIn19"
+            }
+          ]
+        },
+        "scheduledEventId": "51",
+        "startedEventId": "52",
+        "identity": "1@6dacb904ad45"
+      }
+    },
+    {
+      "eventId": "54",
+      "eventTime": "2026-09-05T21:29:25.488Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "55",
+      "eventTime": "2026-09-05T21:29:25.488Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "54",
+        "identity": "1@6dacb904ad45",
+        "historySizeBytes": "15621"
+      }
+    },
+    {
+      "eventId": "56",
+      "eventTime": "2026-09-05T21:29:25.491Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "54",
+        "identity": "1@6dacb904ad45",
+        "binaryChecksum": "899b74c50f6d29e3339528f4c383b564",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "57",
+      "eventTime": "2026-09-05T21:29:25.491Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "timerStartedEventAttributes": {
+        "timerId": "1",
+        "startToFireTimeout": "60s",
+        "workflowTaskCompletedEventId": "55"
+      }
+    },
+    {
+      "eventId": "58",
+      "eventTime": "2026-09-05T21:29:25.491Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "shutdown",
+        "input": {},
+        "identity": "1@6dacb904ad45"
+      }
+    },
+    {
+      "eventId": "59",
+      "eventTime": "2026-09-05T21:29:25.491Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "test-profile-cleanup"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 2
+      }
+    },
+    {
+      "eventId": "60",
+      "eventTime": "2026-09-05T21:29:25.491Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "59",
+        "identity": "1@6dacb904ad45",
+        "historySizeBytes": "15867"
+      }
+    },
+    {
+      "eventId": "61",
+      "eventTime": "2026-09-05T21:29:25.493Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "59",
+        "identity": "1@6dacb904ad45",
+        "binaryChecksum": "899b74c50f6d29e3339528f4c383b564",
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "62",
+      "eventTime": "2026-09-05T21:29:25.493Z",
+      "eventType": "EVENT_TYPE_TIMER_CANCELED",
+      "timerCanceledEventAttributes": {
+        "timerId": "1",
+        "startedEventId": "57",
+        "workflowTaskCompletedEventId": "60"
+      }
+    },
+    {
+      "eventId": "63",
+      "eventTime": "2026-09-05T21:29:25.493Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJydW50aW1lX2lkIjoib3BlbmNvZGUiLCJzdGF0dXMiOiJzaHV0ZG93biJ9"
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "60"
+      }
+    }
+  ]
+}

--- a/tests/unit/workflows/temporal/fixtures/provider_profile_manager_pre_tombstone_purge.json
+++ b/tests/unit/workflows/temporal/fixtures/provider_profile_manager_pre_tombstone_purge.json
@@ -1,0 +1,1119 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2026-09-05T19:19:44.624078337Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "MoonMind.ProviderProfileManager"
+        },
+        "taskQueue": {
+          "name": "mm.workflow.user.v2",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJydW50aW1lX2lkIjoib3BlbmNvZGUiLCJwcm9maWxlcyI6W3sicHJvZmlsZV9pZCI6InRlc3QtZGVmYXVsdCIsIm1heF9wYXJhbGxlbF9ydW5zIjoxLCJjb29sZG93bl9hZnRlcl80Mjlfc2Vjb25kcyI6OTAwLCJyYXRlX2xpbWl0X3BvbGljeSI6InF1ZXVlIiwiZW5hYmxlZCI6dHJ1ZSwiaXNfZGVmYXVsdCI6ZmFsc2UsIm1heF9sZWFzZV9kdXJhdGlvbl9zZWNvbmRzIjo3MjAwLCJjcmVkZW50aWFsX3NvdXJjZSI6InNlY3JldF9yZWYiLCJydW50aW1lX21hdGVyaWFsaXphdGlvbl9tb2RlIjoiY29tcG9zaXRlIn0seyJwcm9maWxlX2lkIjoidGVzdC1sZWFzZWQiLCJtYXhfcGFyYWxsZWxfcnVucyI6MSwiY29vbGRvd25fYWZ0ZXJfNDI5X3NlY29uZHMiOjkwMCwicmF0ZV9saW1pdF9wb2xpY3kiOiJiYWNrb2ZmIiwiZW5hYmxlZCI6dHJ1ZSwiaXNfZGVmYXVsdCI6dHJ1ZSwibWF4X2xlYXNlX2R1cmF0aW9uX3NlY29uZHMiOjcyMDAsImNyZWRlbnRpYWxfc291cmNlIjoibm9uZSIsInJ1bnRpbWVfbWF0ZXJpYWxpemF0aW9uX21vZGUiOiJjb21wb3NpdGUifV0sImxlYXNlcyI6eyJ0ZXN0LWxlYXNlZCI6WyJ0ZXN0LWFjdGl2ZS1hZ2VudCJdfSwibGVhc2VfZ3JhbnRlZF9hdCI6eyJ0ZXN0LWxlYXNlZCI6eyJ0ZXN0LWFjdGl2ZS1hZ2VudCI6IjIwMjYtMDktMDVUMTg6NTA6NDEuNjQyNTExKzAwOjAwIn19fQ=="
+            }
+          ]
+        },
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "continuedExecutionRunId": "4ea14164-ef9a-4884-a87c-fe87c5082586",
+        "initiator": "CONTINUE_AS_NEW_INITIATOR_WORKFLOW",
+        "originalExecutionRunId": "11111111-1111-4111-8111-111111111111",
+        "firstExecutionRunId": "01a02895-b7bf-7487-8e2c-37eb7f02bbea",
+        "attempt": 1,
+        "prevAutoResetPoints": {
+          "points": [
+            {
+              "buildId": "ca61b6a88ae35dba398756b1b562727e",
+              "runId": "82b348b6-06c1-49ff-a9d6-c9edfe5592de",
+              "firstWorkflowTaskCompletedId": "833",
+              "createTime": "2026-08-31T16:01:38.400957732Z",
+              "expireTime": "2026-11-29T19:50:58.164151725Z",
+              "resettable": true
+            },
+            {
+              "buildId": "83a29dced5048d5be9980ca5e29cc41e",
+              "runId": "78183790-8503-41df-9197-1d63913dbe15",
+              "firstWorkflowTaskCompletedId": "1470",
+              "createTime": "2026-09-01T07:08:33.738474941Z",
+              "expireTime": "2026-11-30T08:04:34.272456334Z",
+              "resettable": true
+            },
+            {
+              "buildId": "6499b0f7cb7d310ea6034f9a59ec3ff8",
+              "runId": "3b8f823c-12c3-426a-af17-ee8707102d92",
+              "firstWorkflowTaskCompletedId": "990",
+              "createTime": "2026-09-01T17:39:04.527441091Z",
+              "expireTime": "2026-11-30T19:33:48.526556368Z",
+              "resettable": true
+            },
+            {
+              "buildId": "07b59f16ac55e94a8859ee7d888ba3e8",
+              "runId": "23c0ee98-082b-4a7c-a9d7-17dd7c750b39",
+              "firstWorkflowTaskCompletedId": "735",
+              "createTime": "2026-09-01T21:54:31.578008767Z",
+              "expireTime": "2026-12-01T00:35:07.671966257Z",
+              "resettable": true
+            },
+            {
+              "buildId": "15a80eb9324b2325cb5a3a0145ec3828",
+              "runId": "23c0ee98-082b-4a7c-a9d7-17dd7c750b39",
+              "firstWorkflowTaskCompletedId": "1464",
+              "createTime": "2026-09-01T23:34:25.634861230Z",
+              "expireTime": "2026-12-01T00:35:07.671966257Z",
+              "resettable": true
+            },
+            {
+              "buildId": "ce9876c82983586b54d88f3b35ba297e",
+              "runId": "07abf642-1034-4864-bbc1-4deec564a8f7",
+              "firstWorkflowTaskCompletedId": "1510",
+              "createTime": "2026-09-02T05:25:28.770754825Z",
+              "expireTime": "2026-12-01T06:09:41.502936079Z",
+              "resettable": true
+            },
+            {
+              "buildId": "f3192a285b44b3f9b0c95442a2471e13",
+              "runId": "cd63fa78-d375-4b8f-9a5b-ed637493a757",
+              "firstWorkflowTaskCompletedId": "1640",
+              "createTime": "2026-09-02T21:13:08.546906907Z",
+              "expireTime": "2026-12-01T21:58:51.855740298Z",
+              "resettable": true
+            },
+            {
+              "buildId": "972bd2d71d6f6be5f5917fe9a25d8e2f",
+              "runId": "e9a0f709-ca3b-46c9-add3-547747a40015",
+              "firstWorkflowTaskCompletedId": "748",
+              "createTime": "2026-09-03T00:02:56.411832297Z",
+              "expireTime": "2026-12-02T03:41:24.388328233Z",
+              "resettable": true
+            },
+            {
+              "buildId": "37bdabd2f1c86201893187f1bbe0e422",
+              "runId": "e9a0f709-ca3b-46c9-add3-547747a40015",
+              "firstWorkflowTaskCompletedId": "877",
+              "createTime": "2026-09-03T00:26:39.458754850Z",
+              "expireTime": "2026-12-02T03:41:24.388328233Z",
+              "resettable": true
+            },
+            {
+              "buildId": "ec7db9e247e8548bb8db027c90c12b1a",
+              "runId": "64a13234-a07a-4384-a86a-c16a1fce5a52",
+              "firstWorkflowTaskCompletedId": "1176",
+              "createTime": "2026-09-03T06:19:35.038113489Z",
+              "expireTime": "2026-12-02T07:28:43.203552929Z",
+              "resettable": true
+            },
+            {
+              "buildId": "70fd95638df358cb28f4e3a4e6312681",
+              "runId": "d1a9ba75-3abe-453a-99be-77b400bffafe",
+              "firstWorkflowTaskCompletedId": "353",
+              "createTime": "2026-09-03T07:56:00.805562189Z",
+              "expireTime": "2026-12-02T08:47:43.742289999Z",
+              "resettable": true
+            },
+            {
+              "buildId": "8e181eb813126c66143ff8ea061b16c9",
+              "runId": "28c75c49-a0c7-4956-8f61-54d48f23e5d5",
+              "firstWorkflowTaskCompletedId": "850",
+              "createTime": "2026-09-03T16:26:57.978082016Z",
+              "expireTime": "2026-12-02T18:23:58.478299052Z",
+              "resettable": true
+            },
+            {
+              "buildId": "c42c1b47842992c05ebad3afb56a4160",
+              "runId": "77d8d018-12b8-4c2c-b982-36223c06e3cc",
+              "firstWorkflowTaskCompletedId": "1818",
+              "createTime": "2026-09-03T22:52:15.999323539Z",
+              "expireTime": "2026-12-02T23:21:22.590280203Z",
+              "resettable": true
+            },
+            {
+              "buildId": "841c575f4bce3de28c55b818b89f4631",
+              "runId": "1122167e-d8da-4895-8f72-64cde256e170",
+              "firstWorkflowTaskCompletedId": "1673",
+              "createTime": "2026-09-04T03:45:10.030864069Z",
+              "expireTime": "2026-12-03T04:34:32.424045216Z",
+              "resettable": true
+            },
+            {
+              "buildId": "ef8f79cc7f9e5e6eb2c975c62a132146",
+              "runId": "d157e936-c894-4b03-8f94-0e94a24a5b4e",
+              "firstWorkflowTaskCompletedId": "1319",
+              "createTime": "2026-09-04T08:12:48.841360346Z",
+              "expireTime": "2026-12-03T10:27:14.535159210Z",
+              "resettable": true
+            },
+            {
+              "buildId": "98ff4f78f5144140ed6debc8f7d18ebb",
+              "runId": "50ed167b-06d8-4897-80de-75dfa05fb106",
+              "firstWorkflowTaskCompletedId": "1448",
+              "createTime": "2026-09-04T15:01:03.186490658Z",
+              "expireTime": "2026-12-03T16:50:30.431931654Z",
+              "resettable": true
+            },
+            {
+              "buildId": "71164fc6fff23ef1f55f8f3aafbc7db3",
+              "runId": "a68d185d-fa2e-45d2-8849-cfe66f727e91",
+              "firstWorkflowTaskCompletedId": "417",
+              "createTime": "2026-09-04T23:41:01.288805972Z",
+              "expireTime": "2026-12-04T03:22:21.234389602Z",
+              "resettable": true
+            },
+            {
+              "buildId": "4cac67ce6c8fda1ebf93922ea64186d0",
+              "runId": "b1efc4c0-00f3-4fa4-8513-805afa995ae1",
+              "firstWorkflowTaskCompletedId": "330",
+              "createTime": "2026-09-05T04:20:30.031643197Z",
+              "expireTime": "2026-12-04T08:52:15.458400790Z",
+              "resettable": true
+            },
+            {
+              "buildId": "629ec94c679f686a35ee18831e3848ea",
+              "runId": "b1efc4c0-00f3-4fa4-8513-805afa995ae1",
+              "firstWorkflowTaskCompletedId": "975",
+              "createTime": "2026-09-05T06:25:16.306737798Z",
+              "expireTime": "2026-12-04T08:52:15.458400790Z",
+              "resettable": true
+            },
+            {
+              "buildId": "3dd1f9ed9103f51381e19537c3ecf129",
+              "runId": "4ea14164-ef9a-4884-a87c-fe87c5082586",
+              "firstWorkflowTaskCompletedId": "804",
+              "createTime": "2026-09-05T17:45:49.722538247Z",
+              "expireTime": "2026-12-04T19:19:44.624078337Z",
+              "resettable": true
+            }
+          ]
+        },
+        "workflowId": "provider-profile-manager:opencode",
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2026-09-05T19:19:44.624475825Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "mm.workflow.user.v2",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2026-09-05T19:19:44.654596876Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "historySizeBytes": "6001"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2026-09-05T19:19:44.678692151Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            1,
+            2,
+            3
+          ],
+          "sdkName": "temporal-python",
+          "sdkVersion": "1.32.0"
+        }
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2026-09-05T19:19:44.678732941Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2026-09-05T19:19:44.678766213Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY29kZXgtb2F1dGgtbGVnYWN5LXJlc3RvcmUtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2026-09-05T19:19:44.678782995Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2026-09-05T19:19:44.678792749Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2026-09-05T19:19:44.678799585Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2026-09-05T19:19:44.678807685Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2026-09-05T19:19:44.678814201Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2026-09-05T19:19:44.678821249Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2026-09-05T19:19:44.678827955Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2026-09-05T19:19:44.678835083Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2026-09-05T19:19:44.678841178Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2026-09-05T19:19:44.678848807Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2026-09-05T19:19:44.678855333Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2026-09-05T19:19:44.678864555Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2026-09-05T19:19:44.678891161Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "provider_profile.list"
+        },
+        "taskQueue": {
+          "name": "mm.activity.artifacts",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJydW50aW1lX2lkIjoib3BlbmNvZGUifQ=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "30s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": "2s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "30s",
+          "maximumAttempts": 5
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2026-09-05T19:19:44.692438901Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "19",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2026-09-05T19:19:44.725285992Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJwcm9maWxlcyI6W3sicHJvZmlsZV9pZCI6InRlc3QtbGVhc2VkIiwicnVudGltZV9pZCI6Im9wZW5jb2RlIiwiaXNfZGVmYXVsdCI6dHJ1ZSwiY3JlZGVudGlhbF9zb3VyY2UiOiJub25lIiwicnVudGltZV9tYXRlcmlhbGl6YXRpb25fbW9kZSI6ImNvbXBvc2l0ZSIsIm1heF9wYXJhbGxlbF9ydW5zIjoxLCJjb29sZG93bl9hZnRlcl80Mjlfc2Vjb25kcyI6OTAwLCJyYXRlX2xpbWl0X3BvbGljeSI6ImJhY2tvZmYiLCJtYXhfbGVhc2VfZHVyYXRpb25fc2Vjb25kcyI6NzIwMCwiZW5hYmxlZCI6dHJ1ZSwibGF1bmNoX3JlYWR5Ijp0cnVlfSx7InByb2ZpbGVfaWQiOiJ0ZXN0LWRlZmF1bHQiLCJydW50aW1lX2lkIjoib3BlbmNvZGUiLCJpc19kZWZhdWx0IjpmYWxzZSwiY3JlZGVudGlhbF9zb3VyY2UiOiJzZWNyZXRfcmVmIiwicnVudGltZV9tYXRlcmlhbGl6YXRpb25fbW9kZSI6ImNvbXBvc2l0ZSIsIm1heF9wYXJhbGxlbF9ydW5zIjoxLCJjb29sZG93bl9hZnRlcl80Mjlfc2Vjb25kcyI6OTAwLCJyYXRlX2xpbWl0X3BvbGljeSI6InF1ZXVlIiwibWF4X2xlYXNlX2R1cmF0aW9uX3NlY29uZHMiOjcyMDAsImVuYWJsZWQiOnRydWUsImxhdW5jaF9yZWFkeSI6dHJ1ZX1dfQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "19",
+        "startedEventId": "20"
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2026-09-05T19:19:44.725293962Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "29@243943a21d4a-5bc56c31060441eda8f4fca99ca244ac",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "mm.workflow.user.v2"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2026-09-05T19:19:44.741393627Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "22",
+        "historySizeBytes": "15629"
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2026-09-05T19:19:44.761418613Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "22",
+        "startedEventId": "23",
+        "sdkMetadata": {}
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2026-09-05T19:19:44.761455033Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2026-09-05T19:19:44.761492926Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2026-09-05T19:19:44.761519782Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2026-09-05T19:19:44.761531030Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2026-09-05T19:19:44.761540262Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2026-09-05T19:19:44.761552031Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": "2026-09-05T19:19:44.761558437Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": "2026-09-05T19:19:44.761571038Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHJpb3JpdHktcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcmVmcmVzaC1yZXN0b3JlZC1wcm9maWxlcy12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": "2026-09-05T19:19:44.761577434Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwiZGVwcmVjYXRlZCI6ZmFsc2V9"
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": "2026-09-05T19:19:44.761587719Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHJpb3JpdHktcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcXVldWUtb3JkZXItcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": "2026-09-05T19:19:44.761594686Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1zY2hlZHVsZWQtcGVuZGluZy1yZXF1ZXN0cy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": "2026-09-05T19:19:44.761604290Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2FwYWNpdHktc2NvcGUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY2xhdWRlLW9hdXRoLWV4Y2x1c2l2ZS1jYXBhY2l0eS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jb2RleC1vYXV0aC1sZWdhY3ktcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1hdXRob3JpdGF0aXZlLXByb2ZpbGUtc3luYy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kYi1sZWFzZS1wZXJzaXN0ZW5jZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1kdXJhYmxlLWxlYXNlLWdyYW50LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWZyZXNoLXN0YXJ0LWRiLWxlYXNlLXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHJpb3JpdHktcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNhcGFjaXR5LWxlZGdlci12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wdXJwb3NlLWF3YXJlLWNyZWRlbnRpYWwtbGVhc2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcXVldWUtb3JkZXItcGVuZGluZy1yZXF1ZXN0cy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1yZWZyZXNoLXJlc3RvcmVkLXByb2ZpbGVzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXNjaGVkdWxlZC1wZW5kaW5nLXJlcXVlc3RzLXYxIl0="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": "2026-09-05T19:19:44.761610375Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6ImF1dGgtcHJvZmlsZS1tYW5hZ2VyLXZlcmlmeS1sZWFzZXMtdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": "2026-09-05T19:19:44.761620089Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNhcGFjaXR5LXNjb3BlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNsYXVkZS1vYXV0aC1leGNsdXNpdmUtY2FwYWNpdHktdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItY29kZXgtb2F1dGgtbGVnYWN5LXJlc3RvcmUtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZGItYXV0aG9yaXRhdGl2ZS1wcm9maWxlLXN5bmMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZGItbGVhc2UtcGVyc2lzdGVuY2UtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZHVyYWJsZS1sZWFzZS1ncmFudC12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1mcmVzaC1zdGFydC1kYi1sZWFzZS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXByaW9yaXR5LXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jYXBhY2l0eS1sZWRnZXItdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcHVycG9zZS1hd2FyZS1jcmVkZW50aWFsLWxlYXNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXF1ZXVlLW9yZGVyLXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItcmVmcmVzaC1yZXN0b3JlZC1wcm9maWxlcy12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1zY2hlZHVsZWQtcGVuZGluZy1yZXF1ZXN0cy12MSJd"
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": "2026-09-05T19:19:44.761625963Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1hY3Rpdml0eS1vd25lZC1sZWFzZS12ZXJpZmljYXRpb24tdjEiLCJkZXByZWNhdGVkIjpmYWxzZX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": "2026-09-05T19:19:44.761639767Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWFjdGl2aXR5LW93bmVkLWxlYXNlLXZlcmlmaWNhdGlvbi12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNvZGV4LW9hdXRoLWxlZ2FjeS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWF1dGhvcml0YXRpdmUtcHJvZmlsZS1zeW5jLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWxlYXNlLXBlcnNpc3RlbmNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWR1cmFibGUtbGVhc2UtZ3JhbnQtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZnJlc2gtc3RhcnQtZGItbGVhc2UtcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItc2NoZWR1bGVkLXBlbmRpbmctcmVxdWVzdHMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": "2026-09-05T19:19:44.761645802Z",
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_patch",
+        "details": {
+          "patch-data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJpZCI6InByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktcGVuZGluZy1yZXF1ZXN0cy12MSIsImRlcHJlY2F0ZWQiOmZhbHNlfQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "42",
+      "eventTime": "2026-09-05T19:19:44.761656549Z",
+      "eventType": "EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES",
+      "upsertWorkflowSearchAttributesEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "searchAttributes": {
+          "indexedFields": {
+            "TemporalChangeVersion": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg==",
+                "type": "S2V5d29yZExpc3Q="
+              },
+              "data": "WyJhdXRoLXByb2ZpbGUtbWFuYWdlci12ZXJpZnktbGVhc2VzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWFjdGl2aXR5LW93bmVkLWxlYXNlLXZlcmlmaWNhdGlvbi12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jYXBhY2l0eS1zY29wZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1jbGF1ZGUtb2F1dGgtZXhjbHVzaXZlLWNhcGFjaXR5LXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWNvZGV4LW9hdXRoLWxlZ2FjeS1yZXN0b3JlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWF1dGhvcml0YXRpdmUtcHJvZmlsZS1zeW5jLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWRiLWxlYXNlLXBlcnNpc3RlbmNlLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLWR1cmFibGUtbGVhc2UtZ3JhbnQtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItZnJlc2gtc3RhcnQtZGItbGVhc2UtcmVzdG9yZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1wcmlvcml0eS1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY2FwYWNpdHktbGVkZ2VyLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXB1cnBvc2UtYXdhcmUtY3JlZGVudGlhbC1sZWFzZS12MSIsInByb3ZpZGVyLXByb2ZpbGUtbWFuYWdlci1xdWV1ZS1vcmRlci1wZW5kaW5nLXJlcXVlc3RzLXYxIiwicHJvdmlkZXItcHJvZmlsZS1tYW5hZ2VyLXJlZnJlc2gtcmVzdG9yZWQtcHJvZmlsZXMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItc2NoZWR1bGVkLXBlbmRpbmctcmVxdWVzdHMtdjEiLCJwcm92aWRlci1wcm9maWxlLW1hbmFnZXItdmVyaWZ5LXBlbmRpbmctcmVxdWVzdHMtdjEiXQ=="
+            }
+          }
+        }
+      }
+    },
+    {
+      "eventId": "43",
+      "eventTime": "2026-09-05T19:19:44.761683665Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "provider_profile.verify_lease_holders"
+        },
+        "taskQueue": {
+          "name": "mm.activity.artifacts",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ3b3JrZmxvd19pZHMiOlsidGVzdC1hY3RpdmUtYWdlbnQiXX0="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "30s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "24",
+        "retryPolicy": {
+          "initialInterval": "2s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "30s",
+          "maximumAttempts": 3
+        },
+        "priority": {}
+      }
+    },
+    {
+      "eventId": "44",
+      "eventTime": "2026-09-05T19:19:44.775523859Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "43",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "45",
+      "eventTime": "2026-09-05T19:19:44.793986468Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJ0ZXN0LWFjdGl2ZS1hZ2VudCI6eyJydW5uaW5nIjp0cnVlLCJzdGF0dXMiOiJSVU5OSU5HIn19"
+            }
+          ]
+        },
+        "scheduledEventId": "43",
+        "startedEventId": "44"
+      }
+    },
+    {
+      "eventId": "46",
+      "eventTime": "2026-09-05T19:19:44.793993375Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "29@243943a21d4a-5bc56c31060441eda8f4fca99ca244ac",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "mm.workflow.user.v2"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "47",
+      "eventTime": "2026-09-05T19:19:44.807320826Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "46",
+        "historySizeBytes": "25115"
+      }
+    },
+    {
+      "eventId": "48",
+      "eventTime": "2026-09-05T19:19:44.823562602Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "46",
+        "startedEventId": "47",
+        "sdkMetadata": {}
+      }
+    },
+    {
+      "eventId": "49",
+      "eventTime": "2026-09-05T19:19:44.823592726Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "timerStartedEventAttributes": {
+        "timerId": "1",
+        "startToFireTimeout": "60s",
+        "workflowTaskCompletedEventId": "48"
+      }
+    },
+    {
+      "eventId": "50",
+      "eventTime": "2026-09-05T19:20:44.826816967Z",
+      "eventType": "EVENT_TYPE_TIMER_FIRED",
+      "timerFiredEventAttributes": {
+        "timerId": "1",
+        "startedEventId": "49"
+      }
+    },
+    {
+      "eventId": "51",
+      "eventTime": "2026-09-05T19:20:44.826828301Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "29@243943a21d4a-5bc56c31060441eda8f4fca99ca244ac",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "mm.workflow.user.v2"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "52",
+      "eventTime": "2026-09-05T19:20:44.838140725Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "51",
+        "historySizeBytes": "25510"
+      }
+    }
+  ]
+}

--- a/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
@@ -1,0 +1,199 @@
+"""Production replay and worker-boundary coverage for slot-manager cleanup."""
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from temporalio import activity, exceptions, workflow
+from temporalio.client import WorkflowHistory
+from temporalio.converter import DataConverter
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
+
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    ACTIVITY_TASK_QUEUE,
+    MoonMindProviderProfileManagerWorkflow,
+)
+
+
+@pytest.mark.asyncio
+async def test_pre_tombstone_purge_manager_history_replays() -> None:
+    """A continued manager must verify its held lease before its recorded timer.
+
+    This sanitized 52-event production prefix predates maintenance durability.
+    Inserting purge_released before lease verification used to fail replay at
+    auth-profile-manager-verify-leases-v1, wedging all slot requests.
+    """
+    fixture = (
+        Path(__file__).with_name("fixtures")
+        / "provider_profile_manager_pre_tombstone_purge.json"
+    )
+    history = WorkflowHistory.from_json(
+        "provider-profile-manager:opencode", fixture.read_text()
+    )
+    await Replayer(
+        workflows=[MoonMindProviderProfileManagerWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ).replay_workflow(history)
+
+
+class _ProfileActivities:
+    def __init__(self, runtime_id: str, fail_cleanup: bool) -> None:
+        self.runtime_id = runtime_id
+        self.fail_cleanup = fail_cleanup
+        self.actions: list[str] = []
+        self.cleaned = asyncio.Event()
+        self.verified = asyncio.Event()
+
+    @activity.defn(name="provider_profile.list")
+    async def list_profiles(self, request: dict[str, Any]) -> dict[str, Any]:
+        assert request == {"runtime_id": self.runtime_id}
+        return {
+            "profiles": [
+                {
+                    "profile_id": "test-default",
+                    "runtime_id": self.runtime_id,
+                    "credential_source": "api_key",
+                    "runtime_materialization_mode": "env",
+                    "max_parallel_runs": 1,
+                    "enabled": True,
+                    "launch_ready": True,
+                    "is_default": True,
+                }
+            ]
+        }
+
+    @activity.defn(name="provider_profile.sync_slot_leases")
+    async def sync_leases(self, request: dict[str, Any]) -> dict[str, Any]:
+        assert request["runtime_id"] == self.runtime_id
+        action = request["action"]
+        self.actions.append(action)
+        if action == "purge_released":
+            assert request["leases"] == [{"older_than_seconds": 30 * 24 * 3600}]
+            self.cleaned.set()
+            if self.fail_cleanup:
+                raise exceptions.ApplicationError(
+                    "cleanup unavailable", non_retryable=True
+                )
+        return {"leases": [], "synced": len(request.get("leases", []))}
+
+    @activity.defn(name="provider_profile.pending_request_order")
+    async def pending_order(self, request: dict[str, Any]) -> dict[str, Any]:
+        return {"orders": {owner: {} for owner in request["workflow_ids"]}}
+
+    @activity.defn(name="provider_profile.verify_lease_holders")
+    async def verify(self, request: dict[str, Any]) -> dict[str, Any]:
+        self.verified.set()
+        # A novel status label must not discard the positively verified owner.
+        return {
+            owner: {"running": True, "status": "NEW_STATUS"}
+            for owner in request["workflow_ids"]
+        }
+
+
+@workflow.defn(name="Test.CleanupSlotRequester")
+class _SlotRequester:
+    def __init__(self) -> None:
+        self.assignment: dict[str, Any] | None = None
+        self.stopped = False
+
+    @workflow.signal
+    def slot_assigned(self, payload: dict[str, Any]) -> None:
+        self.assignment = payload
+
+    @workflow.signal
+    def shutdown(self) -> None:
+        self.stopped = True
+
+    @workflow.query
+    def assigned(self) -> dict[str, Any] | None:
+        return self.assignment
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(lambda: self.stopped)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_id", ["opencode", "codex_cli", "claude_code"])
+@pytest.mark.parametrize(
+    "fail_cleanup", [False, True], ids=["cleanup-ok", "cleanup-failed"]
+)
+async def test_current_manager_cleans_then_grants_and_replays(
+    runtime_id: str, fail_cleanup: bool
+) -> None:
+    """Default cleanup, including failure, preserves durable grant authority."""
+    activities = _ProfileActivities(runtime_id, fail_cleanup)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-profile-cleanup",
+            workflows=[MoonMindProviderProfileManagerWorkflow, _SlotRequester],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ), Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                activities.list_profiles,
+                activities.sync_leases,
+                activities.pending_order,
+                activities.verify,
+            ],
+        ):
+            manager = await env.client.start_workflow(
+                MoonMindProviderProfileManagerWorkflow.run,
+                {"runtime_id": runtime_id},
+                id=f"provider-profile-manager:{runtime_id}",
+                task_queue="test-profile-cleanup",
+            )
+            await asyncio.wait_for(activities.cleaned.wait(), timeout=15)
+            requester = await env.client.start_workflow(
+                _SlotRequester.run,
+                id="test-slot-requester",
+                task_queue="test-profile-cleanup",
+            )
+            # The omitted profile selector must choose the default profile.
+            await manager.signal(
+                "request_slot",
+                {
+                    "requester_workflow_id": requester.id,
+                    "runtime_id": runtime_id,
+                },
+            )
+            await asyncio.wait_for(activities.verified.wait(), timeout=15)
+            assignment = await requester.query(_SlotRequester.assigned)
+            assert assignment["profile_id"] == "test-default"
+            assert assignment["fencing_generation"] > 0
+            state = await manager.query("get_state")
+            assert state["profiles"]["test-default"]["current_leases"] == [requester.id]
+            assert "purge_released" in activities.actions
+            await manager.signal("shutdown")
+            assert (await manager.result())["status"] == "shutdown"
+            await requester.signal(_SlotRequester.shutdown)
+            await requester.result()
+            history = await manager.fetch_history()
+
+    # Assert the production command handoff, then replay the new history too.
+    commands = []
+    for event in history.events:
+        if event.HasField("activity_task_scheduled_event_attributes"):
+            attrs = event.activity_task_scheduled_event_attributes
+            if attrs.activity_type.name == "provider_profile.sync_slot_leases":
+                payload = (await DataConverter.default.decode(attrs.input.payloads))[0]
+                commands.append(payload["action"])
+        elif event.HasField(
+            "signal_external_workflow_execution_initiated_event_attributes"
+        ):
+            attrs = event.signal_external_workflow_execution_initiated_event_attributes
+            if attrs.signal_name == "slot_assigned":
+                commands.append("slot_assigned")
+    assert (
+        commands.index("purge_released")
+        < commands.index("grant")
+        < commands.index("slot_assigned")
+    )
+    await Replayer(
+        workflows=[MoonMindProviderProfileManagerWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ).replay_workflow(history)

--- a/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
@@ -13,22 +13,28 @@ from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     ACTIVITY_TASK_QUEUE,
+    LEASE_TOMBSTONE_PURGE_PATCH,
     MoonMindProviderProfileManagerWorkflow,
 )
 
 
 @pytest.mark.asyncio
-async def test_pre_tombstone_purge_manager_history_replays() -> None:
-    """A continued manager must verify its held lease before its recorded timer.
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "provider_profile_manager_pre_tombstone_purge.json",
+        "provider_profile_manager_maintenance_before_purge.json",
+    ],
+    ids=["before-maintenance", "maintenance-without-purge"],
+)
+async def test_pre_tombstone_purge_manager_history_replays(fixture_name: str) -> None:
+    """A manager must verify its held lease before its recorded timer.
 
-    This sanitized 52-event production prefix predates maintenance durability.
-    Inserting purge_released before lease verification used to fail replay at
-    auth-profile-manager-verify-leases-v1, wedging all slot requests.
+    The sanitized production prefix predates maintenance durability. The second
+    fixture was recorded with b40da19f7, which already had that marker but no
+    cleanup activity. Both must preserve the recorded lease verification order.
     """
-    fixture = (
-        Path(__file__).with_name("fixtures")
-        / "provider_profile_manager_pre_tombstone_purge.json"
-    )
+    fixture = Path(__file__).with_name("fixtures") / fixture_name
     history = WorkflowHistory.from_json(
         "provider-profile-manager:opencode", fixture.read_text()
     )
@@ -168,16 +174,30 @@ async def test_current_manager_cleans_then_grants_and_replays(
             state = await manager.query("get_state")
             assert state["profiles"]["test-default"]["current_leases"] == [requester.id]
             assert "purge_released" in activities.actions
-            await manager.signal("shutdown")
-            assert (await manager.result())["status"] == "shutdown"
-            await requester.signal(_SlotRequester.shutdown)
-            await requester.result()
+            # result() enables global time skipping. Keep the idle requester
+            # alive until its shutdown has been processed too; otherwise waiting
+            # on the manager can advance it to the test server's run timeout.
+            with env.auto_time_skipping_disabled():
+                await manager.signal("shutdown")
+                await requester.signal(_SlotRequester.shutdown)
+                assert (await manager.result())["status"] == "shutdown"
+                await requester.result()
             history = await manager.fetch_history()
 
     # Assert the production command handoff, then replay the new history too.
     commands = []
+    patch_ids = []
     for event in history.events:
-        if event.HasField("activity_task_scheduled_event_attributes"):
+        if event.HasField("marker_recorded_event_attributes"):
+            attrs = event.marker_recorded_event_attributes
+            if attrs.marker_name == "core_patch":
+                payload = (
+                    await DataConverter.default.decode(
+                        attrs.details["patch-data"].payloads
+                    )
+                )[0]
+                patch_ids.append(payload["id"])
+        elif event.HasField("activity_task_scheduled_event_attributes"):
             attrs = event.activity_task_scheduled_event_attributes
             if attrs.activity_type.name == "provider_profile.sync_slot_leases":
                 payload = (await DataConverter.default.decode(attrs.input.payloads))[0]
@@ -188,6 +208,7 @@ async def test_current_manager_cleans_then_grants_and_replays(
             attrs = event.signal_external_workflow_execution_initiated_event_attributes
             if attrs.signal_name == "slot_assigned":
                 commands.append("slot_assigned")
+    assert LEASE_TOMBSTONE_PURGE_PATCH in patch_ids
     assert (
         commands.index("purge_released")
         < commands.index("grant")


### PR DESCRIPTION
Existing Provider Profile managers could stop assigning slots after a worker update because the new `purge_released` activity was scheduled before their recorded lease-verification markers. This caused a Temporal nondeterminism error at `auth-profile-manager-verify-leases-v1` and left dependent workflows in `awaiting_slot`.

Gate tombstone cleanup on a dedicated cleanup marker. DB persistence and maintenance durability both predate cleanup, so older managers preserve their recorded lease-verification order while new runs retain cleanup. Required Temporal boundary coverage includes a sanitized production history, a history recorded with the maintenance-era implementation before cleanup existed, and real worker tests for cleanup success/failure, default-profile selection, durable grant-before-signal ordering, and replay across OpenCode, Codex, and Claude. Test teardown disables automatic time skipping so stopping the manager cannot time out its idle requester.

Validation:
- Reproduced the exact nondeterminism for both older history generations before the fix.
- Replayed every active local manager history immediately before deployment: OpenCode (1,090 events), Codex (419), and Claude (1,085).
- 184 targeted tests passed via `tools/test_unit.sh --python-only --no-xdist`, including all eight historical-replay/current-admission cases; repository policy audits and `git diff --check` passed.
- Exact-head CI passed for `7c5edf47`: Temporal boundary, hermetic reliability journey, unit suite, migration gate, and required-test aggregation. The full local Temporal run was stopped after the equivalent remote check passed.

The final dedicated-marker candidate is deployed locally, all three managers are queryable, and the blocked workflow has progressed past slot assignment. Other deployments require replay preflight for every active manager. Histories that already recorded unmarked cleanup require a controlled state-preserving Continue-As-New cutover under their matching old worker; the limitation and required handoff are documented. No workflow reset or lease clearing is used.
