### PR TITLE
For the create workflows page, I do not want the advanced runtime label and chevron to hide the runtime selector. The runtime selector should always b

### DIFF
--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1710,7 +1710,7 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
         available: true,
         launchPolicies: [
           { ref: "on-demand-v1", displayName: "On-demand v1", hostMode: "on_demand_docker", isDefault: true },
-          { ref: "pinned-v1", displayName: "Pinned v1", hostMode: "on_demand_docker" },
+          { ref: "pinned-v1", displayName: "Pinned v1", hostMode: "on_demand_docker", isDefault: false },
         ],
         gateReasons: [],
       }],

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1116,6 +1116,15 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
     fireEvent.change(screen.getByLabelText("Instructions"), { target: { value: "Exercise the Omnigent submit boundary." } });
 
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
+    expect(screen.queryByLabelText("Execution target")).toBeNull();
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
     expect(screen.getByLabelText("Execution target").getAttribute("name")).toBe("omnigentExecutionTargetRef");
     expect(screen.getByLabelText("Execution target").closest(".grid-2")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
@@ -1242,6 +1251,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(screen.getByLabelText("Instructions"), {
       target: { value: "Read the repository through OpenCode." },
     });
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
     await waitFor(() => expect(
       (screen.getByLabelText("Execution target") as HTMLSelectElement).value,
     ).toBe("omnigent-opencode-default@201"));
@@ -1435,6 +1448,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     fireEvent.change(await screen.findByLabelText("Runtime"), {
       target: { value: "omnigent" },
     });
+    {
+      const advancedToggle = await screen.findByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
     await waitFor(() => {
       expect((screen.getByLabelText("Profile") as HTMLSelectElement).value)
         .toBe("oauth-1");
@@ -1660,6 +1677,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     renderWorkflowStartPage(omnigentPayload());
     fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
     fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
 
     const hostPolicy = await screen.findByLabelText("Host policy");
     await waitFor(() => expect((hostPolicy as HTMLSelectElement).value).toBe("on-demand-v2"));
@@ -1895,6 +1916,10 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     const profileSelect = await screen.findByLabelText("Profile");
     await waitFor(() => expect((profileSelect as HTMLSelectElement).value).toBe("codex-oauth"));
     expect(within(profileSelect).queryByRole("option", { name: /Anthropic subscription/ })).toBeTruthy();
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
 
     fireEvent.change(screen.getByLabelText("Execution target"), {
       target: { value: "omnigent-claude@1" },
@@ -22038,7 +22063,7 @@ describe("Task Create runtime switch layout stability", () => {
     expect(screen.getByRole("option", { name: /Codex Default/ })).toBeTruthy();
     expect(fetchSpy.mock.calls.filter(([url]) => String(url).startsWith("/api/v1/provider-profiles"))).toHaveLength(requests);
     expect(screen.queryByLabelText("Agent profile")).toBeNull();
-    expect(screen.getByLabelText("Runtime").closest("details")?.open).toBe(false);
+    expect(screen.getByLabelText("Runtime").closest("details")).toBeNull();
   });
 
   it("submits the native runtime of the selected Profile when switching from Codex to Claude", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -1701,6 +1701,72 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
     expect(request.payload.agentProfile).toBeUndefined();
   });
 
+  it("clears a hidden host-policy override when Advanced mode is turned off", async () => {
+    const twoPolicyCatalog = {
+      ...readyOmnigentCatalog,
+      executionProfiles: [{
+        ref: "omnigent-codex-default",
+        displayName: "Codex default",
+        available: true,
+        launchPolicies: [
+          { ref: "on-demand-v1", displayName: "On-demand v1", hostMode: "on_demand_docker", isDefault: true },
+          { ref: "pinned-v1", displayName: "Pinned v1", hostMode: "on_demand_docker" },
+        ],
+        gateReasons: [],
+      }],
+    } satisfies components["schemas"]["OmnigentCodexCatalogReadiness"];
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/omnigent/codex-catalog-readiness") {
+        return Promise.resolve({ ok: true, json: async () => twoPolicyCatalog } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({ ok: true, json: async () => [{ profile_id: "oauth-1", account_label: "Codex OAuth", provider_id: "openai" }] } as Response);
+      }
+      if (url === "/api/omnigent/agent-profiles") {
+        return Promise.resolve({ ok: true, json: async () => readyAgentProfiles } as Response);
+      }
+      if (url === "/api/executions" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ workflowId: "mm:omnigent-cleared-policy" }) } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve(defaultBranchOptionsResponse());
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ items: [] }) } as Response);
+    });
+
+    renderWorkflowStartPage(omnigentPayload());
+    fireEvent.change(await screen.findByLabelText("Runtime"), { target: { value: "omnigent" } });
+    fireEvent.change(await screen.findByLabelText("Profile"), { target: { value: "oauth-1" } });
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      if (!advancedToggle.checked) fireEvent.click(advancedToggle);
+    }
+
+    const hostPolicy = await screen.findByLabelText("Host policy");
+    fireEvent.change(hostPolicy, { target: { value: "pinned-v1" } });
+    expect((hostPolicy as HTMLSelectElement).value).toBe("pinned-v1");
+
+    {
+      const advancedToggle = screen.getByLabelText("Advanced mode") as HTMLInputElement;
+      fireEvent.click(advancedToggle);
+    }
+    expect(screen.queryByLabelText("Host policy")).toBeNull();
+    expect(screen.queryByLabelText("Execution target")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Submit without a hidden host override." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
+
+    await waitFor(() => expect(navigateTo).toHaveBeenCalledWith("/workflows/mm%3Aomnigent-cleared-policy?source=temporal"));
+    const createCall = fetchSpy.mock.calls.find(([url, options]) =>
+      String(url) === "/api/executions" && (options as RequestInit | undefined)?.method === "POST",
+    );
+    const request = JSON.parse(String((createCall?.[1] as RequestInit | undefined)?.body));
+    expect(request.payload.omnigent).toBeUndefined();
+  });
+
   it("keeps a historical profile version compatible for an Omnigent rerun", async () => {
     window.history.pushState(
       {},

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -14059,7 +14059,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           aria-label="Execution context"
         >
         <div className={providerOptions.length > 0 ? "grid-2" : "stack"}>
-          <details><summary>Advanced runtime</summary><label>
+          <div className="stack"><label>
             Runtime
             <select
               name="runtime"
@@ -14149,7 +14149,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             </div>
           ) : null}
 
-          </details>
+          </div>
 
           {providerOptions.length > 0 ? (
             <div id="queue-provider-profile-wrap">
@@ -14208,8 +14208,8 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           )}
         </div>
 
-        {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) ? (
-          <details><summary>Advanced execution</summary><div className="grid-2" aria-label="Omnigent execution target">
+        {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) && (pageMode.mode !== "create" || remediationDraft || showAdvancedStepOptions) ? (
+          <div className="grid-2" aria-label="Omnigent execution target">
             <label>
               Execution target
               <select
@@ -14261,7 +14261,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                 ))}
               </select>
             </label>
-          </div></details>
+          </div>
         ) : null}
 
         {runtime !== "omnigent" && selectedConfiguredProfile?.execution_selection_error ? (

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -7035,10 +7035,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     setSteps(reconstructedSteps);
     // Context retrieval authoring is only visible in Advanced mode, so a source
     // run that already authored it reveals the controls instead of resubmitting
-    // an invisible retrieval policy.
+    // an invisible retrieval policy. Inherited Omnigent execution targeting is
+    // likewise Advanced-gated, so reveal Advanced mode when the draft carries
+    // an explicit execution target or host-policy override.
     setShowAdvancedStepOptions(
       hasAdvancedStepOptionValues(reconstructedSteps) ||
-        hasAuthoredContextRetrieval(reconstructedContextRetrieval),
+        hasAuthoredContextRetrieval(reconstructedContextRetrieval) ||
+        Boolean(draft.omnigentExecutionTargetRef) ||
+        Boolean(draft.omnigentLaunchPolicyRef),
     );
     setNextStepNumber(reconstructedSteps.length + 1);
     setPersistedObjectiveAttachments(
@@ -7102,10 +7106,14 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
     }
     if (draft.executionProfileRef) {
       setOmnigentExecutionTargetRef(draft.executionProfileRef);
+      // Inherited execution targeting renders only in Advanced mode, so reveal
+      // the controls instead of resubmitting an invisible override.
+      setShowAdvancedStepOptions(true);
     }
     if (draft.launchPolicyRef) {
       setOmnigentLaunchPolicyRef(draft.launchPolicyRef);
       setOmnigentLaunchPolicyAuthored(true);
+      setShowAdvancedStepOptions(true);
     }
     if (draft.contextRetrieval) {
       setContextRetrieval(draft.contextRetrieval);
@@ -10419,6 +10427,15 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       return;
     }
     let submittedOmnigentLaunchPolicyRef = omnigentLaunchPolicyRef;
+    // Host-policy authoring lives behind Advanced mode. While the controls are
+    // hidden the submission carries the unauthored default so a stale value the
+    // operator can no longer see is never validated or submitted as an
+    // explicit override.
+    const effectiveOmnigentLaunchPolicyAuthored =
+      showAdvancedStepOptions && omnigentLaunchPolicyAuthored;
+    if (!showAdvancedStepOptions) {
+      submittedOmnigentLaunchPolicyRef = "";
+    }
     const effectiveOmnigentAgentProfileVersion =
       submittedOmnigentAgentProfileVersion;
     const effectiveOmnigentAgentProfileDigest = submittedOmnigentAgentProfileDigest;
@@ -10477,7 +10494,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
         !refreshedCompatiblePolicies.some(
           (policy) => policy.ref === submittedOmnigentLaunchPolicyRef,
         ) &&
-        !omnigentLaunchPolicyAuthored
+        !effectiveOmnigentLaunchPolicyAuthored
       ) {
         if (refreshedPreferredPolicy) {
           submittedOmnigentLaunchPolicyRef = refreshedPreferredPolicy.ref;
@@ -11669,7 +11686,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   : {}),
               },
             }
-          : normalizedRuntime === "omnigent" && omnigentLaunchPolicyAuthored
+          : normalizedRuntime === "omnigent" && showAdvancedStepOptions && omnigentLaunchPolicyAuthored
             ? { omnigent: { launchPolicyRef: submittedOmnigentLaunchPolicyRef } }
             : {}),
         publishMode: effectivePublishMode,
@@ -14208,7 +14225,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           )}
         </div>
 
-        {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) && (pageMode.mode !== "create" || remediationDraft || showAdvancedStepOptions) ? (
+        {runtime.trim().toLowerCase() === "omnigent" && (omnigentProfiles.length > 0 || Boolean(selectedGenericOmnigentTarget)) && showAdvancedStepOptions ? (
           <div className="grid-2" aria-label="Omnigent execution target">
             <label>
               Execution target
@@ -14417,8 +14434,17 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
                   // the retained state matches the unauthored policy that is
                   // actually submitted. Re-enabling the toggle then cannot
                   // silently restore a retrieval policy the operator can no
-                  // longer see.
+                  // longer see. A hidden host-policy override would be equally
+                  // invisible yet still submitted, so clear its authored flag
+                  // and restore the default selection.
                   setContextRetrieval(defaultContextRetrievalAuthoring());
+                  setOmnigentLaunchPolicyAuthored(false);
+                  const defaultPolicyRef =
+                    selectableOmnigentPolicies.find((policy) => policy.isDefault)?.ref ||
+                    selectableOmnigentPolicies[0]?.ref;
+                  if (defaultPolicyRef) {
+                    setOmnigentLaunchPolicyRef(defaultPolicyRef);
+                  }
                 }
                 updateDashboardPreferences({
                   createExpertMode: advancedEnabled,


### PR DESCRIPTION
For the create workflows page, I do not want the advanced runtime label and chevron to hide the runtime selector. The runtime selector should always be shown without the "Advanced runtime" label and chevron being present at all. The advanced execution options should be hidden by default as they are now, but instead of having an Advanced execution label and chevron, we should just show or hide these options based on the existing Advanced mode checkbox.