### PR TITLE
Fix GitHub issue search preset identity handoff

### DIFF
--- a/api_service/data/presets/github-issue-search-and-implement.yaml
+++ b/api_service/data/presets/github-issue-search-and-implement.yaml
@@ -89,48 +89,25 @@ inputs:
   required: false
   default: true
 steps:
-- title: Search GitHub issues and resolve target issue
-  type: skill
-  instructions: |-
-    Resolve one target GitHub issue and persist it to artifacts/github-issue-search-result.json with keys repository, number, url, and title.
-
-    Repository scope: "{{ inputs.repository }}". When empty, use the repository from workflow context.
-
-    When the search input below is non-empty, search GitHub issues with the query "<search> is:issue state:open" using the authenticated GitHub tooling with deterministic pagination. Use `gh search issues "<search> is:issue state:open --repo <repository>" --limit 100` and page with `--page N` until the result set is exhausted or 500 candidates have been examined. Take the best match as the target issue:
-
-    {{ inputs.issue_search }}
-
-    When the search input is blank, use fallback behavior with deterministic pagination: list open issues with `gh issue list --state open --limit 100 --page N --repo <repository>`, advancing pages until 500 issues have been examined or the list is exhausted. Examine candidates in listed order through the deterministic trusted GitHub blocker preflight (explicit blocking labels or a known blocker section in the issue body counts as blocker evidence). Keep looking until you find the first issue that has no blocking dependencies, and use that issue as the target. Never conclude "no unblocked issue exists" until every fetched page has been examined; report the page count and issues examined as search evidence.
-
-    If no matching (or no unblocked) issue can be resolved from trusted GitHub data, stop without implementing and report the empty search evidence including pages examined and total candidates. Do not invent an issue number. Record the resolved repository, issue number, URL, title, and whether fallback scanning was used in the step result.
-  skill:
-    id: auto
-    args: {}
-    requiredCapabilities:
-    - git
-    - gh
-- title: Load GitHub issue brief for resolved issue
+- title: Resolve GitHub issue and load trusted brief
   type: tool
-  instructions: |-
-    Read artifacts/github-issue-search-result.json from the previous step to get the resolved repository and issue number. Do not use any other issue.
-
-    Fetch that GitHub issue by dispatching the registered github.load_issue_preset_brief tool with the resolved repository, issue number, and artifactPath artifacts/github-issue-implement-brief.json. The resolved issue is discovered at runtime, so this step's static inputs carry only the fallback repository and artifact path; the runtime invocation MUST supply the exact resolved repository and issue number from the search-result artifact.
-
-    Build the canonical implementation input from the issue title, body, labels, state, URL, and any acceptance criteria in the issue body, producing the tool's canonical trustedSource, normalized issue, and presetBrief outputs. Preserve the repository and issue number in the brief so downstream implementation artifacts and the pull request can reference it. On retrieval errors emit the tool's explicit FAILED result and stop without writing a fabricated brief.
-
-    Persist the brief to artifacts/github-issue-implement-brief.json following the GitHub Issue Implement preset (github-issue-implement) brief shape, validate its schema and truncation state, and record the resolved issue reference in the step result.
+  instructions: >-
+    Resolve the best open issue matching issueSearch, or the first unblocked open
+    issue when blank, within 500 candidates. Load its trusted issue brief and
+    preserve the resolved identity and search evidence for downstream steps.
   tool:
     id: github.load_issue_preset_brief
     requiredCapabilities:
     - gh
     inputs:
-      repository: '{{ inputs.repository }}'
+      repository: '{{ inputs.repository or context.get(''repository'', '''') }}'
+      issueSearch: '{{ inputs.issue_search }}'
       artifactPath: artifacts/github-issue-implement-brief.json
 - title: Assess resolved issue implementation state
   repositoryOperation: read
   type: skill
   instructions: |-
-    Read artifacts/github-issue-search-result.json for the resolved issue reference and artifacts/github-issue-implement-brief.json for the brief produced by the github.load_issue_preset_brief tool step. Note the binding constraints for this run (empty means none):
+    Use the resolved issue in MoonMind trusted previous step context and the brief produced by github.load_issue_preset_brief. Read the durable brief attachment when present, and persist it to artifacts/github-issue-implement-brief.json for local implementation steps. Note the binding constraints for this run (empty means none):
 
     {{ inputs.constraints }}
 
@@ -147,9 +124,9 @@ steps:
 - title: Check resolved GitHub issue blockers before implementation
   type: tool
   instructions: |-
-    Read artifacts/github-issue-search-result.json and artifacts/github-issue-implement-assessment.json (or the recorded verdict from the assess step) before deciding how to apply blocker results.
+    Read the resolved issue from MoonMind trusted previous step context and artifacts/github-issue-implement-assessment.json (or the recorded verdict from the assess step) before deciding how to apply blocker results.
 
-    Dispatch the registered github.check_issue_blockers tool with the resolved repository, issue number from the search-result artifact, and the assessment verdict. The static inputs below carry only the fallback repository; the runtime invocation MUST supply the exact resolved repository and issue number. Treat explicit blocking labels or a known blocker section in the issue body as blocker evidence, following the GitHub Issue Implement preset (github-issue-implement) blocker stage.
+    Dispatch the registered github.check_issue_blockers tool with the resolved repository, issue number from the trusted previous step context, and the assessment verdict. The tool resolves the exact issue identity from the preserved trusted previous step context. Treat explicit blocking labels or a known blocker section in the issue body as blocker evidence, following the GitHub Issue Implement preset (github-issue-implement) blocker stage.
 
     If the recorded verdict is FULLY_IMPLEMENTED, report blocker findings for the record but do not stop finalization. Otherwise, if unresolved blockers are detected or blocker evidence cannot be evaluated from trusted GitHub data, emit a structured blocked outcome: write decision blocked with the blocker details AND a parser-recognized `Verdict: BLOCKED` line in the step result, then stop implementation. If the agent responds only with ordinary prose such as "found unresolved blockers" without the structured decision and verdict line, the plan MUST NOT advance to implementation.
   tool:
@@ -157,26 +134,27 @@ steps:
     requiredCapabilities:
     - gh
     inputs:
-      repository: '{{ inputs.repository }}'
+      repository: '{{ inputs.repository or context.get(''repository'', '''') }}'
+      assessmentArtifactPath: artifacts/github-issue-implement-assessment.json
 - title: Mark resolved GitHub issue In Progress
   type: tool
   instructions: |-
-    Read artifacts/github-issue-search-result.json and artifacts/github-issue-implement-assessment.json (or the previous step's recorded verdict) before doing anything.
+    Read the resolved issue from MoonMind trusted previous step context and artifacts/github-issue-implement-assessment.json (or the previous step's recorded verdict) before doing anything.
 
-    If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress update because the issue is already implemented. If the recorded verdict is BLOCKED, stop without changing GitHub. Otherwise dispatch the registered github.update_issue_status tool with the resolved repository, resolved issue number, targetStatus In Progress, and mode start. The static inputs below carry the fallback repository and policy; the runtime invocation MUST supply the exact resolved repository and issue number from the search-result artifact, plus the assessment artifact path, so the update flows through the registered tool's assessment/verification/PR-artifact checks, confirmed GitHub response, and structured side-effect evidence.
+    If the recorded verdict is FULLY_IMPLEMENTED, skip the In Progress update because the issue is already implemented. If the recorded verdict is BLOCKED, stop without changing GitHub. Otherwise dispatch the registered github.update_issue_status tool with the resolved repository, resolved issue number, targetStatus In Progress, and mode start. The tool resolves the exact issue identity from preserved trusted previous step context and uses the declared assessment artifact path, so the update flows through the registered tool's assessment/verification/PR-artifact checks, confirmed GitHub response, and structured side-effect evidence.
   tool:
     id: github.update_issue_status
     requiredCapabilities:
     - gh
     inputs:
-      repository: '{{ inputs.repository }}'
+      repository: '{{ inputs.repository or context.get(''repository'', '''') }}'
       targetStatus: In Progress
       mode: start
       assessmentArtifactPath: artifacts/github-issue-implement-assessment.json
 - title: Implement resolved issue
   type: skill
   instructions: |-
-    Read artifacts/github-issue-search-result.json, artifacts/github-issue-implement-brief.json, and artifacts/github-issue-implement-assessment.json. Binding constraints for this run (empty means none):
+    Read the resolved issue and brief from MoonMind trusted previous step context or its durable brief attachment, and read artifacts/github-issue-implement-assessment.json (or its durable assessment attachment). Binding constraints for this run (empty means none):
 
     {{ inputs.constraints }}
 
@@ -273,7 +251,7 @@ steps:
   annotations:
     issueImplementRole: pull-request-handoff
   instructions: |-
-    Read artifacts/github-issue-search-result.json, artifacts/github-issue-implement-brief.json, and artifacts/github-issue-implement-assessment.json. Binding constraints for this run (empty means none):
+    Read the resolved issue and brief from MoonMind trusted previous step context or its durable brief attachment, and read artifacts/github-issue-implement-assessment.json (or its durable assessment attachment). Binding constraints for this run (empty means none):
 
     {{ inputs.constraints }}
 
@@ -293,7 +271,7 @@ steps:
 - title: Finalize resolved GitHub issue status
   type: tool
   instructions: |-
-    Read artifacts/github-issue-search-result.json and artifacts/github-issue-implement-assessment.json (or the recorded verdict from the assess step) before changing GitHub.
+    Read the resolved issue from MoonMind trusted previous step context and artifacts/github-issue-implement-assessment.json (or the recorded verdict from the assess step) before changing GitHub.
 
     If the recorded verdict is BLOCKED, stop without changing GitHub and report the blocking evidence. If the recorded verdict is FULLY_IMPLEMENTED, apply the configured Done strategy via the trusted GitHub update tool. Otherwise {% if inputs.run_verify %}read artifacts/github-issue-implement-verify.json and require the latest controlling verifier result to report FULLY_IMPLEMENTED before any Code Review update{% else %}confirm implementation is complete and the focused tests required by the issue have passed; verification was disabled for this run so do not require artifacts/github-issue-implement-verify.json{% endif %}. Then read artifacts/github-issue-implement-pr.json, verify it contains a pull_request_url for the resolved issue, and dispatch the registered github.update_issue_status tool with mode finalize_after_pr_or_done, the resolved repository and issue number, the PR artifact path, and the verification artifact path. {% if inputs.run_verify %}If the verifier artifact is missing, terminal, or still reports ADDITIONAL_WORK_NEEDED after remediation is exhausted, stop without changing GitHub.{% else %}If the pull request artifact is missing or lacks a confirmed pull_request_url, stop without changing GitHub.{% endif %} Do not assume a single organization's workflow; use the configured label/comment/close strategy exposed by the trusted GitHub update tool.
   tool:
@@ -301,8 +279,9 @@ steps:
     requiredCapabilities:
     - gh
     inputs:
-      repository: '{{ inputs.repository }}'
+      repository: '{{ inputs.repository or context.get(''repository'', '''') }}'
       mode: finalize_after_pr_or_done
+      assessmentArtifactPath: artifacts/github-issue-implement-assessment.json
       pullRequestArtifactPath: artifacts/github-issue-implement-pr.json
       verificationArtifactPath: artifacts/github-issue-implement-verify.json
       requireVerification: '{{ inputs.run_verify }}'

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -252,6 +252,25 @@ The schema-form renderer uses a reusable widget registry. Initial widgets should
 
 Only widgets are allowed to have custom UI components. Presets consume widgets declaratively through schema metadata.
 
+## GitHub Issue Search
+
+The `github-issue-search-and-implement` preset resolves its optional repository
+input from the workflow repository during expansion. Its first typed
+`github.load_issue_preset_brief` operation accepts `issueSearch`: a nonempty
+query selects GitHub's best open issue match; an empty query scans open issues
+in descending creation order for the first candidate without blocker evidence.
+The scan is bounded to five pages of 100 candidates, excludes pull requests,
+and records pages and candidates examined. Missing, malformed, incomplete, or
+exhausted evidence stops the run before implementation or issue mutation.
+
+The selected issue and brief travel through the workflow's trusted issue
+context and durable brief attachment. Downstream blocker and status tools
+resolve the same issue from that context and reject conflicting identities.
+Tool instructions do not perform dynamic input binding or read agent-local
+files. Existing explicit `repository` / `issueNumber` tool inputs retain their
+direct lookup behavior. Preset changes apply to newly expanded runs; an old
+pinned plan must be resubmitted with the current preset to use search resolution.
+
 ## Jira Issue Input Pattern
 
 A Jira-driven preset should request a Jira issue as an input object rather than relying only on free-text instructions. This allows the Create page to display a picker, the backend to validate the issue reference, and the expansion layer to bind the issue fields into child steps.

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -1,0 +1,133 @@
+"""Bounded GitHub issue selection at the trusted issue-loading Activity boundary."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import httpx
+
+from moonmind.workflows.adapters.github_service import GitHubService
+
+
+async def resolve_issue(
+    *,
+    repository: str,
+    query: str,
+    github_service: GitHubService,
+    blockers_from_issue: Callable[[Mapping[str, Any]], list[dict[str, Any]]],
+) -> tuple[int | None, dict[str, Any]]:
+    """Select the best search match, or first unblocked open issue, within 500 rows."""
+
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise ValueError(
+            "GitHub issue search requires an explicit owner/repository scope."
+        )
+    evidence: dict[str, Any] = {
+        "searchEvidence": {
+            "fallbackScanning": not query,
+            "pagesExamined": 0,
+            "candidatesExamined": 0,
+        }
+    }
+    counts = evidence["searchEvidence"]
+    token, error = await github_service.resolve_github_token(repo=repository)
+    if not token:
+        return None, {
+            **evidence,
+            "error": error or "GitHub issue search is unavailable.",
+        }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for page in range(1, 6):
+            if query:
+                url = "https://api.github.com/search/issues"
+                params = {
+                    "q": f"{query} repo:{repository} is:issue is:open",
+                    "per_page": 100,
+                    "page": page,
+                }
+            else:
+                url = f"https://api.github.com/repos/{repository}/issues"
+                params = {
+                    "state": "open",
+                    "sort": "created",
+                    "direction": "desc",
+                    "per_page": 100,
+                    "page": page,
+                }
+            try:
+                response = await client.get(
+                    url, params=params, headers=github_service._github_headers(token)
+                )
+                response.raise_for_status()
+                payload = response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                return None, {
+                    **evidence,
+                    "error": f"GitHub issue search failed: {type(exc).__name__}.",
+                }
+            counts["pagesExamined"] += 1
+            if query and (
+                not isinstance(payload, Mapping)
+                or payload.get("incomplete_results") is not False
+            ):
+                return None, {
+                    **evidence,
+                    "error": "GitHub returned incomplete or malformed search evidence.",
+                }
+            candidates = payload.get("items") if query else payload
+            if not isinstance(candidates, list) or len(candidates) > 100:
+                return None, {
+                    **evidence,
+                    "error": "GitHub returned malformed issue candidates.",
+                }
+            for candidate in candidates:
+                counts["candidatesExamined"] += 1
+                if not isinstance(candidate, Mapping):
+                    return None, {
+                        **evidence,
+                        "error": "GitHub returned a malformed issue candidate.",
+                    }
+                if "pull_request" in candidate:
+                    continue
+                number = candidate.get("number")
+                if (
+                    type(number) is not int
+                    or number <= 0
+                    or candidate.get("state") != "open"
+                    or str(candidate.get("html_url")).casefold()
+                    != f"https://github.com/{repository}/issues/{number}".casefold()
+                    or not isinstance(candidate.get("body"), (str, type(None)))
+                    or "body" not in candidate
+                    or not isinstance(candidate.get("labels"), list)
+                ):
+                    return None, {
+                        **evidence,
+                        "error": "GitHub candidate identity, state, or blocker evidence is invalid.",
+                    }
+                normalized = dict(candidate)
+                labels = candidate["labels"]
+                if any(
+                    not isinstance(label, Mapping)
+                    or not isinstance(label.get("name"), str)
+                    for label in labels
+                ):
+                    return None, {
+                        **evidence,
+                        "error": "GitHub returned malformed blocker labels.",
+                    }
+                normalized["labels"] = [label["name"] for label in labels]
+                if not query and blockers_from_issue(normalized):
+                    continue
+                return number, evidence
+            if len(candidates) < 100:
+                return None, {
+                    **evidence,
+                    "error": "No eligible open GitHub issue found; candidate pages exhausted.",
+                }
+    return None, {
+        **evidence,
+        "error": "No eligible GitHub issue found within the 500-candidate scan limit.",
+    }

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -11,6 +11,33 @@ import httpx
 from moonmind.workflows.adapters.github_service import GitHubService
 
 
+def is_complete_open_issue(payload: Any, repository: str) -> bool:
+    """Validate raw GitHub evidence before normalization can hide missing fields."""
+
+    if not isinstance(payload, Mapping) or "pull_request" in payload:
+        return False
+    number = payload.get("number")
+    labels = payload.get("labels")
+    return (
+        type(number) is int
+        and number > 0
+        and payload.get("state") == "open"
+        and str(payload.get("html_url")).casefold()
+        == f"https://github.com/{repository}/issues/{number}".casefold()
+        and isinstance(payload.get("title"), str)
+        and bool(payload["title"].strip())
+        and "body" in payload
+        and isinstance(payload["body"], (str, type(None)))
+        and isinstance(labels, list)
+        and all(
+            isinstance(label, Mapping)
+            and isinstance(label.get("name"), str)
+            and bool(label["name"].strip())
+            for label in labels
+        )
+    )
+
+
 async def resolve_issue(
     *,
     repository: str,
@@ -92,36 +119,17 @@ async def resolve_issue(
                     }
                 if "pull_request" in candidate:
                     continue
-                number = candidate.get("number")
-                if (
-                    type(number) is not int
-                    or number <= 0
-                    or candidate.get("state") != "open"
-                    or str(candidate.get("html_url")).casefold()
-                    != f"https://github.com/{repository}/issues/{number}".casefold()
-                    or not isinstance(candidate.get("body"), (str, type(None)))
-                    or "body" not in candidate
-                    or not isinstance(candidate.get("labels"), list)
-                ):
+                if not is_complete_open_issue(candidate, repository):
                     return None, {
                         **evidence,
                         "error": "GitHub candidate identity, state, or blocker evidence is invalid.",
                     }
                 normalized = dict(candidate)
                 labels = candidate["labels"]
-                if any(
-                    not isinstance(label, Mapping)
-                    or not isinstance(label.get("name"), str)
-                    for label in labels
-                ):
-                    return None, {
-                        **evidence,
-                        "error": "GitHub returned malformed blocker labels.",
-                    }
                 normalized["labels"] = [label["name"] for label in labels]
                 if not query and blockers_from_issue(normalized):
                     continue
-                return number, evidence
+                return candidate["number"], evidence
             if len(candidates) < 100:
                 return None, {
                     **evidence,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -27,6 +27,10 @@ from moonmind.integrations.jira.models import (
 from moonmind.integrations.jira.tool import JiraToolService
 from moonmind.workflows.adapters.github_service import GitHubService
 from moonmind.workflows.skills.tool_plan_contracts import ToolResult
+from moonmind.workflows.temporal.github_issue_search import (
+    is_complete_open_issue,
+    resolve_issue,
+)
 
 JIRA_CREATE_ISSUES_TOOL_NAME = "story.create_jira_issues"
 JIRA_ORCHESTRATE_TASKS_TOOL_NAME = "story.create_jira_orchestrate_tasks"
@@ -4464,8 +4468,6 @@ async def load_github_issue_preset_brief(
 
     search_evidence: dict[str, Any] = {}
     if "issueSearch" in inputs:
-        from moonmind.workflows.temporal.github_issue_search import resolve_issue
-
         repository = _string(inputs.get("repository"))
         issue_number, search_evidence = await resolve_issue(
             repository=repository,
@@ -4494,14 +4496,13 @@ async def load_github_issue_preset_brief(
                 "issueNumber": issue_number,
             },
         )
-    issue = _github_issue_payload(issue_data, repository)
     if search_evidence and (
-        issue["number"] != issue_number
-        or issue["url"].casefold()
-        != f"https://github.com/{repository}/issues/{issue_number}".casefold()
-        or issue["state"] != "open"
-        or "pull_request" in issue_data
-        or (not _string(inputs.get("issueSearch")) and _github_blockers_from_issue(issue))
+        not is_complete_open_issue(issue_data, repository)
+        or issue_data["number"] != issue_number
+        or (
+            not _string(inputs.get("issueSearch"))
+            and _github_blockers_from_issue(_github_issue_payload(issue_data, repository))
+        )
     ):
         return ToolResult(
             status="FAILED",
@@ -4510,6 +4511,7 @@ async def load_github_issue_preset_brief(
                 "error": "Selected GitHub issue changed or could not be confirmed before brief loading.",
             },
         )
+    issue = _github_issue_payload(issue_data, repository)
     issue_ref = f"{repository}#{issue['number'] or issue_number}"
     body = _string(issue.get("body"))
     title = _string(issue.get("title"))

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4359,12 +4359,21 @@ async def update_jira_issue_status(
 
 
 def _github_issue_inputs(inputs: Mapping[str, Any]) -> tuple[str, int]:
+    # Tool steps cannot execute prose instructions to recover an agent's file.
+    # Use the issue preserved by the workflow's trusted issue-context channel.
+    previous = _mapping(inputs.get("previousOutputs"))
+    resolved = (
+        _mapping(previous.get("issue"))
+        if previous.get("trustedSource") == "moonmind.github.get_issue"
+        else {}
+    )
     nested = _mapping(inputs.get("github") or inputs.get("issue"))
     repository = _string(
         inputs.get("repository")
         or inputs.get("repo")
         or nested.get("repository")
         or nested.get("repo")
+        or resolved.get("repository")
     )
     issue_number_raw = (
         inputs.get("issueNumber")
@@ -4373,6 +4382,7 @@ def _github_issue_inputs(inputs: Mapping[str, Any]) -> tuple[str, int]:
         or nested.get("issueNumber")
         or nested.get("issue_number")
         or nested.get("number")
+        or resolved.get("number")
     )
     try:
         issue_number = int(str(issue_number_raw).strip())
@@ -4380,6 +4390,11 @@ def _github_issue_inputs(inputs: Mapping[str, Any]) -> tuple[str, int]:
         issue_number = 0
     if not repository or issue_number <= 0:
         raise ValueError("repository and issueNumber are required for GitHub issue tools.")
+    if resolved and (
+        repository.casefold() != _string(resolved.get("repository")).casefold()
+        or issue_number != resolved.get("number")
+    ):
+        raise ValueError("GitHub issue inputs conflict with the resolved issue context.")
     return repository, issue_number
 
 
@@ -4447,7 +4462,24 @@ async def load_github_issue_preset_brief(
 ) -> ToolResult:
     """Load a compact GitHub issue preset brief through trusted GitHub data."""
 
-    repository, issue_number = _github_issue_inputs(inputs)
+    search_evidence: dict[str, Any] = {}
+    if "issueSearch" in inputs:
+        from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+        repository = _string(inputs.get("repository"))
+        issue_number, search_evidence = await resolve_issue(
+            repository=repository,
+            query=_string(inputs.get("issueSearch")),
+            github_service=github_service_factory(),
+            blockers_from_issue=_github_blockers_from_issue,
+        )
+        if issue_number is None:
+            return ToolResult(
+                status="FAILED",
+                outputs={"repository": repository, **search_evidence},
+            )
+    else:
+        repository, issue_number = _github_issue_inputs(inputs)
     issue_data, error = await _fetch_github_issue(
         repository=repository,
         issue_number=issue_number,
@@ -4463,6 +4495,21 @@ async def load_github_issue_preset_brief(
             },
         )
     issue = _github_issue_payload(issue_data, repository)
+    if search_evidence and (
+        issue["number"] != issue_number
+        or issue["url"].casefold()
+        != f"https://github.com/{repository}/issues/{issue_number}".casefold()
+        or issue["state"] != "open"
+        or "pull_request" in issue_data
+        or (not _string(inputs.get("issueSearch")) and _github_blockers_from_issue(issue))
+    ):
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                **search_evidence,
+                "error": "Selected GitHub issue changed or could not be confirmed before brief loading.",
+            },
+        )
     issue_ref = f"{repository}#{issue['number'] or issue_number}"
     body = _string(issue.get("body"))
     title = _string(issue.get("title"))
@@ -4485,6 +4532,7 @@ async def load_github_issue_preset_brief(
         outputs={
             "trustedSource": "moonmind.github.get_issue",
             "issue": issue,
+            **search_evidence,
             "presetBrief": preset_brief,
             "artifactPath": artifact_path,
             "summary": f"Loaded GitHub issue preset brief for {issue_ref} from trusted GitHub data.",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -9398,6 +9398,7 @@ class MoonMindRunWorkflow:
                 "summary",
             ),
             "moonmind.github.get_issue": (
+                "searchEvidence",
                 "repository",
                 "issueNumber",
                 "issueRef",
@@ -9477,6 +9478,7 @@ class MoonMindRunWorkflow:
             key: compact_context[key]
             for key in (
                 "trustedSource",
+                "searchEvidence",
                 "jiraIssueKey",
                 "repository",
                 "issueNumber",

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -1,0 +1,322 @@
+"""Replay the issue-search preset's catalog → Activity → trusted-context handoff."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base
+from api_service.services.presets.catalog import PresetCatalogService
+from moonmind.workflows.adapters.github_service import GitHubService
+from moonmind.workflows.skills.tool_dispatcher import ToolActivityDispatcher
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalSkillActivities,
+    _default_registry_skill_payload,
+)
+from moonmind.workflows.temporal.story_output_tools import (
+    register_story_output_tool_handlers,
+)
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+REPOSITORY = "MoonLadderStudios/MoonMind"
+PRESET = "github-issue-search-and-implement"
+
+
+def issue(number=4025, **overrides):
+    # Minimized incident mm:66e24e5f: search selected #4025 but the following
+    # native load Activity received repository="" and no issueNumber.
+    return {
+        "number": number,
+        "state": "open",
+        "title": "Dashboard update stream",
+        "body": "Reconcile advertised routes and bounded polling recovery.",
+        "html_url": f"https://github.com/{REPOSITORY}/issues/{number}",
+        "labels": [{"name": "bug"}],
+        **overrides,
+    }
+
+
+@pytest.fixture
+def activity_boundary(monkeypatch):
+    requests = []
+    pages = [[issue()]]
+    detail = issue()
+
+    def handler(request):
+        requests.append(request)
+        if request.url.path.endswith("/issues"):
+            payload = pages[int(request.url.params["page"]) - 1]
+            if request.url.path == "/search/issues" and isinstance(payload, list):
+                payload = {"items": payload, "incomplete_results": False}
+        else:
+            payload = detail
+        return httpx.Response(200, json=payload)
+
+    client_type = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: client_type(transport=httpx.MockTransport(handler), **kwargs),
+    )
+    monkeypatch.setattr(
+        GitHubService,
+        "resolve_github_token",
+        AsyncMock(return_value=("test-only", None)),
+    )
+    dispatcher = ToolActivityDispatcher()
+    register_story_output_tool_handlers(dispatcher)
+    names = (
+        "github.load_issue_preset_brief",
+        "github.check_issue_blockers",
+        "github.update_issue_status",
+    )
+    snapshot = ToolRegistrySnapshot(
+        digest="reg:sha256:incident66e24e5f",
+        artifact_ref="art_registry",
+        skills=tuple(
+            parse_tool_definition(_default_registry_skill_payload(name=name))
+            for name in names
+        ),
+    )
+    artifact_service = SimpleNamespace(
+        read=AsyncMock(return_value=(None, {"verdict": "NOT_IMPLEMENTED"}))
+    )
+    activities = TemporalSkillActivities(
+        dispatcher=dispatcher, artifact_service=artifact_service
+    )
+
+    async def execute(name, inputs):
+        return await activities.mm_tool_execute(
+            registry_snapshot=snapshot,
+            principal="test:issue-search",
+            invocation_payload={
+                "id": "incident-step",
+                "tool": {"type": "skill", "name": name},
+                "inputs": inputs,
+            },
+            context={
+                "namespace": "default",
+                "workflow_id": "mm:66e24e5f",
+                "run_id": "run",
+                "node_id": "step",
+            },
+            idempotency_key="incident-step:execute",
+        )
+
+    return SimpleNamespace(
+        execute=execute, pages=pages, requests=requests, detail=detail
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "inputs", [{}, {"repository": "", "issue_search": ""}, {"repository": REPOSITORY}]
+)
+async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
+    tmp_path, activity_boundary, inputs
+):
+    seeds = tmp_path / "seeds"
+    seeds.mkdir()
+    shutil.copy(
+        Path(__file__).resolve().parents[3]
+        / "api_service/data/presets"
+        / f"{PRESET}.yaml",
+        seeds,
+    )
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/catalog.db")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        async with sessionmaker(engine, class_=AsyncSession)() as session:
+            catalog = PresetCatalogService(session)
+            await catalog.sync_seed_templates(seed_dir=seeds)
+            expanded = await catalog.expand_template(
+                slug=PRESET,
+                scope="global",
+                scope_ref=None,
+                inputs=inputs,
+                context={"repository": REPOSITORY},
+            )
+    finally:
+        await engine.dispose()
+    steps = expanded["steps"]
+    assert steps[0]["type"] == "tool"
+    tool = steps[0]["tool"]
+    result = await activity_boundary.execute(tool["id"], tool["inputs"])
+    assert result.status == "COMPLETED"
+    assert result.outputs["issue"]["number"] == 4025
+    assert result.outputs["searchEvidence"] == {
+        "fallbackScanning": True,
+        "pagesExamined": 1,
+        "candidatesExamined": 1,
+    }
+    workflow = MoonMindRunWorkflow()
+    workflow._record_trusted_issue_context(result.outputs)
+    previous = workflow._merge_trusted_issue_context(
+        {
+            "summary": "Omnigent session completed",
+            "assessmentArtifactRef": "art_assessment",
+        }
+    )
+    # No local workspace, issue-number injection, or assistant-text parsing.
+    for step in steps[2:4]:
+        tool = step["tool"]
+        result = await activity_boundary.execute(
+            tool["id"], {**tool["inputs"], "previousOutputs": previous}
+        )
+        assert result.status == "COMPLETED"
+        assert (
+            result.outputs.get("issueRef") == f"{REPOSITORY}#4025"
+            or result.outputs.get("issueUrl") == issue()["html_url"]
+        )
+        workflow._record_assessment_context(result.outputs)
+        previous = workflow._merge_trusted_issue_context(result.outputs)
+    patches = [
+        request for request in activity_boundary.requests if request.method == "PATCH"
+    ]
+    assert len(patches) == 1
+    assert patches[0].url.path == f"/repos/{REPOSITORY}/issues/4025"
+    # Finalization still requires its verification / PR evidence before mutation.
+    final_tool = steps[-1]["tool"]
+    final = await activity_boundary.execute(
+        final_tool["id"], {**final_tool["inputs"], "previousOutputs": previous}
+    )
+    assert final.status == "FAILED"
+    assert (
+        len(
+            [
+                request
+                for request in activity_boundary.requests
+                if request.method == "PATCH"
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_pagination_skips_blocked_issues_and_pull_requests(
+    activity_boundary,
+):
+    activity_boundary.pages[:] = [
+        [issue(n, labels=[{"name": "blocked"}]) for n in range(100, 200)],
+        [issue(200, pull_request={}), issue()],
+    ]
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief", {"repository": REPOSITORY, "issueSearch": ""}
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["issue"]["number"] == 4025
+    assert result.outputs["searchEvidence"]["pagesExamined"] == 2
+    assert result.outputs["searchEvidence"]["candidatesExamined"] == 102
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pages, query, expected",
+    [
+        ([[]], "", "exhausted"),
+        ([[issue(labels=[{"name": "blocked"}])] * 100] * 5, "", "500-candidate"),
+        ([{"items": [issue()], "incomplete_results": True}], "dashboard", "incomplete"),
+        ([[issue(state="unknown")]], "", "invalid"),
+        (
+            [[issue(html_url="https://github.com/other/repo/issues/4025")]],
+            "dashboard",
+            "invalid",
+        ),
+        ([[issue(labels=None)]], "", "invalid"),
+    ],
+)
+async def test_search_stops_on_empty_bounded_or_degraded_evidence(
+    activity_boundary, pages, query, expected
+):
+    activity_boundary.pages[:] = pages
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY, "issueSearch": query},
+    )
+    assert result.status == "FAILED"
+    assert expected in result.outputs["error"]
+    assert not any(request.method != "GET" for request in activity_boundary.requests)
+
+
+@pytest.mark.asyncio
+async def test_repository_scope_is_case_insensitive(activity_boundary):
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY.lower(), "issueSearch": ""},
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["issue"]["number"] == 4025
+
+
+@pytest.mark.asyncio
+async def test_query_search_and_previous_explicit_issue_payload(activity_boundary):
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY, "issueSearch": "dashboard"},
+    )
+    assert result.status == "COMPLETED"
+    assert (
+        activity_boundary.requests[0].url.params["q"]
+        == f"dashboard repo:{REPOSITORY} is:issue is:open"
+    )
+    activity_boundary.requests.clear()
+    # Existing persisted explicit issue inputs keep their original direct lookup.
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY, "issueNumber": 4025},
+    )
+    assert result.status == "COMPLETED"
+    assert len(activity_boundary.requests) == 1
+    assert "searchEvidence" not in result.outputs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "changed", [{"state": "closed"}, {"number": 99}, {"labels": [{"name": "blocked"}]}]
+)
+async def test_selected_issue_is_revalidated_before_loading_brief(
+    activity_boundary, changed
+):
+    activity_boundary.detail.update(changed)
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief", {"repository": REPOSITORY, "issueSearch": ""}
+    )
+    assert result.status == "FAILED"
+    assert "could not be confirmed" in result.outputs["error"]
+    assert "trustedSource" not in result.outputs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous, repository",
+    [
+        ({"issue": issue()}, REPOSITORY),
+        (
+            {
+                "trustedSource": "moonmind.github.get_issue",
+                "issue": {**issue(), "repository": REPOSITORY},
+            },
+            "other/repo",
+        ),
+    ],
+)
+async def test_identity_handoff_rejects_untrusted_or_conflicting_issue(
+    activity_boundary, previous, repository
+):
+    with pytest.raises(Exception, match="required|conflict"):
+        await activity_boundary.execute(
+            "github.update_issue_status",
+            {"repository": repository, "previousOutputs": previous, "mode": "start"},
+        )
+    assert activity_boundary.requests == []

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -167,6 +167,7 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
             "assessmentArtifactRef": "art_assessment",
         }
     )
+    assert previous["searchEvidence"] == result.outputs["searchEvidence"]
     # No local workspace, issue-number injection, or assistant-text parsing.
     for step in steps[2:4]:
         tool = step["tool"]
@@ -180,6 +181,8 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
         )
         workflow._record_assessment_context(result.outputs)
         previous = workflow._merge_trusted_issue_context(result.outputs)
+        assert previous["searchEvidence"]["candidatesExamined"] == 1
+        assert previous["searchEvidence"]["pagesExamined"] == 1
     patches = [
         request for request in activity_boundary.requests if request.method == "PATCH"
     ]
@@ -279,6 +282,11 @@ async def test_query_search_and_previous_explicit_issue_payload(activity_boundar
     assert result.status == "COMPLETED"
     assert len(activity_boundary.requests) == 1
     assert "searchEvidence" not in result.outputs
+    workflow = MoonMindRunWorkflow()
+    workflow._record_trusted_issue_context(result.outputs)
+    previous = workflow._merge_trusted_issue_context({"summary": "Legacy agent result"})
+    assert "searchEvidence" not in previous
+    assert previous["issue"]["number"] == 4025
 
 
 @pytest.mark.asyncio
@@ -295,6 +303,40 @@ async def test_selected_issue_is_revalidated_before_loading_brief(
     assert result.status == "FAILED"
     assert "could not be confirmed" in result.outputs["error"]
     assert "trustedSource" not in result.outputs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["title", "body", "labels"])
+@pytest.mark.parametrize("mode", ["missing", "malformed"])
+async def test_incomplete_selected_details_cannot_produce_a_trusted_brief(
+    activity_boundary, field, mode
+):
+    if mode == "missing":
+        del activity_boundary.detail[field]
+    else:
+        activity_boundary.detail[field] = {"unexpected": "shape"}
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief", {"repository": REPOSITORY, "issueSearch": ""}
+    )
+    assert result.status == "FAILED"
+    assert "trustedSource" not in result.outputs
+    assert "presetBrief" not in result.outputs
+    assert not any(request.method != "GET" for request in activity_boundary.requests)
+
+
+def test_compact_issue_context_preserves_search_evidence():
+    import json
+
+    evidence = {"fallbackScanning": True, "pagesExamined": 5, "candidatesExamined": 499}
+    context = {
+        "trustedSource": "moonmind.github.get_issue",
+        "searchEvidence": evidence,
+        "issue": {"repository": REPOSITORY, **issue()},
+        **{key: "x" * 30000 for key in ("title", "body", "summary", "presetBrief")},
+    }
+    payload, truncated = MoonMindRunWorkflow._trusted_context_payload(context)
+    assert truncated
+    assert json.loads(payload)["searchEvidence"] == evidence
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
@@ -168,7 +168,13 @@ async def test_current_manager_cleans_then_grants_and_replays(
                 },
             )
             await asyncio.wait_for(activities.verified.wait(), timeout=15)
-            assignment = await requester.query(_SlotRequester.assigned)
+            # Activity observation does not order a separate workflow's signal
+            # delivery. Wait for the recipient's authoritative assignment.
+            async with asyncio.timeout(15):
+                while (
+                    assignment := await requester.query(_SlotRequester.assigned)
+                ) is None:
+                    await asyncio.sleep(0.01)
             assert assignment["profile_id"] == "test-default"
             assert assignment["fencing_generation"] > 0
             state = await manager.query("get_state")

--- a/tests/unit/workflows/temporal/test_run_dependency_pause_boundary.py
+++ b/tests/unit/workflows/temporal/test_run_dependency_pause_boundary.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from uuid import uuid4
@@ -20,6 +21,26 @@ from moonmind.workflows.temporal.workflows.run import (
     MoonMindUserWorkflow,
 )
 from tests.helpers.temporal_visibility import register_deployment_search_attributes
+
+
+@pytest.fixture(autouse=True)
+def _collect_closed_workflows():
+    """Finalize abandoned unsandboxed coroutines outside workflow event loops."""
+    # Open-history replay and hard termination can leave coroutine cycles. Their
+    # dependency-wait finally blocks issue commands; GC in the next workflow
+    # thread would attach those commands to that unrelated workflow history,
+    # including the same test's Replayer. Control collection until both close.
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        gc.collect()
+        yield
+    finally:
+        try:
+            gc.collect()
+        finally:
+            if was_enabled:
+                gc.enable()
 
 
 class DependencySnapshot:


### PR DESCRIPTION
Workflow `mm:66e24e5f-aa30-4884-b7d2-c76398974c35` selected GitHub issue #4025, but its next typed tool received an empty repository and no issue number. The preset described reading an agent-local search-result file in prose without implementing that binding; the later blocker and status steps had the same gap.

Resolve search and load the brief within `github.load_issue_preset_brief`, then use the workflow's existing trusted issue context for downstream tools. Blank repository inputs resolve from workflow context. Search is bounded to 500 candidates with pagination evidence, and malformed, incomplete, conflicting, or changed issue evidence stops before mutation. Raw search/detail validation runs before normalization, and compact search counts survive intervening agent steps and context compaction. Existing explicit issue inputs retain direct lookup; old pinned preset plans require resubmission after deployment.

The Temporal test fixtures also wait for the actual slot assignment and finalize abandoned unsandboxed workflow coroutines outside workflow event loops, avoiding races exposed by CI without weakening replay assertions.

Validation:
- 330 targeted unit/catalog/Activity-boundary tests passed.
- 4,188 tests and nine subtests passed in the complete Python 3.12 Temporal boundary shard.
- Final fixture checks: 12 passed; replay stress checks: 41 passed.
- 670 hermetic integration tests passed under isolated Compose project `moonmind-test-issue-search`.
- 166 checkpoint-recovery reliability tests passed.
- Read-only live GitHub checks for blank search and `dashboard` both resolved #4025 and loaded its brief.
