### PR TITLE
Fix Windows Docker Desktop deployment bind sources

### DIFF
--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -707,6 +707,14 @@ with:
 - `MOONMIND_DEPLOYMENT_EXCLUDED_SERVICES` for runner services that must not be
   targeted by `docker compose up`
 
+On Windows Docker Desktop, the Linux worker resolves Compose files through its
+local checkout mount and maps checkout bind sources into the daemon's
+`/run/desktop/mnt/host/<drive>/...` namespace. WSL user-distro `/mnt/<drive>` paths
+are not daemon-visible host mounts. Rewritten checkout binds disable automatic
+host-directory creation, so an unavailable source fails instead of mounting an
+empty directory over application files. POSIX host paths retain their configured
+namespace.
+
 ## 11.2 Ephemeral updater container
 
 A privileged worker starts a one-shot updater container that mounts:

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -11,7 +11,7 @@ import re
 import tempfile
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
 
 from .deployment_tools import (
@@ -30,7 +30,7 @@ DEPLOYMENT_ONE_SHOT_SERVICES = frozenset({"init-db"})
 FILE_LOCK_STALE_AFTER_SECONDS = 6 * 60 * 60
 _REDACTED = "[REDACTED]"
 _STACK_PATH_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
-_WSL_HOST_MOUNT_ROOT = Path("/mnt")
+_DOCKER_DESKTOP_HOST_MOUNT_ROOT = PurePosixPath("/run/desktop/mnt/host")
 _SENSITIVE_KEY_PATTERN = re.compile(
     r"("
     r"token|secret|password|passwd|credential|authorization|"
@@ -419,8 +419,12 @@ def _is_host_absolute_path(path: Path | str) -> bool:
     return False
 
 
-def _wsl_linux_host_path(path: str) -> str | None:
-    """Translate a Windows drive path into WSL's Linux host path."""
+def _docker_desktop_host_path(path: str) -> str | None:
+    """Translate a Windows drive path into Docker Desktop's daemon namespace.
+
+    The Linux deployment worker talks directly to the Desktop daemon. WSL's
+    user-distro ``/mnt/<drive>`` paths are not the daemon's host-file mounts.
+    """
 
     normalized = path.strip()
     if len(normalized) < 3 or normalized[1] != ":" or not normalized[0].isalpha():
@@ -428,8 +432,8 @@ def _wsl_linux_host_path(path: str) -> str | None:
     tail = normalized[2:].replace("\\", "/").lstrip("/")
     drive = normalized[0].lower()
     if tail:
-        return str(_WSL_HOST_MOUNT_ROOT / drive / Path(tail))
-    return str(_WSL_HOST_MOUNT_ROOT / drive)
+        return str(_DOCKER_DESKTOP_HOST_MOUNT_ROOT / drive / tail)
+    return str(_DOCKER_DESKTOP_HOST_MOUNT_ROOT / drive)
 
 
 def _remap_host_compose_path(
@@ -736,8 +740,7 @@ class HostDockerComposeRunner:
         else:
             return local_source
         host_dir = (
-            _wsl_linux_host_path(str(self.project_dir))
-            or str(self.project_dir)
+            _docker_desktop_host_path(str(self.project_dir)) or str(self.project_dir)
         ).rstrip("\\/")
         if not suffix:
             return host_dir
@@ -764,10 +767,16 @@ class HostDockerComposeRunner:
                     if isinstance(raw_volume, Mapping):
                         volume = dict(raw_volume)
                         source = volume.get("source")
-                        if isinstance(source, str):
-                            volume["source"] = self._host_bind_source_for_local_path(
-                                source
-                            )
+                        if volume.get("type") == "bind" and isinstance(source, str):
+                            host_source = self._host_bind_source_for_local_path(source)
+                            if host_source != source:
+                                volume["source"] = host_source
+                                # A missing checkout must fail before Docker can
+                                # create an empty directory over image contents.
+                                volume["bind"] = {
+                                    **volume.get("bind", {}),
+                                    "create_host_path": False,
+                                }
                         rewritten_volumes.append(volume)
                     else:
                         rewritten_volumes.append(raw_volume)

--- a/tests/integration/reliability/replays/deployment-update-windows-bind-source/manifest.json
+++ b/tests/integration/reliability/replays/deployment-update-windows-bind-source/manifest.json
@@ -1,0 +1,13 @@
+{
+  "failureShapeId": "deployment-update-windows-bind-source",
+  "incidentWorkflowId": "mm:fa00d758-3225-4109-ad27-03f4e88f8118",
+  "activityType": "mm.tool.execute",
+  "toolName": "deployment.update_compose_stack",
+  "hostProjectDir": "D:\\code\\MoonMind",
+  "daemonProjectDir": "/run/desktop/mnt/host/d/code/MoonMind",
+  "expectedBindSource": "/run/desktop/mnt/host/d/code/MoonMind/init_db",
+  "observedBindSource": "/mnt/d/code/MoonMind/init_db",
+  "observedExitCode": 2,
+  "observedFailure": "sh: 0: cannot open /app/init_db/init_db_entrypoint.sh: No such file",
+  "invariant": "The Linux deployment worker must use Docker Desktop daemon-visible checkout binds, execute init-db successfully, then reconcile and verify the stack. Missing checkout sources must not create empty host directories."
+}

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -39,7 +39,7 @@ AGENT_SERVICE = "temporal-worker-agent-runtime"
 PROXY_SERVICE = "sandbox-egress-proxy"
 RUNNER_SERVICE = "temporal-worker-deployment-control"
 NETWORK = "restricted-egress-network"
-KNOWN_SERVICES = (AGENT_SERVICE, PROXY_SERVICE, RUNNER_SERVICE)
+KNOWN_SERVICES = (AGENT_SERVICE, PROXY_SERVICE, RUNNER_SERVICE, "init-db")
 
 
 def load_state():
@@ -116,6 +116,26 @@ if command == "pull":
     raise SystemExit(0)
 
 up_services = selected_services(tail)
+if "init-db" in up_services:
+    config = json.loads(Path(args[args.index("-f") + 1]).read_text())
+    volume = config["services"]["init-db"]["volumes"][0]
+    state["initDbBind"] = volume
+    # Model the daemon's mounted host checkout, not the worker's filesystem.
+    if volume["source"] != state["daemonProjectDir"] + "/init_db":
+        save_state(state)
+        print("cannot open /app/init_db/init_db_entrypoint.sh: No such file", file=sys.stderr)
+        raise SystemExit(2)
+    completed = subprocess.run(
+        ["sh", str(Path(state["localProjectDir"]) / "init_db/init_db_entrypoint.sh")],
+        capture_output=True, text=True, check=False,
+    )
+    state["initDbExitCode"] = completed.returncode
+    state["initDbOutput"] = completed.stdout
+    save_state(state)
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    raise SystemExit(completed.returncode)
+
 state["upServices"] = up_services
 if AGENT_SERVICE in up_services and PROXY_SERVICE not in up_services:
     state["networkError"] = f"network {NETWORK} is unavailable"
@@ -173,17 +193,28 @@ raise SystemExit(0)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("windows_host", [False, True])
+@pytest.mark.parametrize("explicit_defaults", [False, True])
 async def test_deployment_update_reconciles_non_image_infrastructure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    windows_host: bool,
+    explicit_defaults: bool,
 ) -> None:
     replay_id = "deployment-update-infrastructure-reconciliation"
     manifest = load_replay(replay_id, "manifest.json")
     expected = load_replay(replay_id, "expected-outcome.json")
     requested_repository = manifest["requestedRepository"]
     requested_image = f"{requested_repository}:latest"
+    windows_replay = (
+        load_replay("deployment-update-windows-bind-source", "manifest.json")
+        if windows_host
+        else None
+    )
     real_docker = shutil.which("docker")
-    assert real_docker is not None, "reliability journey image must provide Docker Compose"
+    assert (
+        real_docker is not None
+    ), "reliability journey image must provide Docker Compose"
 
     compose_path = tmp_path / "docker-compose.yaml"
     compose_path.write_text(
@@ -207,6 +238,25 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
         ).lstrip(),
         encoding="utf-8",
     )
+    if windows_replay:
+        # Keep the real Compose parser in the journey; only the daemon is modeled.
+        compose_text = compose_path.read_text(encoding="utf-8")
+        compose_path.write_text(
+            compose_text.replace(
+                "networks:\n  restricted-egress-network:",
+                "  init-db:\n"
+                f"    image: {requested_image}\n"
+                "    volumes:\n"
+                "      - ./init_db:/app/init_db:ro\n"
+                "    command: sh /app/init_db/init_db_entrypoint.sh\n"
+                "networks:\n  restricted-egress-network:",
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "init_db").mkdir()
+        (tmp_path / "init_db/init_db_entrypoint.sh").write_text(
+            "printf 'init-db completed\\n'\n", encoding="utf-8"
+        )
     state_path = tmp_path / "engine-state.json"
     state_path.write_text(
         json.dumps(
@@ -226,6 +276,10 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
                 ],
                 "images": [],
                 "networks": {},
+                "localProjectDir": str(tmp_path),
+                "daemonProjectDir": (
+                    windows_replay["daemonProjectDir"] if windows_replay else None
+                ),
             }
         ),
         encoding="utf-8",
@@ -243,8 +297,11 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
     monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
 
     runner = HostDockerComposeRunner(
-        project_dir=str(tmp_path),
-        project_name="deployment-replay",
+        project_dir=(
+            windows_replay["hostProjectDir"] if windows_replay else str(tmp_path)
+        ),
+        local_project_dir=str(tmp_path) if windows_replay else None,
+        project_name="moonmind-test-deployment-replay",
         excluded_services=tuple(manifest["excludedServices"]),
     )
     executor = DeploymentUpdateExecutor(
@@ -262,9 +319,11 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
                 "repository": requested_repository,
                 "reference": "latest",
             },
-            "mode": "changed_services",
-            "removeOrphans": True,
-            "wait": True,
+            **(
+                {"mode": "changed_services", "removeOrphans": True, "wait": True}
+                if explicit_defaults
+                else {}
+            ),
             "reason": "Replay production infrastructure reconciliation failure",
         },
         context={"deployment_runner_mode": "privileged_worker"},
@@ -274,7 +333,9 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
     assert result.status == "COMPLETED"
     assert result.outputs["status"] == "SUCCEEDED"
     assert state["composeConfigCalls"] >= 4
-    assert state["pullServices"] == expected["pullServices"]
+    assert state["pullServices"] == expected["pullServices"] + (
+        ["init-db"] if windows_replay else []
+    )
     assert state["upServices"] == expected["reconciliationServices"]
     assert set(state["networks"]["restricted-egress-network"]["services"]) == set(
         expected["reconciliationServices"]
@@ -288,3 +349,9 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
         service not in state["pullServices"] and service not in state["upServices"]
         for service in expected["excludedServices"]
     )
+    if windows_replay:
+        assert state["initDbExitCode"] == 0
+        assert state["initDbOutput"] == "init-db completed\n"
+        assert state["initDbBind"]["source"] == windows_replay["expectedBindSource"]
+        assert state["initDbBind"]["bind"]["create_host_path"] is False
+        assert state["initDbBind"]["read_only"] is True

--- a/tests/unit/workflows/skills/test_deployment_update_execution.py
+++ b/tests/unit/workflows/skills/test_deployment_update_execution.py
@@ -1821,7 +1821,8 @@ async def test_host_compose_runner_rewrites_windows_bind_sources_via_resolved_co
     assert calls[0][calls[0].index("--project-directory") + 1] == str(local_dir)
     assert calls[1][calls[1].index("--project-directory") + 1] == str(local_dir)
     volume = generated_compose["services"]["api"]["volumes"][0]
-    assert volume["source"] == "/mnt/d/code/MoonMind/moonmind"
+    assert volume["source"] == "/run/desktop/mnt/host/d/code/MoonMind/moonmind"
+    assert volume["bind"]["create_host_path"] is False
 
 
 @pytest.mark.asyncio
@@ -2057,3 +2058,43 @@ async def test_run_compose_json_failure_bounds_stderr_in_tool_failure(
     embedded_result = failure.details["result"]
     assert len(embedded_result["stderr"]) <= 2000
     assert len(embedded_result["stderr"]) < len(huge_stderr)
+
+
+@pytest.mark.parametrize(
+    ("host_dir", "expected"),
+    [
+        (r"D:\code\MoonMind", "/run/desktop/mnt/host/d/code/MoonMind"),
+        ("C:/Projects/Moon Mind", "/run/desktop/mnt/host/c/Projects/Moon Mind"),
+        ("D:/", "/run/desktop/mnt/host/d"),
+        ("/srv/moonmind", "/srv/moonmind"),
+    ],
+)
+def test_checkout_bind_mapping_preserves_mount_options_and_other_sources(
+    tmp_path, host_dir, expected
+):
+    runner = HostDockerComposeRunner(
+        project_dir=host_dir, local_project_dir=str(tmp_path)
+    )
+    checkout = {
+        "type": "bind",
+        "source": str(tmp_path / "init_db"),
+        "target": "/app/init_db",
+        "read_only": True,
+        "bind": {"create_host_path": True, "propagation": "rprivate"},
+    }
+    other = {"type": "bind", "source": "/data/shared", "target": "/shared"}
+    neighbor = {"type": "bind", "source": str(tmp_path) + "-other", "target": "/other"}
+    named = {"type": "volume", "source": "data", "target": "/data"}
+    config = {"services": {"init-db": {"volumes": [checkout, other, neighbor, named]}}}
+
+    rewritten = runner._rewrite_local_bind_sources_to_host(config)
+
+    volumes = rewritten["services"]["init-db"]["volumes"]
+    assert volumes[0] == {
+        **checkout,
+        "source": expected + "/init_db",
+        "bind": {"create_host_path": False, "propagation": "rprivate"},
+    }
+    assert volumes[1:] == [other, neighbor, named]
+    assert runner._host_bind_source_for_local_path(str(tmp_path)) == expected
+    assert checkout["bind"]["create_host_path"] is True


### PR DESCRIPTION
The deployment update failed at `init-db` in workflow `mm:fa00d758-3225-4109-ad27-03f4e88f8118`: the Linux worker translated `D:\code\MoonMind` into WSL's `/mnt/d/code/MoonMind`, and Docker mounted an empty directory over the startup script. Use Docker Desktop's daemon-visible `/run/desktop/mnt/host/d/...` namespace and disable automatic directory creation for rewritten checkout binds so missing sources fail explicitly.

Preserve mount options and unrelated sources, document the Windows host boundary, and add a minimized incident replay through the production deployment executor and real Compose parser. The replay covers omitted and explicit defaults on POSIX and Windows paths; restoring the old translation makes it fail at the one-shot service. No workflow payload or activity signature changes are involved.

Validation:
- 111 targeted unit, deployment-dispatch integration, and reliability replay tests passed; the unit runner's contract/status audits also passed.
- Real Docker Compose smoke test through the deployment-control worker: the patched runner read and syntax-checked the actual init-db startup script in a test-only project. A missing checkout source failed without creating a host directory. Both test stacks were cleaned up.
- `git diff --check` passed. Ruff is unavailable in the local/test Python environments.

The production update has not been rerun; the deployment-control worker must load this change before retrying it.
