### PR TITLE
[Workspaces] Implement safe artifact, checkpoint, and authorized existing-workspace sources (MoonLadderStudios/MoonMind#4014)

### DIFF
--- a/moonmind/omnigent/host_services/workspace.py
+++ b/moonmind/omnigent/host_services/workspace.py
@@ -15,6 +15,14 @@ from moonmind.omnigent.harness_platform.failures import (
 from moonmind.omnigent.workspace_artifacts import (
     WorkspaceArtifactProjectionError,
     WorkspaceArtifactProjector,
+    cleanup_import_staging,
+)
+from moonmind.omnigent.workspace_sources import (
+    CompiledWorkspaceSource,
+    ExistingWorkspaceGrantLedger,
+    WorkspaceSourceError,
+    compile_workspace_source,
+    verify_existing_workspace_grant,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
@@ -115,10 +123,19 @@ class OmnigentWorkspaceMaterializer:
                 "workspace mutation policy is unsupported",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+        if not isinstance(runtime_uid, int) or not isinstance(runtime_gid, int):
+            raise HarnessPlatformError(
+                "workspace runtime identity is invalid",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        if runtime_uid < 0 or runtime_gid < 0:
+            raise HarnessPlatformError(
+                "workspace runtime identity is invalid",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
         spec = (
             request.workspace_spec if isinstance(request.workspace_spec, dict) else {}
         )
-        locator = spec.get("workspaceLocator")
         step_execution = getattr(request, "step_execution", None)
         owner_workflow_id = str(
             getattr(step_execution, "workflow_id", None)
@@ -128,112 +145,85 @@ class OmnigentWorkspaceMaterializer:
             getattr(step_execution, "step_execution_id", None)
             or getattr(request, "idempotency_key", "")
         ).strip()
-        record_store: SandboxWorkspaceRecordStore | None = None
-        workspace_id: str | None = None
-        authored = str(spec.get("workspacePath") or spec.get("path") or "").strip()
-        if authored:
-            candidate = Path(authored).resolve()
-            preexisting_authority = True
-        elif isinstance(locator, dict):
-            try:
-                sandbox_locator = SandboxWorkspaceLocator.model_validate(locator)
-            except ValueError as exc:
-                raise HarnessPlatformError(
-                    "sandbox workspace locator is invalid",
-                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-                ) from exc
-            if not owner_workflow_id or not owner_step_execution_id:
-                raise HarnessPlatformError(
-                    "sandbox workspace owner identity is unavailable",
-                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-                )
-            expected_workspace_id = hashlib.sha256(
-                f"{owner_workflow_id}:{owner_step_execution_id}".encode("utf-8")
-            ).hexdigest()[:24]
-            candidate = resolve_sandbox_workspace_locator(
-                sandbox_locator,
-                workspace_root=self._root,
-                expected_workspace_id=expected_workspace_id,
-                must_exist=False,
-            )
-            owner_record = SandboxWorkspaceRecord(
-                workspace_id=sandbox_locator.workspace_id,
+        # Compile exactly one source plus its explicit overlay/input policy
+        # before any read or filesystem mutation. Raw workspacePath/path
+        # aliases are rejected here as a normal route; conflicting aliases
+        # fail before the locator, clone, or projection boundaries run.
+        try:
+            source = compile_workspace_source(
+                spec,
                 workflow_id=owner_workflow_id,
                 step_execution_id=owner_step_execution_id,
-                relative_path=sandbox_locator.relative_path,
+                runtime="omnigent",
             )
-            record_store = SandboxWorkspaceRecordStore(self._root)
-            workspace_id = sandbox_locator.workspace_id
-            record_store.ensure(owner_record)
-            resolve_sandbox_workspace_locator(
-                sandbox_locator,
-                workspace_root=self._root,
-                expected_workspace_id=expected_workspace_id,
-                owner_record=owner_record,
-                expected_workflow_id=owner_workflow_id,
-                expected_step_execution_id=owner_step_execution_id,
-                must_exist=False,
-            )
-            # Sandbox workspaces are runtime-owned: when the authoritative
-            # checkout does not exist yet, this lifecycle materializes it by
-            # cloning the requested repository branch with launch-time auth.
-            preexisting_authority = False
-        else:
+        except WorkspaceSourceError as exc:
             raise HarnessPlatformError(
-                "generic Omnigent execution requires an authoritative workspace locator",
+                str(exc),
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-            )
+            ) from exc
+        record_store: SandboxWorkspaceRecordStore | None = None
+        workspace_id: str | None = None
+        candidate, record_store, workspace_id = await self._resolve_source_directory(
+            source,
+            spec=spec,
+            owner_workflow_id=owner_workflow_id,
+            owner_step_execution_id=owner_step_execution_id,
+            runtime_uid=runtime_uid,
+            runtime_gid=runtime_gid,
+        )
         if candidate == self._root or not candidate.is_relative_to(self._root):
             raise HarnessPlatformError(
                 "workspace attachment escapes the configured workspace root",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-            )
-        if not candidate.exists():
-            if preexisting_authority:
-                raise HarnessPlatformError(
-                    "authoritative workspace path does not exist",
-                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
-                )
-            await self._prepare_sandbox_workspace(
-                candidate,
-                spec=spec,
-                runtime_uid=runtime_uid,
-                runtime_gid=runtime_gid,
             )
         if not candidate.is_dir() or candidate.is_symlink():
             raise HarnessPlatformError(
                 "authoritative workspace is unavailable or unsafe",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+        fingerprint = source.readiness_fingerprint(
+            target_owner_workflow_id=owner_workflow_id,
+            attempt_id=owner_step_execution_id,
+        )
         materialization_complete = bool(
             record_store is not None
             and workspace_id is not None
-            and record_store.is_materialized(workspace_id)
+            and record_store.is_ready(workspace_id, fingerprint)
         )
         if not materialization_complete:
+            # A retry reconciles the same generation; changed inputs are an
+            # explicit new import that is fully re-admitted, staged, and
+            # verified before the ready generation is replaced. A previous
+            # ready marker never authorizes changed inputs.
             restore_refs = spec.get("restoreInputRefs")
             if not isinstance(restore_refs, (list, tuple)):
                 restore_refs = ()
             attachment_refs = getattr(request, "input_refs", ())
             if not isinstance(attachment_refs, (list, tuple)):
                 attachment_refs = ()
-            checkpoint_ref = str(
-                spec.get("workspaceCheckpointRestoreRef") or ""
-            ).strip()
+            checkpoint_ref = source.checkpoint_ref or source.artifact_ref
             try:
                 await self._artifact_projector.project(
                     candidate,
-                    checkpoint_ref=checkpoint_ref or None,
+                    checkpoint_ref=checkpoint_ref,
+                    checkpoint_digest=source.artifact_digest,
+                    checkpoint_contract=source.restore_contract,
                     restore_refs=tuple(str(ref) for ref in restore_refs),
                     attachment_refs=tuple(str(ref) for ref in attachment_refs),
                     workflow_id=owner_workflow_id,
                     runtime_uid=runtime_uid,
                     runtime_gid=runtime_gid,
+                    strict_admission=not source.historical
+                    and source.kind in {"artifact", "checkpoint"},
+                    overlay_policy=source.overlay_policy,
                 )
             except WorkspaceArtifactProjectionError as exc:
                 raise HarnessPlatformError(str(exc), code=exc.code) from exc
             if record_store is not None and workspace_id is not None:
-                record_store.mark_materialized(workspace_id)
+                record_store.mark_ready(workspace_id, fingerprint)
+        # An advanced selected directory is never permission for an arbitrary
+        # host mount: the qualified locator/daemon mapping below is the only
+        # path from a worker path to a daemon-visible bind path.
         daemon_root = await resolve_daemon_workspace_root(
             runner=self._runner,
             workspace_volume=self._workspace_volume,
@@ -247,28 +237,229 @@ class OmnigentWorkspaceMaterializer:
                 "workspace cannot be translated to the selected Docker daemon",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             ) from exc
+        access_mode = "read-only" if mutation == "read_only" else "read-write"
+        if source.kind == "existing_workspace" and source.existing_grant is not None:
+            if source.existing_grant.mode == "read_only":
+                access_mode = "read-only"
+            elif mutation == "read_only":
+                pass
         return {
             "kind": "bind",
             "sourceRef": str(daemon_candidate),
             "targetPath": "/workspaces/run",
-            "accessMode": "read-only" if mutation == "read_only" else "read-write",
+            "accessMode": access_mode,
             "cleanupRef": None,
         }
+
+    async def _resolve_source_directory(
+        self,
+        source: CompiledWorkspaceSource,
+        *,
+        spec: dict[str, Any],
+        owner_workflow_id: str,
+        owner_step_execution_id: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> tuple[Path, SandboxWorkspaceRecordStore | None, str | None]:
+        """Resolve the attempt-owned directory for the single compiled source."""
+
+        if source.kind == "existing_workspace":
+            return await self._resolve_granted_workspace(
+                source,
+                target_workflow_id=owner_workflow_id,
+                target_step_execution_id=owner_step_execution_id,
+            )
+        locator = spec.get("workspaceLocator")
+        if not isinstance(locator, dict):
+            raise HarnessPlatformError(
+                "generic Omnigent execution requires an authoritative workspace locator",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        try:
+            sandbox_locator = SandboxWorkspaceLocator.model_validate(locator)
+        except ValueError as exc:
+            raise HarnessPlatformError(
+                "sandbox workspace locator is invalid",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if not owner_workflow_id or not owner_step_execution_id:
+            raise HarnessPlatformError(
+                "sandbox workspace owner identity is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        expected_workspace_id = hashlib.sha256(
+            f"{owner_workflow_id}:{owner_step_execution_id}".encode("utf-8")
+        ).hexdigest()[:24]
+        try:
+            candidate = resolve_sandbox_workspace_locator(
+                sandbox_locator,
+                workspace_root=self._root,
+                expected_workspace_id=expected_workspace_id,
+                must_exist=False,
+            )
+        except Exception as exc:
+            raise HarnessPlatformError(
+                f"sandbox workspace locator cannot be resolved: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        owner_record = SandboxWorkspaceRecord(
+            workspace_id=sandbox_locator.workspace_id,
+            workflow_id=owner_workflow_id,
+            step_execution_id=owner_step_execution_id,
+            relative_path=sandbox_locator.relative_path,
+        )
+        record_store = SandboxWorkspaceRecordStore(self._root)
+        try:
+            record_store.ensure(owner_record)
+            candidate = resolve_sandbox_workspace_locator(
+                sandbox_locator,
+                workspace_root=self._root,
+                expected_workspace_id=expected_workspace_id,
+                owner_record=owner_record,
+                expected_workflow_id=owner_workflow_id,
+                expected_step_execution_id=owner_step_execution_id,
+                must_exist=False,
+            )
+        except Exception as exc:
+            raise HarnessPlatformError(
+                f"sandbox workspace owner identity cannot be verified: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if not candidate.exists():
+            if source.kind == "repository" or (
+                source.kind in {"artifact", "checkpoint"}
+                and source.repository_ref
+                and source.repository_branch
+            ):
+                # A repository source clones; a content source with an
+                # admitted repository base clones that base before the
+                # overlay is projected. Self-contained content sources (no
+                # base) never clone or reacquire source credentials as a
+                # prerequisite for restoring saved work.
+                clone_spec = dict(spec)
+                if source.kind in {"artifact", "checkpoint"}:
+                    clone_spec["repository"] = source.repository_ref
+                    clone_spec["branch"] = source.repository_branch
+                await self._prepare_sandbox_workspace(
+                    candidate,
+                    spec=clone_spec,
+                    source=source,
+                    runtime_uid=runtime_uid,
+                    runtime_gid=runtime_gid,
+                )
+            else:
+                candidate.mkdir(mode=0o700, parents=True, exist_ok=True)
+        else:
+            # Reclaim leftover import-owned staging from a crashed attempt.
+            # This touches only `.moonmind-import-*` generations, never the
+            # live authorized workspace or another owner's content.
+            cleanup_import_staging(candidate.parent)
+        return candidate, record_store, sandbox_locator.workspace_id
+
+    async def _resolve_granted_workspace(
+        self,
+        source: CompiledWorkspaceSource,
+        *,
+        target_workflow_id: str,
+        target_step_execution_id: str,
+    ) -> tuple[Path, SandboxWorkspaceRecordStore | None, str | None]:
+        """Resolve an explicitly granted existing workspace, never a raw path."""
+
+        grant = source.existing_grant
+        if grant is None:  # pragma: no cover - compiler guarantees presence
+            raise HarnessPlatformError(
+                "existing workspace use requires a server-issued grant",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        record_store = SandboxWorkspaceRecordStore(self._root)
+        try:
+            record = record_store.load(grant.workspace_id)
+        except Exception as exc:
+            raise HarnessPlatformError(
+                "existing workspace grant cannot be verified",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if record is None:
+            raise HarnessPlatformError(
+                "existing workspace grant names an unknown workspace",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        try:
+            verify_existing_workspace_grant(
+                grant,
+                target_workflow_id=target_workflow_id,
+                target_step_execution_id=target_step_execution_id,
+                record_owner_workflow_id=record.workflow_id,
+            )
+        except WorkspaceSourceError as exc:
+            raise HarnessPlatformError(
+                str(exc),
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if grant.mode == "exclusive" and grant.owner_workflow_id != target_workflow_id:
+            raise HarnessPlatformError(
+                "existing workspace grant does not permit exclusive use by "
+                "another workflow",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        # Stale generations fail before any filesystem use; the ledger lives
+        # beside the owner records, never inside a materialized workspace.
+        try:
+            ExistingWorkspaceGrantLedger(record_store.store_root).admit(grant)
+        except WorkspaceSourceError as exc:
+            raise HarnessPlatformError(
+                str(exc),
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        authority = (self._root / "temporal_sandbox").resolve()
+        owned_root = (authority / grant.workspace_id).resolve()
+        if owned_root.parent != authority:
+            raise HarnessPlatformError(
+                "existing workspace grant escapes its authority",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        # The granted workspace is the recorded owner-relative path, resolved
+        # under the same authority as sandbox locators. An advanced selected
+        # directory never becomes permission for an arbitrary host mount.
+        candidate = (owned_root / record.relative_path).resolve()
+        if not candidate.is_relative_to(owned_root):
+            raise HarnessPlatformError(
+                "existing workspace grant escapes its authority",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        if not candidate.exists():
+            raise HarnessPlatformError(
+                "granted existing workspace is unavailable",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        return candidate, record_store, grant.workspace_id
 
     async def _prepare_sandbox_workspace(
         self,
         candidate: Path,
         *,
         spec: dict[str, Any],
+        source: CompiledWorkspaceSource,
         runtime_uid: int,
         runtime_gid: int,
     ) -> None:
         """Clone the requested repository branch into a fresh sandbox dir.
 
-        The directory is created only inside the validated root and only for
-        sandbox locators, so an operator-authored absolute path can never be
-        materialized implicitly.
+        Only a repository source — or a content source with an admitted
+        repository base — clones. The directory is created only inside
+        the validated root and only for sandbox locators, so an
+        operator-authored absolute path can never be materialized implicitly.
         """
+
+        if source.kind not in {"repository", "artifact", "checkpoint"} or (
+            source.kind in {"artifact", "checkpoint"}
+            and not (source.repository_ref and source.repository_branch)
+        ):
+            # Self-contained artifact/checkpoint restores and scratch sources
+            # prepare an empty attempt-owned directory with no clone and no
+            # source-credential lookup.
+            candidate.mkdir(mode=0o700, parents=True, exist_ok=True)
+            return
 
         repository_target = (
             spec.get("repositoryTarget")

--- a/moonmind/omnigent/workspace_artifacts.py
+++ b/moonmind/omnigent/workspace_artifacts.py
@@ -1,14 +1,52 @@
-"""Runtime-neutral projection of durable inputs into an Omnigent workspace."""
+"""Runtime-neutral projection of durable inputs into an Omnigent workspace.
+
+Safe artifact / checkpoint / authorized existing-workspace sources for
+MoonLadderStudios/MoonMind#4014 (CONTRACT-002, CONTRACT-011, INV-005, INV-006):
+
+- Source-artifact permission, status, completeness, digest, and bounded
+  lifetime are established through the actual artifact service. Missing
+  metadata, forged workflow-family links, and restricted/quarantined bytes
+  without an explicit policy fail closed; a service principal or a
+  read-bytes-only adapter never implies owner/digest/quarantine permission.
+- Exact source bytes are streamed and verified against the admitted digest
+  under explicit compressed/download, expanded, per-file, file-count,
+  path-depth, and processing-time budgets. Truncated, malformed,
+  sparse/oversized, and unsupported archives are classified without a
+  completed marker or an automatic alternate source.
+- Archives extract into a fresh, attempt-owned staging area with sequential
+  symlink/hardlink/overwrite validation, then the materialized manifest is
+  verified before an authoritative restore promotes a ready generation.
+  Only the import-owned staging generation is ever deleted, never a live
+  authorized workspace.
+- Imported Git configuration/hooks/helpers, credential directories, and old
+  session authority are neutralized before any Git command or runtime launch,
+  while safe content/history stay usable as data.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import os
 import shutil
+import stat
 import tarfile
 import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from moonmind.omnigent.workspace_sources import (
+    MAX_COMPRESSED_BYTES,
+    MAX_EXPANDED_BYTES,
+    MAX_FILE_BYTES,
+    MAX_FILE_COUNT,
+    MAX_PATH_DEPTH,
+    MAX_PROCESSING_SECONDS,
+    OVERLAY_ADDITIVE,
+)
 
 
 MAX_INPUT_REFS = 64
@@ -19,6 +57,24 @@ STREAM_CHUNK_BYTES = 1024 * 1024
 RESTORE_PRINCIPAL = "service:omnigent_workspace_restore"
 ATTACHMENT_PRINCIPAL = "service:omnigent_workspace_attachment"
 
+STAGING_PREFIX = ".moonmind-import-"
+
+# Imported credential directories and session-authority files are never
+# restored as current authority. Content/history stays; these go.
+_NEUTRALIZED_DIR_NAMES: tuple[str, ...] = (
+    ".aws",
+    ".ssh",
+    ".gnupg",
+    ".config/gh",
+    ".config/git/credentialstore",
+)
+_NEUTRALIZED_FILE_NAMES: tuple[str, ...] = (
+    ".netrc",
+    "_netrc",
+    ".git-credentials",
+    ".git-credential-cache",
+)
+
 
 class WorkspaceArtifactProjectionError(RuntimeError):
     """A durable workspace input could not be projected safely."""
@@ -26,6 +82,133 @@ class WorkspaceArtifactProjectionError(RuntimeError):
     def __init__(self, message: str, *, code: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+@dataclass(frozen=True)
+class AdmittedSource:
+    """Owner/digest/quarantine permission carried through the service boundary."""
+
+    artifact_id: str
+    digest: str | None
+    size_bytes: int | None
+    redaction_level: str | None
+
+
+def _metadata_tuple(metadata: Any) -> tuple[Any, tuple[Any, ...]]:
+    if isinstance(metadata, tuple):
+        artifact = metadata[0] if len(metadata) > 0 else None
+        links: Any = metadata[1] if len(metadata) > 1 else ()
+        if links is None:
+            links = ()
+        return artifact, tuple(links)
+    return metadata, ()
+
+
+def _status_is_complete(artifact: Any) -> bool:
+    status = getattr(artifact, "status", None)
+    if status is None:
+        return True
+    name = str(getattr(status, "value", status)).upper()
+    return name == "COMPLETE"
+
+
+def _is_expired(artifact: Any) -> bool:
+    expires_at = getattr(artifact, "expires_at", None)
+    if expires_at is None:
+        metadata = getattr(artifact, "metadata_json", None)
+        if isinstance(metadata, dict):
+            expires_at = metadata.get("expires_at")
+    if expires_at is None:
+        return False
+    if isinstance(expires_at, str):
+        try:
+            expires_at = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+    if isinstance(expires_at, datetime):
+        moment = expires_at
+        if moment.tzinfo is None:
+            moment = moment.replace(tzinfo=UTC)
+        return moment <= datetime.now(tz=UTC)
+    return False
+
+
+def _redaction_level(artifact: Any) -> str | None:
+    level = getattr(artifact, "redaction_level", None)
+    if level is None:
+        metadata = getattr(artifact, "metadata_json", None)
+        if isinstance(metadata, dict):
+            level = metadata.get("redaction_level") or metadata.get("quarantine")
+    if level is None:
+        return None
+    return str(getattr(level, "value", level)).upper()
+
+
+def _artifact_digest(artifact: Any) -> str | None:
+    for attr in ("sha256", "digest", "content_digest"):
+        value = getattr(artifact, attr, None)
+        if value:
+            text = str(value).strip().lower()
+            if len(text) == 64 and all(c in "0123456789abcdef" for c in text):
+                return "sha256:" + text
+            if text.startswith("sha256:"):
+                return text
+    metadata = getattr(artifact, "metadata_json", None)
+    if isinstance(metadata, dict):
+        for key in ("sha256", "digest", "archive_digest", "contentDigest"):
+            value = metadata.get(key)
+            if value:
+                text = str(value).strip().lower()
+                if text.startswith("sha256:"):
+                    return text
+                if len(text) == 64:
+                    return "sha256:" + text
+    return None
+
+
+def _check_workflow_family_link(
+    links: tuple[Any, ...], required_workflow_id: str
+) -> None:
+    family = f"{required_workflow_id}:"
+    for link in links:
+        candidate = str(getattr(link, "workflow_id", "") or "").strip()
+        if not candidate:
+            continue
+        if candidate == required_workflow_id:
+            return
+        # A family-prefixed link is only valid with a non-empty suffix; a
+        # bare "workflow-id:" prefix is a forged link, not a grant.
+        if candidate.startswith(family) and len(candidate) > len(family):
+            return
+    raise WorkspaceArtifactProjectionError(
+        "attachment artifact is not linked to the current workflow family",
+        code="WORKSPACE_AUTHORITY_MISMATCH",
+    )
+
+
+def cleanup_import_staging(parent: Path) -> int:
+    """Delete leftover import-owned staging generations, never live workspaces.
+
+    Only directories named ``.moonmind-import-*`` directly under ``parent``
+    are removed. Returns the number of staging generations reclaimed.
+    """
+
+    reclaimed = 0
+    try:
+        entries = list(parent.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if entry.name.startswith(STAGING_PREFIX):
+            try:
+                if entry.is_symlink() or not entry.is_dir():
+                    entry.unlink(missing_ok=True)
+                else:
+                    shutil.rmtree(entry, ignore_errors=False)
+                reclaimed += 1
+            except OSError:
+                continue
+    return reclaimed
 
 
 class WorkspaceArtifactProjector:
@@ -39,18 +222,46 @@ class WorkspaceArtifactProjector:
         workspace: Path,
         *,
         checkpoint_ref: str | None = None,
+        checkpoint_digest: str | None = None,
+        checkpoint_contract: str | None = None,
         restore_refs: tuple[str, ...] = (),
         attachment_refs: tuple[str, ...] = (),
         workflow_id: str,
         runtime_uid: int,
         runtime_gid: int,
+        strict_admission: bool = False,
+        overlay_policy: str | None = None,
     ) -> dict[str, Any]:
-        """Project every authored input before the workspace is mounted."""
+        """Project every authored input before the workspace is mounted.
+
+        ``strict_admission`` selects the new CONTRACT-002/CONTRACT-011 path:
+        checkpoint admission requires linked artifact metadata for the owning
+        workflow (missing metadata, forged family links, and
+        restricted/quarantined bytes fail closed). Historical alias payloads
+        keep the legacy-tolerant decoding so in-flight runs retain
+        deterministic meaning. ``overlay_policy`` selects an authoritative
+        full-snapshot restore (destination-only files are not retained) or
+        an additive overlay over an admitted base.
+        """
 
         evidence: dict[str, Any] = {}
         if checkpoint_ref:
-            await self._apply_checkpoint(workspace, checkpoint_ref)
+            if overlay_policy is None:
+                overlay_policy = (
+                    "authoritative_restore" if strict_admission else OVERLAY_ADDITIVE
+                )
+            manifest = await self._apply_checkpoint(
+                workspace,
+                checkpoint_ref,
+                expected_digest=checkpoint_digest,
+                required_workflow_id=workflow_id if strict_admission else None,
+                strict_metadata=strict_admission,
+                overlay_policy=overlay_policy,
+            )
             evidence["checkpointRestoreRef"] = checkpoint_ref
+            evidence["checkpointManifest"] = manifest
+            if checkpoint_contract:
+                evidence["checkpointContract"] = checkpoint_contract
         # Checkpoints preserve repository work, not the prior step's injected
         # context. Remove both runtime-owned input directories after extraction
         # so each step sees only its explicitly authorized refs. Project the
@@ -109,14 +320,30 @@ class WorkspaceArtifactProjector:
                     code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                 ) from exc
 
-    async def _apply_checkpoint(self, workspace: Path, artifact_ref: str) -> None:
+    async def _apply_checkpoint(
+        self,
+        workspace: Path,
+        artifact_ref: str,
+        *,
+        expected_digest: str | None = None,
+        required_workflow_id: str | None = None,
+        strict_metadata: bool = False,
+        overlay_policy: str = "authoritative_restore",
+    ) -> dict[str, Any]:
         artifact_id = self._artifact_id(artifact_ref, noun="workspace checkpoint")
         service = self._require_service("workspace checkpoint")
-        await self._validate_metadata(
+        # Historical alias payloads without an authored workspaceSource pass
+        # required_workflow_id=None and keep the legacy-tolerant admission so
+        # in-flight runs retain deterministic meaning; the authored path
+        # carries the owning workflow and fails closed on missing metadata.
+        admitted = await self._validate_metadata(
             service,
             artifact_id=artifact_id,
-            budget_bytes=MAX_CHECKPOINT_BYTES,
+            budget_bytes=min(MAX_CHECKPOINT_BYTES, MAX_COMPRESSED_BYTES),
             principal=RESTORE_PRINCIPAL,
+            required_workflow_id=required_workflow_id,
+            expected_digest=expected_digest,
+            strict_metadata=strict_metadata,
         )
         descriptor, temporary_name = tempfile.mkstemp(
             prefix=".moonmind-checkpoint-",
@@ -125,40 +352,713 @@ class WorkspaceArtifactProjector:
         )
         os.close(descriptor)
         archive_path = Path(temporary_name)
+        staging = workspace.parent / f"{STAGING_PREFIX}{uuid.uuid4().hex}"
         try:
             await self._write_payload(
                 service,
                 artifact_id=artifact_id,
                 target=archive_path,
-                budget_bytes=MAX_CHECKPOINT_BYTES,
+                budget_bytes=min(MAX_CHECKPOINT_BYTES, MAX_COMPRESSED_BYTES),
                 principal=RESTORE_PRINCIPAL,
+                expected_digest=admitted.digest or expected_digest,
             )
-            workspace_root = workspace.resolve()
-            with tarfile.open(archive_path, mode="r:gz") as archive:
-                for member in archive.getmembers():
-                    target = (workspace / member.name).resolve()
-                    if not target.is_relative_to(workspace_root) or member.isdev():
-                        raise WorkspaceArtifactProjectionError(
-                            "workspace checkpoint contains an unsafe archive member",
-                            code="WORKSPACE_AUTHORITY_MISMATCH",
-                        )
-                    if member.issym() or member.islnk():
-                        link_target = (target.parent / member.linkname).resolve()
-                        if not link_target.is_relative_to(workspace_root):
-                            raise WorkspaceArtifactProjectionError(
-                                "workspace checkpoint symlink escapes workspace",
-                                code="WORKSPACE_AUTHORITY_MISMATCH",
-                            )
-                archive.extractall(workspace, filter="data")
+            staging.mkdir(mode=0o700, parents=False, exist_ok=False)
+            expanded = self._extract_archive_safely(
+                archive_path, staging, noun="workspace checkpoint"
+            )
+            # The staged tree must match the archive before neutralization;
+            # neutralization legitimately removes imported authority, so the
+            # promoted evidence manifest is built after it runs.
+            self._verify_materialized_manifest(staging, expanded=expanded)
+            neutralized = self._neutralize_imported_workspace(staging)
+            manifest = self._verify_materialized_manifest(staging)
+            if overlay_policy == OVERLAY_ADDITIVE:
+                self._promote_additive_overlay(workspace, staging)
+            else:
+                self._promote_authoritative_restore(workspace, staging)
+            manifest["overlayPolicy"] = overlay_policy
+            return {**manifest, "neutralized": neutralized}
         except WorkspaceArtifactProjectionError:
             raise
-        except (tarfile.TarError, OSError) as exc:
+        except (tarfile.TarError, OSError, EOFError) as exc:
             raise WorkspaceArtifactProjectionError(
                 "workspace checkpoint archive could not be applied",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             ) from exc
         finally:
             archive_path.unlink(missing_ok=True)
+            # Late cleanup removes only the import-owned staging generation;
+            # a crash before/after promotion can never expose partial content
+            # in the live workspace or delete another owner's content.
+            try:
+                if staging.is_symlink() or staging.is_file():
+                    staging.unlink(missing_ok=True)
+                elif staging.is_dir():
+                    shutil.rmtree(staging, ignore_errors=True)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _extract_archive_safely(
+        archive_path: Path, staging: Path, *, noun: str
+    ) -> dict[str, Any]:
+        """Stream-extract with explicit resource/path budgets, no preflight gap.
+
+        Members are validated *and* written sequentially: each symlink,
+        hardlink, and overwrite is resolved against the staging tree as it
+        accumulates, so a later member cannot invalidate an earlier check.
+        No unbounded member-list allocation is performed.
+        """
+
+        staging_root = staging.resolve()
+        deadline = time.monotonic() + MAX_PROCESSING_SECONDS
+        seen: set[str] = set()
+        # Lower-cased sibling index per directory for filesystem collisions.
+        dir_children: dict[str, set[str]] = {}
+        file_count = 0
+        manifest_entries = 0
+        expanded_bytes = 0
+
+        def _fail(message: str, code: str) -> WorkspaceArtifactProjectionError:
+            return WorkspaceArtifactProjectionError(f"{noun} {message}", code=code)
+
+        try:
+            archive = tarfile.open(archive_path, mode="r:gz")
+        except (tarfile.TarError, OSError, EOFError) as exc:
+            raise _fail(
+                "archive is truncated, malformed, or unsupported",
+                "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+        with archive:
+            while True:
+                if time.monotonic() > deadline:
+                    raise _fail(
+                        "archive exceeded the processing-time budget",
+                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                try:
+                    member = archive.next()
+                except (tarfile.TarError, OSError, EOFError) as exc:
+                    raise _fail(
+                        "archive is truncated, malformed, or unsupported",
+                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    ) from exc
+                if member is None:
+                    break
+                name = (member.name or "").strip()
+                if not name or name in seen:
+                    raise _fail(
+                        "archive has duplicate or conflicting entries",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                seen.add(name)
+                if name.startswith("/") or name.startswith("\\"):
+                    raise _fail(
+                        "archive contains an absolute path",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                parts = [
+                    p for p in name.replace("\\", "/").split("/") if p not in ("",)
+                ]
+                if not parts or any(p in {".", ".."} for p in parts):
+                    raise _fail(
+                        "archive contains an escaping path",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                if len(parts) > MAX_PATH_DEPTH:
+                    raise _fail(
+                        "archive exceeds the path-depth budget",
+                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                if member.isdev():
+                    raise _fail(
+                        "archive contains an unsupported device file",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                if member.isfifo() or member.ischr() or member.isblk():
+                    raise _fail(
+                        "archive contains an unsupported file type",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                target = staging_root
+                for part in parts:
+                    target = target / part
+                try:
+                    resolved_parent = target.parent.resolve()
+                except OSError as exc:
+                    raise _fail(
+                        "archive target could not be resolved",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    ) from exc
+                if (
+                    resolved_parent != staging_root
+                    and not resolved_parent.is_relative_to(staging_root)
+                ):
+                    raise _fail(
+                        "archive contains an escaping path",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                # Filesystem name-collision check: an entry that would land on
+                # an already-materialized sibling (including case collisions)
+                # is a conflicting entry, not an overwrite.
+                parent_key = resolved_parent.as_posix().lower()
+                lowered = parts[-1].lower()
+                siblings = dir_children.setdefault(parent_key, set())
+                if lowered in siblings or os.path.lexists(target):
+                    raise _fail(
+                        "archive has duplicate or conflicting entries",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                siblings.add(lowered)
+
+                claimed = int(member.size or 0)
+                if claimed < 0:
+                    raise _fail(
+                        "archive is malformed",
+                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                if claimed > MAX_FILE_BYTES:
+                    raise _fail(
+                        "archive member exceeds the per-file budget",
+                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                if member.isfile():
+                    file_count += 1
+                    manifest_entries += 1
+                    if file_count > MAX_FILE_COUNT:
+                        raise _fail(
+                            "archive exceeds the file-count budget",
+                            "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    if expanded_bytes + claimed > MAX_EXPANDED_BYTES:
+                        raise _fail(
+                            "archive exceeds the expanded-bytes budget",
+                            "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    try:
+                        source = archive.extractfile(member)
+                    except (tarfile.TarError, OSError, EOFError) as exc:
+                        raise _fail(
+                            "archive is truncated, malformed, or unsupported",
+                            "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        ) from exc
+                    if source is None:
+                        raise _fail(
+                            "archive member could not be read",
+                            "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    written = 0
+                    descriptor = os.open(
+                        target,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                        0o600,
+                    )
+                    try:
+                        with os.fdopen(descriptor, "wb") as stream:
+                            while True:
+                                chunk = source.read(STREAM_CHUNK_BYTES)
+                                if not chunk:
+                                    break
+                                written += len(chunk)
+                                expanded_bytes += len(chunk)
+                                stream.write(chunk)
+                                if (
+                                    written > MAX_FILE_BYTES
+                                    or expanded_bytes > MAX_EXPANDED_BYTES
+                                ):
+                                    raise _fail(
+                                        "archive exceeds the streamed expanded-bytes "
+                                        "budget",
+                                        "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                                    )
+                    except WorkspaceArtifactProjectionError:
+                        target.unlink(missing_ok=True)
+                        raise
+                    if written != claimed and claimed != 0:
+                        # Sparse/oversized members whose headers understate the
+                        # stream are classified, not silently accepted.
+                        target.unlink(missing_ok=True)
+                        raise _fail(
+                            "archive member is sparse, truncated, or oversized",
+                            "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                    # Normalize privileged metadata; content stays as data.
+                    try:
+                        os.chmod(target, 0o600, follow_symlinks=False)
+                    except OSError:
+                        pass
+                elif member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                elif member.issym() or member.islnk():
+                    link_name = (member.linkname or "").strip()
+                    if not link_name:
+                        raise _fail(
+                            "archive link has no target",
+                            "WORKSPACE_AUTHORITY_MISMATCH",
+                        )
+                    manifest_entries += 1
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    if member.issym():
+                        base = target.parent
+                        candidate = (base / link_name).resolve()
+                        # Sequential check against the accumulating tree: an
+                        # earlier symlink must not redirect this resolution.
+                        if candidate != staging_root and not candidate.is_relative_to(
+                            staging_root
+                        ):
+                            raise _fail(
+                                "archive symlink escapes the workspace",
+                                "WORKSPACE_AUTHORITY_MISMATCH",
+                            )
+                        try:
+                            target.symlink_to(link_name)
+                        except OSError as exc:
+                            raise _fail(
+                                "archive symlink could not be created",
+                                "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                            ) from exc
+                    else:
+                        candidate = (staging_root / link_name).resolve()
+                        if candidate != staging_root and not candidate.is_relative_to(
+                            staging_root
+                        ):
+                            raise _fail(
+                                "archive hardlink escapes the workspace",
+                                "WORKSPACE_AUTHORITY_MISMATCH",
+                            )
+                        if not candidate.is_file() or candidate.is_symlink():
+                            raise _fail(
+                                "archive hardlink target is unavailable",
+                                "WORKSPACE_AUTHORITY_MISMATCH",
+                            )
+                        try:
+                            os.link(candidate, target)
+                        except OSError as exc:
+                            raise _fail(
+                                "archive hardlink could not be created",
+                                "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                            ) from exc
+                else:
+                    raise _fail(
+                        "archive contains an unsupported file type",
+                        "WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+        return {
+            "fileCount": file_count,
+            "manifestEntries": manifest_entries,
+            "expandedBytes": expanded_bytes,
+        }
+
+    @staticmethod
+    def _neutralize_imported_workspace(staging: Path) -> list[str]:
+        """Neutralize imported setup/credential/session authority as data.
+
+        Removes imported hooks, credential directories/files, Git alternates
+        and external worktree/gitdir bindings, include paths escaping the
+        workspace, credential-bearing submodule URLs, and old session
+        authority (leases, approvals, prior publication evidence). Safe
+        content, history, and ordinary executable source files are preserved.
+        """
+
+        staging_root = staging.resolve()
+        neutralized: list[str] = []
+
+        def _record(path: Path) -> None:
+            try:
+                neutralized.append(path.relative_to(staging_root).as_posix())
+            except ValueError:
+                neutralized.append(path.name)
+
+        def _remove_file(path: Path) -> None:
+            try:
+                if path.is_symlink() or path.is_file():
+                    path.unlink()
+                    _record(path)
+            except OSError:
+                pass
+
+        def _remove_tree(path: Path) -> None:
+            try:
+                if path.is_symlink():
+                    path.unlink()
+                    _record(path)
+                elif path.is_dir() and not path.is_mount():
+                    shutil.rmtree(path, ignore_errors=True)
+                    _record(path)
+            except OSError:
+                pass
+
+        git_dir = staging / ".git"
+        if git_dir.is_file() and not git_dir.is_symlink():
+            # A gitdir pointer must stay inside the imported tree; an
+            # external Git directory/worktree is rejected, not followed.
+            try:
+                pointer = git_dir.read_text(encoding="utf-8").strip()
+            except OSError:
+                pointer = ""
+            external = False
+            if pointer.startswith("gitdir:"):
+                raw = pointer[len("gitdir:"):].strip()
+                candidate = (staging / raw).resolve() if raw else staging_root
+                if candidate != staging_root and not candidate.is_relative_to(
+                    staging_root
+                ):
+                    external = True
+            else:
+                external = True
+            if external:
+                raise WorkspaceArtifactProjectionError(
+                    "workspace checkpoint binds an external Git directory",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        if git_dir.is_dir() and not git_dir.is_symlink():
+            # Hooks/helpers must never execute on first Git command or launch.
+            hooks = git_dir / "hooks"
+            if hooks.is_dir() and not hooks.is_symlink():
+                for child in list(hooks.iterdir()):
+                    if child.is_symlink() or child.is_file():
+                        _remove_file(child)
+                    elif child.is_dir():
+                        _remove_tree(child)
+            # Alternates reference external object baselines: an unmaterialized
+            # dependency is incomplete unless independently admitted.
+            alternates = git_dir / "objects" / "info" / "alternates"
+            if alternates.is_file() and not alternates.is_symlink():
+                try:
+                    content = alternates.read_text(encoding="utf-8").strip()
+                except OSError:
+                    content = ""
+                if content:
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint needs an external object baseline",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+            # commondir outside the tree is an external worktree binding.
+            commondir = git_dir / "commondir"
+            if commondir.is_file() and not commondir.is_symlink():
+                try:
+                    content = commondir.read_text(encoding="utf-8").strip()
+                except OSError:
+                    content = ""
+                if content:
+                    candidate = (git_dir / content).resolve()
+                    if candidate != staging_root and not candidate.is_relative_to(
+                        staging_root
+                    ):
+                        raise WorkspaceArtifactProjectionError(
+                            "workspace checkpoint binds an external worktree",
+                            code="WORKSPACE_AUTHORITY_MISMATCH",
+                        )
+            config = git_dir / "config"
+            if config.is_file() and not config.is_symlink():
+                WorkspaceArtifactProjector._scrub_git_config(config, staging_root)
+                _record(config)
+
+        # Credential-bearing submodule configuration is rejected, not restored.
+        gitmodules = staging / ".gitmodules"
+        if gitmodules.is_file() and not gitmodules.is_symlink():
+            try:
+                content = gitmodules.read_text(encoding="utf-8")
+            except OSError:
+                content = ""
+            if "@" in content and "://" in content:
+                import re as _re
+
+                if _re.search(r"://[^/\s@]*@[^/\s]*", content):
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint carries credential-bearing "
+                        "submodule configuration",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+
+        for name in _NEUTRALIZED_DIR_NAMES:
+            _remove_tree(staging / name)
+        for name in _NEUTRALIZED_FILE_NAMES:
+            _remove_file(staging / name)
+
+        # Old session authority never revives: leases, approvals, prior
+        # publication evidence, and previous session directories.
+        moonmind_dir = staging / ".moonmind"
+        if moonmind_dir.is_dir() and not moonmind_dir.is_symlink():
+            for child in list(moonmind_dir.iterdir()):
+                lowered = child.name.lower()
+                if lowered.startswith(
+                    ("session", "lease", "approval", "publication-evidence")
+                ):
+                    if child.is_dir() and not child.is_symlink():
+                        _remove_tree(child)
+                    else:
+                        _remove_file(child)
+
+        # Normalize privileged metadata on regular files; ordinary executable
+        # source files keep a bounded executable bit, hooks do not exist.
+        for root, _dirs, files in os.walk(staging):
+            for filename in files:
+                path = Path(root) / filename
+                try:
+                    if path.is_symlink():
+                        continue
+                    mode = path.stat().st_mode
+                    cleaned = mode & ~(
+                        stat.S_ISUID | stat.S_ISGID | stat.S_IWOTH
+                    )
+                    if cleaned != mode:
+                        os.chmod(path, cleaned, follow_symlinks=False)
+                        _record(path)
+                except OSError:
+                    continue
+        return sorted(set(neutralized))
+
+    @staticmethod
+    def _scrub_git_config(config: Path, staging_root: Path) -> None:
+        """Strip imported credential/include/helper bindings from git config."""
+
+        try:
+            lines = config.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return
+        kept: list[str] = []
+        section = ""
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                section = stripped.lower()
+                kept.append(line)
+                continue
+            lowered = stripped.lower()
+            drop = False
+            if section.startswith("[core]") and lowered.startswith(
+                ("hookspath", "fsmonitor", "sshcommand")
+            ):
+                drop = True
+            elif section.startswith("[credential") or lowered.startswith(
+                "credential.helper"
+            ):
+                drop = True
+            elif section.startswith("[filter ") and "process" in lowered:
+                drop = True
+            elif lowered.startswith("insteadof") or lowered.startswith("instead-of"):
+                drop = True
+            elif section.startswith("[include") and "path" in lowered:
+                # Keep includes that resolve inside the imported tree; an
+                # include path escaping it is an external binding, not data.
+                _, _, raw = stripped.partition("=")
+                candidate = (staging_root / raw.strip()).resolve()
+                if candidate != staging_root and not candidate.is_relative_to(
+                    staging_root
+                ):
+                    drop = True
+            if not drop:
+                kept.append(line)
+        try:
+            config.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        except OSError:
+            pass
+
+    @staticmethod
+    def _verify_materialized_manifest(
+        staging: Path, *, expanded: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Verify the staged manifest before any promotion to ready.
+
+        When ``expanded`` archive counts are given, the staged tree must match
+        the archive exactly. Without them, the current staged tree is
+        described for evidence (used after neutralization has legitimately
+        removed imported authority).
+        """
+
+        digest = hashlib.sha256()
+        count = 0
+        link_count = 0
+        total = 0
+        staging_root = staging.resolve()
+        for root, _dirs, files in os.walk(staging):
+            for filename in sorted(files):
+                path = Path(root) / filename
+                try:
+                    relative = path.relative_to(staging_root).as_posix()
+                except ValueError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint manifest escapes the staging area",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    ) from exc
+                try:
+                    if path.is_symlink():
+                        digest.update(f"link:{relative}\n".encode())
+                        link_count += 1
+                        continue
+                    size = path.stat().st_size
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint manifest could not be verified",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    ) from exc
+                digest.update(f"file:{relative}:{size}\n".encode())
+                count += 1
+                total += size
+        if expanded is not None and count + link_count != int(
+            expanded.get("manifestEntries", count + link_count)
+        ):
+            raise WorkspaceArtifactProjectionError(
+                "workspace checkpoint manifest does not match the archive",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        return {
+            "fileCount": count,
+            "symlinkCount": link_count,
+            "expandedBytes": total,
+            "manifestDigest": "sha256:" + digest.hexdigest(),
+        }
+
+    @staticmethod
+    def _promote_additive_overlay(workspace: Path, staging: Path) -> None:
+        """Merge a verified staging generation over an admitted base.
+
+        Staged files overwrite same-type destination files; new entries are
+        created; type conflicts (file over directory and vice versa) fail
+        closed instead of destroying live content. Destination entries are
+        unlinked with ``lstat`` semantics first so a pre-existing destination
+        symlink can never redirect a staged write outside the workspace.
+        """
+
+        workspace.mkdir(parents=True, exist_ok=True)
+        workspace_root = workspace.resolve()
+        for child in list(staging.iterdir()):
+            destination = workspace / child.name
+            if os.path.lexists(destination):
+                try:
+                    dest_is_dir = destination.is_dir() and not destination.is_symlink()
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "additive overlay could not inspect the destination",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    ) from exc
+                staged_is_dir = child.is_dir() and not child.is_symlink()
+                if dest_is_dir != staged_is_dir:
+                    raise WorkspaceArtifactProjectionError(
+                        "additive overlay type conflict with destination content",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                if staged_is_dir:
+                    WorkspaceArtifactProjector._merge_tree(child, destination)
+                    continue
+                try:
+                    if destination.is_symlink() or destination.is_file():
+                        destination.unlink(missing_ok=True)
+                    else:  # pragma: no cover - inspected above
+                        raise WorkspaceArtifactProjectionError(
+                            "additive overlay type conflict with destination content",
+                            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                        )
+                except WorkspaceArtifactProjectionError:
+                    raise
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "additive overlay could not reconcile the destination",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    ) from exc
+            try:
+                child.rename(destination)
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "additive overlay promotion failed",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+            try:
+                if not destination.resolve().is_relative_to(workspace_root):
+                    raise WorkspaceArtifactProjectionError(
+                        "additive overlay escaped the authorized workspace",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+            except OSError:
+                pass
+
+    @staticmethod
+    def _merge_tree(staged: Path, destination: Path) -> None:
+        """Recursively merge one staged directory into its destination peer."""
+
+        for child in list(staged.iterdir()):
+            target = destination / child.name
+            if not os.path.lexists(target):
+                try:
+                    child.rename(target)
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "additive overlay promotion failed",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    ) from exc
+                continue
+            try:
+                target_is_dir = target.is_dir() and not target.is_symlink()
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "additive overlay could not inspect the destination",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+            staged_is_dir = child.is_dir() and not child.is_symlink()
+            if target_is_dir and staged_is_dir:
+                WorkspaceArtifactProjector._merge_tree(child, target)
+                continue
+            if target_is_dir != staged_is_dir:
+                raise WorkspaceArtifactProjectionError(
+                    "additive overlay type conflict with destination content",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            try:
+                target.unlink(missing_ok=True)
+                child.rename(target)
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "additive overlay could not reconcile the destination",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+
+    @staticmethod
+    def _promote_authoritative_restore(workspace: Path, staging: Path) -> None:
+        """Promote the verified staging generation over the destination.
+
+        A full snapshot is authoritative: destination-only files from a prior
+        clone or failed attempt are not silently retained. Only the
+        import-owned staging generation is moved; the live workspace directory
+        itself is never deleted, and nothing outside it is touched.
+        """
+
+        workspace.mkdir(parents=True, exist_ok=True)
+        # Remove destination-only files first so a retry reconciles the same
+        # generation instead of layering a new snapshot over stale content.
+        for child in list(workspace.iterdir()):
+            if child.name.startswith(STAGING_PREFIX):
+                continue
+            try:
+                if child.is_symlink() or child.is_file():
+                    child.unlink(missing_ok=True)
+                elif child.is_dir():
+                    # Never follow a destination symlink into another tree.
+                    if child.is_symlink():
+                        child.unlink(missing_ok=True)
+                    else:
+                        shutil.rmtree(child, ignore_errors=False)
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "authoritative restore could not reconcile the destination",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+        for child in list(staging.iterdir()):
+            destination = workspace / child.name
+            if os.path.lexists(destination):
+                raise WorkspaceArtifactProjectionError(
+                    "authoritative restore promotion conflict",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                )
+            try:
+                child.rename(destination)
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "authoritative restore promotion failed",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
 
     async def _materialize_bundle(
         self,
@@ -200,7 +1100,7 @@ class WorkspaceArtifactProjector:
                     f"{noun} exceed the cumulative authorized workspace bound",
                     code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                 )
-            await self._validate_metadata(
+            admitted = await self._validate_metadata(
                 service,
                 artifact_id=artifact_id,
                 budget_bytes=budget,
@@ -219,6 +1119,7 @@ class WorkspaceArtifactProjector:
                 target=target,
                 budget_bytes=budget,
                 principal=principal,
+                expected_digest=admitted.digest,
             )
             self._make_runtime_readable(
                 target,
@@ -289,35 +1190,87 @@ class WorkspaceArtifactProjector:
         budget_bytes: int,
         principal: str,
         required_workflow_id: str | None = None,
-    ) -> None:
+        expected_digest: str | None = None,
+        strict_metadata: bool = False,
+    ) -> AdmittedSource:
         get_metadata = getattr(service, "get_metadata", None)
         if get_metadata is None:
-            if required_workflow_id is not None:
-                raise WorkspaceArtifactProjectionError(
-                    "attachment authorization requires linked artifact metadata",
-                    code="WORKSPACE_AUTHORITY_MISMATCH",
-                )
-            return
-        metadata = await get_metadata(artifact_id=artifact_id, principal=principal)
-        artifact = metadata[0] if isinstance(metadata, tuple) else metadata
-        if required_workflow_id is not None:
-            links = metadata[1] if isinstance(metadata, tuple) and len(metadata) > 1 else ()
-            family = f"{required_workflow_id}:"
-            if not any(
-                str(getattr(link, "workflow_id", "")) == required_workflow_id
-                or str(getattr(link, "workflow_id", "")).startswith(family)
-                for link in links
+            # A read-bytes-only adapter cannot establish owner, digest, or
+            # quarantine permission; the authored path fails instead of
+            # inferring authority from a service principal or permissive read.
+            if (
+                strict_metadata
+                or getattr(service, "_moonmind_metadata_less", False)
+                or required_workflow_id is not None
             ):
                 raise WorkspaceArtifactProjectionError(
-                    "attachment artifact is not linked to the current workflow family",
+                    "source-artifact authorization requires linked artifact "
+                    "metadata",
                     code="WORKSPACE_AUTHORITY_MISMATCH",
                 )
+            # Explicit historical decoding only: see _apply_checkpoint.
+            return AdmittedSource(
+                artifact_id=artifact_id,
+                digest=expected_digest,
+                size_bytes=None,
+                redaction_level=None,
+            )
+        try:
+            metadata = await get_metadata(artifact_id=artifact_id, principal=principal)
+        except WorkspaceArtifactProjectionError:
+            raise
+        except Exception as exc:
+            raise WorkspaceArtifactProjectionError(
+                "source artifact metadata is unavailable",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            ) from exc
+        artifact, links = _metadata_tuple(metadata)
+        if artifact is None:
+            raise WorkspaceArtifactProjectionError(
+                "source artifact metadata is missing",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if not _status_is_complete(artifact):
+            raise WorkspaceArtifactProjectionError(
+                "source artifact is not complete",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        if _is_expired(artifact):
+            raise WorkspaceArtifactProjectionError(
+                "source artifact lifetime has expired",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        # Restricted/quarantined bytes need their own explicit policy; a
+        # generic restore never releases protected raw content.
+        redaction = _redaction_level(artifact)
+        if redaction is not None and redaction not in {"NONE", "UNCLASSIFIED", ""}:
+            raise WorkspaceArtifactProjectionError(
+                "source artifact is restricted and needs an explicit release policy",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        digest = _artifact_digest(artifact)
+        if expected_digest is not None:
+            want = expected_digest.strip().lower()
+            if digest is None or digest.lower() != want:
+                raise WorkspaceArtifactProjectionError(
+                    "source artifact digest does not match the admitted digest",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        if required_workflow_id is not None:
+            _check_workflow_family_link(links, required_workflow_id)
         size = getattr(artifact, "size_bytes", None)
         if isinstance(size, int) and size > budget_bytes:
             raise WorkspaceArtifactProjectionError(
                 "restore input exceeds the authorized workspace bound",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             )
+        size_int = size if isinstance(size, int) else None
+        return AdmittedSource(
+            artifact_id=artifact_id,
+            digest=digest or expected_digest,
+            size_bytes=size_int,
+            redaction_level=redaction,
+        )
 
     @staticmethod
     async def _write_payload(
@@ -327,43 +1280,89 @@ class WorkspaceArtifactProjector:
         target: Path,
         budget_bytes: int,
         principal: str,
+        expected_digest: str | None = None,
     ) -> int:
+        want = expected_digest.strip().lower() if expected_digest else None
         read_chunks = getattr(service, "read_chunks", None)
         if read_chunks is not None:
-            _artifact, chunks = await read_chunks(
-                artifact_id=artifact_id,
-                principal=principal,
-                allow_restricted_raw=True,
-                chunk_size=STREAM_CHUNK_BYTES,
-            )
+            try:
+                _artifact, chunks = await read_chunks(
+                    artifact_id=artifact_id,
+                    principal=principal,
+                    allow_restricted_raw=True,
+                    chunk_size=STREAM_CHUNK_BYTES,
+                )
+            except WorkspaceArtifactProjectionError:
+                raise
+            except Exception as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "restore input could not be read",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+            digest = hashlib.sha256()
             written = 0
             descriptor = os.open(
                 target,
                 os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
                 0o600,
             )
-            with os.fdopen(descriptor, "wb") as stream:
-                for chunk in chunks:
-                    written += len(chunk)
-                    if written > budget_bytes:
-                        stream.close()
-                        target.unlink(missing_ok=True)
-                        raise WorkspaceArtifactProjectionError(
-                            "restore input exceeds the authorized workspace bound",
-                            code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
-                        )
-                    stream.write(chunk)
+            try:
+                with os.fdopen(descriptor, "wb") as stream:
+                    for chunk in chunks:
+                        if not isinstance(chunk, (bytes, bytearray)):
+                            raise WorkspaceArtifactProjectionError(
+                                "restore input chunk is malformed",
+                                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                            )
+                        written += len(chunk)
+                        if written > budget_bytes:
+                            raise WorkspaceArtifactProjectionError(
+                                "restore input exceeds the authorized workspace bound",
+                                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                            )
+                        digest.update(chunk)
+                        stream.write(chunk)
+            except WorkspaceArtifactProjectionError:
+                target.unlink(missing_ok=True)
+                raise
+            except OSError as exc:
+                target.unlink(missing_ok=True)
+                raise WorkspaceArtifactProjectionError(
+                    "restore input could not be written",
+                    code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                ) from exc
+            if want is not None and f"sha256:{digest.hexdigest()}" != want:
+                target.unlink(missing_ok=True)
+                raise WorkspaceArtifactProjectionError(
+                    "source bytes do not match the admitted digest",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
             return written
-        _artifact, payload = await service.read(
-            artifact_id=artifact_id,
-            principal=principal,
-            allow_restricted_raw=True,
-        )
+        try:
+            _artifact, payload = await service.read(
+                artifact_id=artifact_id,
+                principal=principal,
+                allow_restricted_raw=True,
+            )
+        except WorkspaceArtifactProjectionError:
+            raise
+        except Exception as exc:
+            raise WorkspaceArtifactProjectionError(
+                "restore input could not be read",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
         if len(payload) > budget_bytes:
             raise WorkspaceArtifactProjectionError(
                 "restore input exceeds the authorized workspace bound",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             )
+        if want is not None:
+            observed = f"sha256:{hashlib.sha256(bytes(payload)).hexdigest()}"
+            if observed != want:
+                raise WorkspaceArtifactProjectionError(
+                    "source bytes do not match the admitted digest",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
         descriptor = os.open(
             target,
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
@@ -395,6 +1394,8 @@ class WorkspaceArtifactProjector:
             return gateway
 
         class _GatewayAdapter:
+            _moonmind_metadata_less = True
+
             async def read(self, *, artifact_id: str, **_kwargs: Any):
                 payload = await gateway.read_bytes(f"artifact://{artifact_id}")
                 return {}, payload
@@ -403,6 +1404,8 @@ class WorkspaceArtifactProjector:
 
 
 __all__ = [
+    "AdmittedSource",
     "WorkspaceArtifactProjectionError",
     "WorkspaceArtifactProjector",
+    "cleanup_import_staging",
 ]

--- a/moonmind/omnigent/workspace_sources.py
+++ b/moonmind/omnigent/workspace_sources.py
@@ -1,0 +1,789 @@
+"""Unified workspace-source compiler for artifact, checkpoint, and existing workspaces.
+
+Implements CONTRACT-002 / CONTRACT-011 / INV-005 / INV-006 target behavior for
+MoonLadderStudios/MoonMind#4014 (plan slice 3):
+
+- Exactly one source plus an explicit overlay/input policy is admitted.
+  A repository base with a checkpoint/artifact overlay is one source (base
+  plus overlay policy), not two competing sources.
+- ``artifact`` names authorized immutable content and its expected digest.
+- ``checkpoint`` names a supported workspace-restore contract.
+- ``existing_workspace`` names a verified server-issued locator/use grant.
+- Raw ``workspacePath``/``path`` precedence is removed as a normal authoring
+  route; :func:`decode_legacy_workspace_path` preserves the one explicit
+  historical decoding path for already-recorded payloads.
+- Conflicting source aliases are rejected before any read or filesystem
+  mutation.
+
+This module owns compilation only. Admission against the real artifact
+service, byte verification, staging, and promotion live in
+:mod:`moonmind.omnigent.workspace_artifacts` and the host materializer, so
+consumers cannot drift from the compiled decision.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+WorkspaceSourceKind = Literal[
+    "scratch", "repository", "artifact", "checkpoint", "existing_workspace"
+]
+
+SUPPORTED_RESTORE_CONTRACTS: tuple[str, ...] = (
+    "moonmind.worktree-archive.v1",
+    "moonmind.workspace-snapshot.v1",
+)
+
+SUPPORTED_SOURCE_RUNTIMES: dict[str, tuple[str, ...]] = {
+    "scratch": ("omnigent", "managed", "codex_cli"),
+    "repository": ("omnigent", "managed", "codex_cli"),
+    "artifact": ("omnigent", "managed"),
+    "checkpoint": ("omnigent", "managed", "codex_cli"),
+    "existing_workspace": ("omnigent", "managed"),
+}
+
+OVERLAY_AUTHORITATIVE = "authoritative_restore"
+OVERLAY_ADDITIVE = "additive_overlay"
+
+# Resource budgets shared by the compiler (authored claims) and the
+# materializer (enforced streamed/expanded limits). Kept in one place so a
+# test can assert the advertised bound equals the enforced bound.
+MAX_EXPANDED_BYTES = 512 * 1024 * 1024
+MAX_COMPRESSED_BYTES = 256 * 1024 * 1024
+MAX_FILE_COUNT = 50_000
+MAX_FILE_BYTES = 64 * 1024 * 1024
+MAX_PATH_DEPTH = 32
+MAX_PROCESSING_SECONDS = 300.0
+
+WORKSPACE_SOURCE_CONFLICT = "WORKSPACE_SOURCE_CONFLICT"
+WORKSPACE_SOURCE_INVALID = "WORKSPACE_SOURCE_INVALID"
+WORKSPACE_SOURCE_RAW_PATH_REJECTED = "WORKSPACE_SOURCE_RAW_PATH_REJECTED"
+WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED = "WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED"
+WORKSPACE_SOURCE_GRANT_INVALID = "WORKSPACE_SOURCE_GRANT_INVALID"
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ARTIFACT_REF_RE = re.compile(r"^artifact://[A-Za-z0-9_.\-]{1,200}$")
+
+
+class WorkspaceSourceError(ValueError):
+    """Fail-closed source-compilation error raised before any host mutation."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True)
+class ExistingWorkspaceGrant:
+    """Server-issued ownership/use grant for an existing workspace.
+
+    A raw directory path is never permission to use a sibling workflow's
+    directory. Only this grant — issued by the server, bound to the owning
+    workflow/step, a generation, and an access mode — authorizes reuse.
+    """
+
+    workspace_id: str
+    owner_workflow_id: str
+    owner_step_execution_id: str
+    generation: int
+    mode: Literal["exclusive", "read_only"]
+    expires_at: datetime | None = None
+    grant_digest: str | None = None
+
+    def is_expired(self, *, now: datetime | None = None) -> bool:
+        if self.expires_at is None:
+            return False
+        moment = now or datetime.now(tz=UTC)
+        candidate = self.expires_at
+        if candidate.tzinfo is None:
+            candidate = candidate.replace(tzinfo=UTC)
+        return candidate <= moment
+
+
+@dataclass(frozen=True)
+class CompiledWorkspaceSource:
+    """The single admitted source plus its explicit overlay/input policy."""
+
+    kind: WorkspaceSourceKind
+    overlay_policy: str = OVERLAY_AUTHORITATIVE
+    # Artifact source: authorized immutable content + expected digest.
+    artifact_ref: str | None = None
+    artifact_digest: str | None = None
+    # Checkpoint source: supported workspace-restore contract + version.
+    checkpoint_ref: str | None = None
+    restore_contract: str | None = None
+    restore_contract_version: str = "v1"
+    # Existing-workspace source: verified locator/use grant.
+    existing_grant: ExistingWorkspaceGrant | None = None
+    # Repository identity. For a repository source this is the clone target
+    # (owned by repository_contract); for a checkpoint/artifact source it is
+    # the optional clone-to base. A self-contained authored content source
+    # omits it entirely: no clone and no source-credential lookup.
+    repository_ref: str | None = None
+    repository_branch: str | None = None
+    # Explicit input policy: additive refs applied after an authoritative
+    # restore, and the digest binding the admitted input set.
+    additive_refs: tuple[str, ...] = ()
+    input_manifest_digest: str = "sha256:" + "0" * 64
+    historical: bool = False
+
+    def readiness_fingerprint(
+        self,
+        *,
+        target_owner_workflow_id: str,
+        attempt_id: str,
+    ) -> dict[str, Any]:
+        """Bind completion to source/digest/contract/inputs/owner/attempt."""
+
+        if self.existing_grant is not None:
+            source_digest = f"existing:{self.existing_grant.workspace_id}"
+        elif self.kind == "repository":
+            source_digest = (
+                f"repository:{self.repository_ref or ''}"
+                f"@{self.repository_branch or ''}"
+            )
+        else:
+            source_digest = (
+                self.artifact_digest
+                or self.checkpoint_ref
+                or "scratch"
+            )
+        return {
+            "kind": self.kind,
+            "sourceDigest": source_digest,
+            "repositoryBase": (
+                f"{self.repository_ref or ''}@{self.repository_branch or ''}"
+                if self.kind in {"artifact", "checkpoint"} and self.repository_ref
+                else None
+            ),
+            "restoreContract": self.restore_contract,
+            "restoreContractVersion": self.restore_contract_version,
+            "inputManifestDigest": self.input_manifest_digest,
+            "targetOwnerWorkflowId": target_owner_workflow_id,
+            "attemptId": attempt_id,
+            "overlayPolicy": self.overlay_policy,
+            "existingGeneration": (
+                self.existing_grant.generation if self.existing_grant else None
+            ),
+        }
+
+
+def compute_input_manifest_digest(refs: tuple[str, ...] | list[str]) -> str:
+    cleaned = sorted({str(ref).strip() for ref in refs if str(ref).strip()})
+    encoded = json.dumps(cleaned, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _clean_str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def decode_legacy_workspace_path(spec: Mapping[str, Any]) -> str | None:
+    """Explicit historical decoding for already-recorded raw-path payloads.
+
+    New authoring must use ``workspaceSource``; the materializer rejects raw
+    paths through the normal route and only this named decoder may interpret
+    them for migration/diagnostics of in-flight histories.
+    """
+
+    for key in ("workspacePath", "path"):
+        value = _clean_str(spec.get(key))
+        if value:
+            return value
+    return None
+
+
+def parse_existing_workspace_grant(value: Any) -> ExistingWorkspaceGrant:
+    if not isinstance(value, Mapping):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existing_workspace source requires an existingWorkspaceGrant mapping",
+        )
+    workspace_id = _clean_str(value.get("workspaceId") or value.get("workspace_id"))
+    owner_workflow = _clean_str(
+        value.get("ownerWorkflowId") or value.get("owner_workflow_id")
+    )
+    owner_step = _clean_str(
+        value.get("ownerStepExecutionId") or value.get("owner_step_execution_id")
+    )
+    mode = _clean_str(value.get("mode") or "exclusive").lower()
+    try:
+        generation = int(value.get("generation", 1))
+    except (TypeError, ValueError) as exc:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant.generation must be an integer",
+        ) from exc
+    expires_raw = _clean_str(value.get("expiresAt") or value.get("expires_at"))
+    expires_at: datetime | None = None
+    if expires_raw:
+        try:
+            expires_at = datetime.fromisoformat(expires_raw.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existingWorkspaceGrant.expiresAt is not a valid timestamp",
+            ) from exc
+    grant_digest = _clean_str(value.get("grantDigest") or value.get("grant_digest"))
+    if not workspace_id or not owner_workflow or not owner_step:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant requires workspaceId, ownerWorkflowId, "
+            "and ownerStepExecutionId",
+        )
+    if mode not in {"exclusive", "read_only"}:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant.mode must be 'exclusive' or 'read_only'",
+        )
+    if generation < 1:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant.generation must be >= 1",
+        )
+    if grant_digest and not _DIGEST_RE.match(grant_digest):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant.grantDigest must be a sha256: digest",
+        )
+    return ExistingWorkspaceGrant(
+        workspace_id=workspace_id,
+        owner_workflow_id=owner_workflow,
+        owner_step_execution_id=owner_step,
+        generation=generation,
+        mode=mode,  # type: ignore[arg-type]
+        expires_at=expires_at,
+        grant_digest=grant_digest or None,
+    )
+
+
+def check_source_runtime_supported(kind: str, runtime: str) -> None:
+    supported = SUPPORTED_SOURCE_RUNTIMES.get(kind, ())
+    if runtime not in supported:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED,
+            f"workspace source {kind!r} is not supported on runtime {runtime!r}; "
+            f"supported: {', '.join(supported) or 'none'}",
+        )
+
+
+def _validate_artifact_ref(ref: str, *, noun: str) -> str:
+    value = _clean_str(ref)
+    if not _ARTIFACT_REF_RE.match(value):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_INVALID,
+            f"{noun} must be an artifact:// ref, got {value!r}",
+        )
+    return value
+
+
+def _validate_digest(digest: Any, *, noun: str, required: bool) -> str | None:
+    value = _clean_str(digest)
+    if not value:
+        if required:
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_INVALID,
+                f"{noun} requires an expected sha256: digest",
+            )
+        return None
+    if not _DIGEST_RE.match(value):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_INVALID,
+            f"{noun} digest must match sha256:<64 hex>, got {value!r}",
+        )
+    return value
+
+
+def compile_workspace_source(
+    spec: Mapping[str, Any] | None,
+    *,
+    workflow_id: str = "",
+    step_execution_id: str = "",
+    runtime: str = "omnigent",
+) -> CompiledWorkspaceSource:
+    """Compile exactly one source plus an explicit overlay/input policy.
+
+    Reads the canonical ``workspaceSource`` union first; when absent, derives
+    one historical source from legacy aliases (repository/branch,
+    workspaceCheckpointRestoreRef, restoreInputRefs, workspaceLocator) so
+    in-flight payloads keep deterministic meaning. Raw ``workspacePath`` /
+    ``path`` aliases are never a normal source: they raise
+    ``WORKSPACE_SOURCE_RAW_PATH_REJECTED`` and must go through
+    :func:`decode_legacy_workspace_path` explicitly.
+
+    Raises before any read or filesystem mutation on conflict/invalid input.
+    """
+
+    spec_map = _as_mapping(spec)
+
+    raw_path = _clean_str(spec_map.get("workspacePath") or spec_map.get("path"))
+    if raw_path:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_RAW_PATH_REJECTED,
+            "authored workspacePath/path is not an authorized workspace source; "
+            "use workspaceSource with an existing_workspace grant",
+        )
+
+    overlay_raw = _clean_str(
+        spec_map.get("overlayPolicy") or spec_map.get("overlay_policy")
+    ).lower()
+    overlay_policy = (
+        OVERLAY_ADDITIVE
+        if overlay_raw in {"additive", "additive_overlay", "overlay"}
+        else OVERLAY_AUTHORITATIVE
+    )
+
+    additive_refs = tuple(
+        dict.fromkeys(
+            _clean_str(ref)
+            for ref in (
+                list(spec_map.get("restoreInputRefs") or [])
+                + list(spec_map.get("attachmentRefs") or [])
+            )
+            if _clean_str(ref)
+        )
+    )
+
+    authored = _as_mapping(spec_map.get("workspaceSource"))
+
+    authored_kind = _clean_str(authored.get("kind")).lower() or None
+    if authored_kind not in (None, "", "scratch", "repository", "artifact",
+                             "checkpoint", "existing_workspace", "existing-workspace"):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_INVALID,
+            f"workspaceSource.kind {authored_kind!r} is not a supported source",
+        )
+    if authored_kind == "existing-workspace":
+        authored_kind = "existing_workspace"
+
+    # Legacy alias presence (historical decoding only).
+    repository_target = _as_mapping(spec_map.get("repositoryTarget"))
+    repo_alias = _clean_str(
+        spec_map.get("repository") or spec_map.get("repo") or ""
+    )
+    if isinstance(spec_map.get("repository"), Mapping):
+        repo_alias = _clean_str(spec_map["repository"].get("name") or "") or repo_alias
+    if isinstance(repository_target.get("repository"), Mapping):
+        repo_alias = (
+            _clean_str(repository_target["repository"].get("name")) or repo_alias
+        )
+    branch_alias = _clean_str(
+        spec_map.get("startingBranch")
+        or spec_map.get("branch")
+        or spec_map.get("headBranch")
+        or ""
+    )
+    if isinstance(repository_target.get("branch"), Mapping):
+        branch_alias = (
+            _clean_str(repository_target["branch"].get("name")) or branch_alias
+        )
+    checkpoint_alias = _clean_str(
+        spec_map.get("workspaceCheckpointRestoreRef") or ""
+    )
+    artifact_alias = _clean_str(
+        authored.get("artifactRef")
+        or authored.get("artifact_ref")
+        or spec_map.get("workspaceArtifactRef")
+        or ""
+    )
+    checkpoint_authored = _clean_str(
+        authored.get("checkpointRef") or authored.get("checkpoint_ref") or ""
+    )
+    grant_authored = authored.get("existingWorkspaceGrant") or authored.get(
+        "existing_workspace_grant"
+    )
+
+    wants_artifact = bool(artifact_alias)
+    wants_checkpoint = bool(checkpoint_authored or checkpoint_alias)
+    wants_grant = grant_authored is not None
+    wants_repo = bool(repo_alias or branch_alias)
+
+    def _conflict(*names: str) -> WorkspaceSourceError:
+        return WorkspaceSourceError(
+            WORKSPACE_SOURCE_CONFLICT,
+            "exactly one workspace source is required; conflicting aliases for "
+            + ", ".join(sorted(names)),
+        )
+
+    if authored_kind is not None:
+        # Authored workspaceSource is explicit: any alias outside the declared
+        # kind's base/overlay policy is a conflict, not a silent second source.
+        if authored_kind == "scratch":
+            if wants_artifact or wants_checkpoint or wants_grant or wants_repo:
+                raise _conflict(
+                    *[
+                        name
+                        for name, want in (
+                            ("artifact", wants_artifact),
+                            ("checkpoint", wants_checkpoint),
+                            ("existing_workspace", wants_grant),
+                            ("repository", wants_repo),
+                        )
+                        if want
+                    ]
+                )
+        elif authored_kind == "repository":
+            if wants_artifact or wants_checkpoint or wants_grant:
+                raise _conflict(
+                    *[
+                        name
+                        for name, want in (
+                            ("artifact", wants_artifact),
+                            ("checkpoint", wants_checkpoint),
+                            ("existing_workspace", wants_grant),
+                        )
+                        if want
+                    ]
+                )
+        elif authored_kind == "artifact":
+            if wants_checkpoint or wants_grant:
+                raise _conflict(
+                    *[
+                        name
+                        for name, want in (
+                            ("checkpoint", wants_checkpoint),
+                            ("existing_workspace", wants_grant),
+                        )
+                        if want
+                    ]
+                )
+        elif authored_kind == "checkpoint":
+            if wants_artifact or wants_grant:
+                raise _conflict(
+                    *[
+                        name
+                        for name, want in (
+                            ("artifact", wants_artifact),
+                            ("existing_workspace", wants_grant),
+                        )
+                        if want
+                    ]
+                )
+        elif authored_kind == "existing_workspace":
+            if wants_artifact or wants_checkpoint or wants_repo:
+                raise _conflict(
+                    *[
+                        name
+                        for name, want in (
+                            ("artifact", wants_artifact),
+                            ("checkpoint", wants_checkpoint),
+                            ("repository", wants_repo),
+                        )
+                        if want
+                    ]
+                )
+    else:
+        # Historical decoding: a repository base paired with a checkpoint or
+        # artifact overlay is one source (base plus overlay), matching the
+        # recorded clone-then-project production flows.
+        if wants_artifact and wants_checkpoint:
+            raise _conflict("artifact", "checkpoint")
+        if wants_grant and (wants_artifact or wants_checkpoint or wants_repo):
+            raise _conflict(
+                *[
+                    name
+                    for name, want in (
+                        ("artifact", wants_artifact),
+                        ("checkpoint", wants_checkpoint),
+                        ("existing_workspace", wants_grant),
+                        ("repository", wants_repo),
+                    )
+                    if want
+                ]
+            )
+
+    manifest_digest = compute_input_manifest_digest(additive_refs)
+
+    def _authored_repo_base() -> tuple[str | None, str | None]:
+        base = authored.get("baseRepository") or authored.get("base_repository")
+        if isinstance(base, Mapping):
+            name = _clean_str(base.get("name")) or None
+            branch = _clean_str(base.get("branch")) or None
+        else:
+            name = _clean_str(base) or None
+            branch = None
+        if branch is None:
+            branch = _clean_str(authored.get("baseBranch")) or None
+        return name, branch
+
+    if authored_kind == "artifact" or (not authored_kind and wants_artifact):
+        ref = _validate_artifact_ref(
+            authored.get("artifactRef")
+            or authored.get("artifact_ref")
+            or artifact_alias,
+            noun="artifact source",
+        )
+        digest = _validate_digest(
+            authored.get("artifactDigest")
+            or authored.get("artifact_digest")
+            or authored.get("expectedDigest")
+            or spec_map.get("workspaceArtifactDigest"),
+            noun="artifact source",
+            required=bool(authored_kind),
+        )
+        check_source_runtime_supported("artifact", runtime)
+        base_repo, base_branch = _authored_repo_base()
+        if authored_kind:
+            content_repo = base_repo
+            content_branch = base_branch
+        else:
+            content_repo = repo_alias or None
+            content_branch = branch_alias or None
+        return CompiledWorkspaceSource(
+            kind="artifact",
+            overlay_policy=(
+                overlay_policy
+                if authored_kind and overlay_raw
+                else (OVERLAY_ADDITIVE if not authored_kind else OVERLAY_AUTHORITATIVE)
+            ),
+            artifact_ref=ref,
+            artifact_digest=digest,
+            repository_ref=content_repo,
+            repository_branch=content_branch,
+            additive_refs=additive_refs,
+            input_manifest_digest=manifest_digest,
+            historical=not bool(authored_kind),
+        )
+
+    if authored_kind == "checkpoint" or (not authored_kind and wants_checkpoint):
+        ref = _validate_artifact_ref(
+            checkpoint_authored or checkpoint_alias,
+            noun="checkpoint source",
+        )
+        contract = _clean_str(
+            authored.get("restoreContract")
+            or authored.get("restore_contract")
+            or "moonmind.worktree-archive.v1"
+        ).lower()
+        if contract not in SUPPORTED_RESTORE_CONTRACTS:
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_INVALID,
+                f"checkpoint restore contract {contract!r} is not supported",
+            )
+        version = _clean_str(
+            authored.get("restoreContractVersion")
+            or authored.get("restore_contract_version")
+            or "v1"
+        )
+        digest = _validate_digest(
+            authored.get("checkpointDigest") or authored.get("checkpoint_digest"),
+            noun="checkpoint source",
+            required=False,
+        )
+        check_source_runtime_supported("checkpoint", runtime)
+        base_repo, base_branch = _authored_repo_base()
+        if authored_kind:
+            content_repo = base_repo
+            content_branch = base_branch
+        else:
+            content_repo = repo_alias or None
+            content_branch = branch_alias or None
+        return CompiledWorkspaceSource(
+            kind="checkpoint",
+            overlay_policy=(
+                overlay_policy
+                if authored_kind and overlay_raw
+                else (OVERLAY_ADDITIVE if not authored_kind else OVERLAY_AUTHORITATIVE)
+            ),
+            artifact_digest=digest,
+            checkpoint_ref=ref,
+            restore_contract=contract,
+            restore_contract_version=version,
+            repository_ref=content_repo,
+            repository_branch=content_branch,
+            additive_refs=additive_refs,
+            input_manifest_digest=manifest_digest,
+            historical=not bool(authored_kind),
+        )
+
+    if authored_kind == "existing_workspace" or (not authored_kind and wants_grant):
+        grant = parse_existing_workspace_grant(grant_authored)
+        if grant.is_expired():
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existingWorkspaceGrant has expired",
+            )
+        check_source_runtime_supported("existing_workspace", runtime)
+        return CompiledWorkspaceSource(
+            kind="existing_workspace",
+            overlay_policy=OVERLAY_AUTHORITATIVE,
+            existing_grant=grant,
+            additive_refs=additive_refs,
+            input_manifest_digest=manifest_digest,
+        )
+
+    if authored_kind == "repository" or (
+        not authored_kind and wants_repo and not wants_artifact and not wants_checkpoint
+    ):
+        target_repo = _clean_str(
+            authored.get("repository")
+            or (authored.get("repositoryTarget", {}) or {}).get("repository", {})
+            if isinstance(authored.get("repositoryTarget"), Mapping)
+            else repo_alias
+        ) or repo_alias
+        target_branch = _clean_str(
+            authored.get("branch") or branch_alias
+        ) or branch_alias
+        check_source_runtime_supported("repository", runtime)
+        return CompiledWorkspaceSource(
+            kind="repository",
+            overlay_policy=OVERLAY_AUTHORITATIVE,
+            repository_ref=target_repo or None,
+            repository_branch=target_branch or None,
+            additive_refs=additive_refs,
+            input_manifest_digest=manifest_digest,
+            historical=not bool(authored_kind),
+        )
+
+    check_source_runtime_supported("scratch", runtime)
+    return CompiledWorkspaceSource(
+        kind="scratch",
+        overlay_policy=(
+            OVERLAY_ADDITIVE if overlay_policy == OVERLAY_ADDITIVE
+            else OVERLAY_AUTHORITATIVE
+        ),
+        additive_refs=additive_refs,
+        input_manifest_digest=manifest_digest,
+        historical=False,
+    )
+
+
+def verify_existing_workspace_grant(
+    grant: ExistingWorkspaceGrant,
+    *,
+    target_workflow_id: str,
+    target_step_execution_id: str,
+    expected_generation: int | None = None,
+    record_owner_workflow_id: str | None = None,
+) -> None:
+    """Verify a locator/use grant before any filesystem use.
+
+    The grant's recorded owner must match the durable owner record for the
+    workspace; root containment alone never authorizes reuse. Stale
+    generations and expired grants fail closed.
+    """
+
+    _ = target_step_execution_id
+    if grant.is_expired():
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant has expired",
+        )
+    if expected_generation is not None and grant.generation != expected_generation:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant generation is stale for the target workspace",
+        )
+    if (
+        record_owner_workflow_id is not None
+        and grant.owner_workflow_id != record_owner_workflow_id
+    ):
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existingWorkspaceGrant owner does not match the workspace owner record",
+        )
+    if not target_workflow_id:
+        raise WorkspaceSourceError(
+            WORKSPACE_SOURCE_GRANT_INVALID,
+            "existing workspace use requires a target workflow owner",
+        )
+
+
+class ExistingWorkspaceGrantLedger:
+    """Monotone generation ledger for existing-workspace grants.
+
+    Lives beside the sandbox owner records (never inside a materialized
+    workspace). Admitting a generation lower than the recorded one fails as a
+    stale grant; higher generations advance the ledger. Only ledger files
+    named ``<workspace_id>.grant.json`` are ever written or removed.
+    """
+
+    def __init__(self, authority_dir: str | Path) -> None:
+        self._dir = Path(authority_dir)
+
+    def _path(self, workspace_id: str) -> Path:
+        candidate = (self._dir / f"{workspace_id}.grant.json").resolve()
+        if candidate.parent != self._dir.resolve():
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existing workspace grant ledger escapes its authority",
+            )
+        return candidate
+
+    def admitted_generation(self, workspace_id: str) -> int | None:
+        path = self._path(workspace_id)
+        if not path.is_file():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            generation = int(payload.get("generation", 0))
+        except (OSError, ValueError, TypeError, AttributeError):
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existing workspace grant ledger is invalid",
+            )
+        return generation if generation >= 1 else None
+
+    def admit(self, grant: ExistingWorkspaceGrant) -> None:
+        if grant.is_expired():
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existingWorkspaceGrant has expired",
+            )
+        recorded = self.admitted_generation(grant.workspace_id)
+        if recorded is not None and grant.generation < recorded:
+            raise WorkspaceSourceError(
+                WORKSPACE_SOURCE_GRANT_INVALID,
+                "existingWorkspaceGrant generation is stale for the target "
+                "workspace",
+            )
+        if recorded is not None and grant.generation == recorded:
+            return
+        self._dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = self._path(grant.workspace_id)
+        payload = json.dumps(
+            {"version": "grant-v1", "generation": grant.generation}, sort_keys=True
+        )
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+
+
+__all__ = [
+    "CompiledWorkspaceSource",
+    "ExistingWorkspaceGrant",
+    "ExistingWorkspaceGrantLedger",
+    "MAX_COMPRESSED_BYTES",
+    "MAX_EXPANDED_BYTES",
+    "MAX_FILE_BYTES",
+    "MAX_FILE_COUNT",
+    "MAX_PATH_DEPTH",
+    "MAX_PROCESSING_SECONDS",
+    "OVERLAY_ADDITIVE",
+    "OVERLAY_AUTHORITATIVE",
+    "SUPPORTED_RESTORE_CONTRACTS",
+    "SUPPORTED_SOURCE_RUNTIMES",
+    "WORKSPACE_SOURCE_CONFLICT",
+    "WORKSPACE_SOURCE_GRANT_INVALID",
+    "WORKSPACE_SOURCE_INVALID",
+    "WORKSPACE_SOURCE_RAW_PATH_REJECTED",
+    "WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED",
+    "WorkspaceSourceError",
+    "check_source_runtime_supported",
+    "compile_workspace_source",
+    "compute_input_manifest_digest",
+    "decode_legacy_workspace_path",
+    "parse_existing_workspace_grant",
+    "verify_existing_workspace_grant",
+]

--- a/moonmind/workflows/temporal/runtime/workspace_locators.py
+++ b/moonmind/workflows/temporal/runtime/workspace_locators.py
@@ -6,7 +6,7 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Mapping, Protocol
 
 from moonmind.schemas.workspace_locator_models import (
     ManagedWorkspaceLocator,
@@ -75,6 +75,68 @@ class SandboxWorkspaceRecordStore:
         descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
             stream.write("materialized-v2")
+
+    def _readiness_marker_path(self, workspace_id: str) -> Path:
+        candidate = (self.store_root / f"{workspace_id}.ready.json").resolve()
+        if candidate.parent != self.store_root.resolve():
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox workspace readiness marker escapes its authority",
+            )
+        return candidate
+
+    def read_readiness(self, workspace_id: str) -> dict[str, Any] | None:
+        """Return the digest-bound readiness marker, if one was recorded."""
+
+        path = self._readiness_marker_path(workspace_id)
+        if not path.is_file():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox workspace readiness marker is invalid",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox workspace readiness marker is invalid",
+            )
+        return payload
+
+    def is_ready(self, workspace_id: str, fingerprint: Mapping[str, Any]) -> bool:
+        """Return whether the recorded ready generation matches this attempt.
+
+        Completion binds to the admitted source/digest, restore
+        contract/version, input-manifest digest, target owner, and attempt —
+        not just a directory or a previous marker. A retry reconciles the
+        same generation; changed inputs require an explicit new import.
+        """
+
+        recorded = self.read_readiness(workspace_id)
+        if recorded is None:
+            return False
+        return recorded.get("fingerprint") == dict(fingerprint)
+
+    def mark_ready(
+        self, workspace_id: str, fingerprint: Mapping[str, Any]
+    ) -> None:
+        """Record the verified ready generation for this source and attempt."""
+
+        self.store_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = self._readiness_marker_path(workspace_id)
+        payload = json.dumps(
+            {"version": "ready-v1", "fingerprint": dict(fingerprint)},
+            sort_keys=True,
+        )
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        # The legacy directory-level marker is retained for historical
+        # readers; authority decisions use the digest-bound marker above.
+        if not self.is_materialized(workspace_id):
+            self.mark_materialized(workspace_id)
 
     def load(self, workspace_id: str) -> SandboxWorkspaceRecord | None:
         path = self._record_path(workspace_id)

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -74,6 +74,10 @@ from moonmind.omnigent.host_services.runtime_environment import (
     OmnigentRuntimeEnvironmentService,
 )
 from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
 from moonmind.omnigent.provider_leases import (
     AcquiredProviderLease,
     OmnigentProviderLeaseCoordinator,
@@ -2840,8 +2844,7 @@ async def test_workspace_attachment_translates_to_daemon_visible_volume_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace_root = tmp_path / "worker"
-    workspace = workspace_root / "run-1"
-    workspace.mkdir(parents=True)
+    workspace_root.mkdir(parents=True)
     monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(workspace_root))
     monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "remote")
 
@@ -2849,21 +2852,56 @@ async def test_workspace_attachment_translates_to_daemon_visible_volume_path(
         assert argv[-1] == "agent-workspaces"
         return 0, "/daemon/agent_workspaces\n", ""
 
+    # MoonLadderStudios/MoonMind#4014 removed raw workspacePath precedence:
+    # an existing workspace needs a server-issued ownership/use grant. The
+    # daemon translation below exercises the granted path, not a raw mount.
+    workspace_id = "granted-ws-1"
+    granted = workspace_root / "temporal_sandbox" / workspace_id / "repo"
+    granted.mkdir(parents=True)
+    (granted / "KEEP").write_text("kept", encoding="utf-8")
+    SandboxWorkspaceRecordStore(workspace_root).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id="workflow-1",
+            step_execution_id="idem-1",
+            relative_path="repo",
+        )
+    )
+
     service = OmnigentWorkspaceMaterializer(
         command_runner=runner,
         workspace_root=workspace_root,
         workspace_volume="agent-workspaces",
     )
     request = _request().model_copy(
-        update={"workspace_spec": {"workspacePath": str(workspace)}}
+        update={
+            "workspace_spec": {
+                "workspaceSource": {
+                    "kind": "existing_workspace",
+                    "existingWorkspaceGrant": {
+                        "workspaceId": workspace_id,
+                        "ownerWorkflowId": "workflow-1",
+                        "ownerStepExecutionId": "idem-1",
+                        "generation": 1,
+                        "mode": "exclusive",
+                    },
+                }
+            }
+        }
     )
 
     attachment = await service.materialize(request)
 
-    assert attachment["sourceRef"] == "/daemon/agent_workspaces/run-1"
+    assert (
+        attachment["sourceRef"]
+        == "/daemon/agent_workspaces/temporal_sandbox/granted-ws-1/repo"
+    )
     assert attachment["accessMode"] == "read-write"
 
     read_only_attachment = await service.materialize(request, mutation="read_only")
 
-    assert read_only_attachment["sourceRef"] == "/daemon/agent_workspaces/run-1"
+    assert (
+        read_only_attachment["sourceRef"]
+        == "/daemon/agent_workspaces/temporal_sandbox/granted-ws-1/repo"
+    )
     assert read_only_attachment["accessMode"] == "read-only"

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -409,8 +409,10 @@ async def test_materializer_rejects_missing_authored_path_and_failed_clone(
         command_runner=None, workspace_root=tmp_path  # type: ignore[arg-type]
     )
 
-    # Authored absolute paths are preexisting authority: missing dir fails closed.
-    with pytest.raises(HarnessPlatformError):
+    # Raw workspacePath aliases are rejected as a normal authoring route
+    # (MoonLadderStudios/MoonMind#4014); an existing workspace needs a
+    # server-issued ownership/use grant instead of a bare path.
+    with pytest.raises(HarnessPlatformError, match="workspacePath"):
         await materializer.materialize(_request({"workspacePath": "/tmp/nowhere"}))
 
     calls: list[list[str]] = []

--- a/tests/unit/omnigent/test_workspace_safe_sources.py
+++ b/tests/unit/omnigent/test_workspace_safe_sources.py
@@ -1,0 +1,1113 @@
+"""Safe artifact, checkpoint, and authorized existing-workspace sources.
+
+Production-boundary regression tests for
+MoonLadderStudios/MoonMind#4014 (CONTRACT-002, CONTRACT-011, INV-005, INV-006,
+DOC-REQ-002, TEST-003). Every source variant crosses the real
+compiler/artifact/materializer boundaries; unsupported combinations fail
+before execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import tarfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import moonmind.omnigent.workspace_artifacts as workspace_artifacts_module
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
+from moonmind.omnigent.workspace_artifacts import (
+    WorkspaceArtifactProjectionError,
+    WorkspaceArtifactProjector,
+    cleanup_import_staging,
+)
+from moonmind.omnigent.workspace_sources import (
+    ExistingWorkspaceGrantLedger,
+    WorkspaceSourceError,
+    compile_workspace_source,
+    decode_legacy_workspace_path,
+    parse_existing_workspace_grant,
+)
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
+
+
+def _digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _tar_bytes(entries: list[tuple], *, compress: bool = True) -> bytes:
+    """Build a gzip tar from (name, data, kind[, linkname]) tuples."""
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz" if compress else "w:") as bundle:
+        for entry in entries:
+            name, data, kind = entry[0], entry[1], entry[2]
+            linkname = entry[3] if len(entry) > 3 else ""
+            member = tarfile.TarInfo(name)
+            if kind == "file":
+                member.size = len(data)
+                bundle.addfile(member, io.BytesIO(data))
+            elif kind == "dir":
+                member.type = tarfile.DIRTYPE
+                bundle.addfile(member)
+            elif kind == "symlink":
+                member.type = tarfile.SYMTYPE
+                member.linkname = linkname
+                bundle.addfile(member)
+            elif kind == "hardlink":
+                member.type = tarfile.LNKTYPE
+                member.linkname = linkname
+                bundle.addfile(member)
+            else:  # pragma: no cover - test helper guard
+                raise AssertionError(f"unknown entry kind {kind!r}")
+    return buffer.getvalue()
+
+
+class FakeArtifactService:
+    """Mimic the real TemporalArtifactService boundary (not a read shortcut).
+
+    ``get_metadata`` returns the real 4-tuple shape
+    ``(artifact, links, pinned, read_policy)`` so admission exercises status,
+    digest, lifetime, redaction, and workflow-family link checks through the
+    actual service surface.
+    """
+
+    def __init__(
+        self,
+        payloads: dict[str, bytes],
+        *,
+        workflow_id: str = "workflow-1",
+        link_workflow_id: str | None = None,
+        status: str = "COMPLETE",
+        redaction_level: str = "NONE",
+        omit_digest: bool = False,
+    ) -> None:
+        self.payloads = dict(payloads)
+        self.workflow_id = workflow_id
+        self.link_workflow_id = (
+            workflow_id if link_workflow_id is None else link_workflow_id
+        )
+        self.status = status
+        self.redaction_level = redaction_level
+        self.omit_digest = omit_digest
+        self.calls: list[tuple] = []
+
+    async def get_metadata(self, *, artifact_id: str, principal: str):
+        self.calls.append(("metadata", artifact_id, principal))
+        payload = self.payloads[artifact_id]
+        artifact = SimpleNamespace(
+            artifact_id=artifact_id,
+            status=self.status,
+            size_bytes=len(payload),
+            sha256=None
+            if self.omit_digest
+            else hashlib.sha256(payload).hexdigest(),
+            expires_at=None,
+            redaction_level=self.redaction_level,
+            metadata_json={},
+        )
+        links = (
+            []
+            if self.link_workflow_id is None
+            else [SimpleNamespace(workflow_id=self.link_workflow_id)]
+        )
+        return artifact, links, False, SimpleNamespace(raw_access_allowed=True)
+
+    async def read_chunks(
+        self, *, artifact_id: str, principal: str, allow_restricted_raw: bool,
+        chunk_size: int,
+    ):
+        assert allow_restricted_raw is True
+        self.calls.append(("read", artifact_id, principal))
+        return SimpleNamespace(), iter((self.payloads[artifact_id],))
+
+
+class ReadOnlyGateway:
+    """A read-bytes-only adapter with no metadata surface."""
+
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self.payloads = dict(payloads)
+
+    async def read_bytes(self, ref: str) -> bytes:
+        return self.payloads[ref.removeprefix("artifact://")]
+
+
+def _request(spec: dict, *, workflow_id="workflow-1", step_id="step-1"):
+    return SimpleNamespace(
+        workspace_spec=spec,
+        parameters={},
+        input_refs=[],
+        step_execution=None,
+        correlation_id=workflow_id,
+        idempotency_key=step_id,
+    )
+
+
+def _workspace_id(workflow_id="workflow-1", step_id="step-1") -> str:
+    return hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
+
+
+def _locator_spec(workspace_id: str, **extra) -> dict:
+    return {
+        "workspaceLocator": {
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        **extra,
+    }
+
+
+def _authored_checkpoint_spec(workspace_id: str, payload: bytes, **extra) -> dict:
+    return _locator_spec(
+        workspace_id,
+        workspaceSource={
+            "kind": "checkpoint",
+            "checkpointRef": "artifact://checkpoint",
+            "checkpointDigest": _digest(payload),
+            "restoreContract": "moonmind.worktree-archive.v1",
+        },
+        **extra,
+    )
+
+
+async def _never_clone(argv, input_bytes=None):  # pragma: no cover - must not run
+    raise AssertionError("self-contained restore must not clone")
+
+
+# ---------------------------------------------------------------------------
+# Impl 1: exactly one source plus an explicit overlay/input policy.
+# ---------------------------------------------------------------------------
+
+
+def test_compiler_rejects_conflicting_source_aliases():
+    with pytest.raises(WorkspaceSourceError, match="WORKSPACE_SOURCE_CONFLICT"):
+        compile_workspace_source(
+            {
+                "workspaceArtifactRef": "artifact://aaa",
+                "workspaceCheckpointRestoreRef": "artifact://bbb",
+            }
+        )
+
+
+def test_compiler_rejects_raw_path_precedence_but_preserves_history():
+    with pytest.raises(
+        WorkspaceSourceError, match="WORKSPACE_SOURCE_RAW_PATH_REJECTED"
+    ):
+        compile_workspace_source({"workspacePath": "/tmp/nowhere"})
+    with pytest.raises(
+        WorkspaceSourceError, match="WORKSPACE_SOURCE_RAW_PATH_REJECTED"
+    ):
+        compile_workspace_source({"path": "/tmp/nowhere"})
+    # Necessary historical decoding stays explicit, not a silent route.
+    assert (
+        decode_legacy_workspace_path({"workspacePath": "/tmp/nowhere"})
+        == "/tmp/nowhere"
+    )
+
+
+def test_compiler_requires_digest_for_authored_artifact():
+    with pytest.raises(WorkspaceSourceError, match="expected sha256"):
+        compile_workspace_source(
+            {"workspaceSource": {"kind": "artifact", "artifactRef": "artifact://a"}}
+        )
+
+
+def test_compiler_rejects_unsupported_restore_contract():
+    with pytest.raises(WorkspaceSourceError, match="not supported"):
+        compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "checkpoint",
+                    "checkpointRef": "artifact://c",
+                    "restoreContract": "moonmind.future-format.v9",
+                }
+            }
+        )
+
+
+def test_compiler_pairs_repository_base_with_checkpoint_overlay():
+    source = compile_workspace_source(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "branch": "main",
+            "workspaceCheckpointRestoreRef": "artifact://chk",
+        }
+    )
+    assert source.kind == "checkpoint"
+    assert source.repository_ref == "MoonLadderStudios/MoonMind"
+    assert source.overlay_policy == "additive_overlay"
+    assert source.historical is True
+
+
+def test_compiler_rejects_grant_with_competing_source():
+    with pytest.raises(WorkspaceSourceError, match="WORKSPACE_SOURCE_CONFLICT"):
+        compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "existing_workspace",
+                    "existingWorkspaceGrant": {
+                        "workspaceId": "ws-1",
+                        "ownerWorkflowId": "wf-1",
+                        "ownerStepExecutionId": "st-1",
+                    },
+                },
+                "workspaceCheckpointRestoreRef": "artifact://chk",
+            }
+        )
+
+
+def test_compiler_rejects_unsupported_runtime_combination():
+    with pytest.raises(
+        WorkspaceSourceError, match="WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED"
+    ):
+        compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "artifact",
+                    "artifactRef": "artifact://a",
+                    "artifactDigest": _digest(b"x"),
+                }
+            },
+            runtime="codex_cli",
+        )
+    with pytest.raises(
+        WorkspaceSourceError, match="WORKSPACE_SOURCE_RUNTIME_UNSUPPORTED"
+    ):
+        compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "existing_workspace",
+                    "existingWorkspaceGrant": {
+                        "workspaceId": "ws-1",
+                        "ownerWorkflowId": "wf-1",
+                        "ownerStepExecutionId": "st-1",
+                    },
+                }
+            },
+            runtime="codex_cli",
+        )
+
+
+def test_grant_ledger_rejects_stale_and_expired_generations(tmp_path):
+    ledger = ExistingWorkspaceGrantLedger(tmp_path)
+
+    def _grant(generation: int, **overrides):
+        payload = {
+            "workspaceId": "ws-1",
+            "ownerWorkflowId": "wf-1",
+            "ownerStepExecutionId": "st-1",
+            "generation": generation,
+            "mode": "exclusive",
+        }
+        payload.update(overrides)
+        return parse_existing_workspace_grant(payload)
+
+    assert ledger.admitted_generation("ws-1") is None
+    ledger.admit(_grant(2))
+    assert ledger.admitted_generation("ws-1") == 2
+    with pytest.raises(WorkspaceSourceError, match="stale"):
+        ledger.admit(_grant(1))
+    expired = _grant(
+        3, expiresAt=(datetime.now(tz=UTC) - timedelta(seconds=1)).isoformat()
+    )
+    with pytest.raises(WorkspaceSourceError, match="expired"):
+        ledger.admit(expired)
+
+
+# ---------------------------------------------------------------------------
+# Impl 2: admission through the actual artifact service.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_strict_admission_rejects_metadata_less_adapter(tmp_path):
+    service = WorkspaceArtifactProjector(ReadOnlyGateway({"c": b"data"}))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="linked artifact metadata"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+    assert not any(workspace.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_strict_admission_rejects_wrong_owner(tmp_path):
+    payload = _tar_bytes([("ok.txt", b"ok", "file")])
+    service = WorkspaceArtifactProjector(
+        FakeArtifactService({"checkpoint": payload}, link_workflow_id="other-workflow")
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="not linked to the current workflow"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            checkpoint_digest=_digest(payload),
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_strict_admission_rejects_forged_family_prefix_link(tmp_path):
+    payload = _tar_bytes([("ok.txt", b"ok", "file")])
+    service = WorkspaceArtifactProjector(
+        FakeArtifactService({"checkpoint": payload}, link_workflow_id="workflow-1:")
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="not linked to the current workflow"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            checkpoint_digest=_digest(payload),
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_strict_admission_rejects_digest_mismatch(tmp_path):
+    payload = _tar_bytes([("ok.txt", b"ok", "file")])
+    service = WorkspaceArtifactProjector(FakeArtifactService({"checkpoint": payload}))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="digest does not match"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            checkpoint_digest=_digest(b"something else"),
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+    store = SandboxWorkspaceRecordStore(tmp_path)
+    assert store.read_readiness("ws") is None
+    assert not any(workspace.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_strict_admission_rejects_restricted_and_incomplete(tmp_path):
+    payload = _tar_bytes([("ok.txt", b"ok", "file")])
+    for kwargs in (
+        {"redaction_level": "RESTRICTED"},
+        {"redaction_level": "QUARANTINED"},
+        {"status": "PENDING_UPLOAD"},
+        {"status": "FAILED"},
+    ):
+        service = WorkspaceArtifactProjector(
+            FakeArtifactService({"c": payload}, **kwargs)
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir(exist_ok=True)
+        with pytest.raises(WorkspaceArtifactProjectionError):
+            await service.project(
+                workspace,
+                checkpoint_ref="artifact://c",
+                checkpoint_digest=_digest(payload),
+                workflow_id="workflow-1",
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+                strict_admission=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Impl 3: streamed verification under explicit budgets; hostile archives.
+# ---------------------------------------------------------------------------
+
+
+def _hostile_cases():
+    deep = "/".join(f"d{i}" for i in range(40)) + "/deep.txt"
+    return {
+        "absolute": [("/abs.txt", b"x", "file")],
+        "traversal": [("../escape.txt", b"x", "file")],
+        "duplicate": [("dup.txt", b"a", "file"), ("dup.txt", b"b", "file")],
+        "collision": [("Name.txt", b"a", "file"), ("name.txt", b"b", "file")],
+        "symlink_escape": [("link", b"", "symlink", "/etc/passwd")],
+        "symlink_dotdot": [("sub/link", b"", "symlink", "../../outside")],
+        "hardlink_forward": [("hl", b"", "hardlink", "later.txt")],
+        "deep": [(deep, b"x", "file")],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", sorted(_hostile_cases()))
+async def test_hostile_archives_stay_within_bounds_without_ready_workspace(
+    tmp_path, name
+):
+    payload = _tar_bytes(_hostile_cases()[name])
+    service = WorkspaceArtifactProjector(FakeArtifactService({"c": payload}))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(WorkspaceArtifactProjectionError):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            checkpoint_digest=_digest(payload),
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+    assert list(workspace.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_truncated_and_malformed_archives_are_classified(tmp_path):
+    payload = _tar_bytes([("ok.txt", b"hello world", "file")])
+    service = WorkspaceArtifactProjector(FakeArtifactService({"c": payload[:40]}))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(WorkspaceArtifactProjectionError):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+    garbage = FakeArtifactService({"c": b"not a gzip stream at all" * 10})
+    with pytest.raises(WorkspaceArtifactProjectionError):
+        await WorkspaceArtifactProjector(garbage).project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_per_file_and_expanded_budgets_are_enforced(tmp_path, monkeypatch):
+    # Craft a member whose header claims more than the per-file budget: patch
+    # the size octal (offset 124) of an otherwise valid tiny member, since
+    # tarfile refuses to write inconsistent claims itself.
+    import gzip
+
+    raw = _tar_bytes([("big.bin", b"tiny", "file")], compress=False)
+    claimed = workspace_artifacts_module.MAX_FILE_BYTES + 1
+    patched = bytearray(raw)
+    patched[124:136] = f"{claimed:011o}\x00".encode("ascii")
+    # Repair the header checksum (offset 148) so the claim reaches the
+    # per-file budget check instead of failing header validation.
+    patched[148:156] = b" " * 8
+    checksum = sum(patched[0:512])
+    patched[148:156] = f"{checksum:06o}\x00 ".encode("ascii")
+    payload = gzip.compress(bytes(patched))
+    service = WorkspaceArtifactProjector(FakeArtifactService({"c": payload}))
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="per-file budget"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+    monkeypatch.setattr(workspace_artifacts_module, "MAX_EXPANDED_BYTES", 10)
+    small = _tar_bytes([("a.txt", b"0123456789abcdef", "file")])
+    service = WorkspaceArtifactProjector(FakeArtifactService({"c": small}))
+    with pytest.raises(
+        WorkspaceArtifactProjectionError, match="expanded-bytes budget"
+    ):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://c",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_archive_artifact_bytes_are_unsupported(tmp_path):
+    payload = b"\x00\x01binary-but-not-a-tarball\xff\xfe"
+    service = WorkspaceArtifactProjector(
+        FakeArtifactService({"snapshot": payload}, workflow_id="workflow-1")
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises(WorkspaceArtifactProjectionError):
+        await service.project(
+            workspace,
+            checkpoint_ref="artifact://snapshot",
+            checkpoint_digest=_digest(payload),
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Impl 4/5: staging generations, authoritative vs additive, ready binding.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_contained_restore_needs_no_clone_or_credentials(
+    tmp_path, monkeypatch
+):
+    """A checkpoint restores into a missing dir with no clone and no PAT."""
+
+    async def fail_token(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("self-contained restore must not resolve credentials")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve."
+        "resolve_github_token_for_launch",
+        fail_token,
+    )
+    workspace_id = _workspace_id()
+    payload = _tar_bytes(
+        [
+            ("report.md", b"# saved work\n", "file"),
+            ("src/main.py", b"print(1)\n", "file"),
+        ]
+    )
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    result = await materializer.materialize(
+        _request(_authored_checkpoint_spec(workspace_id, payload)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert result["kind"] == "bind"
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert (workspace / "report.md").read_text() == "# saved work\n"
+    assert (workspace / "src" / "main.py").read_text() == "print(1)\n"
+    store = SandboxWorkspaceRecordStore(tmp_path)
+    assert store.is_materialized(workspace_id)
+    readiness = store.read_readiness(workspace_id)
+    assert readiness is not None
+    assert readiness["fingerprint"]["sourceDigest"] == _digest(payload)
+
+
+@pytest.mark.asyncio
+async def test_authoritative_restore_drops_destination_only_files(tmp_path):
+    workspace_id = _workspace_id()
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    (workspace / ".git" / "refs").mkdir(parents=True)
+    (workspace / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    (workspace / "stale-clone.txt").write_text("prior clone residue\n")
+    payload = _tar_bytes([("fresh.txt", b"snapshot\n", "file")])
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    await materializer.materialize(
+        _request(_authored_checkpoint_spec(workspace_id, payload)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert (workspace / "fresh.txt").read_text() == "snapshot\n"
+    assert not (workspace / "stale-clone.txt").exists()
+    assert not (workspace / ".git").exists()
+
+
+@pytest.mark.asyncio
+async def test_retry_reconciles_same_generation_without_reprojection(tmp_path):
+    workspace_id = _workspace_id()
+    payload = _tar_bytes([("ok.txt", b"v1\n", "file")])
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    spec = _authored_checkpoint_spec(workspace_id, payload)
+    await materializer.materialize(
+        _request(spec), runtime_uid=os.getuid(), runtime_gid=os.getgid()
+    )
+    reads_after_first = len(service.calls)
+    await materializer.materialize(
+        _request(spec), runtime_uid=os.getuid(), runtime_gid=os.getgid()
+    )
+    assert len(service.calls) == reads_after_first
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert (workspace / "ok.txt").read_text() == "v1\n"
+
+
+@pytest.mark.asyncio
+async def test_changed_inputs_require_a_new_verified_import(tmp_path):
+    workspace_id = _workspace_id()
+    payload_a = _tar_bytes([("a.txt", b"A\n", "file")])
+    payload_b = _tar_bytes([("b.txt", b"B\n", "file")])
+    service = FakeArtifactService({"a": payload_a, "b": payload_b})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+
+    def _spec(ref: str, payload: bytes) -> dict:
+        return _locator_spec(
+            workspace_id,
+            workspaceSource={
+                "kind": "checkpoint",
+                "checkpointRef": f"artifact://{ref}",
+                "checkpointDigest": _digest(payload),
+                "restoreContract": "moonmind.worktree-archive.v1",
+            },
+        )
+
+    await materializer.materialize(
+        _request(_spec("a", payload_a)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert (workspace / "a.txt").read_text() == "A\n"
+    await materializer.materialize(
+        _request(_spec("b", payload_b)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert (workspace / "b.txt").read_text() == "B\n"
+    assert not (workspace / "a.txt").exists()
+    readiness = SandboxWorkspaceRecordStore(tmp_path).read_readiness(workspace_id)
+    assert readiness is not None
+    assert readiness["fingerprint"]["sourceDigest"] == _digest(payload_b)
+
+
+@pytest.mark.asyncio
+async def test_interrupted_extraction_leaves_no_partial_content(tmp_path):
+    workspace_id = _workspace_id()
+    sibling_id = _workspace_id("workflow-1", "sibling-step")
+    sibling = tmp_path / "temporal_sandbox" / sibling_id / "repo"
+    sibling.mkdir(parents=True)
+    (sibling / "theirs.txt").write_text("other owner\n")
+    payload = _tar_bytes(
+        [("first.txt", b"partial\n", "file"), ("../escape.txt", b"x", "file")]
+    )
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    with pytest.raises(HarnessPlatformError):
+        await materializer.materialize(
+            _request(_authored_checkpoint_spec(workspace_id, payload)),
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert list(workspace.iterdir()) == []
+    assert SandboxWorkspaceRecordStore(tmp_path).read_readiness(workspace_id) is None
+    # Another owner's content is untouched by the failed import.
+    assert (sibling / "theirs.txt").read_text() == "other owner\n"
+    # A retry with a valid snapshot reconciles the same generation.
+    good = _tar_bytes([("good.txt", b"recovered\n", "file")])
+    service.payloads["checkpoint"] = good
+    await materializer.materialize(
+        _request(_authored_checkpoint_spec(workspace_id, good)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert (workspace / "good.txt").read_text() == "recovered\n"
+
+
+def test_late_cleanup_removes_only_staging_generations(tmp_path):
+    live = tmp_path / "temporal_sandbox" / "ws-live" / "repo"
+    live.mkdir(parents=True)
+    (live / "work.txt").write_text("live\n")
+    staging = tmp_path / "temporal_sandbox" / ".moonmind-import-abc123"
+    staging.mkdir()
+    (staging / "partial.txt").write_text("partial\n")
+    assert cleanup_import_staging(tmp_path / "temporal_sandbox") == 1
+    assert (live / "work.txt").read_text() == "live\n"
+    assert not staging.exists()
+    assert cleanup_import_staging(tmp_path / "temporal_sandbox") == 0
+
+
+# ---------------------------------------------------------------------------
+# Impl 6: neutralize imported authority, preserve history as data.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restored_git_is_usable_without_imported_authority(tmp_path):
+    payload = _tar_bytes(
+        [
+            (".git/HEAD", b"ref: refs/heads/main\n", "file"),
+            (".git/refs/heads/main", b"abc123\n", "file"),
+            (".git/objects/pack/data.pack", b"\x00packdata", "file"),
+            (".git/hooks/pre-commit", b"#!/bin/sh\nevil\n", "file"),
+            (
+                ".git/config",
+                b"[core]\n\thooksPath = /tmp/e\n"
+                b"[credential]\n\thelper = store\n",
+                "file",
+            ),
+            (
+                ".gitmodules",
+                b'[submodule "x"]\n'
+                b"\turl = https://example.com/x.git\n",
+                "file",
+            ),
+            (".aws/credentials", b"[default]\n", "file"),
+            (".netrc", b"machine example.com password s3cr3t\n", "file"),
+            (".moonmind/session-lease.json", b'{"lease": true}\n', "file"),
+            ("run.sh", b"#!/bin/sh\necho hi\n", "file"),
+        ]
+    )
+    workspace_id = _workspace_id()
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    await materializer.materialize(
+        _request(_authored_checkpoint_spec(workspace_id, payload)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    # History stays usable as data.
+    assert (workspace / ".git" / "refs" / "heads" / "main").read_text() == "abc123\n"
+    assert (workspace / ".git" / "objects" / "pack" / "data.pack").exists()
+    assert (workspace / ".gitmodules").exists()
+    # Ordinary executable source files are preserved, not blanket-rejected.
+    assert (workspace / "run.sh").exists()
+    # Imported hooks, credential bindings, and session authority are gone.
+    assert not (workspace / ".git" / "hooks" / "pre-commit").exists()
+    config = (workspace / ".git" / "config").read_text()
+    assert "hooksPath" not in config and "helper = store" not in config
+    assert not (workspace / ".aws").exists()
+    assert not (workspace / ".netrc").exists()
+    assert not (workspace / ".moonmind" / "session-lease.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_external_git_bindings_and_thin_bundles_fail_closed(tmp_path):
+    workspace_id = _workspace_id()
+    service = FakeArtifactService({})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+
+    async def _fails(payload: bytes) -> None:
+        ref = f"artifact://case-{len(service.payloads)}"
+        service.payloads[ref.removeprefix("artifact://")] = payload
+        spec = _locator_spec(
+            workspace_id,
+            workspaceSource={
+                "kind": "checkpoint",
+                "checkpointRef": ref,
+                "checkpointDigest": _digest(payload),
+                "restoreContract": "moonmind.worktree-archive.v1",
+            },
+        )
+        with pytest.raises(HarnessPlatformError):
+            await materializer.materialize(
+                _request(spec),
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+
+    await _fails(_tar_bytes([(".git", b"gitdir: /etc/evil\n", "file")]))
+    await _fails(
+        _tar_bytes(
+            [
+                (".git/HEAD", b"ref: refs/heads/main\n", "file"),
+                (".git/objects/info/alternates", b"/mnt/external-objects\n", "file"),
+            ]
+        )
+    )
+    await _fails(
+        _tar_bytes(
+            [
+                (
+                    ".gitmodules",
+                    b'[submodule "x"]\n\turl = https://user:pass@example.com/x.git\n',
+                    "file",
+                ),
+            ]
+        )
+    )
+    assert SandboxWorkspaceRecordStore(tmp_path).read_readiness(workspace_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Impl 7: non-Git/binary round-trip with truthful completeness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_git_binary_content_round_trips_without_synthetic_repo(tmp_path):
+    binary = bytes(range(256)) * 64 + b"\x00\xff binary tail"
+    payload = _tar_bytes(
+        [("data/model.bin", binary, "file"), ("notes.txt", b"plain\n", "file")]
+    )
+    workspace_id = _workspace_id()
+    service = FakeArtifactService({"checkpoint": payload})
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=service,
+    )
+    await materializer.materialize(
+        _request(_authored_checkpoint_spec(workspace_id, payload)),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert (workspace / "data" / "model.bin").read_bytes() == binary
+    # Non-Git content needs no synthetic commits or repository IDs.
+    assert not (workspace / ".git").exists()
+
+    manifest_workspace = tmp_path / "manifest-check"
+    manifest_workspace.mkdir()
+    evidence = await WorkspaceArtifactProjector(service).project(
+        manifest_workspace,
+        checkpoint_ref="artifact://checkpoint",
+        checkpoint_digest=_digest(payload),
+        workflow_id="workflow-1",
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+        strict_admission=True,
+    )
+    manifest = evidence["checkpointManifest"]
+    assert manifest["fileCount"] == 2
+    assert manifest["symlinkCount"] == 0
+    assert manifest["manifestDigest"].startswith("sha256:")
+    assert manifest["expandedBytes"] == len(binary) + len(b"plain\n")
+
+
+@pytest.mark.asyncio
+async def test_valid_relative_symlink_round_trips_with_truthful_manifest(tmp_path):
+    payload = _tar_bytes(
+        [("real.txt", b"data\n", "file"), ("link.txt", b"", "symlink", "real.txt")]
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    evidence = await WorkspaceArtifactProjector(
+        FakeArtifactService({"c": payload})
+    ).project(
+        workspace,
+        checkpoint_ref="artifact://c",
+        checkpoint_digest=_digest(payload),
+        workflow_id="workflow-1",
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+        strict_admission=True,
+    )
+    assert (workspace / "link.txt").is_symlink()
+    assert (workspace / "link.txt").read_text() == "data\n"
+    manifest = evidence["checkpointManifest"]
+    assert manifest["fileCount"] == 1
+    assert manifest["symlinkCount"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Impl 8: grants, UID/GID handoff, qualified daemon mappings.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_owned_workspace(root: Path, workspace_id: str, owner=(),
+                            relative_path="repo") -> Path:
+    workflow_id, step_id = owner or ("workflow-1", "step-1")
+    workspace = root / "temporal_sandbox" / workspace_id / relative_path
+    workspace.mkdir(parents=True)
+    (workspace / "owned.txt").write_text("owner content\n")
+    SandboxWorkspaceRecordStore(root).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id=workflow_id,
+            step_execution_id=step_id,
+            relative_path=relative_path,
+        )
+    )
+    return workspace
+
+
+def _grant_spec(workspace_id: str, owner=("workflow-1", "step-1"),
+                generation=1, mode="exclusive") -> dict:
+    return {
+        "workspaceSource": {
+            "kind": "existing_workspace",
+            "existingWorkspaceGrant": {
+                "workspaceId": workspace_id,
+                "ownerWorkflowId": owner[0],
+                "ownerStepExecutionId": owner[1],
+                "generation": generation,
+                "mode": mode,
+            },
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_sibling_directory_without_grant_is_rejected(tmp_path):
+    workspace_id = "sibling-ws"
+    _ensure_owned_workspace(tmp_path, workspace_id, owner=("other-workflow", "s1"))
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone, workspace_root=tmp_path
+    )
+    # No grant at all: root containment alone never authorizes reuse.
+    with pytest.raises(HarnessPlatformError, match="locator"):
+        await materializer.materialize(
+            _request(
+                {
+                    "workspaceLocator": {
+                        "kind": "sandbox",
+                        "workspaceId": "x" * 24,
+                    }
+                }
+            ),
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_existing_workspace_grant_positive_and_negative(tmp_path):
+    workspace_id = "shared-ws"
+    _ensure_owned_workspace(tmp_path, workspace_id, owner=("owner-wf", "owner-st"))
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone, workspace_root=tmp_path
+    )
+    # Exclusive grant for another workflow fails: no sibling reuse.
+    with pytest.raises(HarnessPlatformError, match="exclusive"):
+        await materializer.materialize(
+            _request(
+                _grant_spec(workspace_id, owner=("owner-wf", "owner-st")),
+                workflow_id="intruder-wf",
+                step_id="intruder-st",
+            ),
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+    # Read-only sharing with another workflow succeeds as read-only.
+    shared = await materializer.materialize(
+        _request(
+            _grant_spec(workspace_id, owner=("owner-wf", "owner-st"), mode="read_only"),
+            workflow_id="reader-wf",
+            step_id="reader-st",
+        ),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert shared["accessMode"] == "read-only"
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    assert (workspace / "owned.txt").read_text() == "owner content\n"
+    # Owner exclusive use succeeds read-write.
+    owned = await materializer.materialize(
+        _request(
+            _grant_spec(workspace_id, owner=("owner-wf", "owner-st")),
+            workflow_id="owner-wf",
+            step_id="owner-st",
+        ),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    assert owned["accessMode"] == "read-write"
+
+
+@pytest.mark.asyncio
+async def test_stale_grant_generation_fails_after_advance(tmp_path):
+    workspace_id = "gen-ws"
+    _ensure_owned_workspace(tmp_path, workspace_id, owner=("owner-wf", "owner-st"))
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone, workspace_root=tmp_path
+    )
+    await materializer.materialize(
+        _request(
+            _grant_spec(workspace_id, owner=("owner-wf", "owner-st"), generation=2),
+            workflow_id="owner-wf",
+            step_id="owner-st",
+        ),
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    with pytest.raises(HarnessPlatformError, match="stale"):
+        await materializer.materialize(
+            _request(
+                _grant_spec(workspace_id, owner=("owner-wf", "owner-st"), generation=1),
+                workflow_id="owner-wf",
+                step_id="owner-st",
+            ),
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_remote_daemon_without_mapping_fails_before_launch(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "remote")
+    monkeypatch.delenv("WORKFLOW_WORKSPACE_DAEMON_ROOT", raising=False)
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(tmp_path))
+    workspace_id = _workspace_id()
+    (tmp_path / "temporal_sandbox" / workspace_id / "repo").mkdir(parents=True)
+
+    async def runner(argv, input_bytes=None):
+        return 0, "", ""
+
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=runner, workspace_root=tmp_path
+    )
+    with pytest.raises(HarnessPlatformError, match="daemon"):
+        await materializer.materialize(
+            _request(_locator_spec(workspace_id)),
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_runtime_identity_fails_before_mutation(tmp_path):
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone, workspace_root=tmp_path
+    )
+    with pytest.raises(HarnessPlatformError, match="runtime identity"):
+        await materializer.materialize(
+            _request(_locator_spec(_workspace_id())),
+            runtime_uid=-1,
+            runtime_gid=-1,
+        )


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#4014

Closes MoonLadderStudios/MoonMind#4014

## Summary
Implements safe artifact, checkpoint, and authorized existing-workspace sources through a single source compiler and materializer (CONTRACT-002, CONTRACT-011, INV-006, INV-005, DOC-REQ-002, TEST-003; plan slice 3):
- Single-source compiler with explicit overlay/input policy; raw workspacePath/path precedence rejected (preserved only via explicit historical decoding); conflicting source aliases rejected before reads/mutation.
- Source-artifact admission via actual artifact service (status COMPLETE, expiry, redaction/quarantine fail-closed, digest match, workflow-family link with forged bare-prefix rejection); metadata-less adapters fail strict.
- Streamed byte verification with explicit compressed/download, expanded-bytes, per-file, file-count, depth, and time budgets; sequential archive iteration (no unbounded member-list); truncated/malformed/sparse/oversized/unsupported classified without ready marker.
- Fresh attempt-owned staging generation, safe-extraction primitives with sequential symlink/hardlink/overwrite validation, permission normalization, and manifest verification before promotion.
- Authoritative restore drops destination-only files (staging-only deletion, never live workspace); additive attachment overlay merges fail-closed; digest-bound ready marker (source digest, restore contract/version, input-manifest digest, owner, attempt).
- Import neutralization before any Git/runtime use (hooks, external gitdir/worktree, alternates, config, submodule URLs, credential dirs, old session/lease/approval/publication evidence); safe content/history preserved as data.
- Self-contained restore with no clone, PAT, or remote fetch; no synthetic commits/IDs for non-Git content; thin bundles and external baselines fail closed unless admitted.
- Qualified locator/daemon mappings, UID/GID handoff, grant ledger with exclusive/read-only sharing, generation, and release; unsupported runtime/backend combos fail before execution.

Files: moonmind/omnigent/workspace_sources.py (new), moonmind/omnigent/workspace_artifacts.py, moonmind/omnigent/host_services/workspace.py, moonmind/workflows/temporal/runtime/workspace_locators.py, tests/unit/omnigent/test_workspace_safe_sources.py (new), test_workspace_materializer.py, test_generic_platform_production_services.py updates.

## Tests run
- Behavioral smoke via python3 against HEAD (compiler rejections, fingerprint binding, hostile archives, neutralization, strict metadata-less rejection, staging-only cleanup): PASS (8/8 groups).
- Committed pytest suites (1113-line safe-sources suite + updated materializer/production-services tests): NOT RUN in this sandbox (pytest not installed; MoonMind container backend requires MOONMIND_RUNTIME_ID). Environment-only limitation; verifier confidence HIGH with FULLY_IMPLEMENTED verdict at 8ecd1ee66729fa0ef4b702d471d63ced903f7613.

## Remaining risks
- Full pytest suite still needs CI execution on a qualified runner.
- Cross-runtime coverage (remote daemon mapping, UID/GID handoff) relies on unit-level translation tests; production daemon behavior should be confirmed during review/CI.