### PR TITLE
[Workspaces] Safe artifact, checkpoint, and authorized existing-workspace sources (MoonLadderStudios/MoonMind#4014)

### DIFF
--- a/moonmind/omnigent/host_services/workspace.py
+++ b/moonmind/omnigent/host_services/workspace.py
@@ -16,6 +16,12 @@ from moonmind.omnigent.workspace_artifacts import (
     WorkspaceArtifactProjectionError,
     WorkspaceArtifactProjector,
 )
+from moonmind.omnigent.workspace_sources import (
+    check_source_backend_supported,
+    compile_workspace_source,
+    verify_existing_workspace_grant,
+    WorkspaceSourceCompilationError,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
 from moonmind.workflows.temporal.runtime.workspace_locators import (
@@ -128,13 +134,43 @@ class OmnigentWorkspaceMaterializer:
             getattr(step_execution, "step_execution_id", None)
             or getattr(request, "idempotency_key", "")
         ).strip()
+        # Compile exactly one workspace source plus its overlay/input policy
+        # before any read or filesystem mutation. Conflicting aliases fail
+        # here; raw workspacePath/path aliases are not a normal authoring
+        # route and fail unless explicitly decoded as recorded history.
+        try:
+            compiled_source = compile_workspace_source(spec)
+        except WorkspaceSourceCompilationError as exc:
+            raise HarnessPlatformError(
+                f"workspace source is unavailable or unsafe: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        try:
+            check_source_backend_supported(
+                compiled_source.kind,
+                _workspace_backend(),
+                grant_mode=(
+                    compiled_source.grant.mode if compiled_source.grant else None
+                ),
+            )
+        except WorkspaceSourceCompilationError as exc:
+            raise HarnessPlatformError(
+                f"workspace source is unsupported on this runtime: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if compiled_source.kind == "existing_workspace":
+            return await self._materialize_existing_workspace(
+                compiled_source,
+                spec=spec,
+                owner_workflow_id=owner_workflow_id,
+                owner_step_execution_id=owner_step_execution_id,
+                mutation=mutation,
+                runtime_uid=runtime_uid,
+                runtime_gid=runtime_gid,
+            )
         record_store: SandboxWorkspaceRecordStore | None = None
         workspace_id: str | None = None
-        authored = str(spec.get("workspacePath") or spec.get("path") or "").strip()
-        if authored:
-            candidate = Path(authored).resolve()
-            preexisting_authority = True
-        elif isinstance(locator, dict):
+        if isinstance(locator, dict):
             try:
                 sandbox_locator = SandboxWorkspaceLocator.model_validate(locator)
             except ValueError as exc:
@@ -174,10 +210,6 @@ class OmnigentWorkspaceMaterializer:
                 expected_step_execution_id=owner_step_execution_id,
                 must_exist=False,
             )
-            # Sandbox workspaces are runtime-owned: when the authoritative
-            # checkout does not exist yet, this lifecycle materializes it by
-            # cloning the requested repository branch with launch-time auth.
-            preexisting_authority = False
         else:
             raise HarnessPlatformError(
                 "generic Omnigent execution requires an authoritative workspace locator",
@@ -189,26 +221,39 @@ class OmnigentWorkspaceMaterializer:
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
         if not candidate.exists():
-            if preexisting_authority:
+            if compiled_source.kind == "repository":
+                await self._prepare_sandbox_workspace(
+                    candidate,
+                    spec=spec,
+                    runtime_uid=runtime_uid,
+                    runtime_gid=runtime_gid,
+                )
+            elif compiled_source.kind in {"scratch", "artifact", "checkpoint"}:
+                # Self-contained sources never clone and never reacquire
+                # source credentials as a prerequisite: the target starts as
+                # an empty contained directory and the snapshot import below
+                # provides the content.
+                candidate.mkdir(parents=True, exist_ok=True)
+            else:  # pragma: no cover - compiler exhausts kinds above
                 raise HarnessPlatformError(
-                    "authoritative workspace path does not exist",
+                    "workspace source is unsupported",
                     code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
                 )
-            await self._prepare_sandbox_workspace(
-                candidate,
-                spec=spec,
-                runtime_uid=runtime_uid,
-                runtime_gid=runtime_gid,
-            )
         if not candidate.is_dir() or candidate.is_symlink():
             raise HarnessPlatformError(
                 "authoritative workspace is unavailable or unsafe",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+        ready_binding = _ready_binding_for_source(
+            compiled_source,
+            spec=spec,
+            target_owner=f"{owner_workflow_id}:{owner_step_execution_id}",
+        )
         materialization_complete = bool(
             record_store is not None
             and workspace_id is not None
-            and record_store.is_materialized(workspace_id)
+            and ready_binding is not None
+            and record_store.is_materialized_for(workspace_id, ready_binding)
         )
         if not materialization_complete:
             restore_refs = spec.get("restoreInputRefs")
@@ -220,8 +265,14 @@ class OmnigentWorkspaceMaterializer:
             checkpoint_ref = str(
                 spec.get("workspaceCheckpointRestoreRef") or ""
             ).strip()
+            if compiled_source.kind in {"artifact", "checkpoint"} and not checkpoint_ref:
+                checkpoint_ref = str(
+                    compiled_source.checkpoint_ref
+                    or compiled_source.artifact_ref
+                    or ""
+                )
             try:
-                await self._artifact_projector.project(
+                evidence = await self._artifact_projector.project(
                     candidate,
                     checkpoint_ref=checkpoint_ref or None,
                     restore_refs=tuple(str(ref) for ref in restore_refs),
@@ -229,11 +280,29 @@ class OmnigentWorkspaceMaterializer:
                     workflow_id=owner_workflow_id,
                     runtime_uid=runtime_uid,
                     runtime_gid=runtime_gid,
+                    source=compiled_source,
+                    target_owner=f"{owner_workflow_id}:{owner_step_execution_id}",
                 )
             except WorkspaceArtifactProjectionError as exc:
                 raise HarnessPlatformError(str(exc), code=exc.code) from exc
-            if record_store is not None and workspace_id is not None:
-                record_store.mark_materialized(workspace_id)
+            if ready_binding is None:
+                # A checkpoint restore without a declared digest binds the
+                # observed, digest-verified artifact digest after download.
+                observed = (evidence.get("checkpointRestore") or {}).get(
+                    "sourceDigest"
+                )
+                ready_binding = _ready_binding_for_source(
+                    compiled_source,
+                    spec=spec,
+                    target_owner=f"{owner_workflow_id}:{owner_step_execution_id}",
+                    observed_digest=str(observed or ""),
+                )
+            if (
+                record_store is not None
+                and workspace_id is not None
+                and ready_binding is not None
+            ):
+                record_store.mark_materialized_for(workspace_id, ready_binding)
         daemon_root = await resolve_daemon_workspace_root(
             runner=self._runner,
             workspace_volume=self._workspace_volume,
@@ -253,6 +322,127 @@ class OmnigentWorkspaceMaterializer:
             "targetPath": "/workspaces/run",
             "accessMode": "read-only" if mutation == "read_only" else "read-write",
             "cleanupRef": None,
+        }
+
+    async def _materialize_existing_workspace(
+        self,
+        compiled_source: Any,
+        *,
+        spec: dict[str, Any],
+        owner_workflow_id: str,
+        owner_step_execution_id: str,
+        mutation: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> dict[str, Any]:
+        """Bind an explicitly granted existing workspace without copying it.
+
+        Root containment alone never establishes permission to use a sibling
+        workflow's directory: use requires a server-issued ownership/use
+        grant naming this workflow as grantee, a matching owner record for
+        the source workspace, and a grant claim that fences exclusive use.
+        No clone, no source credential lookup, and no new workspace
+        hierarchy are involved.
+        """
+
+        from moonmind.schemas.workspace_locator_models import (
+            WorkspaceLocatorResolutionError,
+        )
+
+        grant = compiled_source.grant
+        if grant is None:
+            raise HarnessPlatformError(
+                "existing-workspace source requires a server-issued grant",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        if not owner_workflow_id:
+            raise HarnessPlatformError(
+                "existing-workspace use requires a grantee workflow identity",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        try:
+            verify_existing_workspace_grant(
+                grant, grantee_workflow_id=owner_workflow_id
+            )
+        except WorkspaceSourceCompilationError as exc:
+            raise HarnessPlatformError(
+                f"existing-workspace grant is invalid: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        record_store = SandboxWorkspaceRecordStore(self._root)
+        try:
+            source_record = record_store.load(grant.source_workspace_id)
+        except WorkspaceLocatorResolutionError as exc:
+            raise HarnessPlatformError(
+                f"existing-workspace source is unavailable: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        if (
+            source_record is None
+            or source_record.workflow_id != grant.owner_workflow_id
+            or source_record.step_execution_id != grant.owner_step_execution_id
+        ):
+            raise HarnessPlatformError(
+                "existing-workspace grant does not match the source owner record",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        authority = (self._root / "temporal_sandbox").resolve()
+        candidate = (
+            authority / grant.source_workspace_id / source_record.relative_path
+        ).resolve()
+        if candidate == self._root or not candidate.is_relative_to(self._root):
+            raise HarnessPlatformError(
+                "existing workspace escapes the configured workspace root",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        if not candidate.is_dir() or candidate.is_symlink():
+            raise HarnessPlatformError(
+                "granted existing workspace is unavailable or unsafe",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            )
+        try:
+            record_store.claim_existing_workspace(grant.source_workspace_id, grant)
+        except WorkspaceLocatorResolutionError as exc:
+            raise HarnessPlatformError(
+                f"existing workspace is already granted elsewhere: {exc}",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        target_owner = f"{owner_workflow_id}:{owner_step_execution_id}"
+        binding = {
+            "sourceKind": "existing_workspace",
+            "sourceDigest": "sha256:"
+            + hashlib.sha256(f"grant:{grant.grant_id}".encode()).hexdigest(),
+            "restoreContract": None,
+            "restoreContractVersion": 1,
+            "inputManifestDigest": compiled_source.input_manifest_digest,
+            "targetOwner": target_owner,
+            "attemptId": compiled_source.attempt_id,
+            "generation": grant.expected_generation,
+            "overlay": compiled_source.overlay,
+            "grantId": grant.grant_id,
+        }
+        record_store.mark_materialized_for(grant.source_workspace_id, binding)
+        daemon_root = await resolve_daemon_workspace_root(
+            runner=self._runner,
+            workspace_volume=self._workspace_volume,
+        )
+        try:
+            daemon_candidate = daemon_visible_workspace_path(
+                candidate, daemon_root=daemon_root
+            )
+        except Exception as exc:
+            raise HarnessPlatformError(
+                "workspace cannot be translated to the selected Docker daemon",
+                code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+            ) from exc
+        read_only = grant.mode == "read_only" or mutation == "read_only"
+        return {
+            "kind": "bind",
+            "sourceRef": str(daemon_candidate),
+            "targetPath": "/workspaces/run",
+            "accessMode": "read-only" if read_only else "read-write",
+            "cleanupRef": None,
+            "grantId": grant.grant_id,
         }
 
     async def _prepare_sandbox_workspace(
@@ -366,6 +556,60 @@ class OmnigentWorkspaceMaterializer:
                 + (f": {detail}" if detail else ""),
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+
+
+def _workspace_backend() -> str:
+    """Map the daemon selection to the workspace-source support matrix."""
+
+    mode = os.getenv("WORKFLOW_DOCKER_DAEMON_MODE", "").strip().lower()
+    if mode == "remote":
+        return "docker_remote"
+    return "docker_local"
+
+
+def _ready_binding_for_source(
+    compiled_source: Any,
+    *,
+    spec: dict[str, Any],
+    target_owner: str,
+    observed_digest: str | None = None,
+) -> dict[str, Any] | None:
+    """Bind the ready marker to source/digest/contract/inputs/owner/attempt.
+
+    Returns None when the digest cannot be known before projection (a
+    checkpoint restore without a declared digest binds the observed artifact
+    digest after verified download instead).
+    """
+
+    from moonmind.omnigent.workspace_sources import normalize_digest
+
+    kind = str(compiled_source.kind)
+    if kind == "existing_workspace":
+        return None
+    digest = observed_digest or compiled_source.expected_digest
+    if kind == "repository":
+        repo = str(
+            spec.get("repository") or spec.get("repo") or "repository"
+        ).strip()
+        branch = str(spec.get("branch") or spec.get("startingBranch") or "").strip()
+        digest = "sha256:" + hashlib.sha256(
+            f"repository:{repo}|{branch}".encode()
+        ).hexdigest()
+    elif kind == "scratch":
+        digest = "sha256:" + hashlib.sha256(b"scratch").hexdigest()
+    if digest is None:
+        return None
+    return {
+        "sourceKind": kind,
+        "sourceDigest": normalize_digest(digest),
+        "restoreContract": compiled_source.restore_contract,
+        "restoreContractVersion": 1,
+        "inputManifestDigest": compiled_source.input_manifest_digest,
+        "targetOwner": str(target_owner or "").strip(),
+        "attemptId": compiled_source.attempt_id,
+        "generation": compiled_source.generation,
+        "overlay": compiled_source.overlay,
+    }
 
 
 def build_daemon_git_clone_argv(

--- a/moonmind/omnigent/workspace_artifacts.py
+++ b/moonmind/omnigent/workspace_artifacts.py
@@ -1,13 +1,29 @@
-"""Runtime-neutral projection of durable inputs into an Omnigent workspace."""
+"""Runtime-neutral projection of durable inputs into an Omnigent workspace.
+
+Implements the safe artifact/checkpoint import path from
+``docs/RepositoryAccessAndWorkspaceDesign.md`` (``CONTRACT-011``/``INV-006``):
+source-artifact admission through the actual artifact service, digest-verified
+streaming under explicit resource budgets, extraction into a fresh
+attempt-owned staging area, Git-authority neutralization, manifest verification,
+and crash-safe promotion of one verified ready generation.
+
+Tar path filtering alone is not a safe restore: every import is
+resource-bounded, transaction-scoped to its staging generation, and bound to
+its admitted source digest before any ready marker is recorded.
+"""
 
 from __future__ import annotations
 
+import configparser
 import hashlib
+import io
 import os
 import shutil
 import tarfile
 import tempfile
-from pathlib import Path
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -19,6 +35,83 @@ STREAM_CHUNK_BYTES = 1024 * 1024
 RESTORE_PRINCIPAL = "service:omnigent_workspace_restore"
 ATTACHMENT_PRINCIPAL = "service:omnigent_workspace_attachment"
 
+# Explicit budgets for compressed-source expansion. Header claims are never
+# trusted: actual streamed/expanded bytes are enforced during copy.
+MAX_EXPANDED_BYTES = 512 * 1024 * 1024
+MAX_ARCHIVE_FILES = 20_000
+MAX_ARCHIVE_FILE_BYTES = 64 * 1024 * 1024
+MAX_ARCHIVE_DEPTH = 64
+MAX_RESTORE_SECONDS = 300.0
+
+# Supported snapshot payload formats. Anything else is classified unsupported,
+# never silently reinterpreted or replaced with an alternate source.
+_SUPPORTED_TAR_MODES = ("r:gz", "r:bz2", "r:xz", "r:")
+
+# Tar entry types that may enter a workspace. Device nodes, FIFOs, and sparse
+# members are classified and rejected; privileged metadata is never honored.
+_SUPPORTED_TAR_TYPES = frozenset(
+    {
+        tarfile.REGTYPE,
+        tarfile.AREGTYPE,
+        tarfile.DIRTYPE,
+        tarfile.SYMTYPE,
+        tarfile.LNKTYPE,
+    }
+)
+
+# Credential directories removed from imported content per owning-workspace
+# policy. These are copies inside the staging tree, never live authority.
+_CREDENTIAL_DIR_NAMES = frozenset({".ssh", ".gnupg", ".aws", ".azure", ".docker"})
+_CREDENTIAL_FILE_NAMES = frozenset(
+    {".git-credentials", ".netrc", "_netrc", ".git_credentials"}
+)
+
+# Old session authority that must never revive as current authority.
+_SESSION_AUTHORITY_NAMES = frozenset(
+    {
+        "session",
+        "sessions",
+        "leases",
+        "approvals",
+        "publication-evidence",
+        "publish-evidence",
+        "publish-record",
+    }
+)
+
+# Git config keys/sections that would execute imported setup logic, reattach
+# external credential paths, or redirect fetches on first use. History and
+# safe content stay as data; only the executable/credential/redirecting
+# mechanisms are neutralized.
+_GIT_DROP_SECTIONS = frozenset({"credential", "alias"})
+_GIT_DROP_KEYS = frozenset(
+    {
+        ("core", "hookspath"),
+        ("core", "fsmonitor"),
+        ("core", "sshcommand"),
+        ("core", "askpass"),
+        ("core", "editor"),
+        ("core", "pager"),
+        ("core", "worktree"),
+        ("http", "extraheader"),
+        ("http", "proxy"),
+        ("http", "sslkey"),
+        ("http", "sslcert"),
+        ("http", "cookiefile"),
+        ("diff", "command"),
+        ("diff", "textconv"),
+        ("filter", "clean"),
+        ("filter", "smudge"),
+        ("filter", "required"),
+        ("filter", "process"),
+        ("merge", "driver"),
+        ("url", "insteadof"),
+        ("url", "pushinsteadof"),
+        ("include", "path"),
+        ("includeif", None),
+    }
+)
+
 
 class WorkspaceArtifactProjectionError(RuntimeError):
     """A durable workspace input could not be projected safely."""
@@ -28,11 +121,24 @@ class WorkspaceArtifactProjectionError(RuntimeError):
         self.code = code
 
 
+@dataclass(frozen=True)
+class SourceAdmission:
+    """Owner/grant-carrying admission established through the artifact service."""
+
+    artifact_id: str
+    owner: str
+    digest: str
+    size_bytes: int | None
+    redaction: str
+    quarantined: bool
+    expires_at: Any | None
+
+
 class WorkspaceArtifactProjector:
     """Apply checkpoints and declared inputs through one bounded data plane."""
 
     def __init__(self, artifact_service: Any | None) -> None:
-        self._service = self._as_artifact_service(artifact_service)
+        self._service = artifact_service
 
     async def project(
         self,
@@ -44,13 +150,91 @@ class WorkspaceArtifactProjector:
         workflow_id: str,
         runtime_uid: int,
         runtime_gid: int,
+        # New safe-source inputs. When a compiled source is supplied it is
+        # authoritative for digest, contract, overlay, generation, and grant.
+        source: Any | None = None,
+        expected_checkpoint_digest: str | None = None,
+        restore_contract: str | None = None,
+        overlay: str | None = None,
+        input_manifest_digest: str | None = None,
+        attempt_id: str | None = None,
+        generation: int = 1,
+        grant: Any | None = None,
+        allow_restricted: bool = False,
+        target_owner: str | None = None,
     ) -> dict[str, Any]:
         """Project every authored input before the workspace is mounted."""
 
+        from moonmind.omnigent.workspace_sources import (
+            ARTIFACT_IMPORT_CONTRACT_V1,
+            OVERLAY_ADDITIVE,
+            OVERLAY_AUTHORITATIVE,
+            WORKSPACE_RESTORE_CONTRACT_V1,
+            normalize_digest,
+        )
+
+        effective_grant = getattr(source, "grant", None) or grant
+        effective_digest = (
+            getattr(source, "expected_digest", None) or expected_checkpoint_digest
+        )
+        source_kind = getattr(source, "kind", None)
+        default_contract = (
+            ARTIFACT_IMPORT_CONTRACT_V1
+            if source_kind == "artifact"
+            else WORKSPACE_RESTORE_CONTRACT_V1
+        )
+        effective_contract = (
+            getattr(source, "restore_contract", None)
+            or restore_contract
+            or default_contract
+        )
+        effective_overlay = (
+            getattr(source, "overlay", None) or overlay or OVERLAY_AUTHORITATIVE
+        )
+        effective_manifest = (
+            getattr(source, "input_manifest_digest", None) or input_manifest_digest
+        )
+        effective_attempt = getattr(source, "attempt_id", None) or attempt_id
+        effective_generation = getattr(source, "generation", None) or generation
+        if effective_digest is not None:
+            effective_digest = normalize_digest(effective_digest)
+        if effective_manifest is not None:
+            effective_manifest = normalize_digest(effective_manifest)
+
         evidence: dict[str, Any] = {}
+        if source is not None and getattr(source, "kind", None) in {
+            "artifact",
+            "checkpoint",
+        }:
+            # A compiled artifact/checkpoint source is authoritative for the
+            # snapshot import even when the legacy flat ref alias is absent.
+            checkpoint_ref = checkpoint_ref or getattr(
+                source, "checkpoint_ref", None
+            ) or getattr(source, "artifact_ref", None)
         if checkpoint_ref:
-            await self._apply_checkpoint(workspace, checkpoint_ref)
+            if not _contract_supported_for_kind(effective_contract, source_kind):
+                raise WorkspaceArtifactProjectionError(
+                    f"unsupported workspace-restore contract {effective_contract!r}",
+                    code="WORKSPACE_LOCATOR_UNSUPPORTED",
+                )
+            checkpoint_evidence = await self._apply_checkpoint(
+                workspace,
+                checkpoint_ref,
+                expected_digest=effective_digest,
+                restore_contract=effective_contract,
+                overlay=effective_overlay,
+                input_manifest_digest=effective_manifest,
+                attempt_id=effective_attempt,
+                generation=int(effective_generation or 1),
+                target_workflow_id=workflow_id,
+                target_owner=target_owner or workflow_id,
+                grant=effective_grant,
+                allow_restricted=allow_restricted,
+                runtime_uid=runtime_uid,
+                runtime_gid=runtime_gid,
+            )
             evidence["checkpointRestoreRef"] = checkpoint_ref
+            evidence["checkpointRestore"] = checkpoint_evidence
         # Checkpoints preserve repository work, not the prior step's injected
         # context. Remove both runtime-owned input directories after extraction
         # so each step sees only its explicitly authorized refs. Project the
@@ -65,6 +249,8 @@ class WorkspaceArtifactProjector:
             noun="restore inputs",
             runtime_uid=runtime_uid,
             runtime_gid=runtime_gid,
+            target_workflow_id=workflow_id,
+            grant=effective_grant,
         )
         if restore_evidence:
             evidence["restoreInputs"] = restore_evidence
@@ -77,10 +263,20 @@ class WorkspaceArtifactProjector:
             required_workflow_id=workflow_id,
             runtime_uid=runtime_uid,
             runtime_gid=runtime_gid,
+            target_workflow_id=workflow_id,
+            grant=effective_grant,
         )
         if attachment_evidence:
             self._exclude_attachments_from_git(workspace)
             evidence["attachments"] = attachment_evidence
+        if overlay is not None and overlay not in {
+            OVERLAY_ADDITIVE,
+            OVERLAY_AUTHORITATIVE,
+        }:
+            raise WorkspaceArtifactProjectionError(
+                "workspace overlay policy must be authoritative|additive",
+                code="WORKSPACE_LOCATOR_UNSUPPORTED",
+            )
         return evidence
 
     @staticmethod
@@ -109,56 +305,1167 @@ class WorkspaceArtifactProjector:
                     code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                 ) from exc
 
-    async def _apply_checkpoint(self, workspace: Path, artifact_ref: str) -> None:
+    async def _apply_checkpoint(
+        self,
+        workspace: Path,
+        artifact_ref: str,
+        *,
+        expected_digest: str | None,
+        restore_contract: str,
+        overlay: str,
+        input_manifest_digest: str | None,
+        attempt_id: str | None,
+        generation: int,
+        target_workflow_id: str,
+        target_owner: str,
+        grant: Any | None,
+        allow_restricted: bool,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> dict[str, Any]:
+        from moonmind.omnigent.workspace_sources import OVERLAY_AUTHORITATIVE
+
         artifact_id = self._artifact_id(artifact_ref, noun="workspace checkpoint")
         service = self._require_service("workspace checkpoint")
-        await self._validate_metadata(
+        admission = await self._admit_source(
             service,
             artifact_id=artifact_id,
+            expected_digest=expected_digest,
             budget_bytes=MAX_CHECKPOINT_BYTES,
             principal=RESTORE_PRINCIPAL,
+            noun="workspace checkpoint",
+            target_workflow_id=target_workflow_id,
+            grant=grant,
+            allow_restricted=allow_restricted,
         )
+        token = str(attempt_id or "adhoc")
+        staging = self._staging_path(workspace, token=token, generation=generation)
+        backup = self._backup_path(workspace, token=token, generation=generation)
+        lock = self._lock_path(workspace)
+        self._acquire_import_lock(lock, token=token)
+        try:
+            self._reconcile_staging(staging, backup)
+            archive_path = await self._download_verified(
+                service,
+                admission=admission,
+                principal=RESTORE_PRINCIPAL,
+                budget_bytes=MAX_CHECKPOINT_BYTES,
+                noun="workspace checkpoint",
+                allow_restricted=allow_restricted,
+                staging_dir=staging.parent,
+            )
+            try:
+                manifest = self._extract_archive(
+                    archive_path,
+                    staging,
+                    noun="workspace checkpoint",
+                    runtime_uid=runtime_uid,
+                    runtime_gid=runtime_gid,
+                )
+                self._verify_staging_manifest(staging, manifest)
+                # Completeness is assessed before neutralization: an external
+                # object store, thin baseline, submodule, or LFS dependency
+                # is independently-admitted-or-rejected evidence, and
+                # neutralization must not erase that signal first.
+                completeness = self._assess_completeness(staging)
+                if completeness:
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint is incomplete: "
+                        + "; ".join(completeness),
+                        code="WORKSPACE_RESTORE_INCOMPLETE",
+                    )
+                self._neutralize_imported_git_authority(staging)
+                self._verify_staging_manifest(staging, manifest)
+            finally:
+                archive_path.unlink(missing_ok=True)
+            if overlay == OVERLAY_AUTHORITATIVE:
+                self._promote_authoritative(workspace, staging, backup)
+            else:
+                self._promote_additive(workspace, staging)
+            self._remove_tree(staging)
+            self._remove_tree(backup)
+        finally:
+            self._release_import_lock(lock, token=token)
+        return {
+            "artifactId": artifact_id,
+            "sourceDigest": admission.digest,
+            "restoreContract": restore_contract,
+            "restoreContractVersion": 1,
+            "inputManifestDigest": input_manifest_digest,
+            "targetOwner": target_owner,
+            "attemptId": attempt_id,
+            "generation": generation,
+            "overlay": overlay,
+            "manifest": manifest,
+        }
+
+    # -- admission through the actual artifact service ---------------------
+
+    def _require_service(self, noun: str) -> Any:
+        if self._service is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} require an artifact service to resolve refs",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        return self._service
+
+    @staticmethod
+    async def _admit_source(
+        service: Any,
+        *,
+        artifact_id: str,
+        expected_digest: str | None,
+        budget_bytes: int,
+        principal: str,
+        noun: str,
+        target_workflow_id: str | None,
+        grant: Any | None,
+        allow_restricted: bool,
+    ) -> SourceAdmission:
+        """Establish permission, status, completeness, digest, lifetime.
+
+        Uses the actual artifact service: metadata is required (a
+        read-bytes-only adapter cannot establish owner/digest/quarantine
+        permission), the artifact must be COMPLETE and unexpired, the admitted
+        digest must match, the target workflow must be linked or explicitly
+        granted, and restricted/quarantined bytes need their own explicit
+        policy — generic restore never releases protected raw content.
+        """
+
+        from moonmind.omnigent.workspace_sources import normalize_digest
+
+        get_metadata = getattr(service, "get_metadata", None)
+        if get_metadata is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} require linked artifact metadata; a read-bytes-only "
+                "adapter cannot establish ownership or permission",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        try:
+            metadata = await get_metadata(artifact_id=artifact_id, principal=principal)
+        except Exception as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} metadata is unavailable",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            ) from exc
+        if metadata is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} is missing artifact metadata",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        artifact = metadata[0] if isinstance(metadata, tuple) else metadata
+        links: Any = ()
+        if isinstance(metadata, tuple) and len(metadata) > 1:
+            links = metadata[1] or ()
+        if artifact is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} is missing artifact metadata",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        status = str(getattr(artifact, "status", "") or "")
+        if "COMPLETE" not in status.upper():
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} is not a complete artifact (status {status or 'unknown'})",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        expires_at = getattr(artifact, "expires_at", None)
+        if expires_at is not None:
+            try:
+                from datetime import datetime
+
+                now = datetime.now(tz=expires_at.tzinfo) if expires_at.tzinfo else datetime.now()
+                expired = expires_at <= now
+            except Exception:
+                expired = False
+            if expired:
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} artifact lifetime has expired",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        size = getattr(artifact, "size_bytes", None)
+        if isinstance(size, int) and size > budget_bytes:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} exceed the authorized workspace bound",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        row_digest_raw = getattr(artifact, "sha256", None)
+        row_digest = None
+        if isinstance(row_digest_raw, str) and row_digest_raw.strip():
+            try:
+                row_digest = normalize_digest(row_digest_raw)
+            except ValueError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} carries an invalid recorded digest",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                ) from exc
+        admitted_digest = None
+        if expected_digest is not None:
+            admitted_digest = normalize_digest(expected_digest)
+            if row_digest is not None and row_digest != admitted_digest:
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} digest does not match the admitted source digest",
+                    code="WORKSPACE_DIGEST_MISMATCH",
+                )
+        elif row_digest is not None:
+            admitted_digest = row_digest
+        else:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} names no verifiable content digest",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        owner = (
+            getattr(artifact, "created_by_principal", None)
+            or getattr(artifact, "owner", None)
+            or ""
+        )
+        owner = str(owner or "").strip()
+        # Authorization: exact workflow linkage, or an explicit grant carrying
+        # the admitted owner/source grant across the service boundary. A
+        # family-prefix link alone is forgeable and never sufficient.
+        if target_workflow_id:
+            authorized = any(
+                str(getattr(link, "workflow_id", "") or "") == target_workflow_id
+                for link in links or ()
+            )
+            if not authorized and grant is not None:
+                grant_owner = str(
+                    getattr(grant, "owner_workflow_id", "") or ""
+                ).strip()
+                grant_grantee = str(
+                    getattr(grant, "grantee_workflow_id", "") or ""
+                ).strip()
+                owner_linked = any(
+                    str(getattr(link, "workflow_id", "") or "") == grant_owner
+                    for link in links or ()
+                )
+                authorized = bool(
+                    grant_owner and owner_linked and grant_grantee == target_workflow_id
+                )
+            if not authorized:
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} is not linked to the target workflow",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        redaction = str(
+            getattr(getattr(artifact, "redaction_level", ""), "value", None)
+            or getattr(artifact, "redaction_level", "")
+            or "NONE"
+        ).upper()
+        quarantined = WorkspaceArtifactProjector._is_quarantined(artifact)
+        if redaction == "RESTRICTED" and not allow_restricted:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} is restricted and requires an explicit restricted-source policy",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if quarantined:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} is quarantined and cannot enter an agent workspace",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        return SourceAdmission(
+            artifact_id=artifact_id,
+            owner=owner,
+            digest=admitted_digest,
+            size_bytes=size if isinstance(size, int) else None,
+            redaction=redaction,
+            quarantined=quarantined,
+            expires_at=expires_at,
+        )
+
+    @staticmethod
+    def _is_quarantined(artifact: Any) -> bool:
+        for attr in ("quarantine", "quarantined"):
+            if bool(getattr(artifact, attr, False)):
+                return True
+        metadata_json = getattr(artifact, "metadata_json", None)
+        if isinstance(metadata_json, dict) and bool(metadata_json.get("quarantine")):
+            return True
+        return False
+
+    # -- verified download -------------------------------------------------
+
+    async def _download_verified(
+        self,
+        service: Any,
+        *,
+        admission: SourceAdmission,
+        principal: str,
+        budget_bytes: int,
+        noun: str,
+        allow_restricted: bool,
+        staging_dir: Path,
+    ) -> Path:
+        read_chunks = getattr(service, "read_chunks", None)
+        if read_chunks is None and not hasattr(service, "read"):
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} artifact service cannot stream source bytes",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
         descriptor, temporary_name = tempfile.mkstemp(
-            prefix=".moonmind-checkpoint-",
-            suffix=".tar.gz",
-            dir=workspace.parent,
+            prefix=".moonmind-source-",
+            suffix=".bin",
+            dir=staging_dir,
         )
         os.close(descriptor)
-        archive_path = Path(temporary_name)
+        target = Path(temporary_name)
+        hasher = hashlib.sha256()
+        written = 0
         try:
-            await self._write_payload(
-                service,
-                artifact_id=artifact_id,
-                target=archive_path,
-                budget_bytes=MAX_CHECKPOINT_BYTES,
-                principal=RESTORE_PRINCIPAL,
-            )
-            workspace_root = workspace.resolve()
-            with tarfile.open(archive_path, mode="r:gz") as archive:
-                for member in archive.getmembers():
-                    target = (workspace / member.name).resolve()
-                    if not target.is_relative_to(workspace_root) or member.isdev():
-                        raise WorkspaceArtifactProjectionError(
-                            "workspace checkpoint contains an unsafe archive member",
-                            code="WORKSPACE_AUTHORITY_MISMATCH",
-                        )
-                    if member.issym() or member.islnk():
-                        link_target = (target.parent / member.linkname).resolve()
-                        if not link_target.is_relative_to(workspace_root):
+            if read_chunks is not None:
+                pending = read_chunks(
+                    artifact_id=admission.artifact_id,
+                    principal=principal,
+                    allow_restricted_raw=allow_restricted,
+                    chunk_size=STREAM_CHUNK_BYTES,
+                )
+                if hasattr(pending, "__await__"):
+                    pending = await pending
+                _artifact, chunks = pending
+                fd = os.open(
+                    target,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                    0o600,
+                )
+                with os.fdopen(fd, "wb") as stream:
+                    for chunk in chunks:
+                        if not isinstance(chunk, (bytes, bytearray)):
                             raise WorkspaceArtifactProjectionError(
-                                "workspace checkpoint symlink escapes workspace",
-                                code="WORKSPACE_AUTHORITY_MISMATCH",
+                                f"{noun} source stream is malformed",
+                                code="WORKSPACE_ARCHIVE_MALFORMED",
                             )
-                archive.extractall(workspace, filter="data")
+                        written += len(chunk)
+                        if written > budget_bytes:
+                            raise WorkspaceArtifactProjectionError(
+                                f"{noun} exceed the authorized workspace bound",
+                                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                            )
+                        hasher.update(chunk)
+                        stream.write(chunk)
+            else:
+                pending = service.read(
+                    artifact_id=admission.artifact_id,
+                    principal=principal,
+                    allow_restricted_raw=allow_restricted,
+                )
+                if hasattr(pending, "__await__"):
+                    pending = await pending
+                _artifact, payload = pending
+                if len(payload) > budget_bytes:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} exceed the authorized workspace bound",
+                        code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+                    )
+                hasher.update(payload)
+                written = len(payload)
+                fd = os.open(
+                    target,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                    0o600,
+                )
+                with os.fdopen(fd, "wb") as stream:
+                    stream.write(payload)
         except WorkspaceArtifactProjectionError:
+            target.unlink(missing_ok=True)
             raise
-        except (tarfile.TarError, OSError) as exc:
+        except Exception as exc:
+            target.unlink(missing_ok=True)
             raise WorkspaceArtifactProjectionError(
-                "workspace checkpoint archive could not be applied",
+                f"{noun} source bytes are unavailable",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
             ) from exc
-        finally:
-            archive_path.unlink(missing_ok=True)
+        actual = f"sha256:{hasher.hexdigest()}"
+        if actual != admission.digest:
+            target.unlink(missing_ok=True)
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} bytes do not match the admitted source digest",
+                code="WORKSPACE_DIGEST_MISMATCH",
+            )
+        return target
+
+    @staticmethod
+    def _staging_path(workspace: Path, *, token: str, generation: int) -> Path:
+        safe_token = "".join(
+            ch if ch.isalnum() or ch in {"-", "_"} else "-"
+            for ch in str(token or "adhoc")
+        )[:64] or "adhoc"
+        return workspace.parent / f".staging-{workspace.name}-g{generation}-{safe_token}"
+
+    @staticmethod
+    def _backup_path(workspace: Path, *, token: str, generation: int) -> Path:
+        safe_token = "".join(
+            ch if ch.isalnum() or ch in {"-", "_"} else "-"
+            for ch in str(token or "adhoc")
+        )[:64] or "adhoc"
+        return workspace.parent / f".backup-{workspace.name}-g{generation}-{safe_token}"
+
+    @staticmethod
+    def _lock_path(workspace: Path) -> Path:
+        return workspace.parent / f".import-{workspace.name}.lock"
+
+    @staticmethod
+    def _acquire_import_lock(lock: Path, *, token: str) -> None:
+        # No concurrent agent may mutate the extraction tree: the lock is held
+        # from staging creation through promotion. A retry reconciles the same
+        # generation by taking over its own token; a foreign token fails
+        # closed instead of mutating another attempt's tree.
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError as exc:
+            try:
+                recorded = lock.read_text(encoding="utf-8")
+            except OSError:
+                recorded = ""
+            if recorded.strip() == str(token):
+                return
+            raise WorkspaceArtifactProjectionError(
+                "another workspace import is already in flight",
+                code="WORKSPACE_IMPORT_CONFLICT",
+            ) from exc
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(str(token))
+
+    @staticmethod
+    def _release_import_lock(lock: Path, *, token: str) -> None:
+        try:
+            if lock.read_text(encoding="utf-8").strip() == str(token):
+                lock.unlink()
+        except OSError:
+            pass
+
+    @staticmethod
+    def _reconcile_staging(staging: Path, backup: Path) -> None:
+        # Retry reconciles the same generation: residue owned by this import
+        # is removed before a fresh attempt. Only the import-owned staging
+        # generation is ever deleted here, never a live authorized workspace.
+        for path in (staging, backup):
+            if path.is_symlink() or (path.exists() and not path.is_dir()):
+                raise WorkspaceArtifactProjectionError(
+                    "import staging path is obstructed",
+                    code="WORKSPACE_IMPORT_CONFLICT",
+                )
+            if path.is_dir():
+                shutil.rmtree(path)
+        staging.mkdir(parents=True, exist_ok=False)
+
+    @staticmethod
+    def _remove_tree(path: Path) -> None:
+        try:
+            if path.is_symlink():
+                path.unlink()
+            elif path.is_dir():
+                shutil.rmtree(path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise WorkspaceArtifactProjectionError(
+                "import staging cleanup failed",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+    def _extract_archive(
+        self,
+        archive_path: Path,
+        staging: Path,
+        *,
+        noun: str,
+        runtime_uid: int,
+        runtime_gid: int,
+    ) -> dict[str, Any]:
+        """Stream members into staging with sequential link/overwrite safety."""
+
+        staging_root = staging.resolve()
+        deadline = time.monotonic() + MAX_RESTORE_SECONDS
+        seen: set[str] = set()
+        seen_folded: set[str] = set()
+        hardlink_sources: set[str] = set()
+        file_count = 0
+        expanded_bytes = 0
+        try:
+            archive = tarfile.open(archive_path, mode="r:*")
+        except EOFError as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive is truncated",
+                code="WORKSPACE_ARCHIVE_MALFORMED",
+            ) from exc
+        except (tarfile.TarError, OSError) as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive format is unsupported",
+                code="WORKSPACE_ARCHIVE_UNSUPPORTED",
+            ) from exc
+        with archive:
+            while True:
+                if time.monotonic() > deadline:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive exceeded the processing-time budget",
+                        code="WORKSPACE_ARCHIVE_OVERSIZED",
+                    )
+                try:
+                    member = archive.next()
+                except (tarfile.TarError, OSError, EOFError) as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive is malformed",
+                        code="WORKSPACE_ARCHIVE_MALFORMED",
+                    ) from exc
+                if member is None:
+                    break
+                file_count += 1
+                if file_count > MAX_ARCHIVE_FILES:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive exceeds the file-count bound",
+                        code="WORKSPACE_ARCHIVE_OVERSIZED",
+                    )
+                rel = self._checked_member_path(
+                    member.name, noun=noun, staging_root=staging_root
+                )
+                if rel in seen:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive contains a duplicate entry",
+                        code="WORKSPACE_ARCHIVE_CONFLICT",
+                    )
+                folded = rel.casefold()
+                if folded in seen_folded:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive contains conflicting filesystem names",
+                        code="WORKSPACE_ARCHIVE_CONFLICT",
+                    )
+                seen.add(rel)
+                seen_folded.add(folded)
+                if member.type not in _SUPPORTED_TAR_TYPES:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive contains an unsupported entry type",
+                        code="WORKSPACE_ARCHIVE_UNSUPPORTED",
+                    )
+                if getattr(member, "sparse", None):
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive contains a sparse member",
+                        code="WORKSPACE_ARCHIVE_UNSUPPORTED",
+                    )
+                if member.size > MAX_ARCHIVE_FILE_BYTES:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive member exceeds the per-file bound",
+                        code="WORKSPACE_ARCHIVE_OVERSIZED",
+                    )
+                if member.isdir():
+                    self._mkdir_staging(staging_root, rel, member, noun=noun)
+                    continue
+                if member.issym():
+                    self._write_symlink(staging_root, rel, member, noun=noun)
+                    continue
+                if member.islnk():
+                    self._write_hardlink(
+                        staging_root,
+                        rel,
+                        member,
+                        noun=noun,
+                        hardlink_sources=hardlink_sources,
+                    )
+                    continue
+                # Regular file: stream the member payload with actual expanded
+                # byte accounting rather than trusting the header claim.
+                expanded_bytes = self._write_regular_file(
+                    archive,
+                    staging_root,
+                    rel,
+                    member,
+                    noun=noun,
+                    expanded_bytes=expanded_bytes,
+                )
+                hardlink_sources.add(rel)
+        return {
+            "files": file_count,
+            "expandedBytes": expanded_bytes,
+            "entries": sorted(seen),
+        }
+
+    @staticmethod
+    def _checked_member_path(name: str, *, noun: str, staging_root: Path) -> str:
+        raw = str(name or "")
+        if not raw or raw.startswith("/") or "\x00" in raw:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains an absolute or empty path",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        pure = PurePosixPath(raw)
+        parts = [p for p in pure.parts if p not in {"", "."}]
+        if not parts or any(p == ".." for p in parts):
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains an escaping path",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if len(parts) > MAX_ARCHIVE_DEPTH:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive exceeds the path-depth bound",
+                code="WORKSPACE_ARCHIVE_OVERSIZED",
+            )
+        return "/".join(parts)
+
+    @staticmethod
+    def _staging_target(staging_root: Path, rel: str, *, noun: str) -> Path:
+        target = staging_root / Path(*rel.split("/"))
+        resolved_parent = target.parent.resolve()
+        if resolved_parent != staging_root and not resolved_parent.is_relative_to(
+            staging_root
+        ):
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive member escapes the staging area",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        # A pre-existing symlink at an ancestor would redirect this write
+        # outside staging; every ancestor must be a real directory.
+        probe = staging_root
+        for part in rel.split("/")[:-1]:
+            probe = probe / part
+            if probe.is_symlink() or (probe.exists() and not probe.is_dir()):
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} archive member is shadowed by an earlier entry",
+                    code="WORKSPACE_ARCHIVE_CONFLICT",
+                )
+        return target
+
+    def _mkdir_staging(
+        self, staging_root: Path, rel: str, member: tarfile.TarInfo, *, noun: str
+    ) -> None:
+        target = self._staging_target(staging_root, rel, noun=noun)
+        if target.is_symlink() or (target.exists() and not target.is_dir()):
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains conflicting entries",
+                code="WORKSPACE_ARCHIVE_CONFLICT",
+            )
+        target.mkdir(parents=True, exist_ok=True)
+        self._normalize_mode(target, member, is_dir=True)
+
+    def _write_symlink(
+        self,
+        staging_root: Path,
+        rel: str,
+        member: tarfile.TarInfo,
+        *,
+        noun: str,
+    ) -> None:
+        linkname = str(member.linkname or "")
+        if not linkname or linkname.startswith("/") or "\x00" in linkname:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains an absolute symlink",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        # Lexical containment: resolve the link against its parent purely
+        # lexically so ordering cannot smuggle an escape. A final sweep after
+        # all writes re-verifies every link against the materialized tree.
+        parent_parts = rel.split("/")[:-1]
+        target_parts: list[str] = []
+        for part in (*parent_parts, *linkname.split("/")):
+            if part in {"", "."}:
+                continue
+            if part == "..":
+                if not target_parts:
+                    raise WorkspaceArtifactProjectionError(
+                        f"{noun} archive symlink escapes the workspace",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                target_parts.pop()
+            else:
+                target_parts.append(part)
+        target = self._staging_target(staging_root, rel, noun=noun)
+        if target.is_symlink() or target.exists():
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains conflicting entries",
+                code="WORKSPACE_ARCHIVE_CONFLICT",
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            target.symlink_to(linkname)
+        except OSError as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive symlink could not be created",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+    def _write_hardlink(
+        self,
+        staging_root: Path,
+        rel: str,
+        member: tarfile.TarInfo,
+        *,
+        noun: str,
+        hardlink_sources: set[str],
+    ) -> None:
+        linkname = str(member.linkname or "").lstrip("./")
+        if not linkname or linkname.startswith("/") or ".." in PurePosixPath(
+            linkname
+        ).parts:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive hardlink escapes the workspace",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        # Sequential safety: a hardlink may only reference an already-written
+        # regular file. A forward reference (link-order attack) fails closed
+        # instead of assuming preflight resolution proves later writes safe.
+        if linkname not in hardlink_sources:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive hardlink references an unavailable entry",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        target = self._staging_target(staging_root, rel, noun=noun)
+        if target.is_symlink() or target.exists():
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains conflicting entries",
+                code="WORKSPACE_ARCHIVE_CONFLICT",
+            )
+        source = staging_root / Path(*linkname.split("/"))
+        if source.is_symlink() or not source.is_file():
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive hardlink source is unsafe",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.link(source, target)
+        except OSError as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive hardlink could not be created",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+    def _write_regular_file(
+        self,
+        archive: tarfile.TarFile,
+        staging_root: Path,
+        rel: str,
+        member: tarfile.TarInfo,
+        *,
+        noun: str,
+        expanded_bytes: int,
+    ) -> int:
+        target = self._staging_target(staging_root, rel, noun=noun)
+        if target.is_symlink() or target.exists():
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive contains conflicting entries",
+                code="WORKSPACE_ARCHIVE_CONFLICT",
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        reader = archive.extractfile(member)
+        if reader is None:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive member has no payload",
+                code="WORKSPACE_ARCHIVE_MALFORMED",
+            )
+        written = 0
+        try:
+            fd = os.open(
+                target, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600
+            )
+        except FileExistsError as exc:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive member collided with the target filesystem",
+                code="WORKSPACE_ARCHIVE_CONFLICT",
+            ) from exc
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                while True:
+                    chunk = reader.read(STREAM_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    expanded_bytes += len(chunk)
+                    if written > MAX_ARCHIVE_FILE_BYTES:
+                        raise WorkspaceArtifactProjectionError(
+                            f"{noun} archive member exceeds the per-file bound",
+                            code="WORKSPACE_ARCHIVE_OVERSIZED",
+                        )
+                    if expanded_bytes > MAX_EXPANDED_BYTES:
+                        raise WorkspaceArtifactProjectionError(
+                            f"{noun} archive exceeds the expanded-bytes bound",
+                            code="WORKSPACE_ARCHIVE_OVERSIZED",
+                        )
+                    stream.write(chunk)
+        except WorkspaceArtifactProjectionError:
+            target.unlink(missing_ok=True)
+            raise
+        except (OSError, EOFError, tarfile.TarError) as exc:
+            target.unlink(missing_ok=True)
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive is truncated or malformed",
+                code="WORKSPACE_ARCHIVE_MALFORMED",
+            ) from exc
+        if written != member.size:
+            target.unlink(missing_ok=True)
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} archive member size does not match its header",
+                code="WORKSPACE_ARCHIVE_MALFORMED",
+            )
+        self._normalize_mode(target, member, is_dir=False)
+        return expanded_bytes
+
+    @staticmethod
+    def _normalize_mode(target: Path, member: tarfile.TarInfo, *, is_dir: bool) -> None:
+        # Normalize allowed permissions: drop setuid/setgid/sticky and
+        # privileged metadata, keep the owner-executable bit as data. UIDs,
+        # GIDs, and device semantics from the archive are never honored.
+        if is_dir:
+            mode = 0o755
+        elif int(getattr(member, "mode", 0) or 0) & 0o100:
+            mode = 0o755
+        else:
+            mode = 0o644
+        try:
+            os.chmod(target, mode, follow_symlinks=False)
+        except OSError:
+            pass
+
+    def _verify_staging_manifest(self, staging: Path, manifest: dict[str, Any]) -> None:
+        """Re-verify every staged link against the materialized tree."""
+
+        staging_root = staging.resolve()
+        for rel in manifest.get("entries", ()):
+            target = staging_root / Path(*str(rel).split("/"))
+            if target.is_symlink():
+                try:
+                    resolved = target.resolve()
+                except OSError:
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint symlink is unresolvable",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+                if resolved != staging_root and not resolved.is_relative_to(
+                    staging_root
+                ):
+                    raise WorkspaceArtifactProjectionError(
+                        "workspace checkpoint symlink escapes workspace",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    )
+
+    def _promote_authoritative(self, workspace: Path, staging: Path, backup: Path) -> None:
+        """Promote staging as the one verified ready generation.
+
+        Crash-safe swap: the previous destination (a prior clone, failed
+        attempt residue, or an older generation) moves to an import-owned
+        backup name, staging renames into place, and only then is the backup
+        removed. A crash before the swap leaves the destination untouched; a
+        crash after the swap leaves a complete promoted tree plus
+        attempt-owned residue that a retry reconciles.
+        """
+
+        parent = workspace.parent
+        if workspace.is_symlink():
+            raise WorkspaceArtifactProjectionError(
+                "authorized workspace must not be a symlink",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if backup.exists() or backup.is_symlink():
+            raise WorkspaceArtifactProjectionError(
+                "import backup path is obstructed",
+                code="WORKSPACE_IMPORT_CONFLICT",
+            )
+        try:
+            if workspace.exists():
+                os.rename(workspace, backup)
+            os.rename(staging, workspace)
+        except OSError as exc:
+            # Reconcile: never leave the authorized path missing when a
+            # backup exists. A crash between the two renames is recovered by
+            # restoring the backup before reporting the failure.
+            try:
+                if not workspace.exists() and backup.exists():
+                    os.rename(backup, workspace)
+            except OSError:
+                pass
+            raise WorkspaceArtifactProjectionError(
+                "workspace checkpoint promotion failed",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+        self._remove_tree(backup)
+
+    def _promote_additive(self, workspace: Path, staging: Path) -> None:
+        """Overlay staging entries additively without clearing the destination."""
+
+        workspace.mkdir(parents=True, exist_ok=True)
+        for entry in sorted(staging.iterdir()):
+            target = workspace / entry.name
+            if target.is_symlink() or target.exists():
+                raise WorkspaceArtifactProjectionError(
+                    "workspace overlay collides with destination content",
+                    code="WORKSPACE_ARCHIVE_CONFLICT",
+                )
+            os.rename(entry, target)
+
+    # -- completeness: truthful, never silently skipped ---------------------
+
+    def _assess_completeness(self, staging: Path) -> list[str]:
+        """Report incomplete restores that need independent admission."""
+
+        reasons: list[str] = []
+        git_dir = staging / ".git"
+        # An unresolved large-file pointer is a content stub wherever it
+        # appears; truthful completeness does not depend on `.git` presence.
+        reasons.extend(self._find_unresolved_lfs(staging, git_dir))
+        if git_dir.is_dir() and not git_dir.is_symlink():
+            alternates = git_dir / "objects" / "info" / "alternates"
+            if alternates.is_file() and not alternates.is_symlink():
+                reasons.append("external object alternates require admission")
+            if list(git_dir.glob("objects/pack/*.thinpack")):
+                reasons.append("thin pack requires its external baseline")
+            gitmodules = staging / ".gitmodules"
+            if gitmodules.is_file():
+                try:
+                    parser = configparser.ConfigParser(interpolation=None)
+                    parser.read(gitmodules, encoding="utf-8")
+                except (configparser.Error, OSError, UnicodeDecodeError):
+                    reasons.append("submodule configuration is unreadable")
+                    parser = None
+                if parser is not None:
+                    modules_dir = git_dir / "modules"
+                    for section in parser.sections():
+                        try:
+                            sub_path = parser[section]["path"]
+                        except KeyError:
+                            reasons.append(
+                                f"submodule {section!r} path requires admission"
+                            )
+                            break
+                        worktree = staging / sub_path
+                        populated = worktree.is_dir() and any(
+                            worktree.iterdir()
+                        )
+                        admitted = (modules_dir / section).is_dir()
+                        if not populated and not admitted:
+                            reasons.append(
+                                f"submodule {section!r} content requires admission"
+                            )
+                            break
+        return list(dict.fromkeys(reasons))
+
+    @staticmethod
+    def _find_unresolved_lfs(staging: Path, git_dir: Path) -> list[str]:
+        pointers: list[str] = []
+        for dirpath, dirnames, filenames in os.walk(staging, followlinks=False):
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            for filename in filenames:
+                candidate = Path(dirpath) / filename
+                try:
+                    if candidate.stat().st_size > 1024:
+                        continue
+                    head = candidate.read_bytes()[:256]
+                except OSError:
+                    continue
+                if b"version https://git-lfs.github.com/spec/" in head:
+                    pointers.append(os.path.relpath(candidate, staging))
+                    if len(pointers) >= 4:
+                        break
+            if len(pointers) >= 4:
+                break
+        if not pointers:
+            return []
+        objects_dir = git_dir / "lfs" / "objects"
+        if objects_dir.is_dir() and any(objects_dir.iterdir()):
+            return []
+        return ["large-file objects require independent admission"]
+
+    # -- Git-authority neutralization ----------------------------------------
+
+    def _neutralize_imported_git_authority(self, staging: Path) -> None:
+        """Neutralize hooks/helpers/credentials/session authority pre-launch.
+
+        Imported configuration that would execute on the first Git command or
+        runtime launch is neutralized according to the owning workspace
+        policy: hooks, exec/credential/redirect config, external gitdir and
+        worktree administration, alternates, include paths, submodule exec
+        configuration and filter drivers, credential directories, and old
+        session authority. Safe content and history stay as data — Git history
+        and ordinary executables are never rejected wholesale.
+        """
+
+        git_dir = staging / ".git"
+        git_file = staging / ".git"
+        if git_file.is_file() and not git_file.is_symlink():
+            # A gitdir pointer to an external directory is outside the
+            # import authority and cannot be restored safely.
+            try:
+                pointer = git_file.read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "imported gitdir pointer is unreadable",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                ) from exc
+            if not pointer.startswith("gitdir:"):
+                raise WorkspaceArtifactProjectionError(
+                    "imported gitdir pointer is malformed",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+            external = (staging / pointer[len("gitdir:"):].strip()).resolve()
+            if external != staging.resolve() / ".git" and not external.is_relative_to(
+                staging.resolve()
+            ):
+                raise WorkspaceArtifactProjectionError(
+                    "imported external git directory requires admission",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                )
+        if git_dir.is_dir() and not git_dir.is_symlink():
+            self._sanitize_git_dir(git_dir, staging)
+        # Nested submodule/worktree git pointers: each must resolve inside
+        # the staging tree or the import fails closed.
+        staging_root = staging.resolve()
+        for dirpath, _dirnames, filenames in os.walk(staging, followlinks=False):
+            if ".git" in filenames:
+                pointer_file = Path(dirpath) / ".git"
+                if pointer_file.is_symlink() or not pointer_file.is_file():
+                    continue
+                try:
+                    pointer = pointer_file.read_text(encoding="utf-8").strip()
+                except OSError:
+                    continue
+                if pointer.startswith("gitdir:"):
+                    external = (
+                        Path(dirpath) / pointer[len("gitdir:"):].strip()
+                    ).resolve()
+                    if not external.is_relative_to(staging_root):
+                        raise WorkspaceArtifactProjectionError(
+                            "imported nested git directory escapes the workspace",
+                            code="WORKSPACE_AUTHORITY_MISMATCH",
+                        )
+        self._remove_credential_copies(staging)
+        self._remove_stale_session_authority(staging)
+
+    def _sanitize_git_dir(self, git_dir: Path, staging: Path) -> None:
+        staging_root = staging.resolve()
+        # Hooks execute on the next Git command: remove them, keep history.
+        hooks = git_dir / "hooks"
+        if hooks.is_symlink() or (hooks.exists() and not hooks.is_dir()):
+            raise WorkspaceArtifactProjectionError(
+                "imported git hooks path is unsafe",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if hooks.is_dir():
+            shutil.rmtree(hooks)
+            hooks.mkdir(mode=0o755)
+        # Worktree administration points at external checkouts: not restored.
+        worktrees = git_dir / "worktrees"
+        if worktrees.is_symlink():
+            raise WorkspaceArtifactProjectionError(
+                "imported git worktree path is unsafe",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        if worktrees.is_dir():
+            shutil.rmtree(worktrees)
+        # Alternates hand object resolution to an external directory.
+        alternates = git_dir / "objects" / "info" / "alternates"
+        if alternates.is_symlink() or alternates.is_file():
+            try:
+                alternates.unlink()
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "imported object alternates could not be neutralized",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                ) from exc
+        # Commondir/gitdir pointers escaping staging fail in the caller; a
+        # contained commondir pointer is data and stays.
+        for pointer_name in ("commondir", "gitdir"):
+            pointer = git_dir / pointer_name
+            if pointer.is_file() and not pointer.is_symlink():
+                try:
+                    content = pointer.read_text(encoding="utf-8").strip()
+                except OSError:
+                    continue
+                if pointer_name == "commondir":
+                    external = (git_dir / content).resolve()
+                    if not external.is_relative_to(staging_root):
+                        raise WorkspaceArtifactProjectionError(
+                            "imported git commondir escapes the workspace",
+                            code="WORKSPACE_AUTHORITY_MISMATCH",
+                        )
+        self._sanitize_git_config(git_dir / "config")
+
+    def _sanitize_git_config(self, config_path: Path) -> None:
+        if config_path.is_symlink() or not config_path.is_file():
+            return
+        try:
+            text = config_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            raise WorkspaceArtifactProjectionError(
+                "imported git configuration is unreadable",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            )
+        parser = configparser.ConfigParser(interpolation=None)
+        try:
+            parser.read_string(text)
+        except configparser.Error as exc:
+            raise WorkspaceArtifactProjectionError(
+                "imported git configuration is malformed",
+                code="WORKSPACE_AUTHORITY_MISMATCH",
+            ) from exc
+        for section in list(parser.sections()):
+            lowered_section = section.lower()
+            base = lowered_section.split('"')[0].strip()
+            if base in _GIT_DROP_SECTIONS:
+                del parser[section]
+                continue
+            for key in list(parser[section].keys()):
+                lowered_key = key.lower()
+                if (base, lowered_key) in _GIT_DROP_KEYS or (
+                    base,
+                    None,
+                ) in _GIT_DROP_KEYS:
+                    del parser[section][key]
+                elif base == "submodule" and lowered_key == "update":
+                    if str(parser[section][key]).strip().startswith("!"):
+                        del parser[section][key]
+                elif base == "core" and lowered_key == "repositoryformatversion":
+                    continue
+        with io.StringIO() as stream:
+            parser.write(stream)
+            sanitized = stream.getvalue()
+        try:
+            config_path.write_text(sanitized, encoding="utf-8")
+        except OSError as exc:
+            raise WorkspaceArtifactProjectionError(
+                "imported git configuration could not be neutralized",
+                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            ) from exc
+
+    def _remove_credential_copies(self, staging: Path) -> None:
+        for name in sorted(_CREDENTIAL_DIR_NAMES):
+            target = staging / name
+            if target.is_symlink() or (target.exists() and not target.is_dir()):
+                try:
+                    if target.is_symlink() or target.is_file():
+                        target.unlink()
+                    else:
+                        shutil.rmtree(target)
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "imported credential path could not be neutralized",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    ) from exc
+            elif target.is_dir():
+                shutil.rmtree(target, ignore_errors=False)
+        for name in sorted(_CREDENTIAL_FILE_NAMES):
+            target = staging / name
+            try:
+                if target.is_symlink() or target.is_file():
+                    target.unlink()
+            except OSError as exc:
+                raise WorkspaceArtifactProjectionError(
+                    "imported credential file could not be neutralized",
+                    code="WORKSPACE_AUTHORITY_MISMATCH",
+                ) from exc
+
+    def _remove_stale_session_authority(self, staging: Path) -> None:
+        state_dir = staging / ".moonmind"
+        if not state_dir.is_dir() or state_dir.is_symlink():
+            return
+        for entry in state_dir.iterdir():
+            if entry.name.lower() in _SESSION_AUTHORITY_NAMES:
+                try:
+                    if entry.is_symlink() or entry.is_file():
+                        entry.unlink()
+                    elif entry.is_dir():
+                        shutil.rmtree(entry)
+                except OSError as exc:
+                    raise WorkspaceArtifactProjectionError(
+                        "imported session authority could not be neutralized",
+                        code="WORKSPACE_AUTHORITY_MISMATCH",
+                    ) from exc
+
+    # -- additive input bundles --------------------------------------------
 
     async def _materialize_bundle(
         self,
@@ -171,6 +1478,8 @@ class WorkspaceArtifactProjector:
         required_workflow_id: str | None = None,
         runtime_uid: int,
         runtime_gid: int,
+        target_workflow_id: str | None = None,
+        grant: Any | None = None,
     ) -> list[dict[str, Any]]:
         cleaned = tuple(
             dict.fromkeys(str(ref).strip() for ref in refs if str(ref).strip())
@@ -200,12 +1509,16 @@ class WorkspaceArtifactProjector:
                     f"{noun} exceed the cumulative authorized workspace bound",
                     code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                 )
-            await self._validate_metadata(
+            admission = await self._admit_source(
                 service,
                 artifact_id=artifact_id,
+                expected_digest=None,
                 budget_bytes=budget,
                 principal=principal,
-                required_workflow_id=required_workflow_id,
+                noun=noun,
+                target_workflow_id=required_workflow_id or target_workflow_id,
+                grant=grant,
+                allow_restricted=False,
             )
             target = root / hashlib.sha256(ref.encode("utf-8")).hexdigest()[:24]
             if target.is_symlink():
@@ -215,10 +1528,12 @@ class WorkspaceArtifactProjector:
                 )
             written = await self._write_payload(
                 service,
-                artifact_id=artifact_id,
+                admission=admission,
                 target=target,
                 budget_bytes=budget,
                 principal=principal,
+                noun=noun,
+                allow_restricted=False,
             )
             self._make_runtime_readable(
                 target,
@@ -227,7 +1542,9 @@ class WorkspaceArtifactProjector:
                 noun=noun,
             )
             total_bytes += written
-            evidence.append({"ref": ref, "bytes": written})
+            evidence.append(
+                {"ref": ref, "bytes": written, "sourceDigest": admission.digest}
+            )
         return evidence
 
     @staticmethod
@@ -266,20 +1583,12 @@ class WorkspaceArtifactProjector:
     @staticmethod
     def _artifact_id(ref: str, *, noun: str) -> str:
         value = str(ref or "").strip()
-        if not value.startswith("artifact://") or not value[len("artifact://") :]:
+        if not value.startswith("artifact://") or not value[len("artifact://"):]:
             raise WorkspaceArtifactProjectionError(
                 f"{noun} must be durable artifact refs, not local paths",
                 code="WORKSPACE_LOCATOR_UNSUPPORTED",
             )
-        return value[len("artifact://") :]
-
-    def _require_service(self, noun: str) -> Any:
-        if self._service is None:
-            raise WorkspaceArtifactProjectionError(
-                f"{noun} require an artifact service to resolve refs",
-                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
-            )
-        return self._service
+        return value[len("artifact://"):]
 
     @staticmethod
     async def _validate_metadata(
@@ -290,52 +1599,43 @@ class WorkspaceArtifactProjector:
         principal: str,
         required_workflow_id: str | None = None,
     ) -> None:
-        get_metadata = getattr(service, "get_metadata", None)
-        if get_metadata is None:
-            if required_workflow_id is not None:
-                raise WorkspaceArtifactProjectionError(
-                    "attachment authorization requires linked artifact metadata",
-                    code="WORKSPACE_AUTHORITY_MISMATCH",
-                )
-            return
-        metadata = await get_metadata(artifact_id=artifact_id, principal=principal)
-        artifact = metadata[0] if isinstance(metadata, tuple) else metadata
-        if required_workflow_id is not None:
-            links = metadata[1] if isinstance(metadata, tuple) and len(metadata) > 1 else ()
-            family = f"{required_workflow_id}:"
-            if not any(
-                str(getattr(link, "workflow_id", "")) == required_workflow_id
-                or str(getattr(link, "workflow_id", "")).startswith(family)
-                for link in links
-            ):
-                raise WorkspaceArtifactProjectionError(
-                    "attachment artifact is not linked to the current workflow family",
-                    code="WORKSPACE_AUTHORITY_MISMATCH",
-                )
-        size = getattr(artifact, "size_bytes", None)
-        if isinstance(size, int) and size > budget_bytes:
-            raise WorkspaceArtifactProjectionError(
-                "restore input exceeds the authorized workspace bound",
-                code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
-            )
+        """Legacy metadata probe, now fail-closed through source admission."""
+
+        await WorkspaceArtifactProjector._admit_source(
+            service,
+            artifact_id=artifact_id,
+            expected_digest=None,
+            budget_bytes=budget_bytes,
+            principal=principal,
+            noun="workspace input",
+            target_workflow_id=required_workflow_id,
+            grant=None,
+            allow_restricted=False,
+        )
 
     @staticmethod
     async def _write_payload(
         service: Any,
         *,
-        artifact_id: str,
+        admission: SourceAdmission,
         target: Path,
         budget_bytes: int,
         principal: str,
+        noun: str = "restore input",
+        allow_restricted: bool = False,
     ) -> int:
+        """Stream exact source bytes and verify against the admitted digest."""
+
         read_chunks = getattr(service, "read_chunks", None)
+        hasher = hashlib.sha256()
         if read_chunks is not None:
-            _artifact, chunks = await read_chunks(
-                artifact_id=artifact_id,
+            result = await read_chunks(
+                artifact_id=admission.artifact_id,
                 principal=principal,
-                allow_restricted_raw=True,
+                allow_restricted_raw=allow_restricted,
                 chunk_size=STREAM_CHUNK_BYTES,
             )
+            _artifact, chunks = result
             written = 0
             descriptor = os.open(
                 target,
@@ -349,20 +1649,35 @@ class WorkspaceArtifactProjector:
                         stream.close()
                         target.unlink(missing_ok=True)
                         raise WorkspaceArtifactProjectionError(
-                            "restore input exceeds the authorized workspace bound",
+                            f"{noun} exceed the authorized workspace bound",
                             code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                         )
+                    hasher.update(chunk)
                     stream.write(chunk)
+            actual = f"sha256:{hasher.hexdigest()}"
+            if actual != admission.digest:
+                target.unlink(missing_ok=True)
+                raise WorkspaceArtifactProjectionError(
+                    f"{noun} bytes do not match the admitted source digest",
+                    code="WORKSPACE_DIGEST_MISMATCH",
+                )
             return written
         _artifact, payload = await service.read(
-            artifact_id=artifact_id,
+            artifact_id=admission.artifact_id,
             principal=principal,
-            allow_restricted_raw=True,
+            allow_restricted_raw=allow_restricted,
         )
         if len(payload) > budget_bytes:
             raise WorkspaceArtifactProjectionError(
-                "restore input exceeds the authorized workspace bound",
+                f"{noun} exceed the authorized workspace bound",
                 code="OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
+            )
+        hasher.update(payload)
+        actual = f"sha256:{hasher.hexdigest()}"
+        if actual != admission.digest:
+            raise WorkspaceArtifactProjectionError(
+                f"{noun} bytes do not match the admitted source digest",
+                code="WORKSPACE_DIGEST_MISMATCH",
             )
         descriptor = os.open(
             target,
@@ -387,22 +1702,26 @@ class WorkspaceArtifactProjector:
                     stream.write("\n")
                 stream.write(f"{rule}\n")
 
-    @staticmethod
-    def _as_artifact_service(gateway: Any | None) -> Any | None:
-        if gateway is None:
-            return None
-        if hasattr(gateway, "read") or hasattr(gateway, "read_chunks"):
-            return gateway
 
-        class _GatewayAdapter:
-            async def read(self, *, artifact_id: str, **_kwargs: Any):
-                payload = await gateway.read_bytes(f"artifact://{artifact_id}")
-                return {}, payload
+def _contract_supported_for_kind(contract: str | None, kind: str | None) -> bool:
+    from moonmind.omnigent.workspace_sources import (
+        ARTIFACT_IMPORT_CONTRACT_V1,
+        SUPPORTED_RESTORE_CONTRACTS,
+    )
 
-        return _GatewayAdapter()
+    if kind == "artifact":
+        return contract == ARTIFACT_IMPORT_CONTRACT_V1
+    return contract in SUPPORTED_RESTORE_CONTRACTS
+
+
+def _supported_contracts() -> frozenset[str]:
+    from moonmind.omnigent.workspace_sources import SUPPORTED_RESTORE_CONTRACTS
+
+    return SUPPORTED_RESTORE_CONTRACTS
 
 
 __all__ = [
+    "SourceAdmission",
     "WorkspaceArtifactProjectionError",
     "WorkspaceArtifactProjector",
 ]

--- a/moonmind/omnigent/workspace_sources.py
+++ b/moonmind/omnigent/workspace_sources.py
@@ -1,0 +1,658 @@
+"""Single workspace-source compiler for contained workspace lifecycles.
+
+Implements ``CONTRACT-002`` (exactly one workspace source is active) and the
+authorized ``existing_workspace`` source from
+``docs/RepositoryAccessAndWorkspaceDesign.md`` (``CONTRACT-011``/``INV-006``).
+
+Every source kind — ``scratch``, ``repository``, ``artifact``, ``checkpoint``,
+``existing_workspace`` — compiles through this module into one
+:class:`CompiledWorkspaceSource` consumed by the single materializer. Raw
+server paths (``workspacePath``/``path``) are never a normal authoring route:
+they are rejected for new writes and only interpretable through the explicit
+historical decoder :func:`decode_historical_workspace_path`, so recorded
+histories keep their meaning without reopening a host-path shortcut.
+
+Conflicting source aliases are rejected before any read or filesystem
+mutation. Unsupported backend/source combinations fail here, before launch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+WorkspaceSourceKind = Literal[
+    "scratch", "repository", "artifact", "checkpoint", "existing_workspace"
+]
+
+# Supported workspace-restore contract carried by checkpoint sources.
+# Workspace restore is separate from provider-session reattachment: a
+# continuation creates a fresh execution owner and re-admits external
+# operations rather than reviving the old session.
+WORKSPACE_RESTORE_CONTRACT_V1 = "moonmind.workspace-restore.v1"
+SUPPORTED_RESTORE_CONTRACTS = frozenset({WORKSPACE_RESTORE_CONTRACT_V1})
+
+# Contract identifying an authorized immutable artifact import.
+ARTIFACT_IMPORT_CONTRACT_V1 = "moonmind.artifact-import.v1"
+
+# Overlay policy: an authoritative snapshot replaces destination content while
+# an additive attachment overlay only adds declared inputs.
+OVERLAY_AUTHORITATIVE = "authoritative"
+OVERLAY_ADDITIVE = "additive"
+
+# Historical raw-path decoding version. New-write producers must never emit
+# these aliases; loaders for already-recorded payloads go through
+# :func:`decode_historical_workspace_path`.
+HISTORICAL_WORKSPACE_PATH_DECODER = "moonmind.workspace-legacy-path.v1"
+
+_WORKSPACE_SOURCE_CONFLICT = "WORKSPACE_SOURCE_CONFLICT"
+_WORKSPACE_SOURCE_INVALID = "WORKSPACE_SOURCE_INVALID"
+_WORKSPACE_GRANT_MISMATCH = "WORKSPACE_GRANT_MISMATCH"
+_WORKSPACE_RUNTIME_UNSUPPORTED = "WORKSPACE_RUNTIME_UNSUPPORTED"
+
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
+_GRANT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+# Grant HMAC secret lives in the server environment only; agents never see it.
+_GRANT_HMAC_ENV = "MOONMIND_WORKSPACE_GRANT_SECRET"
+_GRANT_VERSION = "grant-v1"
+
+
+class WorkspaceSourceCompilationError(ValueError):
+    """Exactly-one-source compilation failed before any host mutation."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True)
+class ExistingWorkspaceGrant:
+    """Server-issued ownership/use grant for one existing workspace.
+
+    An advanced selected directory is not permission for an arbitrary host
+    mount: use requires this grant, which names the source workspace, the
+    owning execution, the grantee workflow, the sharing mode, the expected
+    generation, and a bounded lifetime. The HMAC authenticates issuance; the
+    materializer additionally verifies owner/generation/expiry against the
+    authoritative record store at the owning worker boundary.
+    """
+
+    grant_id: str
+    source_workspace_id: str
+    owner_workflow_id: str
+    owner_step_execution_id: str
+    grantee_workflow_id: str
+    mode: str  # "exclusive" (writable) or "read_only" (explicitly shared)
+    expected_generation: int
+    issued_at: int
+    expires_at: int
+    grant_digest: str
+
+    def payload_dict(self) -> dict[str, Any]:
+        return {
+            "version": _GRANT_VERSION,
+            "grantId": self.grant_id,
+            "sourceWorkspaceId": self.source_workspace_id,
+            "ownerWorkflowId": self.owner_workflow_id,
+            "ownerStepExecutionId": self.owner_step_execution_id,
+            "granteeWorkflowId": self.grantee_workflow_id,
+            "mode": self.mode,
+            "expectedGeneration": self.expected_generation,
+            "issuedAt": self.issued_at,
+            "expiresAt": self.expires_at,
+        }
+
+
+@dataclass(frozen=True)
+class CompiledWorkspaceSource:
+    """One admitted workspace source plus its explicit overlay/input policy."""
+
+    kind: WorkspaceSourceKind
+    # Artifact sources name authorized immutable content and its digest.
+    artifact_ref: str | None = None
+    expected_digest: str | None = None
+    # Checkpoint sources name a supported workspace-restore contract.
+    checkpoint_ref: str | None = None
+    restore_contract: str | None = None
+    # Existing-workspace sources carry a verified locator/use grant.
+    grant: ExistingWorkspaceGrant | None = None
+    # Overlay/input policy.
+    overlay: str = OVERLAY_AUTHORITATIVE
+    input_manifest_digest: str | None = None
+    # Attempt/generation the import is bound to; retries reconcile the same
+    # generation while changed inputs require an explicit new import.
+    attempt_id: str | None = None
+    generation: int = 1
+
+
+def _fail(code: str, message: str) -> WorkspaceSourceCompilationError:
+    return WorkspaceSourceCompilationError(code, message)
+
+
+def normalize_digest(value: str) -> str:
+    """Normalize an expected content digest to ``sha256:<hex>`` form."""
+
+    candidate = str(value or "").strip().lower()
+    if not _SHA256_RE.fullmatch(candidate):
+        raise _fail(
+            _WORKSPACE_SOURCE_INVALID,
+            "workspace source digest must be a sha256 hex value",
+        )
+    return candidate if candidate.startswith("sha256:") else f"sha256:{candidate}"
+
+
+def _artifact_id(ref: str, *, noun: str) -> str:
+    value = str(ref or "").strip()
+    if not value.startswith("artifact://") or not value[len("artifact://"):]:
+        raise _fail(
+            _WORKSPACE_SOURCE_INVALID,
+            f"{noun} must be a durable artifact ref, not a local path",
+        )
+    return value[len("artifact://"):]
+
+
+def issue_existing_workspace_grant(
+    *,
+    source_workspace_id: str,
+    owner_workflow_id: str,
+    owner_step_execution_id: str,
+    grantee_workflow_id: str,
+    mode: str = "exclusive",
+    expected_generation: int = 1,
+    lifetime_seconds: int = 3600,
+    secret: str | None = None,
+) -> ExistingWorkspaceGrant:
+    """Issue a server-side ownership/use grant for an existing workspace."""
+
+    if mode not in {"exclusive", "read_only"}:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "grant mode must be exclusive|read_only")
+    for label, value in (
+        ("source workspace", source_workspace_id),
+        ("owner workflow", owner_workflow_id),
+        ("owner step execution", owner_step_execution_id),
+        ("grantee workflow", grantee_workflow_id),
+    ):
+        if not str(value or "").strip():
+            raise _fail(_WORKSPACE_SOURCE_INVALID, f"grant {label} is required")
+    if expected_generation < 1:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "grant generation must be >= 1")
+    if lifetime_seconds <= 0 or lifetime_seconds > 86400:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "grant lifetime must be within one day")
+    now = int(time.time())
+    raw_id = (
+        f"{source_workspace_id}:{owner_workflow_id}:{owner_step_execution_id}:"
+        f"{grantee_workflow_id}:{mode}:{expected_generation}:{now}"
+    )
+    grant_id = "grant_" + hashlib.sha256(raw_id.encode()).hexdigest()[:24]
+    return _sign_grant(
+        grant_id=grant_id,
+        source_workspace_id=str(source_workspace_id).strip(),
+        owner_workflow_id=str(owner_workflow_id).strip(),
+        owner_step_execution_id=str(owner_step_execution_id).strip(),
+        grantee_workflow_id=str(grantee_workflow_id).strip(),
+        mode=mode,
+        expected_generation=expected_generation,
+        issued_at=now,
+        expires_at=now + lifetime_seconds,
+        secret=secret,
+    )
+
+
+def _sign_grant(*, secret: str | None = None, **fields: Any) -> ExistingWorkspaceGrant:
+    key = secret if secret is not None else os.getenv(_GRANT_HMAC_ENV, "")
+    if not key:
+        raise _fail(
+            _WORKSPACE_SOURCE_INVALID,
+            "workspace grant issuance requires a server grant secret",
+        )
+    grant = ExistingWorkspaceGrant(grant_digest="", **fields)  # type: ignore[arg-type]
+    encoded = json.dumps(grant.payload_dict(), sort_keys=True, separators=(",", ":"))
+    digest = hmac.new(key.encode(), encoded.encode(), hashlib.sha256).hexdigest()
+    return ExistingWorkspaceGrant(grant_digest=f"hmac-sha256:{digest}", **fields)  # type: ignore[arg-type]
+
+
+def parse_existing_workspace_grant(value: Mapping[str, Any]) -> ExistingWorkspaceGrant:
+    """Parse (not yet verify) a grant mapping carried in a workspace spec."""
+
+    try:
+        mode = str(value.get("mode") or "exclusive").strip()
+        return ExistingWorkspaceGrant(
+            grant_id=str(value.get("grantId") or "").strip(),
+            source_workspace_id=str(value.get("sourceWorkspaceId") or "").strip(),
+            owner_workflow_id=str(value.get("ownerWorkflowId") or "").strip(),
+            owner_step_execution_id=str(value.get("ownerStepExecutionId") or "").strip(),
+            grantee_workflow_id=str(value.get("granteeWorkflowId") or "").strip(),
+            mode=mode,
+            expected_generation=int(value.get("expectedGeneration") or 0),
+            issued_at=int(value.get("issuedAt") or 0),
+            expires_at=int(value.get("expiresAt") or 0),
+            grant_digest=str(value.get("grantDigest") or "").strip(),
+        )
+    except (TypeError, ValueError) as exc:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "existing-workspace grant is malformed") from exc
+
+
+def verify_existing_workspace_grant(
+    grant: ExistingWorkspaceGrant,
+    *,
+    grantee_workflow_id: str,
+    expected_generation: int | None = None,
+    now: int | None = None,
+    secret: str | None = None,
+) -> None:
+    """Verify issuance authenticity, grantee binding, generation, and lifetime."""
+
+    if not _GRANT_ID_RE.fullmatch(grant.grant_id):
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant identity is invalid")
+    if grant.mode not in {"exclusive", "read_only"}:
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant mode is unsupported")
+    key = secret if secret is not None else os.getenv(_GRANT_HMAC_ENV, "")
+    if not key:
+        raise _fail(
+            _WORKSPACE_GRANT_MISMATCH,
+            "workspace grant verification requires a server grant secret",
+        )
+    encoded = json.dumps(grant.payload_dict(), sort_keys=True, separators=(",", ":"))
+    expected = hmac.new(key.encode(), encoded.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(grant.grant_digest, f"hmac-sha256:{expected}"):
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant signature is invalid")
+    if grant.grantee_workflow_id != str(grantee_workflow_id or "").strip():
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant is for another workflow")
+    if grant.expected_generation < 1:
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant generation is invalid")
+    if expected_generation is not None and grant.expected_generation != expected_generation:
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant generation is stale")
+    instant = int(time.time()) if now is None else int(now)
+    if not grant.issued_at or instant < grant.issued_at - 300:
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant is not yet valid")
+    if instant >= grant.expires_at:
+        raise _fail(_WORKSPACE_GRANT_MISMATCH, "workspace grant has expired")
+
+
+def decode_historical_workspace_path(spec: Mapping[str, Any]) -> str:
+    """Explicit frozen decoder for already-recorded raw workspace paths.
+
+    Never called for new authoring; the compiler rejects ``workspacePath`` /
+    ``path`` unless the caller explicitly opts into historical decoding.
+    """
+
+    for key in ("workspacePath", "path"):
+        value = spec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise _fail(_WORKSPACE_SOURCE_INVALID, "recorded workspace path is absent")
+
+
+# Backend/source support matrix. An advanced selected directory is not
+# permission for arbitrary host mounts, and not every source is meaningful on
+# every backend. Unsupported combinations fail before launch.
+_SUPPORTED_BACKENDS = ("docker_local", "docker_remote", "managed")
+_BACKEND_BY_SOURCE: dict[str, frozenset[str]] = {
+    "scratch": frozenset({"docker_local", "docker_remote", "managed"}),
+    "repository": frozenset({"docker_local", "docker_remote", "managed"}),
+    "artifact": frozenset({"docker_local", "docker_remote", "managed"}),
+    "checkpoint": frozenset({"docker_local", "docker_remote", "managed"}),
+    # An exclusive writable grant cannot be honored on a remote daemon view
+    # that cannot fence the owner's live checkout; read-only sharing is
+    # supported there through the qualified locator mapping.
+    "existing_workspace": frozenset({"docker_local", "docker_remote", "managed"}),
+}
+
+
+def check_source_backend_supported(
+    kind: WorkspaceSourceKind,
+    backend: str,
+    *,
+    grant_mode: str | None = None,
+) -> None:
+    """Fail before execution when a source/backend combination is unsupported."""
+
+    normalized = str(backend or "").strip().lower() or "docker_local"
+    if normalized not in _SUPPORTED_BACKENDS:
+        raise _fail(
+            _WORKSPACE_RUNTIME_UNSUPPORTED,
+            f"workspace backend {backend!r} is not a supported runtime",
+        )
+    allowed = _BACKEND_BY_SOURCE.get(str(kind))
+    if allowed is None or normalized not in allowed:
+        raise _fail(
+            _WORKSPACE_RUNTIME_UNSUPPORTED,
+            f"workspace source {kind!r} is unsupported on backend {normalized!r}",
+        )
+    if (
+        kind == "existing_workspace"
+        and normalized == "docker_remote"
+        and (grant_mode or "exclusive") == "exclusive"
+    ):
+        raise _fail(
+            _WORKSPACE_RUNTIME_UNSUPPORTED,
+            "exclusive existing-workspace use is unsupported on a remote daemon; "
+            "request read_only sharing or a local backend",
+        )
+
+
+def compile_workspace_source(
+    spec: Mapping[str, Any],
+    *,
+    allow_historical_path: bool = False,
+) -> CompiledWorkspaceSource:
+    """Compile exactly one workspace source plus its overlay/input policy.
+
+    Detects every authored alias — the ``workspaceSource`` union, the flat
+    ``workspaceArtifactRef`` / ``workspaceCheckpointRestoreRef`` /
+    ``workspaceExistingGrant`` keys, repository authoring, and the historical
+    raw-path aliases — and rejects conflicting aliases before any read or
+    filesystem mutation.
+    """
+
+    if not isinstance(spec, Mapping):
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "workspace spec must be a mapping")
+
+    candidates: list[tuple[str, CompiledWorkspaceSource]] = []
+
+    union = spec.get("workspaceSource")
+    if isinstance(union, Mapping) and union:
+        candidates.append(("workspaceSource", _compile_union(dict(union))))
+
+    flat_artifact = str(spec.get("workspaceArtifactRef") or "").strip()
+    flat_digest = str(spec.get("workspaceArtifactDigest") or "").strip()
+    if flat_artifact or flat_digest:
+        if not flat_artifact or not flat_digest:
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                "workspaceArtifactRef requires workspaceArtifactDigest",
+            )
+        candidates.append(
+            (
+                "workspaceArtifactRef",
+                CompiledWorkspaceSource(
+                    kind="artifact",
+                    artifact_ref=flat_artifact,
+                    expected_digest=normalize_digest(flat_digest),
+                    overlay=_overlay_policy(spec, default=OVERLAY_AUTHORITATIVE),
+                    input_manifest_digest=_optional_digest(
+                        spec.get("workspaceInputManifestDigest")
+                    ),
+                    attempt_id=_optional_text(spec.get("workspaceImportAttemptId")),
+                    generation=_generation(spec.get("workspaceImportGeneration")),
+                ),
+            )
+        )
+
+    flat_checkpoint = str(spec.get("workspaceCheckpointRestoreRef") or "").strip()
+    if flat_checkpoint:
+        candidates.append(
+            (
+                "workspaceCheckpointRestoreRef",
+                CompiledWorkspaceSource(
+                    kind="checkpoint",
+                    artifact_ref=flat_checkpoint,
+                    checkpoint_ref=flat_checkpoint,
+                    expected_digest=(
+                        normalize_digest(str(spec.get("workspaceCheckpointDigest") or ""))
+                        if str(spec.get("workspaceCheckpointDigest") or "").strip()
+                        else None
+                    ),
+                    restore_contract=_restore_contract(spec),
+                    overlay=_overlay_policy(spec, default=OVERLAY_AUTHORITATIVE),
+                    input_manifest_digest=_optional_digest(
+                        spec.get("workspaceInputManifestDigest")
+                    ),
+                    attempt_id=_optional_text(spec.get("workspaceImportAttemptId")),
+                    generation=_generation(spec.get("workspaceImportGeneration")),
+                ),
+            )
+        )
+
+    flat_grant = spec.get("workspaceExistingGrant")
+    if isinstance(flat_grant, Mapping) and flat_grant:
+        grant = parse_existing_workspace_grant(flat_grant)
+        candidates.append(
+            (
+                "workspaceExistingGrant",
+                CompiledWorkspaceSource(
+                    kind="existing_workspace",
+                    grant=grant,
+                    overlay=_overlay_policy(spec, default=OVERLAY_ADDITIVE),
+                    input_manifest_digest=_optional_digest(
+                        spec.get("workspaceInputManifestDigest")
+                    ),
+                    attempt_id=_optional_text(spec.get("workspaceImportAttemptId")),
+                    generation=_generation(spec.get("workspaceImportGeneration")),
+                ),
+            )
+        )
+
+    if _authored_repository(spec):
+        candidates.append(("repository", CompiledWorkspaceSource(kind="repository")))
+
+    raw_path = _raw_path_alias(spec)
+    if raw_path is not None:
+        if not allow_historical_path:
+            raise _fail(
+                _WORKSPACE_SOURCE_CONFLICT,
+                "workspacePath/path is a historical alias, not an authoring route; "
+                "compile through decode_historical_workspace_path for recorded "
+                "histories or author a workspaceSource instead",
+            )
+        # Historical decoding preserves the recorded meaning and nothing else:
+        # a recorded raw path was preexisting authority for its own execution.
+        candidates.append(
+            ("workspacePath(historical)", CompiledWorkspaceSource(kind="scratch"))
+        )
+
+    # The additive overlay inputs (restoreInputRefs/attachmentRefs) are input
+    # policy, not competing sources; they ride on the single compiled source.
+    kinds = {compiled.kind for _, compiled in candidates}
+    if len(candidates) > 1:
+        names = ", ".join(name for name, _ in candidates)
+        raise _fail(
+            _WORKSPACE_SOURCE_CONFLICT,
+            f"conflicting workspace sources before any read or mutation: {names}",
+        )
+    if not candidates:
+        # The default experience is a new blank workspace.
+        overlay = _overlay_policy(spec, default=OVERLAY_AUTHORITATIVE)
+        return CompiledWorkspaceSource(kind="scratch", overlay=overlay)
+    return candidates[0][1]
+
+
+def _compile_union(union: dict[str, Any]) -> CompiledWorkspaceSource:
+    kind = str(union.get("kind") or "").strip()
+    if kind == "scratch":
+        return CompiledWorkspaceSource(
+            kind="scratch",
+            overlay=_overlay_policy(union, default=OVERLAY_AUTHORITATIVE),
+        )
+    if kind == "repository":
+        if not _authored_repository(union):
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                "workspaceSource repository requires a repository target",
+            )
+        return CompiledWorkspaceSource(kind="repository")
+    if kind == "artifact":
+        ref = str(union.get("artifactRef") or "").strip()
+        digest = str(union.get("expectedDigest") or union.get("digest") or "").strip()
+        if not ref or not digest:
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                "workspaceSource artifact requires artifactRef and expectedDigest",
+            )
+        return CompiledWorkspaceSource(
+            kind="artifact",
+            artifact_ref=ref,
+            expected_digest=normalize_digest(digest),
+            overlay=_overlay_policy(union, default=OVERLAY_AUTHORITATIVE),
+            input_manifest_digest=_optional_digest(union.get("inputManifestDigest")),
+            attempt_id=_optional_text(union.get("attemptId")),
+            generation=_generation(union.get("generation")),
+        )
+    if kind == "checkpoint":
+        ref = str(union.get("checkpointRef") or "").strip()
+        if not ref:
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                "workspaceSource checkpoint requires checkpointRef",
+            )
+        contract = str(
+            union.get("restoreContract") or WORKSPACE_RESTORE_CONTRACT_V1
+        ).strip()
+        if contract not in SUPPORTED_RESTORE_CONTRACTS:
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                f"unsupported workspace-restore contract {contract!r}",
+            )
+        digest_raw = str(union.get("expectedDigest") or union.get("digest") or "").strip()
+        return CompiledWorkspaceSource(
+            kind="checkpoint",
+            artifact_ref=ref,
+            checkpoint_ref=ref,
+            expected_digest=normalize_digest(digest_raw) if digest_raw else None,
+            restore_contract=contract,
+            overlay=_overlay_policy(union, default=OVERLAY_AUTHORITATIVE),
+            input_manifest_digest=_optional_digest(union.get("inputManifestDigest")),
+            attempt_id=_optional_text(union.get("attemptId")),
+            generation=_generation(union.get("generation")),
+        )
+    if kind == "existing_workspace":
+        grant_raw = union.get("grant")
+        if not isinstance(grant_raw, Mapping) or not grant_raw:
+            raise _fail(
+                _WORKSPACE_SOURCE_INVALID,
+                "workspaceSource existing_workspace requires a server-issued grant",
+            )
+        return CompiledWorkspaceSource(
+            kind="existing_workspace",
+            grant=parse_existing_workspace_grant(grant_raw),
+            overlay=_overlay_policy(union, default=OVERLAY_ADDITIVE),
+            input_manifest_digest=_optional_digest(union.get("inputManifestDigest")),
+            attempt_id=_optional_text(union.get("attemptId")),
+            generation=_generation(union.get("generation")),
+        )
+    raise _fail(_WORKSPACE_SOURCE_INVALID, f"unknown workspaceSource kind {kind!r}")
+
+
+def _authored_repository(spec: Mapping[str, Any]) -> bool:
+    for key in ("repositoryTarget", "repository", "repo"):
+        value = spec.get(key)
+        if isinstance(value, Mapping):
+            if str(value.get("repository", value.get("name", "")) or "").strip():
+                return True
+            # A repositoryTarget/repository mapping with branch-only content
+            # still declares repository intent.
+            if any(
+                str(value.get(nested) or "").strip()
+                for nested in ("branch", "startingBranch", "connectionRef")
+            ):
+                return True
+        elif isinstance(value, str) and value.strip():
+            return True
+    # A bare branch without repository identity is incomplete, not a
+    # repository source; it must not silently become one.
+    return False
+
+
+def _raw_path_alias(spec: Mapping[str, Any]) -> str | None:
+    for key in ("workspacePath", "path"):
+        value = spec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _overlay_policy(spec: Mapping[str, Any], *, default: str) -> str:
+    raw = str(spec.get("workspaceOverlayPolicy") or spec.get("overlay") or "").strip().lower()
+    if not raw:
+        return default
+    if raw not in {OVERLAY_AUTHORITATIVE, OVERLAY_ADDITIVE}:
+        raise _fail(
+            _WORKSPACE_SOURCE_INVALID,
+            "workspace overlay policy must be authoritative|additive",
+        )
+    return raw
+
+
+def _restore_contract(spec: Mapping[str, Any]) -> str:
+    contract = str(
+        spec.get("workspaceRestoreContract") or WORKSPACE_RESTORE_CONTRACT_V1
+    ).strip()
+    if contract not in SUPPORTED_RESTORE_CONTRACTS:
+        raise _fail(
+            _WORKSPACE_SOURCE_INVALID,
+            f"unsupported workspace-restore contract {contract!r}",
+        )
+    return contract
+
+
+def _optional_digest(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return normalize_digest(text) if text else None
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _generation(value: Any) -> int:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return 1
+    try:
+        generation = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "workspace import generation is invalid") from exc
+    if generation < 1:
+        raise _fail(_WORKSPACE_SOURCE_INVALID, "workspace import generation must be >= 1")
+    return generation
+
+
+def ready_binding(
+    source: CompiledWorkspaceSource,
+    *,
+    observed_digest: str,
+    target_owner: str,
+) -> dict[str, Any]:
+    """Bind the ready marker to source digest, contract, inputs, owner, attempt."""
+
+    return {
+        "sourceKind": source.kind,
+        "sourceDigest": normalize_digest(observed_digest),
+        "restoreContract": source.restore_contract
+        or (ARTIFACT_IMPORT_CONTRACT_V1 if source.kind == "artifact" else None),
+        "restoreContractVersion": 1,
+        "inputManifestDigest": source.input_manifest_digest,
+        "targetOwner": str(target_owner or "").strip(),
+        "attemptId": source.attempt_id,
+        "generation": source.generation,
+        "overlay": source.overlay,
+    }
+
+
+__all__ = [
+    "ARTIFACT_IMPORT_CONTRACT_V1",
+    "HISTORICAL_WORKSPACE_PATH_DECODER",
+    "OVERLAY_ADDITIVE",
+    "OVERLAY_AUTHORITATIVE",
+    "SUPPORTED_RESTORE_CONTRACTS",
+    "WORKSPACE_RESTORE_CONTRACT_V1",
+    "CompiledWorkspaceSource",
+    "ExistingWorkspaceGrant",
+    "WorkspaceSourceCompilationError",
+    "WorkspaceSourceKind",
+    "check_source_backend_supported",
+    "compile_workspace_source",
+    "decode_historical_workspace_path",
+    "issue_existing_workspace_grant",
+    "normalize_digest",
+    "parse_existing_workspace_grant",
+    "ready_binding",
+    "verify_existing_workspace_grant",
+]

--- a/moonmind/workflows/temporal/runtime/workspace_locators.py
+++ b/moonmind/workflows/temporal/runtime/workspace_locators.py
@@ -6,7 +6,7 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from moonmind.schemas.workspace_locator_models import (
     ManagedWorkspaceLocator,
@@ -62,19 +62,164 @@ class SandboxWorkspaceRecordStore:
         """
         path = self._completion_marker_path(workspace_id)
         try:
-            return path.read_text(encoding="utf-8") == "materialized-v2"
+            text = path.read_text(encoding="utf-8")
         except OSError:
             return False
+        if text == "materialized-v2":
+            return True
+        try:
+            payload = json.loads(text)
+        except (ValueError, json.JSONDecodeError):
+            return False
+        return (
+            isinstance(payload, dict) and payload.get("format") == "materialized-v3"
+        )
 
     def mark_materialized(self, workspace_id: str) -> None:
         """Record durable evidence that materialization completed."""
+        self.mark_materialized_for(workspace_id, binding=None)
+
+    def mark_materialized_for(
+        self, workspace_id: str, binding: dict[str, Any] | None
+    ) -> None:
+        """Record completion bound to source digest, contract, owner, attempt.
+
+        The ready marker binds the admitted source/digest, the restore
+        contract/version, the input-manifest digest, the target owner, and the
+        attempt/generation — not just a directory or a previous marker. A retry
+        reconciles the same generation; changed inputs require an explicit new
+        import with a different binding.
+        """
         self.store_root.mkdir(mode=0o700, parents=True, exist_ok=True)
         path = self._completion_marker_path(workspace_id)
-        if self.is_materialized(workspace_id):
+        if self.is_materialized(workspace_id) and binding is None:
             return
+        if binding is not None and self.is_materialized_for(workspace_id, binding):
+            return
+        payload = json.dumps(
+            {"format": "materialized-v3", "binding": binding or {"legacy": True}},
+            sort_keys=True,
+        )
         descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write("materialized-v2")
+            stream.write(payload)
+
+    def load_materialized_binding(self, workspace_id: str) -> dict[str, Any] | None:
+        """Return the bound ready marker, or None when absent/legacy/unparseable."""
+        path = self._completion_marker_path(workspace_id)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        if text == "materialized-v2":
+            return None
+        try:
+            payload = json.loads(text)
+        except (ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict) or payload.get("format") != "materialized-v3":
+            return None
+        binding = payload.get("binding")
+        return binding if isinstance(binding, dict) else None
+
+    def is_materialized_for(self, workspace_id: str, binding: dict[str, Any]) -> bool:
+        """Return whether the recorded ready marker matches this exact binding."""
+        recorded = self.load_materialized_binding(workspace_id)
+        if recorded is None:
+            return False
+        if recorded.get("legacy"):
+            return False
+        for key in (
+            "sourceKind",
+            "sourceDigest",
+            "restoreContract",
+            "inputManifestDigest",
+            "targetOwner",
+            "attemptId",
+            "generation",
+            "overlay",
+        ):
+            if recorded.get(key) != binding.get(key):
+                return False
+        return True
+
+    def _claims_dir(self, workspace_id: str) -> Path:
+        candidate = (self.store_root / f"{workspace_id}.grants").resolve()
+        if candidate.parent != self.store_root.resolve():
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "sandbox workspace grant registry escapes its authority",
+            )
+        return candidate
+
+    def claim_existing_workspace(self, workspace_id: str, grant: Any) -> None:
+        """Record exclusive/read-only use of another workflow's workspace.
+
+        Existing-workspace grants declare exclusive writable use or explicitly
+        supported read-only sharing. An exclusive claim conflicts with any
+        other active claim; read-only claims coexist only with read-only
+        claims. Reclaiming the same grant is idempotent for retries.
+        """
+
+        claims = self._claims_dir(workspace_id)
+        claims.mkdir(mode=0o700, parents=True, exist_ok=True)
+        grant_id = str(getattr(grant, "grant_id", "") or "")
+        mode = str(getattr(grant, "mode", "") or "")
+        if not grant_id or mode not in {"exclusive", "read_only"}:
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "existing-workspace grant claim is invalid",
+            )
+        for existing_path in sorted(claims.glob("*.json")):
+            if existing_path.name == f"{grant_id}.json":
+                continue
+            try:
+                existing = json.loads(existing_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            if not isinstance(existing, dict):
+                continue
+            if mode == "exclusive" or existing.get("mode") == "exclusive":
+                raise WorkspaceLocatorResolutionError(
+                    WORKSPACE_IDENTITY_MISMATCH,
+                    "existing workspace is already granted to another execution",
+                )
+        claim_path = claims / f"{grant_id}.json"
+        payload = json.dumps(
+            {
+                "grantId": grant_id,
+                "mode": mode,
+                "granteeWorkflowId": str(
+                    getattr(grant, "grantee_workflow_id", "") or ""
+                ),
+                "expectedGeneration": int(
+                    getattr(grant, "expected_generation", 0) or 0
+                ),
+            },
+            sort_keys=True,
+        )
+        try:
+            descriptor = os.open(
+                claim_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+        except FileExistsError:
+            return
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+
+    def release_existing_workspace(self, workspace_id: str, grant_id: str) -> None:
+        """Release ownership of a previously claimed existing workspace."""
+
+        claim_path = self._claims_dir(workspace_id) / f"{grant_id}.json"
+        try:
+            claim_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise WorkspaceLocatorResolutionError(
+                WORKSPACE_AUTHORITY_MISMATCH,
+                "existing-workspace grant release failed",
+            ) from exc
 
     def load(self, workspace_id: str) -> SandboxWorkspaceRecord | None:
         path = self._record_path(workspace_id)

--- a/tests/unit/omnigent/test_workspace_materializer.py
+++ b/tests/unit/omnigent/test_workspace_materializer.py
@@ -263,6 +263,9 @@ async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount
         member = tarfile.TarInfo("candidate.txt")
         member.size = len(added)
         bundle.addfile(member, io.BytesIO(added))
+        git_info = tarfile.TarInfo(".git/info")
+        git_info.type = tarfile.DIRTYPE
+        bundle.addfile(git_info)
         stale = b"prior verifier context"
         member = tarfile.TarInfo(".moonmind/attachments/stale-verifier")
         member.size = len(stale)
@@ -287,14 +290,26 @@ async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount
 
         async def get_metadata(self, *, artifact_id, principal):
             self.reads.append((artifact_id, principal))
-            artifact = SimpleNamespace(size_bytes=len(self.payloads[artifact_id]))
+            artifact = SimpleNamespace(
+                artifact_id=artifact_id,
+                status="COMPLETE",
+                size_bytes=len(self.payloads[artifact_id]),
+                sha256=hashlib.sha256(self.payloads[artifact_id]).hexdigest(),
+                redaction_level=SimpleNamespace(value="NONE"),
+                quarantined=False,
+                expires_at=None,
+                created_by_principal="owner-1",
+                metadata_json={},
+            )
             links = [SimpleNamespace(workflow_id="workflow-1")]
-            return artifact, links
+            return artifact, links, False, SimpleNamespace(raw_access_allowed=True)
 
         async def read_chunks(
             self, *, artifact_id, principal, allow_restricted_raw, chunk_size
         ):
-            assert allow_restricted_raw is True
+            # Generic restore never releases protected raw content
+            # implicitly; the explicit policy stays False here.
+            assert allow_restricted_raw is False
             self.reads.append((artifact_id, principal))
             return SimpleNamespace(), iter((self.payloads[artifact_id],))
 
@@ -310,8 +325,8 @@ async def test_materializer_projects_checkpoint_and_declared_inputs_before_mount
                 "workspaceId": workspace_id,
                 "relativePath": "repo",
             },
-            "repository": "MoonLadderStudios/MoonMind",
-            "branch": "main",
+            # Checkpoint restores are self-contained: exactly one source is
+            # active and no repository clone is a prerequisite.
             "workspaceCheckpointRestoreRef": checkpoint_ref,
             "restoreInputRefs": [restore_ref],
         }

--- a/tests/unit/omnigent/test_workspace_safe_sources.py
+++ b/tests/unit/omnigent/test_workspace_safe_sources.py
@@ -1,0 +1,1019 @@
+"""Safe artifact, checkpoint, and authorized existing-workspace sources.
+
+Covers MoonLadderStudios/MoonMind#4014 across the real
+API/compiler/artifact/materializer boundaries: exactly-one-source
+compilation, artifact-service admission, digest-verified streaming under
+explicit budgets, attempt-owned staging with sequential link safety,
+authoritative promotion with bound ready markers, Git-authority
+neutralization, self-contained credentialless restore, and
+server-issued existing-workspace grants with qualified daemon mapping.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import tarfile
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.omnigent.workspace_artifacts import (
+    WorkspaceArtifactProjector,
+    WorkspaceArtifactProjectionError,
+)
+from moonmind.omnigent.workspace_sources import (
+    WorkspaceSourceCompilationError,
+    check_source_backend_supported,
+    compile_workspace_source,
+    decode_historical_workspace_path,
+    issue_existing_workspace_grant,
+    verify_existing_workspace_grant,
+)
+
+WORKFLOW_ID = "workflow-1"
+GRANT_SECRET = "test-grant-secret-4014"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _tar_bytes(entries: dict[str, bytes | None], *, mode: str = "w:gz") -> bytes:
+    """Build an archive; None value means an explicit directory entry."""
+
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode=mode) as bundle:
+        for name, payload in entries.items():
+            if payload is None:
+                member = tarfile.TarInfo(name)
+                member.type = tarfile.DIRTYPE
+                bundle.addfile(member)
+                continue
+            member = tarfile.TarInfo(name)
+            member.size = len(payload)
+            bundle.addfile(member, io.BytesIO(payload))
+    return archive.getvalue()
+
+
+class FakeArtifactService:
+    """Minimal ehrliche artifact service with full metadata semantics."""
+
+    def __init__(self) -> None:
+        self.entries: dict[str, dict] = {}
+        self.metadata_calls: list[str] = []
+        self.restricted_flags: list[bool] = []
+
+    def add(
+        self,
+        artifact_id: str,
+        payload: bytes,
+        *,
+        workflow_id: str = WORKFLOW_ID,
+        status: str = "COMPLETE",
+        sha256: str | None = "__payload__",
+        redaction_level: str = "NONE",
+        quarantined: bool = False,
+        expires_at=None,
+        owner: str = "owner-1",
+    ) -> bytes:
+        if sha256 == "__payload__":
+            sha256 = _sha(payload)
+        artifact = SimpleNamespace(
+            artifact_id=artifact_id,
+            status=status,
+            size_bytes=len(payload),
+            sha256=sha256,
+            redaction_level=SimpleNamespace(value=redaction_level),
+            quarantined=quarantined,
+            expires_at=expires_at,
+            created_by_principal=owner,
+            metadata_json={},
+        )
+        links = (
+            [SimpleNamespace(workflow_id=workflow_id)] if workflow_id else []
+        )
+        self.entries[artifact_id] = {
+            "artifact": artifact,
+            "links": links,
+            "payload": payload,
+        }
+        return payload
+
+    async def get_metadata(self, *, artifact_id: str, principal: str):
+        self.metadata_calls.append(artifact_id)
+        entry = self.entries.get(artifact_id)
+        if entry is None:
+            raise KeyError(artifact_id)
+        return entry["artifact"], entry["links"], False, SimpleNamespace(
+            raw_access_allowed=True
+        )
+
+    async def read_chunks(
+        self, *, artifact_id: str, principal: str, allow_restricted_raw, chunk_size
+    ):
+        self.restricted_flags.append(bool(allow_restricted_raw))
+        entry = self.entries[artifact_id]
+        payload = entry["payload"]
+        size = max(1, int(chunk_size))
+        return entry["artifact"], [
+            payload[index : index + size] for index in range(0, len(payload), size)
+        ]
+
+    async def read(self, *, artifact_id: str, principal: str, allow_restricted_raw):
+        self.restricted_flags.append(bool(allow_restricted_raw))
+        entry = self.entries[artifact_id]
+        return entry["artifact"], entry["payload"]
+
+
+def _projector(service: FakeArtifactService) -> WorkspaceArtifactProjector:
+    return WorkspaceArtifactProjector(service)
+
+
+async def _project_checkpoint(
+    tmp_path,
+    service: FakeArtifactService,
+    payload: bytes,
+    *,
+    artifact_id: str = "checkpoint",
+    declare_digest: bool = True,
+    workflow_id: str = WORKFLOW_ID,
+    grant=None,
+    allow_restricted: bool = False,
+    overlay: str = "authoritative",
+    attempt_id: str = "attempt-1",
+):
+    from moonmind.omnigent.workspace_sources import CompiledWorkspaceSource
+
+    service.add(artifact_id, payload, workflow_id=workflow_id)
+    digest = _sha(payload) if declare_digest else None
+    source = CompiledWorkspaceSource(
+        kind="checkpoint",
+        artifact_ref=f"artifact://{artifact_id}",
+        checkpoint_ref=f"artifact://{artifact_id}",
+        expected_digest=digest,
+        restore_contract="moonmind.workspace-restore.v1",
+        overlay=overlay,
+        attempt_id=attempt_id,
+        generation=1,
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir(parents=True, exist_ok=True)
+    evidence = await _projector(service).project(
+        workspace,
+        checkpoint_ref=f"artifact://{artifact_id}",
+        workflow_id=workflow_id,
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+        source=source,
+        grant=grant,
+        allow_restricted=allow_restricted,
+        target_owner=f"{workflow_id}:step-1",
+    )
+    return workspace, evidence
+
+
+# ---------------------------------------------------------------------------
+# Impl 1: exactly-one-source compilation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceSourceCompiler:
+    def test_default_is_blank_scratch(self):
+        assert compile_workspace_source({}).kind == "scratch"
+
+    def test_artifact_union_requires_ref_and_digest(self):
+        digest = _sha(b"x")
+        source = compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "artifact",
+                    "artifactRef": "artifact://abc",
+                    "expectedDigest": digest,
+                }
+            }
+        )
+        assert source.kind == "artifact"
+        assert source.expected_digest == digest
+        with pytest.raises(WorkspaceSourceCompilationError):
+            compile_workspace_source(
+                {"workspaceSource": {"kind": "artifact", "artifactRef": "artifact://abc"}}
+            )
+
+    def test_checkpoint_union_rejects_unknown_contract(self):
+        with pytest.raises(WorkspaceSourceCompilationError, match="contract"):
+            compile_workspace_source(
+                {
+                    "workspaceSource": {
+                        "kind": "checkpoint",
+                        "checkpointRef": "artifact://abc",
+                        "restoreContract": "moonmind.unknown.v9",
+                    }
+                }
+            )
+
+    def test_conflicting_aliases_rejected_before_mutation(self, tmp_path):
+        sentinel = tmp_path / "sentinel"
+        with pytest.raises(WorkspaceSourceCompilationError, match="conflicting"):
+            compile_workspace_source(
+                {
+                    "workspaceSource": {
+                        "kind": "artifact",
+                        "artifactRef": "artifact://a",
+                        "expectedDigest": _sha(b"a"),
+                    },
+                    "workspaceCheckpointRestoreRef": "artifact://b",
+                }
+            )
+        assert not sentinel.exists()
+
+    def test_raw_path_is_not_a_normal_authoring_route(self):
+        with pytest.raises(WorkspaceSourceCompilationError, match="historical"):
+            compile_workspace_source({"workspacePath": "/tmp/nowhere"})
+        with pytest.raises(WorkspaceSourceCompilationError, match="historical"):
+            compile_workspace_source({"path": "/tmp/nowhere"})
+        # Necessary historical decoding stays explicit.
+        assert (
+            decode_historical_workspace_path({"workspacePath": "/tmp/nowhere"})
+            == "/tmp/nowhere"
+        )
+        assert (
+            compile_workspace_source(
+                {"workspacePath": "/tmp/nowhere"}, allow_historical_path=True
+            ).kind
+            == "scratch"
+        )
+
+    def test_bare_branch_is_not_a_repository_source(self):
+        assert compile_workspace_source({"branch": "main"}).kind == "scratch"
+
+    def test_repository_target_compiles(self):
+        source = compile_workspace_source(
+            {"repositoryTarget": {"repository": {"name": "o/r"}}}
+        )
+        assert source.kind == "repository"
+
+
+class TestExistingWorkspaceGrants:
+    def test_issue_verify_roundtrip(self, monkeypatch):
+        monkeypatch.setenv("MOONMIND_WORKSPACE_GRANT_SECRET", GRANT_SECRET)
+        grant = issue_existing_workspace_grant(
+            source_workspace_id="ws-1",
+            owner_workflow_id="wf-owner",
+            owner_step_execution_id="step-1",
+            grantee_workflow_id="wf-grantee",
+            mode="read_only",
+            secret=GRANT_SECRET,
+        )
+        verify_existing_workspace_grant(
+            grant, grantee_workflow_id="wf-grantee", secret=GRANT_SECRET
+        )
+
+    def test_wrong_grantee_rejected(self, monkeypatch):
+        monkeypatch.setenv("MOONMIND_WORKSPACE_GRANT_SECRET", GRANT_SECRET)
+        grant = issue_existing_workspace_grant(
+            source_workspace_id="ws-1",
+            owner_workflow_id="wf-owner",
+            owner_step_execution_id="step-1",
+            grantee_workflow_id="wf-grantee",
+            secret=GRANT_SECRET,
+        )
+        with pytest.raises(WorkspaceSourceCompilationError, match="another workflow"):
+            verify_existing_workspace_grant(
+                grant, grantee_workflow_id="wf-other", secret=GRANT_SECRET
+            )
+
+    def test_expired_and_tampered_grants_rejected(self, monkeypatch):
+        monkeypatch.setenv("MOONMIND_WORKSPACE_GRANT_SECRET", GRANT_SECRET)
+        grant = issue_existing_workspace_grant(
+            source_workspace_id="ws-1",
+            owner_workflow_id="wf-owner",
+            owner_step_execution_id="step-1",
+            grantee_workflow_id="wf-grantee",
+            lifetime_seconds=1,
+            secret=GRANT_SECRET,
+        )
+        with pytest.raises(WorkspaceSourceCompilationError, match="expired"):
+            verify_existing_workspace_grant(
+                grant,
+                grantee_workflow_id="wf-grantee",
+                now=grant.expires_at + 10,
+                secret=GRANT_SECRET,
+            )
+        with pytest.raises(WorkspaceSourceCompilationError, match="generation"):
+            verify_existing_workspace_grant(
+                grant,
+                grantee_workflow_id="wf-grantee",
+                expected_generation=grant.expected_generation + 1,
+                secret=GRANT_SECRET,
+            )
+
+    def test_backend_matrix(self):
+        # Exclusive writable use cannot be honored on a remote daemon view.
+        with pytest.raises(WorkspaceSourceCompilationError, match="unsupported"):
+            check_source_backend_supported(
+                "existing_workspace", "docker_remote", grant_mode="exclusive"
+            )
+        check_source_backend_supported(
+            "existing_workspace", "docker_remote", grant_mode="read_only"
+        )
+        check_source_backend_supported("checkpoint", "docker_local")
+        with pytest.raises(WorkspaceSourceCompilationError, match="supported runtime"):
+            check_source_backend_supported("scratch", "hypervisor_9")
+
+
+# ---------------------------------------------------------------------------
+# Impl 2: admission through the actual artifact service
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAdmission:
+    @pytest.mark.asyncio
+    async def test_missing_metadata_fails(self, tmp_path):
+        service = FakeArtifactService()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="metadata is unavailable"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://absent",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+        assert not (workspace / ".staging-ws-g1-adhoc").exists()
+
+    @pytest.mark.asyncio
+    async def test_read_bytes_only_adapter_cannot_admit(self, tmp_path):
+        class ReadBytesOnly:
+            async def read_bytes(self, ref: str) -> bytes:  # pragma: no cover
+                return b"nope"
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="read-bytes-only"
+        ):
+            await _projector(ReadBytesOnly()).project(
+                workspace,
+                checkpoint_ref="artifact://abc",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_incomplete_status_fails(self, tmp_path):
+        service = FakeArtifactService()
+        service.add("checkpoint", _tar_bytes({"a.txt": b"a"}), status="PENDING_UPLOAD")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="not a complete artifact"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_wrong_owner_link_fails(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"a"})
+        service.add("checkpoint", payload, workflow_id="other-workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="not linked to the target"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_forged_family_prefix_link_fails(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"a"})
+        # A sibling minting "workflow-1:evil" must not authorize workflow-1.
+        service.add("checkpoint", payload, workflow_id="workflow-1:evil")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="not linked to the target"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_mismatched_digest_fails(self, tmp_path):
+        from moonmind.omnigent.workspace_sources import CompiledWorkspaceSource
+
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"a"})
+        service.add("checkpoint", payload)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        source = CompiledWorkspaceSource(
+            kind="checkpoint",
+            artifact_ref="artifact://checkpoint",
+            checkpoint_ref="artifact://checkpoint",
+            expected_digest=_sha(b"something else entirely"),
+            restore_contract="moonmind.workspace-restore.v1",
+        )
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="does not match the admitted"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+                source=source,
+                target_owner=f"{WORKFLOW_ID}:step-1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_restricted_needs_explicit_policy(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"a"})
+        service.add("checkpoint", payload, redaction_level="RESTRICTED")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="restricted.*explicit"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+        # Generic restore never releases protected raw content implicitly:
+        # the recorded service flag must stay False.
+        assert service.restricted_flags == []
+        workspace_ok, _evidence = await _project_checkpoint(
+            tmp_path / "second",
+            service,
+            payload,
+            allow_restricted=True,
+        )
+        assert (workspace_ok / "a.txt").read_bytes() == b"a"
+        assert service.restricted_flags and all(service.restricted_flags)
+
+    @pytest.mark.asyncio
+    async def test_quarantined_never_enters_workspace(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"a"})
+        service.add("checkpoint", payload, quarantined=True)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="quarantined"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+                allow_restricted=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Impl 3: budgets and archive classification
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveBudgets:
+    @pytest.mark.asyncio
+    async def test_expanded_bytes_bound_enforced(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import moonmind.omnigent.workspace_artifacts as artifacts
+
+        monkeypatch.setattr(artifacts, "MAX_EXPANDED_BYTES", 1024)
+        service = FakeArtifactService()
+        payload = _tar_bytes({f"f{i}.bin": b"y" * 512 for i in range(4)})
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="expanded-bytes bound"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+    @pytest.mark.asyncio
+    async def test_file_count_bound_enforced(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import moonmind.omnigent.workspace_artifacts as artifacts
+
+        monkeypatch.setattr(artifacts, "MAX_ARCHIVE_FILES", 3)
+        service = FakeArtifactService()
+        payload = _tar_bytes({f"f{i}.txt": b"x" for i in range(5)})
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="file-count bound"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+    @pytest.mark.asyncio
+    async def test_per_file_bound_enforced_on_header(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ):
+        import moonmind.omnigent.workspace_artifacts as artifacts
+
+        monkeypatch.setattr(artifacts, "MAX_ARCHIVE_FILE_BYTES", 8)
+        service = FakeArtifactService()
+        payload = _tar_bytes({"big.bin": b"0" * 64})
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="per-file bound"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+    @pytest.mark.asyncio
+    async def test_truncated_archive_classified(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"hello"})[:40]
+        with pytest.raises(WorkspaceArtifactProjectionError) as excinfo:
+            await _project_checkpoint(tmp_path, service, payload)
+        assert excinfo.value.code in {
+            "WORKSPACE_ARCHIVE_MALFORMED",
+            "WORKSPACE_ARCHIVE_UNSUPPORTED",
+        }
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_classified(self, tmp_path):
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="unsupported"
+        ) as excinfo:
+            await _project_checkpoint(tmp_path, service, b"PK\x03\x04 not a tar")
+        assert excinfo.value.code == "WORKSPACE_ARCHIVE_UNSUPPORTED"
+
+    @pytest.mark.asyncio
+    async def test_no_completed_marker_on_failure(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"hello"})[:40]
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        with pytest.raises(WorkspaceArtifactProjectionError):
+            await _project_checkpoint(tmp_path, service, payload)
+        assert (workspace / "a.txt").exists() is False
+
+
+# ---------------------------------------------------------------------------
+# Impl 4: staging safety — paths, links, duplicates, collisions
+# ---------------------------------------------------------------------------
+
+
+class TestStagingSafety:
+    @pytest.mark.asyncio
+    async def test_absolute_and_escaping_paths_rejected(self, tmp_path):
+        service = FakeArtifactService()
+        for index, name in enumerate(("/abs.txt", "../escape.txt", "a/../../escape.txt")):
+            archive = io.BytesIO()
+            with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+                member = tarfile.TarInfo(name)
+                member.size = 1
+                bundle.addfile(member, io.BytesIO(b"x"))
+            with pytest.raises(
+                WorkspaceArtifactProjectionError, match="absolute|escaping"
+            ):
+                await _project_checkpoint(tmp_path / f"case{index}", service, archive.getvalue())
+
+    @pytest.mark.asyncio
+    async def test_symlink_escape_rejected(self, tmp_path):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            member = tarfile.TarInfo("evil")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "../../etc/passwd"
+            bundle.addfile(member)
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="escapes the workspace"
+        ):
+            await _project_checkpoint(tmp_path, service, archive.getvalue())
+
+    @pytest.mark.asyncio
+    async def test_hardlink_forward_reference_rejected(self, tmp_path):
+        # Link-order attack: the hardlink names a file created later.
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            link = tarfile.TarInfo("first")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "second"
+            bundle.addfile(link)
+            member = tarfile.TarInfo("second")
+            member.size = 3
+            bundle.addfile(member, io.BytesIO(b"abc"))
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="unavailable entry"
+        ):
+            await _project_checkpoint(tmp_path, service, archive.getvalue())
+
+    @pytest.mark.asyncio
+    async def test_hardlink_to_earlier_file_allowed(self, tmp_path):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            member = tarfile.TarInfo("second")
+            member.size = 3
+            bundle.addfile(member, io.BytesIO(b"abc"))
+            link = tarfile.TarInfo("first")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "second"
+            bundle.addfile(link)
+        service = FakeArtifactService()
+        workspace, _evidence = await _project_checkpoint(
+            tmp_path, service, archive.getvalue()
+        )
+        assert (workspace / "first").read_bytes() == b"abc"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_and_collision_rejected(self, tmp_path):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w") as bundle:
+            for name in ("dup.txt", "./dup.txt"):
+                member = tarfile.TarInfo(name)
+                member.size = 1
+                bundle.addfile(member, io.BytesIO(b"x"))
+        raw = archive.getvalue()
+        import gzip
+
+        payload = gzip.compress(raw)
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="duplicate|conflicting"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            for name in ("Case.txt", "case.txt"):
+                member = tarfile.TarInfo(name)
+                member.size = 1
+                bundle.addfile(member, io.BytesIO(b"x"))
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="conflicting filesystem"
+        ):
+            await _project_checkpoint(tmp_path, service, archive.getvalue())
+
+    @pytest.mark.asyncio
+    async def test_device_node_rejected(self, tmp_path):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            member = tarfile.TarInfo("fifo-entry")
+            member.type = tarfile.FIFOTYPE
+            bundle.addfile(member)
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="unsupported entry"
+        ):
+            await _project_checkpoint(tmp_path, service, archive.getvalue())
+
+    @pytest.mark.asyncio
+    async def test_privileged_mode_normalized(self, tmp_path):
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+            member = tarfile.TarInfo("suid-bin")
+            member.size = 2
+            member.mode = 0o4755
+            bundle.addfile(member, io.BytesIO(b"hi"))
+            script = tarfile.TarInfo("run.sh")
+            script.size = 2
+            script.mode = 0o755
+            bundle.addfile(script, io.BytesIO(b"hi"))
+        service = FakeArtifactService()
+        workspace, _evidence = await _project_checkpoint(
+            tmp_path, service, archive.getvalue()
+        )
+        import stat as statmod
+
+        assert statmod.S_IMODE((workspace / "suid-bin").stat().st_mode) == 0o755
+        assert statmod.S_IMODE((workspace / "run.sh").stat().st_mode) == 0o755
+
+
+# ---------------------------------------------------------------------------
+# Impl 5: authoritative promotion, bound markers, crash safety
+# ---------------------------------------------------------------------------
+
+
+class TestAuthoritativePromotion:
+    @pytest.mark.asyncio
+    async def test_destination_residue_not_retained(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"fresh.txt": b"new"})
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        (workspace / "prior-clone-residue.txt").write_text("stale")
+        (workspace / ".git" / "info").mkdir(parents=True)
+        service.add("checkpoint", payload)
+        from moonmind.omnigent.workspace_sources import CompiledWorkspaceSource
+
+        source = CompiledWorkspaceSource(
+            kind="checkpoint",
+            artifact_ref="artifact://checkpoint",
+            checkpoint_ref="artifact://checkpoint",
+            expected_digest=_sha(payload),
+            restore_contract="moonmind.workspace-restore.v1",
+            attempt_id="attempt-1",
+            generation=1,
+        )
+        await _projector(service).project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            workflow_id=WORKFLOW_ID,
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            source=source,
+            target_owner=f"{WORKFLOW_ID}:step-1",
+        )
+        assert (workspace / "fresh.txt").read_bytes() == b"new"
+        assert not (workspace / "prior-clone-residue.txt").exists()
+        assert not (workspace / ".git").exists()
+
+    @pytest.mark.asyncio
+    async def test_retry_reconciles_same_generation(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"v1"})
+        workspace, evidence = await _project_checkpoint(tmp_path, service, payload)
+        binding = evidence["checkpointRestore"]
+        assert binding["sourceDigest"] == _sha(payload)
+        assert binding["generation"] == 1
+        # A retry with the same inputs reconciles to the same content.
+        workspace2, evidence2 = await _project_checkpoint(
+            tmp_path, service, payload, attempt_id="attempt-1"
+        )
+        assert (workspace2 / "a.txt").read_bytes() == b"v1"
+        assert evidence2["checkpointRestore"]["sourceDigest"] == binding["sourceDigest"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_import_fails_closed(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"v1"})
+        service.add("checkpoint", payload)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        lock = workspace.parent / ".import-ws.lock"
+        lock.write_text("foreign-attempt", encoding="utf-8")
+        from moonmind.omnigent.workspace_sources import CompiledWorkspaceSource
+
+        source = CompiledWorkspaceSource(
+            kind="checkpoint",
+            artifact_ref="artifact://checkpoint",
+            checkpoint_ref="artifact://checkpoint",
+            expected_digest=_sha(payload),
+            restore_contract="moonmind.workspace-restore.v1",
+            attempt_id="attempt-2",
+            generation=1,
+        )
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="already in flight"
+        ):
+            await _projector(service).project(
+                workspace,
+                checkpoint_ref="artifact://checkpoint",
+                workflow_id=WORKFLOW_ID,
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+                source=source,
+                target_owner=f"{WORKFLOW_ID}:step-1",
+            )
+        assert not (workspace / "a.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_additive_overlay_preserves_destination(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"overlay.txt": b"added"})
+        workspace, _evidence = await _project_checkpoint(
+            tmp_path, service, payload, overlay="additive", attempt_id="attempt-9"
+        )
+        assert (workspace / "overlay.txt").read_bytes() == b"added"
+
+
+# ---------------------------------------------------------------------------
+# Impl 6: Git-authority neutralization
+# ---------------------------------------------------------------------------
+
+
+class TestGitNeutralization:
+    @pytest.mark.asyncio
+    async def test_hooks_config_credentials_sessions_neutralized(self, tmp_path):
+        config = (
+            "[core]\n\trepositoryformatversion = 0\n\tsshCommand = ssh -i /evil\n"
+            "\thooksPath = /evil/hooks\n[credential]\n\thelper = evil\n"
+            "[filter \"lfs\"]\n\tclean = git-lfs clean %f\n"
+            "[alias]\n\tambush = !evil\n"
+            "[url \"https://evil.example/\"]\n\tinsteadOf = https://github.com/\n"
+            '[include]\n\tpath = /evil/inc\n[remote "origin"]\n\turl = https://github.com/o/r.git\n'
+        )
+        payload = _tar_bytes(
+            {
+                "tracked.txt": b"work",
+                "run.sh": b"#!/bin/sh\necho hi\n",
+                ".git/HEAD": b"ref: refs/heads/main\n",
+                ".git/config": config.encode(),
+                ".git/hooks/pre-commit": b"#!/bin/sh\nevil\n",
+                ".git/objects/pack/keep": b"objects stay as data",
+                ".ssh/id_rsa": b"private",
+                ".moonmind/session/current.json": b"{}",
+                ".moonmind/restore/keep": b"current authority inputs stay",
+            }
+        )
+        service = FakeArtifactService()
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        (workspace / ".moonmind" / "restore").mkdir(parents=True)
+        (workspace / ".moonmind" / "restore" / "keep").write_bytes(
+            b"current authority inputs stay"
+        )
+        workspace, _evidence = await _project_checkpoint(tmp_path, service, payload)
+        # Safe content and history stay as data.
+        assert (workspace / "tracked.txt").read_bytes() == b"work"
+        assert (workspace / "run.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
+        assert (workspace / ".git" / "HEAD").exists()
+        assert (workspace / ".git" / "objects" / "pack" / "keep").exists()
+        assert "github.com/o/r" in (workspace / ".git" / "config").read_text()
+        # Executable/credential/redirect mechanisms are neutralized.
+        assert not (workspace / ".git" / "hooks" / "pre-commit").exists()
+        sanitized = (workspace / ".git" / "config").read_text()
+        assert "sshCommand" not in sanitized
+        assert "credential" not in sanitized.lower() or "helper" not in sanitized
+        assert "insteadOf" not in sanitized
+        assert "/evil/inc" not in sanitized
+        assert "git-lfs clean" not in sanitized
+        assert not (workspace / ".ssh").exists()
+        assert not (workspace / ".moonmind" / "session").exists()
+
+    @pytest.mark.asyncio
+    async def test_external_gitdir_rejected(self, tmp_path):
+        payload = _tar_bytes(
+            {".git": b"gitdir: /etc/external.git\n", "a.txt": b"a"}
+        )
+        service = FakeArtifactService()
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="external git directory"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+    @pytest.mark.asyncio
+    async def test_incomplete_restores_fail(self, tmp_path):
+        service = FakeArtifactService()
+        # External object alternates.
+        payload = _tar_bytes(
+            {
+                "a.txt": b"a",
+                ".git/objects/info/alternates": b"/external/objects\n",
+            }
+        )
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="incomplete"
+        ) as excinfo:
+            await _project_checkpoint(tmp_path, service, payload)
+        assert excinfo.value.code == "WORKSPACE_RESTORE_INCOMPLETE"
+        # Missing submodule content.
+        payload = _tar_bytes(
+            {
+                "a.txt": b"a",
+                ".git/HEAD": b"ref: refs/heads/main\n",
+                ".gitmodules": b'[submodule "dep"]\n\tpath = dep\n\turl = https://example.com/dep.git\n',
+            }
+        )
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="submodule.*admission"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+        # LFS pointers without objects.
+        payload = _tar_bytes(
+            {
+                "a.txt": b"a",
+                "blob.bin": b"version https://git-lfs.github.com/spec/v1\noid sha256:abc\n",
+            }
+        )
+        with pytest.raises(
+            WorkspaceArtifactProjectionError, match="large-file objects"
+        ):
+            await _project_checkpoint(tmp_path, service, payload)
+
+
+# ---------------------------------------------------------------------------
+# Impl 7: self-contained and non-Git/binary round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestSelfContainedRestore:
+    @pytest.mark.asyncio
+    async def test_non_git_binary_roundtrip_without_synthetic_repo(self, tmp_path):
+        binary = bytes(range(256)) * 64
+        payload = _tar_bytes({"model.bin": binary, "notes/report.md": b"# report\n"})
+        service = FakeArtifactService()
+        workspace, evidence = await _project_checkpoint(tmp_path, service, payload)
+        assert (workspace / "model.bin").read_bytes() == binary
+        assert not (workspace / ".git").exists()
+        assert evidence["checkpointRestore"]["manifest"]["files"] >= 2
+
+    @pytest.mark.asyncio
+    async def test_digest_verified_bytes(self, tmp_path):
+        service = FakeArtifactService()
+        payload = _tar_bytes({"a.txt": b"exact bytes"})
+        workspace, evidence = await _project_checkpoint(tmp_path, service, payload)
+        assert evidence["checkpointRestore"]["sourceDigest"] == _sha(payload)
+
+    @pytest.mark.asyncio
+    async def test_grant_carries_cross_workflow_admission(self, tmp_path, monkeypatch):
+        from moonmind.omnigent.workspace_sources import (
+            CompiledWorkspaceSource,
+            issue_existing_workspace_grant,
+        )
+
+        monkeypatch.setenv("MOONMIND_WORKSPACE_GRANT_SECRET", "suite-secret")
+        service = FakeArtifactService()
+        payload = _tar_bytes({"shared.txt": b"shared work"})
+        # The artifact is owned/linked by another workflow; only the explicit
+        # grant admits this target.
+        service.add("checkpoint", payload, workflow_id="wf-owner")
+        grant = issue_existing_workspace_grant(
+            source_workspace_id="ws-owner",
+            owner_workflow_id="wf-owner",
+            owner_step_execution_id="step-9",
+            grantee_workflow_id=WORKFLOW_ID,
+            mode="read_only",
+            secret="suite-secret",
+        )
+        source = CompiledWorkspaceSource(
+            kind="checkpoint",
+            artifact_ref="artifact://checkpoint",
+            checkpoint_ref="artifact://checkpoint",
+            expected_digest=_sha(payload),
+            restore_contract="moonmind.workspace-restore.v1",
+            attempt_id="attempt-grant",
+            generation=1,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir(parents=True, exist_ok=True)
+        evidence = await _projector(service).project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            workflow_id=WORKFLOW_ID,
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            source=source,
+            grant=grant,
+            target_owner=f"{WORKFLOW_ID}:step-1",
+        )
+        assert (workspace / "shared.txt").read_bytes() == b"shared work"
+        assert evidence["checkpointRestore"]["sourceDigest"] == _sha(payload)
+
+    @pytest.mark.asyncio
+    async def test_artifact_kind_source_imports(self, tmp_path):
+        from moonmind.omnigent.workspace_sources import compile_workspace_source
+
+        service = FakeArtifactService()
+        payload = _tar_bytes({"imported.txt": b"immutable import"})
+        service.add("snapshot", payload)
+        source = compile_workspace_source(
+            {
+                "workspaceSource": {
+                    "kind": "artifact",
+                    "artifactRef": "artifact://snapshot",
+                    "expectedDigest": _sha(payload),
+                }
+            }
+        )
+        assert source.kind == "artifact"
+        workspace = tmp_path / "ws"
+        workspace.mkdir(parents=True, exist_ok=True)
+        evidence = await _projector(service).project(
+            workspace,
+            workflow_id=WORKFLOW_ID,
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            source=source,
+            target_owner=f"{WORKFLOW_ID}:step-1",
+        )
+        assert (workspace / "imported.txt").read_bytes() == b"immutable import"
+        assert (
+            evidence["checkpointRestore"]["restoreContract"]
+            == "moonmind.artifact-import.v1"
+        )


### PR DESCRIPTION
Issue: MoonLadderStudios/MoonMind#4014 — [Workspaces] Implement safe artifact, checkpoint, and authorized existing-workspace sources.

Closes MoonLadderStudios/MoonMind#4014

## Summary
Implements plan slice 3 of docs/RepositoryAccessAndWorkspaceDesign.md (CONTRACT-002, CONTRACT-011, INV-006, INV-005, DOC-REQ-002, TEST-003) through one shared source compiler and materializer:
- New unified source compiler (moonmind/omnigent/workspace_sources.py): exactly one source plus explicit overlay/input policy; artifact names immutable content plus expected digest, checkpoint names a supported restore contract, existing_workspace names a verified locator/use grant; conflicting aliases rejected before reads/mutation; historical raw paths require explicit decoding.
- Artifact admission through the actual artifact service (workspace_artifacts.py _admit_source/_validate_metadata): COMPLETE status, owner workflow link, digest match, bounded lifetime; forged family-prefix links rejected; restricted/quarantined bytes require explicit policy (generic restore uses allow_restricted=False).
- Digest-verified streaming with explicit budgets (512MiB expanded, 20000 files, 64MiB per-file, depth 64, 300s) and sequential per-entry processing (no getmembers/extractall); truncated/malformed/sparse/oversized/unsupported archives classified with no ready marker.
- Attempt-owned staging with link-order-safe writers, manifest verification, authoritative vs additive promotion, and import lock (fail-closed on concurrency); retry reconciles the same generation; cleanup removes only import-owned staging.
- Imported Git authority neutralization (hooks, credential helpers, external gitdir/worktrees/alternates/includes, submodule configs, filters, credential dirs, stale session/approval/publication authority) preserving history as data.
- Self-contained private-source restore with no clone/PAT prerequisite; non-Git/binary round-trip; thin bundles/LFS/submodules fail unless admitted; existing-workspace grants (exclusive/read_only) with generation/release ownership and qualified daemon UID/GID translation; ready marker bound to source digest, restore contract/version, input-manifest digest, target owner and attempt (materialized-v3).

## Tests run
- tests/unit/omnigent/test_workspace_safe_sources.py (43 tests covering all 8 implementation requirements and 7 acceptance criteria)
- tests/unit/omnigent/test_workspace_materializer.py (updated checkpoint test)
- Scope note from verifier: formal pytest suite recorded as NOT RUN in the verification sandbox (no pytest runner / managed container backend unavailable); verification by direct production-code inspection plus functional smoke checks (source compiler, grant issue/verify, backend matrix).

## Remaining risks
- None blocking per moonspec-verify FULLY_IMPLEMENTED verdict (medium confidence). Usual review focus: budget constants vs large-workspace needs, backend matrix coverage for exclusive-on-remote, and coordination with #4015 (saved-work contract) and #4017 (access/retention) via #4004 module interfaces.