### PR TITLE
[Omnigent concurrency] Complete incremental lease fencing and recovery without snapshot overwrites (MoonLadderStudios/MoonMind#3883)

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3922,10 +3922,27 @@ class ProviderProfileSlotLease(Base):
         Index("ix_provider_slot_leases_owner", "owner_id"),
         Index("ix_provider_slot_leases_profile", "profile_id"),
         Index("ix_provider_slot_leases_scope", "capacity_scope_ref"),
-        UniqueConstraint(
-            "runtime_id", "workflow_id", name="uq_provider_slot_lease_runtime_workflow"
+        # MoonLadderStudios/MoonMind#3883: the owning workflow is an identity
+        # only for a workflow-owned lease. One Activity-owned step legitimately
+        # binds several Provider Profiles from the same runtime, giving each
+        # lease its own owner ID while recording the same owning workflow purely
+        # so the manager can verify liveness, so uniqueness is partial.
+        Index(
+            "uq_provider_slot_lease_runtime_workflow",
+            "runtime_id",
+            "workflow_id",
+            unique=True,
+            postgresql_where=text("owner_is_workflow"),
+            sqlite_where=text("owner_is_workflow"),
         ),
-        UniqueConstraint("lease_id", name="uq_provider_slot_lease_lease_id"),
+        # MoonLadderStudios/MoonMind#3883: a lease ID is unique *within* the
+        # runtime that issued it. Pre-contract rows backfill ``lease_id`` from
+        # ``workflow_id``, and one workflow can legitimately hold a lease on
+        # two runtimes, so a global constraint would either fail the backfill
+        # or force a rewrite that breaks the identity existing holders quote.
+        UniqueConstraint(
+            "runtime_id", "lease_id", name="uq_provider_slot_lease_lease_id"
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/api_service/migrations/versions/369_provider_lease_incr_contract.py
+++ b/api_service/migrations/versions/369_provider_lease_incr_contract.py
@@ -7,8 +7,10 @@ Create Date: 2026-09-04
 Extends provider_profile_slot_leases with a versioned incremental contract
 (state, fencing, scope, credential generation, compatibility, plan ref,
 owner kind, heartbeat/release times, bounded metadata) plus indexes for
-lease/owner/profile/scope lookups. Existing rows remain readable; new
-non-null lease_ids are unique (nulls allowed for pre-contract rows).
+lease/owner/profile/scope lookups. Existing rows remain readable and keep the
+lease identity their holders already quote; non-null lease_ids are unique
+within a runtime (nulls allowed for pre-contract rows), and owning-workflow
+uniqueness narrows to workflow-owned rows.
 """
 
 from __future__ import annotations
@@ -77,22 +79,6 @@ def upgrade() -> None:
         "UPDATE provider_profile_slot_leases SET lease_id = workflow_id "
         "WHERE lease_id IS NULL"
     )
-    # Existing rows are unique per (runtime_id, workflow_id), so backfilling
-    # lease_id from workflow_id can collide across runtime families. A lease ID
-    # is the stable identity every fenced transition quotes, so the collision is
-    # broken deterministically instead of failing the migration or merging two
-    # leases into one: the oldest row keeps the exact identity its holder
-    # already quotes, and each later duplicate is disambiguated by its own row
-    # id (MoonLadderStudios/MoonMind#3883).
-    op.execute(
-        "UPDATE provider_profile_slot_leases "
-        "SET lease_id = lease_id || '#' || id "
-        "WHERE EXISTS ("
-        "  SELECT 1 FROM provider_profile_slot_leases AS other"
-        "  WHERE other.lease_id = provider_profile_slot_leases.lease_id"
-        "    AND other.id < provider_profile_slot_leases.id"
-        ")"
-    )
     with op.batch_alter_table("provider_profile_slot_leases") as batch:
         batch.alter_column("owner_kind", existing_type=sa.String(32), nullable=False)
         batch.alter_column(
@@ -103,18 +89,44 @@ def upgrade() -> None:
         batch.alter_column(
             "fencing_generation", existing_type=sa.Integer(), nullable=False
         )
+        # The owning workflow identifies a workflow-owned lease only. One
+        # Activity-owned step can bind several Provider Profiles from the same
+        # runtime, each with its own owner ID but the same owning workflow
+        # recorded for liveness verification, so the full-table constraint is
+        # replaced by a partial unique index over workflow-owned rows
+        # (MoonLadderStudios/MoonMind#3883).
+        batch.drop_constraint(
+            "uq_provider_slot_lease_runtime_workflow", type_="unique"
+        )
+        batch.create_index(
+            "uq_provider_slot_lease_runtime_workflow",
+            ["runtime_id", "workflow_id"],
+            unique=True,
+            postgresql_where=sa.text("owner_is_workflow"),
+            sqlite_where=sa.text("owner_is_workflow"),
+        )
         batch.create_index("ix_provider_slot_leases_lease", ["lease_id"])
         batch.create_index("ix_provider_slot_leases_owner", ["owner_id"])
         batch.create_index("ix_provider_slot_leases_profile", ["profile_id"])
         batch.create_index("ix_provider_slot_leases_scope", ["capacity_scope_ref"])
+        # Existing rows are unique per (runtime_id, workflow_id), so
+        # backfilling lease_id from workflow_id can repeat one ID across
+        # runtime families. Uniqueness is therefore runtime-scoped: rewriting
+        # the later row's lease_id would break the identity its holder already
+        # quotes on release, leaving that row permanently active
+        # (MoonLadderStudios/MoonMind#3883).
         batch.create_unique_constraint(
-            "uq_provider_slot_lease_lease_id", ["lease_id"]
+            "uq_provider_slot_lease_lease_id", ["runtime_id", "lease_id"]
         )
 
 
 def downgrade() -> None:
     with op.batch_alter_table("provider_profile_slot_leases") as batch:
         batch.drop_constraint("uq_provider_slot_lease_lease_id", type_="unique")
+        batch.drop_index("uq_provider_slot_lease_runtime_workflow")
+        batch.create_unique_constraint(
+            "uq_provider_slot_lease_runtime_workflow", ["runtime_id", "workflow_id"]
+        )
         batch.drop_index("ix_provider_slot_leases_scope")
         batch.drop_index("ix_provider_slot_leases_profile")
         batch.drop_index("ix_provider_slot_leases_owner")

--- a/api_service/migrations/versions/369_provider_lease_incr_contract.py
+++ b/api_service/migrations/versions/369_provider_lease_incr_contract.py
@@ -77,6 +77,22 @@ def upgrade() -> None:
         "UPDATE provider_profile_slot_leases SET lease_id = workflow_id "
         "WHERE lease_id IS NULL"
     )
+    # Existing rows are unique per (runtime_id, workflow_id), so backfilling
+    # lease_id from workflow_id can collide across runtime families. A lease ID
+    # is the stable identity every fenced transition quotes, so the collision is
+    # broken deterministically instead of failing the migration or merging two
+    # leases into one: the oldest row keeps the exact identity its holder
+    # already quotes, and each later duplicate is disambiguated by its own row
+    # id (MoonLadderStudios/MoonMind#3883).
+    op.execute(
+        "UPDATE provider_profile_slot_leases "
+        "SET lease_id = lease_id || '#' || id "
+        "WHERE EXISTS ("
+        "  SELECT 1 FROM provider_profile_slot_leases AS other"
+        "  WHERE other.lease_id = provider_profile_slot_leases.lease_id"
+        "    AND other.id < provider_profile_slot_leases.id"
+        ")"
+    )
     with op.batch_alter_table("provider_profile_slot_leases") as batch:
         batch.alter_column("owner_kind", existing_type=sa.String(32), nullable=False)
         batch.alter_column(

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1381,6 +1381,81 @@ is dropped instead of freeing the replacement holder. A release that carries no
 generation is still honoured, so callers whose handles predate fenced grants keep
 working.
 
+#### The durable lease ledger owns whether a slot is spent
+
+The `provider_profile_slot_leases` row — not an in-memory reservation, a log
+line, or an Activity exception — decides whether a Provider Profile slot is
+available. `provider_profile.sync_slot_leases` is its single persistence owner
+and the only place a state transition happens.
+
+**Lease states.** `held` (the owner may consume the credential),
+`cleanup_requested` (the slot is still spent; the owner's resources are owed
+cleanup), and `released` (a tombstone: the slot is free, the row survives as
+fencing evidence until `purge_released` reaps it past the redelivery horizon).
+A state outside this set is *not* free capacity: recovery reports it as
+unreconciled evidence and refuses to admit new capacity until it is resolved.
+
+**One typed identity per row.** A grant persists the exact lease ID separately
+from the workflow, step, attempt and owner kind, plus the purpose, the
+compatibility class (the ledger mode the lease coexists under), the immutable
+plan and evidence identity, and the credential and capacity-scope generations
+it was admitted against. Recovery restores the same identity rather than
+re-deriving a narrower view of it. Columns that are null on a pre-contract row
+stay explicitly historical; they are never backfilled into current authority.
+
+**Ordering contract.** Every grant path follows the same order:
+
+1. reserve in memory and mark the grant handoff pending;
+2. write the row (`grant`), which is grant-or-get: a retry that matches the
+   complete immutable identity *and* the acquired generations returns the
+   committed row, conflicting reuse of a live identity fails without creating
+   another unit, and a lower generation is rejected as a fencing regression;
+3. only then signal or return the grant.
+
+A reservation whose write has not resolved is never reported as `already_held`.
+A concurrent identical caller waits and joins the committed result — or observes
+the rolled-back state — instead of inheriting a pending reservation.
+
+**Ambiguous write outcomes are reconciled, not guessed at.** A database write
+can time out *after* it commits. The manager re-reads the stable lease identity
+(`describe`) and treats the grant as durable only when the ledger holds the same
+profile, state and generation. It never deletes a possibly live row and never
+issues a second grant on that evidence.
+
+**Releases keep capacity unavailable until they resolve.** `release_one` is
+fenced and returns an explicit outcome — `released`, `already_released`,
+`stale`, `conflict` or `retryable`. Only the first two let the in-memory ledger
+free the slot. A failed Activity, a structured error, or a stale fence leaves the
+slot spent and records the owner for a bounded retry against the same lease
+identity. A logged warning never announces reuse.
+
+**Expiry and terminal ownership request cleanup.** Lease expiry is not evidence
+that the holder stopped: it transitions the row to `cleanup_requested` and
+leaves the slot spent, so the resource owner can reclaim what the run held
+(MoonLadderStudios/MoonMind#1089) without a second credential consumer starting
+while the first may still be running. The slot is released only when workflow
+status verification proves the owner terminal, and that release tombstones the
+row with `cleanupRequested` so the cleanup is still owed. Both paths cost one
+fenced row transition per lease.
+
+**Bounded cost, detected disagreement.** An ordinary grant or release touches
+exactly one row, independent of how many leases the runtime holds. Recovery and
+reconciliation may read the runtime's rows once; nothing rewrites every lease on
+each mutation. The manager keeps a direct reverse index so removing a lease is
+O(1), and duplicate or contradictory identities — one lease on two profiles, one
+owner on two leases, two live rows claiming one workflow or owner — are recorded
+as reconciliation evidence on `get_state` rather than silently skipped.
+
+**The retained snapshot rewrite is fenced durably.** `action=save` still exists
+for histories recorded before the incremental contract, but it carries the
+writer's own fencing high-water mark and preserves every row fenced above it. A
+patch marker in one workflow history cannot fence a stale database writer; a
+durable generation comparison can.
+
+**No credential material reaches a lease row.** Caller metadata passes through a
+fixed allowlist, and the only stored evidence is a compact non-secret identity
+digest plus bounded cleanup/release reasons.
+
 #### Validation identity
 
 A `single_flight_validation` lease is granted against a **versioned evidence
@@ -1420,6 +1495,14 @@ themselves:
 - the per-purpose scope exemption, so a pre-marker manager still gates credential
   repair and revocation on shared-scope availability;
 - withdrawing a pending request when its owner releases.
+
+The durable lease transition contract above has its own workflow marker,
+`provider-profile-manager-lease-transition-contract-v1`. A history recorded
+before it keeps its exact recorded commands: the pre-contract release order, the
+runtime-wide snapshot rewrite on expiry and reclamation, and recovery that does
+not fail closed on unreconciled state. New executions record the marker and use
+the per-lease transitions, the pending-grant handoff, the ambiguous-outcome
+reconciliation and the fail-closed recovery described above.
 
 Periodic released-lease tombstone cleanup has its own workflow marker,
 `provider-profile-manager-lease-tombstone-purge-v1`. Both DB lease persistence and

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1403,6 +1403,22 @@ it was admitted against. Recovery restores the same identity rather than
 re-deriving a narrower view of it. Columns that are null on a pre-contract row
 stay explicitly historical; they are never backfilled into current authority.
 
+**Identity is runtime-scoped.** A lease ID is unique *within* the runtime that
+issued it. Pre-contract rows backfill `lease_id` from `workflow_id`, and one
+workflow may legitimately hold a lease on two runtimes, so every transition
+resolves its row inside its own runtime. Rewriting a colliding lease ID to make
+it globally unique would break the handle its holder already quotes on release:
+that release would resolve the other runtime's row, be refused as a profile
+conflict, and leave the rewritten row permanently active.
+
+The owning workflow is an identity for a **workflow-owned** lease only, and a
+partial unique index enforces it there. One Activity-owned step legitimately
+binds several Provider Profiles from the same runtime — each lease gets its own
+owner ID, and the owning workflow is recorded on all of them purely so the
+manager can verify liveness. Recovery therefore checks lease and owner identity,
+which nothing in the schema constrains, and never treats a repeated owning
+workflow as a durable conflict.
+
 **Ordering contract.** Every grant path follows the same order:
 
 1. reserve in memory and mark the grant handoff pending;
@@ -1418,9 +1434,21 @@ the rolled-back state — instead of inheriting a pending reservation.
 
 **Ambiguous write outcomes are reconciled, not guessed at.** A database write
 can time out *after* it commits. The manager re-reads the stable lease identity
-(`describe`) and treats the grant as durable only when the ledger holds the same
-profile, state and generation. It never deletes a possibly live row and never
-issues a second grant on that evidence.
+(`describe`) and treats the grant as durable only when the row is `held` *and*
+every immutable field of the attempted grant agrees: profile, owner, owner kind,
+purpose, compatibility class, capacity scope, execution plan, evidence identity,
+and the scope, credential and fencing generations. A migrated or conflicting row
+can share the lease ID, state and generation — especially generation 1 — while
+describing authority the ledger never granted to this caller, so a partial match
+leaves capacity blocked. It never deletes a possibly live row and never issues a
+second grant on that evidence.
+
+**A reservation the ledger never accepted is retried, not announced.** The
+signal drain keeps its in-memory reservation when a grant fails, precisely so
+persistence can be retried. The next pass therefore re-drives the grant before
+it announces the slot: taking the re-signal branch — which deliberately writes
+nothing — would hand a signal-based `AgentRun` a slot with no durable row, and a
+manager restart could then grant the same capacity again.
 
 **Releases keep capacity unavailable until they resolve.** `release_one` is
 fenced and returns an explicit outcome — `released`, `already_released`,
@@ -1438,19 +1466,36 @@ status verification proves the owner terminal, and that release tombstones the
 row with `cleanupRequested` so the cleanup is still owed. Both paths cost one
 fenced row transition per lease.
 
+The durable owner of a cleanup request is that terminal-ownership release, and
+the wait for it is deliberately unbounded — freeing the slot earlier would
+authorize a second credential consumer. The *escalation* is bounded instead: a
+cleanup request that outlives its lease duration by
+`_LEASE_CLEANUP_ESCALATION_SECONDS` with the holder still live is published on
+`get_state` as `cleanup_unresolved` reconciliation evidence, and a holder whose
+liveness can never be verified — an Activity-owned lease with no owning workflow
+— as `cleanup_owner_unverifiable`. The slot stays spent either way, but it stops
+looking handled, so a permanently stuck capacity-one Profile is operator-visible
+rather than silent.
+
 **Bounded cost, detected disagreement.** An ordinary grant or release touches
 exactly one row, independent of how many leases the runtime holds. Recovery and
 reconciliation may read the runtime's rows once; nothing rewrites every lease on
 each mutation. The manager keeps a direct reverse index so removing a lease is
 O(1), and duplicate or contradictory identities — one lease on two profiles, one
-owner on two leases, two live rows claiming one workflow or owner — are recorded
-as reconciliation evidence on `get_state` rather than silently skipped.
+owner on two leases, two live rows claiming one owner — are recorded as
+reconciliation evidence on `get_state` rather than silently skipped.
 
 **The retained snapshot rewrite is fenced durably.** `action=save` still exists
 for histories recorded before the incremental contract, but it carries the
 writer's own fencing high-water mark and preserves every row fenced above it. A
 patch marker in one workflow history cannot fence a stale database writer; a
 durable generation comparison can.
+
+An Activity payload recorded *before* this contract carries no writer generation
+at all. That is a zero high-water mark, not permission to delete the runtime: a
+timed-out or retried legacy `save` that lands after a transition-contract
+manager granted rows replaces only the rows its own snapshot re-states, and
+preserves every other fenced row untouched.
 
 No path in a history recorded under the transition contract issues `save`.
 Grant, release, expiry and terminal reclamation are single-row transitions, and
@@ -1510,6 +1555,15 @@ runtime-wide snapshot rewrite on expiry and reclamation, and recovery that does
 not fail closed on unreconciled state. New executions record the marker and use
 the per-lease transitions, the pending-grant handoff, the ambiguous-outcome
 reconciliation and the fail-closed recovery described above.
+
+A rollover under this marker carries the obligations attached to the lease
+snapshot as well as the snapshot itself: unresolved releases, requested
+cleanups, and reservations whose grant never committed. A continued run
+deliberately does not reload the durable ledger, so an obligation left only in
+memory would disappear at the history rollover — the successor would advertise
+an `already_held` lease whose row is already released, strand capacity behind a
+release nobody retries, or announce a reservation the ledger never accepted. A
+pre-contract rollover payload is unchanged.
 
 Periodic released-lease tombstone cleanup has its own workflow marker,
 `provider-profile-manager-lease-tombstone-purge-v1`. Both DB lease persistence and

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1452,6 +1452,13 @@ writer's own fencing high-water mark and preserves every row fenced above it. A
 patch marker in one workflow history cannot fence a stale database writer; a
 durable generation comparison can.
 
+No path in a history recorded under the transition contract issues `save`.
+Grant, release, expiry and terminal reclamation are single-row transitions, and
+re-announcing a slot the manager already holds — the drain branch an
+`AgentRun` reaches when its slot wait times out and it re-sends `request_slot`
+— writes nothing at all, because the row committed before that lease became
+visible is already the authority.
+
 **No credential material reaches a lease row.** Caller metadata passes through a
 fixed allowlist, and the only stored evidence is a compact non-secret identity
 digest plus bounded cleanup/release reasons.

--- a/moonmind/provider_profiles/lease_client.py
+++ b/moonmind/provider_profiles/lease_client.py
@@ -84,6 +84,69 @@ _MAX_MANAGER_UPDATE_ATTEMPTS = 3
 CREDENTIALLESS_CREDENTIAL_SOURCES = frozenset({"none"})
 
 
+class DurableLeaseState(str, Enum):
+    """The authoritative lifecycle state of one persisted lease row.
+
+    MoonLadderStudios/MoonMind#3883: the durable row — not an in-memory
+    reservation, a log line, or an activity exception — decides whether a
+    Provider Profile slot is spent. Every transition names one of these states
+    so the manager and the persistence Activity never disagree about whether
+    capacity is reusable.
+    """
+
+    #: The owner holds the slot and may consume the credential.
+    HELD = "held"
+    #: The owner's slot is still spent, but its resources are owed cleanup.
+    #: MoonLadderStudios/MoonMind#1089: expiry and terminal owner state request
+    #: cleanup rather than freeing a credential consumer that may still run.
+    CLEANUP_REQUESTED = "cleanup_requested"
+    #: A tombstone. The slot is free; the row survives as fencing evidence.
+    RELEASED = "released"
+
+
+#: States in which a row still spends a Provider Profile slot. A state outside
+#: :class:`DurableLeaseState` is *not* treated as free: it is unreconciled
+#: evidence that blocks new admission until an operator resolves it.
+ACTIVE_DURABLE_LEASE_STATES = frozenset(
+    {DurableLeaseState.HELD.value, DurableLeaseState.CLEANUP_REQUESTED.value}
+)
+
+#: Every state the durable contract can express.
+KNOWN_DURABLE_LEASE_STATES = frozenset(state.value for state in DurableLeaseState)
+
+
+class LeaseTransitionOutcome(str, Enum):
+    """The explicit result of one durable lease state transition.
+
+    A transition never reports success because a warning was logged. Each
+    outcome tells the caller exactly what the ledger now says, and only
+    ``RELEASED`` and ``ALREADY_RELEASED`` make capacity reusable.
+    """
+
+    #: This call moved a live row to the released tombstone.
+    RELEASED = "released"
+    #: The row was already released (or already absent). Capacity is free.
+    ALREADY_RELEASED = "already_released"
+    #: The row names a newer grant generation. This caller no longer owns it.
+    STALE = "stale"
+    #: The row names a different immutable identity. Fail closed.
+    CONFLICT = "conflict"
+    #: The ledger did not answer. Capacity stays unavailable and the caller
+    #: retries with the same stable lease identity.
+    RETRYABLE = "retryable"
+    #: Cleanup was requested; the slot stays spent until cleanup completes.
+    CLEANUP_REQUESTED = "cleanup_requested"
+
+
+#: Outcomes after which in-memory accounting may free the slot.
+RELEASING_LEASE_OUTCOMES = frozenset(
+    {
+        LeaseTransitionOutcome.RELEASED.value,
+        LeaseTransitionOutcome.ALREADY_RELEASED.value,
+    }
+)
+
+
 def credential_source_is_credentialless(credential_source: Any) -> bool:
     """Return whether a profile owns no shared mutable credential state."""
 

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -4255,27 +4255,41 @@ class TemporalArtifactActivities:
         runtime_id: str,
         leases: list[dict[str, Any]] | None = None,
         action: str = "load",
+        writer_generation: int | None = None,
     ) -> dict[str, Any]:
-        """Sync slot leases with the database for crash recovery.
+        """Own every durable transition of the Provider Profile lease ledger.
 
-        **load action**: Returns all persisted leases for the given runtime_id.
-            Returns {"leases": [{"workflow_id": ..., "profile_id": ..., "granted_at": ...}, ...]}
+        MoonLadderStudios/MoonMind#3883: this Activity is the single
+        persistence owner for the typed lease contract. A row's ``lease_state``
+        and ``fencing_generation`` — not an in-memory reservation, a log line
+        or a swallowed exception — decide whether a slot is spent.
 
-        **save action**: Snapshot rewrite — replaces every row for the runtime
-            with the provided leases (list of {workflow_id, profile_id}).
-            Returns {"saved": count}
+        **load**: return every row that still spends a slot (``held`` and
+            ``cleanup_requested``), the runtime's fencing high-water mark, rows
+            whose state the contract does not know (``unreconciled``), and
+            identity disagreements between live rows (``conflicts``). Unknown
+            state and index disagreement are reported, never silently dropped.
 
-        **grant action**: Durably records one lease row without touching any
-            other row (MoonLadderStudios/MoonMind#3878). This is the
-            incremental grant path; a runtime-wide rewrite per grant makes
-            durable cost scale with active concurrency.
-            Returns {"granted": True, "duplicate": bool}
+        **describe**: return the authoritative row for one lease ID. This is
+            how an ambiguous write outcome (a timeout that may have committed)
+            is reconciled without deleting a possibly live grant.
 
-        **remove action**: Removes a specific lease by workflow_id.
-            Returns {"removed": True}
+        **grant**: grant-or-get for one row. A retry that matches the complete
+            immutable identity and the acquired admission generations returns
+            the committed row; conflicting reuse of a live identity fails
+            without creating another unit of authority.
 
-        This enables the ProviderProfileManager to recover lease state after a crash,
-        rather than starting with empty state and orphaning all running workflows.
+        **release_one** / **request_cleanup** / **heartbeat**: fenced state
+            transitions that return an explicit
+            :class:`~moonmind.provider_profiles.lease_client.LeaseTransitionOutcome`.
+
+        **save**: the pre-incremental runtime-wide snapshot rewrite, retained
+            only for histories recorded before the incremental contract. It
+            carries a writer generation so a retained old snapshot writer
+            cannot delete leases a newer writer granted.
+
+        **purge_released**: reap release tombstones past the redelivery
+            horizon so the table stays bounded.
         """
         from datetime import datetime, timezone
 
@@ -4283,6 +4297,12 @@ class TemporalArtifactActivities:
 
         from api_service.db.models import ProviderProfileSlotLease
         from api_service.db.base import get_async_session_context
+        from moonmind.provider_profiles.lease_client import (
+            ACTIVE_DURABLE_LEASE_STATES,
+            KNOWN_DURABLE_LEASE_STATES,
+            DurableLeaseState,
+            LeaseTransitionOutcome,
+        )
 
         def _parse_lease_time(value: Any) -> Any:
             if not value:
@@ -4292,20 +4312,133 @@ class TemporalArtifactActivities:
             except (ValueError, TypeError):
                 return None
 
+        def _int_or_zero(value: Any) -> int:
+            try:
+                return int(value or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        def _row_state(row: Any) -> str:
+            # A pre-contract row has no state column value; it predates the
+            # tombstone contract and is therefore still held.
+            return str(getattr(row, "lease_state", None) or DurableLeaseState.HELD.value)
+
+        def _row_identity(row: Any) -> dict[str, Any]:
+            """The compact, non-secret identity one lease row asserts."""
+
+            metadata = getattr(row, "safe_metadata_json", None)
+            return {
+                "lease_id": row.lease_id,
+                "workflow_id": row.workflow_id,
+                "profile_id": row.profile_id,
+                "owner_id": row.owner_id,
+                "owner_kind": getattr(row, "owner_kind", None),
+                "purpose": row.purpose,
+                "compatibility_class": getattr(row, "compatibility_class", None),
+                "capacity_scope_ref": getattr(row, "capacity_scope_ref", None),
+                "scope_generation": getattr(row, "scope_generation", None),
+                "credential_generation": getattr(row, "credential_generation", None),
+                "execution_plan_ref": getattr(row, "execution_plan_ref", None),
+                "lease_state": _row_state(row),
+                "fencing_generation": _int_or_zero(
+                    getattr(row, "fencing_generation", None)
+                ),
+                "evidence_identity": (
+                    str(metadata.get("evidenceIdentity") or "")
+                    if isinstance(metadata, dict)
+                    else ""
+                ),
+            }
+
+        async def _lease_row(session: Any, lease_id: str) -> Any:
+            return (
+                await session.execute(
+                    select(ProviderProfileSlotLease).where(
+                        ProviderProfileSlotLease.lease_id == lease_id
+                    )
+                )
+            ).scalars().first()
+
+        def _admission_generation_conflict(
+            row: Any, payload: dict[str, Any]
+        ) -> bool:
+            """Whether a retry names different admission authority than the row.
+
+            The scope and credential generations, the capacity scope and the
+            execution plan are the admission authority a grant was made
+            against. A retry that quotes different ones is not the same grant,
+            so it may not inherit the committed row.
+            """
+
+            for column, keys in (
+                ("capacity_scope_ref", ("capacity_scope_ref", "capacityScopeRef")),
+                ("execution_plan_ref", ("executionPlanRef", "execution_plan_ref")),
+            ):
+                incoming = ""
+                for key in keys:
+                    if payload.get(key):
+                        incoming = str(payload[key])
+                        break
+                existing = str(getattr(row, column, "") or "")
+                if incoming and existing and incoming != existing:
+                    return True
+            for column, keys in (
+                ("scope_generation", ("scope_generation", "scopeGeneration")),
+                (
+                    "credential_generation",
+                    ("credential_generation", "credentialGeneration"),
+                ),
+            ):
+                incoming_raw = None
+                for key in keys:
+                    if payload.get(key) is not None:
+                        incoming_raw = payload[key]
+                        break
+                existing_raw = getattr(row, column, None)
+                if incoming_raw is None or existing_raw is None:
+                    continue
+                if _int_or_zero(incoming_raw) != _int_or_zero(existing_raw):
+                    return True
+            return False
+
+        def _transition_identity_conflict(row: Any, payload: dict[str, Any]) -> bool:
+            """Whether a transition names a different lease than the row."""
+
+            for column, keys in (
+                ("runtime_id", ("runtime_id",)),
+                ("profile_id", ("profile_id", "profileId")),
+                ("owner_id", ("owner_id", "ownerId")),
+            ):
+                incoming = ""
+                for key in keys:
+                    if payload.get(key):
+                        incoming = str(payload[key])
+                        break
+                if not incoming:
+                    continue
+                existing = str(getattr(row, column, "") or "")
+                if existing and existing != incoming:
+                    return True
+            return False
+
         async with get_async_session_context() as session:
             if action == "load":
                 from sqlalchemy import func as _func
                 from sqlalchemy import or_ as _or_
 
+                # Indexed query on the runtime, narrowed to the states that
+                # still spend a slot. A released row is never resurrected and
+                # a pre-contract NULL state is still held.
+                active_states = sorted(ACTIVE_DURABLE_LEASE_STATES)
                 stmt = select(ProviderProfileSlotLease).where(
                     ProviderProfileSlotLease.runtime_id == runtime_id,
                     _or_(
-                        ProviderProfileSlotLease.lease_state == "held",
+                        ProviderProfileSlotLease.lease_state.in_(active_states),
                         ProviderProfileSlotLease.lease_state.is_(None),
                     ),
                 )
                 result = await session.execute(stmt)
-                rows = result.scalars().all()
+                rows: list[Any] = list(result.scalars().all())
                 # The fencing high-water mark survives released leases:
                 # tombstoned rows keep their generation so a fresh manager
                 # that finds no live rows still resumes above every number
@@ -4317,6 +4450,53 @@ class TemporalArtifactActivities:
                         ).where(ProviderProfileSlotLease.runtime_id == runtime_id)
                     )
                 ).scalar() or 0
+
+                # A state outside the contract is not free capacity and not a
+                # row to drop: it is reconciliation work that blocks admission.
+                unreconciled = [
+                    _row_identity(row)
+                    for row in (
+                        await session.execute(
+                            select(ProviderProfileSlotLease).where(
+                                ProviderProfileSlotLease.runtime_id == runtime_id,
+                                ProviderProfileSlotLease.lease_state.is_not(None),
+                                ProviderProfileSlotLease.lease_state.not_in(
+                                    sorted(KNOWN_DURABLE_LEASE_STATES)
+                                ),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                ]
+
+                # Index disagreement is detected, never silently merged: two
+                # live rows that claim the same workflow or the same owner are
+                # two authorities for one identity.
+                conflicts: list[dict[str, Any]] = []
+                for field_name in ("workflow_id", "owner_id"):
+                    seen: dict[str, Any] = {}
+                    for row in rows:
+                        key = str(getattr(row, field_name, "") or "")
+                        if not key:
+                            continue
+                        previous = seen.get(key)
+                        if previous is None:
+                            seen[key] = row
+                            continue
+                        if str(previous.lease_id or "") == str(row.lease_id or ""):
+                            continue
+                        conflicts.append(
+                            {
+                                "field": field_name,
+                                "value": key,
+                                "leases": [
+                                    _row_identity(previous),
+                                    _row_identity(row),
+                                ],
+                            }
+                        )
+
                 leases_data = [
                     {
                         "workflow_id": row.workflow_id,
@@ -4326,6 +4506,7 @@ class TemporalArtifactActivities:
                         else None,
                         "leaseId": row.lease_id or row.workflow_id,
                         "ownerId": row.owner_id or row.workflow_id,
+                        "ownerKind": getattr(row, "owner_kind", None),
                         "purpose": row.purpose,
                         "ownerIsWorkflow": row.owner_is_workflow,
                         "stepExecutionId": row.step_execution_id,
@@ -4336,6 +4517,17 @@ class TemporalArtifactActivities:
                         # row returns it with the rest of the lease identity.
                         "executionPlanRef": row.execution_plan_ref,
                         "credentialGeneration": row.credential_generation,
+                        # MoonLadderStudios/MoonMind#3883: the compatibility
+                        # class and the acquired scope generation are part of
+                        # the same identity. Restoring a narrower legacy-shaped
+                        # view would rebuild authority the ledger never granted.
+                        "compatibilityClass": getattr(row, "compatibility_class", None),
+                        "capacityScopeRef": getattr(row, "capacity_scope_ref", None),
+                        "scopeGeneration": getattr(row, "scope_generation", None),
+                        "leaseState": _row_state(row),
+                        "heartbeatAt": row.heartbeat_at.isoformat()
+                        if getattr(row, "heartbeat_at", None)
+                        else None,
                         # MoonLadderStudios/MoonMind#3879: the grant generation
                         # and the compact evidence identity are part of the
                         # lease contract, so a manager restart restores the
@@ -4352,18 +4544,59 @@ class TemporalArtifactActivities:
                 return {
                     "leases": leases_data,
                     "max_fencing_generation": int(max_generation or 0),
+                    "unreconciled": unreconciled,
+                    "conflicts": conflicts,
                 }
 
+            elif action == "describe":
+                payload = (leases or [{}])[0]
+                lease_id = str(
+                    payload.get("lease_id") or payload.get("leaseId") or ""
+                ).strip()
+                if not lease_id:
+                    return {"error": "describe requires lease_id"}
+                row = await _lease_row(session, lease_id)
+                if row is None:
+                    return {"found": False, "lease_id": lease_id}
+                return {"found": True, "lease": _row_identity(row)}
+
             elif action == "save":
-                # Snapshot semantics: delete ALL rows for this runtime, then
+                # Snapshot semantics: delete the rows for this runtime, then
                 # bulk-insert only the leases currently held in memory.
                 # This prevents stale rows from accumulating when leases
                 # disappear from memory (eviction, verify, release).
-                await session.execute(
-                    delete(ProviderProfileSlotLease).where(
-                        ProviderProfileSlotLease.runtime_id == runtime_id,
-                    )
+                #
+                # MoonLadderStudios/MoonMind#3883: a retained pre-incremental
+                # writer must not delete authority a newer writer granted. The
+                # barrier is durable row state, not a patch marker in one
+                # workflow history: rows fenced above the snapshot writer's own
+                # high-water generation are preserved untouched.
+                barrier = _int_or_zero(writer_generation)
+                delete_stmt = delete(ProviderProfileSlotLease).where(
+                    ProviderProfileSlotLease.runtime_id == runtime_id,
                 )
+                preserved = 0
+                if barrier > 0:
+                    from sqlalchemy import func as _save_func
+
+                    preserved = int(
+                        (
+                            await session.execute(
+                                select(_save_func.count())
+                                .select_from(ProviderProfileSlotLease)
+                                .where(
+                                    ProviderProfileSlotLease.runtime_id == runtime_id,
+                                    ProviderProfileSlotLease.fencing_generation
+                                    > barrier,
+                                )
+                            )
+                        ).scalar()
+                        or 0
+                    )
+                    delete_stmt = delete_stmt.where(
+                        ProviderProfileSlotLease.fencing_generation <= barrier
+                    )
+                await session.execute(delete_stmt)
                 saved_count = 0
                 for lease in leases or []:
                     workflow_id = lease.get("workflow_id")
@@ -4418,6 +4651,8 @@ class TemporalArtifactActivities:
                     session.add(new_lease)
                     saved_count += 1
                 await session.commit()
+                if barrier > 0:
+                    return {"saved": saved_count, "preserved": preserved}
                 return {"saved": saved_count}
 
             elif action == "remove":
@@ -4434,19 +4669,25 @@ class TemporalArtifactActivities:
                 return {"removed": True}
 
             elif action == "grant":
-                from sqlalchemy import select as _select
-
                 payload = (leases or [{}])[0]
                 lease_id = str(payload.get("lease_id") or payload.get("leaseId") or "").strip()
                 if not lease_id:
                     return {"error": "grant requires lease_id"}
-                existing = (
-                    await session.execute(
-                        _select(ProviderProfileSlotLease).where(
-                            ProviderProfileSlotLease.lease_id == lease_id
-                        )
-                    )
-                ).scalars().first()
+                incoming_purpose = str(
+                    payload.get("purpose") or "execution_direct"
+                )
+                incoming_compatibility = str(
+                    payload.get("compatibility_class")
+                    or payload.get("compatibilityClass")
+                    or incoming_purpose
+                )
+                incoming_metadata = payload.get("safe_metadata")
+                incoming_identity = (
+                    str(incoming_metadata.get("evidenceIdentity") or "")
+                    if isinstance(incoming_metadata, dict)
+                    else ""
+                )
+                existing = await _lease_row(session, lease_id)
                 if existing is not None:
                     if (
                         str(existing.runtime_id) != str(runtime_id)
@@ -4454,41 +4695,33 @@ class TemporalArtifactActivities:
                         or str(existing.owner_id or "") != str(payload.get("owner_id") or payload.get("ownerId") or "")
                     ):
                         return {"error": "lease identity conflict"}
-                    try:
-                        incoming_fence = int(payload.get("fencing_generation") or 0)
-                    except (TypeError, ValueError):
-                        incoming_fence = 0
+                    incoming_fence = _int_or_zero(payload.get("fencing_generation"))
                     if incoming_fence <= 0:
                         # A grant without a generation predates fenced grants;
                         # keep the legacy duplicate acknowledgement.
                         return {"granted": True, "duplicate": True}
-                    existing_live = (
-                        str(existing.lease_state or "held") == "held"
-                    )
-                    incoming_purpose = str(
-                        payload.get("purpose") or "execution_direct"
-                    )
-                    incoming_metadata = payload.get("safe_metadata")
-                    incoming_identity = (
-                        str(incoming_metadata.get("evidenceIdentity") or "")
-                        if isinstance(incoming_metadata, dict)
-                        else ""
-                    )
+                    existing_state = _row_state(existing)
+                    existing_live = existing_state in ACTIVE_DURABLE_LEASE_STATES
                     existing_metadata = existing.safe_metadata_json
                     existing_identity = (
                         str(existing_metadata.get("evidenceIdentity") or "")
                         if isinstance(existing_metadata, dict)
                         else ""
                     )
-                    try:
-                        existing_fence = int(existing.fencing_generation or 0)
-                    except (TypeError, ValueError):
-                        existing_fence = 0
+                    existing_fence = _int_or_zero(existing.fencing_generation)
+                    existing_compatibility = str(
+                        getattr(existing, "compatibility_class", None) or ""
+                    )
                     if (
                         existing_live
                         and existing_fence == incoming_fence
                         and str(existing.purpose or "") == incoming_purpose
                         and existing_identity == incoming_identity
+                        and (
+                            not existing_compatibility
+                            or existing_compatibility == incoming_compatibility
+                        )
+                        and not _admission_generation_conflict(existing, payload)
                     ):
                         # An idempotent retry of the same grant: the complete
                         # grant identity matches, so no new authority is made.
@@ -4498,28 +4731,44 @@ class TemporalArtifactActivities:
                         # it would downgrade the fence, so fail closed and let
                         # the caller roll its in-memory reservation back.
                         return {"error": "lease fencing regression"}
-                    # The row is stale \u2014 a tombstoned release, or a prior
-                    # DB release that failed after the in-memory lease was
-                    # freed while the manager moved on. Atomically replace it
-                    # with the incoming grant instead of reporting durable
-                    # success for authority the row does not describe.
+                    if existing_live and (
+                        str(existing.purpose or "") != incoming_purpose
+                        or (
+                            existing_compatibility
+                            and existing_compatibility != incoming_compatibility
+                        )
+                        or (existing_identity and existing_identity != incoming_identity)
+                        or _admission_generation_conflict(existing, payload)
+                    ):
+                        # Conflicting reuse of an identity that is still live.
+                        # Replacing it here would hand a second purpose, plan
+                        # or admission generation the same authority, so this
+                        # fails without creating another unit.
+                        return {"error": "lease identity conflict"}
+                    # The row is stale — a tombstoned release, or the same
+                    # identity re-granted under a newer generation. Atomically
+                    # replace it instead of reporting durable success for
+                    # authority the row does not describe.
                     await session.delete(existing)
                     await session.flush()
                     replaced_stale_row = True
                 else:
                     replaced_stale_row = False
+                owner_is_workflow = payload.get("ownerIsWorkflow", True) is not False
                 new_lease = ProviderProfileSlotLease(
                     runtime_id=runtime_id,
                     workflow_id=str(payload.get("workflow_id") or lease_id),
                     profile_id=str(payload.get("profile_id") or ""),
                     lease_id=lease_id,
                     owner_id=str(payload.get("owner_id") or payload.get("ownerId") or lease_id),
-                    owner_kind=str(payload.get("owner_kind") or payload.get("ownerKind") or "workflow"),
-                    purpose=str(payload.get("purpose") or "execution_direct"),
-                    compatibility_class=str(
-                        payload.get("compatibility_class") or payload.get("purpose") or "execution_direct"
+                    owner_kind=str(
+                        payload.get("owner_kind")
+                        or payload.get("ownerKind")
+                        or ("workflow" if owner_is_workflow else "activity")
                     ),
-                    owner_is_workflow=payload.get("ownerIsWorkflow", True) is not False,
+                    purpose=incoming_purpose,
+                    compatibility_class=incoming_compatibility,
+                    owner_is_workflow=owner_is_workflow,
                     step_execution_id=payload.get("stepExecutionId"),
                     oauth_session_id=payload.get("oauthSessionId"),
                     idempotency_key=payload.get("idempotencyKey"),
@@ -4527,7 +4776,9 @@ class TemporalArtifactActivities:
                     capacity_scope_ref=payload.get("capacity_scope_ref"),
                     scope_generation=int(payload.get("scope_generation") or 1),
                     credential_generation=payload.get("credential_generation"),
-                    lease_state=str(payload.get("lease_state") or "held"),
+                    lease_state=str(
+                        payload.get("lease_state") or DurableLeaseState.HELD.value
+                    ),
                     fencing_generation=int(payload.get("fencing_generation") or 1),
                     safe_metadata_json=payload.get("safe_metadata"),
                     expires_at=_parse_lease_time(payload.get("expiresAt")),
@@ -4540,26 +4791,15 @@ class TemporalArtifactActivities:
                 return {"granted": True, "duplicate": False}
 
             elif action == "heartbeat":
-                from sqlalchemy import select as _select
-
                 payload = (leases or [{}])[0]
                 lease_id = str(payload.get("lease_id") or "").strip()
                 if not lease_id:
                     return {"error": "heartbeat requires lease_id"}
-                try:
-                    expected_fence = int(payload.get("fencing_generation") or 0)
-                except (TypeError, ValueError):
-                    expected_fence = 0
-                row = (
-                    await session.execute(
-                        _select(ProviderProfileSlotLease).where(
-                            ProviderProfileSlotLease.lease_id == lease_id
-                        )
-                    )
-                ).scalars().first()
+                expected_fence = _int_or_zero(payload.get("fencing_generation"))
+                row = await _lease_row(session, lease_id)
                 if row is None:
                     return {"heartbeat": False, "stale": True}
-                if str(row.lease_state or "held") != "held":
+                if _row_state(row) not in ACTIVE_DURABLE_LEASE_STATES:
                     return {"heartbeat": False, "stale": True}
                 if expected_fence and int(row.fencing_generation) != expected_fence:
                     return {"heartbeat": False, "stale": True}
@@ -4567,39 +4807,104 @@ class TemporalArtifactActivities:
                 await session.commit()
                 return {"heartbeat": True}
 
-            elif action == "release_one":
-                from sqlalchemy import select as _select
+            elif action == "request_cleanup":
+                # MoonLadderStudios/MoonMind#1089: expiry and terminal owner
+                # state request resource cleanup. The slot stays spent, because
+                # the credential consumer this lease authorized may still be
+                # running; only proven-terminal ownership releases it.
+                payload = (leases or [{}])[0]
+                lease_id = str(payload.get("lease_id") or "").strip()
+                if not lease_id:
+                    return {"error": "request_cleanup requires lease_id"}
+                expected_fence = _int_or_zero(payload.get("fencing_generation"))
+                row = await _lease_row(session, lease_id)
+                if row is None:
+                    return {
+                        "outcome": LeaseTransitionOutcome.ALREADY_RELEASED.value,
+                        "cleanup_requested": False,
+                    }
+                if _transition_identity_conflict(row, payload):
+                    return {
+                        "outcome": LeaseTransitionOutcome.CONFLICT.value,
+                        "cleanup_requested": False,
+                        "error": "lease identity conflict",
+                    }
+                if expected_fence and _int_or_zero(row.fencing_generation) != expected_fence:
+                    return {
+                        "outcome": LeaseTransitionOutcome.STALE.value,
+                        "cleanup_requested": False,
+                    }
+                state = _row_state(row)
+                if state == DurableLeaseState.RELEASED.value:
+                    return {
+                        "outcome": LeaseTransitionOutcome.ALREADY_RELEASED.value,
+                        "cleanup_requested": False,
+                    }
+                if state != DurableLeaseState.CLEANUP_REQUESTED.value:
+                    row.lease_state = DurableLeaseState.CLEANUP_REQUESTED.value
+                metadata = dict(row.safe_metadata_json or {})
+                reason = str(payload.get("reason") or "lease_expired")
+                if metadata.get("cleanupReason") != reason:
+                    metadata["cleanupReason"] = reason
+                # Reassign rather than mutate in place: a JSON column only
+                # records a change the ORM can see.
+                row.safe_metadata_json = metadata
+                await session.commit()
+                return {
+                    "outcome": LeaseTransitionOutcome.CLEANUP_REQUESTED.value,
+                    "cleanup_requested": True,
+                }
 
+            elif action == "release_one":
                 payload = (leases or [{}])[0]
                 lease_id = str(payload.get("lease_id") or "").strip()
                 if not lease_id:
                     return {"error": "release_one requires lease_id"}
-                try:
-                    expected_fence = int(payload.get("fencing_generation") or 0)
-                except (TypeError, ValueError):
-                    expected_fence = 0
-                row = (
-                    await session.execute(
-                        _select(ProviderProfileSlotLease).where(
-                            ProviderProfileSlotLease.lease_id == lease_id
-                        )
-                    )
-                ).scalars().first()
+                expected_fence = _int_or_zero(payload.get("fencing_generation"))
+                row = await _lease_row(session, lease_id)
                 if row is None:
-                    return {"released": True, "duplicate": True}
-                if expected_fence and int(row.fencing_generation) != expected_fence:
-                    return {"released": False, "stale": True}
-                if str(row.lease_state or "held") != "held":
-                    return {"released": True, "duplicate": True}
+                    return {
+                        "released": True,
+                        "duplicate": True,
+                        "outcome": LeaseTransitionOutcome.ALREADY_RELEASED.value,
+                    }
+                if _transition_identity_conflict(row, payload):
+                    return {
+                        "released": False,
+                        "outcome": LeaseTransitionOutcome.CONFLICT.value,
+                        "error": "lease identity conflict",
+                    }
+                if expected_fence and _int_or_zero(row.fencing_generation) != expected_fence:
+                    return {
+                        "released": False,
+                        "stale": True,
+                        "outcome": LeaseTransitionOutcome.STALE.value,
+                    }
+                if _row_state(row) == DurableLeaseState.RELEASED.value:
+                    return {
+                        "released": True,
+                        "duplicate": True,
+                        "outcome": LeaseTransitionOutcome.ALREADY_RELEASED.value,
+                    }
                 # Tombstone instead of deleting: the row's fencing generation
                 # remains the runtime's high-water evidence, so a fresh
                 # manager that finds no live rows still resumes above every
                 # number it ever issued. Tombstones are excluded from "load"
                 # and reaped by "purge_released" after the redelivery horizon.
-                row.lease_state = "released"
+                row.lease_state = DurableLeaseState.RELEASED.value
                 row.released_at = datetime.now(timezone.utc)
+                reason = str(payload.get("reason") or "").strip()
+                if reason:
+                    metadata = dict(row.safe_metadata_json or {})
+                    metadata["releaseReason"] = reason
+                    if payload.get("cleanup_requested"):
+                        metadata["cleanupRequested"] = True
+                    row.safe_metadata_json = metadata
                 await session.commit()
-                return {"released": True}
+                return {
+                    "released": True,
+                    "outcome": LeaseTransitionOutcome.RELEASED.value,
+                }
 
             elif action == "purge_released":
                 payload = (leases or [{}])[0]
@@ -4616,7 +4921,8 @@ class TemporalArtifactActivities:
                     await session.execute(
                         delete(ProviderProfileSlotLease).where(
                             ProviderProfileSlotLease.runtime_id == runtime_id,
-                            ProviderProfileSlotLease.lease_state == "released",
+                            ProviderProfileSlotLease.lease_state
+                            == DurableLeaseState.RELEASED.value,
                             ProviderProfileSlotLease.released_at.is_not(None),
                             ProviderProfileSlotLease.released_at < horizon,
                         )
@@ -4626,12 +4932,10 @@ class TemporalArtifactActivities:
                 return {"purged": int(purged)}
 
             elif action == "list_active":
-                from sqlalchemy import select as _select
-
                 scope_filter = None
                 if leases:
                     scope_filter = str((leases[0] or {}).get("capacity_scope_ref") or "").strip() or None
-                stmt = _select(ProviderProfileSlotLease).where(
+                stmt = select(ProviderProfileSlotLease).where(
                     ProviderProfileSlotLease.runtime_id == runtime_id
                 )
                 if scope_filter:

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -4351,10 +4351,20 @@ class TemporalArtifactActivities:
             }
 
         async def _lease_row(session: Any, lease_id: str) -> Any:
+            """Resolve one lease row inside the runtime that issued it.
+
+            MoonLadderStudios/MoonMind#3883: lease identity is runtime-scoped.
+            A pre-contract row backfills ``lease_id`` from ``workflow_id``, so
+            two runtime families can name the same lease; resolving without the
+            runtime would hand one runtime's transition the other runtime's row
+            and report a permanent identity conflict to its real holder.
+            """
+
             return (
                 await session.execute(
                     select(ProviderProfileSlotLease).where(
-                        ProviderProfileSlotLease.lease_id == lease_id
+                        ProviderProfileSlotLease.runtime_id == runtime_id,
+                        ProviderProfileSlotLease.lease_id == lease_id,
                     )
                 )
             ).scalars().first()
@@ -4471,31 +4481,39 @@ class TemporalArtifactActivities:
                 ]
 
                 # Index disagreement is detected, never silently merged: two
-                # live rows that claim the same workflow or the same owner are
-                # two authorities for one identity.
+                # live rows that claim the same lease owner are two authorities
+                # for one identity, and nothing in the schema forbids it.
+                #
+                # MoonLadderStudios/MoonMind#3883: uniqueness is checked on
+                # lease and owner identity only. The owning workflow is an
+                # identity for a workflow-owned lease — the partial unique index
+                # enforces that — but an Activity-owned step legitimately binds
+                # several Provider Profiles from one runtime, each with its own
+                # owner ID and the same owning workflow recorded for liveness.
+                # Treating that repeat as a durable conflict would refuse to
+                # restart the manager on evidence of supported concurrency.
                 conflicts: list[dict[str, Any]] = []
-                for field_name in ("workflow_id", "owner_id"):
-                    seen: dict[str, Any] = {}
-                    for row in rows:
-                        key = str(getattr(row, field_name, "") or "")
-                        if not key:
-                            continue
-                        previous = seen.get(key)
-                        if previous is None:
-                            seen[key] = row
-                            continue
-                        if str(previous.lease_id or "") == str(row.lease_id or ""):
-                            continue
-                        conflicts.append(
-                            {
-                                "field": field_name,
-                                "value": key,
-                                "leases": [
-                                    _row_identity(previous),
-                                    _row_identity(row),
-                                ],
-                            }
-                        )
+                seen: dict[str, Any] = {}
+                for row in rows:
+                    key = str(getattr(row, "owner_id", "") or "")
+                    if not key:
+                        continue
+                    previous = seen.get(key)
+                    if previous is None:
+                        seen[key] = row
+                        continue
+                    if str(previous.lease_id or "") == str(row.lease_id or ""):
+                        continue
+                    conflicts.append(
+                        {
+                            "field": "owner_id",
+                            "value": key,
+                            "leases": [
+                                _row_identity(previous),
+                                _row_identity(row),
+                            ],
+                        }
+                    )
 
                 leases_data = [
                     {
@@ -4571,31 +4589,59 @@ class TemporalArtifactActivities:
                 # barrier is durable row state, not a patch marker in one
                 # workflow history: rows fenced above the snapshot writer's own
                 # high-water generation are preserved untouched.
+                #
+                # A payload recorded before this contract carries no generation
+                # at all. That is a *zero* high-water mark, not permission to
+                # delete the runtime: every positive-generation row belongs to a
+                # writer this snapshot cannot fence, so only the rows the
+                # snapshot itself re-states are replaced.
+                from sqlalchemy import func as _save_func
+                from sqlalchemy import or_ as _save_or_
+
                 barrier = _int_or_zero(writer_generation)
+                snapshot_lease_ids = set()
+                snapshot_workflow_ids = set()
+                for lease in leases or []:
+                    snapshot_workflow_id = str(lease.get("workflow_id") or "")
+                    if not snapshot_workflow_id or not lease.get("profile_id"):
+                        continue
+                    snapshot_workflow_ids.add(snapshot_workflow_id)
+                    snapshot_lease_ids.add(
+                        str(lease.get("leaseId") or snapshot_workflow_id)
+                    )
+                if barrier > 0:
+                    fenced_out = ProviderProfileSlotLease.fencing_generation <= barrier
+                else:
+                    fenced_out = _save_or_(
+                        ProviderProfileSlotLease.fencing_generation <= 0,
+                        # A pre-contract row can still carry a NULL lease_id;
+                        # coalescing keeps the predicate three-valued-logic
+                        # free so "preserved" and "deleted" stay complements.
+                        _save_func.coalesce(
+                            ProviderProfileSlotLease.lease_id,
+                            ProviderProfileSlotLease.workflow_id,
+                        ).in_(snapshot_lease_ids),
+                        ProviderProfileSlotLease.workflow_id.in_(
+                            snapshot_workflow_ids
+                        ),
+                    )
+                preserved = int(
+                    (
+                        await session.execute(
+                            select(_save_func.count())
+                            .select_from(ProviderProfileSlotLease)
+                            .where(
+                                ProviderProfileSlotLease.runtime_id == runtime_id,
+                                ~fenced_out,
+                            )
+                        )
+                    ).scalar()
+                    or 0
+                )
                 delete_stmt = delete(ProviderProfileSlotLease).where(
                     ProviderProfileSlotLease.runtime_id == runtime_id,
+                    fenced_out,
                 )
-                preserved = 0
-                if barrier > 0:
-                    from sqlalchemy import func as _save_func
-
-                    preserved = int(
-                        (
-                            await session.execute(
-                                select(_save_func.count())
-                                .select_from(ProviderProfileSlotLease)
-                                .where(
-                                    ProviderProfileSlotLease.runtime_id == runtime_id,
-                                    ProviderProfileSlotLease.fencing_generation
-                                    > barrier,
-                                )
-                            )
-                        ).scalar()
-                        or 0
-                    )
-                    delete_stmt = delete_stmt.where(
-                        ProviderProfileSlotLease.fencing_generation <= barrier
-                    )
                 await session.execute(delete_stmt)
                 saved_count = 0
                 for lease in leases or []:
@@ -4651,9 +4697,7 @@ class TemporalArtifactActivities:
                     session.add(new_lease)
                     saved_count += 1
                 await session.commit()
-                if barrier > 0:
-                    return {"saved": saved_count, "preserved": preserved}
-                return {"saved": saved_count}
+                return {"saved": saved_count, "preserved": preserved}
 
             elif action == "remove":
                 workflow_id = leases[0].get("workflow_id") if leases else None

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -3271,7 +3271,21 @@ class MoonMindProviderProfileManagerWorkflow:
                 continue
 
             if existing_profile_id:
-                if durable_grants and not await self._sync_leases_to_db():
+                # MoonLadderStudios/MoonMind#3883: re-signalling a lease this
+                # manager already holds is not a lease change, so it must not
+                # cost a runtime-wide `action=save`. Under the transition
+                # contract the grant was committed before the lease became
+                # visible here, so the durable row is already authoritative;
+                # rewriting the snapshot would replace unrelated rows with
+                # model defaults and drop their compatibility class, scope
+                # generation, capacity scope and cleanup-requested state.
+                # Histories recorded before the contract keep the exact
+                # recorded command.
+                if (
+                    durable_grants
+                    and not self._lease_transition_contract
+                    and not await self._sync_leases_to_db()
+                ):
                     remaining.append(req)
                     continue
                 try:

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -327,6 +327,14 @@ _LEASE_TOMBSTONE_RETENTION_SECONDS = 30 * 24 * 3600
 # Purge tombstones at most this often, keyed off the monotonically increasing
 # event count so the cadence is deterministic on replay.
 _LEASE_TOMBSTONE_PURGE_EVENT_INTERVAL = 60
+# MoonLadderStudios/MoonMind#1089: a requested cleanup keeps spending its slot
+# until the owner is proven terminal, which is the only evidence that the
+# credential consumer stopped. That wait is deliberately unbounded for safety,
+# so it needs a bounded *escalation*: once a cleanup request has gone this long
+# past the lease's own expiry with the holder still reported live, the stuck
+# slot is published as actionable reconciliation evidence instead of quietly
+# consuming capacity nobody is watching.
+_LEASE_CLEANUP_ESCALATION_SECONDS = 3600
 
 
 @dataclass
@@ -1024,6 +1032,13 @@ class MoonMindProviderProfileManagerWorkflow:
         # (MoonLadderStudios/MoonMind#1089), so expiry never frees a
         # credential consumer that may still be running.
         self._cleanup_requested_leases: set[str] = set()
+        # Reservations the signal drain holds in memory whose durable grant
+        # never committed, keyed by lease ID. The drain deliberately keeps the
+        # reservation so persistence can be retried; without this record the
+        # next pass would see a held lease, skip persistence and signal a
+        # consumer a slot the ledger never granted
+        # (MoonLadderStudios/MoonMind#3883).
+        self._uncommitted_lease_grants: dict[str, dict[str, Any]] = {}
         # Cache of resolved scheduled/created ordering keyed by queue-order
         # workflow id. Workflow creation/scheduled times are immutable, so a
         # resolved entry never has to be re-queried; this keeps the
@@ -2759,8 +2774,65 @@ class MoonMindProviderProfileManagerWorkflow:
                         configured_limit=profile.max_parallel_runs,
                         effective_limit=profile.effective_limit or profile.max_parallel_runs,
                     )
+        self._restore_lease_obligations(input_payload)
         self._absorb_fencing_generations()
         self._rebuild_lease_indexes()
+
+    def _restore_lease_obligations(self, input_payload: dict[str, Any]) -> None:
+        """Restore the obligations attached to the restored lease snapshot.
+
+        MoonLadderStudios/MoonMind#3883: a continued run deliberately does not
+        reload the durable ledger, so an obligation left only in memory would
+        be dropped at the history rollover. The successor keeps owing every
+        unresolved release, every requested cleanup and every reservation whose
+        grant never committed.
+        """
+
+        self._unresolved_releases = {}
+        releases = input_payload.get("unresolved_releases")
+        if isinstance(releases, dict):
+            for lease_id, details in releases.items():
+                normalized = self._normalize_optional_string(lease_id)
+                if not normalized or not isinstance(details, dict):
+                    continue
+                self._unresolved_releases[normalized] = {
+                    "profile_id": str(details.get("profile_id") or ""),
+                    "fencing_generation": self._normalize_sequence(
+                        details.get("fencing_generation")
+                    ),
+                    "outcome": str(
+                        details.get("outcome")
+                        or LeaseTransitionOutcome.RETRYABLE.value
+                    ),
+                    "retryable": details.get("retryable", True) is not False,
+                }
+
+        cleanup = input_payload.get("cleanup_requested_leases")
+        self._cleanup_requested_leases = {
+            normalized
+            for normalized in (
+                self._normalize_optional_string(entry)
+                for entry in (cleanup if isinstance(cleanup, list) else [])
+            )
+            if normalized
+        }
+
+        self._uncommitted_lease_grants = {}
+        uncommitted = input_payload.get("uncommitted_lease_grants")
+        if isinstance(uncommitted, dict):
+            for lease_id, details in uncommitted.items():
+                normalized = self._normalize_optional_string(lease_id)
+                if not normalized or not isinstance(details, dict):
+                    continue
+                metadata = details.get("metadata")
+                self._uncommitted_lease_grants[normalized] = {
+                    "profile_id": str(details.get("profile_id") or ""),
+                    "purpose": str(
+                        details.get("purpose")
+                        or CredentialLeasePurpose.EXECUTION_DIRECT.value
+                    ),
+                    "metadata": dict(metadata) if isinstance(metadata, dict) else {},
+                }
 
     def _apply_profile_sync(
         self,
@@ -3160,6 +3232,9 @@ class MoonMindProviderProfileManagerWorkflow:
             self._lease_owner_index[lease_id] = owner
 
     def _unindex_lease(self, lease_id: str) -> None:
+        # A lease that leaves the in-memory ledger takes its uncommitted grant
+        # record with it: there is no reservation left to make durable.
+        self._uncommitted_lease_grants.pop(lease_id, None)
         self._lease_profile_index.pop(lease_id, None)
         owner = self._lease_owner_index.pop(lease_id, None)
         if owner is not None:
@@ -3288,6 +3363,19 @@ class MoonMindProviderProfileManagerWorkflow:
                 ):
                     remaining.append(req)
                     continue
+                if (
+                    durable_grants
+                    and self._lease_transition_contract
+                    and not await self._commit_retained_lease_grant(
+                        existing_profile_id, req.requester_workflow_id
+                    )
+                ):
+                    # This reservation is held in memory precisely because its
+                    # grant never committed. Signalling it now would announce a
+                    # slot the ledger does not hold, and a manager restart
+                    # could then grant the same capacity a second time.
+                    remaining.append(req)
+                    continue
                 try:
                     existing_generation: int | None = None
                     if self._durable_maintenance_queue:
@@ -3376,8 +3464,17 @@ class MoonMindProviderProfileManagerWorkflow:
                         # Hold the in-memory reservation and retry persistence on
                         # the next loop. Never signal a consumer before its lease
                         # is durable.
+                        self._record_uncommitted_lease_grant(
+                            req.requester_workflow_id,
+                            profile_id=profile.profile_id,
+                            purpose=req.purpose,
+                            metadata=grant_metadata,
+                        )
                         remaining.append(req)
                         continue
+                    self._uncommitted_lease_grants.pop(
+                        req.requester_workflow_id, None
+                    )
                 try:
                     if grant_generation is not None:
                         await self._signal_slot_assigned(
@@ -3756,6 +3853,33 @@ class MoonMindProviderProfileManagerWorkflow:
                     expired.append((profile.profile_id, lease_id))
         return expired
 
+    @staticmethod
+    def _lease_duration_limit(
+        profile: ProfileSlotState, lease_id: str, max_duration_seconds: int
+    ) -> int:
+        return (
+            min(max_duration_seconds, profile.lease_max_duration_seconds(lease_id))
+            if profile.purpose_aware_capacity
+            else max_duration_seconds
+        )
+
+    @staticmethod
+    def _lease_age_seconds(
+        profile: ProfileSlotState, lease_id: str, now: datetime
+    ) -> float | None:
+        """Seconds since this lease was granted, or ``None`` if unknowable."""
+
+        granted_str = profile.lease_granted_at.get(lease_id)
+        if granted_str is None:
+            return None
+        try:
+            granted_dt = datetime.fromisoformat(granted_str)
+        except (ValueError, TypeError):
+            return None
+        if granted_dt.tzinfo is None:
+            granted_dt = granted_dt.replace(tzinfo=timezone.utc)
+        return (now - granted_dt).total_seconds()
+
     def _lease_is_expired(
         self,
         profile: ProfileSlotState,
@@ -3763,21 +3887,118 @@ class MoonMindProviderProfileManagerWorkflow:
         now: datetime,
         max_duration_seconds: int,
     ) -> bool:
-        granted_str = profile.lease_granted_at.get(lease_id)
-        limit = (
-            min(max_duration_seconds, profile.lease_max_duration_seconds(lease_id))
-            if profile.purpose_aware_capacity
-            else max_duration_seconds
+        age = self._lease_age_seconds(profile, lease_id, now)
+        if age is None:
+            return True
+        return age > self._lease_duration_limit(
+            profile, lease_id, max_duration_seconds
         )
-        if granted_str is None:
+
+    def _escalate_unowned_cleanup(
+        self, profile: ProfileSlotState, lease_id: str
+    ) -> None:
+        """Publish a cleanup request that no owner has resolved in time.
+
+        The slot stays spent — freeing it would authorize a second credential
+        consumer while the first may still be running — but the manager stops
+        treating the request as handled. Recording it as reconciliation
+        evidence gives the stuck slot a named owner: the same operator
+        reconciliation path that already consumes ``lease_index_conflicts``.
+        """
+
+        age = self._lease_age_seconds(profile, lease_id, workflow.now())
+        if age is not None:
+            deadline = (
+                self._lease_duration_limit(
+                    profile,
+                    lease_id,
+                    getattr(profile, "max_lease_duration_seconds", None)
+                    or _MAX_LEASE_DURATION_SECONDS,
+                )
+                + _LEASE_CLEANUP_ESCALATION_SECONDS
+            )
+            if age <= deadline:
+                return
+        if not self._verifiable_lease_owner(profile, lease_id):
+            # Nothing can ever prove this holder terminal, so the durable
+            # release owner will never fire for it. That is the strongest form
+            # of the same stuck slot.
+            self._record_lease_index_conflict(
+                "cleanup_owner_unverifiable",
+                lease_id=lease_id,
+                profile_id=profile.profile_id,
+                existing="cleanup_requested",
+            )
+            return
+        self._record_lease_index_conflict(
+            "cleanup_unresolved",
+            lease_id=lease_id,
+            profile_id=profile.profile_id,
+            existing="cleanup_requested",
+        )
+
+    @staticmethod
+    def _verifiable_lease_owner(profile: ProfileSlotState, lease_id: str) -> bool:
+        """Whether terminal evidence can ever be collected for this holder."""
+
+        metadata = profile.lease_metadata.get(lease_id) or {}
+        if metadata.get("ownerIsWorkflow") is not False:
             return True
-        try:
-            granted_dt = datetime.fromisoformat(granted_str)
-        except (ValueError, TypeError):
+        return bool(str(metadata.get("workflowId") or "").strip())
+
+    def _record_uncommitted_lease_grant(
+        self,
+        lease_id: str,
+        *,
+        profile_id: str,
+        purpose: str,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        """Remember that one retained reservation has no durable row yet."""
+
+        self._uncommitted_lease_grants[lease_id] = {
+            "profile_id": profile_id,
+            "purpose": purpose,
+            "metadata": dict(metadata or {}),
+        }
+        self._get_logger().warning(
+            "Provider profile lease grant for %s on profile %s is not durable "
+            "yet; the reservation is retained for another persistence attempt",
+            lease_id,
+            profile_id,
+        )
+
+    async def _commit_retained_lease_grant(
+        self, profile_id: str, lease_id: str
+    ) -> bool:
+        """Persist a retained reservation before its slot is announced.
+
+        MoonLadderStudios/MoonMind#3883: the drain keeps an in-memory
+        reservation whose grant failed so persistence can be retried. The next
+        pass sees a held lease, so without this retry it would take the
+        re-signal branch — which deliberately writes nothing — and hand a
+        signal-based consumer a slot with no durable lease row. Returns whether
+        the ledger now holds this grant.
+        """
+
+        pending = self._uncommitted_lease_grants.get(lease_id)
+        if pending is None:
             return True
-        if granted_dt.tzinfo is None:
-            granted_dt = granted_dt.replace(tzinfo=timezone.utc)
-        return (now - granted_dt).total_seconds() > limit
+        profile = self._profiles.get(profile_id)
+        if profile is None:
+            # The profile disappeared under the reservation. The lease is not
+            # durable and cannot be made durable, so it is not announced.
+            return False
+        persisted = await self._persist_lease_grant(
+            profile,
+            lease_id,
+            purpose=str(pending.get("purpose") or "execution_direct"),
+            metadata=dict(pending.get("metadata") or {}),
+        )
+        if not persisted:
+            return False
+        self._uncommitted_lease_grants.pop(lease_id, None)
+        return True
 
     async def _request_cleanup_for_expired_leases(self) -> None:
         """Ask for resource cleanup on every expired lease, bounded per lease.
@@ -3786,13 +4007,20 @@ class MoonMindProviderProfileManagerWorkflow:
         here: :meth:`_reclaim_terminal_leases` releases it once the owner is
         verified terminal, which is the only evidence that the credential
         consumer actually stopped.
+
+        That release is the durable owner of the request, and it can only fire
+        while the holder is being verified. A cleanup request that outlives its
+        escalation deadline is therefore published as actionable reconciliation
+        evidence rather than left as an inert row flag on a slot that never
+        comes back (MoonLadderStudios/MoonMind#1089).
         """
 
         for profile_id, lease_id in self._expired_lease_candidates():
-            if lease_id in self._cleanup_requested_leases:
-                continue
             profile = self._profiles.get(profile_id)
             if profile is None:
+                continue
+            if lease_id in self._cleanup_requested_leases:
+                self._escalate_unowned_cleanup(profile, lease_id)
                 continue
             outcome = await self._request_lease_cleanup(
                 lease_id,
@@ -4407,6 +4635,31 @@ class MoonMindProviderProfileManagerWorkflow:
                 if self._durable_maintenance_queue
                 else {}
             ),
+            **(
+                {
+                    # MoonLadderStudios/MoonMind#3883: the successor inherits
+                    # the in-memory lease snapshot, so it must inherit every
+                    # obligation attached to it. A release that never resolved,
+                    # a slot whose cleanup was requested and a reservation whose
+                    # grant never committed are all authority the successor
+                    # would otherwise advertise without owing anything for it.
+                    "unresolved_releases": {
+                        lease_id: dict(details)
+                        for lease_id, details in self._unresolved_releases.items()
+                    },
+                    "cleanup_requested_leases": sorted(
+                        self._cleanup_requested_leases
+                    ),
+                    "uncommitted_lease_grants": {
+                        lease_id: dict(details)
+                        for lease_id, details in (
+                            self._uncommitted_lease_grants.items()
+                        )
+                    },
+                }
+                if self._lease_transition_contract
+                else {}
+            ),
         }
 
     async def _load_profiles_from_db(
@@ -4792,16 +5045,75 @@ class MoonMindProviderProfileManagerWorkflow:
             # the ledger what it actually holds.
             return await self._grant_committed_after_ambiguous_write(
                 lease_id=lease_id,
-                profile_id=profile.profile_id,
-                fencing_generation=fencing_generation or 1,
+                attempted={
+                    "profile_id": profile.profile_id,
+                    "owner_id": owner_id,
+                    "owner_kind": "workflow" if owner_is_workflow else "activity",
+                    "purpose": purpose,
+                    "compatibility_class": compatibility_class,
+                    "capacity_scope_ref": capacity_scope_ref,
+                    "scope_generation": scope_generation,
+                    "credential_generation": safe.get("credentialGeneration"),
+                    "execution_plan_ref": safe.get("executionPlanRef"),
+                    "evidence_identity": (
+                        str(evidence_identity) if evidence_identity else ""
+                    ),
+                    "fencing_generation": fencing_generation or 1,
+                },
             )
+
+    #: Every immutable field of one grant identity, paired with how the two
+    #: sides are compared. A row that matches on lease ID, profile, state and
+    #: fence can still describe a different owner, purpose, compatibility
+    #: class, capacity scope, credential generation, execution plan or
+    #: evidence identity — especially a migrated generation-1 row — so an
+    #: ambiguous write is only treated as committed when every one of them
+    #: agrees (MoonLadderStudios/MoonMind#3883).
+    _GRANT_IDENTITY_FIELDS: tuple[tuple[str, str], ...] = (
+        ("profile_id", "text"),
+        ("owner_id", "text"),
+        ("owner_kind", "text"),
+        ("purpose", "text"),
+        ("compatibility_class", "text"),
+        ("capacity_scope_ref", "text"),
+        ("execution_plan_ref", "text"),
+        ("evidence_identity", "text"),
+        ("scope_generation", "number"),
+        ("credential_generation", "number"),
+        ("fencing_generation", "number"),
+    )
+
+    @staticmethod
+    def _grant_identity_matches(row: dict[str, Any], attempted: dict[str, Any]) -> bool:
+        """Whether a described row is the exact grant this manager attempted."""
+
+        for field, kind in (
+            MoonMindProviderProfileManagerWorkflow._GRANT_IDENTITY_FIELDS
+        ):
+            expected = attempted.get(field)
+            if kind == "number":
+                actual = row.get(field)
+                if expected is None or actual is None:
+                    # A grant that named no generation would have written none.
+                    # A row that carries one is a different unit of authority.
+                    if expected is not None or actual is not None:
+                        return False
+                    continue
+                try:
+                    if int(actual) != int(expected):
+                        return False
+                except (TypeError, ValueError):
+                    return False
+                continue
+            if str(row.get(field) or "") != str(expected or ""):
+                return False
+        return True
 
     async def _grant_committed_after_ambiguous_write(
         self,
         *,
         lease_id: str,
-        profile_id: str,
-        fencing_generation: int,
+        attempted: dict[str, Any],
     ) -> bool:
         """Whether the ledger already holds the grant this write may have made."""
 
@@ -4832,21 +5144,23 @@ class MoonMindProviderProfileManagerWorkflow:
         if not isinstance(result, dict) or not result.get("found"):
             return False
         row = result.get("lease") or {}
-        if str(row.get("profile_id") or "") != str(profile_id):
-            return False
         if str(row.get("lease_state") or "") != DurableLeaseState.HELD.value:
             return False
-        try:
-            recorded_generation = int(row.get("fencing_generation") or 0)
-        except (TypeError, ValueError):
-            recorded_generation = 0
-        if recorded_generation != int(fencing_generation):
+        if not self._grant_identity_matches(row, attempted):
+            # The ledger holds a different unit of authority under this lease
+            # ID. Inheriting it would hand the caller a grant the ledger never
+            # made, so the write stays unresolved and capacity stays blocked.
+            self._get_logger().warning(
+                "An ambiguous lease write for %s names a different durable "
+                "identity than the attempted grant; capacity stays blocked",
+                lease_id,
+            )
             return False
         self._get_logger().info(
             "Reconciled an ambiguous lease grant for %s: the ledger already "
             "holds generation %s",
             lease_id,
-            recorded_generation,
+            row.get("fencing_generation"),
         )
         return True
 

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -35,8 +35,11 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.provider_profiles.lease_client import (
         MANAGER_ROLLOVER_ERROR_TYPE,
+        RELEASING_LEASE_OUTCOMES,
         CredentialLeaseMode,
         CredentialLeasePurpose,
+        DurableLeaseState,
+        LeaseTransitionOutcome,
         credential_lease_mode,
         credential_source_is_credentialless,
     )
@@ -108,6 +111,17 @@ MAINTENANCE_QUEUE_DURABILITY_PATCH = (
 # Incremental durable lease operations replace the runtime-wide snapshot
 # rewrite that every grant previously performed.
 PROVIDER_INCREMENTAL_LEASE_PATCH = "provider-profile-manager-incremental-lease-v1"
+
+# MoonLadderStudios/MoonMind#3883: the incremental row write becomes the whole
+# durable ordering contract. A grant is not usable authority until its row
+# commits, an ambiguous write outcome is reconciled against the ledger instead
+# of guessed at, a release keeps capacity unavailable until it resolves,
+# expiry and terminal ownership request resource cleanup instead of freeing a
+# credential consumer that may still be running, and expiry/reclamation stop
+# rewriting the runtime-wide snapshot.
+LEASE_TRANSITION_CONTRACT_PATCH = (
+    "provider-profile-manager-lease-transition-contract-v1"
+)
 
 # Deterministic sort sentinel for pending requests whose scheduled queue order
 # cannot be resolved (missing scheduled_for / created_at). ISO-8601 strings sort
@@ -966,6 +980,16 @@ class MoonMindProviderProfileManagerWorkflow:
         self._seen_rate_limit_reports: list[str] = []
         self._lease_profile_index: dict[str, str] = {}
         self._owner_lease_index: dict[str, str] = {}
+        # MoonLadderStudios/MoonMind#3883: the reverse direction of
+        # ``_owner_lease_index``. Removing a lease used to scan every owner
+        # entry, so an ordinary release cost O(active leases); the direct
+        # reverse index keeps each ordinary mutation bounded.
+        self._lease_owner_index: dict[str, str] = {}
+        # Duplicate or contradictory lease identities found while indexing.
+        # Index disagreement is actionable reconciliation evidence, not
+        # something to silently skip: two entries for one identity mean two
+        # authorities for one slot.
+        self._lease_index_conflicts: list[dict[str, Any]] = []
         self._pending_requests: list[PendingRequest] = []
         self._pending_requests_ordered: bool = False
         self._handoff_reservations: dict[str, HandoffReservation] = {}
@@ -989,6 +1013,17 @@ class MoonMindProviderProfileManagerWorkflow:
         # restored, and only ever tested for emptiness so set order cannot
         # affect replay.
         self._pending_grant_handoffs: set[str] = set()
+        # MoonLadderStudios/MoonMind#3883 durable transition contract state.
+        self._lease_transition_contract: bool = False
+        # Releases whose durable outcome is still unresolved, keyed by lease
+        # ID. Their capacity stays unavailable until the ledger answers, so a
+        # logged warning can never announce reuse.
+        self._unresolved_releases: dict[str, dict[str, Any]] = {}
+        # Leases whose resources have been asked to clean up. The slot stays
+        # spent until the owner is proven terminal
+        # (MoonLadderStudios/MoonMind#1089), so expiry never frees a
+        # credential consumer that may still be running.
+        self._cleanup_requested_leases: set[str] = set()
         # Cache of resolved scheduled/created ordering keyed by queue-order
         # workflow id. Workflow creation/scheduled times are immutable, so a
         # resolved entry never has to be re-queried; this keeps the
@@ -1046,14 +1081,56 @@ class MoonMindProviderProfileManagerWorkflow:
         self._lease_grant_sequence += 1
         return self._lease_grant_sequence
 
+    def _scope_generation_for(self, profile: "ProfileSlotState | None") -> int:
+        """The capacity-scope generation a grant is admitted against.
+
+        MoonLadderStudios/MoonMind#3883: hard-coding this to 1 recorded a
+        scope authority the grant never acquired, so a scope reassignment or a
+        limit change was indistinguishable from the generation the lease was
+        actually admitted under.
+        """
+
+        if profile is None:
+            return 1
+        scope_ref = self._capacity_scope_ref(profile)
+        scope = self._scopes.get(scope_ref)
+        try:
+            return max(1, int(getattr(scope, "generation", 1) or 1))
+        except (TypeError, ValueError):
+            return 1
+
+    @staticmethod
+    def _capacity_scope_ref(profile: "ProfileSlotState") -> str:
+        return profile.capacity_scope_ref or f"provider-profile:{profile.profile_id}"
+
     def _grant_metadata(
-        self, lease_metadata: dict[str, Any], *, fencing_generation: int
+        self,
+        lease_metadata: dict[str, Any],
+        *,
+        fencing_generation: int,
+        profile: "ProfileSlotState | None" = None,
+        lease_mode: "CredentialLeaseMode | None" = None,
     ) -> dict[str, Any]:
-        """Stamp caller metadata with the manager-owned grant generation."""
+        """Stamp caller metadata with the manager-owned grant identity.
+
+        The caller owns the compact evidence identity, the plan ref and the
+        credential generation it admitted against. The manager owns the grant
+        generation, the compatibility class (the ledger mode this lease
+        coexists under) and the capacity-scope generation it was admitted
+        against. Both halves are one durable identity.
+        """
 
         if not self._durable_maintenance_queue:
             return dict(lease_metadata)
-        return {**lease_metadata, "fencingGeneration": fencing_generation}
+        stamped = {**lease_metadata, "fencingGeneration": fencing_generation}
+        if not self._lease_transition_contract:
+            return stamped
+        if lease_mode is not None:
+            stamped["compatibilityClass"] = CredentialLeaseMode(lease_mode).value
+        if profile is not None:
+            stamped["capacityScopeRef"] = self._capacity_scope_ref(profile)
+            stamped["scopeGeneration"] = self._scope_generation_for(profile)
+        return stamped
 
     def _fence_result(self, fencing_generation: int | None) -> dict[str, Any]:
         """Report the grant generation only when this manager actually fences.
@@ -1140,6 +1217,15 @@ class MoonMindProviderProfileManagerWorkflow:
             )
             return
         released_generation = 0
+        if self._lease_transition_contract:
+            # MoonLadderStudios/MoonMind#3883: the durable ledger decides
+            # whether this slot is reusable, so it is asked first. Freeing the
+            # in-memory accounting before the write meant a failed release
+            # published capacity the database still records as held.
+            await self._release_slot_durably(
+                profile_id=profile_id, requester_id=requester_id, payload=payload
+            )
+            return
         if profile:
             released_generation = profile.lease_fencing_generation(requester_id)
             released = profile.release(requester_id)
@@ -1177,6 +1263,142 @@ class MoonMindProviderProfileManagerWorkflow:
             await self._remove_lease_from_db(
                 requester_id, fencing_generation=released_generation
             )
+
+    async def _release_slot_durably(
+        self,
+        *,
+        profile_id: str,
+        requester_id: str,
+        payload: dict[str, Any],
+    ) -> str:
+        """Release one slot, ledger first, and free capacity only if it says so.
+
+        MoonLadderStudios/MoonMind#3883 acceptance 4: a release failure or a
+        structured database error must not make capacity reusable. The typed
+        outcome — not a log line — decides whether the in-memory accounting is
+        allowed to follow.
+        """
+
+        profile = self._profiles.get(profile_id)
+        fencing_generation = (
+            profile.lease_fencing_generation(requester_id) if profile else 0
+        )
+        outcome = await self._remove_lease_from_db(
+            requester_id,
+            fencing_generation=fencing_generation,
+            profile_id=profile_id,
+            reason="owner_release",
+        )
+        if outcome not in RELEASING_LEASE_OUTCOMES:
+            self._record_unresolved_release(
+                requester_id,
+                profile_id=profile_id,
+                fencing_generation=fencing_generation,
+                outcome=outcome,
+            )
+            return outcome
+
+        self._unresolved_releases.pop(requester_id, None)
+        self._cleanup_requested_leases.discard(requester_id)
+        released = False
+        # Re-resolve: an awaited activity can be interleaved with a profile
+        # refresh that replaced the object this handler started with.
+        profile = self._profiles.get(profile_id)
+        if profile:
+            released = profile.release(requester_id)
+            if released:
+                self._unindex_lease(requester_id)
+            # A release also withdraws any pending maintenance request from the
+            # same owner, so a caller that gave up cannot hold the queue head.
+            profile.dequeue_maintenance_waiter(requester_id)
+        self._pending_requests = [
+            req
+            for req in self._pending_requests
+            if req.requester_workflow_id != requester_id
+        ]
+        lease_group_id = self._normalize_optional_string(
+            payload.get("lease_group_id")
+        )
+        handoff_ttl_seconds = self._coerce_handoff_ttl_seconds(
+            payload.get("handoff_ttl_seconds")
+        )
+        if released and lease_group_id and handoff_ttl_seconds > 0:
+            self._handoff_reservations[lease_group_id] = HandoffReservation(
+                profile_id=profile_id,
+                expires_at=(
+                    workflow.now() + timedelta(seconds=handoff_ttl_seconds)
+                ).isoformat(),
+            )
+        return outcome
+
+    def _record_unresolved_release(
+        self,
+        lease_id: str,
+        *,
+        profile_id: str,
+        fencing_generation: int,
+        outcome: str,
+    ) -> None:
+        """Keep the slot spent and classify why the release did not resolve.
+
+        ``retryable`` is transient: the same stable lease identity is re-driven
+        on the next loop. ``stale`` and ``conflict`` mean the ledger describes a
+        different authority than this manager believes it holds; retrying that
+        forever cannot converge, so it becomes actionable reconciliation
+        evidence instead. Either way the slot stays unavailable.
+        """
+
+        retryable = outcome == LeaseTransitionOutcome.RETRYABLE.value
+        self._unresolved_releases[lease_id] = {
+            "profile_id": profile_id,
+            "fencing_generation": fencing_generation,
+            "outcome": outcome,
+            "retryable": retryable,
+        }
+        if not retryable:
+            self._record_lease_index_conflict(
+                "unresolved_release",
+                lease_id=lease_id,
+                profile_id=profile_id,
+                existing=outcome,
+            )
+        self._get_logger().warning(
+            "Provider profile lease release for owner %s on profile %s is "
+            "unresolved (%s); capacity stays unavailable",
+            lease_id,
+            profile_id,
+            outcome,
+        )
+
+    async def _retry_unresolved_releases(self) -> None:
+        """Re-drive releases whose durable outcome never resolved."""
+
+        if not self._unresolved_releases:
+            return
+        for requester_id in sorted(self._unresolved_releases):
+            pending = self._unresolved_releases.get(requester_id)
+            if pending is None or not pending.get("retryable", True):
+                continue
+            outcome = await self._remove_lease_from_db(
+                requester_id,
+                fencing_generation=int(pending.get("fencing_generation") or 0),
+                profile_id=str(pending.get("profile_id") or ""),
+                reason="owner_release_retry",
+            )
+            if outcome not in RELEASING_LEASE_OUTCOMES:
+                self._record_unresolved_release(
+                    requester_id,
+                    profile_id=str(pending.get("profile_id") or ""),
+                    fencing_generation=int(pending.get("fencing_generation") or 0),
+                    outcome=outcome,
+                )
+                continue
+            self._unresolved_releases.pop(requester_id, None)
+            self._cleanup_requested_leases.discard(requester_id)
+            profile = self._profiles.get(str(pending.get("profile_id") or ""))
+            if profile and profile.release(requester_id):
+                self._unindex_lease(requester_id)
+                self._has_new_events = True
 
     def _release_is_fenced_out(
         self,
@@ -1390,6 +1612,12 @@ class MoonMindProviderProfileManagerWorkflow:
                 await self._assert_activity_lease_owner_running(lease_metadata)
             existing_profile_id = self._profile_id_for_lease(requester_id)
             if existing_profile_id is not None:
+                if self._lease_grant_is_pending(requester_id):
+                    # Another handler reserved this identity but its grant has
+                    # not committed. Reporting ``already_held`` here would
+                    # publish authority the ledger may never hold.
+                    await self._await_pending_grant_handoff(requester_id)
+                    continue
                 return {
                     "profile_id": existing_profile_id,
                     "lease_id": requester_id,
@@ -1414,7 +1642,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 self._next_fencing_generation() if profile is not None else 0
             )
             grant_metadata = self._grant_metadata(
-                lease_metadata, fencing_generation=fencing_generation
+                lease_metadata,
+                fencing_generation=fencing_generation,
+                profile=profile,
+                lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
             )
             if profile and profile.reserve(
                 requester_id,
@@ -1422,32 +1653,41 @@ class MoonMindProviderProfileManagerWorkflow:
                 purpose=purpose,
                 metadata=grant_metadata,
             ):
-                self._index_lease(profile.profile_id, requester_id, requester_id)
-                if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                    persisted = await self._persist_lease_grant(
-                        profile,
-                        requester_id,
-                        purpose=purpose,
-                        metadata=grant_metadata,
-                    )
-                    if (
-                        workflow.patched(DURABLE_LEASE_GRANT_PATCH)
-                        and not persisted
-                    ):
-                        profile.release(requester_id)
-                        self._unindex_lease(requester_id)
-                        raise exceptions.ApplicationError(
-                            "Provider profile lease persistence failed before direct grant",
-                            type="ProviderProfileLeasePersistenceFailed",
+                # The in-memory reservation is tentative until the grant
+                # activity commits it. Marking the handoff keeps a concurrent
+                # identical caller — and a Continue-As-New snapshot — from
+                # treating it as usable authority
+                # (MoonLadderStudios/MoonMind#3883).
+                self._begin_grant_handoff(requester_id)
+                try:
+                    self._index_lease(profile.profile_id, requester_id, requester_id)
+                    if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+                        persisted = await self._persist_lease_grant(
+                            profile,
+                            requester_id,
+                            purpose=purpose,
+                            metadata=grant_metadata,
                         )
-                self._has_new_events = True
-                return {
-                    "profile_id": profile.profile_id,
-                    "lease_id": requester_id,
-                    "already_held": False,
-                    "lease_mode": CredentialLeaseMode.SHARED_EXECUTION.value,
-                    **self._fence_result(fencing_generation),
-                }
+                        if (
+                            workflow.patched(DURABLE_LEASE_GRANT_PATCH)
+                            and not persisted
+                        ):
+                            profile.release(requester_id)
+                            self._unindex_lease(requester_id)
+                            raise exceptions.ApplicationError(
+                                "Provider profile lease persistence failed before direct grant",
+                                type="ProviderProfileLeasePersistenceFailed",
+                            )
+                    self._has_new_events = True
+                    return {
+                        "profile_id": profile.profile_id,
+                        "lease_id": requester_id,
+                        "already_held": False,
+                        "lease_mode": CredentialLeaseMode.SHARED_EXECUTION.value,
+                        **self._fence_result(fencing_generation),
+                    }
+                finally:
+                    self._end_grant_handoff(requester_id)
 
             try:
                 await workflow.wait_condition(
@@ -1550,6 +1790,11 @@ class MoonMindProviderProfileManagerWorkflow:
         requested_identity = self._normalize_optional_string(
             self._safe_lease_metadata(payload).get("evidenceIdentity")
         )
+        if self._lease_grant_is_pending(requester_id):
+            # A concurrent identical caller reserved this identity but its
+            # grant is not committed. Join the committed result instead of
+            # inheriting a pending reservation.
+            await self._await_pending_grant_handoff(requester_id)
         existing_profile_id = self._profile_id_for_lease(requester_id)
         if existing_profile_id is not None:
             if existing_profile_id != profile_id:
@@ -1712,7 +1957,10 @@ class MoonMindProviderProfileManagerWorkflow:
         profile = self._profiles.get(profile_id) or profile
         fencing_generation = self._next_fencing_generation()
         grant_metadata = self._grant_metadata(
-            lease_metadata, fencing_generation=fencing_generation
+            lease_metadata,
+            fencing_generation=fencing_generation,
+            profile=profile,
+            lease_mode=CredentialLeaseMode.SINGLE_FLIGHT_VALIDATION,
         )
         if not profile.reserve_unmetered(
             requester_id,
@@ -1882,6 +2130,9 @@ class MoonMindProviderProfileManagerWorkflow:
                     scope_gated=scope_gated,
                 )
                 current = self._profiles.get(profile_id)
+                if self._lease_grant_is_pending(requester_id):
+                    await self._await_pending_grant_handoff(requester_id)
+                    continue
                 if current is not None and requester_id in current.current_leases:
                     # A caller retry can leave two handlers waiting for one
                     # deterministic owner. Whichever is granted, the other must
@@ -1902,7 +2153,10 @@ class MoonMindProviderProfileManagerWorkflow:
                 if blocker is None and current is not None:
                     fencing_generation = self._next_fencing_generation()
                     grant_metadata = self._grant_metadata(
-                        lease_metadata, fencing_generation=fencing_generation
+                        lease_metadata,
+                        fencing_generation=fencing_generation,
+                        profile=current,
+                        lease_mode=CredentialLeaseMode.EXCLUSIVE_MAINTENANCE,
                     )
                     if current.reserve(
                         requester_id,
@@ -2032,6 +2286,17 @@ class MoonMindProviderProfileManagerWorkflow:
                 for r in self._pending_requests
             ],
             "pending_requests_ordered": self._pending_requests_ordered,
+            # MoonLadderStudios/MoonMind#3883: index and durable-state
+            # disagreements are surfaced, not silently skipped, so an operator
+            # can act on them. Both lists are compact and non-secret.
+            "lease_index_conflicts": [
+                dict(entry) for entry in self._lease_index_conflicts
+            ],
+            "unresolved_releases": {
+                lease_id: dict(details)
+                for lease_id, details in self._unresolved_releases.items()
+            },
+            "cleanup_requested_leases": sorted(self._cleanup_requested_leases),
             "handoff_reservations": {
                 group_id: {
                     "profile_id": reservation.profile_id,
@@ -2065,6 +2330,9 @@ class MoonMindProviderProfileManagerWorkflow:
         )
         self._durable_maintenance_queue = workflow.patched(
             MAINTENANCE_QUEUE_DURABILITY_PATCH
+        )
+        self._lease_transition_contract = workflow.patched(
+            LEASE_TRANSITION_CONTRACT_PATCH
         )
         self._restore_state(
             input_payload,
@@ -2136,11 +2404,23 @@ class MoonMindProviderProfileManagerWorkflow:
             if self._recover_adaptive_capacity() > 0:
                 await self._drain_queue()
 
-            # Evict leases that exceed the max duration (safety net for
-            # cancelled/terminated workflows that failed to release).
-            evicted_count = self._evict_expired_leases()
-            if evicted_count > 0 and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-                await self._sync_leases_to_db()
+            if self._lease_transition_contract:
+                # MoonLadderStudios/MoonMind#1089: an expired lease is not
+                # evidence that its holder stopped. Cleanup is requested on
+                # the same durable row and the slot stays spent until terminal
+                # ownership is proven, so expiry can never free a credential
+                # consumer that may still be running.
+                await self._request_cleanup_for_expired_leases()
+                # Releases whose durable outcome never resolved keep their
+                # capacity unavailable; retry them with the same stable lease
+                # identity rather than assuming either side won.
+                await self._retry_unresolved_releases()
+            else:
+                # Evict leases that exceed the max duration (safety net for
+                # cancelled/terminated workflows that failed to release).
+                evicted_count = self._evict_expired_leases()
+                if evicted_count > 0 and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+                    await self._sync_leases_to_db()
 
             # Reap release tombstones on a deterministic cadence so the lease
             # table stays bounded while the high-water mark outlives them.
@@ -2259,6 +2539,33 @@ class MoonMindProviderProfileManagerWorkflow:
         """Clear one grant handoff once it committed or rolled back."""
 
         self._pending_grant_handoffs.discard(owner_id)
+
+    def _lease_grant_is_pending(self, owner_id: str) -> bool:
+        """Whether one in-memory reservation has no durable outcome yet.
+
+        MoonLadderStudios/MoonMind#3883: a pending reservation is not a usable
+        grant. Returning ``already_held`` for one would hand a concurrent
+        caller authority that the ledger may never commit, so concurrent
+        identical callers wait and then join the committed result — or observe
+        the rolled-back state — instead.
+        """
+
+        if not self._lease_transition_contract:
+            return False
+        return owner_id in self._pending_grant_handoffs
+
+    async def _await_pending_grant_handoff(self, owner_id: str) -> None:
+        """Wait, bounded, for one grant handoff to reach a durable outcome."""
+
+        try:
+            await workflow.wait_condition(
+                lambda: not self._lease_grant_is_pending(owner_id),
+                timeout=timedelta(seconds=60),
+            )
+        except TimeoutError:
+            # Bounded: the caller re-evaluates rather than blocking forever on
+            # an unresponsive persistence activity.
+            pass
 
     def _restore_state(
         self,
@@ -2774,32 +3081,97 @@ class MoonMindProviderProfileManagerWorkflow:
                 reserved_slots += 1
         return reserved_slots
 
+    def _record_lease_index_conflict(
+        self,
+        kind: str,
+        *,
+        lease_id: str,
+        owner_id: str | None = None,
+        profile_id: str | None = None,
+        existing: str | None = None,
+    ) -> None:
+        """Record one contradictory index entry as actionable evidence.
+
+        MoonLadderStudios/MoonMind#3883: skipping a duplicate identity silently
+        is how two authorities for one slot survive. The disagreement is kept
+        (bounded, non-secret) so the manager state query can surface it and the
+        conflicting entry is never merged into the winning one.
+        """
+
+        conflict = {
+            "kind": kind,
+            "leaseId": lease_id,
+            **({"ownerId": owner_id} if owner_id else {}),
+            **({"profileId": profile_id} if profile_id else {}),
+            **({"existing": existing} if existing else {}),
+        }
+        if conflict in self._lease_index_conflicts:
+            return
+        self._lease_index_conflicts.append(conflict)
+        self._get_logger().warning(
+            "Provider profile lease index disagreement (%s) for lease %s: %s",
+            kind,
+            lease_id,
+            conflict,
+        )
+
     def _rebuild_lease_indexes(self) -> None:
         self._lease_profile_index = {}
         self._owner_lease_index = {}
+        self._lease_owner_index = {}
+        self._lease_index_conflicts = []
         for profile in self._profiles.values():
             for lease_id in profile.current_leases:
-                if lease_id in self._lease_profile_index:
-                    continue
-                self._lease_profile_index[lease_id] = profile.profile_id
                 metadata = profile.lease_metadata.get(lease_id) or {}
                 owner = str(metadata.get("ownerId") or lease_id)
-                if owner not in self._owner_lease_index:
-                    self._owner_lease_index[owner] = lease_id
+                self._index_lease(profile.profile_id, lease_id, owner)
 
     def _index_lease(self, profile_id: str, lease_id: str, owner_id: str | None = None) -> None:
-        if lease_id and lease_id not in self._lease_profile_index:
+        if not lease_id:
+            return
+        existing_profile = self._lease_profile_index.get(lease_id)
+        if existing_profile is None:
             self._lease_profile_index[lease_id] = profile_id
+        elif existing_profile != profile_id:
+            # One lease identity cannot be held on two profiles. Keep the
+            # first mapping and surface the disagreement rather than letting
+            # the second profile silently inherit the lease.
+            self._record_lease_index_conflict(
+                "lease_profile",
+                lease_id=lease_id,
+                profile_id=profile_id,
+                existing=existing_profile,
+            )
         owner = str(owner_id or lease_id)
-        if owner and owner not in self._owner_lease_index:
+        if not owner:
+            return
+        existing_lease = self._owner_lease_index.get(owner)
+        if existing_lease is None:
             self._owner_lease_index[owner] = lease_id
+            self._lease_owner_index[lease_id] = owner
+        elif existing_lease != lease_id:
+            self._record_lease_index_conflict(
+                "owner_lease",
+                lease_id=lease_id,
+                owner_id=owner,
+                existing=existing_lease,
+            )
+        else:
+            self._lease_owner_index[lease_id] = owner
 
     def _unindex_lease(self, lease_id: str) -> None:
-        profile_id = self._lease_profile_index.pop(lease_id, None)
-        for owner, mapped_lease in list(self._owner_lease_index.items()):
-            if mapped_lease == lease_id:
+        self._lease_profile_index.pop(lease_id, None)
+        owner = self._lease_owner_index.pop(lease_id, None)
+        if owner is not None:
+            if self._owner_lease_index.get(owner) == lease_id:
                 del self._owner_lease_index[owner]
-        _ = profile_id
+            return
+        # Pre-contract state carries no reverse entry; fall back to the scan
+        # once so a lease indexed before the reverse index existed still
+        # unindexes completely.
+        for mapped_owner, mapped_lease in list(self._owner_lease_index.items()):
+            if mapped_lease == lease_id:
+                del self._owner_lease_index[mapped_owner]
 
     def _profile_id_for_lease(self, requester_workflow_id: str) -> str | None:
         try:
@@ -2891,6 +3263,13 @@ class MoonMindProviderProfileManagerWorkflow:
                     existing_profile_id = p.profile_id
                     break
 
+            if self._lease_grant_is_pending(req.requester_workflow_id):
+                # An Update handler holds an uncommitted reservation for this
+                # requester. Signalling a slot for it now would announce
+                # authority the ledger may never hold.
+                remaining.append(req)
+                continue
+
             if existing_profile_id:
                 if durable_grants and not await self._sync_leases_to_db():
                     remaining.append(req)
@@ -2953,6 +3332,8 @@ class MoonMindProviderProfileManagerWorkflow:
                 grant_metadata = self._grant_metadata(
                     req.lease_metadata,
                     fencing_generation=grant_generation,
+                    profile=profile,
+                    lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
                 )
             if profile is not None and profile.reserve(
                 req.requester_workflow_id,
@@ -2967,12 +3348,16 @@ class MoonMindProviderProfileManagerWorkflow:
                     req.requester_workflow_id,
                 )
                 if durable_grants:
-                    persisted = await self._persist_lease_grant(
-                        profile,
-                        req.requester_workflow_id,
-                        purpose=req.purpose,
-                        metadata=grant_metadata,
-                    )
+                    self._begin_grant_handoff(req.requester_workflow_id)
+                    try:
+                        persisted = await self._persist_lease_grant(
+                            profile,
+                            req.requester_workflow_id,
+                            purpose=req.purpose,
+                            metadata=grant_metadata,
+                        )
+                    finally:
+                        self._end_grant_handoff(req.requester_workflow_id)
                     if not persisted:
                         # Hold the in-memory reservation and retry persistence on
                         # the next loop. Never signal a consumer before its lease
@@ -3326,6 +3711,106 @@ class MoonMindProviderProfileManagerWorkflow:
         handle = workflow.get_external_workflow_handle(requester_workflow_id)
         await handle.signal("slot_assigned", payload)
 
+    def _expired_lease_candidates(self) -> list[tuple[str, str]]:
+        """Return ``(profile_id, lease_id)`` for every lease past its duration.
+
+        Unlike :meth:`_evict_expired_leases` this reports without mutating: an
+        expired lease keeps spending its slot until its resources are cleaned
+        up and its owner is proven terminal.
+        """
+
+        now = workflow.now()
+        expired: list[tuple[str, str]] = []
+        for profile in self._profiles.values():
+            max_duration = (
+                getattr(profile, "max_lease_duration_seconds", None)
+                or _MAX_LEASE_DURATION_SECONDS
+            )
+            if self._durable_maintenance_queue:
+                for owner_id in profile.evict_expired_maintenance_waiters(
+                    now, max_duration
+                ):
+                    self._has_new_events = True
+                    self._get_logger().warning(
+                        "Dropped an abandoned credential maintenance request for "
+                        "profile %s queued by %s",
+                        profile.profile_id,
+                        owner_id,
+                    )
+            for lease_id in list(profile.current_leases):
+                if self._lease_is_expired(profile, lease_id, now, max_duration):
+                    expired.append((profile.profile_id, lease_id))
+        return expired
+
+    def _lease_is_expired(
+        self,
+        profile: ProfileSlotState,
+        lease_id: str,
+        now: datetime,
+        max_duration_seconds: int,
+    ) -> bool:
+        granted_str = profile.lease_granted_at.get(lease_id)
+        limit = (
+            min(max_duration_seconds, profile.lease_max_duration_seconds(lease_id))
+            if profile.purpose_aware_capacity
+            else max_duration_seconds
+        )
+        if granted_str is None:
+            return True
+        try:
+            granted_dt = datetime.fromisoformat(granted_str)
+        except (ValueError, TypeError):
+            return True
+        if granted_dt.tzinfo is None:
+            granted_dt = granted_dt.replace(tzinfo=timezone.utc)
+        return (now - granted_dt).total_seconds() > limit
+
+    async def _request_cleanup_for_expired_leases(self) -> None:
+        """Ask for resource cleanup on every expired lease, bounded per lease.
+
+        Each expired lease costs one row transition. The slot is not freed
+        here: :meth:`_reclaim_terminal_leases` releases it once the owner is
+        verified terminal, which is the only evidence that the credential
+        consumer actually stopped.
+        """
+
+        for profile_id, lease_id in self._expired_lease_candidates():
+            if lease_id in self._cleanup_requested_leases:
+                continue
+            profile = self._profiles.get(profile_id)
+            if profile is None:
+                continue
+            outcome = await self._request_lease_cleanup(
+                lease_id,
+                profile_id=profile_id,
+                fencing_generation=profile.lease_fencing_generation(lease_id),
+                reason="lease_expired",
+            )
+            if outcome == LeaseTransitionOutcome.CLEANUP_REQUESTED.value:
+                self._cleanup_requested_leases.add(lease_id)
+                self._has_new_events = True
+                self._get_logger().warning(
+                    "Requested resource cleanup for the expired lease %s on "
+                    "profile %s; its slot stays reserved until its owner is "
+                    "proven terminal",
+                    lease_id,
+                    profile_id,
+                )
+            elif outcome == LeaseTransitionOutcome.ALREADY_RELEASED.value:
+                # The durable row is already a tombstone, so nothing is
+                # running against it. Reconcile the in-memory ledger.
+                if profile.release(lease_id):
+                    self._unindex_lease(lease_id)
+                    self._has_new_events = True
+            else:
+                self._get_logger().warning(
+                    "Cleanup request for the expired lease %s on profile %s "
+                    "did not resolve (%s)",
+                    lease_id,
+                    profile_id,
+                    outcome,
+                )
+
     def _evict_expired_leases(self) -> int:
         """Remove leases held longer than the max duration. Returns total eviction count."""
         now = workflow.now()
@@ -3420,15 +3905,15 @@ class MoonMindProviderProfileManagerWorkflow:
             statuses.update(result or {})
         return statuses
 
-    def _reclaim_terminal_leases(
+    def _terminal_lease_candidates(
         self,
         workflow_statuses: dict[str, dict[str, Any]],
         *,
         include_activity_owned: bool = False,
-    ) -> bool:
-        """Remove leases held by workflows that are in a terminal state."""
-        reclaimed = False
+    ) -> list[tuple[str, str, str]]:
+        """Return ``(profile_id, lease_id, status)`` for terminal-owner leases."""
 
+        candidates: list[tuple[str, str, str]] = []
         for profile in list(self._profiles.values()):
             for wf_id in list(profile.current_leases):
                 metadata = profile.lease_metadata.get(wf_id) or {}
@@ -3441,15 +3926,88 @@ class MoonMindProviderProfileManagerWorkflow:
                 owner_workflow_id = owner_workflow_id or wf_id
                 status_info = workflow_statuses.get(owner_workflow_id, {})
                 if not status_info.get("running", True):
-                    profile.release(wf_id)
-                    self._unindex_lease(wf_id)
-                    reclaimed = True
-                    self._get_logger().warning(
-                        "Reclaimed slot for profile %s from terminated workflow %s (status=%s)",
-                        profile.profile_id,
-                        wf_id,
-                        status_info.get("status", "UNKNOWN"),
+                    candidates.append(
+                        (
+                            profile.profile_id,
+                            wf_id,
+                            str(status_info.get("status", "UNKNOWN")),
+                        )
                     )
+        return candidates
+
+    async def _reclaim_terminal_leases_durably(
+        self,
+        workflow_statuses: dict[str, dict[str, Any]],
+        *,
+        include_activity_owned: bool = False,
+    ) -> None:
+        """Release each terminal-owner lease through the persistence owner.
+
+        MoonLadderStudios/MoonMind#3883: reclamation used to rewrite the whole
+        runtime snapshot, which let a retained writer replace unrelated rows.
+        Each lease now costs one fenced row transition, and the tombstone
+        records that resource cleanup is owed for it
+        (MoonLadderStudios/MoonMind#1089).
+        """
+
+        for profile_id, lease_id, status in self._terminal_lease_candidates(
+            workflow_statuses, include_activity_owned=include_activity_owned
+        ):
+            profile = self._profiles.get(profile_id)
+            if profile is None:
+                continue
+            outcome = await self._remove_lease_from_db(
+                lease_id,
+                fencing_generation=profile.lease_fencing_generation(lease_id),
+                profile_id=profile_id,
+                reason="owner_terminal",
+                cleanup_requested=True,
+            )
+            if outcome not in RELEASING_LEASE_OUTCOMES:
+                self._record_unresolved_release(
+                    lease_id,
+                    profile_id=profile_id,
+                    fencing_generation=profile.lease_fencing_generation(lease_id),
+                    outcome=outcome,
+                )
+                continue
+            self._unresolved_releases.pop(lease_id, None)
+            self._cleanup_requested_leases.discard(lease_id)
+            profile = self._profiles.get(profile_id)
+            if profile is not None and profile.release(lease_id):
+                self._unindex_lease(lease_id)
+                self._has_new_events = True
+                self._get_logger().warning(
+                    "Reclaimed slot for profile %s from terminated workflow %s (status=%s)",
+                    profile_id,
+                    lease_id,
+                    status,
+                )
+
+    def _reclaim_terminal_leases(
+        self,
+        workflow_statuses: dict[str, dict[str, Any]],
+        *,
+        include_activity_owned: bool = False,
+    ) -> bool:
+        """Remove leases held by workflows that are in a terminal state."""
+        reclaimed = False
+
+        for profile_id, wf_id, status in self._terminal_lease_candidates(
+            workflow_statuses, include_activity_owned=include_activity_owned
+        ):
+            profile = self._profiles.get(profile_id)
+            if profile is None:
+                continue
+            profile.release(wf_id)
+            self._unindex_lease(wf_id)
+            reclaimed = True
+            self._get_logger().warning(
+                "Reclaimed slot for profile %s from terminated workflow %s (status=%s)",
+                profile_id,
+                wf_id,
+                status,
+            )
 
         return reclaimed
 
@@ -3498,7 +4056,12 @@ class MoonMindProviderProfileManagerWorkflow:
             return
 
         reclaimed = False
-        if verify_lease_holders:
+        if verify_lease_holders and self._lease_transition_contract:
+            await self._reclaim_terminal_leases_durably(
+                workflow_statuses,
+                include_activity_owned=verify_activity_owned_leases,
+            )
+        elif verify_lease_holders:
             reclaimed = self._reclaim_terminal_leases(
                 workflow_statuses,
                 include_activity_owned=verify_activity_owned_leases,
@@ -3520,6 +4083,10 @@ class MoonMindProviderProfileManagerWorkflow:
             self._lease_holder_workflow_ids()
         )
         if workflow_statuses is None:
+            return
+
+        if self._lease_transition_contract:
+            await self._reclaim_terminal_leases_durably(workflow_statuses)
             return
 
         reclaimed = self._reclaim_terminal_leases(workflow_statuses)
@@ -3907,7 +4474,15 @@ class MoonMindProviderProfileManagerWorkflow:
         return await self._sync_leases_to_db()
 
     async def _sync_leases_to_db(self) -> bool:
-        """Persist current lease state to the database for crash recovery."""
+        """Persist current lease state to the database for crash recovery.
+
+        The runtime-wide snapshot rewrite is retained only for histories
+        recorded before the incremental contract. It carries this writer's own
+        fencing high-water mark so the persistence owner preserves any row a
+        newer writer granted: a patch marker in one workflow history cannot
+        fence a stale database writer, but a durable generation comparison can
+        (MoonLadderStudios/MoonMind#3883).
+        """
         try:
             leases = []
             for profile in self._profiles.values():
@@ -3915,7 +4490,12 @@ class MoonMindProviderProfileManagerWorkflow:
                     leases.append(self._lease_row(profile, wf_id))
             await workflow.execute_activity(
                 "provider_profile.sync_slot_leases",
-                {"runtime_id": self._runtime_id, "leases": leases, "action": "save"},
+                {
+                    "runtime_id": self._runtime_id,
+                    "leases": leases,
+                    "action": "save",
+                    "writer_generation": int(self._lease_grant_sequence or 0),
+                },
                 task_queue=ACTIVITY_TASK_QUEUE,
                 start_to_close_timeout=timedelta(seconds=10),
                 retry_policy=RetryPolicy(
@@ -3933,9 +4513,22 @@ class MoonMindProviderProfileManagerWorkflow:
             return False
 
     async def _remove_lease_from_db(
-        self, workflow_id: str, *, fencing_generation: int = 0
-    ) -> None:
-        """Remove a single lease from the database."""
+        self,
+        workflow_id: str,
+        *,
+        fencing_generation: int = 0,
+        profile_id: str | None = None,
+        reason: str | None = None,
+        cleanup_requested: bool = False,
+    ) -> str:
+        """Release one lease durably and report exactly what the ledger did.
+
+        MoonLadderStudios/MoonMind#3883: the return value is a
+        :class:`~moonmind.provider_profiles.lease_client.LeaseTransitionOutcome`
+        value. Only ``released`` and ``already_released`` make the slot
+        reusable; every other outcome keeps capacity unavailable. A swallowed
+        exception used to look exactly like success.
+        """
         try:
             use_incremental = False
             try:
@@ -3943,16 +4536,26 @@ class MoonMindProviderProfileManagerWorkflow:
             except Exception:
                 use_incremental = False
             if use_incremental:
-                await workflow.execute_activity(
+                payload: dict[str, Any] = {
+                    "lease_id": workflow_id,
+                    "fencing_generation": fencing_generation or 1,
+                }
+                if self._lease_transition_contract:
+                    # Quote the generation this manager actually acquired. A
+                    # hard-coded 1 asserted authority it never held, so a
+                    # release either matched an unrelated row or read as stale.
+                    payload["fencing_generation"] = int(fencing_generation or 0)
+                    if profile_id:
+                        payload["profile_id"] = profile_id
+                    if reason:
+                        payload["reason"] = reason
+                    if cleanup_requested:
+                        payload["cleanup_requested"] = True
+                result = await workflow.execute_activity(
                     "provider_profile.sync_slot_leases",
                     {
                         "runtime_id": self._runtime_id,
-                        "leases": [
-                            {
-                                "lease_id": workflow_id,
-                                "fencing_generation": fencing_generation or 1,
-                            }
-                        ],
+                        "leases": [payload],
                         "action": "release_one",
                     },
                     task_queue=ACTIVITY_TASK_QUEUE,
@@ -3964,7 +4567,7 @@ class MoonMindProviderProfileManagerWorkflow:
                         maximum_attempts=3,
                     ),
                 )
-                return
+                return self._release_outcome(result, workflow_id)
             await workflow.execute_activity(
                 "provider_profile.sync_slot_leases",
                 {
@@ -3981,10 +4584,93 @@ class MoonMindProviderProfileManagerWorkflow:
                     maximum_attempts=3,
                 ),
             )
+            return LeaseTransitionOutcome.RELEASED.value
         except Exception:
             self._get_logger().warning(
                 "Failed to remove lease for %s from DB", workflow_id
             )
+            return LeaseTransitionOutcome.RETRYABLE.value
+
+    def _release_outcome(self, result: Any, lease_id: str) -> str:
+        """Normalize one ``release_one`` result into a typed outcome."""
+
+        if not isinstance(result, dict):
+            return LeaseTransitionOutcome.RETRYABLE.value
+        outcome = str(result.get("outcome") or "").strip()
+        if outcome:
+            try:
+                return LeaseTransitionOutcome(outcome).value
+            except ValueError:
+                self._get_logger().warning(
+                    "Unknown lease release outcome %r for %s", outcome, lease_id
+                )
+                return LeaseTransitionOutcome.RETRYABLE.value
+        # A pre-contract Activity build answers without an outcome. Its shape
+        # is unambiguous, so it maps onto the same contract.
+        if result.get("error"):
+            return LeaseTransitionOutcome.CONFLICT.value
+        if result.get("stale"):
+            return LeaseTransitionOutcome.STALE.value
+        if result.get("released"):
+            return (
+                LeaseTransitionOutcome.ALREADY_RELEASED.value
+                if result.get("duplicate")
+                else LeaseTransitionOutcome.RELEASED.value
+            )
+        return LeaseTransitionOutcome.RETRYABLE.value
+
+    async def _request_lease_cleanup(
+        self,
+        lease_id: str,
+        *,
+        profile_id: str,
+        fencing_generation: int,
+        reason: str,
+    ) -> str:
+        """Ask the resource owner to clean up while the slot stays spent.
+
+        MoonLadderStudios/MoonMind#1089: an expired lease is not evidence that
+        its holder stopped running. Requesting cleanup records durable,
+        actionable state on the same row instead of freeing a credential
+        consumer that may still be executing.
+        """
+
+        try:
+            result = await workflow.execute_activity(
+                "provider_profile.sync_slot_leases",
+                {
+                    "runtime_id": self._runtime_id,
+                    "leases": [
+                        {
+                            "lease_id": lease_id,
+                            "profile_id": profile_id,
+                            "fencing_generation": int(fencing_generation or 0),
+                            "reason": reason,
+                        }
+                    ],
+                    "action": "request_cleanup",
+                },
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=1),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=10),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception:
+            self._get_logger().warning(
+                "Failed to request resource cleanup for lease %s", lease_id
+            )
+            return LeaseTransitionOutcome.RETRYABLE.value
+        if not isinstance(result, dict):
+            return LeaseTransitionOutcome.RETRYABLE.value
+        outcome = str(result.get("outcome") or "").strip()
+        try:
+            return LeaseTransitionOutcome(outcome).value
+        except ValueError:
+            return LeaseTransitionOutcome.RETRYABLE.value
 
     async def _grant_lease_to_db(
         self,
@@ -4009,6 +4695,21 @@ class MoonMindProviderProfileManagerWorkflow:
         except (TypeError, ValueError):
             fencing_generation = 0
         evidence_identity = safe.get("evidenceIdentity")
+        capacity_scope_ref = str(
+            safe.get("capacityScopeRef") or self._capacity_scope_ref(profile)
+        )
+        # The compatibility class is the ledger mode this lease coexists
+        # under. Recovery reconstructs the same mode from it instead of
+        # re-deriving a narrower legacy-shaped view from the purpose alone.
+        compatibility_class = str(
+            safe.get("compatibilityClass") or profile.lease_mode(lease_id).value
+        )
+        try:
+            scope_generation = int(
+                safe.get("scopeGeneration") or self._scope_generation_for(profile)
+            )
+        except (TypeError, ValueError):
+            scope_generation = self._scope_generation_for(profile)
         try:
             result = await workflow.execute_activity(
                 "provider_profile.sync_slot_leases",
@@ -4022,13 +4723,14 @@ class MoonMindProviderProfileManagerWorkflow:
                             "owner_id": owner_id,
                             "owner_kind": "workflow" if owner_is_workflow else "activity",
                             "purpose": purpose,
+                            "compatibility_class": compatibility_class,
                             "fencing_generation": fencing_generation or 1,
-                            "scope_generation": 1,
-                            "capacity_scope_ref": (
-                                profile.capacity_scope_ref
-                                or f"provider-profile:{profile.profile_id}"
-                            ),
-                            "lease_state": "held",
+                            # The scope generation the grant was actually
+                            # admitted against, not a placeholder
+                            # (MoonLadderStudios/MoonMind#3883).
+                            "scope_generation": scope_generation,
+                            "capacity_scope_ref": capacity_scope_ref,
+                            "lease_state": DurableLeaseState.HELD.value,
                             "stepExecutionId": safe.get("stepExecutionId"),
                             "oauthSessionId": safe.get("oauthSessionId"),
                             "idempotencyKey": safe.get("idempotencyKey"),
@@ -4067,7 +4769,72 @@ class MoonMindProviderProfileManagerWorkflow:
             self._get_logger().warning(
                 "Failed to persist lease grant for %s", lease_id
             )
+            if not self._lease_transition_contract:
+                return False
+            # MoonLadderStudios/MoonMind#3883: a database write can time out
+            # *after* it commits. Rolling the reservation back on that evidence
+            # alone would abandon a live grant, and granting again would create
+            # a second authority. The stable lease identity is reused to ask
+            # the ledger what it actually holds.
+            return await self._grant_committed_after_ambiguous_write(
+                lease_id=lease_id,
+                profile_id=profile.profile_id,
+                fencing_generation=fencing_generation or 1,
+            )
+
+    async def _grant_committed_after_ambiguous_write(
+        self,
+        *,
+        lease_id: str,
+        profile_id: str,
+        fencing_generation: int,
+    ) -> bool:
+        """Whether the ledger already holds the grant this write may have made."""
+
+        try:
+            result = await workflow.execute_activity(
+                "provider_profile.sync_slot_leases",
+                {
+                    "runtime_id": self._runtime_id,
+                    "leases": [{"lease_id": lease_id}],
+                    "action": "describe",
+                },
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=10),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=1),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=10),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception:
+            # Still ambiguous. Report failure so the caller keeps capacity
+            # blocked rather than announcing authority nobody has confirmed.
+            self._get_logger().warning(
+                "Could not reconcile the durable state of lease %s", lease_id
+            )
             return False
+        if not isinstance(result, dict) or not result.get("found"):
+            return False
+        row = result.get("lease") or {}
+        if str(row.get("profile_id") or "") != str(profile_id):
+            return False
+        if str(row.get("lease_state") or "") != DurableLeaseState.HELD.value:
+            return False
+        try:
+            recorded_generation = int(row.get("fencing_generation") or 0)
+        except (TypeError, ValueError):
+            recorded_generation = 0
+        if recorded_generation != int(fencing_generation):
+            return False
+        self._get_logger().info(
+            "Reconciled an ambiguous lease grant for %s: the ledger already "
+            "holds generation %s",
+            lease_id,
+            recorded_generation,
+        )
+        return True
 
     async def _purge_released_lease_rows(self) -> None:
         """Delete release tombstones older than the redelivery horizon."""
@@ -4119,6 +4886,36 @@ class MoonMindProviderProfileManagerWorkflow:
                 ),
             )
             leases = result.get("leases", []) if result else []
+
+            if self._lease_transition_contract:
+                # MoonLadderStudios/MoonMind#3883: a state the contract does
+                # not know is not free capacity and not a row to drop. It
+                # blocks new admission and becomes actionable reconciliation
+                # evidence, as does an index disagreement between live rows.
+                unreconciled = (result or {}).get("unreconciled") or []
+                conflicts = (result or {}).get("conflicts") or []
+                if unreconciled or conflicts:
+                    self._lease_index_conflicts.extend(
+                        [
+                            {"kind": "unreconciled_state", **dict(entry)}
+                            for entry in unreconciled
+                            if isinstance(entry, dict)
+                        ]
+                        + [
+                            {"kind": "durable_identity", **dict(entry)}
+                            for entry in conflicts
+                            if isinstance(entry, dict)
+                        ]
+                    )
+                    self._get_logger().error(
+                        "Provider profile lease recovery found %d unreconciled "
+                        "lease states and %d durable identity conflicts for "
+                        "runtime %s; refusing to admit new capacity",
+                        len(unreconciled),
+                        len(conflicts),
+                        self._runtime_id,
+                    )
+                    return False
 
             # The high-water mark is stored independently of the live rows:
             # release tombstones keep their generation, so a fresh manager
@@ -4220,6 +5017,23 @@ class MoonMindProviderProfileManagerWorkflow:
                             )
                             if lease.get(key) is not None
                         },
+                        # MoonLadderStudios/MoonMind#3883: restore the mode and
+                        # the admission generations the lease was granted
+                        # under, not a narrower legacy-shaped view of them.
+                        **(
+                            {
+                                key: lease[key]
+                                for key in (
+                                    "compatibilityClass",
+                                    "capacityScopeRef",
+                                    "scopeGeneration",
+                                    "ownerKind",
+                                )
+                                if lease.get(key) is not None
+                            }
+                            if self._lease_transition_contract
+                            else {}
+                        ),
                         **(
                             {
                                 "fencingGeneration": self._normalize_sequence(
@@ -4240,6 +5054,14 @@ class MoonMindProviderProfileManagerWorkflow:
                         wf_id,
                         str(lease.get("ownerId") or wf_id),
                     )
+                    if (
+                        self._lease_transition_contract
+                        and str(lease.get("leaseState") or "")
+                        == DurableLeaseState.CLEANUP_REQUESTED.value
+                    ):
+                        # The slot is still spent and its cleanup request is
+                        # already durable; do not re-request it on restore.
+                        self._cleanup_requested_leases.add(wf_id)
                     self._lease_grant_sequence = max(
                         self._lease_grant_sequence,
                         profile.lease_fencing_generation(wf_id),
@@ -4280,6 +5102,15 @@ class MoonMindProviderProfileManagerWorkflow:
                         await self._remove_lease_from_db(
                             wf_id, fencing_generation=restored_generation
                         )
+
+            if self._lease_transition_contract and self._lease_index_conflicts:
+                self._get_logger().error(
+                    "Provider profile lease recovery rebuilt contradictory "
+                    "lease indexes for runtime %s: %s",
+                    self._runtime_id,
+                    self._lease_index_conflicts,
+                )
+                return False
 
             return True
 

--- a/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
+++ b/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
@@ -31,6 +31,7 @@ from typing import Any
 import pytest
 import pytest_asyncio
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -197,16 +198,17 @@ async def _rows(maker) -> list[ProviderProfileSlotLease]:
 
 
 @pytest.mark.asyncio
-async def test_the_migration_versions_existing_rows_and_breaks_id_collisions(
+async def test_the_migration_versions_existing_rows_and_keeps_lease_identity(
     control_plane_postgres_url,
 ) -> None:
-    """Existing rows survive; colliding backfilled lease IDs stay distinct.
+    """Existing rows survive and keep the identity their holders already quote.
 
     Pre-contract rows are unique per ``(runtime_id, workflow_id)``, so two
-    runtime families can hold the same workflow ID. Backfilling ``lease_id``
-    from ``workflow_id`` and then adding a global unique constraint has to
-    resolve that without failing the migration and without merging two leases
-    into one.
+    runtime families can hold the same workflow ID. Uniqueness is therefore
+    runtime-scoped: rewriting the later row's ``lease_id`` would break the
+    handle its holder releases with, so that holder's release would resolve the
+    *other* runtime's row, report a profile conflict, and leave the rewritten
+    row permanently active (MoonLadderStudios/MoonMind#3883).
     """
 
     from alembic.migration import MigrationContext
@@ -255,13 +257,12 @@ async def test_the_migration_versions_existing_rows_and_breaks_id_collisions(
             ).all()
 
         assert len(rows) == 3, "existing rows must survive the migration"
-        # The oldest row keeps the exact identity its holder already quotes.
+        # Both holders keep the exact identity they already quote on release.
         assert rows[0].lease_id == "agent-run-1"
-        # The colliding row is disambiguated instead of merged or dropped.
-        assert rows[1].lease_id.startswith("agent-run-1#")
-        assert rows[1].lease_id != rows[0].lease_id
+        assert rows[1].lease_id == "agent-run-1"
+        assert rows[0].runtime_id != rows[1].runtime_id
         assert rows[2].lease_id == "agent-run-2"
-        assert len({row.lease_id for row in rows}) == 3
+        assert len({(row.runtime_id, row.lease_id) for row in rows}) == 3
 
         # Historical values are versioned, not fabricated.
         assert rows[0].owner_kind == "workflow"
@@ -272,15 +273,34 @@ async def test_the_migration_versions_existing_rows_and_breaks_id_collisions(
         assert all(row.lease_state == DurableLeaseState.HELD.value for row in rows)
 
         async with engine.connect() as conn:
-            constraint = (
+            constrained_columns = (
                 await conn.execute(
                     text(
-                        "SELECT conname FROM pg_constraint "
-                        "WHERE conname = 'uq_provider_slot_lease_lease_id'"
+                        "SELECT array_agg(att.attname ORDER BY att.attname) "
+                        "FROM pg_constraint con "
+                        "JOIN pg_attribute att "
+                        "  ON att.attrelid = con.conrelid "
+                        " AND att.attnum = ANY(con.conkey) "
+                        "WHERE con.conname = 'uq_provider_slot_lease_lease_id'"
                     )
                 )
             ).scalar()
-        assert constraint == "uq_provider_slot_lease_lease_id"
+        assert sorted(constrained_columns or []) == ["lease_id", "runtime_id"]
+
+        # The owning workflow stays an identity for workflow-owned rows only.
+        async with engine.connect() as conn:
+            predicate = (
+                await conn.execute(
+                    text(
+                        "SELECT pg_get_indexdef(indexrelid) FROM pg_index "
+                        "JOIN pg_class ON pg_class.oid = pg_index.indexrelid "
+                        "WHERE relname = 'uq_provider_slot_lease_runtime_workflow'"
+                    )
+                )
+            ).scalar()
+        assert predicate is not None
+        assert "UNIQUE" in predicate
+        assert "WHERE owner_is_workflow" in predicate
     finally:
         async with engine.begin() as conn:
             await conn.execute(
@@ -588,12 +608,20 @@ async def test_a_retained_snapshot_writer_cannot_delete_newer_authority(
 
 
 @pytest.mark.asyncio
-async def test_a_pre_contract_snapshot_without_a_generation_still_replaces(
+async def test_a_pre_contract_snapshot_replaces_only_what_it_restates(
     lease_session_maker,
 ) -> None:
-    """Replay safety: the recorded legacy command keeps its exact semantics."""
+    """An absent writer generation is a zero high-water mark, not a wipe.
+
+    MoonLadderStudios/MoonMind#3883: an Activity payload recorded before this
+    contract carries no ``writer_generation``, so a retried legacy ``save`` that
+    lands after a transition-contract manager granted rows would otherwise
+    execute an unqualified runtime-wide delete and erase authority the ledger
+    had already handed out.
+    """
 
     await _run("grant", [_grant("agent-run-old", fence=2)])
+    await _run("grant", [_grant("agent-run-new", fence=40)])
 
     result = await _run(
         "save",
@@ -607,8 +635,30 @@ async def test_a_pre_contract_snapshot_without_a_generation_still_replaces(
         ],
     )
 
-    assert result == {"saved": 1}
-    assert len(await _rows(lease_session_maker)) == 1
+    assert result == {"saved": 1, "preserved": 1}
+    rows = {row.lease_id: row for row in await _rows(lease_session_maker)}
+    assert set(rows) == {"agent-run-old", "agent-run-new"}
+    # The row the legacy snapshot itself names is still replaced, so the
+    # retained writer keeps its own eviction semantics.
+    assert rows["agent-run-old"].fencing_generation == 2
+    assert rows["agent-run-new"].fencing_generation == 40
+    assert rows["agent-run-new"].lease_state == DurableLeaseState.HELD.value
+
+
+@pytest.mark.asyncio
+async def test_an_empty_pre_contract_snapshot_never_erases_newer_authority(
+    lease_session_maker,
+) -> None:
+    """The worst case: a legacy writer that believes it holds nothing."""
+
+    await _run("grant", [_grant("agent-run-new", fence=40)])
+
+    result = await _run("save", [])
+
+    assert result == {"saved": 0, "preserved": 1}
+    rows = await _rows(lease_session_maker)
+    assert [row.lease_id for row in rows] == ["agent-run-new"]
+    assert rows[0].fencing_generation == 40
 
 
 @pytest.mark.asyncio
@@ -689,6 +739,108 @@ async def test_load_reports_unknown_state_and_identity_conflicts(
         "agent-run-2",
         "agent-run-3",
     ]
+
+
+@pytest.mark.asyncio
+async def test_one_lease_id_in_two_runtimes_releases_independently(
+    lease_session_maker,
+) -> None:
+    """A holder's release resolves its own runtime's row, never a namesake.
+
+    Pre-contract rows backfill ``lease_id`` from ``workflow_id``, so the same
+    lease ID legitimately exists in two runtime families. Resolving a
+    transition without the runtime would hand the later runtime's release the
+    earlier runtime's row, report a profile conflict, and leave the real row
+    permanently active (MoonLadderStudios/MoonMind#3883).
+    """
+
+    activity = _activity()
+    await activity(
+        runtime_id=RUNTIME_ID,
+        leases=[_grant("agent-run-1", fence=1)],
+        action="grant",
+    )
+    await activity(
+        runtime_id="codex_cli",
+        leases=[_grant("agent-run-1", fence=1, profile_id="codex-oauth")],
+        action="grant",
+    )
+
+    released = await activity(
+        runtime_id="codex_cli",
+        leases=[
+            {
+                "lease_id": "agent-run-1",
+                "profile_id": "codex-oauth",
+                "fencing_generation": 1,
+            }
+        ],
+        action="release_one",
+    )
+
+    assert released["outcome"] == LeaseTransitionOutcome.RELEASED.value
+    states = {
+        (row.runtime_id, row.lease_state) for row in await _rows(lease_session_maker)
+    }
+    assert states == {
+        (RUNTIME_ID, DurableLeaseState.HELD.value),
+        ("codex_cli", DurableLeaseState.RELEASED.value),
+    }
+
+
+@pytest.mark.asyncio
+async def test_activity_leases_may_share_one_owning_workflow(
+    lease_session_maker,
+) -> None:
+    """Two Activity-owned Profiles under one workflow is supported concurrency.
+
+    ``OmnigentProviderLeaseCoordinator._acquire_activity_owned`` grants one
+    lease per Provider Profile for a single step, each with its own hashed
+    owner ID, and records the owning workflow only so the manager can verify
+    liveness. Treating that repeated workflow as a durable identity conflict
+    would refuse to restart the runtime manager
+    (MoonLadderStudios/MoonMind#3883).
+    """
+
+    for profile_ref, owner in (
+        (PROFILE_REF, "activity-owner-a"),
+        (OTHER_PROFILE_REF, "activity-owner-b"),
+    ):
+        await _run(
+            "grant",
+            [
+                {
+                    **_grant(owner, fence=1, profile_id=profile_ref),
+                    "workflow_id": "agent-run-1",
+                    "owner_id": owner,
+                    "owner_kind": "activity",
+                    "ownerIsWorkflow": False,
+                }
+            ],
+        )
+
+    loaded = await _run("load")
+
+    assert loaded["conflicts"] == []
+    assert sorted(lease["leaseId"] for lease in loaded["leases"]) == [
+        "activity-owner-a",
+        "activity-owner-b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workflow_owned_rows_still_own_their_workflow_identity(
+    lease_session_maker,
+) -> None:
+    """The partial unique index keeps the workflow an identity where it is one."""
+
+    await _run("grant", [_grant("agent-run-1", fence=1)])
+
+    with pytest.raises(IntegrityError):
+        await _run(
+            "grant",
+            [{**_grant("agent-run-2", fence=2), "workflow_id": "agent-run-1"}],
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
+++ b/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
@@ -710,6 +710,7 @@ class _RestartedManager(MoonMindProviderProfileManagerWorkflow):
     def __init__(self) -> None:
         super().__init__()
         self.reconnected: list[tuple[str, str, int | None]] = []
+        self.ledger_actions: list[str] = []
 
     async def _signal_slot_assigned(
         self,
@@ -725,13 +726,22 @@ class _RestartedManager(MoonMindProviderProfileManagerWorkflow):
 
 async def _restore_manager(monkeypatch: pytest.MonkeyPatch) -> _RestartedManager:
     activity = _activity()
+    manager = _RestartedManager()
 
     async def _execute_activity(name: str, payload: Any, **_kwargs: Any) -> Any:
+        if name == "provider_profile.pending_request_order":
+            return {"orders": {owner: {} for owner in payload["workflow_ids"]}}
         assert name == "provider_profile.sync_slot_leases"
+        manager.ledger_actions.append(payload["action"])
         return await activity(**payload)
 
     monkeypatch.setattr(
         provider_profile_manager.workflow, "execute_activity", _execute_activity
+    )
+    monkeypatch.setattr(
+        provider_profile_manager.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
     )
     monkeypatch.setattr(
         provider_profile_manager.workflow, "patched", lambda _patch_id: True
@@ -751,7 +761,6 @@ async def _restore_manager(monkeypatch: pytest.MonkeyPatch) -> _RestartedManager
         logging.getLogger("test.provider_profile_manager"),
     )
 
-    manager = _RestartedManager()
     manager._runtime_id = RUNTIME_ID
     manager._durable_maintenance_queue = True
     manager._lease_transition_contract = True
@@ -826,6 +835,135 @@ async def test_a_restart_restores_every_mode_owner_and_generation(
     assert manager._lease_grant_sequence == 13
     # Only the execution owner is reconnected; maintenance owners are not.
     assert manager.reconnected == [("agent-run-1", PROFILE_REF, 11)]
+
+
+def _durable_identity(row: ProviderProfileSlotLease) -> dict[str, Any]:
+    """Every field a runtime-wide snapshot rewrite would reset to a default."""
+
+    return {
+        "profile_id": row.profile_id,
+        "owner_kind": row.owner_kind,
+        "purpose": row.purpose,
+        "compatibility_class": row.compatibility_class,
+        "capacity_scope_ref": row.capacity_scope_ref,
+        "scope_generation": row.scope_generation,
+        "credential_generation": row.credential_generation,
+        "execution_plan_ref": row.execution_plan_ref,
+        "lease_state": row.lease_state,
+        "fencing_generation": row.fencing_generation,
+        "safe_metadata_json": row.safe_metadata_json,
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_re_signal_drain_leaves_every_unrelated_row_intact(
+    lease_session_maker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held owner asking again re-signals without replacing runtime rows.
+
+    ``AgentRun._recover_and_request_slot`` re-sends ``request_slot`` when a
+    slot wait times out, so the drain reaches its existing-lease branch while
+    the manager still holds the lease. That branch used to rewrite the whole
+    runtime snapshot, which reset every unrelated row to the model defaults
+    and deleted the release tombstones the fencing high-water mark is read
+    from (MoonLadderStudios/MoonMind#3883).
+    """
+
+    expiry = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    await _run(
+        "grant",
+        [{**_grant("agent-run-1", fence=11, scope_generation=3), "expiresAt": expiry}],
+    )
+    # An unrelated maintenance lease on another profile, in another mode.
+    await _run(
+        "grant",
+        [
+            _grant(
+                "owner-maintenance",
+                fence=12,
+                profile_id=OTHER_PROFILE_REF,
+                purpose="credential_validation",
+                compatibility_class=(
+                    CredentialLeaseMode.SINGLE_FLIGHT_VALIDATION.value
+                ),
+                scope_generation=4,
+                credential_generation=9,
+                plan_ref=OTHER_PLAN_REF,
+                identity="evidence-maint",
+            )
+        ],
+    )
+    # An unrelated lease whose resources were already asked to clean up.
+    await _run("grant", [_grant("agent-run-2", fence=14, scope_generation=3)])
+    await _run(
+        "request_cleanup",
+        [
+            {
+                "lease_id": "agent-run-2",
+                "profile_id": PROFILE_REF,
+                "fencing_generation": 14,
+                "reason": "lease_expired",
+            }
+        ],
+    )
+    # A release tombstone: the durable evidence the high-water mark survives on.
+    await _run("grant", [_grant("agent-run-gone", fence=15)])
+    await _run(
+        "release_one", [{"lease_id": "agent-run-gone", "fencing_generation": 15}]
+    )
+
+    before = {
+        row.lease_id: _durable_identity(row) for row in await _rows(lease_session_maker)
+    }
+    assert set(before) == {
+        "agent-run-1",
+        "owner-maintenance",
+        "agent-run-2",
+        "agent-run-gone",
+    }
+
+    manager = await _restore_manager(monkeypatch)
+    assert await manager._load_leases_from_db() is True
+    manager.ledger_actions.clear()
+    manager.reconnected.clear()
+    manager._pending_requests = [
+        provider_profile_manager.PendingRequest(
+            requester_workflow_id="agent-run-1", runtime_id=RUNTIME_ID
+        )
+    ]
+
+    await manager._drain_queue()
+
+    # The held lease is re-announced with the generation the ledger recorded.
+    assert manager.reconnected == [("agent-run-1", PROFILE_REF, 11)]
+    assert manager._pending_requests == []
+    # And it cost no durable write at all, so nothing could be replaced.
+    assert manager.ledger_actions == []
+
+    after = {
+        row.lease_id: _durable_identity(row) for row in await _rows(lease_session_maker)
+    }
+    assert after == before
+    maintenance = after["owner-maintenance"]
+    assert maintenance["compatibility_class"] == (
+        CredentialLeaseMode.SINGLE_FLIGHT_VALIDATION.value
+    )
+    assert maintenance["scope_generation"] == 4
+    assert maintenance["capacity_scope_ref"] == SCOPE_REF
+    assert maintenance["execution_plan_ref"] == OTHER_PLAN_REF
+    assert after["agent-run-2"]["lease_state"] == (
+        DurableLeaseState.CLEANUP_REQUESTED.value
+    )
+    assert after["agent-run-gone"]["lease_state"] == DurableLeaseState.RELEASED.value
+
+    # The tombstone still carries the high-water mark a fresh manager reads.
+    loaded = await _run("load")
+    assert loaded["max_fencing_generation"] == 15
+    assert sorted(lease["leaseId"] for lease in loaded["leases"]) == [
+        "agent-run-1",
+        "agent-run-2",
+        "owner-maintenance",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
+++ b/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
@@ -1,0 +1,874 @@
+"""Database-backed evidence for the incremental lease contract.
+
+Source: MoonLadderStudios/MoonMind#3883 (remaining implementation 1-7;
+AC1, AC2, AC3, AC4, AC5, AC6, AC7, AC8).
+
+The lease ledger is the authority for whether a Provider Profile slot is
+spent, so its guarantees are proven against a real PostgreSQL cluster running
+the real Alembic migration and the real
+``provider_profile.sync_slot_leases`` Activity — not against mocked Activity
+returns. Covered here:
+
+* the ``369_provider_lease_incr_contract`` migration over pre-contract rows,
+  including lease IDs that would collide when backfilled from ``workflow_id``;
+* grant-or-get under real concurrency and a real unique constraint;
+* conflicting profile / plan / purpose / generation reuse;
+* release, duplicate release, stale fence and cleanup-request transitions;
+* a mixed-generation cutover in which a retained snapshot writer must not
+  delete a newer writer's rows;
+* restart recovery of every mode, owner and generation without resurrecting
+  released state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import ProviderProfileSlotLease
+from moonmind.provider_profiles.lease_client import (
+    CredentialLeaseMode,
+    DurableLeaseState,
+    LeaseTransitionOutcome,
+)
+from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+from moonmind.workflows.temporal.workflows import provider_profile_manager
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    MoonMindProviderProfileManagerWorkflow,
+    ProfileSlotState,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+RUNTIME_ID = "opencode"
+PROFILE_REF = "opencode-zen-free"
+OTHER_PROFILE_REF = "opencode-zen-paid"
+SCOPE_REF = "provider-scope:opencode-zen"
+PLAN_REF = "omnigent-execution-plan:sha256:" + "a" * 64
+OTHER_PLAN_REF = "omnigent-execution-plan:sha256:" + "b" * 64
+
+# The exact pre-369 shape of the lease table: the initial columns plus the
+# owner/purpose/identity columns added by 337_mm1207_omnigent_oauth_hosts.
+_PRE_CONTRACT_DDL = """
+CREATE TABLE provider_profile_slot_leases (
+    id SERIAL PRIMARY KEY,
+    runtime_id VARCHAR(64) NOT NULL,
+    workflow_id VARCHAR(255) NOT NULL,
+    profile_id VARCHAR(128) NOT NULL,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    lease_id VARCHAR(255),
+    owner_id VARCHAR(255),
+    purpose VARCHAR(64) NOT NULL DEFAULT 'execution_direct',
+    owner_is_workflow BOOLEAN NOT NULL DEFAULT true,
+    step_execution_id VARCHAR(255),
+    oauth_session_id VARCHAR(128),
+    idempotency_key VARCHAR(255),
+    expires_at TIMESTAMPTZ,
+    CONSTRAINT uq_provider_slot_lease_runtime_workflow
+        UNIQUE (runtime_id, workflow_id)
+);
+CREATE INDEX ix_provider_slot_leases_runtime
+    ON provider_profile_slot_leases (runtime_id);
+CREATE INDEX ix_provider_slot_leases_workflow
+    ON provider_profile_slot_leases (workflow_id);
+"""
+
+
+def _load_migration_module():
+    """Load the real ``369_provider_lease_incr_contract`` revision module.
+
+    Alembic revision files are not importable as a package (the directory has
+    no ``__init__`` and the module name starts with a digit), so the real file
+    is loaded by path. This runs the shipped migration, not a copy of it.
+    """
+
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "migrations"
+        / "versions"
+        / "369_provider_lease_incr_contract.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "moonmind_test_migration_369", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_lease_table(sync_conn) -> None:
+    ProviderProfileSlotLease.__table__.create(sync_conn, checkfirst=True)
+
+
+def _drop_lease_table(sync_conn) -> None:
+    ProviderProfileSlotLease.__table__.drop(sync_conn, checkfirst=True)
+
+
+@pytest_asyncio.fixture()
+async def lease_session_maker(control_plane_postgres_url, monkeypatch):
+    """Bind the production session factory to an ephemeral PostgreSQL cluster.
+
+    The Activity resolves ``api_service.db.base.async_session_maker`` at call
+    time, so rebinding it exercises the real Activity against a real ledger.
+    """
+
+    import api_service.db.base as db_base
+
+    engine = create_async_engine(control_plane_postgres_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(_create_lease_table)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(db_base, "async_session_maker", maker)
+    try:
+        yield maker
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(_drop_lease_table)
+        await engine.dispose()
+
+
+def _activity() -> Any:
+    return TemporalArtifactActivities(service=None).provider_profile_sync_slot_leases
+
+
+async def _run(action: str, leases: list[dict[str, Any]] | None = None, **kwargs: Any):
+    return await _activity()(
+        runtime_id=RUNTIME_ID, leases=leases, action=action, **kwargs
+    )
+
+
+def _grant(
+    lease_id: str,
+    *,
+    fence: int,
+    profile_id: str = PROFILE_REF,
+    purpose: str = "execution_omnigent",
+    compatibility_class: str = CredentialLeaseMode.SHARED_EXECUTION.value,
+    scope_generation: int = 1,
+    credential_generation: int | None = 7,
+    plan_ref: str = PLAN_REF,
+    identity: str = "evidence-1",
+    scope_ref: str = SCOPE_REF,
+) -> dict[str, Any]:
+    return {
+        "lease_id": lease_id,
+        "workflow_id": lease_id,
+        "profile_id": profile_id,
+        "owner_id": lease_id,
+        "owner_kind": "workflow",
+        "purpose": purpose,
+        "compatibility_class": compatibility_class,
+        "fencing_generation": fence,
+        "scope_generation": scope_generation,
+        "capacity_scope_ref": scope_ref,
+        "credential_generation": credential_generation,
+        "executionPlanRef": plan_ref,
+        "lease_state": DurableLeaseState.HELD.value,
+        "ownerIsWorkflow": True,
+        "safe_metadata": {"evidenceIdentity": identity},
+    }
+
+
+async def _rows(maker) -> list[ProviderProfileSlotLease]:
+    async with maker() as session:
+        result = await session.execute(
+            select(ProviderProfileSlotLease).order_by(ProviderProfileSlotLease.id)
+        )
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 1: the real migration over real pre-contract rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_migration_versions_existing_rows_and_breaks_id_collisions(
+    control_plane_postgres_url,
+) -> None:
+    """Existing rows survive; colliding backfilled lease IDs stay distinct.
+
+    Pre-contract rows are unique per ``(runtime_id, workflow_id)``, so two
+    runtime families can hold the same workflow ID. Backfilling ``lease_id``
+    from ``workflow_id`` and then adding a global unique constraint has to
+    resolve that without failing the migration and without merging two leases
+    into one.
+    """
+
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    migration = _load_migration_module()
+
+    engine = create_async_engine(control_plane_postgres_url)
+    try:
+        async with engine.begin() as conn:
+            for statement in _PRE_CONTRACT_DDL.strip().split(";"):
+                if statement.strip():
+                    await conn.execute(text(statement))
+            await conn.execute(
+                text(
+                    "INSERT INTO provider_profile_slot_leases "
+                    "(runtime_id, workflow_id, profile_id, purpose, "
+                    " owner_id, owner_is_workflow) VALUES "
+                    "('opencode', 'agent-run-1', 'p1', 'execution_omnigent', "
+                    " 'agent-run-1', true), "
+                    "('codex_cli', 'agent-run-1', 'p2', 'credential_validation', "
+                    " 'agent-run-1', false), "
+                    "('opencode', 'agent-run-2', 'p1', 'execution_direct', "
+                    " NULL, true)"
+                )
+            )
+
+        def _upgrade(sync_conn) -> None:
+            context = MigrationContext.configure(sync_conn)
+            with Operations.context(context):
+                migration.upgrade()
+
+        async with engine.begin() as conn:
+            await conn.run_sync(_upgrade)
+
+        async with engine.connect() as conn:
+            rows = (
+                await conn.execute(
+                    text(
+                        "SELECT runtime_id, workflow_id, lease_id, owner_kind, "
+                        "compatibility_class, scope_generation, "
+                        "fencing_generation, lease_state "
+                        "FROM provider_profile_slot_leases ORDER BY id"
+                    )
+                )
+            ).all()
+
+        assert len(rows) == 3, "existing rows must survive the migration"
+        # The oldest row keeps the exact identity its holder already quotes.
+        assert rows[0].lease_id == "agent-run-1"
+        # The colliding row is disambiguated instead of merged or dropped.
+        assert rows[1].lease_id.startswith("agent-run-1#")
+        assert rows[1].lease_id != rows[0].lease_id
+        assert rows[2].lease_id == "agent-run-2"
+        assert len({row.lease_id for row in rows}) == 3
+
+        # Historical values are versioned, not fabricated.
+        assert rows[0].owner_kind == "workflow"
+        assert rows[1].owner_kind == "activity"
+        assert rows[0].compatibility_class == "execution_omnigent"
+        assert all(row.scope_generation == 1 for row in rows)
+        assert all(row.fencing_generation == 1 for row in rows)
+        assert all(row.lease_state == DurableLeaseState.HELD.value for row in rows)
+
+        async with engine.connect() as conn:
+            constraint = (
+                await conn.execute(
+                    text(
+                        "SELECT conname FROM pg_constraint "
+                        "WHERE conname = 'uq_provider_slot_lease_lease_id'"
+                    )
+                )
+            ).scalar()
+        assert constraint == "uq_provider_slot_lease_lease_id"
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DROP TABLE IF EXISTS provider_profile_slot_leases CASCADE")
+            )
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 2: grant-or-get under real concurrency and real constraints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_identical_grants_commit_at_most_one_lease(
+    lease_session_maker,
+) -> None:
+    payload = _grant("agent-run-1", fence=1)
+    results = await asyncio.gather(
+        *(_run("grant", [dict(payload)]) for _ in range(6)),
+        return_exceptions=True,
+    )
+
+    rows = await _rows(lease_session_maker)
+    assert len(rows) == 1, "concurrent grants created more than one authority"
+    fresh = [
+        result
+        for result in results
+        if isinstance(result, dict) and result.get("duplicate") is False
+    ]
+    assert len(fresh) <= 1
+    assert rows[0].fencing_generation == 1
+    assert rows[0].lease_state == DurableLeaseState.HELD.value
+
+
+@pytest.mark.asyncio
+async def test_a_matching_retry_returns_the_committed_row(
+    lease_session_maker,
+) -> None:
+    payload = _grant("agent-run-1", fence=3)
+    assert await _run("grant", [dict(payload)]) == {
+        "granted": True,
+        "duplicate": False,
+    }
+    assert await _run("grant", [dict(payload)]) == {
+        "granted": True,
+        "duplicate": True,
+    }
+    assert len(await _rows(lease_session_maker)) == 1
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"profile_id": OTHER_PROFILE_REF},
+        {"purpose": "credential_validation"},
+        {"compatibility_class": CredentialLeaseMode.EXCLUSIVE_MAINTENANCE.value},
+        {"plan_ref": OTHER_PLAN_REF},
+        {"credential_generation": 8},
+        {"scope_generation": 4},
+        {"identity": "evidence-2"},
+    ],
+    ids=[
+        "profile",
+        "purpose",
+        "compatibility",
+        "plan",
+        "credential-generation",
+        "scope-generation",
+        "evidence",
+    ],
+)
+@pytest.mark.asyncio
+async def test_conflicting_reuse_of_a_live_identity_creates_no_second_unit(
+    lease_session_maker, override: dict[str, Any]
+) -> None:
+    """A different plan, purpose or generation is not the same grant."""
+
+    await _run("grant", [_grant("agent-run-1", fence=3)])
+    result = await _run("grant", [_grant("agent-run-1", fence=4, **override)])
+
+    assert result == {"error": "lease identity conflict"}
+    rows = await _rows(lease_session_maker)
+    assert len(rows) == 1
+    assert rows[0].fencing_generation == 3
+    assert rows[0].profile_id == PROFILE_REF
+
+
+@pytest.mark.asyncio
+async def test_an_older_generation_never_downgrades_a_committed_fence(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=9)])
+    assert await _run("grant", [_grant("agent-run-1", fence=4)]) == {
+        "error": "lease fencing regression"
+    }
+    rows = await _rows(lease_session_maker)
+    assert rows[0].fencing_generation == 9
+
+
+@pytest.mark.asyncio
+async def test_a_tombstoned_identity_can_be_granted_again(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=3)])
+    await _run(
+        "release_one", [{"lease_id": "agent-run-1", "fencing_generation": 3}]
+    )
+    result = await _run(
+        "grant", [_grant("agent-run-1", fence=4, purpose="credential_validation")]
+    )
+
+    assert result["granted"] is True
+    rows = await _rows(lease_session_maker)
+    assert len(rows) == 1
+    assert rows[0].lease_state == DurableLeaseState.HELD.value
+    assert rows[0].fencing_generation == 4
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_grant_and_release_touch_a_single_row(
+    lease_session_maker,
+) -> None:
+    """Durable cost is independent of how many leases the runtime holds."""
+
+    for index in range(6):
+        await _run("grant", [_grant(f"agent-run-{index}", fence=index + 1)])
+    before = {row.lease_id: row.lease_state for row in await _rows(lease_session_maker)}
+
+    await _run("grant", [_grant("agent-run-9", fence=20)])
+    await _run(
+        "release_one", [{"lease_id": "agent-run-3", "fencing_generation": 4}]
+    )
+
+    after = {row.lease_id: row.lease_state for row in await _rows(lease_session_maker)}
+    changed = {
+        lease_id
+        for lease_id in set(before) | set(after)
+        if before.get(lease_id) != after.get(lease_id)
+    }
+    assert changed == {"agent-run-9", "agent-run-3"}
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 3 / 4: releases, fences and the ambiguous-outcome reconciliation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_release_outcomes_are_explicit_and_idempotent(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=5)])
+
+    first = await _run(
+        "release_one", [{"lease_id": "agent-run-1", "fencing_generation": 5}]
+    )
+    second = await _run(
+        "release_one", [{"lease_id": "agent-run-1", "fencing_generation": 5}]
+    )
+    missing = await _run(
+        "release_one", [{"lease_id": "agent-run-nope", "fencing_generation": 1}]
+    )
+
+    assert first["outcome"] == LeaseTransitionOutcome.RELEASED.value
+    assert second["outcome"] == LeaseTransitionOutcome.ALREADY_RELEASED.value
+    assert missing["outcome"] == LeaseTransitionOutcome.ALREADY_RELEASED.value
+    rows = await _rows(lease_session_maker)
+    assert rows[0].lease_state == DurableLeaseState.RELEASED.value
+    assert rows[0].released_at is not None
+    # The tombstone keeps the generation as the runtime's high-water evidence.
+    assert rows[0].fencing_generation == 5
+
+
+@pytest.mark.asyncio
+async def test_a_stale_release_cannot_free_the_replacement_holder(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=5)])
+    await _run("release_one", [{"lease_id": "agent-run-1", "fencing_generation": 5}])
+    await _run("grant", [_grant("agent-run-1", fence=6)])
+
+    stale = await _run(
+        "release_one", [{"lease_id": "agent-run-1", "fencing_generation": 5}]
+    )
+
+    assert stale["outcome"] == LeaseTransitionOutcome.STALE.value
+    rows = await _rows(lease_session_maker)
+    assert rows[0].lease_state == DurableLeaseState.HELD.value
+    assert rows[0].fencing_generation == 6
+
+
+@pytest.mark.asyncio
+async def test_a_release_naming_another_profile_is_a_conflict(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=5)])
+
+    result = await _run(
+        "release_one",
+        [
+            {
+                "lease_id": "agent-run-1",
+                "profile_id": OTHER_PROFILE_REF,
+                "fencing_generation": 5,
+            }
+        ],
+    )
+
+    assert result["outcome"] == LeaseTransitionOutcome.CONFLICT.value
+    assert result["released"] is False
+    rows = await _rows(lease_session_maker)
+    assert rows[0].lease_state == DurableLeaseState.HELD.value
+
+
+@pytest.mark.asyncio
+async def test_describe_reconciles_a_lost_commit_acknowledgment(
+    lease_session_maker,
+) -> None:
+    """The write committed; only its acknowledgment was lost."""
+
+    await _run("grant", [_grant("agent-run-1", fence=5)])
+
+    described = await _run("describe", [{"lease_id": "agent-run-1"}])
+    missing = await _run("describe", [{"lease_id": "agent-run-absent"}])
+
+    assert described["found"] is True
+    assert described["lease"]["fencing_generation"] == 5
+    assert described["lease"]["lease_state"] == DurableLeaseState.HELD.value
+    assert described["lease"]["profile_id"] == PROFILE_REF
+    assert missing == {"found": False, "lease_id": "agent-run-absent"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_requested_without_freeing_the_slot(
+    lease_session_maker,
+) -> None:
+    """MoonLadderStudios/MoonMind#1089: expiry asks for cleanup, it does not free."""
+
+    await _run("grant", [_grant("agent-run-1", fence=5)])
+
+    result = await _run(
+        "request_cleanup",
+        [
+            {
+                "lease_id": "agent-run-1",
+                "profile_id": PROFILE_REF,
+                "fencing_generation": 5,
+                "reason": "lease_expired",
+            }
+        ],
+    )
+    stale = await _run(
+        "request_cleanup",
+        [{"lease_id": "agent-run-1", "fencing_generation": 4}],
+    )
+
+    assert result["outcome"] == LeaseTransitionOutcome.CLEANUP_REQUESTED.value
+    assert stale["outcome"] == LeaseTransitionOutcome.STALE.value
+    rows = await _rows(lease_session_maker)
+    assert rows[0].lease_state == DurableLeaseState.CLEANUP_REQUESTED.value
+    assert rows[0].safe_metadata_json["cleanupReason"] == "lease_expired"
+
+    # A cleanup-requested lease still spends its slot on recovery.
+    loaded = await _run("load")
+    assert [lease["leaseId"] for lease in loaded["leases"]] == ["agent-run-1"]
+    assert loaded["leases"][0]["leaseState"] == (
+        DurableLeaseState.CLEANUP_REQUESTED.value
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 6: mixed-generation cutover and shared scopes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_retained_snapshot_writer_cannot_delete_newer_authority(
+    lease_session_maker,
+) -> None:
+    """A stale writer's snapshot is fenced by durable generations, not a patch."""
+
+    await _run("grant", [_grant("agent-run-old", fence=2)])
+    await _run("grant", [_grant("agent-run-new", fence=40)])
+
+    result = await _run(
+        "save",
+        [
+            {
+                "workflow_id": "agent-run-old",
+                "profile_id": PROFILE_REF,
+                "leaseId": "agent-run-old",
+                "ownerId": "agent-run-old",
+                "fencingGeneration": 2,
+            }
+        ],
+        writer_generation=2,
+    )
+
+    assert result == {"saved": 1, "preserved": 1}
+    rows = {row.lease_id: row for row in await _rows(lease_session_maker)}
+    assert set(rows) == {"agent-run-old", "agent-run-new"}
+    assert rows["agent-run-new"].fencing_generation == 40
+    assert rows["agent-run-new"].lease_state == DurableLeaseState.HELD.value
+
+
+@pytest.mark.asyncio
+async def test_a_pre_contract_snapshot_without_a_generation_still_replaces(
+    lease_session_maker,
+) -> None:
+    """Replay safety: the recorded legacy command keeps its exact semantics."""
+
+    await _run("grant", [_grant("agent-run-old", fence=2)])
+
+    result = await _run(
+        "save",
+        [
+            {
+                "workflow_id": "agent-run-old",
+                "profile_id": PROFILE_REF,
+                "leaseId": "agent-run-old",
+                "fencingGeneration": 2,
+            }
+        ],
+    )
+
+    assert result == {"saved": 1}
+    assert len(await _rows(lease_session_maker)) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_profiles_sharing_one_scope_keep_separate_accounting(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=1)])
+    await _run(
+        "grant", [_grant("agent-run-2", fence=2, profile_id=OTHER_PROFILE_REF)]
+    )
+    await _run(
+        "grant",
+        [_grant("agent-run-3", fence=3, scope_ref="provider-scope:other")],
+    )
+
+    shared = await _run("list_active", [{"capacity_scope_ref": SCOPE_REF}])
+    assert sorted(lease["lease_id"] for lease in shared["leases"]) == [
+        "agent-run-1",
+        "agent-run-2",
+    ]
+    assert {lease["profile_id"] for lease in shared["leases"]} == {
+        PROFILE_REF,
+        OTHER_PROFILE_REF,
+    }
+
+    # Releasing one profile's lease leaves the other's scope accounting intact.
+    await _run("release_one", [{"lease_id": "agent-run-1", "fencing_generation": 1}])
+    still_shared = await _run("list_active", [{"capacity_scope_ref": SCOPE_REF}])
+    live = [
+        lease
+        for lease in still_shared["leases"]
+        if lease["lease_state"] == DurableLeaseState.HELD.value
+    ]
+    assert [lease["lease_id"] for lease in live] == ["agent-run-2"]
+
+
+# ---------------------------------------------------------------------------
+# Item 6 / acceptance 5: recovery reads and the manager restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_reports_unknown_state_and_identity_conflicts(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=1)])
+    await _run("grant", [_grant("agent-run-2", fence=2)])
+    # Two live leases claiming one deterministic owner: the second grant reused
+    # the owner ID while the first row was never released. Nothing in the
+    # schema forbids it, so recovery has to detect it rather than merge them.
+    await _run(
+        "grant",
+        [{**_grant("agent-run-3", fence=3), "owner_id": "agent-run-2"}],
+    )
+    async with lease_session_maker() as session:
+        # A state no contract version defines is reconciliation work, not free
+        # capacity and not a row to drop.
+        await session.execute(
+            text(
+                "UPDATE provider_profile_slot_leases SET lease_state = "
+                "'quarantined' WHERE lease_id = 'agent-run-1'"
+            )
+        )
+        await session.commit()
+
+    loaded = await _run("load")
+
+    assert [entry["lease_id"] for entry in loaded["unreconciled"]] == ["agent-run-1"]
+    assert loaded["unreconciled"][0]["lease_state"] == "quarantined"
+    assert len(loaded["conflicts"]) == 1
+    assert loaded["conflicts"][0]["field"] == "owner_id"
+    assert loaded["conflicts"][0]["value"] == "agent-run-2"
+    assert {
+        lease["lease_id"] for lease in loaded["conflicts"][0]["leases"]
+    } == {"agent-run-2", "agent-run-3"}
+    # The unknown-state row is not returned as usable capacity either.
+    assert sorted(lease["leaseId"] for lease in loaded["leases"]) == [
+        "agent-run-2",
+        "agent-run-3",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_never_resurrects_a_released_row(lease_session_maker) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=11)])
+    await _run("release_one", [{"lease_id": "agent-run-1", "fencing_generation": 11}])
+
+    loaded = await _run("load")
+
+    assert loaded["leases"] == []
+    # The high-water mark outlives the tombstone, so a fresh manager never
+    # reissues a generation a delayed release could still match.
+    assert loaded["max_fencing_generation"] == 11
+
+
+class _RestartedManager(MoonMindProviderProfileManagerWorkflow):
+    """A manager restored from the durable ledger, with no external signals."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reconnected: list[tuple[str, str, int | None]] = []
+
+    async def _signal_slot_assigned(
+        self,
+        requester_workflow_id: str,
+        profile_id: str,
+        *,
+        fencing_generation: int | None = None,
+    ) -> None:
+        self.reconnected.append(
+            (requester_workflow_id, profile_id, fencing_generation)
+        )
+
+
+async def _restore_manager(monkeypatch: pytest.MonkeyPatch) -> _RestartedManager:
+    activity = _activity()
+
+    async def _execute_activity(name: str, payload: Any, **_kwargs: Any) -> Any:
+        assert name == "provider_profile.sync_slot_leases"
+        return await activity(**payload)
+
+    monkeypatch.setattr(
+        provider_profile_manager.workflow, "execute_activity", _execute_activity
+    )
+    monkeypatch.setattr(
+        provider_profile_manager.workflow, "patched", lambda _patch_id: True
+    )
+    monkeypatch.setattr(
+        provider_profile_manager.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            workflow_id="provider-profile-manager-opencode",
+            run_id="run-1",
+            task_queue="agent-runtime",
+        ),
+    )
+    monkeypatch.setattr(
+        provider_profile_manager.workflow,
+        "logger",
+        logging.getLogger("test.provider_profile_manager"),
+    )
+
+    manager = _RestartedManager()
+    manager._runtime_id = RUNTIME_ID
+    manager._durable_maintenance_queue = True
+    manager._lease_transition_contract = True
+    manager._purpose_aware_capacity_ledger = True
+    for profile_ref in (PROFILE_REF, OTHER_PROFILE_REF):
+        manager._profiles[profile_ref] = ProfileSlotState(
+            profile_id=profile_ref,
+            max_parallel_runs=8,
+            cooldown_after_429_seconds=60,
+            rate_limit_policy="cooldown",
+            enabled=True,
+            purpose_aware_capacity=True,
+            capacity_scope_ref=SCOPE_REF,
+        )
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_a_restart_restores_every_mode_owner_and_generation(
+    lease_session_maker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expiry = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    await _run(
+        "grant",
+        [{**_grant("agent-run-1", fence=11, scope_generation=3), "expiresAt": expiry}],
+    )
+    await _run(
+        "grant",
+        [
+            _grant(
+                "owner-maintenance",
+                fence=12,
+                profile_id=OTHER_PROFILE_REF,
+                purpose="credential_validation",
+                compatibility_class=(
+                    CredentialLeaseMode.SINGLE_FLIGHT_VALIDATION.value
+                ),
+                scope_generation=3,
+                identity="evidence-maint",
+            )
+        ],
+    )
+    await _run("grant", [_grant("agent-run-gone", fence=13)])
+    await _run(
+        "release_one", [{"lease_id": "agent-run-gone", "fencing_generation": 13}]
+    )
+
+    manager = await _restore_manager(monkeypatch)
+    assert await manager._load_leases_from_db() is True
+
+    held = manager._profiles[PROFILE_REF]
+    metadata = held.lease_metadata["agent-run-1"]
+    assert held.current_leases == ["agent-run-1"]
+    assert metadata["compatibilityClass"] == CredentialLeaseMode.SHARED_EXECUTION.value
+    assert metadata["scopeGeneration"] == 3
+    assert metadata["capacityScopeRef"] == SCOPE_REF
+    assert metadata["credentialGeneration"] == 7
+    assert metadata["executionPlanRef"] == PLAN_REF
+    assert metadata["evidenceIdentity"] == "evidence-1"
+    assert metadata["fencingGeneration"] == 11
+    assert metadata["ownerKind"] == "workflow"
+
+    maintenance = manager._profiles[OTHER_PROFILE_REF]
+    assert maintenance.current_leases == ["owner-maintenance"]
+    assert maintenance.lease_metadata["owner-maintenance"]["compatibilityClass"] == (
+        CredentialLeaseMode.SINGLE_FLIGHT_VALIDATION.value
+    )
+
+    # The released lease is not resurrected, and the sequence resumes above
+    # every generation the runtime ever issued.
+    assert "agent-run-gone" not in held.current_leases
+    assert manager._lease_grant_sequence == 13
+    # Only the execution owner is reconnected; maintenance owners are not.
+    assert manager.reconnected == [("agent-run-1", PROFILE_REF, 11)]
+
+
+@pytest.mark.asyncio
+async def test_an_unreconciled_row_blocks_a_restarting_manager(
+    lease_session_maker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=1)])
+    async with lease_session_maker() as session:
+        await session.execute(
+            text(
+                "UPDATE provider_profile_slot_leases SET lease_state = "
+                "'quarantined' WHERE lease_id = 'agent-run-1'"
+            )
+        )
+        await session.commit()
+
+    manager = await _restore_manager(monkeypatch)
+
+    assert await manager._load_leases_from_db() is False
+    assert manager._lease_index_conflicts[0]["kind"] == "unreconciled_state"
+    assert manager._profiles[PROFILE_REF].current_leases == []
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 8: no credential material reaches a lease row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_credential_value_is_persisted_on_a_lease_row(
+    lease_session_maker,
+) -> None:
+    await _run("grant", [_grant("agent-run-1", fence=1)])
+
+    rows = await _rows(lease_session_maker)
+    stored = " ".join(
+        str(getattr(rows[0], column.name)) for column in rows[0].__table__.columns
+    ).lower()
+    for secret_marker in ("sk-", "ghp_", "bearer ", "password", "refresh_token"):
+        assert secret_marker not in stored
+    assert set(rows[0].safe_metadata_json or {}) <= {
+        "evidenceIdentity",
+        "cleanupReason",
+        "releaseReason",
+        "cleanupRequested",
+    }

--- a/tests/unit/workflows/temporal/test_provider_profile_incremental_lease_persistence.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_incremental_lease_persistence.py
@@ -293,6 +293,11 @@ class _LeaseRow:
         self.lease_id = fields.get("lease_id", "agent-run-3")
         self.owner_id = fields.get("owner_id", "agent-run-3")
         self.purpose = fields.get("purpose", "execution_direct")
+        self.compatibility_class = fields.get("compatibility_class")
+        self.capacity_scope_ref = fields.get("capacity_scope_ref")
+        self.scope_generation = fields.get("scope_generation")
+        self.owner_kind = fields.get("owner_kind", "workflow")
+        self.heartbeat_at = fields.get("heartbeat_at")
         self.owner_is_workflow = fields.get("owner_is_workflow", True)
         self.step_execution_id = fields.get("step_execution_id")
         self.oauth_session_id = fields.get("oauth_session_id")
@@ -450,6 +455,7 @@ async def test_a_stale_row_is_replaced_by_a_newer_grant() -> None:
         [_grant_payload(6)],
         [
             _LeaseRow(
+                purpose="execution_omnigent",
                 fencing_generation=5,
                 safe_metadata_json={"evidenceIdentity": "evidence-1"},
             )
@@ -492,7 +498,7 @@ async def test_a_release_tombstones_instead_of_deleting() -> None:
         [_LeaseRow(fencing_generation=5)],
     )
 
-    assert recorder.result == {"released": True}
+    assert recorder.result == {"released": True, "outcome": "released"}
     row = recorder.table["agent-run-3"]
     assert row.lease_state == "released"
     assert row.released_at is not None
@@ -523,7 +529,12 @@ async def test_load_excludes_tombstones_but_reports_the_high_water_mark() -> Non
     assert recorder.result["max_fencing_generation"] == 9
     load_statement = recorder.statements[0]
     assert "lease_state" in str(load_statement)
-    assert "held" in list(load_statement.compile().params.values())
+    # The live read is an indexed query narrowed to the states that still
+    # spend a slot, not a full scan filtered in Python.
+    assert list(load_statement.compile().params.values()) == [
+        "opencode",
+        ["cleanup_requested", "held"],
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_provider_profile_incremental_lease_persistence.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_incremental_lease_persistence.py
@@ -194,6 +194,9 @@ class _Recorder:
             def first(self):
                 return None
 
+            def scalar(self):
+                return 0
+
         return _Result()
 
     def add(self, row):
@@ -259,8 +262,15 @@ async def test_grant_deletes_nothing_and_writes_one_row() -> None:
 
 
 @pytest.mark.asyncio
-async def test_save_still_replaces_the_whole_runtime_snapshot() -> None:
-    """Eviction and verification rely on snapshot semantics to drop stale rows."""
+async def test_save_replaces_only_the_rows_its_snapshot_restates() -> None:
+    """Eviction and verification rely on snapshot semantics to drop stale rows.
+
+    MoonLadderStudios/MoonMind#3883: a payload recorded before the incremental
+    contract carries no ``writer_generation``. That is a zero high-water mark,
+    so the delete is scoped to the rows the snapshot itself re-states plus
+    unfenced rows — never a runtime-wide wipe that could erase a newer writer's
+    authority.
+    """
 
     recorder = await _run_action(
         "save",
@@ -269,8 +279,10 @@ async def test_save_still_replaces_the_whole_runtime_snapshot() -> None:
 
     deletes = _delete_targets(recorder)
     assert len(deletes) == 1
-    assert "workflow_id IN" not in deletes[0]
     assert "runtime_id" in deletes[0]
+    assert "fencing_generation <=" in deletes[0]
+    assert "lease_id IN" in deletes[0] or "coalesce" in deletes[0].lower()
+    assert "workflow_id IN" in deletes[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
@@ -40,6 +40,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     PROVIDER_INCREMENTAL_LEASE_PATCH,
     CapacityScopeState,
     MoonMindProviderProfileManagerWorkflow,
+    PendingRequest,
     ProfileSlotState,
 )
 
@@ -734,6 +735,124 @@ async def test_the_retained_snapshot_writer_carries_its_own_generation() -> None
 
     assert ledger.calls[0]["action"] == "save"
     assert ledger.calls[0]["writer_generation"] == 4
+
+
+class _Signals:
+    """Records the external ``slot_assigned`` signals the drain sends."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, dict[str, Any]]] = []
+
+    def handle_for(self, workflow_id: str, **_kwargs: Any) -> Any:
+        recorder = self
+
+        class _Handle:
+            async def signal(self, name: str, payload: dict[str, Any]) -> None:
+                recorder.sent.append((workflow_id, name, payload))
+
+        return _Handle()
+
+
+def _re_signal_manager() -> MoonMindProviderProfileManagerWorkflow:
+    """A manager holding a lease whose owner asked for its slot again.
+
+    This is the production shape of ``AgentRun._recover_and_request_slot``: a
+    slot wait times out and the run re-sends ``request_slot`` to a manager that
+    still holds its lease, so the next drain takes the existing-lease branch.
+    """
+
+    wf = _held_manager(ledger_generation=5)
+    wf._pending_requests = [
+        PendingRequest(requester_workflow_id="agent-run-1", runtime_id="opencode")
+    ]
+    return wf
+
+
+@pytest.mark.asyncio
+async def test_a_re_signal_drain_never_rewrites_the_runtime_wide_snapshot() -> None:
+    """Re-signalling a held lease is not a lease change, so it writes nothing.
+
+    The snapshot rewrite deletes and re-inserts every row for the runtime, so
+    an unrelated maintenance lease would come back with the model defaults and
+    lose its compatibility class, scope generation, capacity scope and any
+    requested cleanup.
+    """
+
+    ledger = _Ledger({"save": {"saved": 1}})
+    wf = _re_signal_manager()
+    signals = _Signals()
+
+    with _patched(ledger), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert ledger.actions() == [], "the ordinary drain touched the durable ledger"
+    assert signals.sent == [
+        (
+            "agent-run-1",
+            "slot_assigned",
+            {"profile_id": PROFILE_ID, "fencing_generation": 5},
+        )
+    ]
+    assert wf._pending_requests == []
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+
+
+@pytest.mark.asyncio
+async def test_a_pre_contract_re_signal_drain_keeps_its_snapshot_save() -> None:
+    """Histories recorded before the contract keep the exact recorded command."""
+
+    ledger = _Ledger({"save": {"saved": 1}})
+    wf = _re_signal_manager()
+    wf._lease_transition_contract = False
+    signals = _Signals()
+
+    with _patched(
+        ledger,
+        enabled={
+            DB_LEASE_PERSISTENCE_PATCH,
+            DURABLE_LEASE_GRANT_PATCH,
+            PROVIDER_INCREMENTAL_LEASE_PATCH,
+        },
+    ), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert ledger.actions() == ["save"]
+    assert [name for _, name, _ in signals.sent] == ["slot_assigned"]
+
+
+@pytest.mark.asyncio
+async def test_a_pre_contract_re_signal_drain_still_blocks_on_a_failed_save() -> None:
+    """The retained branch keeps its guard: no signal without a durable write."""
+
+    ledger = _Ledger({"save": RuntimeError("artifacts worker unavailable")})
+    wf = _re_signal_manager()
+    wf._lease_transition_contract = False
+    signals = _Signals()
+
+    with _patched(
+        ledger,
+        enabled={
+            DB_LEASE_PERSISTENCE_PATCH,
+            DURABLE_LEASE_GRANT_PATCH,
+            PROVIDER_INCREMENTAL_LEASE_PATCH,
+        },
+    ), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert ledger.actions() == ["save"]
+    assert signals.sent == []
+    assert [req.requester_workflow_id for req in wf._pending_requests] == [
+        "agent-run-1"
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
@@ -1,0 +1,953 @@
+"""The durable lease transition contract owns whether a slot is spent.
+
+Source issue: MoonLadderStudios/MoonMind#3883.
+
+The incremental lease row landed first (MoonLadderStudios/MoonMind#3878) and
+the grant fence after it (#3879, #3880). What remained was the *ordering*
+contract around those rows: a grant that is only reserved in memory is not
+authority, an ambiguous write outcome is reconciled rather than guessed at, a
+release keeps capacity unavailable until the ledger answers, expiry and
+terminal ownership request resource cleanup instead of freeing a credential
+consumer that may still be running, and neither path rewrites the runtime-wide
+snapshot.
+
+These tests pin the manager side of that contract at the activity boundary the
+worker actually invokes. The durable half runs against a real PostgreSQL
+cluster in
+``tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from temporalio import exceptions
+
+from moonmind.provider_profiles.lease_client import (
+    CredentialLeaseMode,
+    DurableLeaseState,
+    LeaseTransitionOutcome,
+)
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    DB_LEASE_PERSISTENCE_PATCH,
+    DURABLE_LEASE_GRANT_PATCH,
+    LEASE_TRANSITION_CONTRACT_PATCH,
+    PROVIDER_INCREMENTAL_LEASE_PATCH,
+    CapacityScopeState,
+    MoonMindProviderProfileManagerWorkflow,
+    ProfileSlotState,
+)
+
+NOW = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+PROFILE_ID = "opencode-zen-free"
+SCOPE_REF = "provider-scope:opencode-zen"
+
+
+def _profile(**overrides: Any) -> ProfileSlotState:
+    fields: dict[str, Any] = {
+        "profile_id": PROFILE_ID,
+        "max_parallel_runs": 2,
+        "cooldown_after_429_seconds": 300,
+        "rate_limit_policy": "backoff",
+        "enabled": True,
+        "launch_ready": True,
+        "credential_source": "api_key",
+        "purpose_aware_capacity": True,
+        "capacity_scope_ref": SCOPE_REF,
+    }
+    fields.update(overrides)
+    return ProfileSlotState(**fields)
+
+
+def _manager(
+    *,
+    scope_generation: int = 1,
+    profile: ProfileSlotState | None = None,
+) -> MoonMindProviderProfileManagerWorkflow:
+    wf = MoonMindProviderProfileManagerWorkflow()
+    wf._runtime_id = "opencode"
+    wf._durable_maintenance_queue = True
+    wf._lease_transition_contract = True
+    wf._purpose_aware_capacity_ledger = True
+    resolved = profile if profile is not None else _profile()
+    wf._profiles = {resolved.profile_id: resolved}
+    wf._scopes = {
+        SCOPE_REF: CapacityScopeState(
+            scope_ref=SCOPE_REF,
+            runtime_id="opencode",
+            generation=scope_generation,
+            configured_limit=resolved.max_parallel_runs,
+            effective_limit=resolved.max_parallel_runs,
+        )
+    }
+    return wf
+
+
+class _Ledger:
+    """A recording stand-in for ``provider_profile.sync_slot_leases``."""
+
+    def __init__(self, responses: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses = responses or {}
+
+    async def __call__(self, name: str, payload: dict[str, Any], **_kwargs: Any):
+        assert name == "provider_profile.sync_slot_leases"
+        self.calls.append(payload)
+        response = self.responses.get(payload["action"])
+        if isinstance(response, list):
+            response = response.pop(0) if response else None
+        if isinstance(response, Exception):
+            raise response
+        if callable(response):
+            return response(payload)
+        if response is None:
+            return {}
+        return response
+
+    def actions(self) -> list[str]:
+        return [call["action"] for call in self.calls]
+
+    def rows_for(self, action: str) -> list[dict[str, Any]]:
+        return [
+            row
+            for call in self.calls
+            if call["action"] == action
+            for row in call.get("leases") or []
+        ]
+
+
+@contextlib.contextmanager
+def _patched(ledger: _Ledger, *, enabled: set[str] | None = None, now=NOW):
+    """Run manager code with a controllable patch set and ledger."""
+
+    active = enabled if enabled is not None else {
+        DB_LEASE_PERSISTENCE_PATCH,
+        DURABLE_LEASE_GRANT_PATCH,
+        PROVIDER_INCREMENTAL_LEASE_PATCH,
+        LEASE_TRANSITION_CONTRACT_PATCH,
+    }
+    async def _dispatch(name: str, payload: dict[str, Any], **kwargs: Any):
+        # A real coroutine function, so ``AsyncMock`` awaits it rather than
+        # handing the caller an un-awaited coroutine.
+        return await ledger(name, payload, **kwargs)
+
+    with patch(
+        "temporalio.workflow.patched", side_effect=lambda name: name in active
+    ), patch(
+        "temporalio.workflow.execute_activity", side_effect=_dispatch
+    ), patch(
+        "temporalio.workflow.now", return_value=now
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Item 1: the grant carries the identity it actually acquired
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_grant_records_the_scope_generation_it_was_admitted_against() -> None:
+    """A hard-coded scope generation asserts authority the grant never got."""
+
+    ledger = _Ledger({"grant": {"granted": True, "duplicate": False}})
+    wf = _manager(scope_generation=7)
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {"evidenceIdentity": "evidence-1"},
+        fencing_generation=3,
+        profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-1", NOW, purpose="execution_omnigent", metadata=metadata)
+
+    with _patched(ledger):
+        assert await wf._persist_lease_grant(
+            profile, "agent-run-1", purpose="execution_omnigent", metadata=metadata
+        )
+
+    row = ledger.rows_for("grant")[0]
+    assert row["scope_generation"] == 7
+    assert row["capacity_scope_ref"] == SCOPE_REF
+    assert row["compatibility_class"] == CredentialLeaseMode.SHARED_EXECUTION.value
+    assert row["fencing_generation"] == 3
+    assert row["lease_state"] == DurableLeaseState.HELD.value
+
+
+@pytest.mark.asyncio
+async def test_a_maintenance_grant_records_its_own_compatibility_class() -> None:
+    """Two modes on one profile are not the same compatibility identity."""
+
+    ledger = _Ledger({"grant": {"granted": True, "duplicate": False}})
+    wf = _manager(scope_generation=2)
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {},
+        fencing_generation=4,
+        profile=profile,
+        lease_mode=CredentialLeaseMode.EXCLUSIVE_MAINTENANCE,
+    )
+    profile.reserve("owner-1", NOW, purpose="oauth_reconnect", metadata=metadata)
+
+    with _patched(ledger):
+        await wf._persist_lease_grant(
+            profile, "owner-1", purpose="oauth_reconnect", metadata=metadata
+        )
+
+    row = ledger.rows_for("grant")[0]
+    assert row["compatibility_class"] == CredentialLeaseMode.EXCLUSIVE_MAINTENANCE.value
+    assert row["scope_generation"] == 2
+
+
+def test_no_credential_value_can_reach_a_lease_row() -> None:
+    """The allowlist is the boundary: unknown caller keys never persist."""
+
+    wf = _manager()
+    safe = wf._safe_lease_metadata(
+        {
+            "metadata": {
+                "workflowId": "agent-run-1",
+                "evidenceIdentity": "evidence-1",
+                "apiKey": "sk-live-not-a-real-key",
+                "authorization": "Bearer nope",
+                "oauthRefreshToken": "rt-nope",
+            }
+        }
+    )
+
+    assert safe == {"workflowId": "agent-run-1", "evidenceIdentity": "evidence-1"}
+
+
+# ---------------------------------------------------------------------------
+# Item 2: a pending reservation is not a usable grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_caller_never_joins_an_uncommitted_reservation() -> None:
+    """``already_held`` for a pending grant publishes authority nobody holds."""
+
+    grant_started = asyncio.Event()
+    release_grant = asyncio.Event()
+
+    async def _slow_grant(_name: str, payload: dict[str, Any], **_kwargs: Any):
+        if payload["action"] != "grant":
+            return {}
+        grant_started.set()
+        await release_grant.wait()
+        return {"granted": True, "duplicate": False}
+
+    wf = _manager()
+    with patch(
+        "temporalio.workflow.patched",
+        side_effect=lambda name: name
+        in {
+            DB_LEASE_PERSISTENCE_PATCH,
+            DURABLE_LEASE_GRANT_PATCH,
+            PROVIDER_INCREMENTAL_LEASE_PATCH,
+            LEASE_TRANSITION_CONTRACT_PATCH,
+        },
+    ), patch(
+        "temporalio.workflow.execute_activity", side_effect=_slow_grant
+    ), patch(
+        "temporalio.workflow.now", return_value=NOW
+    ), patch(
+        "temporalio.workflow.wait_condition", new=_immediate_wait_condition
+    ):
+        first = asyncio.create_task(
+            wf.acquire_slot(
+                {"requester_workflow_id": "agent-run-1", "runtime_id": "opencode"}
+            )
+        )
+        await asyncio.wait_for(grant_started.wait(), timeout=5)
+
+        # The reservation exists in memory but has no durable outcome.
+        assert wf._lease_grant_is_pending("agent-run-1") is True
+        assert wf._profile_id_for_lease("agent-run-1") == PROFILE_ID
+
+        second = asyncio.create_task(
+            wf.acquire_slot(
+                {"requester_workflow_id": "agent-run-1", "runtime_id": "opencode"}
+            )
+        )
+        await asyncio.sleep(0)
+        assert not second.done(), "a pending reservation was returned as a grant"
+
+        release_grant.set()
+        first_result = await asyncio.wait_for(first, timeout=5)
+        second_result = await asyncio.wait_for(second, timeout=5)
+
+    assert first_result["already_held"] is False
+    # The second caller joins the committed result, not the pending one.
+    assert second_result["already_held"] is True
+    assert second_result["profile_id"] == PROFILE_ID
+    assert (
+        second_result["lease_fencing_generation"]
+        == first_result["lease_fencing_generation"]
+    )
+
+
+async def _immediate_wait_condition(predicate, timeout=None):
+    """Yield until the predicate holds, without Temporal's event loop."""
+
+    while not predicate():
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_a_rolled_back_reservation_is_not_left_marked_pending() -> None:
+    """A failed grant must clear the handoff, or the manager deadlocks itself."""
+
+    ledger = _Ledger({"grant": {"error": "lease identity conflict"}})
+    wf = _manager()
+
+    with _patched(ledger):
+        with pytest.raises(exceptions.ApplicationError) as excinfo:
+            await wf.acquire_slot(
+                {"requester_workflow_id": "agent-run-1", "runtime_id": "opencode"}
+            )
+
+    assert excinfo.value.type == "ProviderProfileLeasePersistenceFailed"
+    assert wf._lease_grant_is_pending("agent-run-1") is False
+    assert wf._profile_id_for_lease("agent-run-1") is None
+    assert wf._profiles[PROFILE_ID].current_leases == []
+
+
+# ---------------------------------------------------------------------------
+# Item 3: an ambiguous write outcome is reconciled, not guessed at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_lost_commit_acknowledgment_is_reconciled_as_committed() -> None:
+    """A timeout after commit must not abandon a live grant."""
+
+    ledger = _Ledger(
+        {
+            "grant": RuntimeError("database timeout"),
+            "describe": {
+                "found": True,
+                "lease": {
+                    "lease_id": "agent-run-1",
+                    "profile_id": PROFILE_ID,
+                    "lease_state": DurableLeaseState.HELD.value,
+                    "fencing_generation": 5,
+                },
+            },
+        }
+    )
+    wf = _manager()
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {}, fencing_generation=5, profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-1", NOW, purpose="execution_direct", metadata=metadata)
+
+    with _patched(ledger):
+        persisted = await wf._persist_lease_grant(
+            profile, "agent-run-1", metadata=metadata
+        )
+
+    assert persisted is True
+    assert ledger.actions() == ["grant", "describe"]
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_refuses_a_row_the_ledger_does_not_hold() -> None:
+    """A different fence, profile or state is not this caller's grant."""
+
+    for lease in (
+        {"lease_id": "agent-run-1", "profile_id": PROFILE_ID,
+         "lease_state": DurableLeaseState.HELD.value, "fencing_generation": 4},
+        {"lease_id": "agent-run-1", "profile_id": "other",
+         "lease_state": DurableLeaseState.HELD.value, "fencing_generation": 5},
+        {"lease_id": "agent-run-1", "profile_id": PROFILE_ID,
+         "lease_state": DurableLeaseState.RELEASED.value, "fencing_generation": 5},
+    ):
+        ledger = _Ledger(
+            {
+                "grant": RuntimeError("database timeout"),
+                "describe": {"found": True, "lease": lease},
+            }
+        )
+        wf = _manager()
+        profile = wf._profiles[PROFILE_ID]
+        metadata = wf._grant_metadata(
+            {}, fencing_generation=5, profile=profile,
+            lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+        )
+        profile.reserve("agent-run-1", NOW, metadata=metadata)
+
+        with _patched(ledger):
+            assert (
+                await wf._persist_lease_grant(profile, "agent-run-1", metadata=metadata)
+                is False
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_ledger_leaves_capacity_blocked() -> None:
+    """Still ambiguous is still failure; never announce unconfirmed authority."""
+
+    ledger = _Ledger(
+        {
+            "grant": RuntimeError("database timeout"),
+            "describe": RuntimeError("database still unreachable"),
+        }
+    )
+    wf = _manager()
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {}, fencing_generation=5, profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-1", NOW, metadata=metadata)
+
+    with _patched(ledger):
+        assert (
+            await wf._persist_lease_grant(profile, "agent-run-1", metadata=metadata)
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_pre_contract_history_does_not_reconcile() -> None:
+    """Replay safety: an older history keeps its exact recorded commands."""
+
+    ledger = _Ledger({"grant": RuntimeError("database timeout")})
+    wf = _manager()
+    wf._lease_transition_contract = False
+    profile = wf._profiles[PROFILE_ID]
+    profile.reserve("agent-run-1", NOW)
+
+    with _patched(
+        ledger,
+        enabled={
+            DB_LEASE_PERSISTENCE_PATCH,
+            DURABLE_LEASE_GRANT_PATCH,
+            PROVIDER_INCREMENTAL_LEASE_PATCH,
+        },
+    ):
+        assert await wf._persist_lease_grant(profile, "agent-run-1") is False
+
+    assert ledger.actions() == ["grant"]
+
+
+# ---------------------------------------------------------------------------
+# Item 4 / acceptance 4: a release keeps capacity unavailable until it resolves
+# ---------------------------------------------------------------------------
+
+
+def _held_manager(ledger_generation: int = 3) -> MoonMindProviderProfileManagerWorkflow:
+    wf = _manager()
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {}, fencing_generation=ledger_generation, profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-1", NOW, metadata=metadata)
+    wf._index_lease(PROFILE_ID, "agent-run-1", "agent-run-1")
+    wf._lease_grant_sequence = ledger_generation
+    return wf
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        RuntimeError("artifacts worker unavailable"),
+        {"error": "lease identity conflict"},
+        {"released": False, "outcome": LeaseTransitionOutcome.STALE.value},
+        {"released": False, "outcome": LeaseTransitionOutcome.CONFLICT.value},
+    ],
+    ids=["activity-failed", "structured-error", "stale", "conflict"],
+)
+@pytest.mark.asyncio
+async def test_an_unresolved_release_never_makes_capacity_reusable(response) -> None:
+    """A warning is not a release. The slot stays spent until the ledger says so."""
+
+    ledger = _Ledger({"release_one": response})
+    wf = _held_manager()
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert wf._profile_id_for_lease("agent-run-1") == PROFILE_ID
+    assert "agent-run-1" in wf._unresolved_releases
+    # The release quotes the generation the manager actually holds.
+    assert ledger.rows_for("release_one")[0]["fencing_generation"] == 3
+
+
+@pytest.mark.asyncio
+async def test_a_released_lease_frees_capacity_and_quotes_its_fence() -> None:
+    ledger = _Ledger(
+        {"release_one": {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value}}
+    )
+    wf = _held_manager(ledger_generation=9)
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+
+    assert wf._profiles[PROFILE_ID].current_leases == []
+    assert wf._unresolved_releases == {}
+    row = ledger.rows_for("release_one")[0]
+    assert row["fencing_generation"] == 9
+    assert row["profile_id"] == PROFILE_ID
+    # The ordering contract: the ledger is asked before capacity is published.
+    assert ledger.actions() == ["release_one"]
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_release_is_idempotent_not_a_second_free() -> None:
+    ledger = _Ledger(
+        {
+            "release_one": [
+                {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value},
+                {
+                    "released": True,
+                    "duplicate": True,
+                    "outcome": LeaseTransitionOutcome.ALREADY_RELEASED.value,
+                },
+            ]
+        }
+    )
+    wf = _held_manager()
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+
+    assert wf._profiles[PROFILE_ID].current_leases == []
+    assert wf._profiles[PROFILE_ID].execution_lease_count == 0
+    assert wf._unresolved_releases == {}
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_release_is_retried_and_then_frees_capacity() -> None:
+    """Capacity is neither leaked nor published early: it is reconciled."""
+
+    ledger = _Ledger(
+        {
+            "release_one": [
+                RuntimeError("artifacts worker unavailable"),
+                {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value},
+            ]
+        }
+    )
+    wf = _held_manager()
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+        assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+        await wf._retry_unresolved_releases()
+
+    assert wf._profiles[PROFILE_ID].current_leases == []
+    assert wf._unresolved_releases == {}
+    assert ledger.actions() == ["release_one", "release_one"]
+
+
+@pytest.mark.asyncio
+async def test_a_conflicting_release_becomes_evidence_not_an_endless_retry() -> None:
+    """A ledger that describes a different authority cannot converge by retry."""
+
+    ledger = _Ledger(
+        {"release_one": {"released": False, "outcome": LeaseTransitionOutcome.CONFLICT.value}}
+    )
+    wf = _held_manager()
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+        await wf._retry_unresolved_releases()
+        await wf._retry_unresolved_releases()
+
+    assert ledger.actions() == ["release_one"], "a conflict was retried"
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert wf._unresolved_releases["agent-run-1"]["retryable"] is False
+    assert [entry["kind"] for entry in wf._lease_index_conflicts] == [
+        "unresolved_release"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_release_without_a_known_fence_asserts_none(
+) -> None:
+    """A hard-coded fence of 1 asserts authority the manager never acquired."""
+
+    ledger = _Ledger(
+        {"release_one": {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value}}
+    )
+    wf = _manager()
+    # The profile was removed while the owner still held a durable row.
+    wf._profiles = {}
+
+    with _patched(ledger):
+        await wf.release_slot(
+            {"profile_id": PROFILE_ID, "requester_workflow_id": "agent-run-1"}
+        )
+
+    assert ledger.rows_for("release_one")[0]["fencing_generation"] == 0
+
+
+def test_every_release_outcome_maps_onto_the_typed_contract() -> None:
+    wf = _manager()
+    assert wf._release_outcome({"released": True}, "x") == "released"
+    assert wf._release_outcome({"released": True, "duplicate": True}, "x") == (
+        "already_released"
+    )
+    assert wf._release_outcome({"released": False, "stale": True}, "x") == "stale"
+    assert wf._release_outcome({"error": "boom"}, "x") == "conflict"
+    assert wf._release_outcome({"outcome": "nonsense"}, "x") == "retryable"
+    assert wf._release_outcome(None, "x") == "retryable"
+
+
+# ---------------------------------------------------------------------------
+# Item 5 / item 8: expiry and terminal ownership request cleanup, per lease
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expiry_requests_cleanup_instead_of_freeing_a_live_consumer() -> None:
+    """MoonLadderStudios/MoonMind#1089: expiry is not proof the holder stopped."""
+
+    ledger = _Ledger(
+        {
+            "request_cleanup": {
+                "outcome": LeaseTransitionOutcome.CLEANUP_REQUESTED.value,
+                "cleanup_requested": True,
+            }
+        }
+    )
+    wf = _held_manager()
+    profile = wf._profiles[PROFILE_ID]
+    profile.max_lease_duration_seconds = 60
+    profile.lease_granted_at["agent-run-1"] = (NOW - timedelta(hours=3)).isoformat()
+
+    with _patched(ledger):
+        await wf._request_cleanup_for_expired_leases()
+
+    assert ledger.actions() == ["request_cleanup"]
+    assert profile.current_leases == ["agent-run-1"], "an expired slot was freed"
+    assert "agent-run-1" in wf._cleanup_requested_leases
+
+    # A second pass must not re-request the same durable cleanup.
+    with _patched(ledger):
+        await wf._request_cleanup_for_expired_leases()
+    assert ledger.actions() == ["request_cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_expiry_never_rewrites_the_runtime_wide_snapshot() -> None:
+    ledger = _Ledger(
+        {
+            "request_cleanup": {
+                "outcome": LeaseTransitionOutcome.CLEANUP_REQUESTED.value
+            }
+        }
+    )
+    wf = _held_manager()
+    profile = wf._profiles[PROFILE_ID]
+    profile.max_lease_duration_seconds = 60
+    profile.lease_granted_at["agent-run-1"] = (NOW - timedelta(hours=3)).isoformat()
+
+    with _patched(ledger):
+        await wf._request_cleanup_for_expired_leases()
+
+    assert "save" not in ledger.actions()
+
+
+@pytest.mark.asyncio
+async def test_terminal_reclamation_releases_one_row_and_asks_for_cleanup() -> None:
+    """Reclamation costs one fenced row transition, not a snapshot rewrite."""
+
+    ledger = _Ledger(
+        {"release_one": {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value}}
+    )
+    wf = _held_manager(ledger_generation=6)
+    # A second, still-running holder must not be touched.
+    profile = wf._profiles[PROFILE_ID]
+    profile.max_parallel_runs = 4
+    other_metadata = wf._grant_metadata(
+        {}, fencing_generation=7, profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-2", NOW, metadata=other_metadata)
+    wf._index_lease(PROFILE_ID, "agent-run-2", "agent-run-2")
+
+    with _patched(ledger):
+        await wf._reclaim_terminal_leases_durably(
+            {
+                "agent-run-1": {"running": False, "status": "TERMINATED"},
+                "agent-run-2": {"running": True, "status": "RUNNING"},
+            }
+        )
+
+    assert ledger.actions() == ["release_one"]
+    rows = ledger.rows_for("release_one")
+    assert rows[0]["lease_id"] == "agent-run-1"
+    assert rows[0]["fencing_generation"] == 6
+    assert rows[0]["reason"] == "owner_terminal"
+    assert rows[0]["cleanup_requested"] is True
+    assert profile.current_leases == ["agent-run-2"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_reclamation_keeps_the_slot_reserved() -> None:
+    ledger = _Ledger({"release_one": RuntimeError("artifacts worker unavailable")})
+    wf = _held_manager()
+
+    with _patched(ledger):
+        await wf._reclaim_terminal_leases_durably(
+            {"agent-run-1": {"running": False, "status": "TERMINATED"}}
+        )
+
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert "agent-run-1" in wf._unresolved_releases
+
+
+@pytest.mark.asyncio
+async def test_the_retained_snapshot_writer_carries_its_own_generation() -> None:
+    """A patch marker cannot fence a stale database writer; a generation can."""
+
+    ledger = _Ledger({"save": {"saved": 1}})
+    wf = _held_manager(ledger_generation=4)
+
+    with _patched(ledger):
+        assert await wf._sync_leases_to_db() is True
+
+    assert ledger.calls[0]["action"] == "save"
+    assert ledger.calls[0]["writer_generation"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Item 7: the index is a complete conflict and performance boundary
+# ---------------------------------------------------------------------------
+
+
+def test_a_duplicate_lease_identity_is_recorded_not_silently_skipped() -> None:
+    wf = _manager()
+    wf._index_lease(PROFILE_ID, "agent-run-1", "agent-run-1")
+    wf._index_lease("other-profile", "agent-run-1", "agent-run-1")
+
+    assert wf._lease_profile_index["agent-run-1"] == PROFILE_ID
+    assert wf._lease_index_conflicts == [
+        {
+            "kind": "lease_profile",
+            "leaseId": "agent-run-1",
+            "profileId": "other-profile",
+            "existing": PROFILE_ID,
+        }
+    ]
+
+
+def test_two_leases_claiming_one_owner_are_reported_not_merged() -> None:
+    wf = _manager()
+    wf._index_lease(PROFILE_ID, "lease-a", "owner-1")
+    wf._index_lease(PROFILE_ID, "lease-b", "owner-1")
+
+    assert wf._owner_lease_index["owner-1"] == "lease-a"
+    assert wf._lease_index_conflicts == [
+        {
+            "kind": "owner_lease",
+            "leaseId": "lease-b",
+            "ownerId": "owner-1",
+            "existing": "lease-a",
+        }
+    ]
+
+
+def test_unindexing_uses_the_reverse_index_not_a_scan() -> None:
+    wf = _manager()
+    for index in range(50):
+        wf._index_lease(PROFILE_ID, f"lease-{index}", f"owner-{index}")
+
+    wf._unindex_lease("lease-7")
+
+    assert "lease-7" not in wf._lease_profile_index
+    assert "owner-7" not in wf._owner_lease_index
+    assert wf._lease_owner_index.get("lease-7") is None
+    assert len(wf._owner_lease_index) == 49
+
+
+def test_rebuilding_the_index_reports_a_duplicate_across_profiles() -> None:
+    wf = _manager()
+    first = wf._profiles[PROFILE_ID]
+    second = _profile(profile_id="opencode-zen-paid")
+    wf._profiles[second.profile_id] = second
+    first.reserve("agent-run-1", NOW)
+    second.reserve("agent-run-1", NOW)
+
+    wf._rebuild_lease_indexes()
+
+    assert [entry["kind"] for entry in wf._lease_index_conflicts] == ["lease_profile"]
+
+
+def test_manager_state_surfaces_reconciliation_evidence() -> None:
+    wf = _manager()
+    wf._index_lease(PROFILE_ID, "agent-run-1", "agent-run-1")
+    wf._index_lease("other-profile", "agent-run-1", "agent-run-1")
+    wf._unresolved_releases["agent-run-9"] = {
+        "profile_id": PROFILE_ID,
+        "fencing_generation": 2,
+        "outcome": "retryable",
+    }
+    wf._cleanup_requested_leases.add("agent-run-8")
+
+    state = wf.get_state()
+
+    assert state["lease_index_conflicts"][0]["kind"] == "lease_profile"
+    assert state["unresolved_releases"]["agent-run-9"]["outcome"] == "retryable"
+    assert state["cleanup_requested_leases"] == ["agent-run-8"]
+
+
+# ---------------------------------------------------------------------------
+# Item 6 / acceptance 5: recovery restores identity and blocks on the unknown
+# ---------------------------------------------------------------------------
+
+
+def _restore_ledger(result: dict[str, Any]) -> _Ledger:
+    return _Ledger({"load": result})
+
+
+@pytest.mark.asyncio
+async def test_recovery_restores_the_mode_and_generations_it_granted() -> None:
+    ledger = _restore_ledger(
+        {
+            "leases": [
+                {
+                    "workflow_id": "agent-run-1",
+                    "profile_id": PROFILE_ID,
+                    "leaseId": "agent-run-1",
+                    "ownerId": "agent-run-1",
+                    "ownerKind": "workflow",
+                    "purpose": "execution_omnigent",
+                    "fencingGeneration": 12,
+                    "compatibilityClass": (
+                        CredentialLeaseMode.SHARED_EXECUTION.value
+                    ),
+                    "capacityScopeRef": SCOPE_REF,
+                    "scopeGeneration": 5,
+                    "credentialGeneration": 3,
+                    "executionPlanRef": "omnigent-execution-plan:sha256:abc",
+                    "leaseState": DurableLeaseState.HELD.value,
+                    "safeMetadata": {"evidenceIdentity": "evidence-1"},
+                }
+            ],
+            "max_fencing_generation": 12,
+        }
+    )
+    wf = _manager()
+    with _patched(ledger), patch.object(
+        MoonMindProviderProfileManagerWorkflow, "_signal_slot_assigned"
+    ):
+        assert await wf._load_leases_from_db() is True
+
+    metadata = wf._profiles[PROFILE_ID].lease_metadata["agent-run-1"]
+    assert metadata["compatibilityClass"] == CredentialLeaseMode.SHARED_EXECUTION.value
+    assert metadata["scopeGeneration"] == 5
+    assert metadata["capacityScopeRef"] == SCOPE_REF
+    assert metadata["credentialGeneration"] == 3
+    assert metadata["evidenceIdentity"] == "evidence-1"
+    assert metadata["fencingGeneration"] == 12
+    assert wf._lease_grant_sequence == 12
+
+
+@pytest.mark.asyncio
+async def test_recovery_keeps_a_cleanup_requested_lease_spending_its_slot() -> None:
+    ledger = _restore_ledger(
+        {
+            "leases": [
+                {
+                    "workflow_id": "agent-run-1",
+                    "profile_id": PROFILE_ID,
+                    "leaseId": "agent-run-1",
+                    "ownerId": "agent-run-1",
+                    "purpose": "execution_direct",
+                    "fencingGeneration": 4,
+                    "leaseState": DurableLeaseState.CLEANUP_REQUESTED.value,
+                }
+            ],
+            "max_fencing_generation": 4,
+        }
+    )
+    wf = _manager()
+    with _patched(ledger), patch.object(
+        MoonMindProviderProfileManagerWorkflow, "_signal_slot_assigned"
+    ):
+        assert await wf._load_leases_from_db() is True
+
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert "agent-run-1" in wf._cleanup_requested_leases
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_lease_state_blocks_new_admission() -> None:
+    ledger = _restore_ledger(
+        {
+            "leases": [],
+            "max_fencing_generation": 3,
+            "unreconciled": [
+                {"lease_id": "agent-run-9", "lease_state": "quarantined"}
+            ],
+        }
+    )
+    wf = _manager()
+    with _patched(ledger):
+        assert await wf._load_leases_from_db() is False
+
+    assert wf._lease_index_conflicts[0]["kind"] == "unreconciled_state"
+
+
+@pytest.mark.asyncio
+async def test_two_durable_leases_sharing_a_workflow_id_block_admission() -> None:
+    ledger = _restore_ledger(
+        {
+            "leases": [],
+            "max_fencing_generation": 3,
+            "conflicts": [
+                {"field": "workflow_id", "value": "agent-run-1", "leases": []}
+            ],
+        }
+    )
+    wf = _manager()
+    with _patched(ledger):
+        assert await wf._load_leases_from_db() is False
+
+    assert wf._lease_index_conflicts[0]["kind"] == "durable_identity"
+
+
+@pytest.mark.asyncio
+async def test_a_pre_contract_history_ignores_the_new_recovery_evidence() -> None:
+    """Replay safety: an older history keeps admitting exactly as it recorded."""
+
+    ledger = _restore_ledger(
+        {
+            "leases": [],
+            "max_fencing_generation": 3,
+            "unreconciled": [{"lease_id": "agent-run-9", "lease_state": "weird"}],
+        }
+    )
+    wf = _manager()
+    wf._lease_transition_contract = False
+    with _patched(
+        ledger,
+        enabled={DB_LEASE_PERSISTENCE_PATCH, PROVIDER_INCREMENTAL_LEASE_PATCH},
+    ):
+        assert await wf._load_leases_from_db() is True

--- a/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
@@ -42,6 +42,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     MoonMindProviderProfileManagerWorkflow,
     PendingRequest,
     ProfileSlotState,
+    _LEASE_CLEANUP_ESCALATION_SECONDS,
 )
 
 NOW = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
@@ -324,6 +325,34 @@ async def test_a_rolled_back_reservation_is_not_left_marked_pending() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _committed_row(**overrides: Any) -> dict[str, Any]:
+    """The complete durable identity of the grant the manager attempted.
+
+    A reconciliation that compares fewer fields than this would accept a
+    migrated or conflicting row that merely shares the lease ID, profile,
+    state and generation.
+    """
+
+    row = {
+        "lease_id": "agent-run-1",
+        "workflow_id": "agent-run-1",
+        "profile_id": PROFILE_ID,
+        "owner_id": "agent-run-1",
+        "owner_kind": "workflow",
+        "purpose": "execution_direct",
+        "compatibility_class": CredentialLeaseMode.SHARED_EXECUTION.value,
+        "capacity_scope_ref": SCOPE_REF,
+        "scope_generation": 1,
+        "credential_generation": None,
+        "execution_plan_ref": None,
+        "evidence_identity": "",
+        "lease_state": DurableLeaseState.HELD.value,
+        "fencing_generation": 5,
+    }
+    row.update(overrides)
+    return row
+
+
 @pytest.mark.asyncio
 async def test_a_lost_commit_acknowledgment_is_reconciled_as_committed() -> None:
     """A timeout after commit must not abandon a live grant."""
@@ -331,15 +360,7 @@ async def test_a_lost_commit_acknowledgment_is_reconciled_as_committed() -> None
     ledger = _Ledger(
         {
             "grant": RuntimeError("database timeout"),
-            "describe": {
-                "found": True,
-                "lease": {
-                    "lease_id": "agent-run-1",
-                    "profile_id": PROFILE_ID,
-                    "lease_state": DurableLeaseState.HELD.value,
-                    "fencing_generation": 5,
-                },
-            },
+            "describe": {"found": True, "lease": _committed_row()},
         }
     )
     wf = _manager()
@@ -364,12 +385,9 @@ async def test_reconciliation_refuses_a_row_the_ledger_does_not_hold() -> None:
     """A different fence, profile or state is not this caller's grant."""
 
     for lease in (
-        {"lease_id": "agent-run-1", "profile_id": PROFILE_ID,
-         "lease_state": DurableLeaseState.HELD.value, "fencing_generation": 4},
-        {"lease_id": "agent-run-1", "profile_id": "other",
-         "lease_state": DurableLeaseState.HELD.value, "fencing_generation": 5},
-        {"lease_id": "agent-run-1", "profile_id": PROFILE_ID,
-         "lease_state": DurableLeaseState.RELEASED.value, "fencing_generation": 5},
+        _committed_row(fencing_generation=4),
+        _committed_row(profile_id="other"),
+        _committed_row(lease_state=DurableLeaseState.RELEASED.value),
     ):
         ledger = _Ledger(
             {
@@ -390,6 +408,57 @@ async def test_reconciliation_refuses_a_row_the_ledger_does_not_hold() -> None:
                 await wf._persist_lease_grant(profile, "agent-run-1", metadata=metadata)
                 is False
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "difference",
+    [
+        {"owner_id": "someone-else"},
+        {"owner_kind": "activity"},
+        {"purpose": "credential_validation"},
+        {"compatibility_class": CredentialLeaseMode.EXCLUSIVE_MAINTENANCE.value},
+        {"capacity_scope_ref": "provider-scope:other"},
+        {"scope_generation": 9},
+        {"credential_generation": 4},
+        {"execution_plan_ref": "omnigent-execution-plan:sha256:other"},
+        {"evidence_identity": "evidence-other"},
+    ],
+)
+async def test_reconciliation_refuses_a_row_with_another_grant_identity(
+    difference: dict[str, Any],
+) -> None:
+    """A migrated or conflicting row can share the lease ID, fence and state.
+
+    MoonLadderStudios/MoonMind#3883: inheriting it would hand the caller
+    authority — an owner, a purpose, a plan, a credential generation — that the
+    ledger never granted, so every immutable grant field has to agree.
+    """
+
+    ledger = _Ledger(
+        {
+            "grant": RuntimeError("database timeout"),
+            "describe": {"found": True, "lease": _committed_row(**difference)},
+        }
+    )
+    wf = _manager()
+    profile = wf._profiles[PROFILE_ID]
+    metadata = wf._grant_metadata(
+        {
+            "credentialGeneration": None,
+            "executionPlanRef": None,
+        },
+        fencing_generation=5,
+        profile=profile,
+        lease_mode=CredentialLeaseMode.SHARED_EXECUTION,
+    )
+    profile.reserve("agent-run-1", NOW, purpose="execution_direct", metadata=metadata)
+
+    with _patched(ledger):
+        assert (
+            await wf._persist_lease_grant(profile, "agent-run-1", metadata=metadata)
+            is False
+        )
 
 
 @pytest.mark.asyncio
@@ -856,6 +925,272 @@ async def test_a_pre_contract_re_signal_drain_still_blocks_on_a_failed_save() ->
 
 
 # ---------------------------------------------------------------------------
+# A retained reservation is not authority until its grant commits
+# ---------------------------------------------------------------------------
+
+
+def _new_request_manager() -> MoonMindProviderProfileManagerWorkflow:
+    """A manager with free capacity and one queued signal-based requester."""
+
+    wf = _manager()
+    wf._pending_requests = [
+        PendingRequest(requester_workflow_id="agent-run-1", runtime_id="opencode")
+    ]
+    return wf
+
+
+@pytest.mark.asyncio
+async def test_a_failed_signal_grant_is_retried_before_its_slot_is_announced() -> None:
+    """The drain keeps the reservation to retry persistence — so it must retry.
+
+    MoonLadderStudios/MoonMind#3883: the next pass sees a held lease and takes
+    the re-signal branch, which deliberately writes nothing. Without the retry
+    it would hand a signal-based AgentRun a slot that has no durable lease row,
+    and a manager restart could grant the same capacity again.
+    """
+
+    ledger = _Ledger(
+        {
+            "grant": [RuntimeError("database timeout"), {"granted": True}],
+            "describe": {"found": False},
+        }
+    )
+    wf = _new_request_manager()
+    signals = _Signals()
+
+    with _patched(ledger), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert signals.sent == [], "a slot was announced before its row existed"
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert "agent-run-1" in wf._uncommitted_lease_grants
+    assert [req.requester_workflow_id for req in wf._pending_requests] == [
+        "agent-run-1"
+    ]
+
+    with _patched(ledger), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert ledger.actions() == ["grant", "describe", "grant"]
+    assert wf._uncommitted_lease_grants == {}
+    assert [name for _, name, _ in signals.sent] == ["slot_assigned"]
+    assert wf._pending_requests == []
+
+
+@pytest.mark.asyncio
+async def test_a_grant_that_keeps_failing_never_announces_its_slot() -> None:
+    ledger = _Ledger(
+        {
+            "grant": RuntimeError("database timeout"),
+            "describe": {"found": False},
+        }
+    )
+    wf = _new_request_manager()
+    signals = _Signals()
+
+    for _ in range(3):
+        with _patched(ledger), patch(
+            "temporalio.workflow.get_external_workflow_handle",
+            side_effect=signals.handle_for,
+        ):
+            await wf._drain_queue()
+
+    assert signals.sent == []
+    assert "save" not in ledger.actions()
+    assert wf._uncommitted_lease_grants["agent-run-1"]["profile_id"] == PROFILE_ID
+    assert [req.requester_workflow_id for req in wf._pending_requests] == [
+        "agent-run-1"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_committed_signal_grant_is_never_re_persisted() -> None:
+    """The ordinary re-signal path still costs no durable write."""
+
+    ledger = _Ledger({"grant": {"granted": True}})
+    wf = _new_request_manager()
+    signals = _Signals()
+
+    with _patched(ledger), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+    wf._pending_requests = [
+        PendingRequest(requester_workflow_id="agent-run-1", runtime_id="opencode")
+    ]
+    with _patched(ledger), patch(
+        "temporalio.workflow.get_external_workflow_handle",
+        side_effect=signals.handle_for,
+    ):
+        await wf._drain_queue()
+
+    assert ledger.actions() == ["grant"]
+    assert [name for _, name, _ in signals.sent] == ["slot_assigned", "slot_assigned"]
+
+
+# ---------------------------------------------------------------------------
+# Continue-As-New carries the obligations attached to the lease snapshot
+# ---------------------------------------------------------------------------
+
+
+def _manager_with_obligations() -> MoonMindProviderProfileManagerWorkflow:
+    wf = _held_manager(ledger_generation=6)
+    wf._unresolved_releases = {
+        "agent-run-9": {
+            "profile_id": PROFILE_ID,
+            "fencing_generation": 4,
+            "outcome": LeaseTransitionOutcome.RETRYABLE.value,
+            "retryable": True,
+        }
+    }
+    wf._cleanup_requested_leases = {"agent-run-1"}
+    wf._uncommitted_lease_grants = {
+        "agent-run-2": {
+            "profile_id": PROFILE_ID,
+            "purpose": "execution_direct",
+            "metadata": {"fencingGeneration": 7},
+        }
+    }
+    return wf
+
+
+def test_a_rollover_carries_every_obligation_on_the_lease_snapshot() -> None:
+    """MoonLadderStudios/MoonMind#3883: the successor inherits the debts too.
+
+    A continued run keeps the in-memory lease snapshot and deliberately does
+    not reload the durable ledger, so an obligation left only in memory would
+    disappear at the history rollover: the successor would advertise an
+    ``already_held`` lease whose row is released, strand capacity behind a
+    release nobody retries, or announce a reservation that never committed.
+    """
+
+    wf = _manager_with_obligations()
+    payload = wf._build_continue_as_new_input()
+
+    successor = _manager()
+    successor._restore_lease_obligations(payload)
+
+    assert successor._unresolved_releases == wf._unresolved_releases
+    assert successor._cleanup_requested_leases == {"agent-run-1"}
+    assert successor._uncommitted_lease_grants == wf._uncommitted_lease_grants
+
+
+def test_a_pre_contract_rollover_payload_is_unchanged() -> None:
+    """Replay safety: an older history keeps the exact command it recorded."""
+
+    wf = _manager_with_obligations()
+    wf._lease_transition_contract = False
+    payload = wf._build_continue_as_new_input()
+
+    assert "unresolved_releases" not in payload
+    assert "cleanup_requested_leases" not in payload
+    assert "uncommitted_lease_grants" not in payload
+
+
+@pytest.mark.asyncio
+async def test_a_restored_release_obligation_is_retried_after_rollover() -> None:
+    ledger = _Ledger(
+        {"release_one": {"released": True, "outcome": LeaseTransitionOutcome.RELEASED.value}}
+    )
+    wf = _manager_with_obligations()
+    successor = _held_manager(ledger_generation=6)
+    successor._restore_lease_obligations(wf._build_continue_as_new_input())
+
+    with _patched(ledger):
+        await successor._retry_unresolved_releases()
+
+    assert ledger.rows_for("release_one")[0]["lease_id"] == "agent-run-9"
+    assert successor._unresolved_releases == {}
+
+
+# ---------------------------------------------------------------------------
+# A cleanup request nobody can resolve becomes actionable evidence
+# ---------------------------------------------------------------------------
+
+
+def _expired_cleanup_manager(
+    *, owner_is_workflow: bool = True
+) -> MoonMindProviderProfileManagerWorkflow:
+    wf = _held_manager()
+    profile = wf._profiles[PROFILE_ID]
+    profile.max_lease_duration_seconds = 60
+    metadata = dict(profile.lease_metadata.get("agent-run-1") or {})
+    if not owner_is_workflow:
+        metadata["ownerIsWorkflow"] = False
+        metadata.pop("workflowId", None)
+    profile.lease_metadata["agent-run-1"] = metadata
+    profile.lease_granted_at["agent-run-1"] = (NOW - timedelta(hours=3)).isoformat()
+    return wf
+
+
+@pytest.mark.asyncio
+async def test_a_cleanup_request_no_owner_resolves_becomes_evidence() -> None:
+    """The slot stays spent, but the stuck request stops looking handled.
+
+    MoonLadderStudios/MoonMind#1089: the durable owner of a cleanup request is
+    the terminal-ownership release. Once the request has outlived its
+    escalation deadline with the holder still live, the manager publishes the
+    stuck slot instead of skipping it on every later pass.
+    """
+
+    ledger = _Ledger(
+        {
+            "request_cleanup": {
+                "outcome": LeaseTransitionOutcome.CLEANUP_REQUESTED.value
+            }
+        }
+    )
+    wf = _expired_cleanup_manager()
+
+    with _patched(ledger):
+        await wf._request_cleanup_for_expired_leases()
+    assert wf._lease_index_conflicts == []
+
+    later = NOW + timedelta(seconds=_LEASE_CLEANUP_ESCALATION_SECONDS + 60)
+    with _patched(ledger, now=later):
+        await wf._request_cleanup_for_expired_leases()
+
+    assert ledger.actions() == ["request_cleanup"], "cleanup was re-requested"
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+    assert [entry["kind"] for entry in wf._lease_index_conflicts] == [
+        "cleanup_unresolved"
+    ]
+    assert wf.get_state()["cleanup_requested_leases"] == ["agent-run-1"]
+
+
+@pytest.mark.asyncio
+async def test_a_cleanup_request_with_no_verifiable_owner_is_named_as_such() -> None:
+    """An Activity-owned lease with no owning workflow can never be verified."""
+
+    ledger = _Ledger(
+        {
+            "request_cleanup": {
+                "outcome": LeaseTransitionOutcome.CLEANUP_REQUESTED.value
+            }
+        }
+    )
+    wf = _expired_cleanup_manager(owner_is_workflow=False)
+
+    with _patched(ledger):
+        await wf._request_cleanup_for_expired_leases()
+    later = NOW + timedelta(seconds=_LEASE_CLEANUP_ESCALATION_SECONDS + 60)
+    with _patched(ledger, now=later):
+        await wf._request_cleanup_for_expired_leases()
+
+    assert [entry["kind"] for entry in wf._lease_index_conflicts] == [
+        "cleanup_owner_unverifiable"
+    ]
+    assert wf._profiles[PROFILE_ID].current_leases == ["agent-run-1"]
+
+
+# ---------------------------------------------------------------------------
 # Item 7: the index is a complete conflict and performance boundary
 # ---------------------------------------------------------------------------
 
@@ -1035,13 +1370,13 @@ async def test_an_unknown_lease_state_blocks_new_admission() -> None:
 
 
 @pytest.mark.asyncio
-async def test_two_durable_leases_sharing_a_workflow_id_block_admission() -> None:
+async def test_two_durable_leases_sharing_an_owner_block_admission() -> None:
     ledger = _restore_ledger(
         {
             "leases": [],
             "max_fencing_generation": 3,
             "conflicts": [
-                {"field": "workflow_id", "value": "agent-run-1", "leases": []}
+                {"field": "owner_id", "value": "agent-run-1", "leases": []}
             ],
         }
     )

--- a/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
@@ -11,9 +11,11 @@ from temporalio.converter import DataConverter
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Replayer, UnsandboxedWorkflowRunner, Worker
 
+from moonmind.provider_profiles.lease_client import LeaseTransitionOutcome
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     ACTIVITY_TASK_QUEUE,
     LEASE_TOMBSTONE_PURGE_PATCH,
+    LEASE_TRANSITION_CONTRACT_PATCH,
     MoonMindProviderProfileManagerWorkflow,
 )
 
@@ -51,6 +53,7 @@ class _ProfileActivities:
         self.actions: list[str] = []
         self.cleaned = asyncio.Event()
         self.verified = asyncio.Event()
+        self.released = asyncio.Event()
 
     @activity.defn(name="provider_profile.list")
     async def list_profiles(self, request: dict[str, Any]) -> dict[str, Any]:
@@ -82,6 +85,14 @@ class _ProfileActivities:
                 raise exceptions.ApplicationError(
                     "cleanup unavailable", non_retryable=True
                 )
+        if action == "release_one":
+            # MoonLadderStudios/MoonMind#3883: a release answers with an
+            # explicit outcome. The manager frees capacity only for this one.
+            self.released.set()
+            return {
+                "released": True,
+                "outcome": LeaseTransitionOutcome.RELEASED.value,
+            }
         return {"leases": [], "synced": len(request.get("leases", []))}
 
     @activity.defn(name="provider_profile.pending_request_order")
@@ -214,6 +225,115 @@ async def test_current_manager_cleans_then_grants_and_replays(
         < commands.index("grant")
         < commands.index("slot_assigned")
     )
+    await Replayer(
+        workflows=[MoonMindProviderProfileManagerWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ).replay_workflow(history)
+
+
+@pytest.mark.asyncio
+async def test_the_lease_transition_contract_replays_from_its_own_history() -> None:
+    """The durable ordering contract is pinned by production replay.
+
+    MoonLadderStudios/MoonMind#3883: the grant must commit before the slot is
+    signalled, the release must reach the ledger before capacity is published,
+    and the whole history must replay against the current workflow code. A
+    release that never reaches an explicit outcome must not free the slot.
+    """
+
+    runtime_id = "opencode"
+    activities = _ProfileActivities(runtime_id, fail_cleanup=False)
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-lease-transition",
+            workflows=[MoonMindProviderProfileManagerWorkflow, _SlotRequester],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ), Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                activities.list_profiles,
+                activities.sync_leases,
+                activities.pending_order,
+                activities.verify,
+            ],
+        ):
+            manager = await env.client.start_workflow(
+                MoonMindProviderProfileManagerWorkflow.run,
+                {"runtime_id": runtime_id},
+                id=f"provider-profile-manager:{runtime_id}",
+                task_queue="test-lease-transition",
+            )
+            await asyncio.wait_for(activities.cleaned.wait(), timeout=15)
+            requester = await env.client.start_workflow(
+                _SlotRequester.run,
+                id="test-lease-transition-requester",
+                task_queue="test-lease-transition",
+            )
+            await manager.signal(
+                "request_slot",
+                {
+                    "requester_workflow_id": requester.id,
+                    "runtime_id": runtime_id,
+                },
+            )
+            await asyncio.wait_for(activities.verified.wait(), timeout=15)
+            assignment = await requester.query(_SlotRequester.assigned)
+            assert assignment["profile_id"] == "test-default"
+
+            await manager.signal(
+                "release_slot",
+                {
+                    "profile_id": "test-default",
+                    "requester_workflow_id": requester.id,
+                    "fencing_generation": assignment["fencing_generation"],
+                },
+            )
+            await asyncio.wait_for(activities.released.wait(), timeout=15)
+
+            with env.auto_time_skipping_disabled():
+                await manager.signal("shutdown")
+                await requester.signal(_SlotRequester.shutdown)
+                assert (await manager.result())["status"] == "shutdown"
+                await requester.result()
+            history = await manager.fetch_history()
+
+    commands: list[str] = []
+    patch_ids: list[str] = []
+    for event in history.events:
+        if event.HasField("marker_recorded_event_attributes"):
+            attrs = event.marker_recorded_event_attributes
+            if attrs.marker_name == "core_patch":
+                payload = (
+                    await DataConverter.default.decode(
+                        attrs.details["patch-data"].payloads
+                    )
+                )[0]
+                patch_ids.append(payload["id"])
+        elif event.HasField("activity_task_scheduled_event_attributes"):
+            attrs = event.activity_task_scheduled_event_attributes
+            if attrs.activity_type.name == "provider_profile.sync_slot_leases":
+                payload = (await DataConverter.default.decode(attrs.input.payloads))[0]
+                commands.append(payload["action"])
+        elif event.HasField(
+            "signal_external_workflow_execution_initiated_event_attributes"
+        ):
+            attrs = event.signal_external_workflow_execution_initiated_event_attributes
+            if attrs.signal_name == "slot_assigned":
+                commands.append("slot_assigned")
+
+    assert LEASE_TRANSITION_CONTRACT_PATCH in patch_ids
+    # The grant is durable before the consumer is told it has capacity, and the
+    # release reaches the ledger before the slot is published as reusable.
+    assert (
+        commands.index("grant")
+        < commands.index("slot_assigned")
+        < commands.index("release_one")
+    )
+    # Neither the release nor the reclamation rewrote the runtime-wide snapshot.
+    assert "save" not in commands
+
     await Replayer(
         workflows=[MoonMindProviderProfileManagerWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),

--- a/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py
@@ -113,11 +113,13 @@ class _ProfileActivities:
 class _SlotRequester:
     def __init__(self) -> None:
         self.assignment: dict[str, Any] | None = None
+        self.assignments: list[dict[str, Any]] = []
         self.stopped = False
 
     @workflow.signal
     def slot_assigned(self, payload: dict[str, Any]) -> None:
         self.assignment = payload
+        self.assignments.append(payload)
 
     @workflow.signal
     def shutdown(self) -> None:
@@ -127,9 +129,20 @@ class _SlotRequester:
     def assigned(self) -> dict[str, Any] | None:
         return self.assignment
 
+    @workflow.query
+    def assignment_count(self) -> int:
+        return len(self.assignments)
+
     @workflow.run
     async def run(self) -> None:
         await workflow.wait_condition(lambda: self.stopped)
+
+
+async def _wait_for_assignments(handle: Any, expected: int) -> None:
+    """Poll the requester until it has received ``expected`` assignments."""
+
+    while await handle.query(_SlotRequester.assignment_count) < expected:
+        await asyncio.sleep(0.05)
 
 
 @pytest.mark.asyncio
@@ -282,6 +295,21 @@ async def test_the_lease_transition_contract_replays_from_its_own_history() -> N
             assignment = await requester.query(_SlotRequester.assigned)
             assert assignment["profile_id"] == "test-default"
 
+            # The production recovery shape: a slot wait times out and the run
+            # re-sends request_slot to a manager that still holds its lease.
+            # The manager re-signals the held slot without rewriting the
+            # runtime-wide snapshot (MoonLadderStudios/MoonMind#3883).
+            await manager.signal(
+                "request_slot",
+                {
+                    "requester_workflow_id": requester.id,
+                    "runtime_id": runtime_id,
+                },
+            )
+            await asyncio.wait_for(_wait_for_assignments(requester, 2), timeout=15)
+            re_assignment = await requester.query(_SlotRequester.assigned)
+            assert re_assignment == assignment
+
             await manager.signal(
                 "release_slot",
                 {
@@ -331,7 +359,13 @@ async def test_the_lease_transition_contract_replays_from_its_own_history() -> N
         < commands.index("slot_assigned")
         < commands.index("release_one")
     )
-    # Neither the release nor the reclamation rewrote the runtime-wide snapshot.
+    # The re-signal announced the same lease again and cost no durable write:
+    # one grant, two assignments, one release.
+    assert commands.count("slot_assigned") == 2
+    assert commands.count("grant") == 1
+    assert commands.count("release_one") == 1
+    # No path in a new history rewrites the runtime-wide snapshot: not the
+    # grant, not the re-signal drain, not the release, not the reclamation.
     assert "save" not in commands
 
     await Replayer(


### PR DESCRIPTION
## Issue

- Issue: [MoonLadderStudios/MoonMind#3883](https://github.com/MoonLadderStudios/MoonMind/issues/3883) — [Omnigent concurrency] Complete incremental lease fencing and recovery without snapshot overwrites
- Parent: #3878. Coordinates with #3879 (lease compatibility), #3882 (scope accounting), #3880 (admission handoff) and #1089 (resource-safe reclamation).

Closes MoonLadderStudios/MoonMind#3883

## Summary

Finishes the existing incremental lease implementation (migration `369_provider_lease_incr_contract.py` plus the `provider_profile.sync_slot_leases` persistence owner) rather than introducing a second schema, allocator, database-only scheduler, or separate credential store. Every behavior change is gated on the `LEASE_TRANSITION_CONTRACT_PATCH` marker so pre-marker workflow histories keep their exact recorded commands.

1. **One typed durable lease contract end to end.** `DurableLeaseState` (`held` / `cleanup_requested` / `released`) and `LeaseTransitionOutcome` (`released` / `already_released` / `stale` / `conflict` / `retryable`) in `moonmind/provider_profiles/lease_client.py` are carried through grant, consume, heartbeat, release and reclamation. The exact lease ID stays separate from workflow/run/step/attempt and owner kind; purpose/mode, immutable plan/evidence identity, and acquired credential/scope generations travel with the row. A state outside the enum is explicitly not free capacity.
2. **Real acquired authority in the grant payload.** The fencing generation is no longer hard-coded to `1` — the manager issues a monotonic generation and release quotes the generation it actually acquired. Grants now also record the `compatibility_class` and the scope generation they were admitted against, instead of a fabricated `scope_generation=1`.
3. **Grant-or-get validates full identity.** A matching retry returns the committed row; conflicting profile/plan/purpose/generation reuse is rejected without consuming another unit. An uncommitted in-memory reservation can never be reported as `already_held`; concurrent identical callers join the same committed result or observe a pending state.
4. **Ambiguous database outcomes are reconciled, not guessed.** A write that times out after commit is resolved by inspecting authoritative state through the stable lease identity via `describe`, rather than deleting a possibly live grant or granting again.
5. **Ledger-first release with explicit outcomes.** Release persists before freeing in-memory accounting, returns a typed outcome with bounded retry, and keeps capacity unavailable while a release is unresolved. A logged warning no longer announces reuse.
6. **Per-lease expiry and reclamation.** Normal expiry and terminal-owner reclamation are per-lease transitions through the same persistence owner and request #1089 resource cleanup instead of releasing a credential consumer that may still be running. The runtime-wide `action=save` snapshot rewrite is retained only for explicitly supported old histories and is fenced by a durable writer generation, so a retained old snapshot writer cannot overwrite new-generation leases. No new-history path issues `save` on any of the five surviving call sites, including the drain re-signal branch.
7. **Fail-closed recovery and honest indexes.** Recovery restores only authoritative active states via indexed queries, reconstructing the same identities/modes/generations without resurrecting released rows; unknown state blocks new admission and surfaces as actionable reconciliation evidence. The reverse index records duplicate/conflicting identities instead of silently skipping them, `_unindex_lease` no longer scans the owner index, and ordinary row mutations stay bounded independently of active lease count.
8. **Documentation.** `docs/Security/ProviderProfiles.md` now describes the actual persistence and ordering contract, including the writer-generation cutover barrier.

## Tests run

Executed locally through the repository's documented host-local runner (`./tools/test_unit.sh`):

| Suite | Command | Result |
| --- | --- | --- |
| Targeted unit (changed lease area) | `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py test_provider_profile_incremental_lease_persistence.py test_provider_profile_lease_durability.py test_provider_profile_admitted_capacity_fence.py` | PASS — 211 passed |
| Unit (manager scheduling / review remediation) | `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_provider_profile_manager.py test_provider_profile_review_remediation.py` | PASS — 161 passed |
| Workflow/replay boundary (real Temporal time-skipping server) | `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py` | PASS — 9 passed, incl. a replay test asserting one grant, two `slot_assigned` signals, one `release_one`, and no `save` in recorded commands |
| Required temporal_boundary CI shard | `python -m pytest tests/unit/workflows/temporal -m "temporal_boundary and not slow and not provider_verification and not requires_credentials" -q -n auto --dist loadfile --timeout 600` | PASS — 4226 passed, 9 subtests, 18m51s |
| Lint (changed files) | `python -m ruff check` on the changed source and test files | PASS — no finding on any touched line |
| Impact selector | `git diff --name-only origin/main...HEAD \| python3 tools/select_test_suites.py --stdin` | `unit_fast`, `api_component`, `temporal_boundary`, `integration_ci`, `reliability_journey`, `exact_artifact`, `omnigent_conformance` = true |

New coverage added by this change:

- `tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py` (27 tests, `integration_ci`) — real-PostgreSQL migration/transaction coverage for existing rows, duplicate IDs, shared scopes, mixed-generation cutover, and a re-signal drain leaving an unrelated maintenance lease's identity, a `cleanup_requested` state and a release tombstone high-water mark intact.
- `tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py` — the deterministic regressions for every source-verified gap named in the issue.
- `tests/unit/workflows/temporal/test_provider_profile_manager_replayer.py` — pre-contract replay-compatibility plus a real-Temporal-server replay assertion.

**Not executed in this runtime (deferred to required CI):**

- `tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py` — no PostgreSQL binaries (`initdb`/`pg_ctl`) on PATH and `MOONMIND_TEST_POSTGRES_URL` unset; the fixture fails closed by design. The 27 tests collect cleanly at this head and the suite is `integration_ci`, so it is required in CI for this diff.
- `reliability_journey`, `exact_artifact`, `api_component` and `omnigent_conformance` shards — selected by the impact selector because the diff touches Temporal workflow and artifact-activity files; none of their assertions cover the provider-profile lease contract. Required in CI.
- `moonmind container python-tests` was rejected in this workspace (`MOONMIND_AGENT_RUN_ID` unset, no Docker socket), so the host-local runner was used.

## Remaining risks

- **Real-database evidence is CI-gated.** The strongest acceptance criterion (real migration/transaction coverage) is proven by a suite that could not execute in this runtime. Treat the required integration-ci job as the gating evidence before merge.
- **Replay / in-flight compatibility.** Pre-marker histories intentionally retain the runtime-wide snapshot `save` on expiry, reclamation and the drain re-signal. Correctness for already-running managers depends on the `LEASE_TRANSITION_CONTRACT_PATCH` gate and the durable writer-generation barrier holding across a real mixed-version worker fleet; that mix is covered by tests but not by a production soak.
- **Cross-issue coordination.** #1089 resource cleanup is requested rather than performed here, so a terminal owner's actual resource teardown still depends on that issue's consumer. Scope-generation semantics are shared with #3882 and compatibility class with #3879.
- **Pre-existing lint debt untouched.** Two ruff `F601` findings at `moonmind/workflows/temporal/artifacts.py:3781-3782` exist identically on `origin/main` and were left alone to keep scope bounded.
- **Branch is 2 commits behind `origin/main`** (`7643ae6ab`, `043acdd1e`) at open time; both are unrelated (preset identity handoff, Windows Docker bind sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
