### PR TITLE
Replay the second remediation attempt refused as broadening repositoryBranch

### DIFF
--- a/tests/unit/omnigent/fixtures/remediation-second-attempt-handoff.json
+++ b/tests/unit/omnigent/fixtures/remediation-second-attempt-handoff.json
@@ -1,0 +1,25 @@
+{
+  "sourceWorkflowId": "mm:f794b242-604d-557e-9c1c-524caf1f4969",
+  "escapedDispatchError": "remediation may not broaden execution authority: repositoryBranch",
+  "publicationOutputs": {
+    "push_status": "pushed",
+    "push_branch": "moonmind-job-e5dbb4c7",
+    "push_base_branch": "main",
+    "push_head_sha": "1a4683921ca9f33921dc80fa2c31bea3bd591ff3",
+    "push_commit_count": 1,
+    "remote_verified": true,
+    "acceptedRepositoryEvidence": {
+      "schemaVersion": "accepted-repository-evidence/v1",
+      "pushStatus": "pushed",
+      "branch": "moonmind-job-e5dbb4c7",
+      "baseBranch": "main",
+      "headSha": "1a4683921ca9f33921dc80fa2c31bea3bd591ff3",
+      "commitsAheadOfBase": 1,
+      "repositoryChanged": true,
+      "publicationAuthorized": true,
+      "candidateContaminated": false,
+      "remoteVerified": true,
+      "authority": "omnigent.generic_host_execution"
+    }
+  }
+}

--- a/tests/unit/omnigent/test_canonical_turn_producers.py
+++ b/tests/unit/omnigent/test_canonical_turn_producers.py
@@ -35,11 +35,11 @@ from moonmind.omnigent.control_plane import (
     OmnigentControlPlaneStore,
     TurnSource,
 )
-from moonmind.omnigent.control_plane.turn_admission import (
-    RemediationAuthorityBroadenedError,
-)
 from moonmind.omnigent.control_plane.identities import (
     canonical_omnigent_session_id,
+)
+from moonmind.omnigent.control_plane.turn_admission import (
+    RemediationAuthorityBroadenedError,
 )
 from moonmind.omnigent.control_plane.turn_commands import CanonicalTurnCommandService
 from moonmind.omnigent.harness_platform.agent_profile import OmnigentAgentProfileV2
@@ -76,7 +76,6 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,
     MoonMindRunWorkflow,
 )
-
 
 PROVIDER_PROFILE_REF = "codex-profile-1"
 
@@ -384,7 +383,10 @@ def _remediation_node(*, ordinal: int, publish_mode: str) -> dict:
 
 
 def _dispatch_request(
-    wf: MoonMindRunWorkflow, node: dict, *, plan_ref: str,
+    wf: MoonMindRunWorkflow,
+    node: dict,
+    *,
+    plan_ref: str,
     extra_patches: tuple[str, ...] = (),
 ) -> AgentExecutionRequest:
     """Build the request exactly as the run workflow's dispatch loop does.
@@ -575,10 +577,7 @@ async def test_escaped_publication_base_survives_remediation_dispatch(
 ) -> None:
     """Replay the publication handoff that drifted from a job branch to main."""
     fixture = json.loads(
-        (
-            Path(__file__).parent
-            / "fixtures/remediation-branch-handoff.json"
-        ).read_text()
+        (Path(__file__).parent / "fixtures/remediation-branch-handoff.json").read_text()
     )
     wf = _run_workflow(base_step_execution_id=BASE_STEP_EXECUTION_ID)
     realizer, lifecycles = _realizer(turn_commands, session_factory)
@@ -636,6 +635,133 @@ async def test_escaped_publication_base_survives_remediation_dispatch(
     assert result.failure_class is None
     assert len(lifecycles) == 2
     turns, commands, _ = await _turn_journal(session_factory, _session_id_for(request))
+    assert [turn.lineage_kind for turn in turns] == [TurnSource.REMEDIATION.value]
+    assert len(commands) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("accepted_handoff", [True, False])
+async def test_escaped_second_attempt_continues_the_head_its_predecessor_published(
+    turn_commands, session_factory, plan, accepted_handoff
+) -> None:
+    """Replay ``mm:f794b242-604d-557e-9c1c-524caf1f4969``.
+
+    Remediation attempt 1 ran from the authored base and published its
+    candidate. Attempt 2 must continue that published head *and* stay inside
+    attempt 1's recorded authority. The escaped dispatch pinned attempt 2's
+    starting branch to the published job branch because the publication outputs
+    named their base as ``push_base_branch``, which the legacy base-ref recorder
+    never read; the AC6 guard then refused the attempt as broadening
+    ``repositoryBranch``.
+
+    ``accepted_handoff=True`` is every current history: the accepted publication
+    record carries the base atomically and the attempt is admitted.
+    ``accepted_handoff=False`` is the legacy handoff the escaped run executed;
+    it reproduces the refusal so this fixture is known to discriminate.
+    """
+
+    fixture = json.loads(
+        (
+            Path(__file__).parent / "fixtures/remediation-second-attempt-handoff.json"
+        ).read_text()
+    )
+    publication = fixture["publicationOutputs"]
+    patches = (RUN_PUBLISHED_BRANCH_HANDOFF_PATCH,)
+    if accepted_handoff:
+        patches += (RUN_ACCEPTED_PUBLISHED_BRANCH_HANDOFF_PATCH,)
+    authored = {"repository": "MoonLadderStudios/MoonMind", "startingBranch": "main"}
+    realizer, lifecycles = _realizer(turn_commands, session_factory)
+
+    # Attempt 1 repairs the authored implementation; nothing has published yet.
+    wf = _run_workflow(base_step_execution_id=BASE_STEP_EXECUTION_ID)
+    base_node = _base_node(publish_mode="branch")
+    base_node["inputs"].update(authored)
+    base = _dispatch_request(
+        wf, base_node, plan_ref=plan.planRef, extra_patches=patches
+    )
+    await realizer.execute(base, plan)
+    first_node, first_verifier = materialize_attempt_nodes(
+        spec=_loop_spec(),
+        workflow_id=WORKFLOW_ID,
+        run_id=TEMPORAL_RUN_ID,
+        ordinal=1,
+        workspace_head_ref="artifact://loop-head/1",
+        runtime={"mode": "omnigent", "executionProfileRef": PROVIDER_PROFILE_REF},
+        remediation_inputs={"publishMode": "branch"},
+    )
+    first_node["inputs"].update(authored)
+    first = _dispatch_request(
+        wf, first_node, plan_ref=plan.planRef, extra_patches=patches
+    )
+    assert first.workspace_spec["startingBranch"] == "main"
+    assert (await realizer.execute(first, plan)).failure_class is None
+    assert len(lifecycles) == 2
+
+    # Attempt 1 publishes its candidate; the read-only verifier publishes nothing.
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.patched",
+        side_effect=lambda patch_id: patch_id in patches,
+    ), patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.info",
+        return_value=_MockWorkflowInfo(),
+    ), patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.now",
+        return_value=datetime(2026, 9, 6, tzinfo=UTC),
+    ):
+        wf._record_execution_context(
+            node_id=str(first_node["id"]),
+            execution_result={"outputs": publication},
+        )
+        wf._record_execution_context(
+            node_id=str(first_verifier["id"]),
+            execution_result={"outputs": {"push_status": None}},
+        )
+
+    # Attempt 2 continues the head attempt 1 produced and is bounded by it.
+    wf._remediation_loop_state = RemediationLoopState(
+        loopId=LOOP_ID,
+        attemptOrdinal=2,
+        phase=RemediationLoopPhase.REMEDIATION_RUNNING,
+        consumedBudgets=ConsumedRemediationBudgets(attempts=2),
+    )
+    wf._remediation_workspace_head = _loop_head(
+        base_step_execution_id=first.step_execution.step_execution_id
+    )
+    second_node = _remediation_node(ordinal=2, publish_mode="branch")
+    second_node["inputs"].update(authored)
+    second = _dispatch_request(
+        wf, second_node, plan_ref=plan.planRef, extra_patches=patches
+    )
+    lineage = second.step_execution.canonical_turn_lineage
+    assert lineage is not None
+    assert lineage.base_step_execution_id == first.step_execution.step_execution_id
+    workspace = second.workspace_spec
+    assert workspace["targetBranch"] == publication["push_branch"]
+    assert workspace["repositoryTarget"]["branch"]["name"] == publication["push_branch"]
+    assert (
+        workspace["repositoryTarget"]["revision"]["commitSha"]
+        == publication["push_head_sha"]
+    )
+
+    if not accepted_handoff:
+        # The escaped shape: the published branch became the starting branch,
+        # so the attempt asserted a branch its predecessor never held.
+        assert workspace["startingBranch"] == publication["push_branch"]
+        with pytest.raises(RemediationAuthorityBroadenedError) as excinfo:
+            await realizer.execute(second, plan)
+        assert excinfo.value.broadened == ("repositoryBranch",)
+        assert str(excinfo.value) == fixture["escapedDispatchError"]
+        # Refused before provider mutation.
+        assert len(lifecycles) == 2
+        _, commands, _ = await _turn_journal(session_factory, _session_id_for(second))
+        assert commands == []
+        return
+
+    assert workspace["startingBranch"] == "main"
+    result = await realizer.execute(second, plan)
+    assert result.failure_class is None
+    assert len(lifecycles) == 3 and lifecycles[2].requests == [second]
+    turns, commands, _ = await _turn_journal(session_factory, _session_id_for(second))
     assert [turn.lineage_kind for turn in turns] == [TurnSource.REMEDIATION.value]
     assert len(commands) == 1
 
@@ -722,9 +848,7 @@ async def test_the_delivered_provider_session_is_attached_to_canonical_authority
     session_id = _session_id("attach-run")
     async with store.transaction() as repos:
         session = await repos.sessions.get(session_id)
-        by_scope = await repos.sessions.get_by_scope(
-            "attach-run", "provider-session-1"
-        )
+        by_scope = await repos.sessions.get_by_scope("attach-run", "provider-session-1")
 
     assert session.provider_session_ref == "provider-session-1"
     assert by_scope is not None and by_scope.session_id == session_id
@@ -940,15 +1064,19 @@ def test_every_trusted_realizer_is_covered_by_the_routing_assertion() -> None:
     assert set(_PRODUCTION_REALIZERS) == set(KNOWN_REALIZERS)
 
 
-@pytest.mark.parametrize("realizer_class", sorted(
-    _PRODUCTION_REALIZERS.values(), key=lambda cls: cls.ref
-))
+@pytest.mark.parametrize(
+    "realizer_class", sorted(_PRODUCTION_REALIZERS.values(), key=lambda cls: cls.ref)
+)
 def test_no_production_realizer_names_its_own_turn_source(realizer_class) -> None:
     """The wrapper derives the source; a realizer may not assert one."""
 
     tree = ast.parse(textwrap.dedent(inspect.getsource(realizer_class.execute)))
     body = tree.body[0].body
-    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+    ):
         body = body[1:]  # the docstring may legitimately name the vocabulary
     code = "\n".join(ast.unparse(node) for node in body)
     assert "deliver_canonical_turn(" in code


### PR DESCRIPTION
## Summary

Workflow `mm:f794b242-604d-557e-9c1c-524caf1f4969` (GitHub Issue Implement MoonLadderStudios/MoonMind#3825) failed at remediation attempt 2 with:

```
OMNIGENT_GENERIC_DISPATCH_FAILED: Admitted Omnigent execution-plan dispatch failed:
remediation may not broaden execution authority: repositoryBranch
```

This PR adds the minimized replay fixture and boundary test for that escaped journey so the required unit suite pins it.

## Root cause

- Remediation attempt 1 ran from the authored base `main` and published `moonmind-job-e5dbb4c7@1a46839`. Its canonical session recorded `repositoryBranch = main`.
- The verifier and remediation attempt 2 were then pinned to the published head. Attempt 2 carried canonical-turn lineage to attempt 1, so the AC6 guard compared its requested authority against attempt 1's record.
- The Omnigent publication outputs name their base as `push_base_branch`. The legacy base-ref recorder only reads `push_base_ref` / `base_branch`, so `_publish_context["baseRef"]` was never set and `_apply_published_branch_handoff` fell back to `startingBranch = <published branch>`. The request therefore asserted `repositoryBranch = moonmind-job-e5dbb4c7` and was refused before provider mutation.
- #4044 (merged 10:01 PDT) already replaced that path: the accepted publication record carries `baseBranch` atomically and the handoff keeps `startingBranch = main` while pinning `repositoryTarget` to the published head. The failing run started 09:51 PDT on a worker whose process had imported the pre-#4044 module. The worker bind-mounts the host checkout, so the on-disk `run.py` was updated at 10:08 PDT mid-run while the running process kept the old code (`TemporalChangeVersion` on the run lacks `run-accepted-published-branch-handoff-v1`).

## Change

- `tests/unit/omnigent/fixtures/remediation-second-attempt-handoff.json`: publication outputs minimized from the run, plus the escaped error string.
- `tests/unit/omnigent/test_canonical_turn_producers.py::test_escaped_second_attempt_continues_the_head_its_predecessor_published`: dispatches the base step, remediation attempt 1, records attempt 1's publication and the read-only verifier through `_record_execution_context`, then dispatches attempt 2 with lineage to attempt 1 through the real realizer and control-plane store.
  - `accepted_handoff=True` (every current history): attempt 2 keeps `startingBranch = main`, pins `repositoryTarget` to the published head, is admitted, and journals a `remediation` turn.
  - `accepted_handoff=False` (the legacy handoff the escaped run executed): reproduces the exact `repositoryBranch` refusal with no provider mutation, so the fixture is known to discriminate.

No production code changes; the fix landed in #4044.

## Operational follow-up

The local deployment's workers still run the pre-#4044 module in memory. Restart `moonmind-temporal-worker-workflow-1` (and the other bind-mounted workers) once no workflows are executing so they import current `main`.

## Verification

- `tests/unit/omnigent/test_canonical_turn_producers.py tests/unit/omnigent/test_canonical_turn_routing.py`: 77 passed (in a clean worktree via `moonmind-python-tests:local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
