### PR TITLE
Fix branch publishing to update the selected workflow branch

### DIFF
--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -108,6 +108,13 @@ After the agent completes, the infrastructure pushes the current work branch to 
 
 For new authored submissions, `branch` publish uses a single operator-selected `branch` field. That branch is the branch to update and push. MoonMind no longer exposes a separate "clone from X, push to Y" authoring model.
 
+The shared Omnigent publication boundary passes this resolved branch as the
+publication destination for every harness. It must not generate a replacement
+job branch in `branch` mode. Publication uses a fast-forward push and verifies
+the exact remote head; concurrent remote work must fail publication rather than
+be overwritten. A retry whose local head already equals the selected remote
+head returns verified no-change evidence for that same branch.
+
 Example:
 
 ```json

--- a/docs/Workflows/WorkflowPublishing.md
+++ b/docs/Workflows/WorkflowPublishing.md
@@ -110,10 +110,17 @@ For new authored submissions, `branch` publish uses a single operator-selected `
 
 The shared Omnigent publication boundary passes this resolved branch as the
 publication destination for every harness. It must not generate a replacement
-job branch in `branch` mode. Publication uses a fast-forward push and verifies
-the exact remote head; concurrent remote work must fail publication rather than
-be overwritten. A retry whose local head already equals the selected remote
+job branch in `branch` mode. Publication verifies fast-forward ancestry and
+uses an exact remote-tip lease; concurrent remote updates or branch deletion
+must fail publication rather than overwrite or recreate the branch. A retry
+whose local head already equals the selected remote
 head returns verified no-change evidence for that same branch.
+
+When the branch is omitted, publication uses the repository default recorded by
+clone in `origin/HEAD`. Workspaces without that record resolve the remote's
+symbolic `HEAD` and persist it before publishing. Publication never assumes a
+default branch name, and retries retain the resolved selection even if the
+remote default changes. An unavailable default requires explicit branch selection.
 
 Example:
 

--- a/moonmind/omnigent/workspace_publication.py
+++ b/moonmind/omnigent/workspace_publication.py
@@ -229,6 +229,11 @@ class OmnigentWorkspacePublicationService:
             # PR creation remains owned by the durable parent workflow.
             publish_mode="branch",
             publish_base_branch=normalized_base,
+            # Branch mode updates the authored branch. Only PR mode gets a
+            # generated candidate; PR creation stays with the parent workflow.
+            publication_branch_name=(
+                normalized_base if normalized_mode == "branch" else None
+            ),
             runtime_mode="omnigent",
             repo_dir=safe_workspace,
             run_command=run_command,

--- a/moonmind/omnigent/workspace_publication.py
+++ b/moonmind/omnigent/workspace_publication.py
@@ -212,7 +212,37 @@ class OmnigentWorkspacePublicationService:
         # Remediation workspaces may be single-branch clones of the candidate.
         # Materialize the authored comparison ref through the same repository
         # credential before the publisher measures or mutates that candidate.
-        normalized_base = str(base_branch or "main").strip() or "main"
+        normalized_base = str(base_branch or "").strip()
+        if not normalized_base:
+            # Clone records the selected repository default in origin/HEAD.
+            # Keep that selection stable even if the remote default changes.
+            default_head = await run_command(
+                ["git", "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+                check=False,
+            )
+            if default_head.returncode == 0:
+                default_ref = str(default_head.stdout or "").strip()
+                if default_ref.startswith("refs/remotes/origin/"):
+                    normalized_base = default_ref.removeprefix("refs/remotes/origin/")
+            elif default_head.returncode == 1:
+                remote_head = await run_command(
+                    ["git", "ls-remote", "--symref", "origin", "HEAD"]
+                )
+                defaults = {
+                    fields[1].removeprefix("refs/heads/")
+                    for line in remote_head.stdout.splitlines()
+                    if len(fields := line.split()) == 3
+                    and fields[0] == "ref:"
+                    and fields[1].startswith("refs/heads/")
+                    and fields[2] == "HEAD"
+                }
+                if len(defaults) == 1:
+                    normalized_base = defaults.pop()
+            if not normalized_base:
+                raise HarnessPlatformError(
+                    "repository default branch could not be resolved; select a branch explicitly",
+                    code="OMNIGENT_REPOSITORY_PUBLICATION_FAILED",
+                )
         await run_command(["git", "check-ref-format", "--branch", normalized_base])
         await run_command(
             [
@@ -223,6 +253,15 @@ class OmnigentWorkspacePublicationService:
                 f"+refs/heads/{normalized_base}:refs/remotes/origin/{normalized_base}",
             ]
         )
+        if not str(base_branch or "").strip():
+            await run_command(
+                [
+                    "git",
+                    "symbolic-ref",
+                    "refs/remotes/origin/HEAD",
+                    f"refs/remotes/origin/{normalized_base}",
+                ]
+            )
         published = await PublishService().publish(
             job_id=uuid5(NAMESPACE_URL, publication_identity),
             instruction="Publish completed Omnigent repository work",

--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -291,11 +291,30 @@ class PublishService:
             remote_line = str(remote_result.stdout or "").strip().splitlines()
             if remote_line:
                 remote_sha = remote_line[0].split(maxsplit=1)[0].strip()
+            if branch_name == base_branch:
+                if getattr(remote_result, "returncode", 1) != 0 or not re.fullmatch(
+                    r"(?:[0-9a-f]{40}|[0-9a-f]{64})", remote_sha
+                ):
+                    raise RuntimeError("selected publication branch has no remote head")
+                ancestry = await run_command(
+                    [
+                        self._git_binary,
+                        "merge-base",
+                        "--is-ancestor",
+                        remote_sha,
+                        branch_name,
+                    ],
+                    cwd=repo_dir,
+                    check=False,
+                )
+                if getattr(ancestry, "returncode", 1) != 0:
+                    raise RuntimeError(
+                        "selected publication branch is not a fast-forward of the remote head"
+                    )
         push_command = [self._git_binary, "push", "-u"]
-        if verify_remote and branch_name != base_branch:
-            # A generated candidate may be retried with a lease. The authored
-            # branch is shared authority: use Git's atomic fast-forward check
-            # so a stale workspace cannot replace concurrent remote work.
+        if verify_remote:
+            # The ancestry check protects shared history; the exact-tip lease
+            # also rejects deletion or replacement between inspection and push.
             push_command.append(
                 f"--force-with-lease=refs/heads/{branch_name}:{remote_sha}"
             )

--- a/moonmind/publish/service.py
+++ b/moonmind/publish/service.py
@@ -292,7 +292,10 @@ class PublishService:
             if remote_line:
                 remote_sha = remote_line[0].split(maxsplit=1)[0].strip()
         push_command = [self._git_binary, "push", "-u"]
-        if verify_remote:
+        if verify_remote and branch_name != base_branch:
+            # A generated candidate may be retried with a lease. The authored
+            # branch is shared authority: use Git's atomic fast-forward check
+            # so a stale workspace cannot replace concurrent remote work.
             push_command.append(
                 f"--force-with-lease=refs/heads/{branch_name}:{remote_sha}"
             )

--- a/tests/integration/reliability/replays/omnigent-generic-publication-github-auth/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-generic-publication-github-auth/expected-outcome.json
@@ -1,6 +1,6 @@
 {
   "pushStatus": "pushed",
-  "pushBranch": "moonmind-job-9dffe67f",
+  "pushBranch": "main",
   "pushHeadSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "pushCommitCount": 1,
   "remoteVerified": true

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -7857,7 +7857,7 @@ async def test_generic_omnigent_publication_materializes_resolved_github_auth(
         if "ls-remote" in command:
             ls_remote_calls += 1
             if ls_remote_calls == 1:
-                return 0, "", ""
+                return 0, f"{'b' * 40}\trefs/heads/{expected['pushBranch']}\n", ""
             return 0, f"{remote_head}\trefs/heads/{expected['pushBranch']}\n", ""
         if "rev-parse" in command:
             return 0, f"{remote_head}\n", ""

--- a/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py
@@ -162,8 +162,9 @@ async def _materialize_workspace(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("publish_mode", ["branch", "pr"])
 async def test_materialized_workspace_publishes_branch_and_recovery_is_idempotent(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, publish_mode
 ) -> None:
     # The outbound secret scan is the publication layer's own concern and is
     # covered elsewhere; disable it so this journey is deterministic and offline.
@@ -172,7 +173,7 @@ async def test_materialized_workspace_publishes_branch_and_recovery_is_idempoten
     )
     remote = _init_bare_remote_with_seed(tmp_path)
 
-    _runtime, workspace = await _materialize_workspace(
+    runtime, workspace = await _materialize_workspace(
         tmp_path,
         workflow_id="mm:wf-3561",
         step_execution_id="mm:wf-3561:run:implement:execution:1",
@@ -181,7 +182,7 @@ async def test_materialized_workspace_publishes_branch_and_recovery_is_idempoten
         target_branch="agent/implement",
     )
 
-    # Authored source, output, and publication branches stay distinct (AC1).
+    # The agent's local checkout need not name the publication destination.
     assert _git_out(workspace, "rev-parse", "--abbrev-ref", "HEAD") == (
         "agent/implement"
     )
@@ -191,27 +192,31 @@ async def test_materialized_workspace_publishes_branch_and_recovery_is_idempoten
     # canonical publication owns the commit/branch/push for).
     (workspace / "feature.py").write_text("print('feature')\n", encoding="utf-8")
 
-    publisher = PublishService()
-    job_id = UUID("00000000-0000-0000-0000-000000003561")
-    result = await publisher.publish(
-        job_id=job_id,
-        instruction="Add the feature module",
-        publish_mode="branch",
-        publish_base_branch="main",
-        runtime_mode="codex",
-        repo_dir=workspace,
-        run_command=_run_command,
+    workspace_id = workspace.parent.name
+    args = dict(
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        current_workflow_id="mm:wf-3561",
+        current_step_execution_id="mm:wf-3561:run:implement:execution:1",
+        publication_identity="materialized-workspace-publication",
+        publish_mode=publish_mode,
+        base_branch="main",
+        repository="",
+        github_token=None,
     )
+    result = await runtime.publish_workspace(**args)
 
-    assert result is not None
-    assert result.status == "published"
-    assert result.commit_created is True
-    assert result.branch_pushed is True
-    publication_branch = result.branch_name
-    assert publication_branch and publication_branch.startswith("moonmind-job-")
-    # Source (main), output (agent/implement), and publication branch are three
-    # distinct refs; none was silently reset onto another (AC1/AC3).
-    assert publication_branch not in {"main", "agent/implement"}
+    assert result["push_status"] == "pushed"
+    assert result["remote_verified"] is True
+    publication_branch = result["push_branch"]
+    if publish_mode == "branch":
+        assert publication_branch == "main"
+    else:
+        assert publication_branch.startswith("moonmind-job-")
+        assert publication_branch not in {"main", "agent/implement"}
 
     # The push reached the real remote with the mutation.
     remote_branches = _git_out(remote, "branch", "--list", publication_branch)
@@ -221,18 +226,12 @@ async def test_materialized_workspace_publishes_branch_and_recovery_is_idempoten
     # Publication-only recovery from the already-qualified candidate is
     # idempotent: the accepted work is already committed and pushed, so a retry
     # neither creates a second commit nor a divergent remote head (AC4).
-    recovery = await publisher.publish(
-        job_id=job_id,
-        instruction="Add the feature module",
-        publish_mode="branch",
-        publish_base_branch="main",
-        runtime_mode="codex",
-        repo_dir=workspace,
-        run_command=_run_command,
+    recovery = await runtime.publish_workspace(**args)
+    assert recovery["push_status"] == (
+        "no_commits" if publish_mode == "branch" else "pushed"
     )
-    assert recovery is not None
-    assert recovery.status == "skipped"
-    assert recovery.reason_code == "no_commit"
+    assert recovery["remote_verified"] is True
+    assert recovery["push_head_sha"] == remote_head
     assert _git_out(remote, "rev-parse", publication_branch) == remote_head
 
 
@@ -421,9 +420,7 @@ async def test_profile_bound_publication_supplies_missing_git_identity(
 ) -> None:
     """Replay mm:bfc017e9 staged output with no repository-local author."""
 
-    replay = load_replay(
-        "omnigent-publication-missing-git-identity", "manifest.json"
-    )
+    replay = load_replay("omnigent-publication-missing-git-identity", "manifest.json")
     expected = load_replay(
         "omnigent-publication-missing-git-identity", "expected-outcome.json"
     )
@@ -496,7 +493,9 @@ async def test_materialized_workspace_publishes_pull_request_through_canonical_c
     # publishing authority. Stub the resolver so the PR path stays offline.
     monkeypatch.setattr(
         "moonmind.auth.github_credentials.resolve_github_credential",
-        AsyncMock(return_value=SimpleNamespace(token="ghp_journeytoken", safe_summary="stub")),
+        AsyncMock(
+            return_value=SimpleNamespace(token="ghp_journeytoken", safe_summary="stub")
+        ),
     )
     remote = _init_bare_remote_with_seed(tmp_path)
     _runtime, workspace = await _materialize_workspace(
@@ -513,9 +512,7 @@ async def test_materialized_workspace_publishes_pull_request_through_canonical_c
 
     async def _create_pull_request(**kwargs):
         created_calls.append(kwargs)
-        return SimpleNamespace(
-            created=True, url="https://github.com/owner/repo/pull/7"
-        )
+        return SimpleNamespace(created=True, url="https://github.com/owner/repo/pull/7")
 
     publisher = PublishService(github_create_pull_request=_create_pull_request)
     result = await publisher.publish(

--- a/tests/unit/omnigent/fixtures/selected-branch-publication.json
+++ b/tests/unit/omnigent/fixtures/selected-branch-publication.json
@@ -1,0 +1,17 @@
+{
+  "workflowId": "mm:312b27e5-3fc0-4bfa-a800-188a2ef98050",
+  "stepExecutionId": "node-1:execution:1",
+  "request": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "correlationId": "mm:312b27e5-3fc0-4bfa-a800-188a2ef98050",
+    "idempotencyKey": "selected-branch-publication-replay",
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "branch": "moonmind-job-34d23444"
+    },
+    "parameters": {"publishMode": "branch"}
+  },
+  "expectedBranch": "moonmind-job-34d23444",
+  "observedIncorrectBranch": "moonmind-job-22c1dadb"
+}

--- a/tests/unit/omnigent/test_execute.py
+++ b/tests/unit/omnigent/test_execute.py
@@ -1195,6 +1195,7 @@ def _never_started_client(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     "agent_name", ["opencode-native-ui", "codex-native-ui", "claude-native-ui"]
 )
@@ -1275,9 +1276,9 @@ async def test_provider_rejection_after_injection_completion(
     monkeypatch.setenv("OMNIGENT_ENABLED", "true")
     monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.test")
     monkeypatch.setattr("moonmind.omnigent.execute.OmnigentHttpClient", Client)
-    monkeypatch.setattr(
-        "moonmind.omnigent.execute._MARKED_TURN_START_TIMEOUT_SECONDS", 0.05
-    )
+    # Keep the production watchdog budget: this test classifies native failure,
+    # and journal I/O must not race an unrelated 50ms turn-start deadline.
+    # The test-level timeout still bounds a regression that resumes polling.
     async def capture_with_crash(**kwargs):
         nonlocal crashed
         if crash_at == "harvest" and not crashed and kwargs["harvest_resources"]:

--- a/tests/unit/omnigent/test_workspace_publication_base.py
+++ b/tests/unit/omnigent/test_workspace_publication_base.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
 from moonmind.config.settings import settings
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from moonmind.omnigent.workspace_publication import OmnigentWorkspacePublicationService
+from moonmind.publish.service import PublishService
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
     SandboxWorkspaceRecordStore,
@@ -145,6 +149,10 @@ async def test_publish_clean_single_branch_candidate(
     assert evidence["push_head_sha"] == candidate_sha
     assert evidence["push_commit_count"] == (0 if no_new_commits else 1)
     assert evidence["remote_verified"] is True
+    if publish_mode == "branch":
+        assert evidence["push_branch"] == (base_branch or "main")
+    elif not no_new_commits:
+        assert evidence["push_branch"] != (base_branch or "main")
     assert (
         git("rev-parse", f"refs/heads/{evidence['push_branch']}", cwd=origin)
         == candidate_sha
@@ -227,3 +235,158 @@ async def test_unchanged_shared_base_cannot_supply_an_unrelated_pr(
     assert evidence["push_branch"] == branch
     assert "pull_request_url" not in evidence
     resolve_pr.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("authored_branch", [None, "main", "moonmind-job-34d23444"])
+@pytest.mark.parametrize("input_shape", ["branch", "startingBranch", "repository"])
+@pytest.mark.parametrize("publish_mode", ["branch", "pr"])
+async def test_selected_branch_publication_replay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authored_branch: str | None,
+    input_shape: str,
+    publish_mode: str,
+) -> None:
+    """Replay the escaped input through the request boundary and real remote."""
+    replay = json.loads(
+        (
+            Path(__file__).parent / "fixtures/selected-branch-publication.json"
+        ).read_text()
+    )
+    monkeypatch.setattr(settings.security, "high_security_mode", False)
+    for prefix in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{prefix}_NAME", "Test")
+        monkeypatch.setenv(f"GIT_{prefix}_EMAIL", "test@example.invalid")
+    monkeypatch.setattr(
+        "moonmind.omnigent.workspace_publication.resolve_github_credential",
+        AsyncMock(return_value=SimpleNamespace(token="fixture-credential")),
+    )
+    resolve_pr = AsyncMock(return_value=SimpleNamespace(resolved=False))
+    monkeypatch.setattr(
+        "moonmind.omnigent.workspace_publication.GitHubService.resolve_pull_request_selector",
+        resolve_pr,
+    )
+    branch = authored_branch or "main"
+    origin = tmp_path / "origin.git"
+    git("init", "--bare", str(origin), cwd=tmp_path)
+    workflow_id, step_id = replay["workflowId"], replay["stepExecutionId"]
+    workspace_id = hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    workspace.mkdir(parents=True)
+    git("init", f"--initial-branch={branch}", cwd=workspace)
+    (workspace / "work.txt").write_text("original PR\n")
+    git("add", ".", cwd=workspace)
+    git("commit", "-m", "original PR", cwd=workspace)
+    git("remote", "add", "origin", str(origin), cwd=workspace)
+    git("push", "origin", branch, cwd=workspace)
+    original_sha = git("rev-parse", "HEAD", cwd=workspace)
+    (workspace / "work.txt").write_text("completed work\n")
+    git("commit", "-am", "complete existing PR", cwd=workspace)
+    head_sha = git("rev-parse", "HEAD", cwd=workspace)
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(workspace_id, workflow_id, step_id, "repo")
+    )
+    request_payload = replay["request"]
+    spec = request_payload["workspaceSpec"]
+    spec.pop("branch")
+    if input_shape == "repository":
+        spec["repository"] = {"repository": {"name": "MoonLadderStudios/MoonMind"}}
+        if authored_branch is not None:
+            spec["repository"]["branch"] = {"name": authored_branch}
+    elif authored_branch is not None:
+        spec[input_shape] = authored_branch
+    spec["workspaceLocator"] = {
+        "kind": "sandbox",
+        "workspaceId": workspace_id,
+        "relativePath": "repo",
+    }
+    request_payload["parameters"]["publishMode"] = publish_mode
+    request = AgentExecutionRequest.model_validate(request_payload)
+    publisher = OmnigentWorkspacePublicationService(tmp_path)
+    args = dict(
+        request=request,
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_id,
+    )
+    evidence = await publisher.publish_request_workspace(**args)
+
+    assert evidence["push_status"] == "pushed"
+    assert evidence["push_head_sha"] == head_sha
+    assert evidence["remote_verified"] is True
+    assert evidence["push_commit_count"] == 1
+    if publish_mode == "branch":
+        assert evidence["push_branch"] == branch
+        assert git("rev-parse", f"refs/heads/{branch}", cwd=origin) == head_sha
+        assert (
+            git("for-each-ref", "--format=%(refname:short)", "refs/heads", cwd=origin)
+            == branch
+        )
+        # The old payload is retryable without another commit or a new branch.
+        retry = await publisher.publish_request_workspace(**args)
+        assert retry["push_status"] == "no_commits"
+        assert retry["push_branch"] == branch
+        assert retry["push_head_sha"] == head_sha
+        assert retry["remote_verified"] is True
+        resolve_pr.assert_not_awaited()
+    else:
+        assert evidence["push_branch"] != branch
+        assert git("rev-parse", f"refs/heads/{branch}", cwd=origin) == original_sha
+        assert git("rev-parse", evidence["push_branch"], cwd=origin) == head_sha
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("race_during_push", [False, True])
+async def test_selected_branch_rejects_remote_divergence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, race_during_push: bool
+) -> None:
+    """An authored PR branch must never be force-replaced with a stale checkout."""
+    monkeypatch.setattr(settings.security, "high_security_mode", False)
+    for prefix in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{prefix}_NAME", "Test")
+        monkeypatch.setenv(f"GIT_{prefix}_EMAIL", "test@example.invalid")
+    origin = tmp_path / "origin.git"
+    git("init", "--bare", str(origin), cwd=tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    git("init", "--initial-branch=selected", cwd=workspace)
+    (workspace / "work.txt").write_text("original\n")
+    git("add", ".", cwd=workspace)
+    git("commit", "-m", "original", cwd=workspace)
+    git("remote", "add", "origin", str(origin), cwd=workspace)
+    git("push", "origin", "selected", cwd=workspace)
+    peer = tmp_path / "peer"
+    git("clone", "--branch", "selected", str(origin), str(peer), cwd=tmp_path)
+    (peer / "peer.txt").write_text("concurrent work\n")
+    git("add", ".", cwd=peer)
+    git("commit", "-m", "concurrent work", cwd=peer)
+    peer_sha = git("rev-parse", "HEAD", cwd=peer)
+    if not race_during_push:
+        git("push", "origin", "selected", cwd=peer)
+    (workspace / "work.txt").write_text("agent work\n")
+    git("commit", "-am", "agent work", cwd=workspace)
+    agent_sha = git("rev-parse", "HEAD", cwd=workspace)
+
+    async def run_command(command, *, cwd, check=True, **_kwargs):
+        if command[:2] == ["git", "push"] and race_during_push:
+            git("push", "origin", "selected", cwd=peer)
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+        if check and result.returncode:
+            raise RuntimeError(result.stderr)
+        return result
+
+    with pytest.raises(RuntimeError):
+        await PublishService().publish(
+            job_id=uuid4(),
+            instruction="update selected PR",
+            publish_mode="branch",
+            publish_base_branch="selected",
+            publication_branch_name="selected",
+            runtime_mode="omnigent",
+            repo_dir=workspace,
+            run_command=run_command,
+            publish_existing_commits=True,
+            verify_remote=True,
+        )
+    assert git("rev-parse", "selected", cwd=origin) == peer_sha
+    assert git("rev-parse", "HEAD", cwd=workspace) == agent_sha

--- a/tests/unit/omnigent/test_workspace_publication_base.py
+++ b/tests/unit/omnigent/test_workspace_publication_base.py
@@ -57,7 +57,7 @@ async def test_publish_clean_single_branch_candidate(
     monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.invalid")
     origin = tmp_path / "origin.git"
-    git("init", "--bare", str(origin), cwd=tmp_path)
+    git("init", "--bare", "--initial-branch=main", str(origin), cwd=tmp_path)
     source = tmp_path / "source"
     source.mkdir()
     git("init", "--initial-branch=main", cwd=source)
@@ -190,7 +190,7 @@ async def test_unchanged_shared_base_cannot_supply_an_unrelated_pr(
         monkeypatch.setenv(f"GIT_{prefix}_EMAIL", "test@example.invalid")
     branch = base_branch or "main"
     origin = tmp_path / "origin.git"
-    git("init", "--bare", str(origin), cwd=tmp_path)
+    git("init", "--bare", f"--initial-branch={branch}", str(origin), cwd=tmp_path)
     workflow_id, step_id = "workflow", "unchanged"
     workspace_id = hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
     workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
@@ -269,7 +269,7 @@ async def test_selected_branch_publication_replay(
     )
     branch = authored_branch or "main"
     origin = tmp_path / "origin.git"
-    git("init", "--bare", str(origin), cwd=tmp_path)
+    git("init", "--bare", f"--initial-branch={branch}", str(origin), cwd=tmp_path)
     workflow_id, step_id = replay["workflowId"], replay["stepExecutionId"]
     workspace_id = hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
     workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
@@ -337,8 +337,12 @@ async def test_selected_branch_publication_replay(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("race_during_push", [False, True])
-async def test_selected_branch_rejects_remote_divergence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, race_during_push: bool
+@pytest.mark.parametrize("remote_change", ["diverge", "delete"])
+async def test_selected_branch_rejects_remote_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    race_during_push: bool,
+    remote_change: str,
 ) -> None:
     """An authored PR branch must never be force-replaced with a stale checkout."""
     monkeypatch.setattr(settings.security, "high_security_mode", False)
@@ -361,15 +365,22 @@ async def test_selected_branch_rejects_remote_divergence(
     git("add", ".", cwd=peer)
     git("commit", "-m", "concurrent work", cwd=peer)
     peer_sha = git("rev-parse", "HEAD", cwd=peer)
+
+    def change_remote():
+        if remote_change == "diverge":
+            git("push", "origin", "selected", cwd=peer)
+        else:
+            git("push", "origin", "--delete", "selected", cwd=peer)
+
     if not race_during_push:
-        git("push", "origin", "selected", cwd=peer)
+        change_remote()
     (workspace / "work.txt").write_text("agent work\n")
     git("commit", "-am", "agent work", cwd=workspace)
     agent_sha = git("rev-parse", "HEAD", cwd=workspace)
 
     async def run_command(command, *, cwd, check=True, **_kwargs):
         if command[:2] == ["git", "push"] and race_during_push:
-            git("push", "origin", "selected", cwd=peer)
+            change_remote()
         result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
         if check and result.returncode:
             raise RuntimeError(result.stderr)
@@ -388,5 +399,100 @@ async def test_selected_branch_rejects_remote_divergence(
             publish_existing_commits=True,
             verify_remote=True,
         )
-    assert git("rev-parse", "selected", cwd=origin) == peer_sha
+    if remote_change == "diverge":
+        assert git("rev-parse", "selected", cwd=origin) == peer_sha
+    else:
+        assert git("for-each-ref", "refs/heads/selected", cwd=origin) == ""
     assert git("rev-parse", "HEAD", cwd=workspace) == agent_sha
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("publish_mode", ["branch", "pr"])
+@pytest.mark.parametrize("main_exists", [False, True])
+@pytest.mark.parametrize("default_source", ["clone", "remote", "unavailable"])
+async def test_omitted_branch_uses_repository_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    publish_mode: str,
+    main_exists: bool,
+    default_source: str,
+) -> None:
+    """An omitted branch follows the cloned default, including across retries."""
+    monkeypatch.setattr(settings.security, "high_security_mode", False)
+    for prefix in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{prefix}_NAME", "Test")
+        monkeypatch.setenv(f"GIT_{prefix}_EMAIL", "test@example.invalid")
+    origin = tmp_path / "origin.git"
+    git("init", "--bare", "--initial-branch=develop", str(origin), cwd=tmp_path)
+    source = tmp_path / "source"
+    source.mkdir()
+    git("init", "--initial-branch=develop", cwd=source)
+    (source / "work.txt").write_text("base\n")
+    git("add", ".", cwd=source)
+    git("commit", "-m", "base", cwd=source)
+    original_sha = git("rev-parse", "HEAD", cwd=source)
+    git("remote", "add", "origin", str(origin), cwd=source)
+    git("push", "origin", "develop", cwd=source)
+    if main_exists:
+        git("push", "origin", "HEAD:refs/heads/main", cwd=source)
+
+    workflow_id, step_id = "default-branch", "execution-1"
+    workspace_id = hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    workspace.parent.mkdir(parents=True)
+    git("clone", str(origin), str(workspace), cwd=tmp_path)
+    assert git("branch", "--show-current", cwd=workspace) == "develop"
+    if default_source != "clone":
+        git("symbolic-ref", "--delete", "refs/remotes/origin/HEAD", cwd=workspace)
+    if default_source == "unavailable":
+        git("symbolic-ref", "HEAD", "refs/heads/missing", cwd=origin)
+    (workspace / "work.txt").write_text("agent work\n")
+    git("commit", "-am", "agent work", cwd=workspace)
+    head_sha = git("rev-parse", "HEAD", cwd=workspace)
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(workspace_id, workflow_id, step_id, "repo")
+    )
+    publisher = OmnigentWorkspacePublicationService(tmp_path)
+    args = dict(
+        workspace_locator={
+            "kind": "sandbox",
+            "workspaceId": workspace_id,
+            "relativePath": "repo",
+        },
+        current_workflow_id=workflow_id,
+        current_step_execution_id=step_id,
+        publication_identity="default-branch-replay",
+        publish_mode=publish_mode,
+        base_branch=None,
+        repository="",
+        github_token=None,
+    )
+    if default_source == "unavailable":
+        with pytest.raises(
+            HarnessPlatformError, match="default branch could not be resolved"
+        ):
+            await publisher.publish_workspace(**args)
+        assert git("rev-parse", "develop", cwd=origin) == original_sha
+        assert git("rev-parse", "HEAD", cwd=workspace) == head_sha
+        assert "moonmind-job-" not in git("branch", cwd=origin)
+        return
+    result = await publisher.publish_workspace(**args)
+    assert result["push_status"] == "pushed"
+    assert result["push_base_branch"] == "develop"
+    assert result["push_head_sha"] == head_sha
+    assert result["remote_verified"] is True
+    assert (result["push_branch"] == "develop") == (publish_mode == "branch")
+    assert (
+        git("symbolic-ref", "refs/remotes/origin/HEAD", cwd=workspace)
+        == "refs/remotes/origin/develop"
+    )
+    if main_exists:
+        assert git("rev-parse", "main", cwd=origin) == original_sha
+
+    # A change to the remote default cannot retarget publication on retry.
+    git("symbolic-ref", "HEAD", "refs/heads/main", cwd=origin)
+    retry = await publisher.publish_workspace(**args)
+    assert retry["push_base_branch"] == "develop"
+    assert retry["push_branch"] == result["push_branch"]
+    assert retry["push_head_sha"] == head_sha
+    assert retry["remote_verified"] is True


### PR DESCRIPTION
## Related issue

Workflow `mm:312b27e5-3fc0-4bfa-a800-188a2ef98050`; affected PR #4036. Preserved implementation work is in #4050.

## Summary

Omnigent generated a new job branch even when branch publication selected an existing PR branch. The shared publisher now updates the resolved input branch in `branch` mode and retains a generated head in `pr` mode. Fast-forward ancestry checks plus an exact remote-tip lease reject concurrent updates and deletion. Omitted branch inputs use the repository default recorded by clone, resolving and persisting remote symbolic HEAD when needed.

ELI5: choosing “branch” sends the work back to the branch you chose.

The CI replay fixture now expects the selected branch. A provider-failure test also retains the production watchdog budget so journal I/O cannot race an artificial 50ms timeout.

## Test Plan

545 targeted unit tests, 10 hermetic integration tests, and 136 escaped-failure replay tests passed in the installed Python test image. Regression tests failed before the fixes. Coverage includes the incident input, non-main defaults, historical request shapes, committed and uncommitted work, exact remote verification, retries, PR mode, concurrent updates, and branch deletion races.

```bash
bash tools/test_unit.sh --python-only --no-xdist tests/unit/publish tests/unit/omnigent/test_workspace_publication_base.py tests/unit/omnigent/test_execute.py tests/unit/omnigent/test_generic_platform_production_services.py tests/unit/omnigent/test_oauth_profile_lifecycle.py tests/unit/workflows/temporal/workflows/test_run_publication_head_handoff.py tests/unit/workflows/temporal/test_publish_branch_lease.py tests/unit/agents/codex_worker/test_handlers.py

docker compose --project-name moonmind-test-branch-publication -f docker-compose.test.yaml run --rm -e MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS=1 -e MOONMIND_DISABLE_DEFAULT_USER_DB_LOOKUP=1 pytest python -m pytest tests/integration/reliability_journey/test_omnigent_publication_semantics_journey.py -m integration_ci -q --tb=short

python -m pytest -q --tb=short tests/integration/reliability/test_escaped_failure_journeys.py
```

The Compose project was cleaned up after testing. The replay suite used a disposable Linux copy because the Windows worktree metadata is invalid inside Linux. Formatting, diff whitespace, removed-capability, and status-domain checks passed.

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Changes the publication destination to the documented selected branch for both generic and profile-bound Omnigent paths. Shared-branch history cannot be force-replaced or a concurrently deleted branch recreated. Temporal workflow code, activity signatures, and serialized result shapes are unchanged; historical input shapes are covered at the request-to-publication boundary. Previously recorded activity results remain unchanged. No deployment was performed.

## Coverage notes

Regression tests use real Git repositories and bare remotes; existing workflow handoff and host lifecycle suites also passed. Credentialed provider runs were not needed for this publication-only change.

## Changelog

Branch publication updates the workflow’s selected input branch instead of creating an unrelated job branch.
