### PR TITLE
I want to update the GitHub Issue Search and Implement so that the default selector will not choose an issue already marked with status in progress

### DIFF
--- a/api_service/data/presets/github-issue-search-and-implement.yaml
+++ b/api_service/data/presets/github-issue-search-and-implement.yaml
@@ -1,7 +1,8 @@
 slug: github-issue-search-and-implement
 title: GitHub Issue Search and Implement
-description: Search GitHub issues for the best match (or the first unblocked issue
-  when the search is blank), then implement it following the GitHub Issue Implement
+description: Search GitHub issues for the best available match (skipping issues already
+  marked status in-progress), or the first unblocked issue skipping in-progress
+  work when the search is blank, then implement it following the GitHub Issue Implement
   workflow, creating a pull request and updating the issue.
 scope: global
 tags:
@@ -42,9 +43,10 @@ annotations:
       issue_search:
         type: string
         title: GitHub issue search
-        description: Free-text search used as '<search> is:issue state:open'. Leave
-          blank to fall back to scanning open issues for the first one without blocking
-          dependencies.
+        description: Free-text search used as '<search> is:issue state:open' (skipping
+          issues already marked status in-progress). Leave blank to fall back to scanning
+          open issues for the first one without blocking dependencies and without an
+          in-progress status.
       repository:
         type: string
         title: Repository
@@ -92,8 +94,9 @@ steps:
 - title: Resolve GitHub issue and load trusted brief
   type: tool
   instructions: >-
-    Resolve the best open issue matching issueSearch, or the first unblocked open
-    issue when blank, within 500 candidates. Load its trusted issue brief and
+    Resolve the best available open issue matching issueSearch (skipping issues already
+    marked status in-progress), or the first unblocked open issue skipping in-progress
+    work when blank, within 500 candidates. Load its trusted issue brief and
     preserve the resolved identity and search evidence for downstream steps.
   tool:
     id: github.load_issue_preset_brief

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -257,8 +257,10 @@ Only widgets are allowed to have custom UI components. Presets consume widgets d
 The `github-issue-search-and-implement` preset resolves its optional repository
 input from the workflow repository during expansion. Its first typed
 `github.load_issue_preset_brief` operation accepts `issueSearch`: a nonempty
-query selects GitHub's best open issue match; an empty query scans open issues
-in descending creation order for the first candidate without blocker evidence.
+query selects GitHub's best available open issue match, skipping issues already
+marked status in-progress; an empty query scans open issues
+in descending creation order for the first candidate without blocker evidence
+and without an in-progress status.
 The scan is bounded to five pages of 100 candidates, excludes pull requests,
 and records pages and candidates examined. Missing, malformed, incomplete, or
 exhausted evidence stops the run before implementation or issue mutation.
@@ -271,7 +273,9 @@ at most 100 declared prerequisites per candidate. The candidate scan shares a
 100-request prerequisite lookup budget and reuses validated state for repeated
 repository-and-issue identities. Exhausting that budget stops selection with an
 actionable request to select an explicit issue or narrow the search. Confirming
-the selected issue uses fresh prerequisite reads with its own 100-request budget;
+the selected issue uses fresh prerequisite reads with its own 100-request budget
+and re-fetches current issue detail to reject an in-progress status added
+between search and brief loading;
 the later pre-implementation blocker check also fetches current state. An open
 prerequisite blocks admission; closed prerequisites do not. Only the leading
 reference list after a declaration contributes dependencies; subsequent prose,

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -152,6 +152,39 @@ def is_complete_open_issue(payload: Any, repository: str) -> bool:
     )
 
 
+_IN_PROGRESS_LABELS = frozenset(
+    {
+        "status: in-progress",
+        "status:in-progress",
+        "status/in-progress",
+        "status_in-progress",
+        "status in-progress",
+        "status: in progress",
+        "status: inprogress",
+        "in-progress",
+        "in_progress",
+        "in progress",
+    }
+)
+
+
+def has_in_progress_status(issue: Mapping[str, Any]) -> bool:
+    """Return True when the issue already carries an in-progress status label."""
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if isinstance(label, Mapping):
+            name = label.get("name")
+        else:
+            name = label
+        if not isinstance(name, str):
+            continue
+        if name.strip().lower() in _IN_PROGRESS_LABELS:
+            return True
+    return False
+
+
 async def resolve_issue(
     *,
     repository: str,
@@ -159,7 +192,11 @@ async def resolve_issue(
     github_service: GitHubService,
     blockers_from_issue: Callable[[Mapping[str, Any]], Awaitable[list[dict[str, Any]]]],
 ) -> tuple[int | None, dict[str, Any]]:
-    """Select the best search match, or first unblocked open issue, within 500 rows."""
+    """Select the best search match, or first unblocked open issue, within 500 rows.
+
+    The default selector skips issues already marked with an in-progress status
+    label so concurrent work is not selected twice.
+    """
 
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
         raise ValueError(
@@ -241,6 +278,8 @@ async def resolve_issue(
                 normalized = dict(candidate)
                 labels = candidate["labels"]
                 normalized["labels"] = [label["name"] for label in labels]
+                if has_in_progress_status(normalized):
+                    continue
                 if not query and await blockers_from_issue(normalized):
                     continue
                 return candidate["number"], evidence

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -30,6 +30,7 @@ from moonmind.workflows.skills.tool_plan_contracts import ToolResult
 from moonmind.workflows.temporal.github_issue_search import (
     PrerequisiteLookup,
     check_prerequisites,
+    has_in_progress_status,
     is_complete_open_issue,
     resolve_issue,
 )
@@ -4527,6 +4528,7 @@ async def load_github_issue_preset_brief(
         not is_complete_open_issue(issue_data, repository)
         or issue_data["number"] != issue_number
         or (not _string(inputs.get("issueSearch")) and selected_blockers)
+        or has_in_progress_status(issue_data)
     ):
         return ToolResult(
             status="FAILED",

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -572,6 +572,32 @@ async def test_incomplete_selected_details_cannot_produce_a_trusted_brief(
     assert not any(request.method != "GET" for request in activity_boundary.requests)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["", "dashboard"])
+async def test_search_skips_in_progress_issues_and_revalidates_fresh_detail(
+    activity_boundary, query
+):
+    activity_boundary.pages[:] = [
+        [issue(4026, labels=[{"name": "status: in-progress"}]), issue()]
+    ]
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY, "issueSearch": query},
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["issue"]["number"] == 4025
+    assert result.outputs["searchEvidence"]["candidatesExamined"] == 2
+    # A label added between search and brief loading must fail confirmation.
+    activity_boundary.detail.update({"labels": [{"name": "status: in-progress"}]})
+    result = await activity_boundary.execute(
+        "github.load_issue_preset_brief",
+        {"repository": REPOSITORY, "issueSearch": query},
+    )
+    assert result.status == "FAILED"
+    assert "could not be confirmed" in result.outputs["error"]
+    assert "trustedSource" not in result.outputs
+
+
 def test_compact_issue_context_preserves_search_evidence():
     import json
 


### PR DESCRIPTION
I want to update the GitHub Issue Search and Implement so that the default selector will not choose an issue already marked with status in progress