### PR TITLE
Fix missing skill snapshots in scheduled Omnigent workflows

### DIFF
--- a/api_service/services/omnigent_execution_plan_service.py
+++ b/api_service/services/omnigent_execution_plan_service.py
@@ -378,11 +378,24 @@ class PersistedOmnigentExecutionPlan:
     runtime_provider_rollout: dict[str, Any] | None = None
 
 
+def _workflow_payload(initial_parameters: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Read workflow intent, including the persisted schedule task envelope.
+
+    Match execution's precedence without rewriting immutable authored inputs.
+    Existing schedule definitions retain their task envelope across refreshes.
+    """
+
+    workflow = initial_parameters.get("workflow")
+    if isinstance(workflow, Mapping) and workflow:
+        return workflow
+    task = initial_parameters.get("task")
+    return task if isinstance(task, Mapping) else {}
+
+
 def selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
     """Collect the workflow's MoonMind Skill intent for one run snapshot."""
 
-    workflow = initial_parameters.get("workflow")
-    workflow_mapping = dict(workflow) if isinstance(workflow, Mapping) else {}
+    workflow_mapping = _workflow_payload(initial_parameters)
     names: list[str] = []
 
     def add(raw: Any) -> None:
@@ -432,8 +445,7 @@ def selected_skill_names(initial_parameters: Mapping[str, Any]) -> list[str]:
 
 
 def _skill_selector(initial_parameters: Mapping[str, Any]) -> SkillSelector:
-    workflow = initial_parameters.get("workflow")
-    workflow_mapping = dict(workflow) if isinstance(workflow, Mapping) else {}
+    workflow_mapping = _workflow_payload(initial_parameters)
     selectors = workflow_mapping.get("skills")
     selector_mapping = dict(selectors) if isinstance(selectors, Mapping) else {}
     excluded = sorted(
@@ -1054,10 +1066,7 @@ async def compile_and_persist_execution_plan(
     repository_intent_ref = _digest_ref(
         "repository-intent", {"repository": repository, "workspace": workspace}
     )
-    workflow_payload = initial_parameters.get("workflow")
-    workflow_mapping = (
-        dict(workflow_payload) if isinstance(workflow_payload, Mapping) else {}
-    )
+    workflow_mapping = _workflow_payload(initial_parameters)
     authority = {
         "authoredRequestRef": authored_request_ref,
         "authoredRequestDigest": authored_request_digest,
@@ -1154,8 +1163,7 @@ async def compile_and_persist_execution_plan(
     )
     # A client may name an exact rollout row, but only the compiled Profile,
     # policy and harness can establish it. Validate before persisting the plan.
-    workflow = initial_parameters.get("workflow") or {}
-    runtime = workflow.get("runtime") or {}
+    runtime = workflow_mapping.get("runtime") or {}
     requested_target_id = runtime.get("targetId")
     if requested_target_id and (
         plan.payload.runtimeProviderRollout is None

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -547,6 +547,8 @@ The `skills` list in an Agent Profile identifies desired Skill names and constra
 
 Before plan commitment, MoonMind resolves Skill intent through the canonical Skill System into one immutable per-run snapshot.
 
+Admission and scheduled authority refresh read the same workflow intent as execution: a non-empty `workflow` envelope takes precedence over the persisted `task` envelope. The snapshot includes selected step Skills and the Skills declared by dynamic remediation contracts before any step launches. The same envelope governs Skill exclusions, remediation policy, and explicit runtime target validation. Persisted schedule inputs remain immutable; historical execution plans retain their admitted snapshots and dispatch never silently expands them.
+
 ### 10.2 Plan references
 
 The execution plan carries compact references only:

--- a/tests/integration/reliability/replays/scheduled-skill-snapshot-authority/expected-outcome.json
+++ b/tests/integration/reliability/replays/scheduled-skill-snapshot-authority/expected-outcome.json
@@ -1,0 +1,6 @@
+{
+  "selectedSkills": [
+    "moonspec-verify",
+    "remediate-issue"
+  ]
+}

--- a/tests/integration/reliability/replays/scheduled-skill-snapshot-authority/manifest.json
+++ b/tests/integration/reliability/replays/scheduled-skill-snapshot-authority/manifest.json
@@ -1,0 +1,95 @@
+{
+  "incidentWorkflowId": "mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T07:56:37Z",
+  "failure": "selected skill moonspec-verify was not resolved into the agent skill snapshot",
+  "initialParameters": {
+    "task": {
+      "skill": {
+        "id": "auto"
+      },
+      "steps": [
+        {
+          "id": "tpl:github-issue-search-and-implement:01:094d273f",
+          "type": "tool",
+          "tool": {
+            "id": "github.load_issue_preset_brief"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:02:094d273f",
+          "type": "skill",
+          "skill": {
+            "id": "auto"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:03:094d273f",
+          "type": "tool",
+          "tool": {
+            "id": "github.check_issue_blockers"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:04:094d273f",
+          "type": "tool",
+          "tool": {
+            "id": "github.update_issue_status"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:05:094d273f",
+          "type": "skill",
+          "skill": {
+            "id": "auto"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:06:094d273f",
+          "type": "skill",
+          "skill": {
+            "id": "moonspec-verify"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:07:094d273f",
+          "type": "skill",
+          "skill": {
+            "id": "auto"
+          },
+          "annotations": {
+            "remediationLoop": {
+              "kind": "remediation_loop",
+              "remediationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "remediate-issue"
+                }
+              },
+              "verificationTool": {
+                "type": "agent_runtime",
+                "name": "auto",
+                "inputs": {
+                  "selectedSkill": "moonspec-verify"
+                }
+              }
+            }
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:08:094d273f",
+          "type": "skill",
+          "skill": {
+            "id": "auto"
+          }
+        },
+        {
+          "id": "tpl:github-issue-search-and-implement:09:094d273f",
+          "type": "tool",
+          "tool": {
+            "id": "github.update_issue_status"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/integration/reliability/test_omnigent_plan_admission_replays.py
+++ b/tests/integration/reliability/test_omnigent_plan_admission_replays.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -11,6 +12,7 @@ from api_service.services.omnigent_agent_profile_selection import (
 from moonmind.workflows.executions.execution_contract import (
     build_canonical_workflow_view,
 )
+from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from tests.integration.reliability.helpers import load_replay
 from tests.unit.services.test_omnigent_execution_plan_service import (
     _ArtifactService,
@@ -30,6 +32,123 @@ pytestmark = [
 ]
 
 _SERVER_IMAGE_REF = "ghcr.io/omnigent-ai/omnigent-server@sha256:" + "6" * 64
+
+
+@pytest.mark.parametrize("payload_key", ["task", "workflow"])
+async def test_scheduled_skill_snapshot_reaches_agent_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    payload_key: str,
+) -> None:
+    """Replay admission of the persisted schedule envelope through dispatch."""
+
+    replay_id = "scheduled-skill-snapshot-authority"
+    manifest = load_replay(replay_id, "manifest.json")
+    expected = load_replay(replay_id, "expected-outcome.json")
+    artifacts = _ArtifactService()
+    workflow_intent = {
+        **manifest["initialParameters"]["task"],
+        "remediation": {"maxAttempts": 3},
+    }
+    monkeypatch.setattr(
+        service,
+        "resolve_execution_evidence",
+        lambda plan_payload, **_kwargs: (
+            _protected_support_evidence(plan_payload),
+            "supported",
+        ),
+    )
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=artifacts,
+        launch_policy_ref="omnigent-on-demand@1",
+        plan_store=_PlanStore(object()),
+        extra_parameters={
+            "workflow": None,
+            payload_key: workflow_intent,
+        },
+    )
+    snapshot = json.loads(artifacts.payloads[result.resolved_skillset_ref])
+    assert [entry["skill_name"] for entry in snapshot["skills"]] == expected[
+        "selectedSkills"
+    ]
+    assert (
+        result.envelope.payload.authority.remediationPolicyRef
+        == service._digest_ref("remediation-policy", workflow_intent["remediation"])
+    )
+
+    async def read_snapshot(name, request, **_kwargs):
+        assert name == "artifact.read"
+        assert request.artifact_ref == result.resolved_skillset_ref
+        return snapshot
+
+    async def unexpected_resolution(*_args, **_kwargs):
+        pytest.fail("dispatch must retain the immutable admitted snapshot")
+
+    monkeypatch.setattr(run_workflow_module, "execute_typed_activity", read_snapshot)
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "execute_activity", unexpected_resolution
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _id: True)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            workflow_id=manifest["incidentWorkflowId"],
+            run_id="replay-run",
+            namespace="default",
+            search_attributes={},
+        ),
+    )
+    parent = run_workflow_module.MoonMindRunWorkflow()
+    parent._owner_id = "user-1"
+    parameters = {"resolvedSkillsetRef": result.resolved_skillset_ref}
+    for skill in expected["selectedSkills"]:
+        inputs = {"selectedSkill": skill, "targetRuntime": "omnigent"}
+        ref = await parent._resolve_agent_node_skillset_ref(
+            task_skills=None,
+            node_inputs=inputs,
+            node_id=skill,
+            existing_skillset_ref=parent._existing_agent_skillset_ref(
+                parameters=parameters,
+                node={},
+                node_inputs=inputs,
+            ),
+        )
+        request = parent._build_agent_execution_request(
+            node_inputs=inputs,
+            node_id=skill,
+            tool_name="omnigent",
+            resolved_skillset_ref=ref,
+            workflow_parameters=parameters,
+        )
+        assert request.resolved_skillset_ref == result.resolved_skillset_ref
+        assert skill in parent._resolved_skill_required_capabilities_by_step
+
+
+@pytest.mark.parametrize("payload_key", ["task", "workflow"])
+async def test_schedule_envelope_cannot_bypass_runtime_target_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    payload_key: str,
+) -> None:
+    monkeypatch.setattr(
+        service,
+        "resolve_execution_evidence",
+        lambda plan_payload, **_kwargs: (
+            _protected_support_evidence(plan_payload),
+            "supported",
+        ),
+    )
+    with pytest.raises(ValueError, match="Requested runtime target does not match"):
+        await _compile_opencode_plan(
+            monkeypatch,
+            artifacts=_ArtifactService(),
+            launch_policy_ref="omnigent-on-demand@1",
+            plan_store=_PlanStore(object()),
+            extra_parameters={
+                "workflow": None,
+                payload_key: {"runtime": {"targetId": "unselected-runtime-target"}},
+            },
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -135,10 +135,13 @@ async def test_plan_compilation_gates_unseeded_policy_authority(monkeypatch) -> 
     assert "startup reconciliation" in str(exc_info.value)
 
 
-def test_skill_selector_includes_nested_dynamic_execution_skills() -> None:
+@pytest.mark.parametrize("payload_key", ["workflow", "task"])
+def test_skill_selector_includes_nested_dynamic_execution_skills(
+    payload_key: str,
+) -> None:
     selector = service._skill_selector(
         {
-            "workflow": {
+            payload_key: {
                 "steps": [
                     {
                         "skill": {
@@ -179,7 +182,10 @@ def test_skill_selector_includes_nested_dynamic_execution_skills() -> None:
 
 
 @pytest.mark.asyncio
-async def test_admission_persists_nested_dynamic_execution_skills() -> None:
+@pytest.mark.parametrize("payload_key", ["workflow", "task"])
+async def test_admission_persists_nested_dynamic_execution_skills(
+    payload_key: str,
+) -> None:
     artifacts = _ArtifactService()
 
     resolved, manifest_ref, _manifest_digest, content_refs = (
@@ -190,7 +196,7 @@ async def test_admission_persists_nested_dynamic_execution_skills() -> None:
             workflow_id="mm:remediation-skill-snapshot",
             task_input_snapshot_digest="sha256:" + "1" * 64,
             initial_parameters={
-                "workflow": {
+                payload_key: {
                     "steps": [
                         {
                             "skill": {
@@ -235,6 +241,32 @@ async def test_admission_persists_nested_dynamic_execution_skills() -> None:
         "remediate-issue",
     ]
     assert len(content_refs) == 2
+
+
+@pytest.mark.parametrize("workflow", [None, {}, {"skill": {"id": "moonspec-verify"}}])
+def test_skill_admission_preserves_execution_envelope_precedence(workflow) -> None:
+    parameters = {
+        "workflow": workflow,
+        "task": {"skill": {"id": "remediate-issue"}},
+    }
+    before = json.dumps(parameters, sort_keys=True)
+    assert service.selected_skill_names(parameters) == [
+        "moonspec-verify" if workflow else "remediate-issue"
+    ]
+    assert json.dumps(parameters, sort_keys=True) == before
+
+
+@pytest.mark.parametrize("payload_key", ["workflow", "task"])
+def test_skill_admission_rejects_excluded_selected_skill(payload_key: str) -> None:
+    with pytest.raises(ValueError, match="selected Skills cannot also be excluded"):
+        service._skill_selector(
+            {
+                payload_key: {
+                    "skills": {"exclude": ["moonspec-verify"]},
+                    "steps": [{"skill": {"id": "moonspec-verify"}}],
+                }
+            }
+        )
 
 
 def _snapshot(*, harness: str, policy: str, provider_id: str) -> dict:


### PR DESCRIPTION
Scheduled Omnigent executions could admit an empty Skill snapshot and fail at verification after implementation had already pushed a commit. Workflow `mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T07:56:37Z` reproduced this: its persisted `task` envelope selected `moonspec-verify` and dynamic `remediate-issue`, but admission inspected only `workflow`.

Use execution's envelope precedence consistently during plan admission and scheduled authority refresh. Selected Skills, exclusions, remediation policy, and explicit runtime targets now read the same intent. Historical plans keep their immutable snapshots; this fixes newly admitted/refreshed plans without changing Temporal payloads or silently expanding an in-flight snapshot.

Validation: 214 targeted unit tests and 9 subtests passed, covering plan admission, schedule refresh, and agent dispatch. Eight hermetic admission replay tests passed, including the minimized incident fixture through real Skill resolution, content persistence, plan admission, and agent request construction. The persisted `task` regression failed before the fix and passes afterward. The isolated Compose integration suite passed all 715 tests.
