### PR TITLE
Prevent one-shot Claude runs from abandoning background work

### DIFF
--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -218,6 +218,12 @@ reject or hide any tool whose successful contract requires a later callback when
 the runtime has no durable same-session continuation owner. A tool's availability
 is not evidence that the selected execution lane can deliver its result.
 
+The direct Claude Code print-mode launcher disables background Bash and subagent
+tasks with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` after profile materialization,
+in addition to denying deferred wakeup tools. This launch-mode restriction cannot
+be relaxed by profile environment overrides. Long waits stay in the foreground
+or return a validated continuation to a durable owner before the process exits.
+
 A provider response ending in matched tool output while its session remains
 active is not terminal evidence. The execution driver requests same-session
 continuation only when its caller explicitly owns that recovery. Other hosts

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -126,6 +126,20 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
     def effort_application_status(self, effort: str | None) -> str:
         return "applied" if effort else "metadata_only"
 
+    def shape_environment(
+        self,
+        base_env: dict[str, str],
+        profile: Any,
+    ) -> dict[str, str]:
+        env = super().shape_environment(base_env, profile)
+        # Every launch from this strategy uses -p. Background Bash/subagent
+        # callbacks have no owner after that process exits, just like the
+        # deferred wakeup tools denied in build_command. Enforce the provider's
+        # foreground-only mode after profile materialization, including when
+        # a profile attempts to re-enable background tasks.
+        env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1"
+        return env
+
     def classify_exit(
         self,
         exit_code: int | None,

--- a/tests/fixtures/runtime/claude_background_exit.json
+++ b/tests/fixtures/runtime/claude_background_exit.json
@@ -1,0 +1,8 @@
+{
+  "workflowId": "mm:1ca0601f-68de-44fc-bfdd-c3ab724c3eb3",
+  "tool": "Bash",
+  "input": {"run_in_background": true},
+  "resolverReason": "ci_signal_degraded",
+  "exitCode": 0,
+  "terminalStatus": "blocked"
+}

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -3628,6 +3629,58 @@ async def test_launch_pretrusts_claude_code_without_privilege_drop(
     assert captured_launches[-1][0][0] == "claude"
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("background_setting", [None, "0", "1"])
+async def test_claude_one_shot_launch_disables_background_callbacks(
+    tmp_path, monkeypatch, background_setting
+):
+    """Replay the pending-CI exit through materialization and a real subprocess."""
+    incident = json.loads(
+        (Path(__file__).parents[4] / "fixtures/runtime/claude_background_exit.json")
+        .read_text()
+    )
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(
+        ManagedRuntimeLauncher, "_build_managed_runtime_base_env",
+        staticmethod(lambda: {"PATH": os.defpath, "HOME": str(tmp_path)}),
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
+        AsyncMock(return_value=None),
+    )
+    probe = tmp_path / "claude_probe.py"
+    probe.write_text(
+        "import json, os, sys\n"
+        "background_available = os.environ.get('CLAUDE_CODE_DISABLE_BACKGROUND_TASKS') != '1'\n"
+        "print(json.dumps({'backgroundAvailable': background_available, 'args': sys.argv[1:]}))\n"
+    )
+    overrides = (
+        {} if background_setting is None else
+        {"CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": background_setting}
+    )
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=[sys.executable, str(probe)],
+        env_overrides=overrides,
+        passthrough_env_keys=[],
+    )
+    launcher = ManagedRuntimeLauncher(ManagedRunStore(tmp_path / "managed_runs"))
+    workspace = tmp_path / "workspace" / "repo"
+    workspace.mkdir(parents=True)
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="background-exit-replay",
+        request=_make_request(),
+        profile=profile,
+        workspace_path=str(workspace),
+    )
+    stdout, stderr = await process.communicate()
+    assert process.returncode == incident["exitCode"], stderr.decode()
+    observed = json.loads(stdout)
+    assert incident["input"]["run_in_background"] is True
+    assert observed["backgroundAvailable"] is False
+    assert "-p" in observed["args"]
+    assert "ScheduleWakeup" in observed["args"]
+
+@pytest.mark.asyncio
 async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypatch):
     """When launched as root for claude_code runtime, the process should:
     1. chown the full run workspace root to app:app so the app user can write
@@ -3759,6 +3812,7 @@ async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypat
     env_kwargs = runuser_kwargs.get("env")
     assert isinstance(env_kwargs, dict)
     assert env_kwargs["MY_CUSTOM_VAR"] == "test-value"
+    assert env_kwargs["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
     assert env_kwargs["HOME"] == "/home/app"
     assert env_kwargs["USER"] == "app"
     assert env_kwargs["LOGNAME"] == "app"


### PR DESCRIPTION
Workflow `mm:1ca0601f-68de-44fc-bfdd-c3ab724c3eb3` failed after its Claude Code resolver launched background Bash CI watchers and exited with code 0 while the PR gate remained blocked. The one-shot process had no durable owner to deliver those callbacks, so its promise to resume could not complete the work.

Enforce `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in the direct Claude strategy after profile materialization. This closes background Bash/subagent execution for every print-mode launch, including profiles that attempt to enable it. Existing deferred-wakeup denial and terminal/merge validation remain in force. No workflow payload or history shape changes.

Validation:

- 178 targeted launcher and strategy tests passed; the new real-subprocess launch probe failed before the fix for omitted and disabled settings, then passed for all three settings.
- Root-to-app launch environment regression passed.
- 194 checkpoint/resume reliability journey tests passed.
- Hermetic integration: 708 passed initially; seven Omnigent recovery cases failed because the new worktree lacked the pinned submodule. All seven passed after initialization.
- GitHub CI on head `237d3d53a83b2a61f9ddbcabcc1cd463e660ffb8`: all required checks passed, including full backend, Temporal boundary, integration, reliability, and browser checks. The additional local Temporal run stalled and was stopped after the equivalent CI suite passed.

Provider contract: [Claude Code background-task environment switch](https://code.claude.com/docs/en/env-vars).
