### PR TITLE
feat(governance): emit evidence-backed per-run governance reports (#3969)

### DIFF
--- a/docs/Governance/RunGovernanceReports.md
+++ b/docs/Governance/RunGovernanceReports.md
@@ -1,0 +1,99 @@
+# Per-Run Governance Reports
+
+**Document Class:** Canonical declarative
+**Viewpoint:** Cross-Cutting Concept
+**Owners:** MoonMind Engineering
+**Last Updated:** 2026-09-07
+
+> [!NOTE]
+> This document defines the desired-state per-run governance report contract
+> (MoonMind#3969, child of #3930). It is a declarative contract for what one
+> inspectable report per run contains, where each field comes from, and what
+> the report explicitly does not claim. Rollout and backlog notes live under
+> `docs/tmp/` or in gitignored local-only handoffs, not as migration
+> checklists in this file.
+
+## 1. Summary
+
+Each run produces one inspectable governance report built from existing
+authoritative evidence. The report is not a second audit or event system, not
+a compliance certification, and not guaranteed complete visibility into
+arbitrary runtime activity.
+
+The report is a versioned JSON document (`contract_version = 1`,
+`report_kind = "run_governance_report"` in
+`moonmind/governance/run_reports.py`). The human-readable Markdown rendering
+is generated from the same JSON; there are never two independent reports.
+
+## 2. Contract
+
+Identity: logical workflow id, run id, attempt, creation time, evidence
+cutoff, deterministic input digest, and idempotent report id
+(`govrep_<sha256>` over identity plus input digest). Retrying the same input
+digest reuses the stored result. Late or corrected evidence writes a new
+immutable version with an explicit `supersedes` relation; the original is
+never overwritten. Logical-run and attempt relationships survive continuation
+and recovery.
+
+References: policy, profile, and image refs with digests where the owning
+system provides them. Source artifact digests pin every evidence input.
+
+Sections (all bounded, all behind allowlisted fields): credential
+leases/generations with run-owned vs profile-owned ownership, observed egress
+decisions, container jobs, approvals/reviews, outbound scans, workspace
+changes, publications, cleanup disposition, and optional spend/usage.
+
+## 3. Provenance states
+
+Every section carries its owner and evidence source with one of
+`observed`, `unavailable`, `unsupported`, `not_applicable`, or `pending`.
+Missing data is never rendered as zero actions, no secrets, approval granted,
+or successful cleanup. Cleanup defaults to `unknown`/`pending`, scans default
+to `unavailable` (never `pass`), and reviews default to `unavailable` (never
+`approved`). Model-generated explanation may be attached as an optional
+annotation and is never authoritative audit evidence.
+
+## 4. Redaction and bounds
+
+Raw credentials, credential-home contents, prompts, transcripts, sensitive
+URLs, and unbounded command/file content are excluded by field allowlisting,
+not by regex redaction after the fact. Only authorized references (artifact
+refs, lease refs, redacted locations) are serialized. Section cardinality is
+bounded (credentials 32, other sections 50, digests 64). Detailed evidence
+stays behind protected artifacts with retention and access rules; the report
+carries refs and digests only.
+
+## 5. Terminal coverage
+
+Reports are finalized for `succeeded`, `failed`, `cancelled`, and `timed_out`
+executions where evidence exists. A crash before normal finalization is
+covered by a bounded reconciler (`reconcile_missing_reports`) that emits
+retryable work items for existing worker/schedule infrastructure; it starts
+no new always-on service. Reporting failure is auxiliary: it returns a
+visible recoverable status, preserves the canonical task/publication outcome,
+never prevents cancellation, and never suppresses credential/host release.
+
+## 6. Presentation
+
+Workflow Detail links the report under the evidence surface with status
+`ready`, `partial`, `pending`, or `failed`, a safe explanation, and an
+authorized artifact-backed download (never a raw URL). Historical reports stay
+interpretable after host removal or profile rotation: they reference evidence
+as observed at the cutoff, expose no current credentials, and never claim
+unresolved cleanup succeeded.
+
+## 7. Verified observation boundary and blind spots
+
+Observed: MoonMind-mediated egress decisions, bounded native outbound-scan
+evidence as defined by `docs/Security/SecretsSystem.md`, run-owned vs
+profile-owned credential state from the shared-host materializers, container
+job lifecycle, approvals/reviews recorded by the platform, workspace changes
+and publications with artifact refs, and cleanup disposition as observed at
+the evidence cutoff.
+
+Not observed (explicit blind spots): arbitrary agent network/shell actions
+outside mediated boundaries; binary attachments, terminal input, and browser
+automation outside the text-scan contract; provider-internal activity not
+exposed through provider-reported measurements. Spend/usage fields, when
+present, distinguish `provider_reported` measurements from `estimate` values
+and `unavailable` account-wide data.

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -93,6 +93,11 @@ import {
   workflowDetailSubrouteFromPath,
   workflowDetailSubrouteHref,
 } from '../lib/workflowDetailRoutes';
+import {
+  governanceReportExplanation,
+  governanceReportHref,
+  normalizeGovernanceReportStatus,
+} from '../lib/governanceReport';
 import { WorkflowNativeChatRoute } from '../features/workflow-native-chat';
 
 export {
@@ -2857,6 +2862,37 @@ function BridgeTerminalEvidence({ apiBase, envelope }: { apiBase: string; envelo
     ].filter(Boolean).join(' — ')}</p> : null}
     {envelope.failureClass || envelope.failureCode ? <p className="small">Failure: {[envelope.failureClass, envelope.failureCode].filter(Boolean).join(' — ')}</p> : null}
   </section>;
+}
+
+// Per-run governance report (MoonMind#3969): presentation only. The report
+// JSON, status, and explanations are owned by
+// moonmind/governance/run_reports.py; this block maps the server-provided
+// finish-summary block to a safe evidence-surface link.
+function GovernanceReportBlock({ workflowId, report }: { workflowId: string; report: unknown }) {
+  if (!report || typeof report !== 'object') return null;
+  const block = report as {
+    report_id?: unknown;
+    status?: unknown;
+    link?: { href?: unknown; explanation?: unknown } | null;
+  };
+  const reportId = typeof block.report_id === 'string' && block.report_id.trim() ? block.report_id : null;
+  if (!reportId && !block.link) return null;
+  const status = normalizeGovernanceReportStatus(block.status);
+  const serverHref = block.link && typeof block.link.href === 'string' ? block.link.href : null;
+  const href = serverHref || governanceReportHref(workflowId, reportId);
+  const serverExplanation =
+    block.link && typeof block.link.explanation === 'string' ? block.link.explanation : undefined;
+  return (
+    <div className="td-summary-block" aria-label="Governance report">
+      <h4>Governance report</h4>
+      <p className="small">{governanceReportExplanation(status, serverExplanation)}</p>
+      <div className="button-group">
+        <a className="button secondary small" href={href} aria-label="Open governance report evidence">
+          {status === 'ready' ? 'Open report' : `Report: ${status}`}
+        </a>
+      </div>
+    </div>
+  );
 }
 
 async function fetchBridgeSessionResources(apiBase: string, bridgeSessionId: string): Promise<BridgeResourceProjection> {
@@ -10289,6 +10325,10 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
               </p>
             ) : null}
           </div>
+          <GovernanceReportBlock
+            workflowId={workflowId}
+            report={(runSummary as { governanceReport?: unknown } | null)?.governanceReport}
+          />
 
           <MetricStrip
             items={[

--- a/frontend/src/lib/governanceReport.test.ts
+++ b/frontend/src/lib/governanceReport.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  governanceReportExplanation,
+  governanceReportHref,
+  isGovernanceReportStatus,
+  normalizeGovernanceReportStatus,
+} from './governanceReport';
+
+describe('governance report link helpers', () => {
+  it('builds evidence hrefs with and without a report id', () => {
+    expect(governanceReportHref('mm:123', 'govrep_abc')).toBe('/workflows/mm%3A123/evidence?report=govrep_abc');
+    expect(governanceReportHref('mm:123')).toBe('/workflows/mm%3A123/evidence');
+    expect(governanceReportHref('mm:123', '  ')).toBe('/workflows/mm%3A123/evidence');
+  });
+
+  it('accepts only the four server-owned statuses', () => {
+    expect(isGovernanceReportStatus('ready')).toBe(true);
+    expect(isGovernanceReportStatus('partial')).toBe(true);
+    expect(isGovernanceReportStatus('pending')).toBe(true);
+    expect(isGovernanceReportStatus('failed')).toBe(true);
+    expect(isGovernanceReportStatus('pass')).toBe(false);
+    expect(isGovernanceReportStatus('approved')).toBe(false);
+    expect(isGovernanceReportStatus(undefined)).toBe(false);
+  });
+
+  it('never upgrades unknown statuses and prefers server copy', () => {
+    expect(normalizeGovernanceReportStatus('bogus')).toBe('pending');
+    expect(governanceReportExplanation('bogus')).toContain('pending');
+    expect(governanceReportExplanation('ready', 'server copy')).toBe('server copy');
+    expect(governanceReportExplanation('failed')).toContain('auxiliary');
+  });
+});

--- a/frontend/src/lib/governanceReport.ts
+++ b/frontend/src/lib/governanceReport.ts
@@ -1,0 +1,41 @@
+// Workflow Detail governance-report link helpers (MoonMind#3969).
+// Presentation only: the authoritative report JSON, status, and explanations
+// are owned by moonmind/governance/run_reports.py. These helpers map that
+// server-provided status to hrefs and safe fallback copy without inventing
+// new report semantics.
+
+export const GOVERNANCE_REPORT_STATUSES = ['ready', 'partial', 'pending', 'failed'] as const;
+
+export type GovernanceReportStatus = (typeof GOVERNANCE_REPORT_STATUSES)[number];
+
+const GOVERNANCE_STATUS_FALLBACK_COPY: Record<GovernanceReportStatus, string> = {
+  ready: 'Governance report is ready from verified authoritative evidence.',
+  partial: 'Governance report is partial: some evidence was unavailable and is shown as such.',
+  pending: 'Governance report is pending: evidence collection has not completed.',
+  failed:
+    'Report generation failed as an auxiliary step; task and publication state are unchanged.',
+};
+
+export function isGovernanceReportStatus(value: unknown): value is GovernanceReportStatus {
+  return (
+    typeof value === 'string' &&
+    (GOVERNANCE_REPORT_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function normalizeGovernanceReportStatus(value: unknown): GovernanceReportStatus {
+  return isGovernanceReportStatus(value) ? value : 'pending';
+}
+
+export function governanceReportHref(workflowId: string, reportId?: string | null): string {
+  const safeId = encodeURIComponent(workflowId);
+  const report = typeof reportId === 'string' && reportId.trim() ? `?report=${encodeURIComponent(reportId.trim())}` : '';
+  return `/workflows/${safeId}/evidence${report}`;
+}
+
+export function governanceReportExplanation(status: unknown, serverExplanation?: unknown): string {
+  if (typeof serverExplanation === 'string' && serverExplanation.trim()) {
+    return serverExplanation;
+  }
+  return GOVERNANCE_STATUS_FALLBACK_COPY[normalizeGovernanceReportStatus(status)];
+}

--- a/moonmind/governance/__init__.py
+++ b/moonmind/governance/__init__.py
@@ -2,7 +2,18 @@
 
 from moonmind.governance.run_reports import (
     GOVERNANCE_REPORT_CONTRACT_VERSION,
+    GovernanceReportStore,
     build_governance_report,
+    build_workflow_detail_governance_link,
+    finalize_governance_report,
+    reconcile_missing_reports,
 )
 
-__all__ = ["GOVERNANCE_REPORT_CONTRACT_VERSION", "build_governance_report"]
+__all__ = [
+    "GOVERNANCE_REPORT_CONTRACT_VERSION",
+    "GovernanceReportStore",
+    "build_governance_report",
+    "build_workflow_detail_governance_link",
+    "finalize_governance_report",
+    "reconcile_missing_reports",
+]

--- a/moonmind/governance/__init__.py
+++ b/moonmind/governance/__init__.py
@@ -1,0 +1,8 @@
+"""Per-run evidence-backed governance reports."""
+
+from moonmind.governance.run_reports import (
+    GOVERNANCE_REPORT_CONTRACT_VERSION,
+    build_governance_report,
+)
+
+__all__ = ["GOVERNANCE_REPORT_CONTRACT_VERSION", "build_governance_report"]

--- a/moonmind/governance/execution_integration.py
+++ b/moonmind/governance/execution_integration.py
@@ -1,0 +1,235 @@
+"""Production wiring for per-run governance reports (MoonMind#3969).
+
+This module is the single production entrypoint that invokes the portable
+governance helpers from :mod:`moonmind.governance.run_reports` at the actual
+terminal authority handoff. It maps the existing Temporal execution lifecycle
+states to the governance terminal vocabulary, builds explicit
+pending/unavailable evidence (never claiming unobserved success), finalizes
+the report as an auxiliary step that preserves the canonical terminal
+outcome, and builds the Workflow Detail presentation link from the same
+result.
+
+Reporting failure is auxiliary: this module never raises for reporting
+problems and never changes the canonical task/publication outcome.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from moonmind.governance.run_reports import (
+    GovernanceReportStore,
+    ReportGenerationStatus,
+    build_workflow_detail_governance_link,
+    finalize_governance_report,
+    reconcile_missing_reports,
+)
+
+GOVERNANCE_TERMINAL_OUTCOMES = ("succeeded", "failed", "cancelled", "timed_out")
+
+_COMPLETED_STATES = {"completed", "no_commit"}
+_FAILED_STATES = {"failed"}
+_CANCELED_STATES = {"canceled", "cancelled"}
+
+
+def terminal_state_to_governance_outcome(
+    state: object,
+    close_status: object = None,
+) -> str | None:
+    """Map a Temporal lifecycle state to the governance terminal vocabulary.
+
+    Returns one of ``succeeded``/``failed``/``cancelled``/``timed_out`` for
+    terminal executions, or ``None`` when the execution is not terminal and
+    no governance report should be emitted yet. A ``timed_out`` close status
+    always wins over the state mapping so retention-expiry stays explicit.
+    Unknown or blank inputs return ``None`` (fail closed: no report).
+    """
+
+    close = str(close_status or "").strip().lower()
+    if close == "timed_out":
+        return "timed_out"
+    normalized = str(state or "").strip().lower()
+    if normalized in _COMPLETED_STATES:
+        return "succeeded"
+    if normalized in _FAILED_STATES:
+        return "failed"
+    if normalized in _CANCELED_STATES:
+        return "cancelled"
+    return None
+
+
+def build_terminal_governance_evidence(
+    *,
+    logical_workflow_id: object,
+    run_id: object,
+    attempt: object = 0,
+    terminal_outcome: object,
+    owner: object = "unknown-owner",
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build explicit pending/unavailable evidence for one terminal execution.
+
+    Sections without collected evidence stay ``pending``/``unavailable`` so
+    the report renders as ``partial`` and never claims unobserved cleanup
+    succeeded, scans passed, or reviews approved.
+    """
+
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    try:
+        attempt_value = int(attempt if attempt is not None else 0)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        attempt_value = 0
+    if attempt_value < 0:
+        attempt_value = 0
+    workflow_id = str(logical_workflow_id or "").strip() or "unknown-workflow"
+    run = str(run_id or "").strip() or "unknown-run"
+    requester = str(owner or "").strip() or "unknown-owner"
+    cutoff = current.isoformat()
+    return {
+        "logical_workflow_id": workflow_id,
+        "run_id": run,
+        "attempt": attempt_value,
+        "terminal_outcome": str(terminal_outcome or "").strip(),
+        "created_at": cutoff,
+        "evidence_cutoff": cutoff,
+        "completeness": "partial",
+        "owner": requester,
+        "policy": {"provenance": "unavailable"},
+        "profile": {"provenance": "unavailable"},
+        "image": {"provenance": "unavailable"},
+        "credentials": [],
+        "egress": [],
+        "container_jobs": [],
+        "approvals": [],
+        "outbound_scans": [],
+        "workspace_changes": [],
+        "publications": [],
+        "cleanup": {"provenance": "pending", "disposition": "pending"},
+    }
+
+
+def finalize_governance_for_terminal_execution(
+    record: Mapping[str, Any],
+    *,
+    store: GovernanceReportStore | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Finalize one terminal execution record into a governance report.
+
+    ``record`` is the real invocation shape used by the terminal service
+    binding: ``workflow_id``/``logical_workflow_id``, ``run_id``,
+    ``state``, ``close_status``, ``attempt``, and ``owner_id``/``owner``.
+    Older payloads without governance keys remain compatible: missing
+    evidence sections default to pending/unavailable and a missing attempt
+    defaults to ``0``.
+
+    Never raises. Unknown or non-terminal states yield a recoverable
+    ``pending`` status with ``report=None``;store or build failures yield a
+    recoverable ``failed`` status with ``report=None``. The canonical
+    terminal outcome is always preserved in ``canonical_outcome``.
+    """
+
+    if not isinstance(record, Mapping):
+        return {
+            "canonical_outcome": "failed",
+            "report": None,
+            "generation_status": {
+                "status": "failed",
+                "reason_code": "MALFORMED_SOURCE",
+                "detail": "terminal record is not a mapping",
+                "recoverable": True,
+            },
+            "link": None,
+        }
+    state = record.get("state", record.get("mm_state"))
+    close_status = record.get("close_status", record.get("closeStatus"))
+    outcome = terminal_state_to_governance_outcome(state, close_status)
+    if outcome is None:
+        canonical = str(state or "").strip().lower() or "failed"
+        return {
+            "canonical_outcome": canonical,
+            "report": None,
+            "generation_status": {
+                "status": "pending",
+                "reason_code": "NOT_TERMINAL",
+                "detail": "execution is not in a governance terminal state",
+                "recoverable": True,
+            },
+            "link": None,
+        }
+    workflow_id = record.get("logical_workflow_id", record.get("workflow_id"))
+    evidence = build_terminal_governance_evidence(
+        logical_workflow_id=workflow_id,
+        run_id=record.get("run_id"),
+        attempt=record.get("attempt", 0),
+        terminal_outcome=outcome,
+        owner=record.get("owner", record.get("owner_id")),
+        now=now,
+    )
+    try:
+        final = finalize_governance_report(evidence, store=store)
+    except Exception as exc:  # Auxiliary: never break the terminal handoff.
+        return {
+            "canonical_outcome": outcome,
+            "report": None,
+            "generation_status": {
+                "status": "failed",
+                "reason_code": "REPORT_STORE_UNAVAILABLE",
+                "detail": str(exc)[:300],
+                "recoverable": True,
+            },
+            "link": None,
+        }
+    status: ReportGenerationStatus | None = final.generation_status
+    link = build_workflow_detail_governance_link(
+        logical_workflow_id=str(evidence["logical_workflow_id"]),
+        report=final.report,
+        generation_status=status,
+    )
+    status_payload: dict[str, Any] | None = None
+    if status is not None:
+        status_payload = {
+            "status": status.status,
+            "reason_code": status.reason_code,
+            "detail": status.detail,
+            "recoverable": status.recoverable,
+        }
+    return {
+        "canonical_outcome": final.canonical_outcome,
+        "report": final.report,
+        "generation_status": status_payload,
+        "link": {
+            "href": link.href,
+            "status": link.status,
+            "explanation": link.explanation,
+            "download_ref": link.download_ref,
+        },
+    }
+
+
+def reconcile_missing_governance_reports(
+    executions: object,
+    *,
+    known_report_ids: object = (),
+) -> list[dict[str, Any]]:
+    """Emit retryable work items for terminal executions missing reports.
+
+    Thin driver over :func:`reconcile_missing_reports` so existing
+    worker/schedule infrastructure can re-drive finalization without a new
+    always-on service. Malformed rows are skipped, never aborting the batch.
+    """
+
+    known = list(known_report_ids) if isinstance(known_report_ids, (list, tuple, set)) else []
+    items = list(executions) if isinstance(executions, (list, tuple)) else []
+    return reconcile_missing_reports(items, known_report_ids=known)
+
+
+__all__ = [
+    "GOVERNANCE_TERMINAL_OUTCOMES",
+    "build_terminal_governance_evidence",
+    "finalize_governance_for_terminal_execution",
+    "reconcile_missing_governance_reports",
+    "terminal_state_to_governance_outcome",
+]

--- a/moonmind/governance/run_reports.py
+++ b/moonmind/governance/run_reports.py
@@ -250,6 +250,7 @@ def _build_credentials(raw: object) -> dict[str, Any]:
         state = str(item.get("state") or "").strip() or "unknown"
         if len(state) > MAX_REF_CHARS:
             raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.state is too long")
+        _reject_secret_value(state, path=f"{path}.state")
         evidence_ref = None
         if item.get("evidence_ref") is not None:
             evidence_ref = _artifact_ref(item.get("evidence_ref"), path=f"{path}.evidence_ref")
@@ -296,6 +297,7 @@ def _build_container_jobs(raw: object) -> dict[str, Any]:
         status = str(item.get("status") or "").strip() or "unknown"
         if len(status) > MAX_REF_CHARS:
             raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.status is too long")
+        _reject_secret_value(status, path=f"{path}.status")
         jobs.append({"job_ref": job_ref, "status": status})
     return {"provenance": ("observed" if jobs else "unavailable"), "jobs": jobs}
 
@@ -353,6 +355,7 @@ def _build_ref_list_section(raw: object, *, field_name: str, item_key: str, ref_
         status = str(item.get("status") or "").strip() or "unknown"
         if len(status) > MAX_REF_CHARS:
             raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.status is too long")
+        _reject_secret_value(status, path=f"{path}.status")
         evidence_ref = None
         if item.get("evidence_ref") is not None:
             evidence_ref = _artifact_ref(item.get("evidence_ref"), path=f"{path}.evidence_ref")
@@ -480,6 +483,13 @@ def build_governance_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
         evidence.get("publications"), field_name="publications", item_key="publication", ref_key="publication_ref"
     )
     cleanup = _build_cleanup(evidence.get("cleanup"))
+    if status == "ready" and (
+        cleanup.get("disposition") in ("unknown", "pending") or cleanup.get("provenance") == "pending"
+    ):
+        # Unresolved cleanup is never reported as ready: a complete evidence
+        # set with unknown/pending cleanup stays partial so historical entries
+        # never claim unresolved cleanup succeeded.
+        status = "partial"
     spend_usage = _build_spend_usage(evidence.get("spend_usage"))
     source_digests = _build_source_digests(evidence.get("source_artifact_digests"))
 

--- a/moonmind/governance/run_reports.py
+++ b/moonmind/governance/run_reports.py
@@ -1,0 +1,898 @@
+"""Per-run evidence-backed governance reports (MoonMind#3969)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+GOVERNANCE_REPORT_CONTRACT_VERSION = 1
+GOVERNANCE_REPORT_KIND = "run_governance_report"
+
+ProvenanceState = Literal[
+    "observed", "unavailable", "unsupported", "not_applicable", "pending"
+]
+ReportStatus = Literal["ready", "partial", "pending", "failed"]
+TerminalOutcome = Literal["succeeded", "failed", "cancelled", "timed_out"]
+CleanupDisposition = Literal["succeeded", "partial", "pending", "failed", "unknown"]
+ScanOutcome = Literal[
+    "pass", "block", "unavailable", "unsupported", "not_applicable", "pending"
+]
+ReviewOutcome = Literal[
+    "approved", "denied", "pending", "unavailable", "unsupported", "not_applicable"
+]
+CredentialOwnership = Literal["run_owned", "profile_owned"]
+SpendProvenance = Literal["provider_reported", "estimate", "unavailable"]
+
+TERMINAL_OUTCOMES: tuple[TerminalOutcome, ...] = (
+    "succeeded",
+    "failed",
+    "cancelled",
+    "timed_out",
+)
+PROVENANCE_STATES: tuple[ProvenanceState, ...] = (
+    "observed",
+    "unavailable",
+    "unsupported",
+    "not_applicable",
+    "pending",
+)
+
+UNMEDIATED_ACTIONS_DISCLAIMER = (
+    "Observed egress and scan entries cover MoonMind-mediated boundaries only. "
+    "Arbitrary agent network/shell actions outside those boundaries were not "
+    "universally mediated or observed."
+)
+
+OBSERVED_BLIND_SPOTS: tuple[str, ...] = (
+    "Arbitrary agent-initiated network/shell activity outside MoonMind-mediated egress.",
+    "Binary attachments, terminal input, and browser automation outside the text-scan contract.",
+    "Provider-internal activity not exposed through provider-reported measurements.",
+)
+
+MAX_SECTION_ITEMS = 50
+MAX_CREDENTIAL_ITEMS = 32
+MAX_DIGEST_ENTRIES = 64
+MAX_STRING_CHARS = 1024
+MAX_REF_CHARS = 512
+MAX_EVIDENCE_AGE = timedelta(hours=24 * 30)
+MAX_RECONCILE_ITEMS = 100
+
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(token|password|secret|cookie|session|credential|grant|authorization|api[_-]?key|private[_-]?key)"
+)
+_SECRET_VALUE_PATTERN = re.compile(
+    r"(?i)(ghp_|github_pat_|AIza|ATATT|AKIA|sk-ant-|xox[bpas]-|token\s*[=:]|password\s*[=:]|"
+    r"authorization\s*:|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+)
+_RAW_URL_PATTERN = re.compile(r"(?i)^https?://[^\s]+$")
+_SENSITIVE_URL_HINT = re.compile(r"(?i)(token|secret|password|key|auth|session|code=|signature=)")
+
+
+class GovernanceReportError(ValueError):
+    """Malformed governance-report input with a safe failure code."""
+
+    def __init__(self, code: str, detail: str = "") -> None:
+        super().__init__(f"{code}{': ' + detail if detail else ''}")
+        self.code = code
+
+
+TOP_LEVEL_KEYS = frozenset(
+    {
+        "contract_version",
+        "report_kind",
+        "report_id",
+        "logical_workflow_id",
+        "run_id",
+        "attempt",
+        "created_at",
+        "evidence_cutoff",
+        "terminal_outcome",
+        "status",
+        "completeness",
+        "input_digest",
+        "supersedes",
+        "policy",
+        "profile",
+        "image",
+        "credentials",
+        "egress",
+        "container_jobs",
+        "approvals",
+        "outbound_scans",
+        "workspace_changes",
+        "publications",
+        "cleanup",
+        "spend_usage",
+        "annotation",
+        "source_artifact_digests",
+        "observation_boundary",
+        "owner",
+    }
+)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: object, *, field_name: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} must be an ISO-8601 string")
+    text = value.strip()
+    try:
+        normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} is not parseable") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _require_short_str(value: object, *, field_name: str, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} must be a string")
+    text = value.strip()
+    if not text and not allow_empty:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} must not be blank")
+    if len(text) > MAX_REF_CHARS:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} is too long")
+    _reject_secret_value(text, path=field_name)
+    return text
+
+
+def _reject_secret_value(text: str, *, path: str) -> None:
+    if _SECRET_VALUE_PATTERN.search(text):
+        raise GovernanceReportError("UNSAFE_REPORT_FIELD", f"secret-like value at '{path}'")
+    if _RAW_URL_PATTERN.search(text) and _SENSITIVE_URL_HINT.search(text):
+        raise GovernanceReportError("UNSAFE_REPORT_FIELD", f"sensitive URL at '{path}'")
+
+
+def _reject_secret_key(key: str, *, path: str) -> None:
+    if _SECRET_KEY_PATTERN.search(key):
+        raise GovernanceReportError("UNSAFE_REPORT_FIELD", f"secret-like key '{path}'")
+
+
+def _provenance(value: object, *, field_name: str) -> ProvenanceState:
+    text = str(value or "").strip()
+    if text not in PROVENANCE_STATES:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} has unknown provenance '{text}'")
+    return text  # type: ignore[return-value]
+
+
+def _artifact_ref(value: object, *, path: str) -> dict[str, str | int]:
+    if not isinstance(value, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be an artifact ref")
+    artifact_id = str(value.get("artifact_id") or "").strip()
+    if not artifact_id or len(artifact_id) > MAX_REF_CHARS:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.artifact_id is required")
+    _reject_secret_value(artifact_id, path=f"{path}.artifact_id")
+    version = value.get("artifact_ref_v", 1)
+    try:
+        version_int = int(version)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.artifact_ref_v must be 1") from exc
+    if version_int != 1:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.artifact_ref_v must be 1")
+    return {"artifact_ref_v": 1, "artifact_id": artifact_id}
+
+
+def _digest_of_canonical(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_input_digest(evidence: Mapping[str, Any]) -> str:
+    """Compute the deterministic digest identifying one report input."""
+
+    if not isinstance(evidence, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "evidence must be a mapping")
+    return _digest_of_canonical({"v": GOVERNANCE_REPORT_CONTRACT_VERSION, "evidence": dict(evidence)})
+
+
+def governance_report_id(*, logical_workflow_id: str, run_id: str, attempt: int, input_digest: str) -> str:
+    """Return the idempotent report identity for one input digest."""
+
+    seed = f"{logical_workflow_id}|{run_id}|{attempt}|{input_digest}"
+    return f"govrep_{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _bounded_list(items: object, *, limit: int, field_name: str) -> list[Any]:
+    if items is None:
+        return []
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} must be a list")
+    if len(items) > limit:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} exceeds bound of {limit}")
+    return list(items)
+
+
+def _provenanced_ref_section(
+    raw: object, *, field_name: str, allow_empty_ref: bool = True
+) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name} must be a mapping")
+    provenance = _provenance(raw.get("provenance"), field_name=f"{field_name}.provenance")
+    ref_value = raw.get("ref")
+    ref: str | None = None
+    if ref_value is not None:
+        if not isinstance(ref_value, str) or not ref_value.strip():
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name}.ref must be a string")
+        ref = _require_short_str(ref_value, field_name=f"{field_name}.ref")
+    elif provenance == "observed" and not allow_empty_ref:
+        raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name}.ref is required when observed")
+    source = str(raw.get("source") or "").strip()
+    if source:
+        if len(source) > MAX_REF_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{field_name}.source is too long")
+        _reject_secret_value(source, path=f"{field_name}.source")
+    return {"provenance": provenance, "ref": ref, "source": source or None}
+
+
+def _build_credentials(raw: object) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_CREDENTIAL_ITEMS, field_name="credentials")
+    leases: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"credentials[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        for key in item:
+            _reject_secret_key(str(key), path=f"{path}.{key}")
+        lease_ref = _require_short_str(item.get("lease_ref"), field_name=f"{path}.lease_ref")
+        ownership = str(item.get("ownership") or "").strip()
+        if ownership not in ("run_owned", "profile_owned"):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.ownership must be run_owned|profile_owned")
+        state = str(item.get("state") or "").strip() or "unknown"
+        if len(state) > MAX_REF_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.state is too long")
+        evidence_ref = None
+        if item.get("evidence_ref") is not None:
+            evidence_ref = _artifact_ref(item.get("evidence_ref"), path=f"{path}.evidence_ref")
+        leases.append(
+            {"lease_ref": lease_ref, "ownership": ownership, "state": state, "evidence_ref": evidence_ref}
+        )
+    provenance: ProvenanceState = "observed" if leases else "unavailable"
+    return {"provenance": provenance, "leases": leases}
+
+
+def _build_egress(raw: object) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_SECTION_ITEMS, field_name="egress")
+    decisions: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"egress[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        for key in item:
+            _reject_secret_key(str(key), path=f"{path}.{key}")
+        destination = _require_short_str(item.get("destination_ref"), field_name=f"{path}.destination_ref")
+        decision = str(item.get("decision") or "").strip()
+        if decision not in ("allow", "deny", "unavailable"):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.decision must be allow|deny|unavailable")
+        policy_ref = None
+        if item.get("policy_ref") is not None:
+            policy_ref = _require_short_str(item.get("policy_ref"), field_name=f"{path}.policy_ref")
+        decisions.append({"destination_ref": destination, "decision": decision, "policy_ref": policy_ref})
+    provenance: ProvenanceState = "observed" if decisions else "unavailable"
+    return {
+        "provenance": provenance,
+        "decisions": decisions,
+        "coverage_note": UNMEDIATED_ACTIONS_DISCLAIMER,
+    }
+
+
+def _build_container_jobs(raw: object) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_SECTION_ITEMS, field_name="container_jobs")
+    jobs: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"container_jobs[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        job_ref = _require_short_str(item.get("job_ref"), field_name=f"{path}.job_ref")
+        status = str(item.get("status") or "").strip() or "unknown"
+        if len(status) > MAX_REF_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.status is too long")
+        jobs.append({"job_ref": job_ref, "status": status})
+    return {"provenance": ("observed" if jobs else "unavailable"), "jobs": jobs}
+
+
+def _build_approvals(raw: object) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_SECTION_ITEMS, field_name="approvals")
+    reviews: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"approvals[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        review_ref = _require_short_str(item.get("review_ref"), field_name=f"{path}.review_ref")
+        outcome = str(item.get("outcome") or "").strip()
+        if outcome not in ("approved", "denied", "pending", "unavailable", "unsupported", "not_applicable"):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.outcome is unknown")
+        reviews.append({"review_ref": review_ref, "outcome": outcome})
+    return {"provenance": ("observed" if reviews else "unavailable"), "reviews": reviews}
+
+
+def _build_outbound_scans(raw: object) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_SECTION_ITEMS, field_name="outbound_scans")
+    scans: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"outbound_scans[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        surface = _require_short_str(item.get("surface"), field_name=f"{path}.surface")
+        outcome = str(item.get("outcome") or "").strip()
+        if outcome not in ("pass", "block", "unavailable", "unsupported", "not_applicable", "pending"):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.outcome is unknown")
+        categories = _bounded_list(item.get("finding_categories", []), limit=20, field_name=f"{path}.finding_categories")
+        for category in categories:
+            if not isinstance(category, str) or not category.strip() or len(category) > MAX_REF_CHARS:
+                raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.finding_categories entries must be short strings")
+            _reject_secret_value(category, path=f"{path}.finding_categories")
+        locations = _bounded_list(item.get("location_refs", []), limit=20, field_name=f"{path}.location_refs")
+        for location in locations:
+            if not isinstance(location, str) or not location.strip() or len(location) > MAX_REF_CHARS:
+                raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.location_refs entries must be short strings")
+            _reject_secret_value(location, path=f"{path}.location_refs")
+        scans.append(
+            {"surface": surface, "outcome": outcome, "finding_categories": list(categories), "location_refs": list(locations)}
+        )
+    return {"provenance": ("observed" if scans else "unavailable"), "scans": scans}
+
+
+def _build_ref_list_section(raw: object, *, field_name: str, item_key: str, ref_key: str) -> dict[str, Any]:
+    items = _bounded_list(raw, limit=MAX_SECTION_ITEMS, field_name=field_name)
+    entries: list[dict[str, Any]] = []
+    for index, item in enumerate(items):
+        path = f"{field_name}[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        ref = _require_short_str(item.get(ref_key), field_name=f"{path}.{ref_key}")
+        status = str(item.get("status") or "").strip() or "unknown"
+        if len(status) > MAX_REF_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.status is too long")
+        evidence_ref = None
+        if item.get("evidence_ref") is not None:
+            evidence_ref = _artifact_ref(item.get("evidence_ref"), path=f"{path}.evidence_ref")
+        entries.append({item_key: ref, "status": status, "evidence_ref": evidence_ref})
+    return {"provenance": ("observed" if entries else "unavailable"), item_key + "s": entries}
+
+
+def _build_cleanup(raw: object) -> dict[str, Any]:
+    if raw is None:
+        return {"provenance": "pending", "disposition": "unknown", "detail_ref": None}
+    if not isinstance(raw, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "cleanup must be a mapping")
+    disposition = str(raw.get("disposition") or "").strip() or "unknown"
+    if disposition not in ("succeeded", "partial", "pending", "failed", "unknown"):
+        raise GovernanceReportError("MALFORMED_SOURCE", "cleanup.disposition is unknown")
+    detail_ref = None
+    if raw.get("detail_ref") is not None:
+        detail_ref = _artifact_ref(raw.get("detail_ref"), path="cleanup.detail_ref")
+    provenance = _provenance(raw.get("provenance", "observed"), field_name="cleanup.provenance")
+    return {"provenance": provenance, "disposition": disposition, "detail_ref": detail_ref}
+
+
+def _build_spend_usage(raw: object) -> dict[str, Any]:
+    if raw is None:
+        return {"provenance": "unavailable", "measurements": []}
+    if not isinstance(raw, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "spend_usage must be a mapping")
+    provenance = _provenance(raw.get("provenance", "unavailable"), field_name="spend_usage.provenance")
+    measurements = _bounded_list(raw.get("measurements", []), limit=20, field_name="spend_usage.measurements")
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(measurements):
+        path = f"spend_usage.measurements[{index}]"
+        if not isinstance(item, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path} must be a mapping")
+        kind = str(item.get("kind") or "").strip()
+        if kind not in ("provider_reported", "estimate", "unavailable"):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"{path}.kind must distinguish provider-reported/estimate/unavailable")
+        label = _require_short_str(item.get("label"), field_name=f"{path}.label")
+        normalized.append({"kind": kind, "label": label})
+    return {"provenance": provenance, "measurements": normalized}
+
+
+def _build_source_digests(raw: object) -> dict[str, str]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "source_artifact_digests must be a mapping")
+    if len(raw) > MAX_DIGEST_ENTRIES:
+        raise GovernanceReportError("MALFORMED_SOURCE", "source_artifact_digests exceeds bound")
+    digests: dict[str, str] = {}
+    for key, value in raw.items():
+        name = str(key or "").strip()
+        if not name or len(name) > MAX_REF_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", "source_artifact_digests keys must be short strings")
+        _reject_secret_key(name, path=f"source_artifact_digests.{name}")
+        digest = str(value or "").strip()
+        if not re.fullmatch(r"[0-9a-fA-F]{16,128}", digest or ""):
+            raise GovernanceReportError("MALFORMED_SOURCE", f"source_artifact_digests['{name}'] must be a hex digest")
+        digests[name] = digest.lower()
+    return digests
+
+
+def scan_outcome_is_pass(entry: Mapping[str, Any]) -> bool:
+    """Return True only for an explicitly observed pass; never upgrade missing data."""
+
+    return bool(isinstance(entry, Mapping) and entry.get("outcome") == "pass")
+
+
+def review_outcome_is_approved(entry: Mapping[str, Any]) -> bool:
+    """Return True only for an explicitly observed approval."""
+
+    return bool(isinstance(entry, Mapping) and entry.get("outcome") == "approved")
+
+
+def build_governance_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a deterministic, allowlisted governance report from authoritative evidence."""
+
+    if not isinstance(evidence, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "evidence must be a mapping")
+    for key in evidence:
+        name = str(key)
+        if name not in TOP_LEVEL_KEYS:
+            _reject_secret_key(name, path=name)
+            raise GovernanceReportError("MALFORMED_SOURCE", f"unsupported evidence key '{name}'")
+
+    logical_workflow_id = _require_short_str(evidence.get("logical_workflow_id"), field_name="logical_workflow_id")
+    run_id = _require_short_str(evidence.get("run_id"), field_name="run_id")
+    attempt_raw = evidence.get("attempt", 0)
+    try:
+        attempt = int(attempt_raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise GovernanceReportError("MALFORMED_SOURCE", "attempt must be an integer") from exc
+    if attempt < 0 or attempt > 10_000:
+        raise GovernanceReportError("MALFORMED_SOURCE", "attempt is out of range")
+
+    terminal_outcome = str(evidence.get("terminal_outcome") or "").strip()
+    if terminal_outcome not in TERMINAL_OUTCOMES:
+        raise GovernanceReportError("MALFORMED_SOURCE", "terminal_outcome must be succeeded|failed|cancelled|timed_out")
+
+    created_at = str(evidence.get("created_at") or _utcnow_iso())
+    evidence_cutoff = str(evidence.get("evidence_cutoff") or created_at)
+    _parse_time(created_at, field_name="created_at")
+    _parse_time(evidence_cutoff, field_name="evidence_cutoff")
+
+    completeness = str(evidence.get("completeness") or "partial").strip()
+    if completeness not in ("complete", "partial", "pending", "failed"):
+        raise GovernanceReportError("MALFORMED_SOURCE", "completeness is unknown")
+    status: ReportStatus = "ready" if completeness == "complete" else ("failed" if completeness == "failed" else ("pending" if completeness == "pending" else "partial"))
+
+    owner = _require_short_str(evidence.get("owner", "unknown-owner"), field_name="owner")
+
+    policy = _provenanced_ref_section(evidence.get("policy", {"provenance": "unavailable"}), field_name="policy")
+    profile = _provenanced_ref_section(evidence.get("profile", {"provenance": "unavailable"}), field_name="profile")
+    image = _provenanced_ref_section(evidence.get("image", {"provenance": "unavailable"}), field_name="image")
+
+    credentials = _build_credentials(evidence.get("credentials"))
+    egress = _build_egress(evidence.get("egress"))
+    container_jobs = _build_container_jobs(evidence.get("container_jobs"))
+    approvals = _build_approvals(evidence.get("approvals"))
+    outbound_scans = _build_outbound_scans(evidence.get("outbound_scans"))
+    workspace_changes = _build_ref_list_section(
+        evidence.get("workspace_changes"), field_name="workspace_changes", item_key="change", ref_key="change_ref"
+    )
+    publications = _build_ref_list_section(
+        evidence.get("publications"), field_name="publications", item_key="publication", ref_key="publication_ref"
+    )
+    cleanup = _build_cleanup(evidence.get("cleanup"))
+    spend_usage = _build_spend_usage(evidence.get("spend_usage"))
+    source_digests = _build_source_digests(evidence.get("source_artifact_digests"))
+
+    annotation_raw = evidence.get("annotation")
+    annotation: str | None = None
+    if annotation_raw is not None:
+        if not isinstance(annotation_raw, str) or not annotation_raw.strip():
+            raise GovernanceReportError("MALFORMED_SOURCE", "annotation must be a non-empty string")
+        if len(annotation_raw) > MAX_STRING_CHARS:
+            raise GovernanceReportError("MALFORMED_SOURCE", "annotation is too long")
+        _reject_secret_value(annotation_raw, path="annotation")
+        annotation = annotation_raw.strip()
+
+    supersedes_raw = evidence.get("supersedes")
+    supersedes: str | None = None
+    if supersedes_raw is not None:
+        supersedes = _require_short_str(supersedes_raw, field_name="supersedes")
+
+    input_digest = build_input_digest(
+        {
+            "logical_workflow_id": logical_workflow_id,
+            "run_id": run_id,
+            "attempt": attempt,
+            "terminal_outcome": terminal_outcome,
+            "evidence_cutoff": evidence_cutoff,
+            "policy": policy,
+            "profile": profile,
+            "image": image,
+            "credentials": credentials,
+            "egress": egress,
+            "container_jobs": container_jobs,
+            "approvals": approvals,
+            "outbound_scans": outbound_scans,
+            "workspace_changes": workspace_changes,
+            "publications": publications,
+            "cleanup": cleanup,
+            "spend_usage": spend_usage,
+            "source_artifact_digests": source_digests,
+        }
+    )
+    report_id = governance_report_id(
+        logical_workflow_id=logical_workflow_id, run_id=run_id, attempt=attempt, input_digest=input_digest
+    )
+
+    report: dict[str, Any] = {
+        "contract_version": GOVERNANCE_REPORT_CONTRACT_VERSION,
+        "report_kind": GOVERNANCE_REPORT_KIND,
+        "report_id": report_id,
+        "logical_workflow_id": logical_workflow_id,
+        "run_id": run_id,
+        "attempt": attempt,
+        "created_at": created_at,
+        "evidence_cutoff": evidence_cutoff,
+        "terminal_outcome": terminal_outcome,
+        "status": status,
+        "completeness": completeness,
+        "input_digest": input_digest,
+        "supersedes": supersedes,
+        "policy": policy,
+        "profile": profile,
+        "image": image,
+        "credentials": credentials,
+        "egress": egress,
+        "container_jobs": container_jobs,
+        "approvals": approvals,
+        "outbound_scans": outbound_scans,
+        "workspace_changes": workspace_changes,
+        "publications": publications,
+        "cleanup": cleanup,
+        "spend_usage": spend_usage,
+        "annotation": annotation,
+        "source_artifact_digests": source_digests,
+        "observation_boundary": {
+            "coverage_note": UNMEDIATED_ACTIONS_DISCLAIMER,
+            "blind_spots": list(OBSERVED_BLIND_SPOTS),
+        },
+        "owner": owner,
+    }
+    for key in report:
+        if key not in TOP_LEVEL_KEYS:
+            raise GovernanceReportError("MALFORMED_SOURCE", f"unsupported report key '{key}'")
+    # Deterministic serialization check: the report must round-trip byte-identically.
+    serialized = json.dumps(report, sort_keys=True, separators=(",", ":"), default=str)
+    if json.loads(serialized) != report:
+        raise GovernanceReportError("MALFORMED_SOURCE", "report is not deterministically serializable")
+    return report
+
+
+def render_governance_report_markdown(report: Mapping[str, Any]) -> str:
+    """Render human-readable Markdown generated from the same JSON report."""
+
+    if not isinstance(report, Mapping):
+        raise GovernanceReportError("MALFORMED_SOURCE", "report must be a mapping")
+    if report.get("contract_version") != GOVERNANCE_REPORT_CONTRACT_VERSION:
+        raise GovernanceReportError("MALFORMED_SOURCE", "unsupported contract_version")
+    if report.get("report_kind") != GOVERNANCE_REPORT_KIND:
+        raise GovernanceReportError("MALFORMED_SOURCE", "unsupported report_kind")
+
+    def section_state(section: object) -> str:
+        if isinstance(section, Mapping):
+            return str(section.get("provenance") or "unavailable")
+        return "unavailable"
+
+    scans = report.get("outbound_scans") if isinstance(report.get("outbound_scans"), Mapping) else {}
+    scan_lines: list[str] = []
+    for entry in scans.get("scans", []) if isinstance(scans.get("scans"), list) else []:
+        if not isinstance(entry, Mapping):
+            continue
+        outcome = str(entry.get("outcome") or "unavailable")
+        verdict = "PASS" if outcome == "pass" else ("BLOCK" if outcome == "block" else outcome.upper())
+        scan_lines.append(f"- {entry.get('surface')}: {verdict}")
+    scans_block = "\n".join(scan_lines) if scan_lines else "- no observed scans (unavailable is not a pass)"
+
+    lines = [
+        f"# Governance report {report.get('report_id')}",
+        "",
+        f"- Workflow: {report.get('logical_workflow_id')} / run {report.get('run_id')} (attempt {report.get('attempt')})",
+        f"- Outcome: {report.get('terminal_outcome')} — status {report.get('status')} / {report.get('completeness')}",
+        f"- Evidence cutoff: {report.get('evidence_cutoff')}",
+        f"- Input digest: {report.get('input_digest')}",
+    ]
+    if report.get("supersedes"):
+        lines.append(f"- Supersedes: {report.get('supersedes')}")
+    lines += [
+        f"- Policy: {section_state(report.get('policy'))} / Profile: {section_state(report.get('profile'))} / Image: {section_state(report.get('image'))}",
+        f"- Credentials: {section_state(report.get('credentials'))} / Egress: {section_state(report.get('egress'))} / Cleanup: {report.get('cleanup', {}).get('disposition', 'unknown') if isinstance(report.get('cleanup'), Mapping) else 'unknown'}",
+        "",
+        "## Outbound scans (unavailable is never a pass)",
+        "",
+        scans_block,
+        "",
+        "## Observation boundary",
+        "",
+        str(
+            report.get("observation_boundary", {}).get("coverage_note", UNMEDIATED_ACTIONS_DISCLAIMER)
+            if isinstance(report.get("observation_boundary"), Mapping)
+            else UNMEDIATED_ACTIONS_DISCLAIMER
+        ),
+    ]
+    blind_spots = (
+        report.get("observation_boundary", {}).get("blind_spots", [])
+        if isinstance(report.get("observation_boundary"), Mapping)
+        else []
+    )
+    if isinstance(blind_spots, list):
+        for spot in blind_spots:
+            lines.append(f"- {spot}")
+    if report.get("annotation"):
+        lines += ["", "> Model-generated annotation (non-authoritative):", "", f"> {report.get('annotation')}"]
+    lines.append("")
+    return "\n".join(lines)
+
+
+@dataclass
+class ReportGenerationStatus:
+    """Visible, recoverable status when no report bytes exist yet."""
+
+    status: ReportStatus
+    reason_code: str
+    detail: str = ""
+    recoverable: bool = True
+
+
+@dataclass
+class ReportFinalization:
+    """Outcome of finalizing one terminal execution without rewriting canonical state."""
+
+    canonical_outcome: TerminalOutcome
+    canonical_outcome_preserved: bool = True
+    report: dict[str, Any] | None = None
+    generation_status: ReportGenerationStatus | None = None
+
+
+@dataclass
+class GovernanceReportStore:
+    """Immutable in-memory report store with idempotent identity.
+
+    Retrying the same input digest reuses the stored report. Late or corrected
+    evidence writes a new immutable version carrying a ``supersedes`` relation
+    instead of overwriting the original.
+    """
+
+    _reports: dict[str, dict[str, Any]] = field(default_factory=dict)
+    _by_input: dict[str, str] = field(default_factory=dict)
+    fail_writes: bool = False
+
+    def put(self, report: Mapping[str, Any]) -> tuple[dict[str, Any], bool]:
+        """Store a report immutably; return (stored, reused)."""
+
+        if self.fail_writes:
+            raise GovernanceReportError("REPORT_STORE_UNAVAILABLE", "report store is unavailable")
+        if not isinstance(report, Mapping):
+            raise GovernanceReportError("MALFORMED_SOURCE", "report must be a mapping")
+        report_id = str(report.get("report_id") or "").strip()
+        input_digest = str(report.get("input_digest") or "").strip()
+        if not report_id or not input_digest:
+            raise GovernanceReportError("MALFORMED_SOURCE", "report_id and input_digest are required")
+        existing_id = self._by_input.get(input_digest)
+        if existing_id is not None and existing_id in self._reports:
+            return self._reports[existing_id], True
+        if report_id in self._reports:
+            # Immutable write contract: never overwrite an existing report id.
+            if self._reports[report_id] != dict(report):
+                raise GovernanceReportError("REPORT_ID_COLLISION", "report_id already stored with different content")
+            return self._reports[report_id], True
+        stored = dict(report)
+        self._reports[report_id] = stored
+        self._by_input[input_digest] = report_id
+        return stored, False
+
+    def get(self, report_id: str) -> dict[str, Any] | None:
+        """Return a stored report copy or None."""
+
+        stored = self._reports.get(str(report_id or ""))
+        return dict(stored) if stored is not None else None
+
+    def supersede(self, old_report_id: str, new_evidence: Mapping[str, Any]) -> dict[str, Any]:
+        """Write a new immutable version that explicitly supersedes the old report."""
+
+        old = self._reports.get(str(old_report_id or ""))
+        if old is None:
+            raise GovernanceReportError("REPORT_NOT_FOUND", "superseded report is unknown")
+        merged = dict(new_evidence)
+        merged["supersedes"] = old["report_id"]
+        # Preserve logical-run/attempt continuity across continuation and recovery.
+        for key in ("logical_workflow_id", "run_id", "attempt"):
+            merged.setdefault(key, old[key])
+        new_report = build_governance_report(merged)
+        stored, reused = self.put(new_report)
+        if reused:
+            return stored
+        return stored
+
+    def __len__(self) -> int:
+        return len(self._reports)
+
+
+def finalize_governance_report(
+    evidence: Mapping[str, Any],
+    *,
+    store: GovernanceReportStore | None = None,
+    cancelled_during_finalization: bool = False,
+) -> ReportFinalization:
+    """Finalize one terminal execution into a report or a recoverable status.
+
+    Reporting failure is auxiliary: the canonical terminal outcome is always
+    preserved, cancellation is never prevented, and no exception escapes for
+    store failures or cancellation races.
+    """
+
+    canonical = str(evidence.get("terminal_outcome") or "").strip()
+    if canonical not in TERMINAL_OUTCOMES:
+        return ReportFinalization(
+            canonical_outcome="failed",
+            report=None,
+            generation_status=ReportGenerationStatus(
+                status="failed", reason_code="MALFORMED_SOURCE", detail="terminal_outcome is unknown", recoverable=False
+            ),
+        )
+    outcome: TerminalOutcome = canonical  # type: ignore[assignment]
+    if cancelled_during_finalization:
+        return ReportFinalization(
+            canonical_outcome=outcome,
+            report=None,
+            generation_status=ReportGenerationStatus(
+                status="pending",
+                reason_code="CANCELLED_DURING_FINALIZATION",
+                detail="cancellation preserved; report generation can be retried by the reconciler",
+                recoverable=True,
+            ),
+        )
+    try:
+        report = build_governance_report(evidence)
+    except GovernanceReportError as exc:
+        return ReportFinalization(
+            canonical_outcome=outcome,
+            report=None,
+            generation_status=ReportGenerationStatus(
+                status="failed", reason_code=exc.code, detail=str(exc), recoverable=True
+            ),
+        )
+    if store is None:
+        return ReportFinalization(canonical_outcome=outcome, report=report)
+    try:
+        stored, _ = store.put(report)
+    except GovernanceReportError as exc:
+        return ReportFinalization(
+            canonical_outcome=outcome,
+            report=None,
+            generation_status=ReportGenerationStatus(
+                status="failed", reason_code=exc.code, detail=str(exc), recoverable=True
+            ),
+        )
+    return ReportFinalization(canonical_outcome=outcome, report=stored)
+
+
+def reconcile_missing_reports(
+    executions: Sequence[Mapping[str, Any]],
+    *,
+    known_report_ids: Sequence[str] = (),
+    limit: int = MAX_RECONCILE_ITEMS,
+) -> list[dict[str, Any]]:
+    """Bounded reconciler for crash-before-finalization gaps.
+
+    Pure function returning retryable work items so existing worker/schedule
+    infrastructure can drive re-finalization without a new always-on service.
+    """
+
+    known = {str(report_id) for report_id in known_report_ids}
+    items: list[dict[str, Any]] = []
+    for execution in list(executions or [])[:limit]:
+        if not isinstance(execution, Mapping):
+            continue
+        run_id = str(execution.get("run_id") or "").strip()
+        if not run_id:
+            continue
+        report_id = str(execution.get("report_id") or "").strip()
+        if report_id and report_id in known:
+            continue
+        outcome = str(execution.get("terminal_outcome") or "").strip()
+        if outcome not in TERMINAL_OUTCOMES:
+            continue
+        items.append(
+            {
+                "run_id": run_id,
+                "logical_workflow_id": str(execution.get("logical_workflow_id") or "").strip() or "unknown-workflow",
+                "attempt": int(execution.get("attempt", 0) or 0),
+                "terminal_outcome": outcome,
+                "reason": "missing_report_after_terminal_outcome",
+            }
+        )
+    return items
+
+
+@dataclass(frozen=True)
+class GovernanceAccessResult:
+    allowed: bool
+    code: str
+    detail: str = ""
+
+
+def authorize_governance_report_access(
+    report: Mapping[str, Any],
+    *,
+    requester_owner: str,
+    now: datetime | None = None,
+    expected_digests: Mapping[str, str] | None = None,
+) -> GovernanceAccessResult:
+    """Enforce owner, expiry, digest, and shape checks with explicit safe outcomes."""
+
+    if not isinstance(report, Mapping) or report.get("report_kind") != GOVERNANCE_REPORT_KIND:
+        return GovernanceAccessResult(False, "MALFORMED_SOURCE", "report shape is not a governance report")
+    owner = str(report.get("owner") or "").strip()
+    requester = str(requester_owner or "").strip()
+    if not requester or requester != owner:
+        return GovernanceAccessResult(False, "WRONG_OWNER", "requester does not own this report")
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    try:
+        cutoff = _parse_time(report.get("evidence_cutoff"), field_name="evidence_cutoff")
+    except GovernanceReportError as exc:
+        return GovernanceAccessResult(False, exc.code, str(exc))
+    if current - cutoff > MAX_EVIDENCE_AGE:
+        return GovernanceAccessResult(False, "EVIDENCE_EXPIRED", "evidence cutoff is beyond retention")
+    stored_digests = report.get("source_artifact_digests") if isinstance(report.get("source_artifact_digests"), Mapping) else {}
+    for name, expected in dict(expected_digests or {}).items():
+        actual = stored_digests.get(name) if isinstance(stored_digests, Mapping) else None
+        if actual != expected:
+            return GovernanceAccessResult(False, "DIGEST_MISMATCH", f"source artifact '{name}' digest mismatch")
+    return GovernanceAccessResult(True, "OK")
+
+
+@dataclass(frozen=True)
+class WorkflowDetailGovernanceLink:
+    href: str
+    status: ReportStatus
+    explanation: str
+    download_ref: dict[str, str | int] | None = None
+
+
+def build_workflow_detail_governance_link(
+    *,
+    logical_workflow_id: str,
+    report: Mapping[str, Any] | None = None,
+    generation_status: ReportGenerationStatus | None = None,
+    download_ref: Mapping[str, Any] | None = None,
+) -> WorkflowDetailGovernanceLink:
+    """Build the Workflow Detail governance link with safe, authorized download."""
+
+    workflow_id = str(logical_workflow_id or "").strip() or "unknown-workflow"
+    safe_id = workflow_id.replace("/", "_")
+    if report is not None:
+        status = str(report.get("status") or "partial").strip()
+        if status not in ("ready", "partial", "pending", "failed"):
+            status = "partial"
+        detail_ref: dict[str, str | int] | None = None
+        if download_ref is not None:
+            detail_ref = _artifact_ref(download_ref, path="download_ref")
+        explanations = {
+            "ready": "Governance report is ready from verified authoritative evidence.",
+            "partial": "Governance report is partial: some evidence was unavailable and is shown as such.",
+            "pending": "Governance report is pending: evidence collection has not completed.",
+            "failed": "Report generation failed as an auxiliary step; task and publication state are unchanged.",
+        }
+        return WorkflowDetailGovernanceLink(
+            href=f"/workflows/{safe_id}/evidence?report={report.get('report_id', 'unknown')}",
+            status=status,  # type: ignore[assignment]
+            explanation=explanations[status],
+            download_ref=detail_ref,
+        )
+    reason = generation_status.reason_code if generation_status is not None else "REPORT_PENDING"
+    status_value: ReportStatus = generation_status.status if generation_status is not None else "pending"
+    return WorkflowDetailGovernanceLink(
+        href=f"/workflows/{safe_id}/evidence",
+        status=status_value,
+        explanation=f"Governance report is {status_value}: {reason}. Historical entries never expose current credentials and never claim unresolved cleanup succeeded.",
+    )

--- a/moonmind/governance/run_reports.py
+++ b/moonmind/governance/run_reports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import re
@@ -9,6 +10,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
+from urllib.parse import quote
 
 GOVERNANCE_REPORT_CONTRACT_VERSION = 1
 GOVERNANCE_REPORT_KIND = "run_governance_report"
@@ -60,6 +62,7 @@ MAX_DIGEST_ENTRIES = 64
 MAX_STRING_CHARS = 1024
 MAX_REF_CHARS = 512
 MAX_EVIDENCE_AGE = timedelta(hours=24 * 30)
+MAX_CLOCK_SKEW = timedelta(minutes=5)
 MAX_RECONCILE_ITEMS = 100
 
 _SECRET_KEY_PATTERN = re.compile(
@@ -375,6 +378,12 @@ def _build_cleanup(raw: object) -> dict[str, Any]:
     if raw.get("detail_ref") is not None:
         detail_ref = _artifact_ref(raw.get("detail_ref"), path="cleanup.detail_ref")
     provenance = _provenance(raw.get("provenance", "observed"), field_name="cleanup.provenance")
+    if disposition == "succeeded" and provenance != "observed":
+        # Explicitly missing cleanup evidence must never be reported as a
+        # success; only authoritative observed evidence may claim succeeded.
+        raise GovernanceReportError(
+            "MALFORMED_SOURCE", "cleanup.disposition succeeded requires observed provenance"
+        )
     return {"provenance": provenance, "disposition": disposition, "detail_ref": detail_ref}
 
 
@@ -514,7 +523,12 @@ def build_governance_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
             "run_id": run_id,
             "attempt": attempt,
             "terminal_outcome": terminal_outcome,
+            "created_at": created_at,
             "evidence_cutoff": evidence_cutoff,
+            "completeness": completeness,
+            "owner": owner,
+            "annotation": annotation,
+            "supersedes": supersedes,
             "policy": policy,
             "profile": profile,
             "image": image,
@@ -689,22 +703,22 @@ class GovernanceReportStore:
             raise GovernanceReportError("MALFORMED_SOURCE", "report_id and input_digest are required")
         existing_id = self._by_input.get(input_digest)
         if existing_id is not None and existing_id in self._reports:
-            return self._reports[existing_id], True
+            return copy.deepcopy(self._reports[existing_id]), True
         if report_id in self._reports:
             # Immutable write contract: never overwrite an existing report id.
             if self._reports[report_id] != dict(report):
                 raise GovernanceReportError("REPORT_ID_COLLISION", "report_id already stored with different content")
-            return self._reports[report_id], True
-        stored = dict(report)
+            return copy.deepcopy(self._reports[report_id]), True
+        stored = copy.deepcopy(dict(report))
         self._reports[report_id] = stored
         self._by_input[input_digest] = report_id
-        return stored, False
+        return copy.deepcopy(stored), False
 
     def get(self, report_id: str) -> dict[str, Any] | None:
         """Return a stored report copy or None."""
 
         stored = self._reports.get(str(report_id or ""))
-        return dict(stored) if stored is not None else None
+        return copy.deepcopy(stored) if stored is not None else None
 
     def supersede(self, old_report_id: str, new_evidence: Mapping[str, Any]) -> dict[str, Any]:
         """Write a new immutable version that explicitly supersedes the old report."""
@@ -714,9 +728,12 @@ class GovernanceReportStore:
             raise GovernanceReportError("REPORT_NOT_FOUND", "superseded report is unknown")
         merged = dict(new_evidence)
         merged["supersedes"] = old["report_id"]
-        # Preserve logical-run/attempt continuity across continuation and recovery.
+        # Preserve logical-run/attempt continuity across continuation and recovery:
+        # the new version always belongs to the superseded run, so identity
+        # fields supplied with the late evidence never reassign the version to
+        # another run and corrupt the immutable audit chain.
         for key in ("logical_workflow_id", "run_id", "attempt"):
-            merged.setdefault(key, old[key])
+            merged[key] = old[key]
         new_report = build_governance_report(merged)
         stored, reused = self.put(new_report)
         if reused:
@@ -812,11 +829,18 @@ def reconcile_missing_reports(
         outcome = str(execution.get("terminal_outcome") or "").strip()
         if outcome not in TERMINAL_OUTCOMES:
             continue
+        try:
+            attempt = int(execution.get("attempt", 0) or 0)
+        except (TypeError, ValueError):
+            # One malformed row must not abort the whole batch or block later
+            # valid executions from being repaired; it stays eligible for a
+            # future reconciler pass once corrected.
+            continue
         items.append(
             {
                 "run_id": run_id,
                 "logical_workflow_id": str(execution.get("logical_workflow_id") or "").strip() or "unknown-workflow",
-                "attempt": int(execution.get("attempt", 0) or 0),
+                "attempt": attempt,
                 "terminal_outcome": outcome,
                 "reason": "missing_report_after_terminal_outcome",
             }
@@ -851,6 +875,10 @@ def authorize_governance_report_access(
         cutoff = _parse_time(report.get("evidence_cutoff"), field_name="evidence_cutoff")
     except GovernanceReportError as exc:
         return GovernanceAccessResult(False, exc.code, str(exc))
+    if cutoff - current > MAX_CLOCK_SKEW:
+        # A future cutoff would otherwise authorize with a negative age and
+        # bypass retention until that date; invalid evidence fails closed.
+        return GovernanceAccessResult(False, "EVIDENCE_EXPIRED", "evidence cutoff is in the future")
     if current - cutoff > MAX_EVIDENCE_AGE:
         return GovernanceAccessResult(False, "EVIDENCE_EXPIRED", "evidence cutoff is beyond retention")
     stored_digests = report.get("source_artifact_digests") if isinstance(report.get("source_artifact_digests"), Mapping) else {}
@@ -879,7 +907,11 @@ def build_workflow_detail_governance_link(
     """Build the Workflow Detail governance link with safe, authorized download."""
 
     workflow_id = str(logical_workflow_id or "").strip() or "unknown-workflow"
-    safe_id = workflow_id.replace("/", "_")
+    # Path-segment encoding matching the TypeScript helper's
+    # encodeURIComponent: the safe set is exactly the characters
+    # encodeURIComponent leaves unescaped, so both hosts build the same href
+    # and distinct ids (for example "team/run" vs "team_run") never alias.
+    safe_id = quote(workflow_id, safe="-_.!~*'()")
     if report is not None:
         status = str(report.get("status") or "partial").strip()
         if status not in ("ready", "partial", "pending", "failed"):

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -3677,6 +3677,7 @@ class TemporalExecutionService:
                 finish_outcome_code=finish_outcome_code,
                 finish_summary=finish_summary,
             )
+            self._attach_terminal_governance_report(record)
             if record.close_status is None:
                 self._set_state(record, target_state, close_status=target_close_status)
                 if isinstance(record, TemporalExecutionCanonicalRecord):
@@ -3694,6 +3695,7 @@ class TemporalExecutionService:
             finish_outcome_code=finish_outcome_code,
             finish_summary=finish_summary,
         )
+        self._attach_terminal_governance_report(record)
         if summary:
             if target_state is MoonMindWorkflowState.FAILED:
                 category = str(error_category or "execution_error").strip()
@@ -3715,6 +3717,54 @@ class TemporalExecutionService:
             return record
         await self._fan_out_dependency_resolution(record)
         return await self._sync_projection_best_effort(record)
+
+    def _attach_terminal_governance_report(
+        self,
+        record: TemporalExecutionCanonicalRecord | TemporalExecutionRecord,
+    ) -> None:
+        """Attach an auxiliary per-run governance report at the terminal handoff.
+
+        Reporting failure is auxiliary: the canonical terminal state,
+        close status, and finish summary are always preserved, and no
+        exception escapes. The report (or its recoverable generation
+        status) is stored inside ``finish_summary_json["governanceReport"]``
+        so it is durable and projected through the existing execution API.
+        """
+
+        try:
+            from moonmind.governance.execution_integration import (
+                finalize_governance_for_terminal_execution,
+            )
+
+            payload = {
+                "workflow_id": getattr(record, "workflow_id", None),
+                "run_id": getattr(record, "run_id", None),
+                "state": getattr(getattr(record, "state", None), "value", getattr(record, "state", None)),
+                "close_status": getattr(
+                    getattr(record, "close_status", None), "value", getattr(record, "close_status", None)
+                ),
+                "owner_id": getattr(record, "owner_id", None),
+            }
+            result = finalize_governance_for_terminal_execution(payload)
+            current = getattr(record, "finish_summary_json", None)
+            summary = dict(current) if isinstance(current, Mapping) else {}
+            existing = summary.get("governanceReport")
+            if isinstance(existing, Mapping) and existing.get("report_id"):
+                return
+            report = result.get("report")
+            block: dict[str, Any] = {
+                "canonical_outcome": result.get("canonical_outcome"),
+                "generation_status": result.get("generation_status"),
+                "link": result.get("link"),
+            }
+            if isinstance(report, Mapping):
+                block["report_id"] = report.get("report_id")
+                block["status"] = report.get("status")
+                block["evidence_cutoff"] = report.get("evidence_cutoff")
+            summary["governanceReport"] = block
+            record.finish_summary_json = summary
+        except Exception:
+            return
 
     def _record_finish_summary(
         self,

--- a/tests/unit/governance/test_execution_integration.py
+++ b/tests/unit/governance/test_execution_integration.py
@@ -1,0 +1,112 @@
+"""Unit tests for the governance terminal-handoff integration (MoonMind#3969)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from moonmind.governance.execution_integration import (
+    build_terminal_governance_evidence,
+    finalize_governance_for_terminal_execution,
+    reconcile_missing_governance_reports,
+    terminal_state_to_governance_outcome,
+)
+from moonmind.governance.run_reports import GovernanceReportStore
+
+
+def _record(**overrides):
+    base = {
+        "workflow_id": "wf-3930",
+        "run_id": "run-001",
+        "attempt": 0,
+        "state": "completed",
+        "close_status": "completed",
+        "owner_id": "owner-1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_terminal_state_mapping_covers_all_outcomes() -> None:
+    assert terminal_state_to_governance_outcome("completed", "completed") == "succeeded"
+    assert terminal_state_to_governance_outcome("no_commit", "completed") == "succeeded"
+    assert terminal_state_to_governance_outcome("failed", "failed") == "failed"
+    assert terminal_state_to_governance_outcome("canceled", "canceled") == "cancelled"
+    # A timed_out close status always wins so retention expiry stays explicit.
+    assert terminal_state_to_governance_outcome("completed", "timed_out") == "timed_out"
+    assert terminal_state_to_governance_outcome("failed", "timed_out") == "timed_out"
+
+
+def test_non_terminal_and_degraded_inputs_emit_nothing() -> None:
+    assert terminal_state_to_governance_outcome("executing", "running") is None
+    assert terminal_state_to_governance_outcome("", "") is None
+    assert terminal_state_to_governance_outcome(None, None) is None
+    assert terminal_state_to_governance_outcome("exploded", "weird") is None
+
+
+def test_finalize_emits_partial_report_for_every_terminal_outcome() -> None:
+    now = datetime(2026, 9, 1, 10, 6, tzinfo=UTC)
+    for state, close, outcome in (
+        ("completed", "completed", "succeeded"),
+        ("failed", "failed", "failed"),
+        ("canceled", "canceled", "cancelled"),
+        ("failed", "timed_out", "timed_out"),
+    ):
+        result = finalize_governance_for_terminal_execution(
+            _record(state=state, close_status=close), now=now
+        )
+        assert result["canonical_outcome"] == outcome
+        assert result["report"] is not None
+        assert result["report"]["terminal_outcome"] == outcome
+        # Minimal evidence defaults to partial, never ready with pending cleanup.
+        assert result["report"]["status"] == "partial"
+        assert result["link"] is not None
+        assert result["link"]["href"].startswith("/workflows/wf-3930/evidence")
+
+
+def test_finalize_preserves_canonical_outcome_when_store_fails() -> None:
+    store = GovernanceReportStore(fail_writes=True)
+    result = finalize_governance_for_terminal_execution(_record(), store=store)
+    assert result["canonical_outcome"] == "succeeded"
+    assert result["report"] is None
+    assert result["generation_status"]["recoverable"] is True
+
+
+def test_finalize_never_raises_for_malformed_or_non_terminal_records() -> None:
+    pending = finalize_governance_for_terminal_execution(_record(state="executing"))
+    assert pending["report"] is None
+    assert pending["generation_status"]["reason_code"] == "NOT_TERMINAL"
+
+    malformed = finalize_governance_for_terminal_execution("not-a-mapping")  # type: ignore[arg-type]
+    assert malformed["report"] is None
+    assert malformed["generation_status"]["reason_code"] == "MALFORMED_SOURCE"
+
+
+def test_evidence_defaults_are_explicitly_partial() -> None:
+    evidence = build_terminal_governance_evidence(
+        logical_workflow_id="wf-1",
+        run_id="run-9",
+        terminal_outcome="succeeded",
+        now=datetime(2026, 9, 1, 10, 6, tzinfo=UTC),
+    )
+    assert evidence["completeness"] == "partial"
+    assert evidence["cleanup"] == {"provenance": "pending", "disposition": "pending"}
+    assert evidence["attempt"] == 0
+
+
+def test_reconciler_is_bounded_and_skips_known_reports() -> None:
+    executions = [
+        {"logical_workflow_id": "wf-1", "run_id": "run-1", "attempt": 0, "terminal_outcome": "succeeded"},
+        {"logical_workflow_id": "wf-1", "run_id": "run-2", "attempt": 1, "terminal_outcome": "timed_out",
+         "report_id": "govrep_x"},
+        {"logical_workflow_id": "wf-1", "run_id": "", "terminal_outcome": "failed"},
+        "malformed-row",
+    ]
+    items = reconcile_missing_governance_reports(executions, known_report_ids=["govrep_x"])
+    assert [item["run_id"] for item in items] == ["run-1"]
+
+
+def test_legacy_record_shape_without_governance_keys_stays_compatible() -> None:
+    legacy = {"workflow_id": "wf-legacy", "run_id": "run-legacy", "state": "failed"}
+    result = finalize_governance_for_terminal_execution(legacy)
+    assert result["canonical_outcome"] == "failed"
+    assert result["report"] is not None

--- a/tests/unit/governance/test_run_reports.py
+++ b/tests/unit/governance/test_run_reports.py
@@ -1,0 +1,254 @@
+"""Unit tests for per-run evidence-backed governance reports (MoonMind#3969)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from moonmind.governance.run_reports import (
+    GOVERNANCE_REPORT_CONTRACT_VERSION,
+    GovernanceReportError,
+    GovernanceReportStore,
+    ReportGenerationStatus,
+    authorize_governance_report_access,
+    build_governance_report,
+    build_input_digest,
+    build_workflow_detail_governance_link,
+    finalize_governance_report,
+    reconcile_missing_reports,
+    render_governance_report_markdown,
+    review_outcome_is_approved,
+    scan_outcome_is_pass,
+)
+
+CANARY = "ghp_canaryValue1234567890abcdef"
+CANARY_KEY = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----"
+
+
+def _evidence(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "logical_workflow_id": "wf-3930",
+        "run_id": "run-001",
+        "attempt": 0,
+        "terminal_outcome": "succeeded",
+        "created_at": "2026-09-01T10:00:00Z",
+        "evidence_cutoff": "2026-09-01T10:05:00Z",
+        "completeness": "complete",
+        "owner": "owner-1",
+        "policy": {"provenance": "observed", "ref": "policy:v3", "source": "policy-store"},
+        "profile": {"provenance": "observed", "ref": "profile:prod"},
+        "image": {"provenance": "observed", "ref": "image:sha256-abc"},
+        "credentials": [
+            {"lease_ref": "lease-1", "ownership": "run_owned", "state": "released"},
+            {"lease_ref": "lease-2", "ownership": "profile_owned", "state": "active"},
+        ],
+        "egress": [{"destination_ref": "api.provider.example:443", "decision": "allow", "policy_ref": "egress:v2"}],
+        "container_jobs": [{"job_ref": "job-1", "status": "succeeded"}],
+        "approvals": [{"review_ref": "review-1", "outcome": "approved"}],
+        "outbound_scans": [
+            {
+                "surface": "chat.openai.messages[0].content",
+                "outcome": "pass",
+                "finding_categories": [],
+                "location_refs": ["chat.openai.messages[0].content"],
+            }
+        ],
+        "workspace_changes": [{"change_ref": "art-change-1", "status": "applied"}],
+        "publications": [{"publication_ref": "pub-1", "status": "published"}],
+        "cleanup": {"provenance": "observed", "disposition": "succeeded"},
+        "spend_usage": {"provenance": "unavailable", "measurements": []},
+        "source_artifact_digests": {"primary": "a" * 32},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_terminal_outcomes_each_produce_report_or_recoverable_status() -> None:
+    for outcome in ("succeeded", "failed", "cancelled", "timed_out"):
+        final = finalize_governance_report(_evidence(terminal_outcome=outcome), store=GovernanceReportStore())
+        assert final.canonical_outcome == outcome
+        assert final.canonical_outcome_preserved is True
+        assert final.report is not None
+        assert final.report["terminal_outcome"] == outcome
+
+
+def test_deterministic_fixture_matches_json_and_rendering_with_missing_states() -> None:
+    evidence = _evidence(
+        credentials=[],
+        egress=[],
+        approvals=[],
+        outbound_scans=[],
+        cleanup=None,
+        completeness="partial",
+    )
+    first = build_governance_report(evidence)
+    second = build_governance_report(json.loads(json.dumps(evidence)))
+    assert first == second
+    assert first["contract_version"] == GOVERNANCE_REPORT_CONTRACT_VERSION
+    assert first["status"] == "partial"
+    assert first["credentials"]["provenance"] == "unavailable"
+    assert first["egress"]["provenance"] == "unavailable"
+    assert first["cleanup"]["disposition"] == "unknown"
+    assert first["cleanup"]["provenance"] == "pending"
+    assert "unavailable is never a pass" in render_governance_report_markdown(first)
+    assert "not" in first["egress"]["coverage_note"].lower() or "only" in first["egress"]["coverage_note"]
+    # Deterministic serialization: sorted-keys canonical bytes are stable.
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_duplicate_finalization_reuses_result_and_late_evidence_supersedes() -> None:
+    store = GovernanceReportStore()
+    evidence = _evidence()
+    first = finalize_governance_report(evidence, store=store)
+    second = finalize_governance_report(evidence, store=store)
+    assert first.report is not None and second.report is not None
+    assert first.report["report_id"] == second.report["report_id"]
+    assert len(store) == 1
+
+    superseded = store.supersede(
+        first.report["report_id"],
+        _evidence(evidence_cutoff="2026-09-01T11:00:00Z", completeness="complete"),
+    )
+    assert superseded["supersedes"] == first.report["report_id"]
+    assert superseded["report_id"] != first.report["report_id"]
+    assert superseded["logical_workflow_id"] == "wf-3930"
+    assert superseded["run_id"] == "run-001"
+    assert store.get(first.report["report_id"]) is not None
+    assert len(store) == 2
+
+
+def test_store_failure_cancellation_and_partial_cleanup_stay_auxiliary() -> None:
+    failing = GovernanceReportStore(fail_writes=True)
+    failed = finalize_governance_report(_evidence(), store=failing)
+    assert failed.report is None
+    assert failed.canonical_outcome == "succeeded"
+    assert failed.canonical_outcome_preserved is True
+    assert isinstance(failed.generation_status, ReportGenerationStatus)
+    assert failed.generation_status.status == "failed"
+    assert failed.generation_status.recoverable is True
+    assert failed.generation_status.reason_code == "REPORT_STORE_UNAVAILABLE"
+
+    cancelled = finalize_governance_report(_evidence(), store=GovernanceReportStore(), cancelled_during_finalization=True)
+    assert cancelled.report is None
+    assert cancelled.canonical_outcome == "succeeded"
+    assert cancelled.generation_status is not None
+    assert cancelled.generation_status.status == "pending"
+    assert cancelled.generation_status.reason_code == "CANCELLED_DURING_FINALIZATION"
+
+    partial = build_governance_report(_evidence(cleanup={"provenance": "observed", "disposition": "partial"}))
+    assert partial["cleanup"]["disposition"] == "partial"
+    assert partial["status"] == "ready"  # completeness complete; cleanup stays partial, not rewritten
+
+
+def test_canaries_absent_from_output_rendering_diagnostics_and_logs() -> None:
+    with pytest.raises(GovernanceReportError):
+        build_governance_report(_evidence(annotation=CANARY))
+    with pytest.raises(GovernanceReportError):
+        build_governance_report(_evidence(policy={"provenance": "observed", "ref": CANARY}))
+    with pytest.raises(GovernanceReportError):
+        build_governance_report(_evidence(credentials=[{"lease_ref": "l", "ownership": "run_owned", "state": CANARY_KEY}]))
+    with pytest.raises(GovernanceReportError):
+        build_governance_report(_evidence(**{"api_key": "x"}))
+
+    report = build_governance_report(_evidence())
+    blob = json.dumps(report) + render_governance_report_markdown(report)
+    assert "ghp_" not in blob
+    assert "PRIVATE KEY" not in blob
+
+
+def test_access_expiry_digest_and_malformed_sources_have_safe_outcomes() -> None:
+    report = build_governance_report(_evidence())
+    assert authorize_governance_report_access(report, requester_owner="owner-1").allowed is True
+
+    wrong_owner = authorize_governance_report_access(report, requester_owner="owner-2")
+    assert (wrong_owner.allowed, wrong_owner.code) == (False, "WRONG_OWNER")
+
+    expired = authorize_governance_report_access(
+        report, requester_owner="owner-1", now=datetime(2027, 12, 1, tzinfo=UTC)
+    )
+    assert (expired.allowed, expired.code) == (False, "EVIDENCE_EXPIRED")
+
+    mismatch = authorize_governance_report_access(
+        report, requester_owner="owner-1", expected_digests={"primary": "b" * 32}
+    )
+    assert (mismatch.allowed, mismatch.code) == (False, "DIGEST_MISMATCH")
+
+    malformed = authorize_governance_report_access({"report_kind": "nope"}, requester_owner="owner-1")
+    assert (malformed.allowed, malformed.code) == (False, "MALFORMED_SOURCE")
+
+    with pytest.raises(GovernanceReportError, match="MALFORMED_SOURCE"):
+        build_governance_report(_evidence(terminal_outcome="exploded"))
+    with pytest.raises(GovernanceReportError, match="MALFORMED_SOURCE"):
+        build_governance_report(_evidence(source_artifact_digests={"primary": "not-a-digest"}))
+
+
+def test_missing_scans_reviews_never_upgrade_to_pass_or_approval() -> None:
+    assert scan_outcome_is_pass({"outcome": "unavailable"}) is False
+    assert scan_outcome_is_pass({"outcome": "pending"}) is False
+    assert scan_outcome_is_pass({"outcome": "pass"}) is True
+    assert review_outcome_is_approved({"outcome": "unavailable"}) is False
+    assert review_outcome_is_approved({"outcome": "approved"}) is True
+
+    report = build_governance_report(_evidence(outbound_scans=[], approvals=[]))
+    assert report["outbound_scans"]["provenance"] == "unavailable"
+    assert report["approvals"]["provenance"] == "unavailable"
+    rendered = render_governance_report_markdown(report)
+    assert "PASS" not in rendered
+    assert "unavailable is never a pass" in rendered
+
+
+def test_reconciler_is_bounded_and_skips_known_reports() -> None:
+    executions = [
+        {"logical_workflow_id": "wf-1", "run_id": "run-1", "attempt": 0, "terminal_outcome": "succeeded"},
+        {"logical_workflow_id": "wf-1", "run_id": "run-2", "attempt": 1, "terminal_outcome": "timed_out", "report_id": "govrep_x"},
+        {"logical_workflow_id": "wf-1", "run_id": "", "terminal_outcome": "failed"},
+        {"logical_workflow_id": "wf-1", "run_id": "run-3", "terminal_outcome": "exploded"},
+    ]
+    items = reconcile_missing_reports(executions, known_report_ids=["govrep_x"])
+    assert [item["run_id"] for item in items] == ["run-1"]
+    assert items[0]["reason"] == "missing_report_after_terminal_outcome"
+
+
+def test_workflow_detail_link_statuses_and_authorized_download() -> None:
+    report = build_governance_report(_evidence())
+    link = build_workflow_detail_governance_link(
+        logical_workflow_id="wf-3930",
+        report=report,
+        download_ref={"artifact_ref_v": 1, "artifact_id": "art-report-1"},
+    )
+    assert link.status == "ready"
+    assert "wf-3930" in link.href
+    assert link.download_ref == {"artifact_ref_v": 1, "artifact_id": "art-report-1"}
+
+    pending = build_workflow_detail_governance_link(
+        logical_workflow_id="wf-3930",
+        generation_status=ReportGenerationStatus(status="pending", reason_code="REPORT_PENDING"),
+    )
+    assert pending.status == "pending"
+    assert "never claim unresolved cleanup succeeded" in pending.explanation
+
+    historical = build_workflow_detail_governance_link(
+        logical_workflow_id="wf/gone", report=build_governance_report(_evidence(cleanup=None))
+    )
+    assert historical.status == "partial"
+    assert CANARY not in historical.explanation
+
+
+def test_input_digest_and_report_identity_are_stable() -> None:
+    evidence = _evidence()
+    assert build_input_digest({"a": 1}) == build_input_digest({"a": 1})
+    assert build_governance_report(evidence)["report_id"] == build_governance_report(evidence)["report_id"]
+    other = build_governance_report(_evidence(evidence_cutoff="2026-09-01T12:00:00Z"))
+    assert other["report_id"] != build_governance_report(evidence)["report_id"]
+
+
+def test_evidence_ttl_boundary() -> None:
+    report = build_governance_report(_evidence(evidence_cutoff="2026-09-01T10:05:00Z"))
+    cutoff = datetime(2026, 9, 1, 10, 5, tzinfo=UTC)
+    inside = cutoff + timedelta(hours=24 * 30) - timedelta(seconds=1)
+    outside = cutoff + timedelta(hours=24 * 30) + timedelta(seconds=1)
+    assert authorize_governance_report_access(report, requester_owner="owner-1", now=inside).code == "OK"
+    assert authorize_governance_report_access(report, requester_owner="owner-1", now=outside).code == "EVIDENCE_EXPIRED"

--- a/tests/unit/governance/test_run_reports.py
+++ b/tests/unit/governance/test_run_reports.py
@@ -161,9 +161,12 @@ def test_canaries_absent_from_output_rendering_diagnostics_and_logs() -> None:
 
 def test_access_expiry_digest_and_malformed_sources_have_safe_outcomes() -> None:
     report = build_governance_report(_evidence())
-    assert authorize_governance_report_access(report, requester_owner="owner-1").allowed is True
+    # Frozen clock inside the 30-day retention window: the fixture cutoff is
+    # fixed, so the live clock must not decide this assertion.
+    now = datetime(2026, 9, 15, tzinfo=UTC)
+    assert authorize_governance_report_access(report, requester_owner="owner-1", now=now).allowed is True
 
-    wrong_owner = authorize_governance_report_access(report, requester_owner="owner-2")
+    wrong_owner = authorize_governance_report_access(report, requester_owner="owner-2", now=now)
     assert (wrong_owner.allowed, wrong_owner.code) == (False, "WRONG_OWNER")
 
     expired = authorize_governance_report_access(
@@ -172,7 +175,7 @@ def test_access_expiry_digest_and_malformed_sources_have_safe_outcomes() -> None
     assert (expired.allowed, expired.code) == (False, "EVIDENCE_EXPIRED")
 
     mismatch = authorize_governance_report_access(
-        report, requester_owner="owner-1", expected_digests={"primary": "b" * 32}
+        report, requester_owner="owner-1", now=now, expected_digests={"primary": "b" * 32}
     )
     assert (mismatch.allowed, mismatch.code) == (False, "DIGEST_MISMATCH")
 
@@ -252,3 +255,94 @@ def test_evidence_ttl_boundary() -> None:
     outside = cutoff + timedelta(hours=24 * 30) + timedelta(seconds=1)
     assert authorize_governance_report_access(report, requester_owner="owner-1", now=inside).code == "OK"
     assert authorize_governance_report_access(report, requester_owner="owner-1", now=outside).code == "EVIDENCE_EXPIRED"
+
+
+def test_input_digest_binds_every_report_affecting_field() -> None:
+    base = build_governance_report(_evidence())
+    for field, value in (
+        ("annotation", "operator note"),
+        ("owner", "owner-2"),
+        ("completeness", "partial"),
+        ("created_at", "2026-09-01T11:00:00Z"),
+        ("supersedes", "govrep_" + "c" * 32),
+    ):
+        other = build_governance_report(_evidence(**{field: value}))
+        assert other["report_id"] != base["report_id"], field
+        assert other["input_digest"] != base["input_digest"], field
+
+
+def test_store_returns_deep_immutable_copies() -> None:
+    store = GovernanceReportStore()
+    final = finalize_governance_report(_evidence(), store=store)
+    assert final.report is not None
+    report_id = final.report["report_id"]
+    final.report["policy"]["ref"] = "mutated"
+    stored = store.get(report_id)
+    assert stored is not None
+    assert stored["policy"]["ref"] == "policy:v3"
+    stored["policy"]["ref"] = "mutated-again"
+    fresh = store.get(report_id)
+    assert fresh is not None
+    assert fresh["policy"]["ref"] == "policy:v3"
+
+
+def test_supersede_keeps_the_superseded_run_identity() -> None:
+    store = GovernanceReportStore()
+    first = finalize_governance_report(_evidence(), store=store)
+    assert first.report is not None
+    foreign = _evidence(
+        logical_workflow_id="wf-other",
+        run_id="run-other",
+        attempt=9,
+        evidence_cutoff="2026-09-01T11:00:00Z",
+    )
+    superseded = store.supersede(first.report["report_id"], foreign)
+    assert superseded["supersedes"] == first.report["report_id"]
+    assert superseded["logical_workflow_id"] == "wf-3930"
+    assert superseded["run_id"] == "run-001"
+    assert superseded["attempt"] == 0
+
+
+def test_reconciler_skips_malformed_attempt_rows() -> None:
+    executions = [
+        {"logical_workflow_id": "wf-1", "run_id": "run-bad", "attempt": "not-an-int", "terminal_outcome": "succeeded"},
+        {"logical_workflow_id": "wf-1", "run_id": "run-good", "attempt": 2, "terminal_outcome": "failed"},
+    ]
+    items = reconcile_missing_reports(executions)
+    assert [item["run_id"] for item in items] == ["run-good"]
+    assert items[0]["attempt"] == 2
+
+
+def test_governance_link_encodes_workflow_id_without_aliasing() -> None:
+    report = build_governance_report(_evidence())
+    link = build_workflow_detail_governance_link(logical_workflow_id="team/run?x#y", report=report)
+    assert "team/run" not in link.href.split("/workflows/", 1)[1].split("?", 1)[0]
+    assert "team%2Frun%3Fx%23y" in link.href
+    assert link.href.startswith("/workflows/team%2Frun%3Fx%23y/evidence?report=")
+
+    slash = build_workflow_detail_governance_link(logical_workflow_id="team/run", report=report)
+    underscore = build_workflow_detail_governance_link(logical_workflow_id="team_run", report=report)
+    assert slash.href != underscore.href
+
+
+def test_cleanup_succeeded_requires_observed_evidence() -> None:
+    with pytest.raises(GovernanceReportError, match="observed"):
+        build_governance_report(_evidence(cleanup={"provenance": "unavailable", "disposition": "succeeded"}))
+    assert (
+        build_governance_report(_evidence(cleanup={"provenance": "observed", "disposition": "succeeded"}))["status"]
+        == "ready"
+    )
+
+
+def test_future_evidence_cutoff_fails_closed() -> None:
+    report = build_governance_report(_evidence(evidence_cutoff="2026-09-01T10:05:00Z"))
+    future_now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    result = authorize_governance_report_access(report, requester_owner="owner-1", now=future_now)
+    assert (result.allowed, result.code) == (False, "EVIDENCE_EXPIRED")
+
+
+def test_unresolved_cleanup_is_partial_not_ready() -> None:
+    report = build_governance_report(_evidence(cleanup=None))
+    assert report["completeness"] == "complete"
+    assert report["status"] == "partial"
+    assert report["cleanup"] == {"provenance": "pending", "disposition": "unknown", "detail_ref": None}

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -3394,10 +3394,13 @@ async def test_record_terminal_state_fans_out_dependency_resolution_signals(
         assert source.state is MoonMindWorkflowState.COMPLETED
         assert source.close_status is TemporalExecutionCloseStatus.COMPLETED
         assert source.finish_outcome_code == "SUCCESS"
-        assert source.finish_summary_json == {
-            "finishOutcome": {"code": "SUCCESS"},
-            "artifacts": {"count": 1},
-        }
+        assert source.finish_summary_json["finishOutcome"] == {"code": "SUCCESS"}
+        assert source.finish_summary_json["artifacts"] == {"count": 1}
+        governance = source.finish_summary_json["governanceReport"]
+        assert governance["canonical_outcome"] == "succeeded"
+        assert governance["report_id"].startswith("govrep_")
+        assert governance["status"] == "partial"
+        assert governance["link"]["status"] == "partial"
         mock_client_adapter.signal_workflow.assert_awaited_once()
         assert mock_client_adapter.signal_workflow.await_args.args[0] == (
             dependent.workflow_id
@@ -3473,7 +3476,11 @@ async def test_record_terminal_state_updates_projection_only_child_workflow(
         assert result.close_status is TemporalExecutionCloseStatus.FAILED
         assert result.closed_at is not None
         assert result.finish_outcome_code == "FAILED"
-        assert result.finish_summary_json == {"finishOutcome": {"code": "FAILED"}}
+        assert result.finish_summary_json["finishOutcome"] == {"code": "FAILED"}
+        governance = result.finish_summary_json["governanceReport"]
+        assert governance["canonical_outcome"] == "failed"
+        assert governance["report_id"].startswith("govrep_")
+        assert governance["status"] == "partial"
         assert result.memo["summary"] == (
             "execution_error: codex app-server closed unexpectedly"
         )
@@ -3707,10 +3714,24 @@ async def test_record_terminal_state_derives_snake_case_finish_outcome_code(
         )
         assert source is not None
         assert source.finish_outcome_code == "PUBLISH_DISABLED"
-        assert source.finish_summary_json == finish_summary
+        assert source.finish_summary_json["finish_outcome"] == {
+            "code": "PUBLISH_DISABLED",
+            "stage": "publish",
+            "reason": "publishing disabled",
+        }
+        snake_governance = source.finish_summary_json["governanceReport"]
+        assert snake_governance["canonical_outcome"] == "succeeded"
+        assert snake_governance["report_id"].startswith("govrep_")
         assert isinstance(projection, TemporalExecutionRecord)
         assert projection.finish_outcome_code == "PUBLISH_DISABLED"
-        assert projection.finish_summary_json == finish_summary
+        assert projection.finish_summary_json["finish_outcome"] == {
+            "code": "PUBLISH_DISABLED",
+            "stage": "publish",
+            "reason": "publishing disabled",
+        }
+        assert projection.finish_summary_json["governanceReport"]["report_id"] == (
+            snake_governance["report_id"]
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Implements MoonLadderStudios/MoonMind#3969: one inspectable per-run evidence-backed governance report from existing authoritative evidence.

- Versioned JSON contract (`run_governance_report`, v1) with logical workflow/run/attempt identity, creation time, policy/profile/image refs, evidence cutoff, completeness state, source artifact digests, and bounded sections (credentials/egress/container jobs/approvals/outbound scans/workspace changes/publications/cleanup/spend usage). Markdown rendering generated from the same JSON.
- Explicit provenance states (observed/unavailable/unsupported/not_applicable/pending); missing data never becomes zero-actions, pass, or approval granted.
- Allowlisted bounded serializer; no raw credentials, prompts, transcripts, sensitive URLs, or unbounded content. Synthetic canaries rejected in all paths.
- Terminal-outcome finalization for succeeded/failed/cancelled/timed_out plus bounded pure-function reconciler for crash-before-finalization; reporting failure stays auxiliary.
- Idempotent identity with immutable writes and supersedes versioning; preserves run/attempt continuity.
- Workflow Detail governance link helpers (ready/partial/pending/failed) with safe explanations and authorized download.
- Canonical observation-boundary doc at docs/Governance/RunGovernanceReports.md.

## Verification outcome
Controlling post-remediation moonspec-verify verdict in artifacts/github-issue-implement-verify.json: **FULLY_IMPLEMENTED** (HIGH confidence) at 10b0c6e46. All 7 plan requirements + acceptance verified by direct code inspection plus direct execution; no gaps remain.

## Tests run
- Direct-execution harness over moonmind.governance.run_reports (terminal outcomes, determinism, idempotency/supersede, auxiliary failure, canary rejection, access control, no-upgrade predicates, reconciler, detail link): PASS (8/8 behavior groups).
- tools/test_unit.sh tests/unit/governance/test_run_reports.py: NOT RUN in this runtime (no pytest module); 11 tests present covering terminal outcomes, fixture determinism, resilience, canary absence, safe errors, truthful coverage.
- Frontend governanceReport.test.ts: NOT RUN (no node_modules); presentation-only mapping verified by inspection.

## Remaining risks
- Unit and frontend suites still need CI execution to confirm hermetic pass.
- Historical interpretability after host removal/profile rotation relies on stored refs; expired evidence surfaces as explicit unavailable states by design.
- Spend/usage depends on provider-reported vs estimate/unavailable distinction; account-wide completeness is explicitly not claimed.

Closes MoonLadderStudios/MoonMind#3969