### PR TITLE
[Docs] Revalidate DocsReview findings and repair high-value defects (MoonLadderStudios/MoonMind#3966)

### DIFF
--- a/docs/Artifacts/ReportArtifacts.md
+++ b/docs/Artifacts/ReportArtifacts.md
@@ -1,5 +1,6 @@
 # Report Artifacts
 
+**Document Class:** Module Contract Specification
 Status: Adopted (implemented)
 Owners: MoonMind Platform + Dashboard
 Last updated: 2026-05-15
@@ -37,9 +38,9 @@ Instead, it defines:
 
 - `docs/Temporal/WorkflowArtifactSystemDesign.md`
   - Owns artifact identity, storage, linkage, retention, authorization, and lifecycle.
-- `docs/Temporal/ArtifactPresentationContract.md`
+- `docs/Artifacts/ArtifactPresentationContract.md`
   - Owns generic artifact presentation, preview behavior, metadata hints, and rendering rules.
-- `docs/ManagedAgents/LiveLogs.md`
+- `docs/Observability/LiveLogs.md`
   - Owns observability, live tails, stdout/stderr, diagnostics, and session-aware run timelines.
 - `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
   - Owns canonical runtime result contracts such as `AgentRunHandle`, `AgentRunStatus`, and `AgentRunResult`.

--- a/docs/DocumentationArchitectureValidation.md
+++ b/docs/DocumentationArchitectureValidation.md
@@ -36,6 +36,38 @@ python tools/check_documentation_architecture.py docs/MyNewView.md
 
 By default it scopes to **new/changed** docs (`git diff` vs `--base`, default `origin/main`) so it focuses on what a change introduces; `--scope all` audits the full tree. If git is unavailable it falls back to a full scan.
 
+## 3b. Bounded local link validation (separate helper)
+
+Local link and anchor correctness is **not** covered by the architecture
+checker above: a zero exit code there is not zero broken links. Bounded
+local-link validation lives in the separate helper
+`tools/check_documentation_links.py` (deliverable of
+MoonLadderStudios/MoonMind#3966), also **advisory-only** (exits `0`
+regardless of findings; `--strict` is reserved for a future gate and must
+not run in CI):
+
+```bash
+# Advisory scan of docs changed vs origin/main (default):
+python tools/check_documentation_links.py
+
+# Scan the canonical in-scope docs/ tree:
+python tools/check_documentation_links.py --scope all
+
+# Machine-readable output (structured warnings):
+python tools/check_documentation_links.py --scope all --format json
+```
+
+Documented scope: canonical docs per the same `is_canonical_doc`
+definition, minus frozen review evidence that is dispositioned rather than
+repaired in place (`docs/DocsReview.md`, the 2026-08-11 review snapshot,
+and `docs/tmp/historical/`). Fenced code examples are classified
+separately, not link-checked (an `../X.md` path inside an example may be
+correct for a `docs/tmp/` working document). External URLs are counted,
+never fetched. Rules: `broken-local-link` (relative paths, images,
+reference-definition targets; case-sensitive on the Linux checkout),
+`broken-local-anchor` (GitHub-slug heading or explicit `<a name|id>`
+match), and `undefined-link-reference`.
+
 ## 3. What it checks
 
 Each check maps to one acceptance criterion of MM-908 and emits a finding with a stable `rule` id:

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -1,12 +1,13 @@
 # Codex CLI Managed Sessions
 
+**Document Class:** Module Contract Specification
 Status: Desired state  
 Owners: MoonMind Platform  
 Last updated: 2026-08-10
 Related:
 
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
-- [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
+- [`docs/Artifacts/ArtifactPresentationContract.md`](../Artifacts/ArtifactPresentationContract.md)
 - [`docs/ManagedAgents/DockerBackendService.md`](./DockerBackendService.md)
 - [`docs/Steps/SkillSystem.md`](../Steps/SkillSystem.md)
 

--- a/docs/ManagedAgents/ManagedAgentArchitecture.md
+++ b/docs/ManagedAgents/ManagedAgentArchitecture.md
@@ -1,5 +1,6 @@
 # Managed Agent Architecture
 
+**Document Class:** Module Architecture View
 - **Status:** Desired state
 - **Audience:** Contributors, operators, runtime authors, and integration authors
 - **Purpose:** Subsystem architecture entrypoint for MoonMind managed agents and managed sessions
@@ -12,7 +13,7 @@
 - [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
 - [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/ManagedAgents/ClaudeCodeManagedSessions.md`](./ClaudeCodeManagedSessions.md)
-- [`docs/ManagedAgents/LiveLogs.md`](./LiveLogs.md)
+- [`docs/Observability/LiveLogs.md`](../Observability/LiveLogs.md)
 - [`docs/ManagedAgents/DockerBackendService.md`](./DockerBackendService.md)
 - [`docs/ManagedAgents/OAuthTerminal.md`](./OAuthTerminal.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)

--- a/docs/ManagedAgents/ManagedAgentsAuthentication.md
+++ b/docs/ManagedAgents/ManagedAgentsAuthentication.md
@@ -21,5 +21,5 @@
 | Selection and assignment | [ProviderProfiles.md §8–9](../Security/ProviderProfiles.md) |
 | Materialization pipeline | [ProviderProfiles.md §10](../Security/ProviderProfiles.md) |
 | Security requirements | [ProviderProfiles.md §12](../Security/ProviderProfiles.md) |
-| OAuth session UX | [TmateArchitecture.md](TmateArchitecture.md), [OAuthTerminal.md](OAuthTerminal.md) |
+| OAuth session UX | [OAuthTerminal.md](OAuthTerminal.md) |
 | OAuth volume provisioning scripts | `tools/auth-codex-volume.sh`, `tools/auth-claude-volume.sh` |

--- a/docs/ManagedAgents/ManagedRuntimeCleanup.md
+++ b/docs/ManagedAgents/ManagedRuntimeCleanup.md
@@ -13,7 +13,7 @@
 - [`docs/ManagedAgents/DockerSidecarRuntime.md`](./DockerSidecarRuntime.md)
 - [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
 - [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
-- [`docs/ManagedAgents/LiveLogs.md`](./LiveLogs.md)
+- [`docs/Observability/LiveLogs.md`](../Observability/LiveLogs.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 
 ---

--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -1,5 +1,6 @@
 # OAuth Terminal and Managed Session Auth Volumes
 
+**Document Class:** Module Contract Specification
 **Replaces:** `docs/ManagedAgents/TmateArchitecture.md`
 **Status:** Desired state, Codex CLI and Claude Code session target
 **Owners:** MoonMind Engineering
@@ -10,7 +11,7 @@ Related:
 - [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
-- [`docs/ManagedAgents/LiveLogs.md`](./LiveLogs.md)
+- [`docs/Observability/LiveLogs.md`](../Observability/LiveLogs.md)
 
 ## 1. Purpose
 

--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -1,5 +1,6 @@
 # Shared Managed Agent Abstractions
 
+**Document Class:** Module Contract Specification
 - **Status:** Desired state
 - **Audience:** Runtime authors, workflow authors, adapter authors, and dashboard authors
 - **Purpose:** Runtime-neutral contract layer underneath the managed-agent architecture entrypoint
@@ -10,7 +11,7 @@
 - [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
 - [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/ManagedAgents/ClaudeCodeManagedSessions.md`](./ClaudeCodeManagedSessions.md)
-- [`docs/ManagedAgents/LiveLogs.md`](./LiveLogs.md)
+- [`docs/Observability/LiveLogs.md`](../Observability/LiveLogs.md)
 - [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/Security/SecretsSystem.md`](../Security/SecretsSystem.md)
@@ -634,6 +635,6 @@ Use the managed-agent docs as follows:
 - [`CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md) is the current Codex runtime-specific architecture entrypoint.
 - [`CodexCliManagedSessions.md`](./CodexCliManagedSessions.md) defines Codex-specific session details.
 - [`ClaudeCodeManagedSessions.md`](./ClaudeCodeManagedSessions.md) defines Claude Code-specific session details.
-- [`LiveLogs.md`](./LiveLogs.md) defines session-aware observability.
+- [`LiveLogs.md`](../Observability/LiveLogs.md) defines session-aware observability.
 
 Canonical docs should stay focused on target architecture and contracts. Migration notes, rollout sequencing, and incomplete implementation checklists belong under `local-only handoffs`.

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -1,5 +1,6 @@
 # MoonMind Architecture
 
+**Document Class:** System Architecture View
 Codex managed-runtime support is governed by the versioned
 [`CodexSupportAndCutover`](./Omnigent/CodexSupportAndCutover.md) contract.
 Codex-through-Omnigent is currently opt-in pending complete protected-live
@@ -614,7 +615,7 @@ Engine endpoint without changing public tools.
 - [`Temporal/ManagedAndExternalAgentExecutionModel.md`](Temporal/ManagedAndExternalAgentExecutionModel.md): true agent execution lifecycle and canonical contracts.
 - [`ManagedAgents/ManagedAgentArchitecture.md`](ManagedAgents/ManagedAgentArchitecture.md): managed-agent and managed-session subsystem.
 - [`ManagedAgents/CodexCliManagedSessions.md`](ManagedAgents/CodexCliManagedSessions.md): Codex session binding.
-- [`ManagedAgents/LiveLogs.md`](ManagedAgents/LiveLogs.md): session-aware log and
+- [`Observability/LiveLogs.md`](Observability/LiveLogs.md): session-aware log and
   observability contract.
 - [`ManagedAgents/DockerBackendService.md`](ManagedAgents/DockerBackendService.md):
   container-job API, backend, image cache, workspace, and cleanup contract.

--- a/docs/Observability/LiveLogs.md
+++ b/docs/Observability/LiveLogs.md
@@ -1,5 +1,6 @@
 # Live Logs and Session-Aware Run Observability in MoonMind
 
+**Document Class:** Module Contract Specification
 Status: Desired state
 Owners: MoonMind Platform
 Last updated: 2026-04-08
@@ -9,9 +10,9 @@ Last updated: 2026-04-08
 - `specs/084-live-log-tailing/spec.md`
 
 **Related:**
-- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](../ManagedAgents/CodexCliManagedSessions.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
-- [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
+- [`docs/Artifacts/ArtifactPresentationContract.md`](../Artifacts/ArtifactPresentationContract.md)
 - 
 
 ## 1. Summary

--- a/docs/Omnigent/CombinedStackValidationAndRollback.md
+++ b/docs/Omnigent/CombinedStackValidationAndRollback.md
@@ -19,7 +19,7 @@ phase stays available without rewriting those immutable per-run snapshots.
 **Audience:** Local and self-hosted MoonMind operators  
 **Authority:** Operator-facing startup, validation, rollback, and troubleshooting behavior for the combined MoonMind plus Omnigent Docker Compose stack  
 **Owning Surface:** Canonical `docker-compose.yaml`, its supported profiles, and workflow-requested profile-bound Codex hosts  
-**Related Docs:** [MoonMind vs Omnigent](MoonMindVsOmnigent.md), [MoonMind Architecture](../MoonMindArchitecture.md), [Omnigent Adapter](OmnigentAdapter.md), [Omnigent Host OAuth](OmnigentHostOAuth.md), [Omnigent Conformance](ConformanceAndLiveSmoke.md)  
+**Related Docs:** [MoonMind Architecture](../MoonMindArchitecture.md), [Omnigent Adapter](OmnigentAdapter.md), [Omnigent Host OAuth](OmnigentHostOAuth.md), [Omnigent Conformance](ConformanceAndLiveSmoke.md)  
 **Related Implementation:** MM-972, source issue MM-968, coverage DESIGN-REQ-019 through DESIGN-REQ-022, DESIGN-REQ-010, DESIGN-REQ-018
 
 ## Purpose

--- a/docs/Temporal/StepLedgerAndProgressModel.md
+++ b/docs/Temporal/StepLedgerAndProgressModel.md
@@ -1,5 +1,6 @@
 # Step Ledger and Progress Model
 
+**Document Class:** Module Contract Specification
 Status: Normative  
 Owners: MoonMind Platform + Dashboard  
 Last updated: 2026-06-13
@@ -22,7 +23,7 @@ This document does **not** redefine plan syntax, artifact storage internals, or 
 
 - `docs/Workflows/SkillAndPlanContracts.md`
 - `docs/Temporal/WorkflowArtifactSystemDesign.md`
-- `docs/ManagedAgents/LiveLogs.md`
+- `docs/Observability/LiveLogs.md`
 
 ## 2. Core model
 

--- a/docs/Temporal/TemporalAgentExecution.md
+++ b/docs/Temporal/TemporalAgentExecution.md
@@ -1,5 +1,6 @@
 # Temporal Agent Execution
 
+**Document Class:** Module Architecture View
 **Status:** Active design
 **Owner:** MoonMind Platform  
 **Last updated:** 2026-03-19
@@ -13,12 +14,11 @@ receive agent work - whether a registered **tool** invocation (currently a
 execute it end to end.
 
 It maps every step from HTTP submission through the Temporal workflow, into the
-relevant activity workers, and back. Open migration gaps are tracked in
-`docs/Temporal/RemainingWork.md`.
+relevant activity workers, and back. Completed migration cutovers are recorded in
+the [`MM-730 hard-switch cutover release note`](../ReleaseNotes/MM-730-hard-switch-cutover.md).
 
 For broader architecture context see
-[TemporalArchitecture.md](TemporalArchitecture.md) and
-[RemainingWork.md](RemainingWork.md). Required execution capability semantics
+[TemporalArchitecture.md](TemporalArchitecture.md). Required execution capability semantics
 are canonical in [RequiredCapabilities.md](../Workflows/RequiredCapabilities.md):
 the normalized `requiredCapabilities` list is a hard pre-launch readiness
 contract, not an authorization grant or informational label.
@@ -279,9 +279,9 @@ Serialized payload form (legacy accepted): `{ id, skill: { name }, inputs: {...}
 
 ## 5. Remaining Work
 
-The execution-stage work items formerly listed here are now implemented. The
-canonical open backlog is maintained in
-[`docs/Temporal/RemainingWork.md`](RemainingWork.md).
+The execution-stage work items formerly listed here are now implemented. Open
+product and rollout sequencing, if any, belongs in `docs/tmp/` or the owning
+module tracker — not in a `RemainingWork.md` file that no longer exists.
 
 ---
 

--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -1,5 +1,6 @@
 # Temporal Architecture
 
+**Document Class:** Module Architecture View
 **Implementation tracking:** Rollout, backlog, one-off implementation notes, migration checklists, and work sequencing live under `docs/tmp/`, issues, pull requests, gitignored handoffs, or local-only files. Canonical `docs/` files describe durable architecture and product contracts.
 
 **Status:** Normative architecture hub (Temporal-native; compatibility projections and hardening work remain repo-visible)
@@ -63,7 +64,7 @@ This document is the architecture hub. Detailed contracts live in:
 - `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
 - `docs/Temporal/VisibilityAndUiQueryModel.md`
 - `docs/Temporal/WorkflowArtifactSystemDesign.md`
-- `docs/Temporal/ArtifactPresentationContract.md`
+- `docs/Artifacts/ArtifactPresentationContract.md`
 - `docs/Temporal/SourceOfTruthAndProjectionModel.md`
 - `docs/Temporal/WorkflowExecutionProductModel.md`
 - `docs/Temporal/TemporalTypeSafety.md`
@@ -74,7 +75,7 @@ This document is the architecture hub. Detailed contracts live in:
 - `docs/Security/SecretsSystem.md`
 - `docs/ManagedAgents/ManagedAgentArchitecture.md`
 - `docs/ManagedAgents/CodexCliManagedSessions.md`
-- `docs/ManagedAgents/LiveLogs.md`
+- `docs/Observability/LiveLogs.md`
 - `docs/ManagedAgents/DockerOutOfDocker.md`
 - `docs/Steps/SkillSystem.md`
 - `docs/MoonMindArchitecture.md`

--- a/docs/UI/WorkflowConsoleArchitecture.md
+++ b/docs/UI/WorkflowConsoleArchitecture.md
@@ -1,5 +1,6 @@
 # Workflow Console Architecture
 
+**Document Class:** Module Architecture View
 Status: Active
 Owners: MoonMind Engineering
 Last updated: 2026-06-10
@@ -36,7 +37,7 @@ Detailed backend contracts live in the Temporal docs. This document defines the 
 - `docs/Temporal/StepLedgerAndProgressModel.md`
 - `docs/Temporal/VisibilityAndUiQueryModel.md`
 - `docs/Temporal/WorkflowArtifactSystemDesign.md`
-- `docs/ManagedAgents/LiveLogs.md` — canonical design for artifact-first logs, MoonMind-owned observability APIs, SSE live follow, and the non-terminal log viewer UI
+- `docs/Observability/LiveLogs.md` — canonical design for artifact-first logs, MoonMind-owned observability APIs, SSE live follow, and the non-terminal log viewer UI
 - `docs/Steps/SkillSystem.md`
 - `docs/UI/DashboardDesignSystem.md`
 - `docs/UI/WorkflowWorkspaceSidebar.md` — addendum for desktop workspace shell, sidebar navigation, list-context preservation, and mobile standalone detail presentation

--- a/docs/Workflows/ImageSystem.md
+++ b/docs/Workflows/ImageSystem.md
@@ -1,5 +1,6 @@
 # Workflow Image Input System
 
+**Document Class:** Module Contract Specification
 Status: Proposed
 Owners: MoonMind Engineering
 Last updated: 2026-04-16
@@ -28,7 +29,7 @@ This document is declarative. It defines the target system contract. It is not a
 - `docs/Workflows/WorkflowArchitecture.md`
 - `docs/Temporal/TemporalArchitecture.md`
 - `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
-- `docs/Temporal/ArtifactPresentationContract.md`
+- `docs/Artifacts/ArtifactPresentationContract.md`
 
 ---
 

--- a/docs/tmp/DocsReviewRevalidationMM3966.md
+++ b/docs/tmp/DocsReviewRevalidationMM3966.md
@@ -1,0 +1,119 @@
+# DocsReview Revalidation Disposition (MoonLadderStudios/MoonMind#3966)
+
+**Document Class:** Imperative working document
+**Status:** Active revalidation record
+**Owner:** MoonMind maintainers
+**Scope/revision:** Full `docs/` tree revalidated against repository revision
+`8504ac360b0e5385419487dfb02106ad8a27ecf9`, plus the working-tree repairs
+landed by this issue. The August 11 counts in `docs/DocsReview.md`
+(21 broken links, 139 advisory findings) are a frozen snapshot at that
+date and **do not apply** to the current revision: the pre-repair full-tree
+architecture scan reported 166 advisory findings (154 after this issue's
+incremental metadata adoption, exit 0), and the bounded link scan
+(`tools/check_documentation_links.py --scope all`) reports 7 advisory
+findings after the repairs below — all in `docs/Rag/`, outside the August
+repair set.
+**Delete/Archive Trigger:** Delete this file when #3966 closes and its
+successor consolidation/disposal children (#3961/#3962/#3963) have landed;
+its durable content is the per-finding owner pointers, which must be
+re-homed before deletion. `docs/DocsReview.md` itself must be preserved
+until every still-applicable item below has a durable owning document.
+
+## 1. Broken-link repair set (DocsReview §"Broken-link repair set")
+
+All targets verified against the actual canonical successor (move commits
+and owning-document migration notes cited); no tombstone documents created.
+
+| # | Source | Old target | Disposition | Canonical successor / evidence |
+|---|---|---|---|---|
+| 1 | `docs/ManagedAgents/ManagedAgentArchitecture.md` | `./LiveLogs.md` | **Fixed** | `../Observability/LiveLogs.md` (moved in `03d21c00e`) |
+| 2 | `docs/ManagedAgents/ManagedRuntimeCleanup.md` | `./LiveLogs.md` | **Fixed** | same as 1 |
+| 3 | `docs/ManagedAgents/OAuthTerminal.md` | `./LiveLogs.md` | **Fixed** | same as 1 |
+| 4 | `docs/ManagedAgents/SharedManagedAgentAbstractions.md` (2x) | `./LiveLogs.md` | **Fixed** | same as 1 |
+| 5 | `docs/MoonMindArchitecture.md` | `ManagedAgents/LiveLogs.md` | **Fixed** | `Observability/LiveLogs.md` |
+| 6 | `docs/ManagedAgents/CodexCliManagedSessions.md` | `../Temporal/ArtifactPresentationContract.md` | **Fixed** | `../Artifacts/ArtifactPresentationContract.md` (owning doc §17.1 declares the Temporal path stale and asks refs to move) |
+| 7 | `docs/Observability/LiveLogs.md` (2x) | `./CodexCliManagedSessions.md`, `../Temporal/ArtifactPresentationContract.md` | **Fixed** | `../ManagedAgents/CodexCliManagedSessions.md`, `../Artifacts/ArtifactPresentationContract.md` |
+| 8 | `docs/Omnigent/CombinedStackValidationAndRollback.md` | `MoonMindVsOmnigent.md` | **Fixed** | No successor: the file was empty when deleted (`354ac483c`). Dead link removed per "remove references to deleted documents rather than creating new tombstones". |
+| 9 | `docs/Temporal/TemporalAgentExecution.md` (3x) | `RemainingWork.md` | **Fixed** | No successor file exists; §5 already states execution-stage items are implemented. Dangling links replaced with the `MM-730` cutover release note and owning-module pointers. |
+| 10 | `docs/ManagedAgents/ManagedAgentsAuthentication.md` | `TmateArchitecture.md` | **Fixed** | `OAuthTerminal.md` (which `Replaces: docs/ManagedAgents/TmateArchitecture.md`); Provider Profiles own the rest |
+| 11 | `docs/DocumentationArchitecture.md` §10 example `../DocumentationArchitecture.md` | — | **Superseded (not a defect)** | Fenced example for an Implementation Plan, which lives in `docs/tmp/` — from there `../DocumentationArchitecture.md` correctly resolves to `docs/DocumentationArchitecture.md`. Fences are classified separately by the link verifier. |
+| 12 | Stale code-span path mentions (`docs/ManagedAgents/LiveLogs.md` in `TemporalArchitecture.md`, `StepLedgerAndProgressModel.md`, `ReportArtifacts.md`, `WorkflowConsoleArchitecture.md`; `docs/Temporal/ArtifactPresentationContract.md` in `TemporalArchitecture.md`, `ReportArtifacts.md`, `ImageSystem.md`) | — | **Fixed** | Same successors as 1 and 6 |
+| 13 | `docs/DocsReview.md` internal `Workflows/Workflow%53tatus.md` (URL-encoded) | — | **Unverified / frozen evidence** | Inside the frozen August snapshot; not repaired in place. Excluded from the link verifier scope with this record as justification. |
+| 14 | `docs/tmp/historical/LiveWorkflowManagement.md` (5x `../ManagedAgents/LiveLogs.md`) | — | **Superseded / frozen evidence** | Archived historical doc superseded by `docs/Observability/LiveLogs.md`; not rewritten. Excluded from the link verifier scope with this record as justification. |
+
+## 2. Architecture-checker findings (full-tree `--scope all`)
+
+August 139 → pre-repair 166 → **154 post-repair** advisory findings (`missing-document-class`,
+`duplicate-claim-id`, `imperative-plan-in-canonical-area`), exit 0
+(advisory-only posture preserved; no rule added, removed, or weakened).
+
+- `missing-document-class` (122): incremental adoption continues — this
+  change adds correct markers to the 10 substantively edited docs that
+  lacked them (Module/System Architecture View and Module Contract
+  Specification per §3 viewpoints). No metadata-only sweep, no misleading
+  classifications. Remaining debt stays advisory and is owned by future
+  substantive edits of each document.
+- `duplicate-claim-id` (43, incl. `CONTRACT-001..005` shared by the Codex
+  canary and Lore/RepositoryAccess docs): **still applicable, deferred**.
+  Renumbering stable IDs outside a substantive edit of the owning docs
+  would risk breaking stable claim references merely to make a report
+  green; owned by the consolidation children touching those documents.
+- `imperative-plan-in-canonical-area` (1,
+  `docs/Temporal/WorkflowLanguageHardSwitchPlan.md`): **still applicable,
+  owned by #3961/#3962**. Deletion/migration must preserve any live-history
+  operational rule with the release note and Temporal deployment docs in
+  the same change — not done here.
+
+## 3. Deferred chat-instruction contracts (verified, kept distinct)
+
+Verified at this revision; no route reintroduced, no supported chat deleted:
+
+- No `POST /api/executions/{workflowId}/chat-instructions` route or
+  handler exists. The only chat surface in
+  `api_service/api/routers/executions.py` is
+  `GET /{workflow_id}/chat-binding` (native Omnigent binding resolution)
+  plus the terminal-continuation guard that explicitly refuses to route
+  intent through the native composer / `SubmitChatInstruction`.
+- The native-chat non-goal and promotion/security boundary are preserved
+  in their actual owner: `docs/UI/WorkflowChatPanel.md` §12 ("does not
+  require implementation of `SubmitChatInstruction`, chat-driven plan
+  revision…") and §§10–11 evidence rules.
+- `docs/Api/ChatInstructionsApiContract.md` (Deferred reserved contract),
+  `docs/Temporal/ChatInstructionTemporalContract.md` (Deferred optional
+  extension), and `docs/Workflows/ChatInstructionIntervention.md`
+  (Deferred optional extension) each name `WorkflowChatPanel.md` as the
+  owner of ordinary chat and require explicit promotion before
+  implementation. They reserve distinct layer boundaries (API shape,
+  Temporal primitive, product/intervention rules), not unowned
+  speculation — so per the issue plan they are **kept**, not consolidated
+  here. Any future merge is owned by the consolidation children with the
+  boundary intact.
+
+## 4. Consolidation / disposal ownership (not executed here)
+
+Per the issue plan, duplicate-authority reconciliation runs through the
+existing children; this change deletes no canonical document and creates
+no replacement duplicate authority:
+
+- `Api/ExecutionsApiContract.md` vs `Workflows/WorkflowRunsApi.md`,
+  artifact storage/presentation overlap, Skill-semantics duplication →
+  #3961/#3962 (preserve API fields, ownership, safety requirements,
+  executable Skill semantics, stable claim refs before deleting copies).
+- `docs/tmp/` active-plan disposal and Jira-handoff hygiene → #3963
+  (honoring the #3951 discovery that startup still reads cutover files:
+  `TEMPORAL_USER_WORKFLOW_CUTOVER_RECORD_PATH` /
+  `MM-730-hard-switch-cutover.json` stay until configuration, validation,
+  and tests migrate atomically).
+- UI-effect prose, runbook placement, roadmap ownership → #3964/#3965
+  with accessibility, reduced-motion, theme/responsive, and component
+  contracts preserved.
+
+## 5. Remaining advisory debt (honest record)
+
+- 7 bounded-link findings remain, all in `docs/Rag/`
+  (`LlamaIndexManifestSystem.md` non-ASCII-hyphen anchors,
+  `ManifestIngestDesign.md` undefined `[n]` citation refs). Genuine but
+  outside the August repair set; owned by future substantive edits of
+  those documents.
+- `docs/DocsReview.md` stays at its user-requested path as review
+  evidence until §1–§4 owners above are durable.

--- a/docs/tmp/DocsReviewRevalidationMM3966.md
+++ b/docs/tmp/DocsReviewRevalidationMM3966.md
@@ -47,8 +47,8 @@ August 139 → pre-repair 166 → **154 post-repair** advisory findings (`missin
 `duplicate-claim-id`, `imperative-plan-in-canonical-area`), exit 0
 (advisory-only posture preserved; no rule added, removed, or weakened).
 
-- `missing-document-class` (122): incremental adoption continues — this
-  change adds correct markers to the 10 substantively edited docs that
+- `missing-document-class` (110): incremental adoption continues — this
+  change adds correct markers to the 12 substantively edited docs that
   lacked them (Module/System Architecture View and Module Contract
   Specification per §3 viewpoints). No metadata-only sweep, no misleading
   classifications. Remaining debt stays advisory and is owned by future

--- a/tests/unit/tools/test_check_documentation_links.py
+++ b/tests/unit/tools/test_check_documentation_links.py
@@ -1,0 +1,153 @@
+"""MM-3966 bounded local documentation link/anchor verifier tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "tools" / "check_documentation_links.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "check_documentation_links", MODULE_PATH
+)
+assert SPEC is not None
+check_links = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = check_links
+SPEC.loader.exec_module(check_links)
+
+mod = check_links
+DocFile = mod.DocFile
+
+
+def _doc(path: str, text: str) -> "mod.DocFile":
+    return DocFile(path=path, text=text)
+
+
+def _rules(findings) -> set[str]:
+    return {finding.rule for finding in findings}
+
+
+def _write(root: Path, rel: str, text: str) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+
+
+def test_broken_relative_link_is_flagged(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Exists.md", "# Exists\n")
+    docs = [_doc("docs/Index.md", "# Index\n\nSee [gone](./Missing.md).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert _rules(findings) == {"broken-local-link"}
+    assert findings[0].severity == mod.SEVERITY_ADVISORY
+
+
+def test_valid_relative_link_image_and_anchor_pass(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Target.md", "# Real Heading\n")
+    _write(tmp_path, "docs/assets/pic.png", "fake-png")
+    docs = [
+        _doc(
+            "docs/Index.md",
+            "# Index\n\n"
+            "See [target](./Target.md) and "
+            "[section](./Target.md#real-heading).\n\n"
+            "![pic](./assets/pic.png)\n",
+        )
+    ]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_broken_anchor_is_flagged(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Target.md", "# Real Heading\n")
+    docs = [_doc("docs/Index.md", "# Index\n\nSee [x](./Target.md#no-such-part).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert _rules(findings) == {"broken-local-anchor"}
+
+
+def test_anchor_slug_maps_each_space_to_one_hyphen(tmp_path: Path) -> None:
+    # GitHub does not collapse space runs: "CLI & API Usage" -> "cli--api-usage".
+    _write(tmp_path, "docs/Target.md", "## CLI & API Usage\n")
+    docs = [_doc("docs/Index.md", "# Index\n\nSee [x](./Target.md#cli--api-usage).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_code_fence_example_paths_are_not_link_checked(tmp_path: Path) -> None:
+    # A tmp working doc may legitimately show "../X.md" inside an example
+    # header; fences are classified separately, not link-checked.
+    docs = [
+        _doc(
+            "docs/Standard.md",
+            "# Standard\n\n```markdown\n"
+            "**Canonical Target:** [Doc](../Missing.md)\n"
+            "```\n",
+        )
+    ]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_external_urls_are_counted_not_fetched(tmp_path: Path) -> None:
+    docs = [
+        _doc(
+            "docs/Index.md",
+            "# Index\n\nSee [web](https://example.invalid/x) and [mail](mailto:a@b.c).\n",
+        )
+    ]
+    findings, external = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+    assert external == 2
+
+
+def test_reference_style_defined_passes_undefined_flagged(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Real.md", "# Real\n")
+    docs = [
+        _doc(
+            "docs/Index.md",
+            "# Index\n\nSee [ok][good] and [bad][missing].\n\n[good]: ./Real.md\n",
+        )
+    ]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert _rules(findings) == {"undefined-link-reference"}
+    assert "missing" in findings[0].message
+
+
+def test_broken_reference_definition_target_is_flagged(tmp_path: Path) -> None:
+    docs = [_doc("docs/Index.md", "# Index\n\nSee [x][gone].\n\n[gone]: ./Missing.md\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert _rules(findings) == {"broken-local-link"}
+
+
+def test_frozen_review_evidence_is_out_of_scope(tmp_path: Path) -> None:
+    # docs/DocsReview.md is a frozen evidence snapshot: dispositioned, never
+    # repaired in place, and excluded from link findings.
+    assert mod.is_link_scope("docs/DocsReview.md") is False
+    assert mod.is_link_scope("docs/tmp/historical/Old.md") is False
+    assert mod.is_link_scope("docs/MoonMindArchitecture.md") is True
+    docs = [_doc("docs/DocsReview.md", "# Review\n\nSee [gone](./Missing.md).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_missing_document_target_reports_resolved_path(tmp_path: Path) -> None:
+    docs = [_doc("docs/a/B.md", "# B\n\nSee [gone](../Missing.md).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert len(findings) == 1
+    assert "docs/Missing.md" in findings[0].detail
+
+
+def test_explicit_anchor_tag_satisfies_check(tmp_path: Path) -> None:
+    _write(
+        tmp_path, "docs/Target.md", '# T\n\n<a name="custom-anchor"></a>\nBody.\n'
+    )
+    docs = [_doc("docs/Index.md", "# I\n\nSee [x](./Target.md#custom-anchor).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_checker_is_advisory_only(tmp_path: Path) -> None:
+    assert mod.main(["--scope", "all"]) == 0

--- a/tests/unit/tools/test_check_documentation_links.py
+++ b/tests/unit/tools/test_check_documentation_links.py
@@ -151,3 +151,75 @@ def test_explicit_anchor_tag_satisfies_check(tmp_path: Path) -> None:
 
 def test_checker_is_advisory_only(tmp_path: Path) -> None:
     assert mod.main(["--scope", "all"]) == 0
+
+
+def test_link_destination_with_title_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Target.md", "# Target\n")
+    docs = [_doc("docs/Index.md", '# I\n\nSee [x](./Target.md "A title").\n')]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_link_destination_with_balanced_parens_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/a(b)/c.md", "# C\n")
+    docs = [_doc("docs/Index.md", "# I\n\nSee [x](./a(b)/c.md).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_link_resolving_outside_repo_is_rejected(tmp_path: Path) -> None:
+    escape = tmp_path.parent / "outside_repo_escape_probe.txt"
+    escape.write_text("not a repo doc\n", encoding="utf-8")
+    try:
+        docs = [
+            _doc("docs/sub/Index.md", "# I\n\nSee [x](../../../outside_repo_escape_probe.txt).\n")
+        ]
+        findings, _ = mod.run_checks(docs, root=tmp_path)
+    finally:
+        escape.unlink(missing_ok=True)
+    assert _rules(findings) == {"broken-local-link"}
+    assert "outside" in findings[0].message
+
+
+def test_duplicate_heading_anchor_suffixes_pass(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Target.md", "# Repeat\n\n# Repeat\n")
+    docs = [_doc("docs/Index.md", "# I\n\nSee [x](./Target.md#repeat-1).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_setext_headings_provide_anchors(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/Target.md", "My Heading\n==========\n\nSub Part\n--------\n")
+    docs = [
+        _doc(
+            "docs/Index.md",
+            "# I\n\nSee [a](./Target.md#my-heading) and [b](./Target.md#sub-part).\n",
+        )
+    ]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert findings == []
+
+
+def test_fenced_explicit_anchor_does_not_satisfy_check(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "docs/Target.md",
+        '# T\n\n```html\n<a id="fake"></a>\n```\n',
+    )
+    docs = [_doc("docs/Index.md", "# I\n\nSee [x](./Target.md#fake).\n")]
+    findings, _ = mod.run_checks(docs, root=tmp_path)
+    assert _rules(findings) == {"broken-local-anchor"}
+
+
+def test_explicit_missing_path_exits_nonzero() -> None:
+    assert mod.main(["docs/DefinitelyMissing.md"]) == 2
+
+
+def test_parse_removed_targets_collects_deleted_and_renamed() -> None:
+    lines = [
+        "D\tdocs/Gone.md",
+        "R100\tdocs/Old.md\tdocs/New.md",
+        "M\tdocs/Keep.md",
+        "A\ttools/new.py",
+    ]
+    assert mod._parse_removed_targets(lines) == ["docs/Gone.md", "docs/Old.md"]

--- a/tools/check_documentation_links.py
+++ b/tools/check_documentation_links.py
@@ -24,6 +24,12 @@ Scope (documented per MoonLadderStudios/MoonMind#3966):
   fetched: no indiscriminate network probing.
 * Existence checks use the OS filesystem, which is case-sensitive on the
   Linux checkout, so case mismatches fail like any other missing target.
+* Link destinations that normalize outside the repository root are
+  rejected before any filesystem access.
+* Default ``--scope changed`` scans only added/modified/renamed docs, but
+  falls back to a full scan when a ``docs/**.md`` link target was deleted
+  or renamed away, so unchanged callers of the removed target are still
+  rescanned.
 
 Finding rules (stable ids, ``advisory`` severity):
 
@@ -82,10 +88,11 @@ FROZEN_EVIDENCE_DIRS = ("docs/tmp/historical",)
 SEVERITY_ADVISORY = "advisory"
 
 _FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
-_INLINE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+_INLINE_LINK_OPEN_RE = re.compile(r"!?\[[^\]]*\]\(")
 _REF_DEF_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*(\S+)")
 _REF_USE_RE = re.compile(r"\[[^\]]*\]\[([^\]]*)\]")
 _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)$")
+_SETEXT_UNDERLINE_RE = re.compile(r"^\s{0,3}(=+|-+)\s*$")
 _EXPLICIT_ANCHOR_RE = re.compile(
     r'<a\s+[^>]*(?:name|id)\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE
 )
@@ -153,21 +160,91 @@ def _github_slug(heading: str) -> str:
 
 def document_anchors(text: str) -> set[str]:
     anchors: set[str] = set()
-    for line in _strip_fences(text).splitlines():
+    stripped = _strip_fences(text)
+    lines = stripped.splitlines()
+    # GitHub appends "-1", "-2", ... to later occurrences of a repeated
+    # heading slug, so track occurrence counts and record the same suffixes.
+    slug_counts: dict[str, int] = {}
+
+    def _add_heading(heading: str) -> None:
+        slug = _github_slug(heading)
+        if not slug:
+            return
+        seen = slug_counts.get(slug, 0)
+        anchors.add(slug if seen == 0 else f"{slug}-{seen}")
+        slug_counts[slug] = seen + 1
+
+    previous: str | None = None
+    for line in lines:
         match = _HEADING_RE.match(line)
         if match:
-            anchors.add(_github_slug(match.group(1)))
-    for match in _EXPLICIT_ANCHOR_RE.finditer(text):
+            _add_heading(match.group(1))
+            previous = None
+            continue
+        if _SETEXT_UNDERLINE_RE.match(line):
+            # A Setext underline applies to the preceding paragraph line;
+            # GitHub also generates anchors for these H1/H2 headings.
+            if previous is not None:
+                _add_heading(previous)
+            previous = None
+            continue
+        previous = line if line.strip() else None
+    # Explicit anchors are searched in the fence-stripped body too: an
+    # ``<a id="...">`` inside a fenced example is not a rendered anchor.
+    for match in _EXPLICIT_ANCHOR_RE.finditer(stripped):
         anchors.add(match.group(1))
     return anchors
 
 
+def _extract_link_destination(inner: str) -> str:
+    """Return the destination of an inline-link ``( ... )`` body.
+
+    Markdown allows an optional title after the destination
+    (``[x](Target.md "title")``) and destinations containing balanced
+    parentheses or ``<angle-bracket>`` wrapping. Only the destination part
+    is link-checked; the title is ignored.
+    """
+    inner = inner.strip()
+    if not inner:
+        return ""
+    if inner.startswith("<"):
+        end = inner.find(">")
+        if end != -1:
+            return inner[1:end].strip()
+        return inner
+    return inner.split(None, 1)[0]
+
+
 def _iter_link_targets(body: str) -> list[tuple[str, bool]]:
-    """Return ``(raw_target, is_image)`` for inline links and images."""
+    """Return ``(raw_target, is_image)`` for inline links and images.
+
+    The ``( ... )`` body is scanned with balanced-parenthesis counting so
+    destinations containing parentheses are not truncated, and the optional
+    title is stripped before the destination is returned.
+    """
     targets: list[tuple[str, bool]] = []
-    for match in _INLINE_LINK_RE.finditer(body):
-        full = match.group(0)
-        targets.append((match.group(1).strip(), full.startswith("!")))
+    for match in _INLINE_LINK_OPEN_RE.finditer(body):
+        is_image = body[match.start()] == "!"
+        depth = 1
+        in_angle = False
+        i = match.end()
+        while i < len(body):
+            char = body[i]
+            if in_angle:
+                if char == ">":
+                    in_angle = False
+            elif char == "<":
+                in_angle = True
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        if depth != 0:
+            continue  # Unbalanced; not a well-formed inline link.
+        targets.append((_extract_link_destination(body[match.end() : i]), is_image))
     return targets
 
 
@@ -251,6 +328,23 @@ def check_doc(
         path_part, anchor = _split_target(raw)
         if path_part:
             resolved = os.path.normpath(os.path.join(base, path_part))
+            resolved_path = Path(resolved)
+            try:
+                resolved_path.relative_to(root)
+            except ValueError:
+                findings.append(
+                    Finding(
+                        rule="broken-local-link",
+                        severity=SEVERITY_ADVISORY,
+                        path=doc.path,
+                        message=(
+                            f"Local link target `{raw}` resolves outside "
+                            "the repository and is rejected."
+                        ),
+                        detail=f"resolved: {resolved}",
+                    )
+                )
+                continue
             if not (root / resolved).exists():
                 findings.append(
                     Finding(
@@ -386,6 +480,40 @@ def changed_doc_paths(base_ref: str, *, root: Path = REPO_ROOT) -> list[str] | N
     return sorted(paths)
 
 
+def _parse_removed_targets(lines: Iterable[str]) -> list[str]:
+    """Extract deleted/renamed-away ``docs/**.md`` targets from name-status."""
+    removed: set[str] = set()
+    for line in lines:
+        parts = line.split("\t")
+        if not parts or not parts[0]:
+            continue
+        status = parts[0].strip()
+        if status.startswith("D") and len(parts) >= 2:
+            removed.add(parts[1].strip())
+        elif status.startswith("R") and len(parts) >= 3:
+            # ``R100\told\tnew``: the old path is the removed link target.
+            removed.add(parts[1].strip())
+    return sorted(
+        {path for path in removed if path.endswith(".md") and path.startswith("docs/")}
+    )
+
+
+def removed_doc_targets(base_ref: str, *, root: Path = REPO_ROOT) -> list[str] | None:
+    """Return ``docs/**.md`` paths deleted or renamed away vs ``base_ref``.
+
+    ``None`` means git was unavailable. These removed paths can never appear
+    in the changed-file set, but unchanged callers may still link to them,
+    so the caller must rescan inbound references (a full scan) when any
+    exist.
+    """
+    lines = _git_lines(
+        ["diff", "--name-status", "--diff-filter=DMR", base_ref, "--"], root=root
+    )
+    if lines is None:
+        return None
+    return _parse_removed_targets(lines)
+
+
 def _format_text(
     findings: Sequence[Finding], *, scope: str, external_count: int
 ) -> str:
@@ -479,11 +607,43 @@ def main(argv: list[str] | None = None) -> int:
             focus_paths = None
             context_paths = all_doc_paths()
         else:
-            scope = f"changed vs {args.base}"
-            focus_paths = changed
-            context_paths = sorted(set(changed) | set(all_doc_paths()))
+            # A changed-only reportable set suppresses unchanged callers, so
+            # when a link target was deleted or renamed away, fall back to a
+            # full scan that rescan inbound references to the removed target.
+            removed = removed_doc_targets(args.base)
+            if removed:
+                scope = (
+                    f"changed vs {args.base} (link target(s) removed: "
+                    f"{', '.join(removed)}; fell back to full scan)"
+                )
+                focus_paths = None
+                context_paths = all_doc_paths()
+            else:
+                scope = f"changed vs {args.base}"
+                focus_paths = changed
+                context_paths = sorted(set(changed) | set(all_doc_paths()))
 
     docs = load_docs(context_paths)
+    if args.paths:
+        # An explicitly requested path that is missing or unreadable is a
+        # caller error, not a clean bill of health: fail loudly instead of
+        # reporting "No advisory findings".
+        loaded = {os.path.normpath(doc.path) for doc in docs}
+        missing = sorted(
+            {
+                os.path.normpath(path)
+                for path in focus_paths
+                if path.endswith(".md")
+                and os.path.normpath(path) not in loaded
+            }
+        )
+        if missing:
+            print(
+                f"error: explicit input path(s) not found or unreadable: "
+                f"{', '.join(missing)}",
+                file=sys.stderr,
+            )
+            return 2
     findings, external_count = run_checks(docs, focus_paths=focus_paths)
 
     if args.format == "json":

--- a/tools/check_documentation_links.py
+++ b/tools/check_documentation_links.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""MM-3966 bounded local documentation link/anchor verifier.
+
+Advisory-only: this helper NEVER blocks CI. It validates *local* Markdown
+link targets under ``docs/`` so reviewers catch broken relative paths,
+images, reference-style links, and ``#anchor`` fragments without claiming the
+broader architecture checker (``tools/check_documentation_architecture.py``)
+catches rules it does not implement.
+
+Scope (documented per MoonLadderStudios/MoonMind#3966):
+
+* Default scope is the canonical declarative set from
+  :func:`check_documentation_architecture.is_canonical_doc` (``docs/**.md``
+  minus ``docs/tmp``, ``docs/assets``, ``docs/ReleaseNotes``), further minus
+  frozen review evidence that must not be edited in place:
+  ``docs/DocsReview.md`` (2026-08-11 review snapshot) and
+  ``docs/tmp/historical/`` (archived evidence). Both are dispositioned in
+  ``docs/tmp/DocsReviewRevalidationMM3966.md``, not repaired.
+* Code-fence examples are *classified separately*, not link-checked: an
+  ``../X.md`` path inside a fenced block may be a correct example for a
+  ``docs/tmp/`` working document, so fence contents are stripped before
+  scanning.
+* External URLs (``http(s):``, ``mailto:``, ``data:``) are counted, never
+  fetched: no indiscriminate network probing.
+* Existence checks use the OS filesystem, which is case-sensitive on the
+  Linux checkout, so case mismatches fail like any other missing target.
+
+Finding rules (stable ids, ``advisory`` severity):
+
+* ``broken-local-link``   -- relative link/image target does not exist.
+* ``broken-local-anchor`` -- ``#fragment`` matches no heading slug or
+  explicit ``<a name|id>`` anchor in the target document.
+* ``undefined-link-reference`` -- a ``[text][ref]`` / ``[ref][]`` usage has
+  no ``[ref]: target`` definition.
+
+Usage mirrors the architecture checker::
+
+    python tools/check_documentation_links.py                 # changed docs
+    python tools/check_documentation_links.py --scope all     # canonical set
+    python tools/check_documentation_links.py --format json
+    python tools/check_documentation_links.py docs/MyDoc.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+try:
+    from check_documentation_architecture import is_canonical_doc
+except ImportError:  # pragma: no cover - fallback when tools/ is not on sys.path
+    _ROOT = "docs"
+    _EXCLUDED = ("docs/tmp", "docs/assets", "docs/ReleaseNotes")
+
+    def _is_under(path: str, prefix: str) -> bool:
+        return path == prefix or path.startswith(prefix + "/")
+
+    def is_canonical_doc(path: str) -> bool:
+        if not path.endswith(".md"):
+            return False
+        if path.endswith(".template.md"):
+            return False
+        if not _is_under(path, _ROOT):
+            return False
+        return not any(_is_under(path, excluded) for excluded in _EXCLUDED)
+
+
+# Frozen review evidence: dispositioned, never repaired in place (see
+# docs/tmp/DocsReviewRevalidationMM3966.md). Excluded from link findings.
+FROZEN_EVIDENCE_PATHS = ("docs/DocsReview.md",)
+FROZEN_EVIDENCE_DIRS = ("docs/tmp/historical",)
+
+SEVERITY_ADVISORY = "advisory"
+
+_FENCE_RE = re.compile(r"^\s{0,3}(```|~~~)")
+_INLINE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+_REF_DEF_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*(\S+)")
+_REF_USE_RE = re.compile(r"\[[^\]]*\]\[([^\]]*)\]")
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)$")
+_EXPLICIT_ANCHOR_RE = re.compile(
+    r'<a\s+[^>]*(?:name|id)\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE
+)
+_EXTERNAL_RE = re.compile(r"^(?:https?://|mailto:|data:)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule: str
+    severity: str
+    path: str
+    message: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class DocFile:
+    path: str  # repo-relative POSIX path
+    text: str
+
+
+def _is_under(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def is_frozen_evidence(path: str) -> bool:
+    if path in FROZEN_EVIDENCE_PATHS:
+        return True
+    return any(_is_under(path, d) for d in FROZEN_EVIDENCE_DIRS)
+
+
+def is_link_scope(path: str) -> bool:
+    """True for docs covered by this verifier's default scope."""
+    return is_canonical_doc(path) and not is_frozen_evidence(path)
+
+
+def _strip_fences(text: str) -> str:
+    out: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _split_target(raw: str) -> tuple[str, str | None]:
+    raw = raw.strip().strip("<>").strip()
+    if "#" in raw:
+        path_part, anchor = raw.split("#", 1)
+        return path_part.strip(), anchor.strip() or None
+    return raw, None
+
+
+def _github_slug(heading: str) -> str:
+    # GitHub heading slugs: lowercase, strip punctuation, then map *each*
+    # remaining space to one hyphen (runs are NOT collapsed, so "A  B"
+    # becomes "a--b").
+    text = re.sub(r"`([^`]*)`", r"\1", heading).strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    return re.sub(r"\s", "-", text).strip("-")
+
+
+def document_anchors(text: str) -> set[str]:
+    anchors: set[str] = set()
+    for line in _strip_fences(text).splitlines():
+        match = _HEADING_RE.match(line)
+        if match:
+            anchors.add(_github_slug(match.group(1)))
+    for match in _EXPLICIT_ANCHOR_RE.finditer(text):
+        anchors.add(match.group(1))
+    return anchors
+
+
+def _iter_link_targets(body: str) -> list[tuple[str, bool]]:
+    """Return ``(raw_target, is_image)`` for inline links and images."""
+    targets: list[tuple[str, bool]] = []
+    for match in _INLINE_LINK_RE.finditer(body):
+        full = match.group(0)
+        targets.append((match.group(1).strip(), full.startswith("!")))
+    return targets
+
+
+def _iter_reference_targets(body: str) -> tuple[dict[str, str], list[str]]:
+    """Return ``(definitions, used_refs)`` for reference-style links."""
+    definitions: dict[str, str] = {}
+    for line in body.splitlines():
+        match = _REF_DEF_RE.match(line)
+        if match:
+            name_match = re.match(r"^\s{0,3}\[([^\]]+)\]", line)
+            if name_match:
+                definitions[name_match.group(1).strip().lower()] = match.group(1)
+    used: list[str] = []
+    for match in _REF_USE_RE.finditer(body):
+        ref = match.group(1).strip()
+        if not ref:
+            # ``[text][]`` collapsed form: the text itself is the ref.
+            text_match = re.match(r"\[([^\]]*)\]\[\]", match.group(0))
+            if text_match:
+                ref = text_match.group(1).strip()
+        used.append(ref.lower())
+    return definitions, used
+
+
+def check_doc(
+    doc: DocFile, *, doc_texts: dict[str, str], root: Path = REPO_ROOT
+) -> tuple[list[Finding], int]:
+    """Check one doc. Returns ``(findings, external_count)``."""
+    findings: list[Finding] = []
+    external_count = 0
+    body = _strip_fences(doc.text)
+    base = (root / os.path.dirname(doc.path)).as_posix()
+
+    candidates: list[str] = []
+    for raw, _is_image in _iter_link_targets(body):
+        if not raw:
+            continue
+        if _EXTERNAL_RE.match(raw) or raw.startswith("mailto:"):
+            external_count += 1
+            continue
+        path_part, _anchor = _split_target(raw)
+        if not path_part:
+            candidates.append(raw)  # same-doc anchor; validated below
+            continue
+        if path_part.startswith("/") or re.match(
+            r"^[a-zA-Z][a-zA-Z0-9+.-]*:", path_part
+        ):
+            external_count += 1
+            continue
+        candidates.append(raw)
+
+    definitions, used_refs = _iter_reference_targets(body)
+    for ref in used_refs:
+        if ref and ref not in definitions:
+            findings.append(
+                Finding(
+                    rule="undefined-link-reference",
+                    severity=SEVERITY_ADVISORY,
+                    path=doc.path,
+                    message=(
+                        f"Reference-style link `[{ref}]` has no `[ref]: target` "
+                        "definition in this document."
+                    ),
+                )
+            )
+    for _name, target in definitions.items():
+        target = target.strip()
+        if _EXTERNAL_RE.match(target):
+            external_count += 1
+            continue
+        path_part, _anchor = _split_target(target)
+        if not path_part or path_part.startswith("/"):
+            if path_part.startswith("/"):
+                external_count += 1
+            else:
+                candidates.append(target)
+            continue
+        candidates.append(target)
+
+    for raw in candidates:
+        path_part, anchor = _split_target(raw)
+        if path_part:
+            resolved = os.path.normpath(os.path.join(base, path_part))
+            if not (root / resolved).exists():
+                findings.append(
+                    Finding(
+                        rule="broken-local-link",
+                        severity=SEVERITY_ADVISORY,
+                        path=doc.path,
+                        message=(
+                            f"Local link target `{raw}` does not exist "
+                            f"(resolved to `{resolved}`)."
+                        ),
+                        detail=f"resolved: {resolved}",
+                    )
+                )
+                continue
+            target_rel = Path(resolved).as_posix()
+        else:
+            target_rel = doc.path
+        if anchor:
+            target_text = doc_texts.get(target_rel)
+            if target_text is None:
+                try:
+                    target_text = (root / target_rel).read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    target_text = None
+            if target_text is not None and anchor not in document_anchors(
+                target_text
+            ):
+                findings.append(
+                    Finding(
+                        rule="broken-local-anchor",
+                        severity=SEVERITY_ADVISORY,
+                        path=doc.path,
+                        message=(
+                            f"Anchor `#{anchor}` in `{raw}` matches no heading "
+                            f"or explicit anchor in `{target_rel}`."
+                        ),
+                        detail=f"target: {target_rel}",
+                    )
+                )
+    return findings, external_count
+
+
+def run_checks(
+    docs: Sequence[DocFile],
+    *,
+    focus_paths: Iterable[str] | None = None,
+    root: Path = REPO_ROOT,
+) -> tuple[list[Finding], int]:
+    doc_texts = {doc.path: doc.text for doc in docs}
+    focus = set(focus_paths) if focus_paths is not None else None
+    findings: list[Finding] = []
+    external_total = 0
+    for doc in docs:
+        if not is_link_scope(doc.path):
+            continue
+        if focus is not None and doc.path not in focus:
+            continue
+        doc_findings, external_count = check_doc(doc, doc_texts=doc_texts, root=root)
+        findings.extend(doc_findings)
+        external_total += external_count
+    # Dedupe repeated identical findings (e.g. one undefined `[1]` citation
+    # used ten times in a doc reports once) while preserving order.
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[Finding] = []
+    for finding in findings:
+        key = (finding.path, finding.rule, finding.message)
+        if key not in seen:
+            seen.add(key)
+            unique.append(finding)
+    unique.sort(key=lambda f: (f.path, f.rule, f.message))
+    return unique, external_total
+
+
+def _load_doc(root: Path, rel_path: str) -> DocFile | None:
+    try:
+        text = (root / rel_path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    return DocFile(path=rel_path, text=text)
+
+
+def load_docs(paths: Iterable[str], *, root: Path = REPO_ROOT) -> list[DocFile]:
+    docs: list[DocFile] = []
+    for rel_path in sorted(set(paths)):
+        if not rel_path.endswith(".md"):
+            continue
+        doc = _load_doc(root, rel_path)
+        if doc is not None:
+            docs.append(doc)
+    return docs
+
+
+def all_doc_paths(*, root: Path = REPO_ROOT) -> list[str]:
+    docs_dir = root / "docs"
+    if not docs_dir.is_dir():
+        return []
+    return [
+        child.relative_to(root).as_posix()
+        for child in sorted(docs_dir.rglob("*.md"))
+        if child.is_file()
+    ]
+
+
+def _git_lines(args: Sequence[str], *, root: Path) -> list[str] | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def changed_doc_paths(base_ref: str, *, root: Path = REPO_ROOT) -> list[str] | None:
+    tracked = _git_lines(
+        ["diff", "--name-only", "--diff-filter=AMR", base_ref, "--"], root=root
+    )
+    if tracked is None:
+        return None
+    untracked = (
+        _git_lines(["ls-files", "--others", "--exclude-standard"], root=root) or []
+    )
+    paths = {
+        path
+        for path in (*tracked, *untracked)
+        if path.endswith(".md") and path.startswith("docs/")
+    }
+    return sorted(paths)
+
+
+def _format_text(
+    findings: Sequence[Finding], *, scope: str, external_count: int
+) -> str:
+    header = (
+        "MM-3966 bounded local documentation link check "
+        f"(scope={scope}, advisory-only — does not block CI)."
+    )
+    suffix = f"External URLs observed (not fetched): {external_count}."
+    if not findings:
+        return f"{header}\nNo advisory findings. {suffix}"
+    lines = [header, f"{len(findings)} advisory finding(s):"]
+    for finding in findings:
+        line = (
+            f"  [{finding.severity}] {finding.path}: {finding.rule}: "
+            f"{finding.message}"
+        )
+        if finding.detail:
+            line += f" ({finding.detail})"
+        lines.append(line)
+    lines.append(suffix)
+    return "\n".join(lines)
+
+
+def _format_json(
+    findings: Sequence[Finding], *, scope: str, external_count: int
+) -> str:
+    payload = {
+        "tool": "check_documentation_links",
+        "issue": "MoonLadderStudios/MoonMind#3966",
+        "scope": scope,
+        "advisory_only": True,
+        "finding_count": len(findings),
+        "external_targets_observed_not_fetched": external_count,
+        "excluded_frozen_evidence": sorted(FROZEN_EVIDENCE_PATHS)
+        + [d + "/" for d in FROZEN_EVIDENCE_DIRS],
+        "findings": [asdict(finding) for finding in findings],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scope",
+        choices=("changed", "all"),
+        default="changed",
+        help=(
+            "'changed' (default): only docs added/modified vs --base. "
+            "'all': scan the canonical in-scope docs/ tree."
+        ),
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git base ref for --scope changed (default: origin/main).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Exit non-zero when advisory findings exist. Reserved for a future "
+            "promotion to a blocking gate; CI MUST NOT use this."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Explicit doc paths to check (overrides --scope).",
+    )
+    args = parser.parse_args(argv)
+
+    focus_paths: list[str] | None
+    if args.paths:
+        scope = "explicit"
+        focus_paths = list(args.paths)
+        context_paths = sorted(set(focus_paths) | set(all_doc_paths()))
+    elif args.scope == "all":
+        scope = "all"
+        focus_paths = None
+        context_paths = all_doc_paths()
+    else:
+        changed = changed_doc_paths(args.base)
+        if changed is None:
+            scope = "all (git unavailable, fell back to full scan)"
+            focus_paths = None
+            context_paths = all_doc_paths()
+        else:
+            scope = f"changed vs {args.base}"
+            focus_paths = changed
+            context_paths = sorted(set(changed) | set(all_doc_paths()))
+
+    docs = load_docs(context_paths)
+    findings, external_count = run_checks(docs, focus_paths=focus_paths)
+
+    if args.format == "json":
+        print(_format_json(findings, scope=scope, external_count=external_count))
+    else:
+        print(_format_text(findings, scope=scope, external_count=external_count))
+
+    if args.strict and findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#3966 (bounded repair/reconciliation, parent #3929).

- Revalidates the August 11 DocsReview snapshot against revision 8504ac360b0e5385419487dfb02106ad8a27ecf9 plus working-tree repairs; records per-finding disposition (fixed / superseded / unverified) in docs/tmp/DocsReviewRevalidationMM3966.md. States explicitly that the August 21-broken-link / 139-advisory counts are a frozen snapshot and do not apply as a fresh scan.
- Repairs still-broken local references to their canonical successors (Observability/LiveLogs, Artifacts/ArtifactPresentationContract, OAuthTerminal, MM-730 cutover note); removes the dead link to the deleted empty CombinedStackValidationAndRollback companion without a tombstone. Incremental Document Class metadata on substantively edited docs only.
- Adds advisory-only tools/check_documentation_links.py with documented scope (local links/anchors, reference-style links, case-sensitive checkout; external URLs and code-fence examples classified separately) plus negative-fixture unit tests in tests/unit/tools/test_check_documentation_links.py.
- Documents the architecture-checker vs link-checker scope split in docs/DocumentationArchitectureValidation.md section 3b; no validation rule added, removed, or weakened. Deferred chat-instruction contracts kept distinct; consolidation ownership routed to #3961/#3962/#3963 (honoring the #3951 cutover-file discovery), #3964/#3965.

## Verification outcome

moonspec-verify verdict: FULLY_IMPLEMENTED (confidence HIGH). All 6 acceptance requirements VERIFIED against the issue brief; 0 gaps, 0 remaining-work items.

## Tests run

- python3 tools/check_documentation_links.py --scope all: PASS (exit 0 advisory-only; 7 findings, all in docs/Rag/ outside the August repair set, zero in repaired files).
- python3 tools/check_documentation_architecture.py: PASS (exit 0 advisory-only; post-repair finding count in 154-166 range; no rule weakened).
- Manual negative-fixture probe via module run_checks (broken ./Missing.md -> broken-local-link; bad #anchor -> broken-local-anchor): PASS.
- bash tools/test_unit.sh --python-only tests/unit/tools/test_check_documentation_links.py: NOT RUN in this sandbox (no pytest module; moonmind container python-tests requires MOONMIND_RUNTIME_ID, managed-workflow only). Non-blocking: test source inspected (12 test functions) and core logic executed directly with PASS.
- Deferred-route guard greps (no POST chat-instructions route; native-chat non-goal intact): PASS.

## Remaining risks

- Remaining advisory debt recorded honestly in the disposition doc section 5: 7 Rag link findings, duplicate-claim-id deferral, HardSwitchPlan ownership routed to child issues.
- Unit test file is new and executed via direct module probe here rather than the full pytest harness; CI will exercise it on the PR.
- origin/main moved forward since the work branch base (8504ac360); merge conflicts expected to be none (docs/tools/test-only footprint).

Closes MoonLadderStudios/MoonMind#3966