### PR TITLE
Fix provider slot allocation for long remediation identities

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3947,10 +3947,13 @@ class ProviderProfileSlotLease(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     runtime_id: Mapped[str] = mapped_column(String(64), nullable=False)
-    workflow_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    # These are opaque identities from workflow/step/operation composition.
+    # Preserve them exactly: a storage-only length cap must not strand a grant,
+    # and hashing or truncating here would break retry and release authority.
+    workflow_id: Mapped[str] = mapped_column(Text, nullable=False)
     profile_id: Mapped[str] = mapped_column(String(128), nullable=False)
-    lease_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    owner_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    lease_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    owner_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     owner_kind: Mapped[str] = mapped_column(
         String(32), nullable=False, default="workflow", server_default=text("'workflow'")
     )
@@ -3966,9 +3969,9 @@ class ProviderProfileSlotLease(Base):
     owner_is_workflow: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
     )
-    step_execution_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    step_execution_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     oauth_session_id: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
-    idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    idempotency_key: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     execution_plan_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     capacity_scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     scope_generation: Mapped[int] = mapped_column(

--- a/api_service/migrations/versions/373_lease_identity_text.py
+++ b/api_service/migrations/versions/373_lease_identity_text.py
@@ -1,0 +1,55 @@
+"""Preserve composed lease identities without a storage-only length cap.
+
+An AgentRun remediation operation can already produce a 268-character
+idempotency key. Widen the related opaque identities together, without changing
+the values that in-flight workflows use for retry, inspection and release.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "373_lease_identity_text"
+down_revision = "372_machine_reservations"
+branch_labels = None
+depends_on = None
+
+_TABLE = "provider_profile_slot_leases"
+_COLUMNS = (
+    "workflow_id",
+    "lease_id",
+    "owner_id",
+    "step_execution_id",
+    "idempotency_key",
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch:
+        for column in _COLUMNS:
+            batch.alter_column(
+                column,
+                existing_type=sa.String(255),
+                type_=sa.Text(),
+                existing_nullable=column != "workflow_id",
+            )
+
+
+def downgrade() -> None:
+    # Never silently truncate an identity that a live workflow still quotes.
+    # Check every column before issuing any DDL, including on SQLite.
+    table = sa.table(_TABLE, *(sa.column(name, sa.Text()) for name in _COLUMNS))
+    oversized = sa.or_(*(sa.func.length(table.c[name]) > 255 for name in _COLUMNS))
+    if op.get_bind().execute(sa.select(sa.exists().where(oversized))).scalar():
+        raise RuntimeError(
+            "Cannot downgrade lease identities to VARCHAR(255): retained rows "
+            "contain longer identities. Keep this schema until those leases "
+            "have completed and their retention period has expired."
+        )
+    with op.batch_alter_table(_TABLE) as batch:
+        for column in _COLUMNS:
+            batch.alter_column(
+                column,
+                existing_type=sa.Text(),
+                type_=sa.String(255),
+                existing_nullable=column != "workflow_id",
+            )

--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1411,6 +1411,15 @@ it globally unique would break the handle its holder already quotes on release:
 that release would resolve the other runtime's row, be refused as a profile
 conflict, and leave the rewritten row permanently active.
 
+Workflow, lease, owner, step-execution and idempotency identities in the lease
+ledger are opaque text. Storage preserves the full value admitted by the
+originating contract, including composed remediation identifiers longer than
+255 characters. Persistence never truncates, hashes or renames an identity:
+in-flight grants, retries, inspection and release all quote the same value.
+Schema upgrades preserve existing rows and indexes so a retained grant can
+retry unchanged after migration. A downgrade to bounded columns must refuse
+while any retained identity exceeds that bound.
+
 The owning workflow is an identity for a **workflow-owned** lease only, and a
 partial unique index enforces it there. One Activity-owned step legitimately
 binds several Provider Profiles from the same runtime — each lease gets its own

--- a/tests/integration/omnigent/fixtures/remediation_lease_grant.json
+++ b/tests/integration/omnigent/fixtures/remediation_lease_grant.json
@@ -1,0 +1,24 @@
+{
+  "runtime_id": "opencode",
+  "action": "grant",
+  "leases": [
+    {
+      "lease_id": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:agent:mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:issue-implementation-remediation:remediation:1",
+      "workflow_id": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:agent:mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:issue-implementation-remediation:remediation:1",
+      "profile_id": "opencode-go-default",
+      "owner_id": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:agent:mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:issue-implementation-remediation:remediation:1",
+      "owner_kind": "workflow",
+      "purpose": "execution_direct",
+      "compatibility_class": "shared_execution",
+      "fencing_generation": 108,
+      "scope_generation": 1,
+      "capacity_scope_ref": "provider-profile:opencode-go-default",
+      "lease_state": "held",
+      "stepExecutionId": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:issue-implementation-remediation:remediation:1:execution:1",
+      "idempotencyKey": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-07T15:49:37Z:01a07c8f-8b35-7956-acf4-2f5bd33f8e56:issue-implementation-remediation:remediation:1:execution:1:agent_execute",
+      "executionPlanRef": "omnigent-execution-plan:sha256:73991882b9a91ced3b55948dc89218bf580d419e17f8eb21b34f8a20dd3696f5",
+      "credential_generation": 1,
+      "ownerIsWorkflow": true
+    }
+  ]
+}

--- a/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
+++ b/tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py
@@ -23,15 +23,17 @@ returns. Covered here:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 import pytest_asyncio
 from sqlalchemy import select, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -84,8 +86,8 @@ CREATE INDEX ix_provider_slot_leases_workflow
 """
 
 
-def _load_migration_module():
-    """Load the real ``369_provider_lease_incr_contract`` revision module.
+def _load_migration_module(revision="369_provider_lease_incr_contract"):
+    """Load a shipped revision module, rather than a copy of its DDL.
 
     Alembic revision files are not importable as a package (the directory has
     no ``__init__`` and the module name starts with a digit), so the real file
@@ -93,17 +95,16 @@ def _load_migration_module():
     """
 
     import importlib.util
-    from pathlib import Path
 
     path = (
         Path(__file__).resolve().parents[3]
         / "api_service"
         / "migrations"
         / "versions"
-        / "369_provider_lease_incr_contract.py"
+        / f"{revision}.py"
     )
     spec = importlib.util.spec_from_file_location(
-        "moonmind_test_migration_369", path
+        f"moonmind_test_migration_{revision}", path
     )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -1162,3 +1163,157 @@ async def test_no_credential_value_is_persisted_on_a_lease_row(
         "releaseReason",
         "cleanupRequested",
     }
+
+
+def _remediation_grant() -> dict[str, Any]:
+    """Minimized 2026-09-07 production Activity payload (no credentials)."""
+    return json.loads(
+        (Path(__file__).parent / "fixtures/remediation_lease_grant.json").read_text()
+    )
+
+
+async def _migrate_identities(maker, direction: str) -> None:
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    migration = _load_migration_module("373_lease_identity_text")
+
+    def migrate(conn):
+        with Operations.context(MigrationContext.configure(conn)):
+            getattr(migration, direction)()
+
+    async with maker.kw["bind"].begin() as conn:
+        await conn.run_sync(migrate)
+
+
+@pytest.mark.asyncio
+async def test_recorded_remediation_grant_resumes_unchanged_after_schema_upgrade(
+    lease_session_maker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reproduce the real failed handoff, migrate, then drain the same request.
+
+    No reset, new ID, synthetic slot signal or replacement grant is needed.
+    The manager runs its real queue and persistence code against PostgreSQL.
+    """
+    payload = _remediation_grant()
+    grant = payload["leases"][0]
+    owner = grant["lease_id"]
+    assert len(grant["stepExecutionId"]) == 254
+    assert len(grant["idempotencyKey"]) == 268
+
+    # Reconstruct the previous schema and retain a pre-existing short lease.
+    await _migrate_identities(lease_session_maker, "downgrade")
+    await _run("grant", [_grant("historical-owner", fence=4)])
+    with pytest.raises(DBAPIError, match="value too long"):
+        await _activity()(**payload)
+
+    manager = await _restore_manager(monkeypatch)
+    manager._profiles[grant["profile_id"]] = ProfileSlotState(
+        profile_id=grant["profile_id"],
+        max_parallel_runs=1,
+        cooldown_after_429_seconds=900,
+        rate_limit_policy="queue",
+        enabled=True,
+        purpose_aware_capacity=True,
+        capacity_scope_ref=grant["capacity_scope_ref"],
+    )
+    manager._lease_grant_sequence = 107
+    manager.request_slot(
+        {
+            "requester_workflow_id": owner,
+            "runtime_id": payload["runtime_id"],
+            "execution_profile_ref": grant["profile_id"],
+            "purpose": grant["purpose"],
+            "metadata": {
+                "workflowId": owner,
+                "ownerIsWorkflow": True,
+                "stepExecutionId": grant["stepExecutionId"],
+                "idempotencyKey": grant["idempotencyKey"],
+                "executionPlanRef": grant["executionPlanRef"],
+                "credentialGeneration": grant["credential_generation"],
+            },
+        }
+    )
+    await manager._drain_queue()
+    assert manager.reconnected == []
+    assert len(manager._pending_requests) == 1
+    assert await _run("describe", [{"lease_id": owner}]) == {
+        "found": False,
+        "lease_id": owner,
+    }
+
+    await _migrate_identities(lease_session_maker, "upgrade")
+    await manager._drain_queue()
+    assert manager.reconnected == [(owner, grant["profile_id"], 108)]
+    assert manager._pending_requests == []
+    rows = {row.lease_id: row for row in await _rows(lease_session_maker)}
+    assert set(rows) == {owner, "historical-owner"}
+    assert rows["historical-owner"].fencing_generation == 4
+    assert rows[owner].idempotency_key == grant["idempotencyKey"]
+    assert rows[owner].step_execution_id == grant["stepExecutionId"]
+    assert rows[owner].fencing_generation == 108
+    # The recorded failed Activity can also retry verbatim after migration.
+    assert await _activity()(**payload) == {"granted": True, "duplicate": True}
+
+    restarted = await _restore_manager(monkeypatch)
+    restarted._profiles[grant["profile_id"]] = ProfileSlotState(
+        profile_id=grant["profile_id"],
+        max_parallel_runs=1,
+        cooldown_after_429_seconds=900,
+        rate_limit_policy="queue",
+        enabled=True,
+        purpose_aware_capacity=True,
+        capacity_scope_ref=grant["capacity_scope_ref"],
+    )
+    assert await restarted._load_leases_from_db() is True
+    assert (owner, grant["profile_id"], 108) in restarted.reconnected
+    inspection = restarted.inspect_credential_lease({"lease_id": owner})
+    assert inspection["idempotencyKey"] == grant["idempotencyKey"]
+    assert inspection["stepExecutionId"] == grant["stepExecutionId"]
+    released = await _run(
+        "release_one", [{"lease_id": owner, "fencing_generation": 108}]
+    )
+    assert released["outcome"] == "released"
+    assert (
+        await _run("release_one", [{"lease_id": owner, "fencing_generation": 108}])
+    )["outcome"] == "already_released"
+
+
+@pytest.mark.parametrize("identity_length", [255, 256, 512, 1000])
+@pytest.mark.asyncio
+async def test_composed_identity_fields_round_trip_without_prefix_collisions(
+    lease_session_maker, identity_length: int
+) -> None:
+    await _migrate_identities(lease_session_maker, "downgrade")
+    await _migrate_identities(lease_session_maker, "upgrade")
+    # Opaque IDs need no table-specific 255/512 cap. Distinct long IDs with
+    # identical prefixes must keep independent retry and release authority.
+    for suffix in ("a", "b"):
+        identity = "w" * (identity_length - 1) + suffix
+        grant = {
+            **_grant(identity, fence=1),
+            "stepExecutionId": identity + ":step:execution:1",
+            "idempotencyKey": identity + ":step:execution:1:agent_execute",
+        }
+        assert (await _run("grant", [grant]))["duplicate"] is False
+        assert (await _run("grant", [grant]))["duplicate"] is True
+        row = await _run("describe", [{"lease_id": identity}])
+        assert row["found"] is True
+        stored = next(
+            r for r in await _rows(lease_session_maker) if r.lease_id == identity
+        )
+        assert stored.workflow_id == stored.owner_id == stored.lease_id == identity
+        assert stored.step_execution_id == grant["stepExecutionId"]
+        assert stored.idempotency_key == grant["idempotencyKey"]
+    assert len(await _rows(lease_session_maker)) == 2
+
+
+@pytest.mark.asyncio
+async def test_downgrade_refuses_to_truncate_retained_identity(
+    lease_session_maker,
+) -> None:
+    await _activity()(**_remediation_grant())
+    with pytest.raises(RuntimeError, match="Cannot downgrade lease identities"):
+        await _migrate_identities(lease_session_maker, "downgrade")
+    row = (await _rows(lease_session_maker))[0]
+    assert row.idempotency_key == _remediation_grant()["leases"][0]["idempotencyKey"]


### PR DESCRIPTION
## Related issue

N/A — diagnosed from a scheduled workflow stuck awaiting a provider slot.

## Summary

A remediation step generated a 268-character idempotency key for a `VARCHAR(255)` lease column. PostgreSQL rejected every grant attempt, leaving the profile's only slot reserved in memory and the same run queued indefinitely.

Store the five composed lease identity fields as text, with a data-preserving Alembic migration and guarded downgrade. Existing workflow payloads and identities remain unchanged, so retained grants can retry after migration. In plain terms, the database can now store the complete claim ticket that the workflow already owns.

## Test Plan

```bash
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/workflows/temporal/test_provider_profile_incremental_lease_persistence.py \
  tests/unit/workflows/temporal/test_provider_profile_admitted_capacity_fence.py \
  tests/unit/workflows/temporal/test_provider_profile_lease_durability.py \
  tests/unit/workflows/temporal/test_provider_profile_lease_transition_contract.py
pytest tests/integration/omnigent/test_provider_lease_incremental_contract_postgres.py -m integration_ci -q --tb=short
python tools/check_alembic_graph.py
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local ./tools/test_integration.sh
```

All 228 targeted unit tests and all six new PostgreSQL regression cases pass. The full local integration run passed 714 cases; seven cases required initializing the pinned Omnigent submodule, then all seven passed on rerun. Required CI, including integration and the clean-database migration gate, is green.

The PostgreSQL regression reproduces the original failure, upgrades the schema, retries the unchanged queued grant, verifies restart recovery and duplicate release, and covers 255/256/512/1000-character identities and downgrade refusal.

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Deployment must apply migration `373_lease_identity_text`. It widens columns without rewriting IDs, rows, indexes, workflow commands or serialized payloads. Provider selection and concurrency remain unchanged. Downgrade refuses while retained identities exceed 255 characters, including release tombstones; it never truncates authority. The migration takes PostgreSQL's normal table DDL lock.

## Coverage notes

The checked-in fixture contains only the minimized failed lease-grant payload. Tests use the real manager queue and lease Activity against isolated PostgreSQL, with signal delivery captured at the external boundary. Existing short leases survive migration alongside the resumed grant.

## Changelog

Prevent long remediation identifiers from leaving workflows stuck awaiting a provider slot.
