### PR TITLE
Fix missing PR handoff in issue-search workflows

### DIFF
--- a/api_service/data/presets/github-issue-search-and-implement.yaml
+++ b/api_service/data/presets/github-issue-search-and-implement.yaml
@@ -258,7 +258,9 @@ steps:
 
     {{ inputs.constraints }}
 
-    Following the GitHub Issue Implement preset (github-issue-implement) work-PR stage for the resolved issue: if the verdict is FULLY_IMPLEMENTED, make no code changes and ensure artifacts/github-issue-implement-pr.json explains the no-change outcome. If BLOCKED, stop without changes. Otherwise {% if inputs.run_verify %}only proceed when the latest controlling post-remediation moonspec-verify verdict in artifacts/github-issue-implement-verify.json is FULLY_IMPLEMENTED. If the verifier reported ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, or FAILED_UNRECOVERABLE, or if 6 remediation attempts have been exhausted without FULLY_IMPLEMENTED, stop without creating a pull request.{% else %}confirm implementation is complete and the focused tests required by the issue have passed; verification was disabled for this run so do not require artifacts/github-issue-implement-verify.json.{% endif %}
+    The initial assessment verdict and the later verification verdict have different roles. Skip PR creation only when the initial assessment in artifacts/github-issue-implement-assessment.json was FULLY_IMPLEMENTED and this run produced no repository changes. If the initial assessment was BLOCKED, stop without changes. If it was NOT_IMPLEMENTED or PARTIALLY_IMPLEMENTED, publish the implementation produced by this run even when the restored work branch is clean and its commits are already pushed. A later FULLY_IMPLEMENTED verification approves that implementation for publication; it does not mean the work was already on the base branch and does not authorize a no-change outcome.
+
+    {% if inputs.run_verify %}Only proceed when the latest controlling post-remediation moonspec-verify verdict in artifacts/github-issue-implement-verify.json is FULLY_IMPLEMENTED. If the verifier reported ADDITIONAL_WORK_NEEDED, NO_DETERMINATION, BLOCKED, or FAILED_UNRECOVERABLE, or if 6 remediation attempts have been exhausted without FULLY_IMPLEMENTED, stop without creating a pull request.{% else %}Confirm implementation is complete and the focused tests required by the issue have passed; verification was disabled for this run so do not require artifacts/github-issue-implement-verify.json.{% endif %}
 
     Commit intentional changes only (no raw credentials), push the non-protected work branch, and create a non-draft pull request. The pull request title must reference the resolved issue. The pull request body must include a summary, the verification outcome, tests run, remaining risks, AND a standalone `Closes <owner>/<repository>#<number>` line for the resolved issue (for example `Closes MoonLadderStudios/MoonMind#123`) so GitHub closes the issue on merge. A mere mention of the issue without the closing keyword is not sufficient. Propagate the resolved canonical issue identity (repository, number, url) into the PR artifact and publication handoffs. Record the confirmed pull_request_url in the step result and in artifacts/github-issue-implement-pr.json with keys issue_provider, issue_ref, repository, issue_number, and pull_request_url.
   skill:
@@ -273,6 +275,8 @@ steps:
     - gh
 - title: Finalize resolved GitHub issue status
   type: tool
+  annotations:
+    issueImplementRole: code-review-handoff
   instructions: |-
     Read the resolved issue from MoonMind trusted previous step context and artifacts/github-issue-implement-assessment.json (or the recorded verdict from the assess step) before changing GitHub.
 

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -196,6 +196,8 @@ The selected issue and brief travel through trusted context and a durable attach
 
 The initial assessment controls whether an issue needs implementation and a PR. A later `FULLY_IMPLEMENTED` verifier result approves the candidate for publication; a clean restored work branch or an already-pushed commit does not make that candidate a no-change outcome. The search preset declares the same `code-review-handoff` role as explicit issue implementation. Before updating issue status, the workflow creates or adopts a missing PR from its accepted remote branch and carries the confirmed URL into the trusted status tool. The resolved issue identity supplies the PR closing reference and post-merge completion target.
 
+Remediation Continue-As-New carries the compact trusted issue identity, initial assessment verdict, assessment/brief artifact references, and assessed repository/branch alongside the accepted candidate head. The resumed run restores that authority before publication or issue finalization; issue bodies and detailed requirements remain in artifacts.
+
 ## Preset Step and Provenance
 
 An authored step contains task-specific inputs:

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -194,6 +194,8 @@ Open prerequisites block admission; closed prerequisites do not. Only the leadin
 
 The selected issue and brief travel through trusted context and a durable attachment. Downstream blocker/status tools use the same identity and reject conflicts. Instructions do not perform dynamic binding or read agent-local files. Explicit resolved tool repository/issue inputs remain execution arguments, not competing user-level overrides. A pinned historical plan keeps its old search/selection behavior until newly admitted authoring selects the current definition.
 
+The initial assessment controls whether an issue needs implementation and a PR. A later `FULLY_IMPLEMENTED` verifier result approves the candidate for publication; a clean restored work branch or an already-pushed commit does not make that candidate a no-change outcome. The search preset declares the same `code-review-handoff` role as explicit issue implementation. Before updating issue status, the workflow creates or adopts a missing PR from its accepted remote branch and carries the confirmed URL into the trusted status tool. The resolved issue identity supplies the PR closing reference and post-merge completion target.
+
 ## Preset Step and Provenance
 
 An authored step contains task-specific inputs:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -964,6 +964,9 @@ RUN_OMNIGENT_PUBLICATION_CHECKPOINT_RESTORE_PATCH = (
 RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH = (
     "run-issue-implement-pr-handoff-authority-v1"
 )
+# Search-driven workflows resolve the issue after admission. Preserve the old
+# PR and merge-handoff payloads when replaying histories without this marker.
+RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH = "run-trusted-github-issue-identity-v1"
 # Carry only the atomic, accepted publication head into a downstream publisher.
 # Existing histories retain requests without this optional no-commit authority.
 RUN_ACCEPTED_PUBLICATION_HEAD_HANDOFF_PATCH = (
@@ -4944,6 +4947,12 @@ class MoonMindRunWorkflow:
             task_payload = self._mapping_value(parameters, "task")
         inputs = self._mapping_value(task_payload, "inputs")
         issue = self._mapping_value(inputs, "github_issue")
+        if not issue and self._patched_or_false_outside_workflow(
+            RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH
+        ):
+            resolved = self._canonical_github_issue_from_parameters(parameters)
+            if resolved:
+                return f"{resolved['repository']}#{resolved['issueNumber']}"
         repository = str(issue.get("repository") or "").strip()
         number = issue.get("number")
         if not repository or isinstance(number, bool):
@@ -18244,6 +18253,15 @@ class MoonMindRunWorkflow:
                 nested = template.get("inputs")
                 if isinstance(nested, Mapping):
                     mappings.append(nested)
+        trusted = self._trusted_issue_context
+        if (
+            isinstance(trusted, Mapping)
+            and trusted.get("trustedSource") == "moonmind.github.get_issue"
+            and self._patched_or_false_outside_workflow(
+                RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH
+            )
+        ):
+            mappings.append({"githubIssue": trusted.get("issue")})
         for mapping in mappings:
             issue = mapping.get("github_issue") or mapping.get("githubIssue")
             if not isinstance(issue, Mapping):

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -967,6 +967,11 @@ RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH = (
 # Search-driven workflows resolve the issue after admission. Preserve the old
 # PR and merge-handoff payloads when replaying histories without this marker.
 RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH = "run-trusted-github-issue-identity-v1"
+# Continue-As-New must retain the initial issue/assessment authority without
+# carrying issue bodies, requirements, or other artifact-owned content.
+RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH = (
+    "run-remediation-issue-authority-continuation-v1"
+)
 # Carry only the atomic, accepted publication head into a downstream publisher.
 # Existing histories retain requests without this optional no-commit authority.
 RUN_ACCEPTED_PUBLICATION_HEAD_HANDOFF_PATCH = (
@@ -4011,6 +4016,13 @@ class MoonMindRunWorkflow:
             published_head = continuation.get("acceptedPublishedHead")
             if isinstance(published_head, Mapping):
                 self._publish_context["acceptedPublishedHead"] = dict(published_head)
+        if workflow.patched(RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH):
+            assessment = continuation.get("assessmentContext")
+            if isinstance(assessment, Mapping):
+                self._assessment_context = dict(assessment)
+            trusted_issue = continuation.get("trustedIssueContext")
+            if isinstance(trusted_issue, Mapping):
+                self._record_trusted_issue_context(trusted_issue)
         carried_session = continuation.get("managedSessionBinding")
         if isinstance(carried_session, Mapping) and workflow.patched(
             RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH
@@ -4067,6 +4079,38 @@ class MoonMindRunWorkflow:
             published_head = self._publish_context.get("acceptedPublishedHead")
             if isinstance(published_head, Mapping):
                 continuation["acceptedPublishedHead"] = dict(published_head)
+        if workflow.patched(RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH):
+            continuation["assessmentContext"] = {
+                key: value
+                for key, value in self._assessment_context.items()
+                if isinstance(value, str)
+                and key in {
+                    "assessmentArtifactRef",
+                    "assessment_artifact_ref",
+                    "assessmentVerdict",
+                    "assessment_verdict",
+                    "briefArtifactRef",
+                    "brief_artifact_ref",
+                    "assessedRepository",
+                    "assessedBranch",
+                }
+            }
+            trusted_issue = self._trusted_issue_context or {}
+            compact_issue = {
+                key: trusted_issue[key]
+                for key in ("trustedSource", "jiraIssueKey")
+                if isinstance(trusted_issue.get(key), str)
+            }
+            for key in ("issue", "githubIssue"):
+                issue = trusted_issue.get(key)
+                if isinstance(issue, Mapping):
+                    compact_issue[key] = {
+                        field: issue[field]
+                        for field in ("repository", "number", "url")
+                        if field in issue
+                    }
+            if compact_issue:
+                continuation["trustedIssueContext"] = compact_issue
         binding = self._codex_session_binding
         if binding is not None and workflow.patched(
             RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH

--- a/tests/integration/reliability/replays/issue-search-publication-handoff/manifest.json
+++ b/tests/integration/reliability/replays/issue-search-publication-handoff/manifest.json
@@ -29,6 +29,7 @@
     "Expand the seeded search preset with omitted or explicit default inputs",
     "Load the selected issue through the registered GitHub tool",
     "Restore the accepted publication head and independent assessment/verifier evidence",
+    "Carry compact issue and assessment authority through repeated Continue-As-New before the verifier passes",
     "Resume the compiled finalization step after the agent omitted its PR",
     "Create or adopt the PR before the registered issue status activity mutates GitHub"
   ],

--- a/tests/integration/reliability/replays/issue-search-publication-handoff/manifest.json
+++ b/tests/integration/reliability/replays/issue-search-publication-handoff/manifest.json
@@ -1,0 +1,41 @@
+{
+  "failureShapeId": "issue-search-publication-handoff",
+  "incidentWorkflowId": "mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T16:15:48Z",
+  "runtime": "external/omnigent",
+  "cause": "The publication agent mistook successful verification on the restored work branch for an initially implemented issue. The search preset omitted the code-review-handoff annotation, bypassing the existing PR recovery boundary.",
+  "repository": "MoonLadderStudios/MoonMind",
+  "issueNumber": 3963,
+  "assessmentVerdict": "NOT_IMPLEMENTED",
+  "verificationVerdict": "FULLY_IMPLEMENTED",
+  "acceptedRepositoryEvidence": {
+    "schemaVersion": "accepted-repository-evidence/v1",
+    "authority": "omnigent.generic_host_execution",
+    "publicationAuthorized": true,
+    "candidateContaminated": false,
+    "pushStatus": "pushed",
+    "branch": "moonmind-job-aacfde57",
+    "headSha": "49d3a2a7c81afb4f2b07b0d9f82a868525f576b0",
+    "baseBranch": "main",
+    "remoteVerified": true,
+    "repositoryChanged": true,
+    "commitsAheadOfBase": 1
+  },
+  "agentOutcome": {
+    "summary": "Omnigent session completed",
+    "pull_request_url": null,
+    "outcome": "no_change_already_implemented"
+  },
+  "eventScript": [
+    "Expand the seeded search preset with omitted or explicit default inputs",
+    "Load the selected issue through the registered GitHub tool",
+    "Restore the accepted publication head and independent assessment/verifier evidence",
+    "Resume the compiled finalization step after the agent omitted its PR",
+    "Create or adopt the PR before the registered issue status activity mutates GitHub"
+  ],
+  "expected": {
+    "issueState": "open",
+    "issueLabel": "status: code-review",
+    "publishStatus": "published",
+    "closingLine": "Closes MoonLadderStudios/MoonMind#3963"
+  }
+}

--- a/tests/integration/reliability/test_issue_search_publication.py
+++ b/tests/integration/reliability/test_issue_search_publication.py
@@ -1,0 +1,282 @@
+"""Replay search-preset publication through the worker and status boundaries."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import Base
+from api_service.services.presets.catalog import PresetCatalogService
+from moonmind.workflows.adapters.github_service import GitHubService
+from moonmind.workflows.skills.tool_dispatcher import ToolActivityDispatcher
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalSkillActivities,
+    _default_registry_skill_payload,
+)
+from moonmind.workflows.temporal.story_output_tools import (
+    register_story_output_tool_handlers,
+)
+from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+from .helpers import load_replay
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.reliability_journey]
+
+
+@pytest.mark.parametrize("inputs", [{}, {"run_verify": True}, {"run_verify": False}])
+@pytest.mark.parametrize("pr_created", [True, False, "unavailable"])
+async def test_search_publication_recovers_missing_pr_before_status(
+    tmp_path, monkeypatch, inputs, pr_created
+):
+    evidence = load_replay("issue-search-publication-handoff", "manifest.json")
+    repository = evidence["repository"]
+    number = evidence["issueNumber"]
+    expected = evidence["expected"]
+    pr_url = f"https://github.com/{repository}/pull/9999"
+    operations = []
+    issue = {
+        "number": number,
+        "state": "open",
+        "title": "Dispose of completed temporary plans",
+        "body": "Preserve active dependencies and durable evidence.",
+        "html_url": f"https://github.com/{repository}/issues/{number}",
+        "labels": [],
+    }
+
+    def github_http(request):
+        operations.append((request.method, request.url.path))
+        if request.method == "PATCH":
+            assert operations[0][0] == "repo.create_pr"
+            issue.update(json.loads(request.content))
+        if request.method == "POST":
+            assert pr_url in json.loads(request.content)["body"]
+            return httpx.Response(201, json={"id": 1})
+        result = [issue] if request.url.path.endswith("/issues") else issue
+        return httpx.Response(200, json=result)
+
+    client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: client(transport=httpx.MockTransport(github_http), **kwargs),
+    )
+    monkeypatch.setattr(
+        GitHubService,
+        "resolve_github_token",
+        AsyncMock(return_value=("test-only", None)),
+    )
+    seeds = tmp_path / "seeds"
+    seeds.mkdir()
+    shutil.copy(
+        Path("api_service/data/presets/github-issue-search-and-implement.yaml"), seeds
+    )
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/catalog.db")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        async with async_sessionmaker(engine)() as session:
+            catalog = PresetCatalogService(session)
+            await catalog.sync_seed_templates(seed_dir=seeds)
+            expanded = await catalog.expand_template(
+                slug="github-issue-search-and-implement",
+                scope="global",
+                scope_ref=None,
+                inputs=inputs,
+                context={"repository": repository},
+            )
+    finally:
+        await engine.dispose()
+
+    dispatcher = ToolActivityDispatcher()
+    register_story_output_tool_handlers(dispatcher)
+    snapshot = ToolRegistrySnapshot(
+        digest="reg:sha256:search-publication",
+        artifact_ref="art:sha256:registry",
+        skills=tuple(
+            parse_tool_definition(_default_registry_skill_payload(name=name))
+            for name in ("github.load_issue_preset_brief", "github.update_issue_status")
+        ),
+    )
+    activities = TemporalSkillActivities(
+        dispatcher=dispatcher,
+        artifact_service=SimpleNamespace(
+            read=AsyncMock(
+                return_value=(None, {"verdict": evidence["assessmentVerdict"]})
+            )
+        ),
+    )
+
+    async def invoke(payload):
+        return await activities.mm_tool_execute(
+            registry_snapshot=snapshot,
+            principal="test:search-publication",
+            invocation_payload=payload,
+            context={
+                "namespace": "default",
+                "workflow_id": "mm:replay",
+                "run_id": "run",
+                "node_id": payload["id"],
+            },
+            idempotency_key=f"{payload['id']}:execute",
+        )
+
+    load_tool = expanded["steps"][0]["tool"]
+    selected = await invoke(
+        {
+            "id": "search",
+            "tool": {"type": "skill", "name": load_tool["id"]},
+            "inputs": load_tool["inputs"],
+        }
+    )
+    assert selected.status == "COMPLETED"
+    parent = MoonMindRunWorkflow()
+    parent._owner_id = "test:search-publication"
+    parent._repo = repository
+    parent._record_trusted_issue_context(selected.outputs)
+    parent._assessment_context = {
+        "assessmentVerdict": evidence["assessmentVerdict"],
+        "assessmentArtifactRef": "art_assessment",
+    }
+    parent._record_accepted_published_head(evidence)
+    parent._publish_context["moonSpecGate"] = {
+        "verdict": evidence["verificationVerdict"],
+        "gateResultRef": "art_verify",
+    }
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {"title": "Implement selected issue", "inputs": inputs},
+    }
+    # Compile real seed metadata; constructing an annotated node by hand hid
+    # the missing annotation in the preceding incident's regression test.
+    planner = _build_runtime_planner()
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Implement the selected issue and publish its PR.",
+                "steps": expanded["steps"],
+                "publish": {"mode": "pr"},
+                "runtime": {"mode": "omnigent"},
+            }
+        },
+        parameters=parameters,
+        snapshot=snapshot,
+    )
+    final_node = plan["nodes"][-1]
+    assert parent._issue_implement_handoff_role(final_node) == "code-review-handoff"
+    # The minimized replay resumes just after the publication agent returned
+    # the captured false no-change outcome, retaining its accepted branch.
+    plan["nodes"] = [final_node]
+    plan["edges"] = []
+    operations.clear()
+    enabled_patches = {
+        run_module.RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+        run_module.RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH,
+        run_module.RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
+        run_module.RUN_AUTHORITATIVE_PR_REQUIREMENT_PATCH,
+    }
+    monkeypatch.setattr(run_module.workflow, "patched", enabled_patches.__contains__)
+    monkeypatch.setattr(run_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_module.workflow, "upsert_search_attributes", lambda _attrs: None
+    )
+    monkeypatch.setattr(run_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(
+        run_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            namespace="default",
+            workflow_id="mm:replay",
+            run_id="run",
+            search_attributes={},
+        ),
+    )
+    monkeypatch.setattr(run_module.workflow, "logger", logging.getLogger(__name__))
+
+    async def wait_condition(predicate, **_kwargs):
+        assert predicate()
+
+    monkeypatch.setattr(run_module.workflow, "wait_condition", wait_condition)
+    monkeypatch.setattr(run_module.workflow, "all_handlers_finished", lambda: True)
+
+    async def execute_activity(name, payload, **_kwargs):
+        data = payload if isinstance(payload, dict) else payload.model_dump()
+        if name == "artifact.create":
+            return ({"artifact_id": "art_manifest"}, {})
+        if name == "artifact.read":
+            if data["artifact_ref"] == "art_plan":
+                return json.dumps(plan).encode()
+            return json.dumps(
+                {
+                    "skills": [
+                        _default_registry_skill_payload(
+                            name="github.update_issue_status"
+                        )
+                    ]
+                }
+            ).encode()
+        if name == "repo.create_pr":
+            operations.append((name, data))
+            assert data["head"] == evidence["acceptedRepositoryEvidence"]["branch"]
+            assert data["base"] == "main"
+            assert expected["closingLine"] in data["body"].splitlines()
+            assert f"{repository}#{number}" in data["title"]
+            if pr_created == "unavailable":
+                return {"created": False, "summary": "GitHub publication unavailable"}
+            return {"url": pr_url, "created": pr_created, "adopted": not pr_created}
+        if name == "mm.tool.execute":
+            result = await invoke(data["invocation_payload"])
+            assert result.status == "COMPLETED", result.outputs
+            return result
+        raise AssertionError(f"Unexpected activity {name}")
+
+    monkeypatch.setattr(run_module.workflow, "execute_activity", execute_activity)
+    if pr_created == "unavailable":
+        with pytest.raises(ValueError, match="PR creation returned no URL"):
+            await parent._run_execution_stage(
+                parameters=parameters, plan_ref="art_plan"
+            )
+        assert [op[0] for op in operations] == ["repo.create_pr"]
+        assert parent._accepted_published_head() == (
+            evidence["acceptedRepositoryEvidence"]["branch"],
+            evidence["acceptedRepositoryEvidence"]["headSha"],
+        )
+        return
+    await parent._run_execution_stage(parameters=parameters, plan_ref="art_plan")
+    assert issue["state"] == expected["issueState"]
+    assert expected["issueLabel"] in issue["labels"]
+    assert parent._publish_status == expected["publishStatus"]
+    assert parent._publish_context["pullRequestUrl"] == pr_url
+    assert sum(op[0] == "repo.create_pr" for op in operations) == 1
+    assert parent._canonical_github_issue_from_parameters(parameters) == {
+        "repository": repository,
+        "issueNumber": number,
+    }
+    merge_request = parent._merge_automation_request(
+        {
+            **parameters,
+            "mergeAutomation": {"enabled": True},
+        }
+    )
+    assert merge_request["postMergeGithub"]["issueNumber"] == number
+    assert merge_request["postMergeGithub"]["repository"] == repository
+    # Retrying the finalization boundary reuses the confirmed PR.
+    assert (
+        await parent._ensure_issue_implement_pr_before_status(
+            node=final_node, parameters=parameters
+        )
+        == pr_url
+    )
+    assert sum(op[0] == "repo.create_pr" for op in operations) == 1

--- a/tests/integration/reliability/test_issue_search_publication.py
+++ b/tests/integration/reliability/test_issue_search_publication.py
@@ -27,6 +27,12 @@ from moonmind.workflows.temporal.activity_runtime import (
 from moonmind.workflows.temporal.story_output_tools import (
     register_story_output_tool_handlers,
 )
+from moonmind.workflows.temporal.remediation_loop import (
+    ConsumedRemediationBudgets,
+    RemediationLoopPhase,
+    RemediationLoopSpec,
+    RemediationLoopState,
+)
 from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
@@ -36,10 +42,18 @@ from .helpers import load_replay
 pytestmark = [pytest.mark.asyncio, pytest.mark.reliability_journey]
 
 
-@pytest.mark.parametrize("inputs", [{}, {"run_verify": True}, {"run_verify": False}])
+@pytest.mark.parametrize(
+    "inputs,restart_count",
+    [
+        ({}, 0),
+        ({"run_verify": True}, 0),
+        ({"run_verify": False}, 0),
+        ({}, 2),
+    ],
+)
 @pytest.mark.parametrize("pr_created", [True, False, "unavailable"])
 async def test_search_publication_recovers_missing_pr_before_status(
-    tmp_path, monkeypatch, inputs, pr_created
+    tmp_path, monkeypatch, inputs, restart_count, pr_created
 ):
     evidence = load_replay("issue-search-publication-handoff", "manifest.json")
     repository = evidence["repository"]
@@ -149,12 +163,11 @@ async def test_search_publication_recovers_missing_pr_before_status(
     parent._assessment_context = {
         "assessmentVerdict": evidence["assessmentVerdict"],
         "assessmentArtifactRef": "art_assessment",
+        "briefArtifactRef": "art_brief",
+        "assessedRepository": repository,
+        "assessedBranch": "main",
     }
     parent._record_accepted_published_head(evidence)
-    parent._publish_context["moonSpecGate"] = {
-        "verdict": evidence["verificationVerdict"],
-        "gateResultRef": "art_verify",
-    }
     parameters = {
         "publishMode": "pr",
         "workflow": {"title": "Implement selected issue", "inputs": inputs},
@@ -186,6 +199,8 @@ async def test_search_publication_recovers_missing_pr_before_status(
         run_module.RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH,
         run_module.RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
         run_module.RUN_AUTHORITATIVE_PR_REQUIREMENT_PATCH,
+        run_module.RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH,
+        run_module.RUN_ACCEPTED_PUBLISHED_BRANCH_HANDOFF_PATCH,
     }
     monkeypatch.setattr(run_module.workflow, "patched", enabled_patches.__contains__)
     monkeypatch.setattr(run_module.workflow, "upsert_memo", lambda _memo: None)
@@ -210,6 +225,42 @@ async def test_search_publication_recovers_missing_pr_before_status(
 
     monkeypatch.setattr(run_module.workflow, "wait_condition", wait_condition)
     monkeypatch.setattr(run_module.workflow, "all_handlers_finished", lambda: True)
+
+    if restart_count:
+        spec = RemediationLoopSpec.model_validate(
+            next(
+                step["annotations"]["remediationLoop"]
+                for step in expanded["steps"]
+                if "remediationLoop" in step.get("annotations", {})
+            )
+        )
+        parent._remediation_loop_spec = spec
+        parent._remediation_loop_state = RemediationLoopState(
+            loopId=spec.loop_id,
+            attemptOrdinal=3,
+            phase=RemediationLoopPhase.VERIFICATION_PENDING,
+            consumedBudgets=ConsumedRemediationBudgets(attempts=3),
+        )
+        for _ in range(restart_count):
+            carried = parent._build_remediation_loop_continue_as_new_input(
+                ordered_nodes=[final_node]
+            )["remediation_loop_continuation"]
+            assert "body" not in json.dumps(carried["trustedIssueContext"])
+            restored = MoonMindRunWorkflow()
+            restored._owner_id = parent._owner_id
+            restored._repo = repository
+            restored._remediation_loop_spec = spec
+            restored._remediation_loop_continuation = carried
+            restored._restore_remediation_loop_continuation(ordered_nodes=[])
+            assert restored._assessment_context == parent._assessment_context
+            assert restored._issue_implement_pr_required()
+            parent = restored
+    # The verifier in the resumed run approves the candidate. This must not
+    # replace the initial assessment carried across either restart.
+    parent._publish_context["moonSpecGate"] = {
+        "verdict": evidence["verificationVerdict"],
+        "gateResultRef": "art_verify",
+    }
 
     async def execute_activity(name, payload, **_kwargs):
         data = payload if isinstance(payload, dict) else payload.model_dump()

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -41,6 +41,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_REMEDIATION_MANAGED_SESSION_SOURCE_IDENTITY_PATCH,
     RUN_REMEDIATION_CONTINUE_MANAGED_SESSION_PATCH,
     RUN_REMEDIATION_STABLE_PROGRESS_IDENTITY_PATCH,
+    RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH,
     RUN_RUNTIME_EXECUTION_CAPABILITIES_PATCH,
     RUN_AGENT_RUNTIME_RETRY_CLASSIFICATION_PATCH,
     RUN_STEP_RETRY_OVERRIDES_PATCH,
@@ -5350,6 +5351,69 @@ def test_continue_as_new_preserves_stable_progress_identity_only_after_patch(
     )["remediation_loop_continuation"]
 
     assert "latestProgressSignature" not in legacy["state"]
+
+
+@pytest.mark.parametrize("patch_enabled", [False, True])
+@pytest.mark.parametrize("provider", ["github", "jira"])
+def test_continue_as_new_carries_only_compact_issue_authority(
+    mock_run_workflow, monkeypatch, patch_enabled, provider
+):
+    from moonmind.workflows.temporal.remediation_loop import (
+        RemediationLoopSpec,
+        RemediationLoopState,
+    )
+
+    spec = RemediationLoopSpec.model_validate(_dynamic_loop_spec_payload())
+    mock_run_workflow._remediation_loop_spec = spec
+    mock_run_workflow._remediation_loop_state = RemediationLoopState(
+        loopId=spec.loop_id, phase="verification_pending", consumedBudgets={}
+    )
+    context = {
+        "trustedSource": f"moonmind.{provider}.get_issue",
+        "presetBrief": "Large issue content belongs in artifacts.",
+    }
+    if provider == "github":
+        context["issue"] = {
+            "repository": "org/repo",
+            "number": 3963,
+            "body": "Large issue body",
+        }
+    else:
+        context["jiraIssueKey"] = "MM-123"
+    mock_run_workflow._record_trusted_issue_context(context)
+    assessment = {
+        "assessmentVerdict": "NOT_IMPLEMENTED",
+        "assessmentArtifactRef": "art_assessment",
+        "briefArtifactRef": "art_brief",
+    }
+    mock_run_workflow._assessment_context = {
+        **assessment,
+        "requirements": "Large requirements",
+    }
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_enabled
+        and patch_id == RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH,
+    )
+    carried = mock_run_workflow._build_remediation_loop_continue_as_new_input(
+        ordered_nodes=[]
+    )["remediation_loop_continuation"]
+    if patch_enabled:
+        assert carried["assessmentContext"] == assessment
+        assert "Large" not in str(carried["trustedIssueContext"])
+    else:
+        assert "assessmentContext" not in carried
+        assert "trustedIssueContext" not in carried
+    restored = MoonMindRunWorkflow()
+    restored._remediation_loop_spec = spec
+    restored._remediation_loop_continuation = carried
+    restored._restore_remediation_loop_continuation(ordered_nodes=[])
+    assert restored._assessment_context == (assessment if patch_enabled else {})
+    if patch_enabled:
+        assert restored._trusted_issue_context == carried["trustedIssueContext"]
+    else:
+        assert restored._trusted_issue_context is None
 
 
 def test_continuation_written_without_a_head_still_restores(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -25,6 +25,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_HEADLESS_REMEDIATION_VERIFIED_WORKSPACE_PATCH,
     RUN_HEADLESS_REMEDIATION_EXECUTION_PATCH,
     RUN_ISSUE_IMPLEMENT_PR_HANDOFF_AUTHORITY_PATCH,
+    RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH,
     RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH,
@@ -6703,6 +6704,59 @@ async def test_issue_implement_status_handoff_does_not_create_pr_for_fully_imple
 
     assert url is None
     execute_activity.assert_not_awaited()
+
+
+@pytest.mark.parametrize("patch_enabled", [False, True])
+def test_search_issue_identity_preserves_historical_publication_payloads(
+    mock_run_workflow, monkeypatch, patch_enabled
+):
+    mock_run_workflow._record_trusted_issue_context(
+        {
+            "trustedSource": "moonmind.github.get_issue",
+            "issue": {"repository": "org/repo", "number": 3963},
+        }
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "patched",
+        lambda patch_id: patch_enabled
+        and patch_id == RUN_TRUSTED_GITHUB_ISSUE_IDENTITY_PATCH,
+    )
+    assert mock_run_workflow._github_issue_ref_from_parameters({}) == (
+        "org/repo#3963" if patch_enabled else None
+    )
+    assert mock_run_workflow._canonical_github_issue_from_parameters({}) == (
+        {"repository": "org/repo", "issueNumber": 3963} if patch_enabled else None
+    )
+    # Explicit issue input retains the same identity on both history paths.
+    explicit = {
+        "workflow": {
+            "inputs": {
+                "github_issue": {"repository": "org/repo", "number": 123},
+            }
+        }
+    }
+    assert (
+        mock_run_workflow._github_issue_ref_from_parameters(explicit) == "org/repo#123"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", ["", "UNKNOWN", "BLOCKED", "NEW_PROVIDER_STATUS"])
+async def test_issue_handoff_does_not_infer_publication_from_unknown_assessment(
+    mock_run_workflow, monkeypatch, verdict
+):
+    mock_run_workflow._assessment_context = {"assessmentVerdict": verdict}
+    create_pr = AsyncMock()
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", create_pr)
+    assert (
+        await mock_run_workflow._ensure_issue_implement_pr_before_status(
+            node={"annotations": {"issueImplementRole": "code-review-handoff"}},
+            parameters={"publishMode": "pr"},
+        )
+        is None
+    )
+    create_pr.assert_not_awaited()
 
 
 def test_partial_issue_implementation_no_commits_cannot_satisfy_pr_handoff(


### PR DESCRIPTION
The hourly issue-search workflow could push its implementation and then fail at issue finalization with no PR URL. Its publication instructions conflated the initial assessment with later successful verification, and the search preset omitted the annotation that activates the existing PR recovery handoff.

Clarify when publication can be skipped, declare the finalization handoff, and carry the trusted search result into the PR closing reference and post-merge issue target. Carry compact issue identity, initial assessment, and artifact references through remediation Continue-As-New. Preserve historical payloads behind Temporal patches. A minimized replay of `mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T16:15:48Z` expands the actual preset, compiles its plan, resumes workflow execution, and invokes the registered GitHub status tool. It covers omitted/default verification, verification disabled, PR creation/adoption, retries, repeated Continue-As-New, and publication failure without issue mutation.

Validation: 698 targeted unit tests and 10 publication replay cases passed. Broader deterministic checks passed 341 workflow/recovery tests and 200 UI tests. The macOS conformance run encountered missing PostgreSQL binaries and Linux/filesystem-specific test failures; rerunning the affected checks plus the new replay in the Linux Python test image passed all 193 tests.

Final continuation validation: 289 targeted workflow/remediation/replay tests passed, including 12 publication journey cases and old/new continuation payload coverage for GitHub and Jira.

Existing pinned workflow plans retain their recorded definition. The updated preset applies after deployment and fresh preset expansion; this change does not reset the failed run or publish its unrelated implementation branch.
