### PR TITLE
[Docs] Consolidate Omnigent documentation while preserving exact-support and credential contracts (MoonLadderStudios/MoonMind#3962)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The migration is deliberately evidence-gated. OpenCode is the first generic-host
 
 The intended host direction is one digest-pinned MoonMind Omnigent image reused by Codex, Claude Code, and OpenCode wherever practical. Separate Host Classes, runtime-pack adapters, credential materializers, and support rows preserve strict runtime and credential isolation even when they share the same image digest.
 
-See the canonical [Omnigent Primary Runtime Provider Strategy](docs/Omnigent/PrimaryRuntimeProviderStrategy.md), the [Omnigent Harness Platform Design](docs/Omnigent/OmnigentHarnessPlatformDesign.md), and the [MoonMind Roadmap](docs/MoonMindRoadmap.md).
+See the [Omnigent module entrypoint](docs/Omnigent/README.md), the canonical [Omnigent Primary Runtime Provider Strategy](docs/Omnigent/PrimaryRuntimeProviderStrategy.md), the [Omnigent Harness Platform Design](docs/Omnigent/OmnigentHarnessPlatformDesign.md), and the [MoonMind Roadmap](docs/MoonMindRoadmap.md).
 
 ## Quick Start
 

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -941,7 +941,10 @@ runtime, artifact collection, and cleanup.
 
 Omnigent and MoonMind managed sessions use the same tools and job contract. An
 agent runtime does not need a Docker CLI to run repository tests and must not
-advertise a session-local `DOCKER_HOST`.
+advertise a session-local `DOCKER_HOST`. The Omnigent side of this contract —
+supported startup path, Host Classes, credential materializers, and session
+control — is owned by the [Omnigent module entrypoint](../Omnigent/README.md);
+this section owns only the container-job and MCP tooling both sides share.
 
 The default profile-bound Omnigent host receives a host-lease-scoped bearer
 capability and a dependency-free `moonmind` CLI projection. Its capability pins

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -453,6 +453,9 @@ normal agent interface.
 
 ## 9. Omnigent integration
 
+Start at the [Omnigent module entrypoint](./Omnigent/README.md) for the
+supported startup path, exact limitations, and contract owners.
+
 Omnigent provides a common host and orchestration layer over multiple coding
 harnesses. MoonMind integration preserves the following boundary:
 

--- a/docs/Omnigent/CodexSupportAndCutover.md
+++ b/docs/Omnigent/CodexSupportAndCutover.md
@@ -17,6 +17,11 @@ authority, and complete failure matrix that this support state qualifies are
 reconciled in
 [Normal Codex product-path reconciliation](./NormalCodexProductPathReconciliation.md).
 
+Ownership note: this document owns the Codex exact support rows, cutover
+phases, and operator remediation matrix. The versioned rollout mechanism that
+promotes every combination (states, canary, rollback, migration status) is
+owned by [Runtime-Provider Rollout Policy](./RuntimeProviderRollout.md).
+
 ## Compatibility inventory
 
 | Direct Codex surface | Classification | Owner and supported behavior | Evidence contract / control | Removal condition | Rollback implication |

--- a/docs/Omnigent/ContractOwnership.md
+++ b/docs/Omnigent/ContractOwnership.md
@@ -106,21 +106,6 @@ Deliberately *not* merged (distinct responsibilities, per #3962):
 
 ## Reduction report
 
-Reduction is an outcome of this pass, not a justification for dropping
-contracts: every contract above retains exactly one surviving owner and no
-owner text was deleted, only duplicated restatements were replaced with
-pointers. Measured with `git diff` word counts on `docs/Omnigent/`:
-
-- Eight duplicated sections replaced by surviving-owner pointers
-  (Strategy §§7–8, HostOAuth §§10–11, OpenCodeHost §§1–3, 6): about 400
-  words of second descriptions removed.
-- Two new routing docs added: `README.md` entrypoint (~615 words) and this
-  map (~1,030 words).
-- Ten existing files gained owner cross-links (`Related documents` blocks
-  plus ownership notes in `CodexSupportAndCutover.md`,
-  `OmnigentHarnessPlatformDesign.md`, `OpenCodeHost.md` §15).
-- Net word delta is positive by design: routing words replaced duplicate
-  contract words. No relied-upon contract lost its owner; the guard test
-  `tests/unit/docs/test_omnigent_consolidation_3962.py` pins the entrypoint,
-  the per-file coverage of this map, the surviving credential/exact-support
-  phrases, the pointer replacements, and link/anchor validity.
+Moved to `../tmp/OmnigentConsolidation3962ReductionReport.md`: that note
+records this pass's implementation history (removed duplicates, word
+counts, touched files). This map keeps only the target ownership state.

--- a/docs/Omnigent/ContractOwnership.md
+++ b/docs/Omnigent/ContractOwnership.md
@@ -1,0 +1,126 @@
+# Omnigent Contract Ownership Map
+
+**Document Class:** Module ownership map
+**Status:** Current
+**Owners:** MoonMind Platform
+**Last updated:** 2026-09-07
+**Authority:** Maps every `docs/Omnigent/` path and known duplicated section to
+its one surviving owner. Owners hold the contract; all other docs point.
+**Issue:** [MoonLadderStudios/MoonMind#3962](https://github.com/MoonLadderStudios/MoonMind/issues/3962).
+
+Parent: #3929. Coordinates with #3928 (integration boundaries) and
+#3832–#3835 (qualification, default promotion, Compose consolidation,
+retirement). Completed scaffolding is disposed under #3963; current rollout
+work stays in its owning issue plan (`docs/tmp/OmnigentBridgeRollout.md`).
+
+## Unique contracts and surviving owners
+
+| # | Contract | Surviving owner |
+| --- | --- | --- |
+| 1 | Pinned upstream transport, provider/service session facade, native Workflow Chat facade, bridge session store | `OmnigentBridge.md` |
+| 2 | Adapter launch modes, workspace/mount/network contract, readiness, session/stream/artifact contract | `OmnigentAdapter.md` |
+| 3 | Module packages, dependency direction, ports | `OmnigentModuleArchitecture.md` §§1–4, 6 |
+| 4 | Retained duplicate architecture and removal staging (code-owned inventory) | `OmnigentModuleArchitecture.md` §5 over `moonmind/omnigent/legacy_retirement.py` |
+| 5 | Target harness-platform model (catalog, attestation, plans, bindings, capability negotiation) | `OmnigentHarnessPlatformDesign.md` (Status: Proposed) |
+| 6 | Product selection, defaults, migration stages, acceptance gates | `PrimaryRuntimeProviderStrategy.md` |
+| 7 | Shared image, runtime packs, Host Classes, credential ownership, realizer admission | `SharedHostImage.md` |
+| 8 | Credential materializer mechanisms, enrollment, launch ordering, rotation, cleanup detail | `OmnigentHostOAuth.md` |
+| 9 | OpenCode runtime contract on the shared image | `OpenCodeHost.md` |
+| 10 | Agent / Provider Profile identities and discovery/launch security | `AgentProfiles.md` |
+| 11 | Canonical turn-command boundary, admission, terminal meanings | `CanonicalTurnCommandBoundary.md` |
+| 12 | Lifecycle reconciler transition contract | `OmnigentLifecycleReconciler.md` |
+| 13 | Control-plane aggregates, concurrency/fencing, telemetry/timeline | `ControlPlaneAggregates.md`, `ControlPlaneConcurrencyAndFencing.md`, `OmnigentSemanticTelemetryAndTimeline.md` |
+| 14 | Versioned rollout states, canary, rollback, migration status | `RuntimeProviderRollout.md` |
+| 15 | Codex exact support rows, cutover phases, remediation matrix | `CodexSupportAndCutover.md` |
+| 16 | Codex create-to-host wire contract | `CodexCreateToHostContract.md` |
+| 17 | Codex product-path reconciliation | `NormalCodexProductPathReconciliation.md` |
+| 18 | Conformance tiers and live-smoke boundaries | `ConformanceAndLiveSmoke.md` |
+| 19 | Concurrency qualification record | `ConcurrencyQualification.md` |
+| 20 | Fault-injection suite and invariants | `OmnigentFaultInjectionSuite.md` |
+| 21 | Mounted runtime tools and `gh` capability | `OmnigentHostMountedTools.md` |
+| 22 | Policy authority, persistence, approvals | `PolicyAuthority.md` |
+| 23 | Embedded host-auth compatibility surface | `EmbeddedHostAuthCompatibility.md` |
+| 24 | Combined-stack validation and rollback runbook | `CombinedStackValidationAndRollback.md` |
+
+## Duplicated sections and their surviving owners
+
+These sections restated an owner-held contract. Each now points at its owner
+instead of carrying a second description:
+
+| Duplicated section | Surviving owner |
+| --- | --- |
+| `PrimaryRuntimeProviderStrategy.md` §7 shared-image rules | `SharedHostImage.md` §1 |
+| `PrimaryRuntimeProviderStrategy.md` §8 runtime-pack descriptor rules | `SharedHostImage.md` §2 |
+| `OmnigentHostOAuth.md` §10 shared-image isolation | `SharedHostImage.md` §§3–4 |
+| `OmnigentHostOAuth.md` §11 Host Class / runtime-pack listing | `SharedHostImage.md` §3 |
+| `OpenCodeHost.md` §1 shared-image implementation | `SharedHostImage.md` §1 |
+| `OpenCodeHost.md` §2 governing image rules | `SharedHostImage.md` §1 |
+| `OpenCodeHost.md` §3 Host Class mapping | `SharedHostImage.md` §3 |
+| `OpenCodeHost.md` §6 shared-image credential isolation | `SharedHostImage.md` §4 |
+
+Deliberately *not* merged (distinct responsibilities, per #3962):
+
+- Omnigent vs ManagedAgents execution: provider-native session semantics stay
+  in `docs/ManagedAgents/`; only the shared container-job/MCP contract is
+  cross-linked (`DockerBackendService.md` §15).
+- Run-owned vs profile-owned credential cleanup: never collapsed into one
+  "delete credentials" instruction (`SharedHostImage.md` §4).
+- `CodexSupportAndCutover.md` vs `RuntimeProviderRollout.md`: the former owns
+  Codex exact rows and cutover phases; the latter owns the versioned rollout
+  mechanism for every combination.
+- `CodexCreateToHostContract.md` vs
+  `NormalCodexProductPathReconciliation.md`: the former owns the wire contract;
+  the latter owns the reconciliation. Both are test-pinned and keep their text.
+
+## Per-file disposition
+
+| File | Disposition | Design status / outstanding refs |
+| --- | --- | --- |
+| `README.md` | Module entrypoint (new, #3962) | Current |
+| `ContractOwnership.md` | Ownership map (new, #3962) | Current |
+| `SharedHostImage.md` | Owner: image, packs, Host Classes, credential ownership | Implemented; qualification/promotion/retirement evidence-gated (#3832–#3835) |
+| `PrimaryRuntimeProviderStrategy.md` | Owner: selection/defaults/stages/gates; §§7–8 point to `SharedHostImage.md` | Canonical desired state, evidence-gated per combination |
+| `OmnigentHostOAuth.md` | Owner: materializer mechanisms; §§10–11 point to `SharedHostImage.md` | Current desired state |
+| `OpenCodeHost.md` | Owner: OpenCode runtime contract; §§1–3, 6 point to `SharedHostImage.md` | Current |
+| `OmnigentBridge.md` | Owner: transport and native UI contract | Design with open questions (§21); #3635 |
+| `OmnigentAdapter.md` | Owner: adapter launch/lifecycle contract | Current |
+| `OmnigentModuleArchitecture.md` | Owner: packages, dependencies, retirement description | Current; #3711 (retirement execution #3712) |
+| `OmnigentHarnessPlatformDesign.md` | Owner: target harness-platform model | Proposed (target, not shipped) |
+| `RuntimeProviderRollout.md` | Owner: rollout mechanism | Implemented mechanism; promotion per combination |
+| `CodexSupportAndCutover.md` | Owner: Codex rows, phases, remediation matrix | Exact evidence pending; #3518, #3563, #3564, #3622, #3626 |
+| `CodexCreateToHostContract.md` | Owner: create-to-host wire contract (test-pinned) | Accepted; #3449 |
+| `NormalCodexProductPathReconciliation.md` | Owner: product-path reconciliation (test-pinned) | Accepted; #3565 |
+| `AgentProfiles.md` | Owner: Profile identities | #3517 |
+| `CanonicalTurnCommandBoundary.md` | Owner: turn-command boundary | #3707 |
+| `OmnigentLifecycleReconciler.md` | Owner: transition contract | Accepted; #3702 |
+| `ControlPlaneAggregates.md` | Owner: durable aggregates | #3703 |
+| `ControlPlaneConcurrencyAndFencing.md` | Owner: fencing generations | #3704 |
+| `OmnigentSemanticTelemetryAndTimeline.md` | Owner: telemetry and timeline | #3708 |
+| `ConformanceAndLiveSmoke.md` | Owner: conformance tiers | Current; #3480, #3508, #3642, #3710 |
+| `ConcurrencyQualification.md` | Owner: concurrency qualification | #3885 |
+| `OmnigentFaultInjectionSuite.md` | Owner: fault-injection suite | #3709 |
+| `OmnigentHostMountedTools.md` | Owner: mounted tools | Desired-state design |
+| `PolicyAuthority.md` | Owner: policy authority | Canonical desired state; #3515 |
+| `EmbeddedHostAuthCompatibility.md` | Owner: embedded compat surface | Experimental, not default |
+| `CombinedStackValidationAndRollback.md` | Owner: validation/rollback runbook | Current; #3564 |
+
+## Reduction report
+
+Reduction is an outcome of this pass, not a justification for dropping
+contracts: every contract above retains exactly one surviving owner and no
+owner text was deleted, only duplicated restatements were replaced with
+pointers. Measured with `git diff` word counts on `docs/Omnigent/`:
+
+- Eight duplicated sections replaced by surviving-owner pointers
+  (Strategy §§7–8, HostOAuth §§10–11, OpenCodeHost §§1–3, 6): about 400
+  words of second descriptions removed.
+- Two new routing docs added: `README.md` entrypoint (~615 words) and this
+  map (~1,030 words).
+- Ten existing files gained owner cross-links (`Related documents` blocks
+  plus ownership notes in `CodexSupportAndCutover.md`,
+  `OmnigentHarnessPlatformDesign.md`, `OpenCodeHost.md` §15).
+- Net word delta is positive by design: routing words replaced duplicate
+  contract words. No relied-upon contract lost its owner; the guard test
+  `tests/unit/docs/test_omnigent_consolidation_3962.py` pins the entrypoint,
+  the per-file coverage of this map, the surviving credential/exact-support
+  phrases, the pointer replacements, and link/anchor validity.

--- a/docs/Omnigent/OmnigentAdapter.md
+++ b/docs/Omnigent/OmnigentAdapter.md
@@ -15,6 +15,8 @@ The normal product selection and request-compilation boundary for **Codex via Om
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/Omnigent/OmnigentBridge.md`](./OmnigentBridge.md)
 - [`docs/Omnigent/OmnigentHostOAuth.md`](./OmnigentHostOAuth.md)
 - [`docs/Omnigent/CombinedStackValidationAndRollback.md`](./CombinedStackValidationAndRollback.md)

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -9,6 +9,8 @@ Last updated: 2026-09-05
 
 ## Related docs
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/UI/WorkflowChatPanel.md`](../UI/WorkflowChatPanel.md)
 - [`docs/Omnigent/AgentProfiles.md`](./AgentProfiles.md)
 - [`docs/Omnigent/CodexCreateToHostContract.md`](./CodexCreateToHostContract.md)

--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -8,6 +8,9 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
+- [`docs/Omnigent/SharedHostImage.md`](./SharedHostImage.md) — shared image, runtime packs, Host Classes, credential ownership (implemented)
 - [`docs/Omnigent/OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md)
 - [`docs/Omnigent/OmnigentAdapter.md`](./OmnigentAdapter.md)
 - [`docs/Omnigent/OmnigentBridge.md`](./OmnigentBridge.md)
@@ -44,6 +47,12 @@ MoonMind is moving toward Omnigent as the primary wrapper around coding-agent ha
 This design generalizes the existing Codex-through-Omnigent system. It does not discard that work. The current Codex lane supplies the reference implementation for Agent Profile selection, Provider Profile leasing, OAuth-generation fencing, host leasing, workspace materialization, resolved Skill delivery, bridge authorization, session execution, publication, checkpoint evidence, cleanup, and support qualification.
 
 The design owns the generic target architecture. The existing Codex documents continue to own the current Codex specialization until a later evidence-backed cutover explicitly moves that specialization onto the generic realizer. A conflict is resolved without weakening the current Codex contract.
+
+Implemented counterparts: this document stays the Proposed target model. The
+shipped shared image, runtime packs, Host Classes, and OAuth-home materializers
+are owned by [`SharedHostImage.md`](./SharedHostImage.md) and
+[`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md); read those for current
+behavior, not §§11–13 below.
 
 ## 2. Goals
 

--- a/docs/Omnigent/OmnigentHostOAuth.md
+++ b/docs/Omnigent/OmnigentHostOAuth.md
@@ -10,6 +10,9 @@ Implementation progress belongs in the roadmap, issues, and pull requests. This 
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
+- [`docs/Omnigent/SharedHostImage.md`](./SharedHostImage.md) — shared image, runtime packs, Host Classes, credential ownership
 - [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
 - [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
 - [`docs/Omnigent/CodexCreateToHostContract.md`](./CodexCreateToHostContract.md)
@@ -299,47 +302,25 @@ The same Provider Profile capacity, generation, fencing, cleanup, and release-la
 
 ## 10. Shared-image isolation
 
-The shared MoonMind Omnigent host image may contain Codex, Claude Code, and OpenCode binaries. The selected host receives only one runtime's credentials.
-
-A Codex host must prove:
-
-- the Codex materializer and generation are present
-- Claude and OpenCode credential attachments are absent
-- conflicting API-key selectors are absent
-- the Host Class declares `codex-native`
-- the runtime pack is the selected Codex pack
-
-A Claude host must prove the equivalent Claude-only credential state.
-
-An OpenCode host must prove that neither OAuth home is mounted.
-
-The image itself is never credential or harness authority.
+Shared-image isolation is owned by [`SharedHostImage.md`](./SharedHostImage.md)
+§§3–4: separate Host Classes on one digest, one runtime's credentials per
+selected host, and the rule that the image itself is never credential or
+harness authority. This document owns the materializer mechanisms (§§6–9)
+that enforce that isolation at launch. Preserved guarantee: a Codex host
+carries the Codex materializer and generation with no Claude/OpenCode
+credential attachments and no conflicting API-key selectors (and symmetrically
+for Claude and OpenCode hosts).
 
 ## 11. Host Classes and runtime packs
 
-Separate Host Classes may reference one shared image digest:
-
-```text
-omnigent-codex@1
-omnigent-claude@1
-omnigent-opencode@2
-```
-
-Each class declares only its approved harness implementations, runtime dependencies, materializers, architectures, integration modes, and features.
-
-The immutable execution plan records:
-
-- harness implementation ref
-- Host Class ref
-- shared image ref
-- runtime-pack ref
-- credential materializer ref
-- Provider Profile selection
-- launch policy
-- model configuration
-- execution realizer
-
-A Host Class that points to the shared image does not authorize every runtime in that image.
+The Host Class inventory on the shared digest is owned by
+[`SharedHostImage.md`](./SharedHostImage.md) §3. The durable rules this
+document relies on: each class declares only its approved harness
+implementations, runtime dependencies, materializers, architectures,
+integration modes, and features; the immutable execution plan records the
+harness, Host Class, shared image, runtime-pack, materializer, Profile,
+launch policy, model, and realizer refs; and a Host Class that points to the
+shared image does not authorize every runtime in that image.
 
 ## 12. Durable host binding and lease
 

--- a/docs/Omnigent/OmnigentModuleArchitecture.md
+++ b/docs/Omnigent/OmnigentModuleArchitecture.md
@@ -10,6 +10,8 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md) — target harness-platform model
 - [`docs/Omnigent/ControlPlaneAggregates.md`](./ControlPlaneAggregates.md)
 - [`docs/Omnigent/ControlPlaneConcurrencyAndFencing.md`](./ControlPlaneConcurrencyAndFencing.md)

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -92,13 +92,15 @@ and the one-harness admission rule are owned by
 [`SharedHostImage.md`](./SharedHostImage.md) §3; separate Host Classes
 preserve independent support and rollout decisions.
 
-A representative OpenCode class remains:
+A representative OpenCode class remains (`omnigent-opencode@2` is the
+shared-image row; `@1` is the dedicated-image legacy row):
 
 ```yaml
 hostClassId: omnigent-opencode
-version: 1
+version: 2
 imageRef: ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:...
 omnigentBuildDigest: sha256:...
+runtimePackRef: opencode-native-pack@1
 declaredHarnessImplementations:
   - harnessId: opencode-native
     implementationRef: omnigent-harness-implementation:sha256:...

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -8,6 +8,9 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
+- [`docs/Omnigent/SharedHostImage.md`](./SharedHostImage.md) — shared image, runtime packs, Host Classes, credential ownership
 - [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
 - [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
 - [`docs/Omnigent/OmnigentHostOAuth.md`](./OmnigentHostOAuth.md)
@@ -49,43 +52,24 @@ RUN npm install --cache /opt/moonmind/opencode-npm-cache '@opencode-ai/plugin@1.
 
 ### Shared-image implementation
 
-The default Compose image is:
-
-```text
-ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:<digest>
-```
-
-The shared image contains and verifies the approved versions of:
-
-```text
-omnigent
-codex
-claude
-opencode
-```
-
-An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF` or image/tag override remains authoritative for specialized deployments. It must pass the same bootstrap checks. An incompatible pin is quarantined rather than silently replaced. Existing environment files selecting the old image repository must be updated explicitly. A rejected Host Class reports the underlying reason, including missing or placeholder digests, mismatched compatibility evidence, build/version mismatch, and a missing offline bootstrap contract. A valid digest alone does not prove launch readiness. For an obsolete image, select a qualified shared host and its matching server build, then restart the API and runtime workers so reconciliation and launch use the same image pair. A rejected Host Class reports the underlying reason, including missing or placeholder digests, mismatched compatibility evidence, build/version mismatch, and a missing offline bootstrap contract. A valid digest alone does not prove launch readiness. For an obsolete image, select a qualified shared host and its matching server build, then restart the API and runtime workers so reconciliation and launch use the same image pair.
-
-The image migration does not by itself move Codex or Claude execution to the generic realizer. Those changes require their own runtime-pack, credential-materializer, conformance, rollout, and replay-safe retirement work.
+The shared image, its publication, and its deployment configuration are owned
+by [`SharedHostImage.md`](./SharedHostImage.md) §1, which also holds the
+verified vendor pins. OpenCode-specific rules that remain here: no workflow
+installs OpenCode dynamically, and the warm plugin-SDK cache contract in §4
+below. An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF` override remains
+authoritative for specialized deployments but must pass the same bootstrap
+checks; an incompatible pin is quarantined rather than silently replaced.
 
 ## 2. Governing image rules
 
-The shared image must:
-
-- derive from an immutable compatible Omnigent host base
-- install or inherit every supported runtime at image-build time
-- warm every dependency a supported runtime installs on its own first start (today the OpenCode plugin SDK npm cache) and prove it resolves offline
-- perform no package installation during workflow launch
-- run as the normal non-root Omnigent host user
-- preserve `/home/app` as the runtime home contract
-- contain no provider credentials
-- publish SBOM and provenance data
-- publish the portable `moonmind.omnigent.build_digest` identity
-- support the architectures claimed by its manifest and Host Classes
-- verify every included CLI and required harness integration in release CI
-- remain digest-pinned at execution-plan and Host Class boundaries
-
-A shared image is an implementation artifact, not a permission boundary. The selected immutable plan still controls which harness, materializer, Provider Profile, model, and runtime pack are authorized.
+The generic shared-image rules are owned by
+[`SharedHostImage.md`](./SharedHostImage.md) §1. The OpenCode-specific rules
+that remain here: the image warms every dependency a supported runtime
+installs on its own first start (today the OpenCode plugin SDK npm cache) and
+proves it resolves offline; a shared image is an implementation artifact, not
+a permission boundary — the selected immutable plan still controls which
+harness, materializer, Provider Profile, model, and runtime pack are
+authorized.
 
 Image admission checks the selected digest's executable Omnigent version and
 offline plugin-enabled OpenCode startup from the warm cache. Matching
@@ -103,22 +87,10 @@ release remain fenced by the durable lease owner.
 
 ## 3. Separate Host Classes share the image
 
-OpenCode retains its own Host Class on the shared image.
-
-The default image mapping is:
-
-```text
-omnigent-opencode@1
-  -> shared omnigent-host-moonmind digest
-
-omnigent-codex@1
-  -> shared omnigent-host-moonmind digest
-
-omnigent-claude@1
-  -> shared omnigent-host-moonmind digest
-```
-
-Each class declares only the harnesses and materializers that it authorizes. Separate Host Classes preserve independent support and rollout decisions.
+OpenCode retains its own Host Class on the shared image. The class inventory
+and the one-harness admission rule are owned by
+[`SharedHostImage.md`](./SharedHostImage.md) §3; separate Host Classes
+preserve independent support and rollout decisions.
 
 A representative OpenCode class remains:
 
@@ -283,9 +255,9 @@ explicit `opencode-go` profile and must never be inherited by the Zen profile.
 
 ## 6. Shared-image credential isolation
 
-When the image also contains Codex and Claude Code, an OpenCode execution must still receive only the OpenCode credential attachment.
-
-Exact-host conformance must prove:
+Credential ownership is owned by [`SharedHostImage.md`](./SharedHostImage.md)
+§4. The OpenCode-specific isolation proof that remains here — exact-host
+conformance must prove:
 
 - `/home/app/.codex` is not mounted from a Codex Provider Profile
 - Claude credential paths are not mounted
@@ -646,6 +618,10 @@ valid launch-ready Provider Profile does not require changing the runtime
 default or manual requalification. The deployment evidence publication retains
 one independently signed entry per launchable materializer class; entries are
 replaced only by a newly qualified entry for the same deployment-scoped class.
+
+Conformance tiers and live-smoke boundaries are owned by
+[`ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md); rollout states
+and promotion by [`RuntimeProviderRollout.md`](./RuntimeProviderRollout.md).
 
 ## 16. Deployment upgrades and rollback
 

--- a/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
+++ b/docs/Omnigent/PrimaryRuntimeProviderStrategy.md
@@ -8,6 +8,8 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/MoonMindArchitecture.md`](../MoonMindArchitecture.md)
 - [`docs/MoonMindRoadmap.md`](../MoonMindRoadmap.md)
 - [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)
@@ -367,54 +369,24 @@ Provider-specific logic stops at the registered runtime pack, credential materia
 
 ## 7. Shared image contract
 
-The shared image must:
-
-- derive from an immutable compatible Omnigent host base
-- contain the exact approved Codex, Claude Code, and OpenCode runtimes
-- install runtimes at image-build time, never during a workflow launch
-- run as the normal non-root Omnigent host user
-- preserve the generic `/home/app` runtime contract
-- publish an SBOM and provenance
-- publish the portable Omnigent build identity label
-- expose immutable multi-architecture manifest digests
-- verify every required CLI and Omnigent harness during build and release tests
-- avoid embedding provider credentials
-- avoid making every installed CLI active by default
-
-The image release record should identify each runtime independently. An OpenCode upgrade can produce a new image digest without asserting that the Codex or Claude support row has been requalified.
+The shared-image rules are owned by
+[`SharedHostImage.md`](./SharedHostImage.md) §1. The durable rule this
+strategy relies on: the image derives from an immutable compatible base,
+installs runtimes at build time only, publishes SBOM/provenance and immutable
+multi-architecture digests, embeds no provider credentials, and never makes
+every installed CLI active by default. An OpenCode upgrade may produce a new
+image digest without asserting that the Codex or Claude support row has been
+requalified.
 
 ## 8. Runtime-pack contract
 
-A representative trusted descriptor is:
-
-```yaml
-schemaVersion: moonmind.omnigent-harness-runtime-pack.v1
-ref: codex-native-pack@1
-harnessId: codex-native
-providerRuntimeId: codex_cli
-binary:
-  command: codex
-  supportedVersion: ">=<minimum>,<maximum>"
-credentialMaterializers:
-  - codex-oauth-home@1
-forbiddenAmbientEnvironment:
-  - OPENAI_API_KEY
-probes:
-  version: codex --version
-  authentication: codex login status
-hostModes:
-  - static-connected
-  - on-demand
-```
-
-The exact schema may evolve. The durable rules are:
-
-- references are versioned
-- descriptors contain no secrets
-- descriptors are not workflow-authored
-- commands are bounded and allowlisted by trusted code
-- the execution plan records the selected runtime-pack ref
-- exact-host evidence records the observed pack and runtime identity
+The runtime-pack descriptor rules are owned by
+[`SharedHostImage.md`](./SharedHostImage.md) §2, which holds the per-pack
+table (harness, vendor range, credential home). The durable rules this
+strategy relies on: references are versioned, descriptors contain no secrets
+and are never workflow-authored, commands are bounded and allowlisted by
+trusted code, the execution plan records the selected runtime-pack ref, and
+exact-host evidence records the observed pack and runtime identity.
 
 ## 9. Product selection and defaults
 

--- a/docs/Omnigent/README.md
+++ b/docs/Omnigent/README.md
@@ -35,8 +35,9 @@ interchangeable responsibilities.
 
 - A shared image never authorizes every installed runtime. Each Host Class
   declares only its own harness, runtime pack, and materializers.
-- Generic Codex and Claude Code combinations are explicit-only until their
-  exact protected-live evidence passes; explicit selection before qualification
+- Generic Codex and Claude Code combinations are `disabled` until their
+  exact protected-live evidence passes and the qualification flag promotes
+  them (see `RuntimeProviderRollout.md`); selection before qualification
   fails closed and never falls back to another runtime, profile, or host mode.
 - "Supported" means repository evidence or a protected live artifact proves the
   exact combination (image digest, harness, pack, materializer, model, policy,
@@ -65,7 +66,8 @@ interchangeable responsibilities.
 | Credential materializers and enrollment | [`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md); ownership table in [`SharedHostImage.md`](./SharedHostImage.md) §4 |
 | Session and turn control | [`CanonicalTurnCommandBoundary.md`](./CanonicalTurnCommandBoundary.md); lifecycle decisions in [`OmnigentLifecycleReconciler.md`](./OmnigentLifecycleReconciler.md) |
 | Exact support evidence | [`ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md); Codex rows in [`CodexSupportAndCutover.md`](./CodexSupportAndCutover.md) |
-| Cleanup and recovery | [`SharedHostImage.md`](./SharedHostImage.md) §4 (ownership) with launch-order detail in [`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md) §13+ |
+| Credential cleanup (materializer teardown, ownership) | [`SharedHostImage.md`](./SharedHostImage.md) §4 (ownership) with launch-order detail in [`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md) §13+ |
+| Session recovery (retry, checkpoint restore, terminal evidence) | [`PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md) §5.11 with transition decisions in [`OmnigentLifecycleReconciler.md`](./OmnigentLifecycleReconciler.md) §§3–5 |
 | Module packages and dependency direction | [`OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md) |
 | Retirement of duplicate architecture | Code-owned `moonmind/omnigent/legacy_retirement.py`, described in [`OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md) §5 |
 

--- a/docs/Omnigent/README.md
+++ b/docs/Omnigent/README.md
@@ -1,0 +1,91 @@
+# Omnigent
+
+**Document Class:** Module entrypoint
+**Status:** Current
+**Owners:** MoonMind Platform
+**Last updated:** 2026-09-07
+**Authority:** Short architecture/operator entrypoint for the Omnigent module. Each contract below has one surviving owner; this page routes, it does not restate.
+**Issue:** [MoonLadderStudios/MoonMind#3962](https://github.com/MoonLadderStudios/MoonMind/issues/3962).
+
+Omnigent is becoming MoonMind's primary runtime provider: one generic execution
+plane over approved harnesses (Codex, Claude Code, OpenCode), while MoonMind
+keeps Temporal orchestration, Provider Profiles, OAuth enrollment, policy,
+workspaces, evidence, publication, and cleanup. Provider-native execution and
+MoonMind-owned credentials, policy, workflow control, and evidence are not
+interchangeable responsibilities.
+
+## Supported startup path
+
+1. Select Runtime (`external/omnigent`) and one Provider Profile; resolve its
+   pinned execution configuration.
+2. Admission compiles one immutable execution plan (harness, Provider Profile,
+   runtime pack, credential materializer, Host Class, launch policy, model,
+   realizer) through the one shared selection boundary.
+3. The trusted planner binds the plan to a fenced runtime binding: acquired
+   credential generation, host lease, exact shared-image digest, and
+   exact-host attestation.
+4. The generic host lifecycle launches the Host Class image, attaches only the
+   selected runtime's credential material, and runs the canonical session and
+   turn-command path.
+5. Terminal, event, resource, checkpoint, and publication evidence is harvested;
+   run-owned state is destroyed and profile-owned state is detached but
+   preserved.
+
+## Exact limitations
+
+- A shared image never authorizes every installed runtime. Each Host Class
+  declares only its own harness, runtime pack, and materializers.
+- Generic Codex and Claude Code combinations are explicit-only until their
+  exact protected-live evidence passes; explicit selection before qualification
+  fails closed and never falls back to another runtime, profile, or host mode.
+- "Supported" means repository evidence or a protected live artifact proves the
+  exact combination (image digest, harness, pack, materializer, model, policy,
+  realizer). Code presence alone is "implemented" or "unverified".
+- Direct Codex / direct Claude paths remain labeled compatibility paths until
+  their retirement rows close.
+
+## Status vocabulary
+
+| Term | Meaning |
+| --- | --- |
+| registered | Harness is registration data, not lifecycle code. |
+| discovered | Seen in provider inventory; no trust implied. |
+| installed | Binary present in the image; not support. |
+| admitted | A plan selected it through the shared selection boundary. |
+| qualified | Exact-combination evidence passed for this deployment. |
+| selected-by-default | A qualified combination promoted per combination by rollout policy. |
+
+## Contract owners
+
+| Contract | Surviving owner |
+| --- | --- |
+| Pinned upstream transport and native UI contract | [`OmnigentBridge.md`](./OmnigentBridge.md) |
+| Agent / Provider Profile selection and defaults | [`PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md) §9, enforced by [`RuntimeProviderRollout.md`](./RuntimeProviderRollout.md) |
+| Host Classes and runtime packs | [`SharedHostImage.md`](./SharedHostImage.md) §§2–3 |
+| Credential materializers and enrollment | [`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md); ownership table in [`SharedHostImage.md`](./SharedHostImage.md) §4 |
+| Session and turn control | [`CanonicalTurnCommandBoundary.md`](./CanonicalTurnCommandBoundary.md); lifecycle decisions in [`OmnigentLifecycleReconciler.md`](./OmnigentLifecycleReconciler.md) |
+| Exact support evidence | [`ConformanceAndLiveSmoke.md`](./ConformanceAndLiveSmoke.md); Codex rows in [`CodexSupportAndCutover.md`](./CodexSupportAndCutover.md) |
+| Cleanup and recovery | [`SharedHostImage.md`](./SharedHostImage.md) §4 (ownership) with launch-order detail in [`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md) §13+ |
+| Module packages and dependency direction | [`OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md) |
+| Retirement of duplicate architecture | Code-owned `moonmind/omnigent/legacy_retirement.py`, described in [`OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md) §5 |
+
+The full per-file map — every `docs/Omnigent/` path and duplicated section
+mapped to its surviving owner, with design status and outstanding issue
+references — lives in [`ContractOwnership.md`](./ContractOwnership.md).
+
+## Credential ownership (summary, not a copy)
+
+Run-owned material (for example `opencode-auth-json@1`) may be destroyed on
+cleanup. Profile-owned OAuth homes (for example `codex-oauth-home@1`) are
+generation-fenced and detached but preserved. The binding table is
+[`SharedHostImage.md`](./SharedHostImage.md) §4; the mechanisms are
+[`OmnigentHostOAuth.md`](./OmnigentHostOAuth.md) §§6–9.
+
+## ManagedAgents boundary
+
+Omnigent hosts and MoonMind managed sessions share the container-job and MCP
+tool contract but not execution ownership. The shared contract is owned from
+the ManagedAgents side by
+[`../ManagedAgents/DockerBackendService.md`](../ManagedAgents/DockerBackendService.md)
+§15; provider-native session semantics stay in their owning ManagedAgents docs
+(for example `CodexCliManagedSessions.md`, `ClaudeCodeManagedSessions.md`).

--- a/docs/Omnigent/RuntimeProviderRollout.md
+++ b/docs/Omnigent/RuntimeProviderRollout.md
@@ -8,6 +8,8 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
 - [`docs/Omnigent/SharedHostImage.md`](./SharedHostImage.md)
 - [`docs/Omnigent/CanonicalTurnCommandBoundary.md`](./CanonicalTurnCommandBoundary.md)

--- a/docs/Omnigent/SharedHostImage.md
+++ b/docs/Omnigent/SharedHostImage.md
@@ -80,9 +80,13 @@ Changing a vendor pin is a deployment change that must land in the image build a
 ## 3. Host Classes on the shared digest
 
 ```text
-omnigent-codex@1    codex-native   + codex-native-pack@1   + codex-oauth-home@1, none@1
-omnigent-claude@1   claude-native  + claude-native-pack@1  + claude-oauth-home@1, none@1
+omnigent-codex@1     codex-native     + codex-native-pack@1     + codex-oauth-home@1, none@1
+omnigent-claude@1    claude-native    + claude-native-pack@1    + claude-oauth-home@1, none@1
+omnigent-opencode@2  opencode-native  + opencode-native-pack@1  + opencode-auth-json@1, none@1
 ```
+
+(`omnigent-opencode@1` remains the dedicated-image legacy row for historical
+reads; `@2` is the shared-image row.)
 
 Separate classes reference the same `OMNIGENT_SHARED_HOST_IMAGE_REF` digest without conflating harness support. Each class declares only its own harness, runtime pack, and materializers, so a shared image never authorizes every installed runtime. One-harness admission is enforced at selection (the pack must own the harness, the materializers must be allowlisted) and again at planning (the Host Class must declare the plan's harness implementation).
 

--- a/docs/Omnigent/SharedHostImage.md
+++ b/docs/Omnigent/SharedHostImage.md
@@ -8,6 +8,8 @@
 
 ## Related documents
 
+- [`docs/Omnigent/README.md`](./README.md) — module entrypoint and contract owners
+- [`docs/Omnigent/ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
 - [`docs/Omnigent/PrimaryRuntimeProviderStrategy.md`](./PrimaryRuntimeProviderStrategy.md)
 - [`docs/Omnigent/RuntimeProviderRollout.md`](./RuntimeProviderRollout.md)
 - [`docs/Omnigent/OmnigentHarnessPlatformDesign.md`](./OmnigentHarnessPlatformDesign.md)

--- a/docs/tmp/OmnigentConsolidation3962ReductionReport.md
+++ b/docs/tmp/OmnigentConsolidation3962ReductionReport.md
@@ -1,0 +1,25 @@
+# Omnigent Consolidation Reduction Report (MoonLadderStudios/MoonMind#3962)
+
+Implementation history for the consolidation pass that produced
+`docs/Omnigent/README.md` and `docs/Omnigent/ContractOwnership.md`.
+Kept here (not in canonical docs) so the ownership map stays a durable
+target-state contract.
+
+Reduction is an outcome of this pass, not a justification for dropping
+contracts: every contract retains exactly one surviving owner and no
+owner text was deleted, only duplicated restatements were replaced with
+pointers. Measured with `git diff` word counts on `docs/Omnigent/`:
+
+- Eight duplicated sections replaced by surviving-owner pointers
+  (Strategy §§7–8, HostOAuth §§10–11, OpenCodeHost §§1–3, 6): about 400
+  words of second descriptions removed.
+- Two new routing docs added: `README.md` entrypoint (~615 words) and the
+  ownership map (~1,030 words).
+- Ten existing files gained owner cross-links (`Related documents` blocks
+  plus ownership notes in `CodexSupportAndCutover.md`,
+  `OmnigentHarnessPlatformDesign.md`, `OpenCodeHost.md` §15).
+- Net word delta is positive by design: routing words replaced duplicate
+  contract words. No relied-upon contract lost its owner; the guard test
+  `tests/unit/docs/test_omnigent_consolidation_3962.py` pins the entrypoint,
+  the per-file coverage of the map, the surviving credential/exact-support
+  phrases, the pointer replacements, and link/anchor validity.

--- a/tests/unit/docs/test_omnigent_consolidation_3962.py
+++ b/tests/unit/docs/test_omnigent_consolidation_3962.py
@@ -98,7 +98,6 @@ def test_internal_links_and_anchors_resolve() -> None:
     checked = 0
     for path in sorted(OMNIGENT.glob("*.md")):
         text = _read(path)
-        anchors = _slugs(text)
         for match in re.finditer(r"\]\(([^)]+)\)", text):
             link = match.group(1)
             if link.startswith(("http", "mailto:")) or link.startswith("#"):

--- a/tests/unit/docs/test_omnigent_consolidation_3962.py
+++ b/tests/unit/docs/test_omnigent_consolidation_3962.py
@@ -1,0 +1,118 @@
+"""Consolidation guardrails for Omnigent documentation.
+
+Source: MoonLadderStudios/MoonMind#3962 (consolidate Omnigent docs while
+preserving exact-support and credential contracts). These assertions pin the
+durable outcomes: one short module entrypoint, one surviving-owner map that
+covers every ``docs/Omnigent/`` file, preserved credential-ownership and
+exact-support contracts, duplicate sections replaced by owner pointers, and
+valid internal links/anchors.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OMNIGENT = REPO_ROOT / "docs" / "Omnigent"
+ENTRYPOINT = OMNIGENT / "README.md"
+OWNERSHIP = OMNIGENT / "ContractOwnership.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _slugs(text: str) -> set[str]:
+    slugs: set[str] = set()
+    for match in re.finditer(r"^(#{1,6})\s+(.*)", text, re.M):
+        slug = match.group(2).strip().lower()
+        slug = re.sub(r"[^\w\s-]", "", slug)
+        slugs.add(re.sub(r"\s+", "-", slug))
+    return slugs
+
+
+def test_entrypoint_exists_with_startup_path_and_limitations() -> None:
+    text = _read(ENTRYPOINT)
+    assert "MoonLadderStudios/MoonMind#3962" in text
+    assert "Supported startup path" in text
+    assert "Exact limitations" in text
+    # Status vocabulary: registered through selected-by-default.
+    for term in (
+        "registered",
+        "discovered",
+        "installed",
+        "admitted",
+        "qualified",
+        "selected-by-default",
+    ):
+        assert term in text, term
+    # A shared image never authorizes every installed harness.
+    assert "never authorizes every installed runtime" in text
+    # Credential ownership distinction is summarized, not merged.
+    assert "detached but preserved" in text
+    # ManagedAgents boundary is cross-linked, not copied.
+    assert "ManagedAgents/DockerBackendService.md" in text
+
+
+def test_ownership_map_covers_every_omnigent_file() -> None:
+    text = _read(OWNERSHIP)
+    assert "MoonLadderStudios/MoonMind#3962" in text
+    for path in sorted(OMNIGENT.glob("*.md")):
+        assert path.name in text, path.name
+
+
+def test_credential_ownership_contract_survives() -> None:
+    shared = _read(OMNIGENT / "SharedHostImage.md")
+    assert "destroyed on cleanup" in shared
+    assert "detached but preserved on cleanup" in shared
+    assert "generation-marker fenced" in shared or "generation" in shared
+    oauth = _read(OMNIGENT / "OmnigentHostOAuth.md")
+    assert "no Claude/OpenCode" in oauth or "credential attachments" in oauth
+
+
+def test_exact_support_contract_survives() -> None:
+    strategy = _read(OMNIGENT / "PrimaryRuntimeProviderStrategy.md")
+    assert "evidence-gated" in strategy
+    assert "never silently" in strategy or "No silent fallback" in strategy
+    cutover = _read(OMNIGENT / "CodexSupportAndCutover.md")
+    assert "never" in cutover and "supported" in cutover
+    assert "RuntimeProviderRollout.md" in cutover
+
+
+def test_duplicates_are_owner_pointers() -> None:
+    strategy = _read(OMNIGENT / "PrimaryRuntimeProviderStrategy.md")
+    assert "The shared image must:" not in strategy
+    assert "SharedHostImage.md" in strategy
+    oauth = _read(OMNIGENT / "OmnigentHostOAuth.md")
+    assert "A Codex host must prove:" not in oauth
+    assert "SharedHostImage.md" in oauth
+    opencode = _read(OMNIGENT / "OpenCodeHost.md")
+    assert "The default image mapping is:" not in opencode
+    assert "The shared image must:" not in opencode
+    assert "SharedHostImage.md" in opencode
+
+
+def test_internal_links_and_anchors_resolve() -> None:
+    checked = 0
+    for path in sorted(OMNIGENT.glob("*.md")):
+        text = _read(path)
+        anchors = _slugs(text)
+        for match in re.finditer(r"\]\(([^)]+)\)", text):
+            link = match.group(1)
+            if link.startswith(("http", "mailto:")) or link.startswith("#"):
+                continue
+            if "#" in link:
+                rel, anchor = link.split("#", 1)
+                target = path.parent / rel if rel else path
+                assert target.exists(), f"{path.name}: {link}"
+                if target.suffix == ".md":
+                    assert anchor in _slugs(_read(target)), (
+                        f"{path.name}: {link}"
+                    )
+                    checked += 1
+            elif link.endswith(".md"):
+                assert (path.parent / link).exists(), f"{path.name}: {link}"
+                checked += 1
+    assert checked > 0

--- a/tests/unit/docs/test_omnigent_consolidation_3962.py
+++ b/tests/unit/docs/test_omnigent_consolidation_3962.py
@@ -77,7 +77,12 @@ def test_exact_support_contract_survives() -> None:
     assert "evidence-gated" in strategy
     assert "never silently" in strategy or "No silent fallback" in strategy
     cutover = _read(OMNIGENT / "CodexSupportAndCutover.md")
-    assert "never" in cutover and "supported" in cutover
+    assert "## Support and conformance matrix v1" in cutover
+    assert "REQUIRED_ROW_CATALOG" in cutover
+    assert "REQUIRED_MATRIX_ROWS" in cutover
+    assert "codex-omnigent-support-matrix/v1" in cutover
+    assert "## Operator remediation support matrix v1" in cutover
+    assert "## Release thresholds and telemetry" in cutover
     assert "RuntimeProviderRollout.md" in cutover
 
 


### PR DESCRIPTION
## Summary

Consolidates the docs/Omnigent module around a single short architecture/operator entrypoint (docs/Omnigent/README.md, 91 lines) and a surviving-owner map (docs/Omnigent/ContractOwnership.md) covering all 27 module files, duplicated sections, design status, and outstanding issue references.

- Replaces 8 duplicated restatements with surviving-owner pointers (PrimaryRuntimeProviderStrategy ss7-8, OmnigentHostOAuth ss10-11, OpenCodeHost ss1-3/6 -> SharedHostImage; Cutover/Rollout and HarnessPlatformDesign ownership notes). No owner text deleted (~400 duplicated words removed, +1645 routing words added).
- Preserves exact-support gating (shared image contents never authorize every installed harness; generic Codex/Claude explicit-only until exact evidence passes; fail-closed, no silent fallback).
- Preserves credential ownership: run-owned material destroyed on cleanup vs profile-owned OAuth homes generation-fenced, detached but preserved.
- Preserves native facade authorization, canonical turn identity, historical evidence, and cleanup guarantees in their owners.
- Cross-links ManagedAgents at the shared container-job contract; routes README.md and docs/MoonMindArchitecture.md section 9 through the entrypoint.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (HIGH confidence, candidate head bae6f29). All six acceptance criteria VERIFIED, zero gaps, zero remaining work. Remaining qualification, default promotion, Compose consolidation, and retirement work stays in owning issues #3832-#3835, #3928, with scaffolding disposal under #3963, as recorded in the ContractOwnership map.

## Tests run

- tests/unit/docs/test_omnigent_consolidation_3962.py — all 6 guard tests PASS (entrypoint, ownership coverage of every Omnigent file, credential survival, exact-support survival, duplicate pointers, link/anchor validity). Executed via direct python3 invocation (pytest module unavailable in this runtime); same suite the verifier ran.
- git status clean after reverting incidental mode-only changes; intentional change set is exactly the bae6f29 commit (16 files).

## Remaining risks

- Low: link/anchor validity is pinned by a guard test, but future doc edits could drift the ownership map; the guard test fails closed on new unmapped files.
- None for rollout: no runtime, compose, credential, or default-selection behavior changed (docs-only).

Closes MoonLadderStudios/MoonMind#3962