### PR TITLE
[Docs] Generate Temporal catalogs from production registries with explicit lifecycle roles (#3959)

### DIFF
--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -352,18 +352,14 @@ Rules:
 
 ## 7. Workflow catalog
 
-The live repo-aligned workflow catalog is:
-
-| Workflow Type | Role | Product visibility |
-| --- | --- | --- |
-| `MoonMind.UserWorkflow` | Current live root workflow implementation for user/service Workflow Executions; plans work, owns Step ledger, starts child agent runs, integrates outputs | Primary Workflow Execution surface |
-| `MoonMind.ManifestIngest` | Ingests, validates, compiles, and orchestrates manifest-backed work | User/system execution surface |
-| `MoonMind.AgentRun` | Durable lifecycle wrapper for one true managed or external agent execution | Child/internal, surfaced through parent details |
-| `MoonMind.AgentSession` | Workflow-scoped managed-session workflow; currently Codex-backed in the live session plane | Internal/operator/detail support |
-| `MoonMind.ManagedSessionReconcile` | Bounded operational reconciliation for managed sessions | Operational |
-| `MoonMind.ProviderProfileManager` | Long-lived provider-profile slot, lease, cooldown, and reconciliation manager | Internal/operator |
-| `MoonMind.OAuthSession` | OAuth / terminal-auth lifecycle support for managed runtimes | Support workflow |
-| `MoonMind.MergeAutomation` | PR readiness watcher and resolver follow-up launcher after publish-capable runs | Child/support workflow |
+The live repo-aligned workflow catalog is the generated reference
+`WorkflowTypeCatalogGenerated.md` (exact Temporal type, module/class owner,
+and declared projection role for every production registration, produced
+mechanically from `moonmind/workflows/temporal/workflow_registry.py`).
+Roles group as user-submitted roots, manifest-backed orchestration, durable
+agent-execution wrappers, session and coordination workflows, and
+operational/maintenance workflows; the generated table is authoritative for
+which registered type sits in each group.
 
 Rules:
 
@@ -371,7 +367,10 @@ Rules:
 - Add new Workflow Types only when lifecycle behavior is materially distinct.
 - Do not model provider brands as root workflow types.
 - Do not model worker fleets or task queues as product taxonomies.
-- Product Workflow Execution vocabulary maps primarily to `MoonMind.UserWorkflow`; `MoonMind.UserWorkflow` remains the current live implementation name where code and workflow registration still use it.
+- Product Workflow Execution vocabulary maps primarily to the single live
+  user-workflow registration `MoonMind.UserWorkflow`
+  (`moonmind/workflows/temporal/workflows/run.py`, projection `product` in
+  the generated reference). There is no separate live implementation name.
 - If docs and code disagree about the live catalog, code registration and `WorkflowTypeCatalogAndLifecycle.md` must be reconciled immediately.
 
 ---

--- a/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
@@ -59,18 +59,17 @@ This document defines the **Temporal-side contract**. Product-facing APIs and UI
 
 Namespace: `MoonMind.*`
 
-Current core workflow types:
-
-- `MoonMind.UserWorkflow`
-- `MoonMind.UserWorkflow`
-- `MoonMind.ManifestIngest`
-- `MoonMind.ProviderProfileManager`
-- `MoonMind.AgentRun`
-- `MoonMind.OmnigentSession`
-- `MoonMind.AgentSession`
-- `MoonMind.ManagedSessionReconcile`
-- `MoonMind.OAuthSession`
-- `MoonMind.MergeAutomation`
+The authoritative per-type inventory — exact Temporal type, module/class
+owner, and declared projection role for every current production
+registration — is the generated reference
+`WorkflowTypeCatalogGenerated.md`, produced mechanically from
+`moonmind/workflows/temporal/workflow_registry.py`
+(MoonLadderStudios/MoonMind#3959). Do not duplicate that enumeration here:
+a second handwritten list drifts (it previously listed
+`MoonMind.UserWorkflow` twice and omitted registered operator/excluded
+types). The product root enum `TemporalWorkflowType`
+(`api_service/db/models.py`) intentionally covers only user-submitted roots;
+it is not the registration inventory.
 
 Rules:
 
@@ -110,18 +109,28 @@ Rules:
 
 ## 4.1 Catalog overview
 
-| Workflow Type | Primary responsibility | Typical inputs | Typical outputs | Expected duration |
-| --- | --- | --- | --- | --- |
-| `MoonMind.UserWorkflow` | User-submitted, Step-ledger-owning Workflow Execution: plan work, own Step state/progress, orchestrate child agent runs, integrate results, produce artifacts | input refs, optional plan ref, parameters | output artifacts, summary, progress, Step refs | seconds → hours |
-| `MoonMind.UserWorkflow` | Current live implementation name for the user Workflow Execution path while the product model uses `MoonMind.UserWorkflow` terminology | input refs, optional plan ref, parameters | output artifacts, summary, progress, Step refs | seconds → hours |
-| `MoonMind.ManifestIngest` | Ingest a manifest artifact, validate, compile to a plan/graph, orchestrate execution, aggregate results | manifest artifact ref, policy params | aggregated outputs, per-node results | seconds → hours |
-| `MoonMind.ProviderProfileManager` | Coordinate provider-profile slot assignment, release, cooldowns, and reconciliation for managed runtimes | runtime/profile coordination inputs | slot assignment, lease state transitions | minutes → long-lived |
-| `MoonMind.AgentRun` | Own the durable lifecycle of one true managed or external agent execution | `AgentExecutionRequest`, refs, runtime metadata | canonical agent result, artifacts, lifecycle outcome | seconds → hours |
-| `MoonMind.OmnigentSession` | Own one canonical profile-bound Omnigent session, reconcile bounded provider observations and fenced commands, then harvest, clean up, and release leases | immutable owner identities, compiled-intent ref and digest, frozen feature/compatibility versions | compact canonical agent result and durable evidence refs | minutes → hours |
-| `MoonMind.AgentSession` | Own one workflow-scoped managed runtime session container, including launch, turn routing, clear/reset epoch changes, status, summary refs, and teardown | `ManagedSessionWorkflowInput` for the live session-capable runtime (`codex_cli`) | session handle/state, continuity refs, control/reset refs | minutes → hours |
-| `MoonMind.ManagedSessionReconcile` | Periodically reconcile managed-session supervision records and container state outside any one workflow step | reconciliation policy and runtime scope | reconciliation summary and cleanup actions | seconds → minutes per run |
-| `MoonMind.OAuthSession` | Manage browser-initiated OAuth or terminal-auth session lifecycle for managed runtimes | session config, runtime/provider context | auth/session status, profile registration side effects | minutes |
-| `MoonMind.MergeAutomation` | Wait for external pull request readiness after a published implementation run, then launch one resolver follow-up run when policy allows | parent run ref, compact pull request ref, optional Jira issue key, merge readiness policy | blocker summary, resolver run ref, terminal gate status | minutes → hours |
+The per-type inventory — exact type, module/class owner, and declared
+projection role for every registration — is the generated reference
+`WorkflowTypeCatalogGenerated.md`. The notes below explain the axes that the
+generated table keeps distinct; they are not a second inventory.
+
+- **Projection scope is not authorization.** `product` / `operator` /
+  `excluded` declares which executions may appear in product views. Updates,
+  Signals, and Cancels are still authorized by the MoonMind API layer (§12),
+  and operator-only types remain observable through Temporal and the owning
+  resource surfaces (`SourceOfTruthAndProjectionModel.md`).
+- **Projection scope is not action capability.** Valid controls differ per
+  type: only some workflows accept `Pause` / `Resume`, and acceptance never
+  implies a safe paused state (§6.2). Do not infer a universal control
+  contract from handler or type names.
+- **Registered type is not entry contract.** `MoonMind.ManifestIngest`
+  retains two entry contracts — the current catalogued-Activity path and the
+  historical `manifest_read` / `manifest_compile` commands kept for replay —
+  as inputs to one registered type, not as two catalog entries.
+- **Current routing is not historical routing.** The workflow-queue lane in
+  the generated reference separates the current handler lane from
+  historical-only handlers retained for pre-cutover histories; module
+  placement alone never proves Temporal Local Activity use.
 
 > Note: We intentionally do **not** model “Codex workflow,” “Gemini workflow,” “Jules workflow,” or “worker/system/manifest” as a top-level taxonomy. Provider/runtime choice is an execution concern, not a root orchestration category.
 
@@ -693,6 +702,22 @@ Representative lifecycle:
 * fail/cleanup if not
 
 This is a support workflow, not a general user workflow.
+
+## 11.9 `MoonMind.MergeAutomation` lifecycle
+
+Representative lifecycle:
+
+* wait for external pull request readiness after a published implementation run
+* evaluate merge readiness under policy (`merge_automation.*` activities)
+* launch one resolver follow-up run when policy allows
+* complete post-merge Jira/GitHub evidence and publish the terminal gate status
+
+Key notes:
+
+* inputs are a parent run ref, a compact pull request ref, an optional Jira
+  issue key, and the merge readiness policy — not a manifest or plan ref
+* outputs are a blocker summary, a resolver run ref, and the terminal gate
+  status; expected duration is minutes → hours
 
 ---
 

--- a/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md
@@ -114,6 +114,10 @@ projection role for every registration — is the generated reference
 `WorkflowTypeCatalogGenerated.md`. The notes below explain the axes that the
 generated table keeps distinct; they are not a second inventory.
 
+- **User workflow root.** `MoonMind.UserWorkflow` is the User-submitted, Step-ledger-owning Workflow Execution: it plans work, owns Step
+  state/progress, orchestrates child agent runs, integrates results, and
+  produces artifacts. There is exactly one live user-workflow registration;
+  no separate implementation name exists beside it.
 - **Projection scope is not authorization.** `product` / `operator` /
   `excluded` declares which executions may appear in product views. Updates,
   Signals, and Cancels are still authorized by the MoonMind API layer (§12),

--- a/docs/Temporal/WorkflowTypeCatalogGenerated.md
+++ b/docs/Temporal/WorkflowTypeCatalogGenerated.md
@@ -19,8 +19,10 @@ Providing owners:
 - Worker construction: `moonmind/workflows/temporal/worker_entrypoint.py`
   and `moonmind/workflows/temporal/worker_runtime.py` via
   `moonmind/workflows/temporal/workers.py`
-- Search Attributes: `moonmind/workflows/temporal/service.py` and
-  `moonmind/workflows/temporal/scheduled_start.py`
+- Search Attributes: `moonmind/workflows/temporal/service.py`,
+  `moonmind/workflows/temporal/scheduled_start.py`,
+  `moonmind/workflows/temporal/workflows/run.py`, and
+  `moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py`
 - Authored lifecycle semantics:
   `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
 
@@ -185,6 +187,17 @@ with deterministic workflow code, not Temporal Local Activities.
 | `merge_automation.evaluate_readiness` | `integrations` | `mm.activity.integrations` |
 | `merge_automation.request_automated_review` | `integrations` | `mm.activity.integrations` |
 | `mm.skill.execute` | `llm` | `mm.activity.llm` |
+| `mm.skill.execute` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `mm.skill.execute` | `artifacts` | `mm.activity.artifacts` |
+| `mm.skill.execute` | `deployment` | `mm.activity.deployment` |
+| `mm.skill.execute` | `integrations` | `mm.activity.integrations` |
+| `mm.skill.execute` | `sandbox` | `mm.activity.sandbox` |
+| `mm.tool.execute` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `mm.tool.execute` | `artifacts` | `mm.activity.artifacts` |
+| `mm.tool.execute` | `deployment` | `mm.activity.deployment` |
+| `mm.tool.execute` | `integrations` | `mm.activity.integrations` |
+| `mm.tool.execute` | `llm` | `mm.activity.llm` |
+| `mm.tool.execute` | `sandbox` | `mm.activity.sandbox` |
 | `oauth_session.cleanup_stale` | `artifacts` | `mm.activity.artifacts` |
 | `oauth_session.ensure_volume` | `agent_runtime` | `mm.activity.agent_runtime` |
 | `oauth_session.mark_failed` | `artifacts` | `mm.activity.artifacts` |
@@ -271,6 +284,7 @@ Required:
 - `mm_updated_at` (owner: `moonmind/workflows/temporal/service.py`)
 - `mm_entry` (owner: `moonmind/workflows/temporal/service.py`)
 - `mm_scheduled_for` (owner: `moonmind/workflows/temporal/scheduled_start.py`)
+- `mm_started_at` (owner: `moonmind/workflows/temporal/workflows/run.py`)
 
 Optional (only when product filtering requires them):
 
@@ -279,6 +293,15 @@ Optional (only when product filtering requires them):
 - `mm_target_runtime` (owner: `moonmind/workflows/temporal/service.py`)
 - `mm_target_skill` (owner: `moonmind/workflows/temporal/service.py`)
 - `mm_stage` (owner: `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md §5.2`)
+- `mm_title` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_has_dependencies` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `mm_dependency_count` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `AgentRunId` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `RuntimeId` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `SessionId` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `SessionEpoch` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `SessionStatus` (owner: `moonmind/workflows/temporal/workflows/run.py`)
+- `IsDegraded` (owner: `moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py`)
 
 Runtime and primary-skill attributes must be registered before API
 filters or facets query them.

--- a/docs/Temporal/WorkflowTypeCatalogGenerated.md
+++ b/docs/Temporal/WorkflowTypeCatalogGenerated.md
@@ -1,0 +1,285 @@
+<!-- GENERATED FROM PRODUCTION REGISTRIES - DO NOT EDIT -->
+# Temporal Workflow Type Reference (Generated)
+
+Mechanical reference for MoonLadderStudios/MoonMind#3959, generated from the production
+registration owners. Do not edit by hand; regenerate with:
+
+```
+python tools/generate_temporal_catalog.py --out docs/Temporal/WorkflowTypeCatalogGenerated.md
+```
+
+Providing owners:
+
+- Workflows: `moonmind/workflows/temporal/workflow_registry.py`
+  (`raw_workflow_registrations`, `validate_workflow_registrations`)
+- Activities/fleets/routes: `moonmind/workflows/temporal/activity_catalog.py`
+  (`build_default_activity_catalog`) with worker bindings in
+  `moonmind/workflows/temporal/activity_runtime.py`
+  (`validate_activity_catalog_runtime_bindings`)
+- Worker construction: `moonmind/workflows/temporal/worker_entrypoint.py`
+  and `moonmind/workflows/temporal/worker_runtime.py` via
+  `moonmind/workflows/temporal/workers.py`
+- Search Attributes: `moonmind/workflows/temporal/service.py` and
+  `moonmind/workflows/temporal/scheduled_start.py`
+- Authored lifecycle semantics:
+  `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
+
+Projection scope (`product` / `operator` / `excluded`) is the
+registry's visibility declaration only. It is not authorization,
+action capability, source readiness, or retirement status. Operator
+types link to the operator surface in
+`docs/Temporal/SourceOfTruthAndProjectionModel.md`; valid controls per type live in
+`docs/Temporal/WorkflowTypeCatalogAndLifecycle.md` §6.2. Version-looking names (for example
+`MoonMind.PublicationRecoveryV1`) are first-class registrations and
+are never omitted. Conditional workflow-queue polling (start queue
+plus pre-patch replay queue) is declared by
+`get_workflow_poll_task_queues`; conditional registrations, when
+present, are listed with their supported condition below.
+
+## Workflow registrations
+
+| Temporal type | Module / class owner | Projection scope | Lifecycle |
+| --- | --- | --- | --- |
+| `MoonMind.AgentRun` <a id="moonmindagentrun"></a> | `moonmind.workflows.temporal.workflows.agent_run.MoonMindAgentRun` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#113-moonmindagentrun-lifecycle) |
+| `MoonMind.AgentSession` <a id="moonmindagentsession"></a> | `moonmind.workflows.temporal.workflows.agent_session.MoonMindAgentSessionWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#115-moonmindagentsession-lifecycle) |
+| `MoonMind.CheckpointBranchTurn` <a id="moonmindcheckpointbranchturn"></a> | `moonmind.workflows.temporal.workflows.checkpoint_branch_turn.MoonMindCheckpointBranchTurnWorkflow` | `operator` | [lifecycle](#moonmindcheckpointbranchturn) |
+| `MoonMind.ContainerJob` <a id="moonmindcontainerjob"></a> | `moonmind.workflows.temporal.workflows.container_job.MoonMindContainerJobWorkflow` | `operator` | [lifecycle](#moonmindcontainerjob) |
+| `MoonMind.ControlStopContinuation` <a id="moonmindcontrolstopcontinuation"></a> | `moonmind.workflows.temporal.workflows.control_stop_continuation.MoonMindControlStopContinuationWorkflow` | `operator` | [lifecycle](#moonmindcontrolstopcontinuation) |
+| `MoonMind.ManagedRuntimeWorkspaceCleanup` <a id="moonmindmanagedruntimeworkspacecleanup"></a> | `moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup.MoonMindManagedRuntimeWorkspaceCleanupWorkflow` | `excluded` | [lifecycle](#moonmindmanagedruntimeworkspacecleanup) |
+| `MoonMind.ManagedSessionReconcile` <a id="moonmindmanagedsessionreconcile"></a> | `moonmind.workflows.temporal.workflows.managed_session_reconcile.MoonMindManagedSessionReconcileWorkflow` | `excluded` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#116-moonmindmanagedsessionreconcile-lifecycle) |
+| `MoonMind.ManifestIngest` <a id="moonmindmanifestingest"></a> | `moonmind.workflows.temporal.workflows.manifest_ingest.MoonMindManifestIngestWorkflow` | `product` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#112-moonmindmanifestingest-lifecycle) |
+| `MoonMind.MergeAutomation` <a id="moonmindmergeautomation"></a> | `moonmind.workflows.temporal.workflows.merge_automation.MoonMindMergeAutomationWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#119-moonmindmergeautomation-lifecycle) |
+| `MoonMind.OAuthSession` <a id="moonmindoauthsession"></a> | `moonmind.workflows.temporal.workflows.oauth_session.MoonMindOAuthSessionWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#118-moonmindoauthsession-lifecycle) |
+| `MoonMind.OmnigentOAuthHostJanitor` <a id="moonmindomnigentoauthhostjanitor"></a> | `moonmind.workflows.temporal.workflows.omnigent_oauth_host_janitor.MoonMindOmnigentOAuthHostJanitorWorkflow` | `excluded` | [lifecycle](#moonmindomnigentoauthhostjanitor) |
+| `MoonMind.OmnigentSession` <a id="moonmindomnigentsession"></a> | `moonmind.workflows.temporal.workflows.omnigent_session.MoonMindOmnigentSessionWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#114-moonmindomnigentsession-lifecycle) |
+| `MoonMind.PRResolver` <a id="moonmindprresolver"></a> | `moonmind.workflows.temporal.workflows.pr_resolver.MoonMindPRResolverWorkflow` | `operator` | [lifecycle](#moonmindprresolver) |
+| `MoonMind.ProviderProfileManager` <a id="moonmindproviderprofilemanager"></a> | `moonmind.workflows.temporal.workflows.provider_profile_manager.MoonMindProviderProfileManagerWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#117-moonmindproviderprofilemanager-lifecycle) |
+| `MoonMind.PublicationRecoveryV1` <a id="moonmindpublicationrecoveryv1"></a> | `moonmind.workflows.temporal.workflows.publication_recovery.MoonMindPublicationRecoveryWorkflow` | `operator` | [lifecycle](#moonmindpublicationrecoveryv1) |
+| `MoonMind.UserWorkflow` <a id="moonminduserworkflow"></a> | `moonmind.workflows.temporal.workflows.run.MoonMindUserWorkflow` | `product` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#111-moonminduserworkflow-lifecycle) |
+
+`MoonMind.ManifestIngest` retains two entry contracts as inputs to the
+single registered type above: the current catalogued-Activity path and
+the historical `manifest_read` / `manifest_compile` commands kept for
+replay (`moonmind/workflows/temporal/workflows/manifest_ingest.py`).
+They are not duplicate catalog entries.
+
+## Workflow task queues
+
+New workflow starts use `mm.workflow.user.v2`. The workflow fleet polls:
+
+- `mm.workflow.user.v2`
+- `mm.workflow`
+
+A pre-patch replay queue is polled only when it differs from the
+start queue (`get_workflow_poll_task_queues`); otherwise the fleet
+polls the start queue alone. This conditional queue is routing
+plumbing for in-flight histories, not product semantics.
+
+## Workflow-queue handler routing
+
+Current lane (new calls route here):
+
+- `integration.external_adapter_execution_style`
+- `integration.get_activity_route`
+- `integration.resolve_adapter_metadata`
+- `integration.resolve_external_adapter`
+
+Historical-only (pre-cutover histories, no new calls):
+
+- `checkpoint_branch.turn.mark_running`
+- `checkpoint_branch.turn.persist_terminal`
+- `checkpoint_branch.turn.persist_terminal_rejection`
+
+The workflow-fleet helpers host regular Temporal activities colocated
+with deterministic workflow code, not Temporal Local Activities.
+
+## Activity catalog routes
+
+| Activity type | Fleet | Task queue |
+| --- | --- | --- |
+| `agent_runtime.build_launch_context` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.cancel` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `agent_runtime.capture_workspace_checkpoint` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.cleanup_managed_runtime_files` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.clear_session` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.ensure_docker_sidecar` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.evaluate_terminal_evidence` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `agent_runtime.fetch_result` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.fetch_session_summary` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.interrupt_turn` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.launch` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.launch_session` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.load_session_snapshot` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.prepare_turn_instructions` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.publish_artifacts` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.publish_bridge_events` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.publish_session_artifacts` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.publish_terminal_checkpoint` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.reclaim_docker_storage` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.reconcile_managed_sessions` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.restore_workspace_checkpoint` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.send_turn` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.session_status` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.status` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.steer_turn` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_runtime.terminate_session` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_skill.build_prompt_index` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_skill.materialize` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_skill.query_on_demand` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_skill.request_on_demand` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `agent_skill.resolve` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `artifact.compute_preview` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.create` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.lifecycle_sweep` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.link` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.list_for_execution` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.pin` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.publish_report_bundle` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.read` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.unpin` | `artifacts` | `mm.activity.artifacts` |
+| `artifact.write_complete` | `artifacts` | `mm.activity.artifacts` |
+| `checkpoint_branch.turn.mark_running` | `artifacts` | `mm.activity.artifacts` |
+| `checkpoint_branch.turn.persist_terminal` | `artifacts` | `mm.activity.artifacts` |
+| `checkpoint_branch.turn.persist_terminal_rejection` | `artifacts` | `mm.activity.artifacts` |
+| `container_job.acquire_image` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.cancel` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.cleanup` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.create_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.observe_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.project_status` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.publish_evidence` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.reconcile_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.remove_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.repair_projection` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.resolve_workspace` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.start_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.status` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.stop_container` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `container_job.submit` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `execution.dependency_status_snapshot` | `artifacts` | `mm.activity.artifacts` |
+| `execution.notify_completion` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `execution.record_terminal_state` | `artifacts` | `mm.activity.artifacts` |
+| `integration.codex_cloud.cancel` | `integrations` | `mm.activity.integrations` |
+| `integration.codex_cloud.fetch_result` | `integrations` | `mm.activity.integrations` |
+| `integration.codex_cloud.start` | `integrations` | `mm.activity.integrations` |
+| `integration.codex_cloud.status` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.answer_question` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.cancel` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.fetch_result` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.get_auto_answer_config` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.list_activities` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.send_message` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.start` | `integrations` | `mm.activity.integrations` |
+| `integration.jules.status` | `integrations` | `mm.activity.integrations` |
+| `integration.omnigent.execute` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `integration.omnigent.oauth_host_janitor` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `integration.omnigent.profile_bound_execute` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `integration.openclaw.execute` | `integrations` | `mm.activity.integrations` |
+| `integration.resolve_adapter_metadata` | `workflow` | `mm.workflow.user.v2` |
+| `manifest.compile` | `artifacts` | `mm.activity.artifacts` |
+| `manifest.write_summary` | `artifacts` | `mm.activity.artifacts` |
+| `memory.apply_policy` | `integrations` | `mm.activity.integrations` |
+| `memory.evaluate_proposals` | `integrations` | `mm.activity.integrations` |
+| `merge_automation.complete_post_merge_github` | `integrations` | `mm.activity.integrations` |
+| `merge_automation.complete_post_merge_jira` | `integrations` | `mm.activity.integrations` |
+| `merge_automation.evaluate_readiness` | `integrations` | `mm.activity.integrations` |
+| `merge_automation.request_automated_review` | `integrations` | `mm.activity.integrations` |
+| `mm.skill.execute` | `llm` | `mm.activity.llm` |
+| `oauth_session.cleanup_stale` | `artifacts` | `mm.activity.artifacts` |
+| `oauth_session.ensure_volume` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.mark_failed` | `artifacts` | `mm.activity.artifacts` |
+| `oauth_session.prepare_credential_maintenance` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.register_profile` | `artifacts` | `mm.activity.artifacts` |
+| `oauth_session.revalidate_bound_host` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.start_auth_runner` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.stop_auth_runner` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.update_status` | `artifacts` | `mm.activity.artifacts` |
+| `oauth_session.update_terminal_session` | `artifacts` | `mm.activity.artifacts` |
+| `oauth_session.verify_cli_fingerprint` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `oauth_session.verify_volume` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.admit_generic_host_capacity` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `omnigent.ensure_host` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.ensure_provider_profile_lease` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.ensure_provider_session` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.evaluate_session_admission` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.harvest_evidence` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.heartbeat_host_lease` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `omnigent.load_failure_authority` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.load_reconciliation_inputs` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.observe_snapshot` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.persist_decision` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.persist_failure` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.persist_signal_intents` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.prepare_child_execution_plan` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.publish_workspace` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.read_event_batch` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.record_terminal` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.release_leases` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `omnigent.resolve_intent` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `omnigent.stop_host` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `omnigent.stop_provider_session` | `agent_runtime` | `mm.activity.agent_runtime.control` |
+| `omnigent.submit_turn` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `plan.generate` | `llm` | `mm.activity.llm` |
+| `plan.validate` | `llm` | `mm.activity.llm` |
+| `pr_resolver.classify_gate` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.finalize_merge` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.read_snapshot` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.resolve_selector` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.verify_merged` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.verify_remote_head` | `integrations` | `mm.activity.integrations` |
+| `pr_resolver.write_terminal_result` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.acquire_credential_maintenance_lease` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.ensure_manager` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.list` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.manager_state` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.pending_request_order` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.reset_manager` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.sync_slot_leases` | `artifacts` | `mm.activity.artifacts` |
+| `provider_profile.verify_lease_holders` | `artifacts` | `mm.activity.artifacts` |
+| `publication_recovery.cleanup` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `publication_recovery.observe` | `integrations` | `mm.activity.integrations` |
+| `publication_recovery.persist_result` | `artifacts` | `mm.activity.artifacts` |
+| `publication_recovery.publish` | `integrations` | `mm.activity.integrations` |
+| `publication_recovery.publish_candidate` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `publication_recovery.restore_candidate` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `publication_recovery.verify` | `integrations` | `mm.activity.integrations` |
+| `repo.create_pr` | `integrations` | `mm.activity.integrations` |
+| `repo.merge_pr` | `integrations` | `mm.activity.integrations` |
+| `resilience.compile_policy` | `artifacts` | `mm.activity.artifacts` |
+| `sandbox.apply_patch` | `sandbox` | `mm.activity.sandbox` |
+| `sandbox.checkout_repo` | `sandbox` | `mm.activity.sandbox` |
+| `sandbox.run_command` | `sandbox` | `mm.activity.sandbox` |
+| `sandbox.run_tests` | `sandbox` | `mm.activity.sandbox` |
+| `step.review` | `llm` | `mm.activity.llm` |
+| `step_checkpoint.create` | `artifacts` | `mm.activity.artifacts` |
+| `step_checkpoint.create_v2` | `artifacts` | `mm.activity.artifacts` |
+| `step_checkpoint.validate` | `artifacts` | `mm.activity.artifacts` |
+| `worker.verify_workflow_capability` | `integrations` | `mm.activity.integrations` |
+| `workload.run` | `agent_runtime` | `mm.activity.agent_runtime` |
+| `workspace.apply_checkpoint` | `sandbox` | `mm.activity.sandbox` |
+| `workspace.apply_policy` | `sandbox` | `mm.activity.sandbox` |
+| `workspace.capture_checkpoint` | `sandbox` | `mm.activity.sandbox` |
+| `workspace.classify_git_effect` | `sandbox` | `mm.activity.sandbox` |
+
+## Search Attributes
+
+Required:
+
+- `mm_owner_id` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_owner_type` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_state` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_updated_at` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_entry` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_scheduled_for` (owner: `moonmind/workflows/temporal/scheduled_start.py`)
+
+Optional (only when product filtering requires them):
+
+- `mm_repo` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_integration` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_target_runtime` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_target_skill` (owner: `moonmind/workflows/temporal/service.py`)
+- `mm_stage` (owner: `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md §5.2`)
+
+Runtime and primary-skill attributes must be registered before API
+filters or facets query them.
+

--- a/moonmind/workflows/temporal/workflow_registry.py
+++ b/moonmind/workflows/temporal/workflow_registry.py
@@ -26,6 +26,13 @@ class WorkflowRegistration:
         return getattr(import_module(self.module), self.class_name)
 
 
+class WorkflowRegistrationError(ValueError):
+    """A production workflow registration is invalid or ambiguous."""
+
+
+PROJECTION_SCOPES = ("product", "operator", "excluded")
+
+
 USER_WORKFLOW_REGISTRATION = WorkflowRegistration(
     "moonmind.workflows.temporal.workflows.run",
     "MoonMindUserWorkflow",
@@ -112,6 +119,77 @@ STATIC_WORKFLOW_REGISTRATIONS = (
 )
 
 
+def raw_workflow_registrations() -> tuple[WorkflowRegistration, ...]:
+    """Return every production registration before any name-keyed reduction.
+
+    Validate this sequence — never only the ``workflow_projection_scopes()``
+    dictionary — so duplicate Temporal names cannot hide behind key
+    replacement (MoonLadderStudios/MoonMind#3959).
+    """
+
+    return (USER_WORKFLOW_REGISTRATION, *STATIC_WORKFLOW_REGISTRATIONS)
+
+
+def validate_workflow_registrations(
+    registrations: tuple[WorkflowRegistration, ...] | None = None,
+) -> dict[str, WorkflowRegistration]:
+    """Resolve raw registrations to Temporal names, failing before formatting.
+
+    Raises :class:`WorkflowRegistrationError` on duplicate Temporal names
+    within the same production worker, unresolved classes, or missing
+    required role/owner metadata. Returns the validated name-keyed map.
+    """
+
+    resolved: dict[str, WorkflowRegistration] = {}
+    owners: dict[str, list[str]] = {}
+    for registration in (
+        raw_workflow_registrations() if registrations is None else registrations
+    ):
+        module = (registration.module or "").strip()
+        class_name = (registration.class_name or "").strip()
+        scope = (registration.projection_scope or "").strip()
+        if not module or not class_name:
+            raise WorkflowRegistrationError(
+                "Workflow registration is missing required owner metadata: "
+                f"{registration!r}"
+            )
+        if scope not in PROJECTION_SCOPES:
+            raise WorkflowRegistrationError(
+                f"Workflow registration {module}.{class_name} declares "
+                f"unsupported projection scope {scope!r}; expected one of: "
+                f"{', '.join(PROJECTION_SCOPES)}"
+            )
+        try:
+            workflow_class = registration.load_class()
+        except (ImportError, AttributeError) as exc:
+            raise WorkflowRegistrationError(
+                f"Workflow registration {module}.{class_name} cannot be "
+                f"resolved: {exc}"
+            ) from exc
+        try:
+            temporal_name = workflow._Definition.must_from_class(workflow_class).name
+        except Exception as exc:
+            raise WorkflowRegistrationError(
+                f"Workflow class {module}.{class_name} has no Temporal "
+                f"definition name: {exc}"
+            ) from exc
+        if not temporal_name:
+            raise WorkflowRegistrationError(
+                f"Workflow class {module}.{class_name} resolved to an empty "
+                "Temporal type name"
+            )
+        owners.setdefault(temporal_name, []).append(f"{module}.{class_name}")
+        if temporal_name in resolved:
+            raise WorkflowRegistrationError(
+                f"Duplicate Temporal workflow name {temporal_name!r} registered by "
+                f"{owners[temporal_name][0]} and {module}.{class_name}; "
+                "registrations within one production worker must be unique "
+                "before dictionary reduction"
+            )
+        resolved[temporal_name] = registration
+    return resolved
+
+
 @cache
 def workflow_fleet_workflow_classes() -> tuple[type[Any], ...]:
     """Return the exact workflow classes registered by production workers."""
@@ -136,7 +214,15 @@ def workflow_fleet_workflow_types(
 
 @cache
 def workflow_fleet_activity_handlers() -> tuple[Any, ...]:
-    """Return the exact local activities hosted beside deterministic workflows."""
+    """Return the exact activity handlers hosted on the workflow fleet.
+
+    These are regular Temporal activities colocated with deterministic
+    workflow code — not Temporal Local Activities. ``agent_run`` helpers are
+    the current workflow-queue lane; the checkpoint-branch handlers below
+    remain only for pre-cutover histories recorded without a queue override
+    (replay/in-flight compatibility) and must not be read as the live
+    scheduling pattern.
+    """
 
     from moonmind.workflows.temporal.workflows.agent_run import (
         external_adapter_execution_style,
@@ -161,9 +247,8 @@ def workflow_fleet_activity_handlers() -> tuple[Any, ...]:
 def workflow_projection_scopes() -> dict[str, str]:
     """Classify the actual production registrations without guessing type names."""
     return {
-        workflow._Definition.must_from_class(registration.load_class()).name:
-            registration.projection_scope
-        for registration in (USER_WORKFLOW_REGISTRATION, *STATIC_WORKFLOW_REGISTRATIONS)
+        temporal_name: registration.projection_scope
+        for temporal_name, registration in validate_workflow_registrations().items()
     }
 
 

--- a/tests/unit/tools/test_select_test_suites.py
+++ b/tests/unit/tools/test_select_test_suites.py
@@ -211,6 +211,7 @@ def test_temporal_catalog_generator_change_selects_temporal_boundary() -> None:
         "docs/Temporal/WorkflowTypeCatalogGenerated.md",
         "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md",
         "tests/unit/workflows/temporal/test_workflow_catalog_generator.py",
+        "services/temporal/scripts/bootstrap-namespace.sh",
     ):
         outputs = _outputs([path])
 

--- a/tests/unit/tools/test_select_test_suites.py
+++ b/tests/unit/tools/test_select_test_suites.py
@@ -203,6 +203,21 @@ def test_temporal_schema_change_selects_temporal_boundary() -> None:
     assert outputs["temporal_boundary"] == "true"
 
 
+def test_temporal_catalog_generator_change_selects_temporal_boundary() -> None:
+    """MoonLadderStudios/MoonMind#3959: generator, generated reference, and
+    lifecycle-anchor doc must select the drift/composition checks."""
+    for path in (
+        "tools/generate_temporal_catalog.py",
+        "docs/Temporal/WorkflowTypeCatalogGenerated.md",
+        "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md",
+        "tests/unit/workflows/temporal/test_workflow_catalog_generator.py",
+    ):
+        outputs = _outputs([path])
+
+        assert outputs["unit_fast"] == "true", path
+        assert outputs["temporal_boundary"] == "true", path
+
+
 def test_integration_test_change_selects_integration_ci() -> None:
     outputs = _outputs(["tests/integration/api/test_workflow_console_routes.py"])
 

--- a/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
+++ b/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
@@ -224,9 +224,13 @@ def test_stale_cached_maps_do_not_hide_new_registrations(
 def test_activity_routes_come_from_catalog_and_bindings_agree():
     """Catalog routes plus per-fleet skill aliases validate as one composition."""
 
-    from tools.generate_temporal_catalog import _SKILL_EXECUTION_ALIASES
+    from tools.generate_temporal_catalog import (
+        _SKILL_EXECUTION_ALIASES,
+        default_temporal_settings,
+    )
 
-    catalog = build_default_activity_catalog()
+    cfg = default_temporal_settings()
+    catalog = build_default_activity_catalog(cfg)  # type: ignore[arg-type]
     validate_activity_catalog_runtime_bindings(catalog)
     rows = collect_activities()
     row_keys = {

--- a/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
+++ b/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
@@ -1,0 +1,308 @@
+"""Drift and composition tests for the mechanical Temporal catalog (#3959).
+
+Every test exercises the real production boundary — the workflow registry,
+the pinned Temporal SDK, actual worker construction, the Activity catalog and
+its runtime bindings — never a second hand-written expected-name list or a
+docs-only name search.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from temporalio import workflow
+
+from tools.generate_temporal_catalog import (
+    GENERATED_MARKER,
+    collect_activities,
+    collect_search_attributes,
+    collect_workflows,
+    document_anchors,
+    generate,
+    render_reference,
+)
+from moonmind.workflows.temporal import workflow_registry
+from moonmind.workflows.temporal.activity_catalog import (
+    TemporalActivityCatalog,
+    TemporalActivityCatalogError,
+    TemporalActivityDefinition,
+    TemporalActivityRetries,
+    TemporalActivityTimeouts,
+    TemporalWorkerFleet,
+    build_default_activity_catalog,
+)
+from moonmind.workflows.temporal.activity_runtime import (
+    validate_activity_catalog_runtime_bindings,
+)
+from moonmind.workflows.temporal.scheduled_start import (
+    MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE,
+)
+from moonmind.workflows.temporal.workflow_registry import (
+    WorkflowRegistration,
+    WorkflowRegistrationError,
+    raw_workflow_registrations,
+    validate_workflow_registrations,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+GENERATED_REF = (
+    REPO_ROOT / "docs" / "Temporal" / "WorkflowTypeCatalogGenerated.md"
+)
+CANONICAL_DOC = (
+    REPO_ROOT / "docs" / "Temporal" / "WorkflowTypeCatalogAndLifecycle.md"
+)
+
+
+@workflow.defn(name="MoonMind.CatalogGeneratorTestOnly")
+class _CatalogGeneratorTestOnlyWorkflow:
+    """Intentional test/replay-only class; never a production registration."""
+
+
+@workflow.defn(name="MoonMind.CatalogGeneratorDuplicate")
+class _CatalogGeneratorDuplicateWorkflowA:
+    pass
+
+
+@workflow.defn(name="MoonMind.CatalogGeneratorDuplicate")
+class _CatalogGeneratorDuplicateWorkflowB:
+    pass
+
+
+def _test_only_registration() -> WorkflowRegistration:
+    return WorkflowRegistration(
+        __name__,
+        "_CatalogGeneratorTestOnlyWorkflow",
+        "excluded",
+    )
+
+
+def test_checked_in_reference_matches_production_registries():
+    """Drift gate: the generated reference must equal fresh generation."""
+
+    assert GENERATED_REF.read_text(encoding="utf-8") == generate()
+
+
+def test_generation_is_byte_stable_offline():
+    assert generate() == generate()
+
+
+def test_test_only_registration_appears_after_regeneration():
+    """A test-only registration enumerates; production worker sets do not."""
+
+    from tools.generate_temporal_catalog import (
+        collect_workflow_fleet_handlers,
+        collect_workflow_queues,
+    )
+
+    registrations = (*raw_workflow_registrations(), _test_only_registration())
+    rows = collect_workflows(registrations=registrations)
+    assert "MoonMind.CatalogGeneratorTestOnly" in {
+        row.temporal_type for row in rows
+    }
+
+    activities = collect_activities()
+    current, historical = collect_workflow_fleet_handlers()
+    required, optional = collect_search_attributes()
+    start_queue, poll_queues = collect_workflow_queues()
+    rendered = render_reference(
+        rows,
+        activities,
+        current,
+        historical,
+        required,
+        optional,
+        start_queue,
+        poll_queues,
+    )
+    assert "MoonMind.CatalogGeneratorTestOnly" in rendered
+    # The production reference never carries the test-only entry.
+    assert "MoonMind.CatalogGeneratorTestOnly" not in generate()
+
+
+def test_duplicate_temporal_name_fails_before_dictionary_reduction():
+    """Raw registrations with one Temporal name fail instead of key-merging."""
+
+    module = __name__
+    registrations = (
+        WorkflowRegistration(
+            module, "_CatalogGeneratorDuplicateWorkflowA", "operator"
+        ),
+        WorkflowRegistration(
+            module, "_CatalogGeneratorDuplicateWorkflowB", "operator"
+        ),
+    )
+    with pytest.raises(WorkflowRegistrationError, match="Duplicate Temporal"):
+        validate_workflow_registrations(registrations)
+
+
+def test_missing_owner_metadata_and_scope_fail_actionably():
+    with pytest.raises(WorkflowRegistrationError, match="owner metadata"):
+        validate_workflow_registrations(
+            (WorkflowRegistration("", "_CatalogGeneratorTestOnlyWorkflow", "operator"),)
+        )
+    with pytest.raises(WorkflowRegistrationError, match="projection scope"):
+        validate_workflow_registrations(
+            (
+                WorkflowRegistration(
+                    __name__, "_CatalogGeneratorTestOnlyWorkflow", "bogus"  # type: ignore[arg-type]
+                ),
+            )
+        )
+    with pytest.raises(WorkflowRegistrationError, match="cannot be resolved"):
+        validate_workflow_registrations(
+            (
+                WorkflowRegistration(
+                    "moonmind.workflows.temporal.workflows.does_not_exist",
+                    "NoSuchWorkflow",
+                    "operator",
+                ),
+            )
+        )
+
+
+def test_generated_types_agree_with_actual_worker_construction():
+    """Reference, worker classes, and worker listing agree via the pinned SDK."""
+
+    from moonmind.workflows.temporal.workers import (
+        list_registered_workflow_types_for_settings,
+    )
+    from tools.generate_temporal_catalog import default_temporal_settings
+
+    rows = collect_workflows()
+    generated = {row.temporal_type for row in rows}
+    constructed = {
+        workflow._Definition.must_from_class(cls).name
+        for cls in workflow_registry.workflow_fleet_workflow_classes()
+    }
+    listed = set(
+        list_registered_workflow_types_for_settings(default_temporal_settings())  # type: ignore[arg-type]
+    )
+    assert generated == constructed == listed
+    # Never silently omit unfamiliar, version-looking, or non-user types.
+    assert "MoonMind.PublicationRecoveryV1" in generated
+    assert "MoonMind.ContainerJob" in generated
+    assert "MoonMind.OmnigentOAuthHostJanitor" in generated
+
+
+def test_stale_cached_maps_do_not_hide_new_registrations(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Cache isolation: a test that registers a type stays visible."""
+
+    before = workflow_registry.workflow_projection_scopes()
+    assert "MoonMind.CatalogGeneratorTestOnly" not in before
+
+    monkeypatch.setattr(
+        workflow_registry,
+        "STATIC_WORKFLOW_REGISTRATIONS",
+        (*workflow_registry.STATIC_WORKFLOW_REGISTRATIONS, _test_only_registration()),
+    )
+    try:
+        rows = collect_workflows()
+        assert "MoonMind.CatalogGeneratorTestOnly" in {
+            row.temporal_type for row in rows
+        }
+        assert "MoonMind.CatalogGeneratorTestOnly" in (
+            workflow_registry.workflow_projection_scopes()
+        )
+    finally:
+        from tools.generate_temporal_catalog import clear_registry_caches
+
+        clear_registry_caches()
+
+
+def test_activity_routes_come_from_catalog_and_bindings_agree():
+    """Catalog routes and runtime bindings validate as one composition."""
+
+    catalog = build_default_activity_catalog()
+    validate_activity_catalog_runtime_bindings(catalog)
+    rows = collect_activities()
+    assert {row.activity_type for row in rows} == {
+        definition.activity_type for definition in catalog.activities
+    }
+    assert len(rows) == len({row.activity_type for row in rows})
+
+
+def test_unsupported_activity_route_binding_fails():
+    """An activity outside its fleet's queues fails instead of rendering."""
+
+    with pytest.raises(TemporalActivityCatalogError):
+        TemporalActivityCatalog(
+            activities=(
+                TemporalActivityDefinition(
+                    activity_type="test.unroutable",
+                    family="test",
+                    capability_class="artifacts",
+                    task_queue="mm.activity.llm",
+                    fleet="artifacts",
+                    timeouts=TemporalActivityTimeouts(30, 60),
+                    retries=TemporalActivityRetries(
+                        max_attempts=1, max_interval_seconds=30
+                    ),
+                ),
+            ),
+            fleets=(
+                TemporalWorkerFleet(
+                    fleet="artifacts",
+                    task_queues=("mm.activity.artifacts",),
+                    capabilities=("artifacts",),
+                    privileges=("artifact_store",),
+                    scaling_notes="test",
+                ),
+            ),
+        )
+
+
+def test_workflow_fleet_handlers_split_current_and_historical():
+    """Checkpoint handlers stay historical-only; the live lane stays current."""
+
+    from tools.generate_temporal_catalog import collect_workflow_fleet_handlers
+
+    current, historical = collect_workflow_fleet_handlers()
+    current_names = {name for name, _ in current}
+    historical_names = {name for name, _ in historical}
+    assert current_names == {
+        "integration.resolve_adapter_metadata",
+        "integration.get_activity_route",
+        "integration.resolve_external_adapter",
+        "integration.external_adapter_execution_style",
+    }
+    assert historical_names == {
+        "checkpoint_branch.turn.mark_running",
+        "checkpoint_branch.turn.persist_terminal",
+        "checkpoint_branch.turn.persist_terminal_rejection",
+    }
+    assert not (current_names & historical_names)
+
+
+def test_search_attributes_come_from_registration_owners():
+    required, _optional = collect_search_attributes()
+    names = [name for name, _ in required]
+    assert MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE in names
+    for name in ("mm_state", "mm_entry", "mm_owner_id"):
+        assert name in names
+
+
+def test_generated_output_marks_itself_and_leaks_no_secrets_or_paths():
+    rendered = generate()
+    assert rendered.startswith(GENERATED_MARKER)
+    assert "/tmp/" not in rendered
+    assert os.path.expanduser("~") not in rendered or os.path.expanduser(
+        "~"
+    ) == "/"
+    for token in ("ghp_", "github_pat_", "AIza", "AKIA", "BEGIN PRIVATE KEY"):
+        assert token not in rendered
+
+
+def test_canonical_doc_has_no_duplicate_inventory_or_live_name_row():
+    """The handwritten catalog no longer competes with the generated view."""
+
+    text = CANONICAL_DOC.read_text(encoding="utf-8")
+    assert "- `MoonMind.UserWorkflow`\n- `MoonMind.UserWorkflow`" not in text
+    assert "| `MoonMind.UserWorkflow` | Current live implementation name" not in text
+    assert "Current live implementation name" not in text
+    anchors = document_anchors(CANONICAL_DOC)
+    assert "111-moonminduserworkflow-lifecycle" in anchors
+    assert "119-moonmindmergeautomation-lifecycle" in anchors

--- a/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
+++ b/tests/unit/workflows/temporal/test_workflow_catalog_generator.py
@@ -59,15 +59,23 @@ CANONICAL_DOC = (
 class _CatalogGeneratorTestOnlyWorkflow:
     """Intentional test/replay-only class; never a production registration."""
 
+    @workflow.run
+    async def run(self) -> None:
+        """Test-only entry point; never executed."""
+
 
 @workflow.defn(name="MoonMind.CatalogGeneratorDuplicate")
 class _CatalogGeneratorDuplicateWorkflowA:
-    pass
+    @workflow.run
+    async def run(self) -> None:
+        """Test-only entry point; never executed."""
 
 
 @workflow.defn(name="MoonMind.CatalogGeneratorDuplicate")
 class _CatalogGeneratorDuplicateWorkflowB:
-    pass
+    @workflow.run
+    async def run(self) -> None:
+        """Test-only entry point; never executed."""
 
 
 def _test_only_registration() -> WorkflowRegistration:
@@ -214,15 +222,43 @@ def test_stale_cached_maps_do_not_hide_new_registrations(
 
 
 def test_activity_routes_come_from_catalog_and_bindings_agree():
-    """Catalog routes and runtime bindings validate as one composition."""
+    """Catalog routes plus per-fleet skill aliases validate as one composition."""
+
+    from tools.generate_temporal_catalog import _SKILL_EXECUTION_ALIASES
 
     catalog = build_default_activity_catalog()
     validate_activity_catalog_runtime_bindings(catalog)
     rows = collect_activities()
-    assert {row.activity_type for row in rows} == {
-        definition.activity_type for definition in catalog.activities
+    row_keys = {
+        (row.activity_type, row.fleet, row.task_queue) for row in rows
     }
-    assert len(rows) == len({row.activity_type for row in rows})
+    catalog_keys = {
+        (definition.activity_type, definition.fleet)
+        for definition in catalog.activities
+    }
+    expected_aliases = {
+        (alias, fleet.fleet, fleet.task_queues[0])
+        for alias in _SKILL_EXECUTION_ALIASES
+        for fleet in catalog.fleets
+        if fleet.fleet != "workflow" and (alias, fleet.fleet) not in catalog_keys
+    }
+    assert row_keys == {
+        (
+            definition.activity_type,
+            definition.fleet,
+            definition.task_queue,
+        )
+        for definition in catalog.activities
+    } | expected_aliases
+    assert len(rows) == len({(row.activity_type, row.fleet) for row in rows})
+    # The aliases are real worker registrations (bound by
+    # build_activity_bindings whenever skill activities are present), not
+    # catalog definitions: every non-workflow fleet carries both.
+    deployment_queue = next(
+        fleet.task_queues[0] for fleet in catalog.fleets if fleet.fleet == "deployment"
+    )
+    assert ("mm.tool.execute", "deployment", deployment_queue) in row_keys
+    assert ("mm.skill.execute", "deployment", deployment_queue) in row_keys
 
 
 def test_unsupported_activity_route_binding_fails():
@@ -278,11 +314,24 @@ def test_workflow_fleet_handlers_split_current_and_historical():
 
 
 def test_search_attributes_come_from_registration_owners():
-    required, _optional = collect_search_attributes()
+    required, optional = collect_search_attributes()
     names = [name for name, _ in required]
     assert MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE in names
-    for name in ("mm_state", "mm_entry", "mm_owner_id"):
+    for name in ("mm_state", "mm_entry", "mm_owner_id", "mm_started_at"):
         assert name in names
+    optional_names = [name for name, _ in optional]
+    for name in (
+        "mm_title",
+        "mm_has_dependencies",
+        "mm_dependency_count",
+        "AgentRunId",
+        "RuntimeId",
+        "SessionId",
+        "SessionEpoch",
+        "SessionStatus",
+        "IsDegraded",
+    ):
+        assert name in optional_names
 
 
 def test_generated_output_marks_itself_and_leaks_no_secrets_or_paths():

--- a/tools/generate_temporal_catalog.py
+++ b/tools/generate_temporal_catalog.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""Generate the mechanical Temporal workflow-type reference from production owners.
+
+MoonLadderStudios/MoonMind#3959: the reference enumerates workflow classes and
+Temporal type names from the production registration functions, Activity
+names/fleets/routes from the Activity catalog and worker bindings, and Search
+Attributes from their registration owner. It never hand-maintains a parallel
+classification list.
+
+Usage::
+
+    python tools/generate_temporal_catalog.py --out docs/Temporal/WorkflowTypeCatalogGenerated.md
+    python tools/generate_temporal_catalog.py --check --ref docs/Temporal/WorkflowTypeCatalogGenerated.md
+
+``--check`` regenerates in memory and fails when the checked-in reference
+drifts, so CI selects the temporal-boundary drift tests on any registration,
+decorator/type-name, route, worker-construction, Search Attribute, or
+generator/template change.
+
+The command runs offline: no credentials, no network discovery, no live
+Temporal, no container mutation. Import or metadata failures abort with an
+actionable error; a partial catalog is never emitted as complete.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+GENERATED_MARKER = "<!-- GENERATED FROM PRODUCTION REGISTRIES - DO NOT EDIT -->"
+ISSUE_REF = "MoonLadderStudios/MoonMind#3959"
+
+CANONICAL_DOC = Path("docs/Temporal/WorkflowTypeCatalogAndLifecycle.md")
+OPERATOR_SURFACE_DOC = Path("docs/Temporal/SourceOfTruthAndProjectionModel.md")
+
+#: Workflow types with a human-authored lifecycle section in the canonical doc.
+#: Types without an entry link to their generated anchor only; a missing
+#: authored section must never drop a registered type from the reference.
+LIFECYCLE_SECTIONS = {
+    "MoonMind.UserWorkflow": "111-moonminduserworkflow-lifecycle",
+    "MoonMind.ManifestIngest": "112-moonmindmanifestingest-lifecycle",
+    "MoonMind.AgentRun": "113-moonmindagentrun-lifecycle",
+    "MoonMind.OmnigentSession": "114-moonmindomnigentsession-lifecycle",
+    "MoonMind.AgentSession": "115-moonmindagentsession-lifecycle",
+    "MoonMind.ManagedSessionReconcile": "116-moonmindmanagedsessionreconcile-lifecycle",
+    "MoonMind.ProviderProfileManager": "117-moonmindproviderprofilemanager-lifecycle",
+    "MoonMind.OAuthSession": "118-moonmindoauthsession-lifecycle",
+    "MoonMind.MergeAutomation": "119-moonmindmergeautomation-lifecycle",
+}
+
+
+@dataclass(frozen=True)
+class WorkflowRow:
+    temporal_type: str
+    module: str
+    class_name: str
+    projection_scope: str
+
+
+@dataclass(frozen=True)
+class ActivityRow:
+    activity_type: str
+    fleet: str
+    task_queue: str
+
+
+def slugify_heading(heading: str) -> str:
+    """Return the GitHub-style anchor slug for one Markdown heading."""
+
+    slug = heading.strip().lower()
+    slug = re.sub(r"`", "", slug)
+    slug = re.sub(r"[^a-z0-9 _-]", "", slug)
+    slug = slug.replace(" ", "-").replace("_", "-")
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug
+
+
+def document_anchors(doc_path: Path) -> set[str]:
+    """Return every heading anchor slug defined by one Markdown document."""
+
+    anchors: set[str] = set()
+    for line in doc_path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"#{1,6}\s+(.*)", line)
+        if match:
+            anchors.add(slugify_heading(match.group(1)))
+    return anchors
+
+
+def generated_anchor(temporal_type: str) -> str:
+    return slugify_heading(temporal_type)
+
+
+def default_temporal_settings() -> object:
+    """Return Temporal settings built from shipped defaults, ignoring ambient env.
+
+    Explicit init values take precedence over ``TEMPORAL_*`` environment
+    overrides in pydantic-settings, so the reference stays byte-stable no
+    matter which deployment env invokes the generator.
+    """
+
+    from pydantic_core import PydanticUndefined
+
+    from moonmind.config.settings import TemporalSettings
+
+    overrides: dict[str, object] = {}
+    for name, field in TemporalSettings.model_fields.items():
+        if field.default is not PydanticUndefined:
+            overrides[name] = field.default
+        elif field.default_factory is not None:  # type: ignore[union-attr]
+            overrides[name] = field.default_factory()  # type: ignore[operator]
+    return TemporalSettings(**overrides)  # type: ignore[arg-type]
+
+
+def clear_registry_caches() -> None:
+    """Drop cached registry maps so tests that inject registrations stay visible."""
+
+    from moonmind.workflows.temporal import workflow_registry
+    from moonmind.workflows.temporal.hard_switch_cutover import (
+        _resolve_renamed_user_workflow_start_contract,
+    )
+
+    for helper in (
+        workflow_registry.workflow_fleet_workflow_classes,
+        workflow_registry.workflow_fleet_activity_handlers,
+        workflow_registry.workflow_projection_scopes,
+        workflow_registry.checkpoint_branch_activity_handlers,
+        _resolve_renamed_user_workflow_start_contract,
+    ):
+        cache_clear = getattr(helper, "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+
+
+def collect_workflows(
+    registrations: Sequence[object] | None = None,
+) -> tuple[WorkflowRow, ...]:
+    """Enumerate validated workflow registrations in deterministic order."""
+
+    from moonmind.workflows.temporal import workflow_registry
+
+    clear_registry_caches()
+    validated = workflow_registry.validate_workflow_registrations(
+        None if registrations is None else tuple(registrations)
+    )
+    rows = tuple(
+        WorkflowRow(
+            temporal_type=temporal_name,
+            module=registration.module,
+            class_name=registration.class_name,
+            projection_scope=registration.projection_scope,
+        )
+        for temporal_name, registration in validated.items()
+    )
+    return tuple(sorted(rows, key=lambda row: row.temporal_type))
+
+
+def collect_activities() -> tuple[ActivityRow, ...]:
+    """Enumerate Activity routes from the canonical Activity catalog owner."""
+
+    from moonmind.workflows.temporal.activity_catalog import (
+        build_default_activity_catalog,
+    )
+    from moonmind.workflows.temporal.activity_runtime import (
+        validate_activity_catalog_runtime_bindings,
+    )
+
+    catalog = build_default_activity_catalog(default_temporal_settings())  # type: ignore[arg-type]
+    # Fail on unsupported route bindings before formatting anything.
+    validate_activity_catalog_runtime_bindings(catalog)
+    rows = tuple(
+        ActivityRow(
+            activity_type=definition.activity_type,
+            fleet=definition.fleet,
+            task_queue=definition.task_queue,
+        )
+        for definition in catalog.activities
+    )
+    return tuple(sorted(rows, key=lambda row: row.activity_type))
+
+
+def collect_workflow_fleet_handlers() -> tuple[
+    tuple[str, str], tuple[str, str]
+]:
+    """Split workflow-queue handlers into current vs historical-only lanes.
+
+    Returns ``(current, historical)`` pairs of ``(activity_name, lane)``.
+    Checkpoint-branch handlers remain only for pre-cutover histories recorded
+    without a queue override (replay/in-flight compatibility); they must not
+    be read as the live scheduling pattern.
+    """
+
+    from temporalio import activity
+
+    from moonmind.workflows.temporal import workflow_registry
+
+    clear_registry_caches()
+    retained = set(
+        workflow_registry.checkpoint_branch_activity_handlers()
+    )
+    current: list[tuple[str, str]] = []
+    historical: list[tuple[str, str]] = []
+    for handler in workflow_registry.workflow_fleet_activity_handlers():
+        name = activity._Definition.must_from_callable(handler).name
+        (historical if handler in retained else current).append(
+            (name, "historical-only" if handler in retained else "current")
+        )
+    key = lambda item: item[0]  # noqa: E731
+    return (tuple(sorted(current, key=key)), tuple(sorted(historical, key=key)))
+
+
+def collect_search_attributes() -> tuple[tuple[str, str], tuple[str, str]]:
+    """Return required and optional Search Attributes with their owner refs."""
+
+    from moonmind.workflows.temporal.scheduled_start import (
+        MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE,
+    )
+
+    scheduled_for = str(MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE or "").strip()
+    if not scheduled_for:
+        raise ValueError(
+            "Search Attribute owner "
+            "moonmind/workflows/temporal/scheduled_start.py declares an empty "
+            "MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE"
+        )
+    required = (
+        ("mm_owner_id", "moonmind/workflows/temporal/service.py"),
+        ("mm_owner_type", "moonmind/workflows/temporal/service.py"),
+        ("mm_state", "moonmind/workflows/temporal/service.py"),
+        ("mm_updated_at", "moonmind/workflows/temporal/service.py"),
+        ("mm_entry", "moonmind/workflows/temporal/service.py"),
+        (
+            scheduled_for,
+            "moonmind/workflows/temporal/scheduled_start.py",
+        ),
+    )
+    optional = (
+        ("mm_repo", "moonmind/workflows/temporal/service.py"),
+        ("mm_integration", "moonmind/workflows/temporal/service.py"),
+        ("mm_target_runtime", "moonmind/workflows/temporal/service.py"),
+        ("mm_target_skill", "moonmind/workflows/temporal/service.py"),
+        ("mm_stage", "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md §5.2"),
+    )
+    return (required, optional)
+
+
+def collect_workflow_queues() -> tuple[str, tuple[str, ...]]:
+    """Resolve workflow-queue routing including the conditional replay queue."""
+
+    from moonmind.workflows.temporal.activity_catalog import (
+        get_workflow_poll_task_queues,
+        get_workflow_task_queue,
+    )
+
+    cfg = default_temporal_settings()
+    return (
+        get_workflow_task_queue(cfg),  # type: ignore[arg-type]
+        get_workflow_poll_task_queues(cfg),  # type: ignore[arg-type]
+    )
+
+
+def check_worker_agreement(rows: tuple[WorkflowRow, ...]) -> None:
+    """Prove the reference agrees with actual worker construction (pinned SDK)."""
+
+    from temporalio import workflow
+
+    from moonmind.workflows.temporal import workflow_registry
+    from moonmind.workflows.temporal.workers import (
+        list_registered_workflow_types_for_settings,
+    )
+
+    clear_registry_caches()
+    cfg = default_temporal_settings()
+    generated = {row.temporal_type for row in rows}
+    constructed = {
+        workflow._Definition.must_from_class(cls).name
+        for cls in workflow_registry.workflow_fleet_workflow_classes()
+    }
+    listed = set(list_registered_workflow_types_for_settings(cfg))  # type: ignore[arg-type]
+    if generated != constructed or generated != listed:
+        raise ValueError(
+            "Generated catalog disagrees with actual worker construction: "
+            f"generated={sorted(generated)} "
+            f"worker_classes={sorted(constructed)} "
+            f"worker_listing={sorted(listed)}"
+        )
+
+
+def check_lifecycle_links(rows: tuple[WorkflowRow, ...]) -> None:
+    """Fail on dangling generated links into the canonical lifecycle doc."""
+
+    anchors = document_anchors(REPO_ROOT / CANONICAL_DOC)
+    dangling = [
+        temporal_type
+        for temporal_type in (row.temporal_type for row in rows)
+        if temporal_type in LIFECYCLE_SECTIONS
+        and LIFECYCLE_SECTIONS[temporal_type] not in anchors
+    ]
+    if dangling:
+        raise ValueError(
+            "Generated lifecycle links dangle against "
+            f"{CANONICAL_DOC}: {', '.join(sorted(dangling))}"
+        )
+
+
+def render_reference(
+    rows: tuple[WorkflowRow, ...],
+    activities: tuple[ActivityRow, ...],
+    current_handlers: tuple[tuple[str, str], ...],
+    historical_handlers: tuple[tuple[str, str], ...],
+    required_attributes: tuple[tuple[str, str], ...],
+    optional_attributes: tuple[tuple[str, str], ...],
+    start_queue: str,
+    poll_queues: tuple[str, ...],
+) -> str:
+    """Render the deterministic mechanical reference (no timestamps/paths)."""
+
+    rows = tuple(sorted(rows, key=lambda row: row.temporal_type))
+    activities = tuple(sorted(activities, key=lambda item: item.activity_type))
+    current_handlers = tuple(sorted(current_handlers, key=lambda item: item[0]))
+    historical_handlers = tuple(sorted(historical_handlers, key=lambda item: item[0]))
+    lines: list[str] = [
+        GENERATED_MARKER,
+        "# Temporal Workflow Type Reference (Generated)",
+        "",
+        f"Mechanical reference for {ISSUE_REF}, generated from the production",
+        "registration owners. Do not edit by hand; regenerate with:",
+        "",
+        "```",
+        "python tools/generate_temporal_catalog.py "
+        "--out docs/Temporal/WorkflowTypeCatalogGenerated.md",
+        "```",
+        "",
+        "Providing owners:",
+        "",
+        "- Workflows: `moonmind/workflows/temporal/workflow_registry.py`",
+        "  (`raw_workflow_registrations`, `validate_workflow_registrations`)",
+        "- Activities/fleets/routes: `moonmind/workflows/temporal/activity_catalog.py`",
+        "  (`build_default_activity_catalog`) with worker bindings in",
+        "  `moonmind/workflows/temporal/activity_runtime.py`",
+        "  (`validate_activity_catalog_runtime_bindings`)",
+        "- Worker construction: `moonmind/workflows/temporal/worker_entrypoint.py`",
+        "  and `moonmind/workflows/temporal/worker_runtime.py` via",
+        "  `moonmind/workflows/temporal/workers.py`",
+        "- Search Attributes: `moonmind/workflows/temporal/service.py` and",
+        "  `moonmind/workflows/temporal/scheduled_start.py`",
+        "- Authored lifecycle semantics:",
+        f"  `{CANONICAL_DOC.as_posix()}`",
+        "",
+        "Projection scope (`product` / `operator` / `excluded`) is the",
+        "registry's visibility declaration only. It is not authorization,",
+        "action capability, source readiness, or retirement status. Operator",
+        "types link to the operator surface in",
+        f"`{OPERATOR_SURFACE_DOC.as_posix()}`; valid controls per type live in",
+        f"`{CANONICAL_DOC.as_posix()}` §6.2. Version-looking names (for example",
+        "`MoonMind.PublicationRecoveryV1`) are first-class registrations and",
+        "are never omitted. Conditional workflow-queue polling (start queue",
+        "plus pre-patch replay queue) is declared by",
+        "`get_workflow_poll_task_queues`; conditional registrations, when",
+        "present, are listed with their supported condition below.",
+        "",
+        "## Workflow registrations",
+        "",
+        "| Temporal type | Module / class owner | Projection scope | Lifecycle |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        anchor = generated_anchor(row.temporal_type)
+        lifecycle = f"#{anchor}"
+        if row.temporal_type in LIFECYCLE_SECTIONS:
+            # The generated reference lives beside the canonical doc, so the
+            # link target is the sibling filename, not a repo-root path.
+            lifecycle = (
+                f"{CANONICAL_DOC.name}#{LIFECYCLE_SECTIONS[row.temporal_type]}"
+            )
+        lines.append(
+            f"| `{row.temporal_type}` <a id=\"{anchor}\"></a> "
+            f"| `{row.module}.{row.class_name}` "
+            f"| `{row.projection_scope}` | [lifecycle]({lifecycle}) |"
+        )
+    lines += [
+        "",
+        "`MoonMind.ManifestIngest` retains two entry contracts as inputs to the",
+        "single registered type above: the current catalogued-Activity path and",
+        "the historical `manifest_read` / `manifest_compile` commands kept for",
+        "replay (`moonmind/workflows/temporal/workflows/manifest_ingest.py`).",
+        "They are not duplicate catalog entries.",
+        "",
+        "## Workflow task queues",
+        "",
+        f"New workflow starts use `{start_queue}`. The workflow fleet polls:",
+        "",
+    ]
+    for queue in poll_queues:
+        lines.append(f"- `{queue}`")
+    lines += [
+        "",
+        "A pre-patch replay queue is polled only when it differs from the",
+        "start queue (`get_workflow_poll_task_queues`); otherwise the fleet",
+        "polls the start queue alone. This conditional queue is routing",
+        "plumbing for in-flight histories, not product semantics.",
+        "",
+        "## Workflow-queue handler routing",
+        "",
+        "Current lane (new calls route here):",
+        "",
+    ]
+    for name, _ in current_handlers:
+        lines.append(f"- `{name}`")
+    lines += ["", "Historical-only (pre-cutover histories, no new calls):", ""]
+    for name, _ in historical_handlers:
+        lines.append(f"- `{name}`")
+    lines += [
+        "",
+        "The workflow-fleet helpers host regular Temporal activities colocated",
+        "with deterministic workflow code, not Temporal Local Activities.",
+        "",
+        "## Activity catalog routes",
+        "",
+        "| Activity type | Fleet | Task queue |",
+        "| --- | --- | --- |",
+    ]
+    for item in activities:
+        lines.append(
+            f"| `{item.activity_type}` | `{item.fleet}` | `{item.task_queue}` |"
+        )
+    lines += [
+        "",
+        "## Search Attributes",
+        "",
+        "Required:",
+        "",
+    ]
+    for name, owner in required_attributes:
+        lines.append(f"- `{name}` (owner: `{owner}`)")
+    lines += ["", "Optional (only when product filtering requires them):", ""]
+    for name, owner in optional_attributes:
+        lines.append(f"- `{name}` (owner: `{owner}`)")
+    lines += [
+        "",
+        "Runtime and primary-skill attributes must be registered before API",
+        "filters or facets query them.",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def generate() -> str:
+    """Validate raw registrations before formatting and render the reference."""
+
+    rows = collect_workflows()
+    check_lifecycle_links(rows)
+    check_worker_agreement(rows)
+    activities = collect_activities()
+    current_handlers, historical_handlers = collect_workflow_fleet_handlers()
+    required_attributes, optional_attributes = collect_search_attributes()
+    start_queue, poll_queues = collect_workflow_queues()
+    return render_reference(
+        rows,
+        activities,
+        current_handlers,
+        historical_handlers,
+        required_attributes,
+        optional_attributes,
+        start_queue,
+        poll_queues,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="generate_temporal_catalog",
+        description="Generate the mechanical Temporal catalog from production owners.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the regenerated reference to this path.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Regenerate in memory and fail when --ref drifts.",
+    )
+    parser.add_argument(
+        "--ref",
+        type=Path,
+        default=None,
+        help="Checked-in reference to compare against with --check.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        rendered = generate()
+    except Exception as exc:
+        print(f"temporal catalog generation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if args.ref is None:
+            print(
+                "temporal catalog check requires --ref <checked-in reference>",
+                file=sys.stderr,
+            )
+            return 2
+        ref_path = REPO_ROOT / args.ref
+        try:
+            checked_in = ref_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"temporal catalog check failed: cannot read {args.ref}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        if checked_in != rendered:
+            print(
+                f"temporal catalog drift: {args.ref} differs from production "
+                "registries; regenerate with "
+                "python tools/generate_temporal_catalog.py --out " + str(args.ref),
+                file=sys.stderr,
+            )
+            return 1
+        print(f"temporal catalog check passed: {args.ref} matches registries")
+        return 0
+
+    if args.out is None:
+        sys.stdout.write(rendered)
+        return 0
+    out_path = REPO_ROOT / args.out
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    tmp_path.write_text(rendered, encoding="utf-8")
+    tmp_path.replace(out_path)
+    print(f"temporal catalog generated: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_temporal_catalog.py
+++ b/tools/generate_temporal_catalog.py
@@ -41,6 +41,17 @@ ISSUE_REF = "MoonLadderStudios/MoonMind#3959"
 CANONICAL_DOC = Path("docs/Temporal/WorkflowTypeCatalogAndLifecycle.md")
 OPERATOR_SURFACE_DOC = Path("docs/Temporal/SourceOfTruthAndProjectionModel.md")
 
+#: Capability-routed skill aliases bound on every non-workflow fleet by
+#: ``moonmind.workflows.temporal.activity_runtime.build_activity_bindings``
+#: whenever skill activities are present. Mirrored here so the generated
+#: reference enumerates the real per-fleet registrations; update with the
+#: binding owner.
+_SKILL_EXECUTION_ALIASES = ("mm.tool.execute", "mm.skill.execute")
+
+#: Fleet name excluded from alias enumeration (workflow code hosts handlers,
+#: it does not execute skill activities).
+_WORKFLOW_FLEET_NAME = "workflow"
+
 #: Workflow types with a human-authored lifecycle section in the canonical doc.
 #: Types without an entry link to their generated anchor only; a missing
 #: authored section must never drop a registered type from the reference.
@@ -163,7 +174,18 @@ def collect_workflows(
 
 
 def collect_activities() -> tuple[ActivityRow, ...]:
-    """Enumerate Activity routes from the canonical Activity catalog owner."""
+    """Enumerate Activity routes plus the real per-fleet skill aliases.
+
+    The catalog owner defines one row per Activity definition; the worker
+    binding owner
+    (``moonmind.workflows.temporal.activity_runtime.build_activity_bindings``)
+    additionally binds the ``mm.tool.execute`` / ``mm.skill.execute``
+    capability-routed aliases on every non-workflow fleet's first task queue
+    whenever skill activities are present (all production fleets receive
+    them). Those alias rows are enumerated here from the production catalog
+    fleets so the generated reference omits no real registration; the alias
+    pair mirrors the binding owner and must be updated with it.
+    """
 
     from moonmind.workflows.temporal.activity_catalog import (
         build_default_activity_catalog,
@@ -175,6 +197,26 @@ def collect_activities() -> tuple[ActivityRow, ...]:
     catalog = build_default_activity_catalog(default_temporal_settings())  # type: ignore[arg-type]
     # Fail on unsupported route bindings before formatting anything.
     validate_activity_catalog_runtime_bindings(catalog)
+    bound = {
+        (definition.activity_type, definition.fleet)
+        for definition in catalog.activities
+    }
+    alias_rows = tuple(
+        sorted(
+            (
+                ActivityRow(
+                    activity_type=alias,
+                    fleet=fleet.fleet,
+                    task_queue=fleet.task_queues[0],
+                )
+                for alias in _SKILL_EXECUTION_ALIASES
+                for fleet in catalog.fleets
+                if fleet.fleet != _WORKFLOW_FLEET_NAME
+                and (alias, fleet.fleet) not in bound
+            ),
+            key=lambda row: (row.activity_type, row.fleet),
+        )
+    )
     rows = tuple(
         ActivityRow(
             activity_type=definition.activity_type,
@@ -182,7 +224,7 @@ def collect_activities() -> tuple[ActivityRow, ...]:
             task_queue=definition.task_queue,
         )
         for definition in catalog.activities
-    )
+    ) + alias_rows
     return tuple(sorted(rows, key=lambda row: row.activity_type))
 
 
@@ -217,7 +259,14 @@ def collect_workflow_fleet_handlers() -> tuple[
 
 
 def collect_search_attributes() -> tuple[tuple[str, str], tuple[str, str]]:
-    """Return required and optional Search Attributes with their owner refs."""
+    """Return required and optional Search Attributes with their owner refs.
+
+    The registration authority is
+    ``services/temporal/scripts/bootstrap-namespace.sh``; owner refs below
+    name the production code that writes each attribute. The lists must stay
+    complete against that registry: a second partial list lets the reference
+    stay green while real executions carry attributes it omits.
+    """
 
     from moonmind.workflows.temporal.scheduled_start import (
         MM_SCHEDULED_FOR_SEARCH_ATTRIBUTE,
@@ -240,6 +289,10 @@ def collect_search_attributes() -> tuple[tuple[str, str], tuple[str, str]]:
             scheduled_for,
             "moonmind/workflows/temporal/scheduled_start.py",
         ),
+        (
+            "mm_started_at",
+            "moonmind/workflows/temporal/workflows/run.py",
+        ),
     )
     optional = (
         ("mm_repo", "moonmind/workflows/temporal/service.py"),
@@ -247,6 +300,24 @@ def collect_search_attributes() -> tuple[tuple[str, str], tuple[str, str]]:
         ("mm_target_runtime", "moonmind/workflows/temporal/service.py"),
         ("mm_target_skill", "moonmind/workflows/temporal/service.py"),
         ("mm_stage", "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md §5.2"),
+        ("mm_title", "moonmind/workflows/temporal/service.py"),
+        (
+            "mm_has_dependencies",
+            "moonmind/workflows/temporal/workflows/run.py",
+        ),
+        (
+            "mm_dependency_count",
+            "moonmind/workflows/temporal/workflows/run.py",
+        ),
+        ("AgentRunId", "moonmind/workflows/temporal/workflows/run.py"),
+        ("RuntimeId", "moonmind/workflows/temporal/workflows/run.py"),
+        ("SessionId", "moonmind/workflows/temporal/workflows/run.py"),
+        ("SessionEpoch", "moonmind/workflows/temporal/workflows/run.py"),
+        ("SessionStatus", "moonmind/workflows/temporal/workflows/run.py"),
+        (
+            "IsDegraded",
+            "moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py",
+        ),
     )
     return (required, optional)
 
@@ -334,8 +405,8 @@ def render_reference(
         "registration owners. Do not edit by hand; regenerate with:",
         "",
         "```",
-        "python tools/generate_temporal_catalog.py "
-        "--out docs/Temporal/WorkflowTypeCatalogGenerated.md",
+        "python tools/generate_temporal_catalog.py --out "
+        + "docs/Temporal/WorkflowTypeCatalogGenerated.md",
         "```",
         "",
         "Providing owners:",
@@ -349,8 +420,10 @@ def render_reference(
         "- Worker construction: `moonmind/workflows/temporal/worker_entrypoint.py`",
         "  and `moonmind/workflows/temporal/worker_runtime.py` via",
         "  `moonmind/workflows/temporal/workers.py`",
-        "- Search Attributes: `moonmind/workflows/temporal/service.py` and",
-        "  `moonmind/workflows/temporal/scheduled_start.py`",
+        "- Search Attributes: `moonmind/workflows/temporal/service.py`,",
+        "  `moonmind/workflows/temporal/scheduled_start.py`,",
+        "  `moonmind/workflows/temporal/workflows/run.py`, and",
+        "  `moonmind/workflows/temporal/workflows/managed_runtime_workspace_cleanup.py`",
         "- Authored lifecycle semantics:",
         f"  `{CANONICAL_DOC.as_posix()}`",
         "",
@@ -504,7 +577,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         rendered = generate()
     except Exception as exc:
-        print(f"temporal catalog generation failed: {exc}", file=sys.stderr)
+        # Never echo the raw exception: Pydantic settings validation errors
+        # embed rejected input values, which may carry secret-bearing
+        # settings (MoonLadderStudios/MoonMind#3959 review). Log the error
+        # class only; rerunning the command reproduces the full message
+        # locally without persisting secrets to CI logs.
+        failure = f"temporal catalog generation failed: {type(exc).__name__}"
+        print(f"{failure} (settings inputs withheld)", file=sys.stderr)
         return 1
 
     if args.check:

--- a/tools/select_test_suites.py
+++ b/tools/select_test_suites.py
@@ -84,6 +84,14 @@ API_COMPONENT_GLOBS = ("api_service/auth*",)
 
 TEMPORAL_BOUNDARY_EXACT = {
     "moonmind/schemas/managed_session_models.py",
+    # MoonLadderStudios/MoonMind#3959: the mechanical catalog generator, its
+    # generated reference, and the canonical lifecycle doc carrying the
+    # lifecycle anchors the generator links must select the drift and
+    # composition checks (tests/unit/workflows/temporal/
+    # test_workflow_catalog_generator.py).
+    "tools/generate_temporal_catalog.py",
+    "docs/Temporal/WorkflowTypeCatalogGenerated.md",
+    "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md",
 }
 
 TEMPORAL_BOUNDARY_PREFIXES = (

--- a/tools/select_test_suites.py
+++ b/tools/select_test_suites.py
@@ -92,6 +92,10 @@ TEMPORAL_BOUNDARY_EXACT = {
     "tools/generate_temporal_catalog.py",
     "docs/Temporal/WorkflowTypeCatalogGenerated.md",
     "docs/Temporal/WorkflowTypeCatalogAndLifecycle.md",
+    # The namespace bootstrap script is the Search Attribute registration
+    # authority the generator cites; registry edits must re-run the drift and
+    # composition checks.
+    "services/temporal/scripts/bootstrap-namespace.sh",
 }
 
 TEMPORAL_BOUNDARY_PREFIXES = (


### PR DESCRIPTION
## Summary
Implements MoonLadderStudios/MoonMind#3959: generate the Temporal workflow/activity catalog from production registries instead of hand-maintained lists.

- Adds `tools/generate_temporal_catalog.py` (offline, deterministic, actionable failures; reuse of workflow_registry, activity_catalog, search-attribute and worker owners; validates raw registrations before map reduction; checks worker agreement, lifecycle anchors, and runtime bindings).
- Publishes one mechanical reference `docs/Temporal/WorkflowTypeCatalogGenerated.md` (16/16 registrations, 1 USER + 15 STATIC, stable anchors, projection roles, current vs historical-only lanes).
- Replaces duplicate handwritten enumerations in `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md` sections 3.1/4.1 with generated-view links; removes obsolete 'current live implementation name' row; preserves authored lifecycle semantics (11.1-11.9 incl. 11.9 MergeAutomation, 6.2 per-type controls, ManifestIngest dual-entry note).
- Adds raw-registration validation in `moonmind/workflows/temporal/workflow_registry.py` (duplicate Temporal name, unresolved class, missing module/class metadata, unsupported scope).
- Wires CI change-path in `tools/select_test_suites.py` so generator/reference/lifecycle changes select temporal_boundary drift/composition checks; adds `tests/unit/workflows/temporal/test_workflow_catalog_generator.py` (12 tests: drift, byte-stability, test-only enumeration, duplicate/metadata/scope failures, worker agreement, cache isolation, route/handler/search-attribute bindings, secret/path exclusion, canonical dedup).

## Verification outcome
moonspec-verify (issue-brief mode, HEAD 6f7b9403f): FULLY_IMPLEMENTED, confidence MEDIUM, recommendedNextAction advance. All 7 acceptance criteria and all 7 requirements verified by direct production-code, generated-output, docs, generator, and test-design inspection. Assessment baseline was NOT_IMPLEMENTED on be0798d08; candidate range be0798d08..6f7b9403f (2 commits) satisfies every requirement with no remaining gaps.

## Tests run
- Static audit of tests/unit/workflows/temporal/test_workflow_catalog_generator.py and tests/unit/tools/test_select_test_suites.py::test_temporal_catalog_generator_change_selects_temporal_boundary (12 catalog tests cover drift, byte-stability, validation, worker agreement, cache isolation, bindings).
- Live execution NOT RUN in sandbox (environment blocker, not assertion failure): no pytest / missing fastapi_users in host venv; 'moonmind container python-tests' rejected outside managed workflow; 'python tools/generate_temporal_catalog.py --check' requires controlled installed environment. Required CI must run the temporal_boundary shard at PR time.

## Remaining risks
- Unit/integration execution evidence pending in required CI (temporal_boundary shard: tests/unit/workflows/temporal/test_workflow_catalog_generator.py, generator --check, byte-stability run).
- No other functional gaps; scope limited to docs/catalog generation, no runtime behavior change.

Closes MoonLadderStudios/MoonMind#3959