### PR TITLE
Prevent long idempotency keys from stranding provider slots

### DIFF
--- a/docs/Security/ProviderProfiles.md
+++ b/docs/Security/ProviderProfiles.md
@@ -1420,6 +1420,13 @@ Schema upgrades preserve existing rows and indexes so a retained grant can
 retry unchanged after migration. A downgrade to bounded columns must refuse
 while any retained identity exceeds that bound.
 
+Before taking Provider Profile or host capacity, new Omnigent executions validate
+the complete serialized Activity request, including its admission ticket, against
+a 64 KiB handoff budget. Oversized requests fail with an actionable error before
+acquiring a lease. The ticket preserves the full request idempotency key; other
+session identity limits still apply. Retained histories keep their recorded
+admission path through the workflow's payload-preflight patch marker.
+
 The owning workflow is an identity for a **workflow-owned** lease only, and a
 partial unique index enforces it there. One Activity-owned step legitimately
 binds several Provider Profiles from the same runtime — each lease gets its own

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -948,8 +948,10 @@ class AdmittedProviderCapacity(BaseModel):
     ] = Field(ADMITTED_PROVIDER_CAPACITY_SCHEMA_V2, alias="schemaVersion")
     #: The manager-visible owner of every lease below. One owner across grant,
     #: scheduling, consumption and cleanup (#3880 remaining implementation 3).
+    #: Composed identities must retain the same unbounded text accepted by the
+    #: request and lease ledger, including when retrying an in-flight grant.
     lease_owner_id: str = Field(
-        ..., alias="leaseOwnerId", min_length=1, max_length=255
+        ..., alias="leaseOwnerId", min_length=1
     )
     profiles: tuple[AdmittedProviderProfileCapacity, ...] = Field(
         ..., alias="profiles", min_length=1, max_length=16
@@ -959,19 +961,19 @@ class AdmittedProviderCapacity(BaseModel):
         None, alias="executionPlanRef", max_length=255
     )
     agent_run_workflow_id: str | None = Field(
-        None, alias="agentRunWorkflowId", max_length=255
+        None, alias="agentRunWorkflowId"
     )
     agent_run_run_id: str | None = Field(
         None, alias="agentRunRunId", max_length=255
     )
     step_execution_id: str | None = Field(
-        None, alias="stepExecutionId", max_length=255
+        None, alias="stepExecutionId"
     )
     #: Immutable request identity the manager recorded with the grant. Together
     #: with the owner and plan refs this is the durable lease fence: it survives
     #: a manager restart because it is persisted on the lease row.
     idempotency_key: str | None = Field(
-        None, alias="idempotencyKey", max_length=255
+        None, alias="idempotencyKey"
     )
     #: Monotonic per-run admission counter. A deliberate re-admission bumps it,
     #: so operators and diagnostics can order attempts at one authority.

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -948,10 +948,8 @@ class AdmittedProviderCapacity(BaseModel):
     ] = Field(ADMITTED_PROVIDER_CAPACITY_SCHEMA_V2, alias="schemaVersion")
     #: The manager-visible owner of every lease below. One owner across grant,
     #: scheduling, consumption and cleanup (#3880 remaining implementation 3).
-    #: Composed identities must retain the same unbounded text accepted by the
-    #: request and lease ledger, including when retrying an in-flight grant.
     lease_owner_id: str = Field(
-        ..., alias="leaseOwnerId", min_length=1
+        ..., alias="leaseOwnerId", min_length=1, max_length=255
     )
     profiles: tuple[AdmittedProviderProfileCapacity, ...] = Field(
         ..., alias="profiles", min_length=1, max_length=16
@@ -961,17 +959,19 @@ class AdmittedProviderCapacity(BaseModel):
         None, alias="executionPlanRef", max_length=255
     )
     agent_run_workflow_id: str | None = Field(
-        None, alias="agentRunWorkflowId"
+        None, alias="agentRunWorkflowId", max_length=255
     )
     agent_run_run_id: str | None = Field(
         None, alias="agentRunRunId", max_length=255
     )
     step_execution_id: str | None = Field(
-        None, alias="stepExecutionId"
+        None, alias="stepExecutionId", max_length=255
     )
     #: Immutable request identity the manager recorded with the grant. Together
     #: with the owner and plan refs this is the durable lease fence: it survives
     #: a manager restart because it is persisted on the lease row.
+    #: Preserve composed request keys; the workflow bounds the complete
+    #: serialized handoff before taking capacity, rather than truncating keys.
     idempotency_key: str | None = Field(
         None, alias="idempotencyKey"
     )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -257,6 +257,12 @@ OMNIGENT_EXECUTION_PLAN_ADMISSION_PATCH_ID = (
 OMNIGENT_PRE_ACTIVITY_CAPACITY_ADMISSION_PATCH_ID = (
     "agent-run-omnigent-pre-activity-capacity-admission-v1"
 )
+OMNIGENT_CAPACITY_PAYLOAD_PREFLIGHT_PATCH_ID = (
+    "agent-run-omnigent-capacity-payload-preflight-v1"
+)
+# Keep the complete request, including duplicated admission identities, well
+# below Temporal's transport ceiling. Large context belongs in artifact refs.
+OMNIGENT_EXECUTION_HANDOFF_MAX_BYTES = 64 * 1024
 # MoonLadderStudios/MoonMind#3880 requirement 4: an advertised pre-Activity
 # admission path must not silently restore Activity-side queueing, so a plan
 # that names the Activity as its capacity owner is rejected before execution.
@@ -3785,6 +3791,39 @@ class MoonMindAgentRun:
             )
         _, step_execution_id = self._omnigent_owner_identities(request)
         self._omnigent_admission_epoch += 1
+        admitted_request = request.model_copy(
+            update={
+                "admitted_provider_capacity": AdmittedProviderCapacity(
+                    leaseOwnerId=workflow.info().workflow_id,
+                    profiles=tuple(
+                        AdmittedProviderProfileCapacity.model_validate(item)
+                        for item in profiles
+                    ),
+                    executionPlanRef=plan_ref,
+                    agentRunWorkflowId=workflow.info().workflow_id,
+                    agentRunRunId=workflow.info().run_id,
+                    stepExecutionId=step_execution_id,
+                    idempotencyKey=request.idempotency_key,
+                    admissionEpoch=self._omnigent_admission_epoch,
+                )
+            }
+        )
+        # Validate the actual Activity handoff before either capacity owner is
+        # contacted. Checking the original request alone misses the extra key
+        # copy in its ticket. Retained histories preserve their recorded grant
+        # and Activity ordering rather than failing a newly introduced budget.
+        if workflow.patched(OMNIGENT_CAPACITY_PAYLOAD_PREFLIGHT_PATCH_ID):
+            payload_bytes = len(
+                admitted_request.model_dump_json(by_alias=True).encode("utf-8")
+            )
+            if payload_bytes > OMNIGENT_EXECUTION_HANDOFF_MAX_BYTES:
+                raise ApplicationError(
+                    "Agent execution request including admitted capacity must "
+                    f"serialize to <= {OMNIGENT_EXECUTION_HANDOFF_MAX_BYTES} bytes; "
+                    "use compact request identities and artifact refs for context",
+                    type="AgentExecutionPayloadTooLarge",
+                    non_retryable=True,
+                )
         await self._admit_omnigent_provider_capacity(
             request=request,
             runtime_id=profiles[0]["providerRuntimeId"],
@@ -3812,23 +3851,7 @@ class MoonMindAgentRun:
             # go back to the queue immediately.
             await self._release_omnigent_provider_capacity(request=request)
             raise
-        return request.model_copy(
-            update={
-                "admitted_provider_capacity": AdmittedProviderCapacity(
-                    leaseOwnerId=workflow.info().workflow_id,
-                    profiles=tuple(
-                        AdmittedProviderProfileCapacity.model_validate(item)
-                        for item in profiles
-                    ),
-                    executionPlanRef=plan_ref,
-                    agentRunWorkflowId=workflow.info().workflow_id,
-                    agentRunRunId=workflow.info().run_id,
-                    stepExecutionId=step_execution_id,
-                    idempotencyKey=request.idempotency_key,
-                    admissionEpoch=self._omnigent_admission_epoch,
-                )
-            }
-        )
+        return admitted_request
 
     def _omnigent_admits_capacity_before_activity(
         self,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py
@@ -20,7 +20,9 @@ acquiring capacity inside the execution slot.
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -37,6 +39,7 @@ from moonmind.schemas.agent_runtime_models import (
     ADMITTED_PROVIDER_CAPACITY_SCHEMA_V2,
     AgentExecutionRequest,
     AgentRunResult,
+    AgentRuntimeStepExecutionLaunch,
 )
 from moonmind.schemas.omnigent_session_models import (
     OmnigentSessionAdmissionDecision,
@@ -750,6 +753,76 @@ class _ExecutingRun(_RecordingRun):
             self.capacity_states.append(self._omnigent_capacity_state)
             return self.results.pop(0)
         return await super()._execute_routed_activity(name, payload, **kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("extended_identities", [False, True])
+async def test_remediation_lease_identities_survive_the_execution_handoff(
+    monkeypatch: pytest.MonkeyPatch, extended_identities: bool
+) -> None:
+    """Replay the long-identity grant that stranded a run after slot assignment."""
+
+    fixture = (
+        Path(__file__).resolve().parents[4]
+        / "integration/omnigent/fixtures/remediation_lease_grant.json"
+    )
+    lease = json.loads(fixture.read_text())["leases"][0]
+    _configure_workflow_runtime(monkeypatch)
+    owner_id = lease["workflow_id"]
+    step_id = lease["stepExecutionId"]
+    request_id = lease["idempotencyKey"]
+    workflow_id = owner_id.split(":agent:", 1)[0]
+    run_id = step_id[len(workflow_id) + 1:][:36]
+    logical_step_id = step_id[len(workflow_id) + len(run_id) + 2:].removesuffix(
+        ":execution:1"
+    )
+    if extended_identities:
+        owner_id += ":continuation" * 8
+        logical_step_id += ":continuation" * 8
+        step_id = f"{workflow_id}:{run_id}:{logical_step_id}:execution:1"
+        request_id = f"{step_id}:agent_execute"
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            namespace="default", workflow_id=owner_id, run_id="run-1",
+            search_attributes={}, parent=None,
+        ),
+    )
+    request = _omnigent_request().model_copy(update={
+        "idempotency_key": request_id,
+        "step_execution": AgentRuntimeStepExecutionLaunch(
+            workflowId=workflow_id, runId=run_id,
+            logicalStepId=logical_step_id,
+            executionOrdinal=1, stepExecutionId=step_id,
+            runtimeContextPolicy="fresh_agent_run",
+        ),
+    })
+    run = _ExecutingRun([{"summary": "completed"}])
+    _capture_release_signals(monkeypatch, run)
+    await run._execute_omnigent_with_admitted_capacity(
+        act_name="integration.omnigent.execute",
+        request=request, admission=_admission(), parent_info=None,
+        stc_seconds=600, admit_capacity_before_activity=True,
+        execution_plan_admission=True,
+    )
+
+    assert len(request_id) > 255
+    assert len(run.executions) == 1
+    # Deserialize the same payload shape the Activity receives from Temporal.
+    received = AgentExecutionRequest.model_validate_json(
+        run.executions[0].model_dump_json(by_alias=True)
+    )
+    capacity = received.admitted_provider_capacity
+    assert capacity.lease_owner_id == owner_id
+    assert capacity.agent_run_workflow_id == owner_id
+    assert capacity.step_execution_id == step_id
+    assert capacity.idempotency_key == received.idempotency_key == request_id
+    grant = next(p for name, p in run.signals if name == "request_slot")
+    assert grant["lease_metadata"]["idempotencyKey"] == request_id
+    assert grant["lease_metadata"]["stepExecutionId"] == step_id
+    release = next(p for name, p in run.signals if name == "release_slot")
+    assert release["requester_workflow_id"] == owner_id
 
 
 async def _run_execution(run: _ExecutingRun) -> tuple[Any, Any]:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py
@@ -756,9 +756,8 @@ class _ExecutingRun(_RecordingRun):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("extended_identities", [False, True])
 async def test_remediation_lease_identities_survive_the_execution_handoff(
-    monkeypatch: pytest.MonkeyPatch, extended_identities: bool
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Replay the long-identity grant that stranded a run after slot assignment."""
 
@@ -776,11 +775,6 @@ async def test_remediation_lease_identities_survive_the_execution_handoff(
     logical_step_id = step_id[len(workflow_id) + len(run_id) + 2:].removesuffix(
         ":execution:1"
     )
-    if extended_identities:
-        owner_id += ":continuation" * 8
-        logical_step_id += ":continuation" * 8
-        step_id = f"{workflow_id}:{run_id}:{logical_step_id}:execution:1"
-        request_id = f"{step_id}:agent_execute"
     monkeypatch.setattr(
         agent_run_module.workflow,
         "info",
@@ -800,14 +794,28 @@ async def test_remediation_lease_identities_survive_the_execution_handoff(
     })
     run = _ExecutingRun([{"summary": "completed"}])
     _capture_release_signals(monkeypatch, run)
+    admission = await run._evaluate_omnigent_session_admission(
+        request, include_execution_plan_ref=True
+    )
     await run._execute_omnigent_with_admitted_capacity(
         act_name="integration.omnigent.execute",
-        request=request, admission=_admission(), parent_info=None,
+        request=request, admission=admission, parent_info=None,
         stc_seconds=600, admit_capacity_before_activity=True,
         execution_plan_admission=True,
     )
 
     assert len(request_id) > 255
+    admission_payload = next(
+        payload for name, payload in run.activity_calls
+        if name == "omnigent.evaluate_session_admission"
+    )
+    assert admission_payload["workflowId"] == workflow_id
+    assert admission_payload["stepExecutionId"] == step_id
+    assert admission_payload["agentRunId"] == owner_id
+    assert all(
+        len(admission_payload[field]) <= 255
+        for field in ("workflowId", "stepExecutionId", "agentRunId")
+    )
     assert len(run.executions) == 1
     # Deserialize the same payload shape the Activity receives from Temporal.
     received = AgentExecutionRequest.model_validate_json(
@@ -835,6 +843,66 @@ async def _run_execution(run: _ExecutingRun) -> tuple[Any, Any]:
         admit_capacity_before_activity=True,
         execution_plan_admission=True,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key", ["x" * 40_000, "é" * 20_000], ids=["ascii", "multibyte"])
+@pytest.mark.parametrize("preflight_enabled", [True, False])
+@pytest.mark.parametrize("activity_name", [
+    "integration.omnigent.execute", "integration.omnigent.profile_bound_execute",
+])
+async def test_capacity_payload_budget_precedes_grant_and_preserves_recorded_path(
+    monkeypatch: pytest.MonkeyPatch, key: str, preflight_enabled: bool,
+    activity_name: str,
+) -> None:
+    """The key fits on input but its ticket copy exceeds the handoff budget."""
+
+    _configure_workflow_runtime(monkeypatch)
+    monkeypatch.setattr(
+        agent_run_module.workflow, "patched",
+        lambda marker: (
+            preflight_enabled
+            if marker == agent_run_module.OMNIGENT_CAPACITY_PAYLOAD_PREFLIGHT_PATCH_ID
+            else True
+        ),
+    )
+    request = _production_started_omnigent_request().model_copy(
+        update={"idempotency_key": key}
+    )
+    # Initial deserialization must accept the value; the guard must account for
+    # the future ticket, not simply check this smaller initial payload.
+    request = AgentExecutionRequest.model_validate_json(
+        request.model_dump_json(by_alias=True)
+    )
+    budget = agent_run_module.OMNIGENT_EXECUTION_HANDOFF_MAX_BYTES
+    assert len(request.model_dump_json(by_alias=True).encode("utf-8")) < budget
+    run = _ExecutingRun([{"summary": "completed"}])
+    _capture_release_signals(monkeypatch, run)
+
+    async def execute():
+        return await run._execute_omnigent_with_admitted_capacity(
+            act_name=activity_name, request=request, admission=_admission(),
+            parent_info=None, stc_seconds=600,
+            admit_capacity_before_activity=True, execution_plan_admission=True,
+        )
+
+    if preflight_enabled:
+        with pytest.raises(ApplicationError) as error:
+            await execute()
+        assert error.value.type == "AgentExecutionPayloadTooLarge"
+        assert error.value.non_retryable
+        assert run.signals == []
+        assert run.activity_calls == []
+        assert run.executions == []
+    else:
+        # Histories without the marker retain their scheduled invocation. The
+        # new size policy cannot strand an already-held lease during replay.
+        await execute()
+        assert len(run.executions) == 1
+        serialized = run.executions[0].model_dump_json(by_alias=True).encode("utf-8")
+        assert len(serialized) > budget
+        assert run.executions[0].admitted_provider_capacity.idempotency_key == key
+        assert [name for name, _ in run.signals] == ["request_slot", "release_slot"]
 
 
 def _capacity_failure(code: str) -> dict[str, Any]:


### PR DESCRIPTION
## Related issue

Follow-up to #4073.

## Summary

An AgentRun with a 268-character remediation idempotency key could obtain its provider slot, then repeatedly fail workflow-task validation while the dashboard remained on `awaiting_slot`. Remove the ticket’s 255-character idempotency-key limit while preserving existing owner and step constraints. Before taking capacity, validate the complete serialized request, including the ticket, against a 64 KiB budget; retain the old admission path for recorded histories through a Temporal patch marker.

Reuse the production remediation-grant fixture to verify upstream session admission, execution-payload deserialization, and release with the original 268-character key. Cover ASCII and multibyte oversized requests on both execution Activity paths and retained-history behavior.

## Test Plan

```bash
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py \
  tests/unit/omnigent/test_provider_leases_workflow_owned_capacity.py \
  tests/unit/workflows/temporal/test_provider_profile_admitted_capacity_fence.py \
  tests/unit/schemas/test_agent_runtime_models.py \
  tests/unit/schemas/test_agent_runtime_models_boundary.py
```

166 tests passed in the dedicated Python test image. The affected production child's recorded history also passed Temporal replay with the fix. After worker reload, the same child resumed its execution activity and reported an active agent turn.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

This relaxes idempotency-key length validation on the provider-capacity handoff and adds a replay-versioned 64 KiB pre-admission request budget. Serialized field names and identity values remain unchanged, so retained grants and retries keep their original authority. Existing profile, plan, scope, and credential-generation checks remain enforced. No database migration is needed beyond #4073.

## Coverage notes

The regression crosses upstream session admission, workflow capacity admission, and the serialized Activity-input boundary using the retained grant fixture; existing tests cover retained v1 tickets and capacity fencing. Manual verification included replay of the affected live child and confirmation that its existing run resumed after worker reload.

## Changelog

Prevent long remediation identities from stranding workflows after provider-slot admission.
