### PR TITLE
[Omnigent boundary] Automate reviewed upstream pin updates with exact-artifact qualification (#3957)

### DIFF
--- a/.github/workflows/omnigent-upstream-pin-updater.yml
+++ b/.github/workflows/omnigent-upstream-pin-updater.yml
@@ -1,0 +1,326 @@
+name: Omnigent Upstream Pin Updater
+
+# Source issue: MoonLadderStudios/MoonMind#3957.
+#
+# Scheduled/manual updater for the `omnigent` gitlink.  Each run discovers
+# eligible upstream releases of omnigent-ai/omnigent, resolves tags to
+# immutable commits, and opens or updates exactly one evidence-backed
+# candidate PR.  It never changes main directly, never tracks upstream main,
+# never executes newly fetched upstream code, and never consumes production
+# secrets: the plan job reads release metadata only, the qualify job runs
+# the checked-in hermetic shards, and the propose job moves only the
+# submodule pointer plus the evidence artifacts.
+#
+# Explicit outcomes (closed vocabulary from
+# moonmind/omnigent/upstream_pin_update.py):
+# up_to_date | candidate_available | no_suitable_release |
+# blocked_invalid_tag | blocked_transient_upstream.  A failed qualification
+# or an incompatible release leaves the known-good pin intact, records a
+# blocked reason in status.json, and never creates duplicate PRs.
+#
+# Freshness publication: status.json distinguishes available / tested /
+# qualified / promoted versions.  Merge-time hermetic success (tested) never
+# implies protected live evidence (qualified) or product-default promotion
+# (promoted).
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      allow_prereleases:
+        description: "Consider upstream prereleases as candidates"
+        required: false
+        default: false
+        type: boolean
+      upstream_repo:
+        description: "Upstream repository to check"
+        required: false
+        default: "omnigent-ai/omnigent"
+        type: string
+      dry_run:
+        description: "Plan and qualify without opening or updating the candidate PR"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: omnigent-upstream-pin-updater
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Discover candidate and record evidence
+    runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.evaluate.outputs.outcome }}
+      candidate_tag: ${{ steps.evaluate.outputs.candidate_tag }}
+      candidate_commit: ${{ steps.evaluate.outputs.candidate_commit }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Read current omnigent pin
+        id: pin
+        run: |
+          PIN="$(git ls-tree HEAD omnigent | awk '{print $3}')"
+          echo "pin=${PIN}" >> "$GITHUB_OUTPUT"
+          echo "Current omnigent pin: ${PIN}"
+
+      - name: Fetch upstream releases metadata
+        id: releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'omnigent-ai/omnigent' }}
+        run: |
+          # Metadata only: release tags, prerelease/draft flags, publish
+          # dates.  Fetched code is never executed in this workflow.
+          if gh api "repos/${UPSTREAM_REPO}/releases?per_page=30" --paginate \
+              > /tmp/upstream-releases-raw.json; then
+            echo "fetch_error=" >> "$GITHUB_OUTPUT"
+          else
+            echo "fetch_error=upstream releases API request failed (transient)" >> "$GITHUB_OUTPUT"
+            echo "[]" > /tmp/upstream-releases-raw.json
+          fi
+
+      - name: Resolve release tags to immutable commits
+        if: steps.releases.outputs.fetch_error == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'omnigent-ai/omnigent' }}
+        run: |
+          python - <<'PY'
+          import json, subprocess, urllib.request
+
+          raw = json.load(open("/tmp/upstream-releases-raw.json"))
+          releases = raw if isinstance(raw, list) else raw.get("releases", [])
+          import os
+          repo = os.environ["UPSTREAM_REPO"]
+          resolved = []
+          for rel in releases:
+              if not isinstance(rel, dict):
+                  continue
+              tag = (rel.get("tag_name") or "").strip()
+              entry = {
+                  "tag_name": tag,
+                  "name": rel.get("name", ""),
+                  "html_url": rel.get("html_url", ""),
+                  "published_at": rel.get("published_at", ""),
+                  "prerelease": bool(rel.get("prerelease", False)),
+                  "draft": bool(rel.get("draft", False)),
+                  "resolved_commit": "",
+              }
+              if tag:
+                  # Annotated tags dereference to the commit via ^{commit};
+                  # a missing or moved tag leaves resolved_commit empty and
+                  # the planner reports blocked_invalid_tag explicitly.
+                  for ref in (
+                      f"tags/{tag}^{{commit}}",
+                      f"tags/{tag}",
+                  ):
+                      try:
+                          out = subprocess.run(
+                              ["gh", "api", f"repos/{repo}/git/matching-refs/{ref}"],
+                              capture_output=True, text=True, check=True, timeout=60,
+                          )
+                          refs = json.loads(out.stdout or "[]")
+                          sha = ""
+                          if isinstance(refs, dict):
+                              sha = refs.get("object", {}).get("sha", "")
+                          elif isinstance(refs, list) and refs:
+                              sha = refs[0].get("object", {}).get("sha", "")
+                          if len(sha) == 40:
+                              entry["resolved_commit"] = sha
+                              break
+                      except Exception:
+                          continue
+              resolved.append(entry)
+          json.dump(resolved, open("/tmp/upstream-releases.json", "w"), indent=2)
+          print(f"resolved {len(resolved)} releases")
+          PY
+
+      - name: Evaluate updater outcome
+        id: evaluate
+        run: |
+          ARGS=(--current-commit "${{ steps.pin.outputs.pin }}")
+          if [ "${{ steps.releases.outputs.fetch_error }}" != "" ]; then
+            ARGS+=(--fetch-error "${{ steps.releases.outputs.fetch_error }}")
+          else
+            ARGS+=(--releases-json /tmp/upstream-releases.json)
+          fi
+          if [ "${{ inputs.allow_prereleases }}" = "true" ]; then
+            ARGS+=(--allow-prereleases)
+          fi
+          ARGS+=(--upstream-repo "${{ inputs.upstream_repo || 'omnigent-ai/omnigent' }}")
+          ARGS+=(--output-dir artifacts/omnigent-upstream-pin-update)
+          python tools/check_omnigent_upstream_pin_update.py "${ARGS[@]}"
+          echo "outcome=$(python -c "import json;print(json.load(open('artifacts/omnigent-upstream-pin-update/candidate.json'))['status'])")" >> "$GITHUB_OUTPUT"
+          echo "candidate_tag=$(python -c "import json;d=json.load(open('artifacts/omnigent-upstream-pin-update/candidate.json'));print((d['candidate'] or {}).get('tag',''))")" >> "$GITHUB_OUTPUT"
+          echo "candidate_commit=$(python -c "import json;d=json.load(open('artifacts/omnigent-upstream-pin-update/candidate.json'));print((d['candidate'] or {}).get('commit',''))")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish freshness to job summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          try:
+              status = json.load(open("artifacts/omnigent-upstream-pin-update/status.json"))
+          except OSError:
+              print("No updater status produced.")
+              raise SystemExit(0)
+          lines = [
+              "## Omnigent upstream-pin freshness",
+              f"- Outcome: `{status['outcome']}`",
+              f"- Available: `{status['available']['tag'] or '-'}` @ `{status['available']['commit'] or '-'}`",
+              f"- Last qualified: `{status['lastQualifiedVersion']['tag'] or '-'}` @ `{status['lastQualifiedVersion']['commit']}`",
+              f"- Promoted: `{status['promoted']['commit']}`",
+              f"- Blocked reason: {status['blockedReason'] or '-'}",
+              f"- Checked at: `{status['checkedAt']}` (weekly cadence)",
+          ]
+          with open("summary.md", "w") as fh:
+              fh.write("\n".join(lines) + "\n")
+          PY
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload updater evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: omnigent-upstream-pin-update-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/omnigent-upstream-pin-update/
+          if-no-files-found: warn
+          retention-days: 30
+
+  qualify:
+    name: Hermetic qualification shards
+    needs: plan
+    if: needs.plan.outputs.outcome == 'candidate_available'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Run owning hermetic shards
+        run: |
+          python -m pytest -q \
+            tests/unit/omnigent/test_adapter_contracts.py \
+            tests/unit/omnigent/test_host_protocol_adapter.py \
+            tests/unit/omnigent/test_host_registration_inventory.py \
+            tests/unit/omnigent/test_oauth_home_materializers.py \
+            tests/unit/omnigent/test_omnigent_session_timeline_api.py \
+            tests/unit/omnigent/test_session_supervisor_admission.py \
+            tests/unit/omnigent/test_control_plane_readiness.py \
+            tests/unit/omnigent/test_native_ui.py \
+            tests/unit/omnigent/test_native_ui_compat.py \
+            tests/unit/omnigent/test_omnigent_facade_unknown_route_fails_closed.py \
+            tests/unit/omnigent/test_authority_chain_evidence.py \
+            tests/unit/omnigent/test_execution_support_evidence.py \
+            tests/unit/omnigent/test_deployment_evidence_publishing.py \
+            tests/unit/omnigent/test_host_cleanup_service.py \
+            tests/unit/omnigent/test_oauth_host_janitor.py
+
+  propose:
+    name: Open or update single candidate PR
+    needs: [plan, qualify]
+    if: needs.plan.outputs.outcome == 'candidate_available' && needs.qualify.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Prepare candidate branch without touching main
+        id: branch
+        env:
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          SHORT="$(echo "${CANDIDATE_COMMIT}" | cut -c1-12)"
+          BRANCH="automation/omnigent-pin-${SHORT}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          git fetch origin main --quiet
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "${BRANCH}:${BRANCH}" --quiet
+            git checkout "${BRANCH}"
+          else
+            git checkout -b "${BRANCH}" origin/main
+          fi
+
+      - name: Move only the omnigent pointer to the resolved commit
+        env:
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          # The tag is provenance only; the gitlink records the immutable
+          # commit.  No fetched upstream code is executed here.
+          git update-index --cacheinfo 160000 "${CANDIDATE_COMMIT}" omnigent
+          git diff --cached --stat
+          git diff --cached --quiet && echo "pointer already at candidate" || true
+
+      - name: Attach evidence artifacts to the branch
+        run: |
+          mkdir -p artifacts/omnigent-upstream-pin-update
+          gh run download "${{ github.run_id }}" \
+            --name "omnigent-upstream-pin-update-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --dir artifacts/omnigent-upstream-pin-update || true
+          git add artifacts/omnigent-upstream-pin-update/candidate.json \
+            artifacts/omnigent-upstream-pin-update/evidence.json \
+            artifacts/omnigent-upstream-pin-update/status.json 2>/dev/null || true
+          git -c user.name="moonmind-updater" -c user.email="moonmind-updater@users.noreply.github.com" \
+            commit -m "MoonLadderStudios/MoonMind#3957: candidate omnigent pin ${{ needs.plan.outputs.candidate_tag }} (${{ needs.plan.outputs.candidate_commit }})" || echo "nothing to commit"
+          git push --force-with-lease origin HEAD:"${{ steps.branch.outputs.branch }}"
+
+      - name: Open or update the single candidate PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_TAG: ${{ needs.plan.outputs.candidate_tag }}
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "dry_run: skipping PR creation/update"
+            exit 0
+          fi
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Candidate omnigent pin update for MoonLadderStudios/MoonMind#3957."
+            echo ""
+            echo "- Release: \`${CANDIDATE_TAG}\` (provenance only)"
+            echo "- Resolved commit: \`${CANDIDATE_COMMIT}\`"
+            echo "- Hermetic qualification shards: passed (see checks)"
+            echo "- Protected live evidence still required before promotion;"
+            echo "  prior support evidence for the old commit does not qualify"
+            echo "  this combination."
+            echo "- Rollback: previous qualified pin retained in evidence.json;"
+            echo "  historical run bindings are never rewritten."
+            echo ""
+            echo "Evidence: artifacts/omnigent-upstream-pin-update/{candidate,evidence,status}.json"
+          } > "${BODY_FILE}"
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          if gh pr view "${BRANCH}" --json number >/dev/null 2>&1; then
+            gh pr edit "${BRANCH}" --title "MoonLadderStudios/MoonMind#3957: candidate omnigent pin ${CANDIDATE_TAG}" --body-file "${BODY_FILE}"
+            echo "updated existing candidate PR"
+          else
+            gh pr create --base main --head "${BRANCH}" \
+              --title "MoonLadderStudios/MoonMind#3957: candidate omnigent pin ${CANDIDATE_TAG}" \
+              --body-file "${BODY_FILE}" \
+              --label dependencies --label testing
+          fi

--- a/.github/workflows/omnigent-upstream-pin-updater.yml
+++ b/.github/workflows/omnigent-upstream-pin-updater.yml
@@ -8,8 +8,9 @@ name: Omnigent Upstream Pin Updater
 # candidate PR.  It never changes main directly, never tracks upstream main,
 # never executes newly fetched upstream code, and never consumes production
 # secrets: the plan job reads release metadata only, the qualify job runs
-# the checked-in hermetic shards, and the propose job moves only the
-# submodule pointer plus the evidence artifacts.
+# the checked-in hermetic shards against the candidate commit, and the
+# propose job moves the submodule pointer plus every canonical pin consumer
+# and the evidence artifacts.
 #
 # Explicit outcomes (closed vocabulary from
 # moonmind/omnigent/upstream_pin_update.py):
@@ -22,6 +23,10 @@ name: Omnigent Upstream Pin Updater
 # qualified / promoted versions.  Merge-time hermetic success (tested) never
 # implies protected live evidence (qualified) or product-default promotion
 # (promoted).
+#
+# Trust boundary: upstream release tags and names are untrusted input.  They
+# always travel through step outputs into `env` and are expanded as quoted
+# shell data, never interpolated into `run` scripts.
 
 on:
   schedule:
@@ -86,7 +91,10 @@ jobs:
         run: |
           # Metadata only: release tags, prerelease/draft flags, publish
           # dates.  Fetched code is never executed in this workflow.
-          if gh api "repos/${UPSTREAM_REPO}/releases?per_page=30" --paginate \
+          # --slurp wraps each paginated REST page into one outer array so
+          # large release histories (>30 entries) still parse as one
+          # document; the resolver flattens pages before planning.
+          if gh api "repos/${UPSTREAM_REPO}/releases?per_page=100" --paginate --slurp \
               > /tmp/upstream-releases-raw.json; then
             echo "fetch_error=" >> "$GITHUB_OUTPUT"
           else
@@ -101,14 +109,82 @@ jobs:
           UPSTREAM_REPO: ${{ inputs.upstream_repo || 'omnigent-ai/omnigent' }}
         run: |
           python - <<'PY'
-          import json, subprocess, urllib.request
+          import json, os, re, subprocess
 
-          raw = json.load(open("/tmp/upstream-releases-raw.json"))
-          releases = raw if isinstance(raw, list) else raw.get("releases", [])
-          import os
+          FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+          def read_pages(path):
+              raw = json.load(open(path))
+              if isinstance(raw, dict):
+                  return raw.get("releases", [])
+              if not isinstance(raw, list):
+                  return []
+              # --slurp output is a list of pages (lists); a single page is
+              # a list of release objects.
+              if raw and all(isinstance(page, list) for page in raw):
+                  flattened = []
+                  for page in raw:
+                      flattened.extend(page)
+                  return flattened
+              return raw
+
+          def peel_to_commit(repo, sha):
+              """Follow an annotated tag object to its commit target."""
+              try:
+                  out = subprocess.run(
+                      ["gh", "api", f"repos/{repo}/git/tags/{sha}"],
+                      capture_output=True, text=True, check=True, timeout=60,
+                  )
+                  tag_obj = json.loads(out.stdout or "{}")
+                  if not isinstance(tag_obj, dict):
+                      return ""
+                  target = tag_obj.get("object", {})
+                  if target.get("type") == "commit" and FULL_SHA.match(target.get("sha", "")):
+                      return target["sha"]
+                  return ""
+              except Exception:
+                  return ""
+
+          def resolve_tag(repo, tag):
+              """Resolve one release tag to its immutable commit SHA.
+
+              Returns (sha, failed) where failed is True only when the
+              resolution itself errored (transient); a missing or moved tag
+              yields ("", False) so the planner reports blocked_invalid_tag.
+              """
+              try:
+                  out = subprocess.run(
+                      ["gh", "api", f"repos/{repo}/git/matching-refs/tags/{tag}"],
+                      capture_output=True, text=True, check=True, timeout=60,
+                  )
+              except Exception:
+                  return "", True
+              try:
+                  refs = json.loads(out.stdout or "[]")
+              except ValueError:
+                  return "", True
+              candidates = refs if isinstance(refs, list) else [refs]
+              for ref in candidates:
+                  if not isinstance(ref, dict):
+                      continue
+                  obj = ref.get("object", {})
+                  sha = obj.get("sha", "")
+                  if not FULL_SHA.match(sha):
+                      continue
+                  if obj.get("type") == "commit":
+                      return sha, False
+                  if obj.get("type") == "tag":
+                      peeled = peel_to_commit(repo, sha)
+                      if peeled:
+                          return peeled, False
+                      return "", False
+              return "", False
+
+          raw_releases = read_pages("/tmp/upstream-releases-raw.json")
           repo = os.environ["UPSTREAM_REPO"]
           resolved = []
-          for rel in releases:
+          failures = []
+          for rel in raw_releases:
               if not isinstance(rel, dict):
                   continue
               tag = (rel.get("tag_name") or "").strip()
@@ -122,32 +198,19 @@ jobs:
                   "resolved_commit": "",
               }
               if tag:
-                  # Annotated tags dereference to the commit via ^{commit};
-                  # a missing or moved tag leaves resolved_commit empty and
-                  # the planner reports blocked_invalid_tag explicitly.
-                  for ref in (
-                      f"tags/{tag}^{{commit}}",
-                      f"tags/{tag}",
-                  ):
-                      try:
-                          out = subprocess.run(
-                              ["gh", "api", f"repos/{repo}/git/matching-refs/{ref}"],
-                              capture_output=True, text=True, check=True, timeout=60,
-                          )
-                          refs = json.loads(out.stdout or "[]")
-                          sha = ""
-                          if isinstance(refs, dict):
-                              sha = refs.get("object", {}).get("sha", "")
-                          elif isinstance(refs, list) and refs:
-                              sha = refs[0].get("object", {}).get("sha", "")
-                          if len(sha) == 40:
-                              entry["resolved_commit"] = sha
-                              break
-                      except Exception:
-                          continue
+                  # A missing or moved tag leaves resolved_commit empty and
+                  # the planner reports blocked_invalid_tag explicitly.  A
+                  # resolution error is recorded separately and blocks the
+                  # run so a newer-but-unresolvable release can never lose
+                  # silently to an older candidate.
+                  sha, failed = resolve_tag(repo, tag)
+                  entry["resolved_commit"] = sha
+                  if failed:
+                      failures.append(tag)
               resolved.append(entry)
           json.dump(resolved, open("/tmp/upstream-releases.json", "w"), indent=2)
-          print(f"resolved {len(resolved)} releases")
+          json.dump(failures, open("/tmp/upstream-resolve-failures.json", "w"), indent=2)
+          print(f"resolved {len(resolved)} releases, {len(failures)} resolution failures")
           PY
 
       - name: Evaluate updater outcome
@@ -156,6 +219,8 @@ jobs:
           ARGS=(--current-commit "${{ steps.pin.outputs.pin }}")
           if [ "${{ steps.releases.outputs.fetch_error }}" != "" ]; then
             ARGS+=(--fetch-error "${{ steps.releases.outputs.fetch_error }}")
+          elif [ -s /tmp/upstream-resolve-failures.json ] && [ "$(python -c "import json;print(len(json.load(open('/tmp/upstream-resolve-failures.json'))))")" != "0" ]; then
+            ARGS+=(--fetch-error "transient tag-resolution failures for: $(python -c "import json;print(','.join(json.load(open('/tmp/upstream-resolve-failures.json'))))") (retry on next check)")
           else
             ARGS+=(--releases-json /tmp/upstream-releases.json)
           fi
@@ -210,11 +275,38 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e .[tests]
+
+      - name: Check out the candidate commit for qualification
+        env:
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          set -euo pipefail
+          if ! echo "${CANDIDATE_COMMIT}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::candidate commit is not a full 40-hex SHA" >&2
+            exit 1
+          fi
+          # The gate must test the candidate, never the base checkout: point
+          # the working-tree gitlink at the candidate and initialize the
+          # submodule at exactly that commit.
+          git update-index --cacheinfo 160000 "${CANDIDATE_COMMIT}" omnigent
+          git submodule update --init --depth 1 -- omnigent
+          ACTUAL="$(git -C omnigent rev-parse HEAD)"
+          if [ "${ACTUAL}" != "${CANDIDATE_COMMIT}" ]; then
+            echo "::error::submodule HEAD ${ACTUAL} != candidate ${CANDIDATE_COMMIT}" >&2
+            exit 1
+          fi
 
       - name: Run owning hermetic shards
         run: |
@@ -235,19 +327,95 @@ jobs:
             tests/unit/omnigent/test_host_cleanup_service.py \
             tests/unit/omnigent/test_oauth_host_janitor.py
 
+      - name: Download plan evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/omnigent-upstream-pin-update
+          gh run download "${{ github.run_id }}" \
+            --name "omnigent-upstream-pin-update-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --dir artifacts/omnigent-upstream-pin-update
+
+      - name: Record tested qualification outcome
+        # The plan artifact carries outcome=candidate_available with an empty
+        # tested stage; republish it with the hermetic result so success and
+        # failure states are both durable lifecycle evidence.
+        if: always()
+        env:
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          python - <<'PY'
+          import json, os, sys
+          sys.path.insert(0, ".")
+          from moonmind.omnigent.upstream_pin_update import mark_tested, normalize_commit
+          status = json.load(open("artifacts/omnigent-upstream-pin-update/status.json"))
+          commit = os.environ["CANDIDATE_COMMIT"]
+          normalize_commit(commit)
+          run_ref = f"{os.environ.get('GITHUB_RUN_ID', '')}/{os.environ.get('GITHUB_RUN_ATTEMPT', '')}"
+          tested = mark_tested(status, commit=commit, hermetic_run_ref=run_ref)
+          json.dump(tested, open("artifacts/omnigent-upstream-pin-update/status.json", "w"), indent=2)
+          print(f"recorded tested commit {commit} run {run_ref}")
+          PY
+
+      - name: Upload tested evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: omnigent-upstream-pin-tested-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/omnigent-upstream-pin-update/
+          if-no-files-found: error
+          retention-days: 30
+
   propose:
     name: Open or update single candidate PR
     needs: [plan, qualify]
-    if: needs.plan.outputs.outcome == 'candidate_available' && needs.qualify.result == 'success'
+    if: needs.plan.outputs.outcome == 'candidate_available' && needs.qualify.result == 'success' && inputs.dry_run != true
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Verify candidate against the configured submodule remote
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_REPO: ${{ inputs.upstream_repo || 'omnigent-ai/omnigent' }}
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os, re, subprocess, sys
+          upstream = os.environ["UPSTREAM_REPO"]
+          candidate = os.environ["CANDIDATE_COMMIT"]
+          if not re.fullmatch(r"[0-9a-f]{40}", candidate):
+              print(f"::error::candidate commit is not a full 40-hex SHA: {candidate!r}")
+              raise SystemExit(1)
+          # The gitlink is always fetched from the .gitmodules remote, so a
+          # fork override that the configured remote cannot serve must fail
+          # here instead of producing an unreachable submodule commit.
+          remote_url = subprocess.run(
+              ["git", "config", "-f", ".gitmodules", "--get", "submodule.omnigent.url"],
+              capture_output=True, text=True, check=True,
+          ).stdout.strip()
+          m = re.search(r"github\.com[/:]([^/]+/[^/]+?)(?:\.git)?$", remote_url)
+          if not m or m.group(1).lower() != upstream.lower():
+              print(f"::error::upstream_repo {upstream!r} does not match submodule remote {remote_url!r}")
+              raise SystemExit(1)
+          proc = subprocess.run(
+              ["gh", "api", f"repos/{upstream}/git/commits/{candidate}"],
+              capture_output=True, text=True,
+          )
+          if proc.returncode != 0:
+              print(f"::error::candidate {candidate} is not reachable in {upstream}")
+              raise SystemExit(1)
+          print(f"candidate {candidate} verified in {upstream}")
+          PY
 
       - name: Prepare candidate branch without touching main
         id: branch
@@ -275,24 +443,91 @@ jobs:
           git diff --cached --stat
           git diff --cached --quiet && echo "pointer already at candidate" || true
 
-      - name: Attach evidence artifacts to the branch
+      - name: Update canonical pin consumers with the gitlink
+        # PINNED_OMNIGENT_COMMIT is the single runtime authority imported by
+        # settings, embedded evidence, and the host adapters; the native-UI
+        # network fixture records the same source commit.  Moving only the
+        # gitlink would keep admitting, reporting, and testing the old
+        # commit, so all three move atomically in this change.
+        env:
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
         run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json, os, re
+          from pathlib import Path
+          candidate = os.environ["CANDIDATE_COMMIT"]
+          assert re.fullmatch(r"[0-9a-f]{40}", candidate), candidate
+          adapter = Path("moonmind/omnigent/host_auth_adapter.py")
+          text = adapter.read_text(encoding="utf-8")
+          updated, count = re.subn(
+              r'PINNED_OMNIGENT_COMMIT = "[0-9a-f]{40}"',
+              f'PINNED_OMNIGENT_COMMIT = "{candidate}"',
+              text,
+          )
+          if count != 1:
+              raise SystemExit(f"expected exactly one pin literal in {adapter}, found {count}")
+          adapter.write_text(updated, encoding="utf-8")
+          fixture = Path("tests/fixtures/omnigent/native_ui_network_contract_v1.json")
+          doc = json.loads(fixture.read_text(encoding="utf-8"))
+          doc["evidence"]["sourceCommit"] = candidate
+          fixture.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+          print(f"pin consumers updated to {candidate}")
+          PY
+          git submodule update --init --depth 1 -- omnigent
+          ACTUAL="$(git -C omnigent rev-parse HEAD)"
+          if [ "${ACTUAL}" != "${CANDIDATE_COMMIT}" ]; then
+            echo "::error::submodule HEAD ${ACTUAL} != candidate ${CANDIDATE_COMMIT}" >&2
+            exit 1
+          fi
+          git diff --stat
+
+      - name: Attach evidence artifacts to the branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
           mkdir -p artifacts/omnigent-upstream-pin-update
           gh run download "${{ github.run_id }}" \
             --name "omnigent-upstream-pin-update-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --dir artifacts/omnigent-upstream-pin-update || true
-          git add artifacts/omnigent-upstream-pin-update/candidate.json \
+            --dir artifacts/omnigent-upstream-pin-update
+          # artifacts*/ is gitignored, so force-add the exact evidence files
+          # and verify they are staged; never silence a staging failure.
+          git add -f \
+            artifacts/omnigent-upstream-pin-update/candidate.json \
             artifacts/omnigent-upstream-pin-update/evidence.json \
-            artifacts/omnigent-upstream-pin-update/status.json 2>/dev/null || true
+            artifacts/omnigent-upstream-pin-update/status.json
+          STAGED="$(git diff --cached --name-only)"
+          echo "${STAGED}"
+          for required in candidate.json evidence.json status.json; do
+            echo "${STAGED}" | grep -q "${required}" || {
+              echo "::error::evidence file ${required} is not staged" >&2
+              exit 1
+            }
+          done
           git -c user.name="moonmind-updater" -c user.email="moonmind-updater@users.noreply.github.com" \
-            commit -m "MoonLadderStudios/MoonMind#3957: candidate omnigent pin ${{ needs.plan.outputs.candidate_tag }} (${{ needs.plan.outputs.candidate_commit }})" || echo "nothing to commit"
+            commit -m "MoonLadderStudios/MoonMind#3957: candidate omnigent pin from plan evidence ($(git rev-parse --short HEAD))" || echo "nothing to commit"
+
+      - name: Set candidate tag and commit for PR metadata
+        id: candidate
+        env:
+          CANDIDATE_TAG: ${{ needs.plan.outputs.candidate_tag }}
+          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+        run: |
+          # Untrusted upstream release fields cross into shell only as
+          # quoted env data, never as interpolated workflow expressions.
+          {
+            echo "tag=${CANDIDATE_TAG}"
+            echo "commit=${CANDIDATE_COMMIT}"
+          } >> "$GITHUB_OUTPUT"
           git push --force-with-lease origin HEAD:"${{ steps.branch.outputs.branch }}"
 
       - name: Open or update the single candidate PR
         env:
           GH_TOKEN: ${{ github.token }}
-          CANDIDATE_TAG: ${{ needs.plan.outputs.candidate_tag }}
-          CANDIDATE_COMMIT: ${{ needs.plan.outputs.candidate_commit }}
+          CANDIDATE_TAG: ${{ steps.candidate.outputs.tag }}
+          CANDIDATE_COMMIT: ${{ steps.candidate.outputs.commit }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if [ "${DRY_RUN}" = "true" ]; then
@@ -311,10 +546,13 @@ jobs:
             echo "  this combination."
             echo "- Rollback: previous qualified pin retained in evidence.json;"
             echo "  historical run bindings are never rewritten."
+            echo "- Follow-up before promotion: re-run the native-UI network"
+            echo "  contract capture for the candidate (per-file source hashes)"
+            echo "  and refresh protected live evidence; this PR moves the pin"
+            echo "  records only."
             echo ""
             echo "Evidence: artifacts/omnigent-upstream-pin-update/{candidate,evidence,status}.json"
           } > "${BODY_FILE}"
-          BRANCH="${{ steps.branch.outputs.branch }}"
           if gh pr view "${BRANCH}" --json number >/dev/null 2>&1; then
             gh pr edit "${BRANCH}" --title "MoonLadderStudios/MoonMind#3957: candidate omnigent pin ${CANDIDATE_TAG}" --body-file "${BODY_FILE}"
             echo "updated existing candidate PR"
@@ -324,3 +562,21 @@ jobs:
               --body-file "${BODY_FILE}" \
               --label dependencies --label testing
           fi
+
+      - name: Trigger required CI for the generated pull request
+        # Pushes and PR events created with GITHUB_TOKEN do not start new
+        # workflow runs, so the candidate branch would otherwise carry no
+        # authoritative checks.  Dispatch the test suite explicitly at the
+        # pushed head so the candidate is gated before review.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA="$(git ls-remote origin "${BRANCH}" | awk '{print $1}')"
+          if [ -z "${HEAD_SHA}" ]; then
+            echo "::error::candidate branch ${BRANCH} has no remote head" >&2
+            exit 1
+          fi
+          gh workflow run pytest-unit-tests.yml --ref "${BRANCH}"
+          echo "dispatched pytest-unit-tests.yml at ${BRANCH} (${HEAD_SHA})"

--- a/moonmind/omnigent/upstream_pin_update.py
+++ b/moonmind/omnigent/upstream_pin_update.py
@@ -84,7 +84,6 @@ QUALIFICATION_SHARDS = (
 )
 
 _FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
-_SHORT_SHA = re.compile(r"^[0-9a-f]{7,40}$")
 
 
 class UpstreamPinUpdateError(ValueError):

--- a/moonmind/omnigent/upstream_pin_update.py
+++ b/moonmind/omnigent/upstream_pin_update.py
@@ -1,0 +1,388 @@
+"""Reviewed upstream omnigent pin updates with exact-artifact qualification.
+
+Source issue: MoonLadderStudios/MoonMind#3957.
+
+This module is the hermetic planning contract behind the scheduled/manual
+``omnigent-upstream-pin-updater`` workflow.  It contains no network access,
+no subprocess calls, and no provider semantics: it turns an already-fetched
+upstream release inventory (plus the already-resolved immutable tag commits)
+into one explicit outcome, one evidence record, and one freshness status.
+
+Non-negotiables enforced here:
+
+* The ``omnigent`` gitlink is an immutable commit pin.  A release tag is
+  provenance, never a substitute for the resolved commit.
+* Prereleases and drafts are excluded unless the caller explicitly allows
+  prereleases.  Drafts are never eligible.
+* A release without a resolved immutable commit (missing, moved, or invalid
+  tag) blocks the update instead of silently tracking upstream main.
+* An empty eligible set is reported as ``no_suitable_release``, never as
+  an instruction to track upstream main.
+* Selection is idempotent: re-running with the same inputs yields the same
+  outcome, and an already-current pin yields ``up_to_date``.
+* Merge-time hermetic success (``tested``) never implies protected live
+  evidence (``qualified``) or product-default promotion (``promoted``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Sequence
+
+from moonmind.omnigent.conformance import assert_secret_free
+
+ISSUE_REF = "MoonLadderStudios/MoonMind#3957"
+UPSTREAM_REPO_DEFAULT = "omnigent-ai/omnigent"
+CHECK_CADENCE = "weekly"
+
+CANDIDATE_SCHEMA_VERSION = "moonmind.omnigent-upstream-pin-candidate/v1"
+EVIDENCE_SCHEMA_VERSION = "moonmind.omnigent-upstream-pin-evidence/v1"
+STATUS_SCHEMA_VERSION = "moonmind.omnigent-upstream-pin-status/v1"
+
+OutcomeStatus = Literal[
+    "up_to_date",
+    "candidate_available",
+    "no_suitable_release",
+    "blocked_invalid_tag",
+    "blocked_transient_upstream",
+]
+
+VersionStage = Literal["available", "tested", "qualified", "promoted"]
+
+#: Exact affected-asset inventory the evidence record must name.  Kept as a
+#: tuple so the workflow and the tests share one canonical list.
+AFFECTED_ASSETS = (
+    "omnigent gitlink",
+    "generated adapter assets",
+    "lockfiles",
+    "runtime-pack compatibility",
+    "server/host images",
+    "native network-contract fixtures",
+)
+
+#: Hermetic qualification shards that own the suites the update must run
+#: through (adapter, host-registration, credential-materializer,
+#: session/control, native UI/facade, evidence, cleanup).
+QUALIFICATION_SHARDS = (
+    "tests/unit/omnigent/test_adapter_contracts.py",
+    "tests/unit/omnigent/test_host_protocol_adapter.py",
+    "tests/unit/omnigent/test_host_registration_inventory.py",
+    "tests/unit/omnigent/test_oauth_home_materializers.py",
+    "tests/unit/omnigent/test_omnigent_session_timeline_api.py",
+    "tests/unit/omnigent/test_session_supervisor_admission.py",
+    "tests/unit/omnigent/test_control_plane_readiness.py",
+    "tests/unit/omnigent/test_native_ui.py",
+    "tests/unit/omnigent/test_native_ui_compat.py",
+    "tests/unit/omnigent/test_omnigent_facade_unknown_route_fails_closed.py",
+    "tests/unit/omnigent/test_authority_chain_evidence.py",
+    "tests/unit/omnigent/test_execution_support_evidence.py",
+    "tests/unit/omnigent/test_deployment_evidence_publishing.py",
+    "tests/unit/omnigent/test_host_cleanup_service.py",
+    "tests/unit/omnigent/test_oauth_host_janitor.py",
+)
+
+_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+_SHORT_SHA = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class UpstreamPinUpdateError(ValueError):
+    """Raised when updater inputs cannot be interpreted safely."""
+
+
+def normalize_commit(value: Any) -> str:
+    """Validate a gitlink commit pin (full 40-hex immutable SHA)."""
+    if not isinstance(value, str) or not _FULL_SHA.match(value.strip().lower()):
+        raise UpstreamPinUpdateError(
+            "current commit must be a full 40-hex immutable SHA "
+            f"(got {value!r}); read it from `git ls-tree HEAD omnigent`"
+        )
+    return value.strip().lower()
+
+
+def _normalize_resolved_commit(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    return candidate if _FULL_SHA.match(candidate) else None
+
+
+def _is_draft_release(release: Mapping[str, Any]) -> bool:
+    return bool(release.get("draft", False))
+
+
+def _is_prerelease(release: Mapping[str, Any]) -> bool:
+    return bool(release.get("prerelease", False))
+
+
+def _release_tag(release: Mapping[str, Any]) -> str:
+    tag = release.get("tag_name", release.get("tag"))
+    return tag.strip() if isinstance(tag, str) else ""
+
+
+def is_eligible_release(
+    release: Mapping[str, Any], *, allow_prereleases: bool = False
+) -> bool:
+    """Return True when a release may become an update candidate.
+
+    Eligibility is deliberately narrow: named tag, not a draft, not a
+    prerelease unless explicitly allowed, and carrying a resolved immutable
+    commit.  Anything else is either skipped (draft/prerelease when not
+    allowed) or a blocking input problem (missing/invalid commit) handled
+    by :func:`select_candidate`.
+    """
+    if not isinstance(release, Mapping):
+        return False
+    if _is_draft_release(release):
+        return False
+    if _is_prerelease(release) and not allow_prereleases:
+        return False
+    if not _release_tag(release):
+        return False
+    return _normalize_resolved_commit(release.get("resolved_commit")) is not None
+
+
+def _published_at_sort_key(release: Mapping[str, Any]) -> str:
+    published = release.get("published_at", release.get("publishedAt", ""))
+    return published if isinstance(published, str) else ""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateResult:
+    """Explicit planner outcome for one updater evaluation."""
+
+    status: OutcomeStatus
+    candidate: dict[str, Any] | None
+    reason: str
+
+
+def select_candidate(
+    current_commit: str,
+    releases: Sequence[Mapping[str, Any]],
+    *,
+    allow_prereleases: bool = False,
+    upstream_repo: str = UPSTREAM_REPO_DEFAULT,
+) -> CandidateResult:
+    """Select the newest eligible upstream release, or report an explicit state.
+
+    Never raises for domain states: missing releases, moved/invalid tags,
+    and repeated runs each map to a closed-vocabulary outcome.  Only
+    malformed caller inputs (bad current pin, non-list inventory) raise.
+    """
+    current = normalize_commit(current_commit)
+    if not isinstance(releases, Sequence) or isinstance(releases, (str, bytes)):
+        raise UpstreamPinUpdateError("releases must be a sequence of release objects")
+    if not upstream_repo or not isinstance(upstream_repo, str):
+        raise UpstreamPinUpdateError("upstream_repo must be a non-empty string")
+
+    inventory: list[Mapping[str, Any]] = [
+        rel for rel in releases if isinstance(rel, Mapping)
+    ]
+    eligible = [
+        rel
+        for rel in inventory
+        if is_eligible_release(rel, allow_prereleases=allow_prereleases)
+    ]
+    if not eligible:
+        if not inventory:
+            return CandidateResult(
+                status="no_suitable_release",
+                candidate=None,
+                reason=(
+                    "upstream published no releases; leaving the known-good pin "
+                    "intact instead of tracking upstream main"
+                ),
+            )
+        tagged = [rel for rel in inventory if _release_tag(rel) and not _is_draft_release(rel)]
+        if tagged and all(
+            _normalize_resolved_commit(rel.get("resolved_commit")) is None
+            for rel in tagged
+        ):
+            return CandidateResult(
+                status="blocked_invalid_tag",
+                candidate=None,
+                reason=(
+                    "eligible tags carry no resolvable immutable commit "
+                    "(moved, deleted, or invalid tag); leaving the known-good "
+                    "pin intact"
+                ),
+            )
+        excluded = "prereleases/drafts" if not allow_prereleases else "drafts"
+        return CandidateResult(
+            status="no_suitable_release",
+            candidate=None,
+            reason=(
+                f"no eligible release after excluding {excluded}; leaving the "
+                "known-good pin intact instead of tracking upstream main"
+            ),
+        )
+
+    newest = sorted(
+        eligible,
+        key=lambda rel: (_published_at_sort_key(rel), _release_tag(rel)),
+        reverse=True,
+    )[0]
+    resolved = _normalize_resolved_commit(newest.get("resolved_commit"))
+    assert resolved is not None  # guaranteed by eligibility filter
+    tag = _release_tag(newest)
+    if resolved == current:
+        return CandidateResult(
+            status="up_to_date",
+            candidate=None,
+            reason=f"pin already resolves {tag} ({resolved}); no update required",
+        )
+    return CandidateResult(
+        status="candidate_available",
+        candidate={
+            "tag": tag,
+            "commit": resolved,
+            "name": newest.get("name", ""),
+            "url": newest.get("html_url", newest.get("url", "")),
+            "publishedAt": newest.get("published_at", newest.get("publishedAt", "")),
+            "prerelease": _is_prerelease(newest),
+            "upstreamRepo": upstream_repo,
+        },
+        reason=f"eligible release {tag} resolves to {resolved}",
+    )
+
+
+def blocked_transient_upstream(detail: str) -> CandidateResult:
+    """Explicit outcome for transient upstream fetch failures (retryable)."""
+    bounded = (detail or "upstream request failed").strip()[:300]
+    return CandidateResult(
+        status="blocked_transient_upstream",
+        candidate=None,
+        reason=f"transient upstream error ({bounded}); pin left intact, retry on next check",
+    )
+
+
+def _utc_now_iso(checked_at: str | None) -> str:
+    if checked_at:
+        parsed = datetime.fromisoformat(checked_at.replace("Z", "+00:00"))
+        return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def build_update_evidence(
+    *,
+    result: CandidateResult,
+    current_commit: str,
+    upstream_repo: str = UPSTREAM_REPO_DEFAULT,
+    qualification_shards: Sequence[str] = QUALIFICATION_SHARDS,
+    api_host_ui_changes: str = "",
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the exact-artifact evidence record for a planner outcome.
+
+    The record always names old/new commits, release provenance, the exact
+    affected assets, qualification inputs (all pinned), and the owning
+    shards.  Prior support evidence for the old commit is referenced as
+    rollback identity, never carried over as qualification of the new
+    combination.
+    """
+    current = normalize_commit(current_commit)
+    candidate = result.candidate or {}
+    new_commit = str(candidate.get("commit", current))
+    evidence: dict[str, Any] = {
+        "schemaVersion": EVIDENCE_SCHEMA_VERSION,
+        "issueRef": ISSUE_REF,
+        "status": result.status,
+        "reason": result.reason,
+        "upstreamRepo": upstream_repo,
+        "oldCommit": current,
+        "newCommit": new_commit,
+        "releaseProvenance": {
+            "tag": candidate.get("tag", ""),
+            "name": candidate.get("name", ""),
+            "url": candidate.get("url", ""),
+            "publishedAt": candidate.get("publishedAt", ""),
+            "prerelease": bool(candidate.get("prerelease", False)),
+        },
+        "apiHostUiChanges": api_host_ui_changes[:2000],
+        "affectedAssets": list(AFFECTED_ASSETS),
+        "qualificationInputs": {
+            "currentCommit": current,
+            "candidateCommit": new_commit,
+            "releaseTag": candidate.get("tag", ""),
+            "upstreamRepo": upstream_repo,
+            "qualificationShards": list(qualification_shards),
+        },
+        "rollbackIdentity": {
+            "previousQualifiedCommit": current,
+            "note": (
+                "retain the previous qualified artifact identities for the "
+                "documented rollback path; historical run bindings are never "
+                "rewritten"
+            ),
+        },
+        "generatedAt": _utc_now_iso(checked_at),
+    }
+    assert_secret_free(evidence)
+    return evidence
+
+
+def build_freshness_status(
+    *,
+    result: CandidateResult,
+    current_commit: str,
+    last_qualified_commit: str | None = None,
+    last_qualified_tag: str = "",
+    promoted_commit: str | None = None,
+    blocked_reason: str = "",
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    """Publish update freshness with available/tested/qualified/promoted stages.
+
+    * ``available`` — the candidate the updater discovered (may be empty).
+    * ``tested`` — set only by a merge-time hermetic qualification run.
+    * ``qualified`` — set only by protected live evidence for the exact
+      combination (never copied from a previous commit or image digest).
+    * ``promoted`` — set only when the rollout policy makes the qualified
+      combination a product default.
+    """
+    current = normalize_commit(current_commit)
+    qualified = (
+        normalize_commit(last_qualified_commit)
+        if last_qualified_commit is not None
+        else current
+    )
+    promoted = (
+        normalize_commit(promoted_commit) if promoted_commit is not None else qualified
+    )
+    candidate = result.candidate or {}
+    if result.status in ("blocked_invalid_tag", "blocked_transient_upstream"):
+        blocked = result.reason
+    else:
+        blocked = blocked_reason
+    status: dict[str, Any] = {
+        "schemaVersion": STATUS_SCHEMA_VERSION,
+        "issueRef": ISSUE_REF,
+        "checkCadence": CHECK_CADENCE,
+        "checkedAt": _utc_now_iso(checked_at),
+        "outcome": result.status,
+        "available": {
+            "tag": candidate.get("tag", ""),
+            "commit": candidate.get("commit", ""),
+        },
+        "tested": {"commit": "", "hermeticRunRef": ""},
+        "qualified": {"commit": qualified, "tag": last_qualified_tag},
+        "promoted": {"commit": promoted},
+        "lastQualifiedVersion": {"commit": qualified, "tag": last_qualified_tag},
+        "blockedReason": blocked,
+    }
+    assert_secret_free(status)
+    return status
+
+
+def mark_tested(
+    status: Mapping[str, Any], *, commit: str, hermetic_run_ref: str
+) -> dict[str, Any]:
+    """Record merge-time hermetic success without implying qualification."""
+    updated = dict(status)
+    updated["tested"] = {
+        "commit": normalize_commit(commit),
+        "hermeticRunRef": hermetic_run_ref,
+    }
+    assert_secret_free(updated)
+    return updated

--- a/tests/unit/omnigent/test_upstream_pin_update.py
+++ b/tests/unit/omnigent/test_upstream_pin_update.py
@@ -25,7 +25,7 @@ from moonmind.omnigent.upstream_pin_update import (
     select_candidate,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 CURRENT = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
 NEWER = "a" * 40

--- a/tests/unit/omnigent/test_upstream_pin_update.py
+++ b/tests/unit/omnigent/test_upstream_pin_update.py
@@ -1,0 +1,264 @@
+"""Unit tests for the omnigent upstream-pin updater contract.
+
+Source issue: MoonLadderStudios/MoonMind#3957.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from moonmind.omnigent.upstream_pin_update import (
+    AFFECTED_ASSETS,
+    QUALIFICATION_SHARDS,
+    UpstreamPinUpdateError,
+    blocked_transient_upstream,
+    build_freshness_status,
+    build_update_evidence,
+    is_eligible_release,
+    mark_tested,
+    normalize_commit,
+    select_candidate,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CURRENT = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
+NEWER = "a" * 40
+OLDER = "b" * 40
+
+
+def _release(tag, commit, **overrides):
+    release = {
+        "tag_name": tag,
+        "name": tag,
+        "html_url": f"https://github.com/omnigent-ai/omnigent/releases/tag/{tag}",
+        "published_at": "2026-08-01T00:00:00Z",
+        "prerelease": False,
+        "draft": False,
+        "resolved_commit": commit,
+    }
+    release.update(overrides)
+    return release
+
+
+def test_normalize_commit_rejects_short_or_non_hex() -> None:
+    assert normalize_commit(CURRENT) == CURRENT
+    with pytest.raises(UpstreamPinUpdateError):
+        normalize_commit("ed9369474")
+    with pytest.raises(UpstreamPinUpdateError):
+        normalize_commit("not-a-sha")
+
+
+def test_prereleases_excluded_unless_allowed_and_drafts_never() -> None:
+    pre = _release("v0.13.0-rc1", NEWER, prerelease=True)
+    draft = _release("v0.13.0", NEWER, draft=True)
+    assert not is_eligible_release(pre)
+    assert is_eligible_release(pre, allow_prereleases=True)
+    assert not is_eligible_release(draft)
+    assert not is_eligible_release(draft, allow_prereleases=True)
+
+
+def test_unresolvable_tag_is_not_eligible() -> None:
+    assert not is_eligible_release(_release("v0.13.0", ""))
+    assert not is_eligible_release(_release("v0.13.0", "moved"))
+
+
+def test_up_to_date_is_idempotent() -> None:
+    releases = [_release("v0.12.0", CURRENT)]
+    first = select_candidate(CURRENT, releases)
+    second = select_candidate(CURRENT, releases)
+    assert first.status == "up_to_date"
+    assert first == second
+    assert first.candidate is None
+
+
+def test_selects_newest_eligible_release() -> None:
+    releases = [
+        _release("v0.11.0", OLDER, published_at="2026-06-01T00:00:00Z"),
+        _release("v0.13.0", NEWER, published_at="2026-09-01T00:00:00Z"),
+    ]
+    result = select_candidate(CURRENT, releases)
+    assert result.status == "candidate_available"
+    assert result.candidate is not None
+    assert result.candidate["tag"] == "v0.13.0"
+    assert result.candidate["commit"] == NEWER
+    # Tag is provenance: the candidate carries the immutable commit.
+    assert len(result.candidate["commit"]) == 40
+
+
+def test_no_suitable_release_on_empty_inventory() -> None:
+    result = select_candidate(CURRENT, [])
+    assert result.status == "no_suitable_release"
+    assert result.candidate is None
+    assert "main" in result.reason  # must not silently track upstream main
+
+
+def test_no_suitable_release_when_only_prereleases() -> None:
+    releases = [_release("v0.13.0-rc1", NEWER, prerelease=True)]
+    result = select_candidate(CURRENT, releases)
+    assert result.status == "no_suitable_release"
+    assert result.candidate is None
+
+
+def test_blocked_invalid_tag_when_no_resolvable_commit() -> None:
+    releases = [_release("v0.13.0", "", published_at="2026-09-01T00:00:00Z")]
+    result = select_candidate(CURRENT, releases)
+    assert result.status == "blocked_invalid_tag"
+    assert result.candidate is None
+
+
+def test_blocked_transient_upstream_leaves_pin_intact() -> None:
+    result = blocked_transient_upstream("connection reset")
+    assert result.status == "blocked_transient_upstream"
+    assert result.candidate is None
+    assert "intact" in result.reason
+
+
+def test_evidence_names_commits_provenance_assets_and_pins() -> None:
+    result = select_candidate(CURRENT, [_release("v0.13.0", NEWER)])
+    evidence = build_update_evidence(result=result, current_commit=CURRENT)
+    assert evidence["oldCommit"] == CURRENT
+    assert evidence["newCommit"] == NEWER
+    assert evidence["releaseProvenance"]["tag"] == "v0.13.0"
+    assert evidence["affectedAssets"] == list(AFFECTED_ASSETS)
+    assert "generated adapter assets" in evidence["affectedAssets"]
+    assert "native network-contract fixtures" in evidence["affectedAssets"]
+    inputs = evidence["qualificationInputs"]
+    assert inputs["currentCommit"] == CURRENT
+    assert inputs["candidateCommit"] == NEWER
+    assert inputs["qualificationShards"] == list(QUALIFICATION_SHARDS)
+    assert evidence["rollbackIdentity"]["previousQualifiedCommit"] == CURRENT
+
+
+def test_freshness_status_distinguishes_lifecycle_stages() -> None:
+    result = select_candidate(CURRENT, [_release("v0.13.0", NEWER)])
+    status = build_freshness_status(
+        result=result,
+        current_commit=CURRENT,
+        last_qualified_tag="v0.12.0",
+        checked_at="2026-09-07T00:00:00Z",
+    )
+    assert status["available"] == {"tag": "v0.13.0", "commit": NEWER}
+    assert status["qualified"]["commit"] == CURRENT
+    assert status["lastQualifiedVersion"]["commit"] == CURRENT
+    assert status["promoted"]["commit"] == CURRENT
+    assert status["tested"] == {"commit": "", "hermeticRunRef": ""}
+    assert status["checkCadence"] == "weekly"
+
+
+def test_mark_tested_never_implies_qualified_or_promoted() -> None:
+    result = select_candidate(CURRENT, [_release("v0.13.0", NEWER)])
+    status = build_freshness_status(result=result, current_commit=CURRENT)
+    tested = mark_tested(status, commit=NEWER, hermetic_run_ref="run-123")
+    assert tested["tested"] == {"commit": NEWER, "hermeticRunRef": "run-123"}
+    assert tested["qualified"]["commit"] == CURRENT
+    assert tested["promoted"]["commit"] == CURRENT
+
+
+def test_blocked_outcome_surfaces_blocked_reason() -> None:
+    result = select_candidate(CURRENT, [_release("v0.13.0", "")])
+    status = build_freshness_status(result=result, current_commit=CURRENT)
+    assert status["outcome"] == "blocked_invalid_tag"
+    assert status["blockedReason"] == result.reason
+    assert status["available"] == {"tag": "", "commit": ""}
+
+
+def test_qualification_shards_cover_all_owning_suites() -> None:
+    names = "\n".join(QUALIFICATION_SHARDS)
+    for suite in (
+        "adapter",
+        "registration",
+        "materializers",
+        "timeline",
+        "supervisor",
+        "readiness",
+        "native_ui",
+        "facade",
+        "evidence",
+        "cleanup",
+        "janitor",
+    ):
+        assert suite in names
+    for shard in QUALIFICATION_SHARDS:
+        assert (REPO_ROOT / shard).exists(), f"missing owning shard: {shard}"
+
+
+def test_cli_writes_candidate_evidence_and_status(tmp_path: Path) -> None:
+    releases_file = tmp_path / "releases.json"
+    releases_file.write_text(
+        json.dumps([_release("v0.13.0", NEWER)]), encoding="utf-8"
+    )
+    out_dir = tmp_path / "out"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tools/check_omnigent_upstream_pin_update.py"),
+            "--current-commit",
+            CURRENT,
+            "--releases-json",
+            str(releases_file),
+            "--output-dir",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, proc.stderr
+    candidate = json.loads((out_dir / "candidate.json").read_text(encoding="utf-8"))
+    evidence = json.loads((out_dir / "evidence.json").read_text(encoding="utf-8"))
+    status = json.loads((out_dir / "status.json").read_text(encoding="utf-8"))
+    assert candidate["status"] == "candidate_available"
+    assert candidate["candidate"]["commit"] == NEWER
+    assert evidence["oldCommit"] == CURRENT
+    assert evidence["newCommit"] == NEWER
+    assert status["outcome"] == "candidate_available"
+    assert status["available"]["commit"] == NEWER
+
+
+def test_cli_reports_no_release_state_without_tracking_main(tmp_path: Path) -> None:
+    releases_file = tmp_path / "releases.json"
+    releases_file.write_text("[]", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tools/check_omnigent_upstream_pin_update.py"),
+            "--current-commit",
+            CURRENT,
+            "--releases-json",
+            str(releases_file),
+            "--output-dir",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, proc.stderr
+    candidate = json.loads((out_dir / "candidate.json").read_text(encoding="utf-8"))
+    assert candidate["status"] == "no_suitable_release"
+
+
+def test_cli_rejects_tool_misuse() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tools/check_omnigent_upstream_pin_update.py"),
+            "--current-commit",
+            "short-sha",
+            "--fetch-error",
+            "boom",
+            "--output-dir",
+            "/tmp/omnigent-pin-misuse-probe",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 2

--- a/tests/unit/test_omnigent_upstream_pin_updater_workflow.py
+++ b/tests/unit/test_omnigent_upstream_pin_updater_workflow.py
@@ -43,6 +43,8 @@ def test_updater_uses_minimum_permissions() -> None:
     propose_permissions = workflow["jobs"]["propose"]["permissions"]
     assert propose_permissions["contents"] == "write"
     assert propose_permissions["pull-requests"] == "write"
+    # Evidence download via `gh run download` needs the actions API.
+    assert propose_permissions["actions"] == "read"
 
 
 def test_updater_never_runs_fetched_code_or_production_secrets() -> None:
@@ -115,3 +117,50 @@ def test_updater_leaves_pin_intact_without_candidate() -> None:
     )
     assert "candidate_available" in workflow["jobs"]["propose"]["if"]
     assert "needs.qualify.result == 'success'" in workflow["jobs"]["propose"]["if"]
+    # A dry run must not create branches, move pointers, or push.
+    assert "dry_run" in workflow["jobs"]["propose"]["if"]
+
+
+def test_updater_passes_untrusted_tags_as_env_data() -> None:
+    raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "needs.plan.outputs.candidate_tag" in raw  # outputs + env only
+    for step in (
+        workflow_steps("propose", "Attach evidence artifacts to the branch"),
+        workflow_steps("propose", "Open or update the single candidate PR"),
+    ):
+        assert "needs.plan.outputs.candidate_tag" not in step.get("run", ""), step.get("name")
+
+
+def workflow_steps(job: str, name: str) -> dict:
+    for step in _workflow()["jobs"][job]["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"missing step {name!r} in job {job!r}")
+
+
+def test_updater_qualifies_the_candidate_commit() -> None:
+    steps = _workflow()["jobs"]["qualify"]["steps"]
+    run_text = "\n".join(step.get("run", "") for step in steps)
+    env_text = "\n".join(
+        str(step.get("env", "")) for step in steps
+    )
+    assert "uv pip install --system -e .[tests]" in run_text
+    assert "needs.plan.outputs.candidate_commit" in env_text
+    assert "git submodule update --init" in run_text
+    assert "rev-parse HEAD" in run_text
+    assert "mark_tested" in run_text
+
+
+def test_updater_stages_evidence_loudly_and_verifies_remote() -> None:
+    raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "git add -f" in raw
+    assert "not staged" in raw
+    assert "does not match submodule remote" in raw
+    assert "gh workflow run pytest-unit-tests.yml" in raw
+
+
+def test_updater_updates_pin_consumers_with_gitlink() -> None:
+    steps = _workflow()["jobs"]["propose"]["steps"]
+    run_text = "\n".join(step.get("run", "") for step in steps)
+    assert "PINNED_OMNIGENT_COMMIT" in run_text
+    assert "native_ui_network_contract_v1.json" in run_text

--- a/tests/unit/test_omnigent_upstream_pin_updater_workflow.py
+++ b/tests/unit/test_omnigent_upstream_pin_updater_workflow.py
@@ -1,0 +1,117 @@
+"""Structure tests for the omnigent upstream-pin updater workflow.
+
+Source issue: MoonLadderStudios/MoonMind#3957.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/omnigent-upstream-pin-updater.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True) or {}
+
+
+def test_updater_is_scheduled_weekly_and_dispatchable() -> None:
+    triggers = _triggers(_workflow())
+    assert triggers["schedule"] == [{"cron": "0 7 * * 1"}]
+    dispatch = triggers["workflow_dispatch"]["inputs"]
+    assert "allow_prereleases" in dispatch
+    assert dispatch["allow_prereleases"].get("default") is False
+    assert dispatch["upstream_repo"]["default"] == "omnigent-ai/omnigent"
+    assert "dry_run" in dispatch
+
+
+def test_updater_uses_minimum_permissions() -> None:
+    workflow = _workflow()
+    assert workflow["permissions"] == {"contents": "read", "actions": "read"}
+    # Only the propose job (which opens the single candidate PR) escalates.
+    assert workflow["jobs"]["plan"].get("permissions", workflow["permissions"]) == {
+        "contents": "read",
+        "actions": "read",
+    }
+    propose_permissions = workflow["jobs"]["propose"]["permissions"]
+    assert propose_permissions["contents"] == "write"
+    assert propose_permissions["pull-requests"] == "write"
+
+
+def test_updater_never_runs_fetched_code_or_production_secrets() -> None:
+    raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "OMNIGENT_API_TOKEN" not in raw
+    assert "MOONMIND_OMNIGENT_ACTION_COMMAND" not in raw
+    for match in re.finditer(r"secrets\.([A-Za-z_]+)", raw):
+        assert match.group(0) == "secrets.GITHUB_TOKEN", match.group(0)
+    assert "secrets.GITHUB_TOKEN" not in raw or "github.token" in raw
+    # No piping fetched archives into a shell, no package installs from
+    # upstream, no checkout of the upstream repository itself.
+    assert "curl " not in raw or "| sh" not in raw
+    assert "| sh" not in raw
+    assert "| bash" not in raw
+    assert "omnigent-ai/omnigent@" not in raw
+
+
+def test_updater_is_idempotent_single_pr() -> None:
+    workflow = _workflow()
+    assert workflow["concurrency"]["group"] == "omnigent-upstream-pin-updater"
+    raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # One controlled branch per candidate commit, updated in place.
+    assert "automation/omnigent-pin-" in raw
+    assert "gh pr view" in raw
+    assert "gh pr create" in raw
+    assert "force-with-lease" in raw
+    # Never changes main directly: the pointer moves on the candidate branch.
+    assert "--base main" in raw or "--base=main" in raw
+    assert "dry_run" in raw
+
+
+def test_updater_plans_through_hermetic_cli() -> None:
+    steps = _workflow()["jobs"]["plan"]["steps"]
+    run_text = "\n".join(step.get("run", "") for step in steps)
+    assert "tools/check_omnigent_upstream_pin_update.py" in run_text
+    assert "git ls-tree HEAD omnigent" in run_text
+    assert "repos/" in run_text and "/releases" in run_text
+
+
+def test_updater_runs_owning_hermetic_shards() -> None:
+    steps = _workflow()["jobs"]["qualify"]["steps"]
+    run_text = "\n".join(step.get("run", "") for step in steps)
+    for shard in (
+        "tests/unit/omnigent/test_adapter_contracts.py",
+        "tests/unit/omnigent/test_host_registration_inventory.py",
+        "tests/unit/omnigent/test_oauth_home_materializers.py",
+        "tests/unit/omnigent/test_omnigent_session_timeline_api.py",
+        "tests/unit/omnigent/test_native_ui.py",
+        "tests/unit/omnigent/test_omnigent_facade_unknown_route_fails_closed.py",
+        "tests/unit/omnigent/test_execution_support_evidence.py",
+        "tests/unit/omnigent/test_host_cleanup_service.py",
+    ):
+        assert shard in run_text
+
+
+def test_updater_records_evidence_and_freshness() -> None:
+    raw = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "candidate.json" in raw
+    assert "evidence.json" in raw
+    assert "status.json" in raw
+    assert "known-good pin intact" in raw
+    assert "upload-artifact" in raw
+
+
+def test_updater_leaves_pin_intact_without_candidate() -> None:
+    workflow = _workflow()
+    assert (
+        workflow["jobs"]["qualify"]["if"]
+        == "needs.plan.outputs.outcome == 'candidate_available'"
+    )
+    assert "candidate_available" in workflow["jobs"]["propose"]["if"]
+    assert "needs.qualify.result == 'success'" in workflow["jobs"]["propose"]["if"]

--- a/tests/unit/tools/test_check_github_workflow_names.py
+++ b/tests/unit/tools/test_check_github_workflow_names.py
@@ -42,6 +42,7 @@ def test_current_workflows_have_stable_names() -> None:
         "omnigent-live-verification-health.yml": (
             "Provider / Omnigent Live Verification Health"
         ),
+        "omnigent-upstream-pin-updater.yml": "Omnigent Upstream Pin Updater",
         "promote-ghcr-stable.yml": "Release / Promote Stable",
         "pytest-unit-tests.yml": "CI / Test Suite",
     }

--- a/tools/check_omnigent_upstream_pin_update.py
+++ b/tools/check_omnigent_upstream_pin_update.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Evaluate one omnigent upstream-pin updater check (hermetic planner).
+
+Source issue: MoonLadderStudios/MoonMind#3957.
+
+Reads the current ``omnigent`` gitlink commit and an already-fetched upstream
+release inventory (GitHub releases API payload where each entry carries a
+``resolved_commit`` immutable SHA resolved from its tag), then writes three
+artifacts into the output directory:
+
+* ``candidate.json``   — explicit planner outcome (closed vocabulary)
+* ``evidence.json``    — exact-artifact evidence record (old/new commit,
+  release provenance, affected assets, pinned qualification inputs,
+  rollback identity)
+* ``status.json``      — freshness publication (available / tested /
+  qualified / promoted stages, blocked reason, last qualified version)
+
+The tool never mutates the gitlink, never executes fetched upstream code,
+and never consumes production secrets.  All explicit domain outcomes exit 0;
+only tool misuse or unreadable inputs exit 2.  A transient upstream fetch
+failure is reported with ``--fetch-error`` instead of a releases file.
+
+Usage:
+    python tools/check_omnigent_upstream_pin_update.py \\
+        --current-commit f04b0354fb5344c1ea8b92795ceb6760a9ad7595 \\
+        --releases-json /tmp/upstream-releases.json \\
+        --output-dir artifacts/omnigent-upstream-pin-update
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from moonmind.omnigent.upstream_pin_update import (  # noqa: E402
+    UPSTREAM_REPO_DEFAULT,
+    UpstreamPinUpdateError,
+    blocked_transient_upstream,
+    build_freshness_status,
+    build_update_evidence,
+    select_candidate,
+)
+
+
+def _load_releases(path: str) -> list[dict[str, Any]]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(raw, dict) and isinstance(raw.get("releases"), list):
+        return raw["releases"]
+    if isinstance(raw, list):
+        return raw
+    raise UpstreamPinUpdateError(
+        "releases JSON must be an array or an object with a 'releases' array"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current-commit", required=True)
+    parser.add_argument("--releases-json", default="")
+    parser.add_argument("--fetch-error", default="")
+    parser.add_argument("--allow-prereleases", action="store_true")
+    parser.add_argument("--upstream-repo", default=UPSTREAM_REPO_DEFAULT)
+    parser.add_argument("--api-host-ui-changes", default="")
+    parser.add_argument("--last-qualified-commit", default="")
+    parser.add_argument("--last-qualified-tag", default="")
+    parser.add_argument("--promoted-commit", default="")
+    parser.add_argument("--blocked-reason", default="")
+    parser.add_argument("--checked-at", default="")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.fetch_error:
+            result = blocked_transient_upstream(args.fetch_error)
+        else:
+            if not args.releases_json:
+                raise UpstreamPinUpdateError(
+                    "either --releases-json or --fetch-error is required"
+                )
+            releases = _load_releases(args.releases_json)
+            result = select_candidate(
+                args.current_commit,
+                releases,
+                allow_prereleases=args.allow_prereleases,
+                upstream_repo=args.upstream_repo,
+            )
+        checked_at = args.checked_at or None
+        evidence = build_update_evidence(
+            result=result,
+            current_commit=args.current_commit,
+            upstream_repo=args.upstream_repo,
+            api_host_ui_changes=args.api_host_ui_changes,
+            checked_at=checked_at,
+        )
+        status = build_freshness_status(
+            result=result,
+            current_commit=args.current_commit,
+            last_qualified_commit=args.last_qualified_commit or None,
+            last_qualified_tag=args.last_qualified_tag,
+            promoted_commit=args.promoted_commit or None,
+            blocked_reason=args.blocked_reason,
+            checked_at=checked_at,
+        )
+    except (UpstreamPinUpdateError, json.JSONDecodeError, OSError) as exc:
+        print(f"::error::omnigent upstream-pin check failed: {exc}")
+        return 2
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    candidate_doc = {
+        "schemaVersion": "moonmind.omnigent-upstream-pin-candidate/v1",
+        "status": result.status,
+        "reason": result.reason,
+        "candidate": result.candidate,
+        "allowPrereleases": args.allow_prereleases,
+        "upstreamRepo": args.upstream_repo,
+    }
+    (out_dir / "candidate.json").write_text(
+        json.dumps(candidate_doc, indent=2) + "\n", encoding="utf-8"
+    )
+    (out_dir / "evidence.json").write_text(
+        json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+    )
+    (out_dir / "status.json").write_text(
+        json.dumps(status, indent=2) + "\n", encoding="utf-8"
+    )
+    level = "notice" if result.status in ("up_to_date", "candidate_available") else "warning"
+    print(f"::{level}::omnigent upstream-pin outcome: {result.status} — {result.reason}")
+    print(f"candidate={json.dumps(result.candidate or {})}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#3957: a scheduled/manual updater that discovers eligible upstream omnigent releases, resolves tags to immutable commits, and opens or updates one controlled, evidence-backed candidate PR without touching `main` directly.

New assets:
- `moonmind/omnigent/upstream_pin_update.py` — hermetic planner (eligibility, candidate selection, update evidence, freshness status); no network/subprocess; secret-free assertions.
- `.github/workflows/omnigent-upstream-pin-updater.yml` — weekly cron + manual dispatch (`allow_prereleases`, `upstream_repo`, `dry_run`), minimum permissions, concurrency-guarded single-PR flow (`automation/omnigent-pin-<short>`), hermetic qualify gates through 15 owning shards, evidence artifact upload, freshness job summary.
- `tools/check_omnigent_upstream_pin_update.py` — hermetic CLI that never mutates the gitlink; writes `candidate.json`/`evidence.json`/`status.json`.
- `tests/unit/omnigent/test_upstream_pin_update.py`, `tests/unit/test_omnigent_upstream_pin_updater_workflow.py` — planner + workflow-structure coverage including negative paths.

Key behaviors: prereleases excluded unless explicitly allowed; no-suitable-release reported rather than tracking upstream main; tag is provenance only (gitlink keeps the resolved commit + image/asset digests); incompatible releases stay blocked with the known-good pin (`f04b0354`) intact; no auto-merge; rollback identity retained; freshness distinguishes available/tested/qualified/promoted.

## Verification outcome

Controlling post-remediation verifier `artifacts/github-issue-implement-verify.json` verdict: **FULLY_IMPLEMENTED** (confidence MEDIUM, checked 2026-09-08T00:00:00Z against candidate `1e4de4c8`). All six acceptance criteria VERIFIED with file/line evidence; zero gaps and zero remaining work. Recommended next action: publish.

## Tests run

- planner-direct (PASS): direct import assertions mirroring `test_upstream_pin_update.py` — `normalize_commit` / `is_eligible_release` / `select_candidate` / `build_update_evidence` / `build_freshness_status` / `mark_tested`; all 15 qualification shards exist on disk.
- cli-hermetic (PASS): `tools/check_omnigent_upstream_pin_update.py` over 5 inventories + fetch-error + misuse probe — `candidate_available` / `no_suitable_release` / `blocked_invalid_tag` / `up_to_date` / `blocked_transient_upstream` exit 0; misuse exits 2.
- workflow-structure (PASS): YAML parse + grep audits (minimum perms, single-PR idempotency, hermetic CLI, owning shards, evidence artifacts, intact-pin gates, no secrets/auto-merge/pipe-to-shell/upstream checkout).
- compile (PASS): `py_compile` on planner, CLI, and both new test files.
- pytest-unit (NOT RUN): `tools/test_unit.sh` pytest suite could not run in this sandbox (no pytest module; no managed `moonmind container` runner). Compensated with the hermetic executions above; rerun `tests/unit/omnigent/test_upstream_pin_update.py` + `tests/unit/test_omnigent_upstream_pin_updater_workflow.py` in CI or a managed run before merge.

## Remaining risks

- The pytest unit suite has not executed in this environment (see above); CI must run the targeted unit suite before merge.
- Live upstream release discovery and exact-artifact rebuild/qualification (server/host images, digests) require protected live evidence outside the hermetic path; merge-time success must not be treated as qualified/promoted.
- Upstream contract breaks remain possible; the updater blocks rather than weakens gates, but operators should watch the published freshness/blocked-reason output.

Closes MoonLadderStudios/MoonMind#3957
