### PR TITLE
[Docs] Replace brittle prose assertions without removing semantic verification (MoonLadderStudios/MoonMind#3964)

### DIFF
--- a/tests/unit/docs/_semantic_docs_3964.py
+++ b/tests/unit/docs/_semantic_docs_3964.py
@@ -1,0 +1,77 @@
+"""Shared semantic-assertion helpers for issue #3964.
+
+Classification (inventory of ``tests/unit/docs`` assertions):
+
+- Incidental prose (loosened by callers): exact long sentences whose wording
+  can change without changing the contract, e.g. em-dash phrasing, "promote
+  or supersede ...", "never authorizes every installed runtime", duplicated
+  fail-closed invariant paragraphs. Replaced with normalized term
+  co-occurrence checks below.
+- Structural metadata/schema (kept, exact): frontmatter keys
+  (``**Document Class:**``), stable claim-ID headings (``DOC-REQ-001``),
+  ``schemaVersion`` counts, JSON example validity, template header fields.
+- Internal links/anchors (kept): ``tools/check_documentation_links.py`` plus
+  per-suite anchor resolution tests.
+- Generated references / registry drift (kept): ``#3959`` catalog checks and
+  the ``#3960`` production-derived reconciliation suite.
+- Executable examples (kept): JSON examples validated against production
+  models (``AgentExecutionRequest``), fenced code blocks parsed as JSON/YAML.
+- Skill frontmatter/instructions (kept, strengthened): see
+  ``test_skill_contracts_3964.py``, which validates ``SKILL.md`` through the
+  production frontmatter loader.
+- Guards standing in for production behavior (kept AND duplicated at the
+  owning boundary): secret-shape scans, caller-authored hostId rejection,
+  no-silent-fallback. The production-boundary twins live in
+  ``test_skill_contracts_3964.py`` so deleting a doc assertion cannot hide a
+  semantic change.
+
+Helpers normalize whitespace and case so harmless rewording and line-wrap
+changes pass, while removal of any required concept still fails. Each helper
+has mutation/regression coverage in ``test_skill_contracts_3964.py`` (reworded
+text passes, concept-removed text fails).
+"""
+
+from __future__ import annotations
+
+import re
+
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Collapse whitespace and lowercase for wording-tolerant comparison."""
+    return _WS_RE.sub(" ", text).strip().lower()
+
+
+def assert_semantic_present(
+    text: str, required_terms: tuple[str, ...], *, context: str = ""
+) -> None:
+    """Assert every required concept term survives in ``text``.
+
+    Terms are short normalized keywords, not sentences, so rewording the
+    surrounding prose does not break the check. Removing the concept (all
+    occurrences of any term) fails with an actionable message naming the
+    missing term and the owning context.
+    """
+    normalized = normalize(text)
+    for term in required_terms:
+        needle = normalize(term)
+        assert needle in normalized, (
+            f"missing required concept {term!r}"
+            + (f" in {context}" if context else "")
+            + "; the owning document must still state this contract"
+        )
+
+
+def assert_semantic_absent(
+    text: str, forbidden_terms: tuple[str, ...], *, context: str = ""
+) -> None:
+    """Assert no forbidden concept term appears in ``text`` (normalized)."""
+    normalized = normalize(text)
+    for term in forbidden_terms:
+        needle = normalize(term)
+        assert needle not in normalized, (
+            f"forbidden concept {term!r}"
+            + (f" in {context}" if context else "")
+            + " must stay absent"
+        )

--- a/tests/unit/docs/test_combined_stack_validation_docs.py
+++ b/tests/unit/docs/test_combined_stack_validation_docs.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -46,8 +51,16 @@ def test_combined_stack_doc_separates_normal_rollback_from_destructive_cleanup()
     normal_rollback = text.index("## DOC-REQ-009 Normal Rollback")
     destructive_cleanup = text.index("## DOC-REQ-010 Optional Destructive Cleanup")
     assert normal_rollback < destructive_cleanup
-    assert "Normal rollback preserves PostgreSQL, MoonMind, and Omnigent volumes." in text
-    assert "optional, destructive, and separate from normal rollback" in text
+    assert_semantic_present(
+        text,
+        ("normal rollback preserves", "volumes"),
+        context="combined stack normal rollback",
+    )
+    assert_semantic_present(
+        text,
+        ("optional, destructive, and separate from normal rollback",),
+        context="combined stack destructive cleanup separation",
+    )
     assert "docker compose down -v" in text
 
 
@@ -88,7 +101,15 @@ def test_combined_stack_doc_documents_omnigent_host_workspace_and_credentials() 
     assert "local deployment secrets" in text
 
     # Generic hosts preserve API-key-backed runners and do not expose Codex
-    # subscription OAuth material to every process in the host container.
-    assert "preserves configured provider API keys" in text
-    assert "does not mount MoonMind's Codex OAuth volume" in text
-    assert "does not mount MoonMind's Codex OAuth volume or set `CODEX_HOME` globally" in text
+    # subscription OAuth material to every process in the host container
+    # (#3964: exact prose loosened; the mount prohibition is the contract).
+    assert_semantic_present(
+        text,
+        ("preserves configured provider api keys",),
+        context="combined stack generic host keys",
+    )
+    assert_semantic_present(
+        text,
+        ("does not mount moonmind's codex oauth volume",),
+        context="combined stack OAuth mount prohibition",
+    )

--- a/tests/unit/docs/test_combined_stack_validation_docs.py
+++ b/tests/unit/docs/test_combined_stack_validation_docs.py
@@ -113,3 +113,11 @@ def test_combined_stack_doc_documents_omnigent_host_workspace_and_credentials() 
         ("does not mount moonmind's codex oauth volume",),
         context="combined stack OAuth mount prohibition",
     )
+    # P2 (Codex review): the generic-host contract also prohibits setting
+    # `CODEX_HOME` globally; pin it separately so removing that clause alone
+    # fails even though the volume clause above still passes.
+    assert_semantic_present(
+        text,
+        ("codex_home", "globally"),
+        context="combined stack CODEX_HOME global prohibition",
+    )

--- a/tests/unit/docs/test_documentation_architecture_conformance.py
+++ b/tests/unit/docs/test_documentation_architecture_conformance.py
@@ -20,6 +20,12 @@ from pathlib import Path
 
 import pytest
 
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_absent, assert_semantic_present
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -48,10 +54,21 @@ def _read(path: Path) -> str:
 def test_standard_is_declarative_desired_state_not_a_tracker() -> None:
     text = _read(STANDARD_DOC)
 
-    # Declarative status, not a migration/checklist/status framing.
-    assert "**Status:** Current standard and target direction" in text
-    # The standard explicitly declares itself a desired-state strategy, not a plan.
-    assert "not a migration plan or a checklist" in text
+    # Declarative status, not a migration/checklist/status framing. Wording
+    # tolerant (#3964): rewording the status line must not break this guard
+    # as long as the declarative desired-state contract survives.
+    assert_semantic_present(
+        text,
+        ("current standard", "target direction"),
+        context="DocumentationArchitecture.md declarative status",
+    )
+    assert_semantic_present(
+        text,
+        ("desired state",),
+        context="DocumentationArchitecture.md desired-state strategy",
+    )
+    # No checklist/status checkbox framing leaks into the canonical standard
+    # (structural, kept exact).
     # No checklist/status checkbox framing leaks into the canonical standard.
     assert "- [ ]" not in text
     assert "- [x]" not in text
@@ -82,13 +99,20 @@ def test_standard_introduces_no_adr_or_decision_log_authority() -> None:
 def test_standard_does_not_force_bounded_contexts() -> None:
     text = _read(STANDARD_DOC)
     # Architectural boundary / ownership surface is the default, not Bounded Context.
-    assert "architectural boundary" in text
-    assert "ownership surface" in text
-    # Bounded Context is gated as a subtype behind boundary tests.
-    assert "subtype" in text.lower()
-    assert (
-        "the directory is an architectural boundary or ownership surface — not a Bounded Context"
-        in text
+    assert_semantic_present(
+        text,
+        ("architectural boundary", "ownership surface"),
+        context="DocumentationArchitecture.md boundary default",
+    )
+    # Bounded Context is gated as a subtype behind boundary tests (#3964:
+    # exact em-dash sentence loosened; the subtype gate is the contract).
+    assert_semantic_present(
+        text, ("subtype",), context="DocumentationArchitecture.md bounded-context gate"
+    )
+    assert_semantic_absent(
+        text,
+        ("bounded context is the default", "every module is a bounded context"),
+        context="DocumentationArchitecture.md",
     )
 
 
@@ -103,10 +127,20 @@ def test_standard_does_not_treat_specs_as_durable_docs() -> None:
 def test_standard_defers_to_document_model_no_second_authority() -> None:
     assert DOCUMENT_MODEL_DOC.exists()
     text = _read(STANDARD_DOC)
-    # The standard extends, not replaces, the Document Model — no second authority.
-    assert "extends, and does not replace" in text
+    # The standard extends, not replaces, the Document Model — no second authority
+    # (#3964: exact "extends, and does not replace" / "additive refinements"
+    # wording loosened to the underlying authority contract).
+    assert_semantic_present(
+        text,
+        ("extends", "does not replace"),
+        context="DocumentationArchitecture.md document-model deference",
+    )
     assert "MoonSpecDocumentModel.md" in text
-    assert "additive refinements" in text
+    assert_semantic_present(
+        text,
+        ("refinement",),
+        context="DocumentationArchitecture.md additive refinements",
+    )
 
 
 def test_conformance_review_is_non_canonical_working_doc_with_traceability() -> None:
@@ -140,7 +174,13 @@ def test_migration_plan_records_authority_conflict_outcome() -> None:
             "MM-900 completes without failing the required unit suite."
         )
     text = _read(MIGRATION_PLAN)
-    assert "MM-909 self-conformance and authority-conflict record" in text
+    # Self-traceability to the conformance record (#3964: exact title
+    # loosened; the link target and outcome heading are the contract).
+    assert_semantic_present(
+        text,
+        ("mm-909", "authority-conflict record"),
+        context="migration plan conformance traceability",
+    )
     assert "MoonSpecDocsArchitectureConformanceReview.md" in text
     # The recorded outcome: no unresolved authority conflict.
     assert "Unresolved documentation-authority conflicts:" in text
@@ -155,7 +195,11 @@ def test_stale_documentation_migration_plan_is_not_active_or_contradictory() -> 
     text = _read(STALE_MIGRATION_PLAN)
     assert "MM-928" in text
     assert "**Status:** Superseded / closed" in text
-    assert "no longer records active authority conflicts" in text
+    assert_semantic_present(
+        text,
+        ("no longer records active authority conflicts",),
+        context="stale migration plan closure",
+    )
     assert "## 7. Historical documentation-authority conflicts (closed)" in text
     assert "## 7. Unresolved documentation-authority conflicts" not in text
     assert "Draft / active" not in text

--- a/tests/unit/docs/test_documentation_architecture_standard.py
+++ b/tests/unit/docs/test_documentation_architecture_standard.py
@@ -7,6 +7,12 @@ and the incremental adoption policy to ``docs/DocumentationArchitecture.md``.
 
 from pathlib import Path
 
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 STANDARD_DOC = REPO_ROOT / "docs" / "DocumentationArchitecture.md"
 
@@ -71,10 +77,22 @@ def test_module_architecture_is_preferred_filename() -> None:
 def test_system_filename_is_durable_and_design_filename_is_transitional() -> None:
     text = _read()
     assert "<SystemName>System.md" in text
-    assert "durable system or capability description" in text
+    assert_semantic_present(
+        text,
+        ("durable system or capability description",),
+        context="system filename durability",
+    )
     assert "<FeatureName>Design.md" in text
-    assert "transitional design" in text
-    assert "promote or supersede it when the design becomes settled desired state" in text
+    assert_semantic_present(
+        text, ("transitional design",), context="design filename transience"
+    )
+    # Settled designs are promoted or superseded (#3964: exact sentence
+    # loosened to the lifecycle contract).
+    assert_semantic_present(
+        text,
+        ("promote or supersede", "settled desired state"),
+        context="design promotion lifecycle",
+    )
 
 
 def test_docs_capitalization_variants_covered() -> None:
@@ -85,7 +103,13 @@ def test_docs_capitalization_variants_covered() -> None:
 
 def test_filename_alone_does_not_define_authority() -> None:
     text = _read()
-    assert "Filename alone does not define authority" in text
+    # Authority ladder heading (#3964: exact heading loosened; class +
+    # declared-authority + precedence ladder is the contract).
+    assert_semantic_present(
+        text,
+        ("filename alone does not define authority",),
+        context="filename authority rule",
+    )
     # Authority is established by class, declared Authority, and the precedence
     # ladder (§7) -- not by a separate documentation index that does not exist.
     assert "its declared Authority" in text
@@ -97,8 +121,16 @@ def test_filename_alone_does_not_define_authority() -> None:
 def test_incremental_adoption_policy_present() -> None:
     text = _read()
     assert "Incremental Adoption Policy" in text
-    assert "new and substantially-edited docs first" in text.lower()
-    assert "no retroactive metadata-only churn PR is mandated" in text
+    assert_semantic_present(
+        text,
+        ("new and substantially-edited docs first",),
+        context="incremental adoption scope",
+    )
+    assert_semantic_present(
+        text,
+        ("no retroactive metadata-only churn",),
+        context="incremental adoption churn guard",
+    )
 
 
 def test_stable_canonical_claim_id_families_present() -> None:
@@ -126,8 +158,14 @@ def test_claim_id_validation_is_advisory_and_incremental() -> None:
 
 def test_downstream_minor_local_adjustment_path_documented() -> None:
     text = _read()
-    assert "minor local adjustments" in text.lower()
-    assert "preserving the MoonSpec document classes and authority rules" in text
+    assert_semantic_present(
+        text, ("minor local adjustments",), context="downstream adjustment path"
+    )
+    assert_semantic_present(
+        text,
+        ("preserving", "document classes", "authority rules"),
+        context="downstream adjustment constraints",
+    )
 
 
 def test_source_traceability_preserved() -> None:

--- a/tests/unit/docs/test_dood_phase0_contract.py
+++ b/tests/unit/docs/test_dood_phase0_contract.py
@@ -1,5 +1,11 @@
 from pathlib import Path
 
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BACKEND_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "DockerBackendService.md"
@@ -48,12 +54,20 @@ def test_docker_backend_service_reuses_provisioned_images_across_workflows() -> 
     text = _read(BACKEND_DOC)
 
     assert "Optional images are acquired on demand" in text
-    assert "Deployment-owned local image recipes are provisioned on demand" in text
+    assert_semantic_present(
+        text,
+        ("deployment-owned local image recipes", "provisioned on demand"),
+        context="backend image provisioning",
+    )
     assert "cross-workflow image cache" in text
     assert "reusableAcrossWorkflows: true" in text
     assert "removeOnJobEnd: false" in text
     assert "per-source, per-build-key lock" in text
-    assert "Job cleanup never removes shared images" in text
+    assert_semantic_present(
+        text,
+        ("job cleanup never removes shared images",),
+        context="backend shared-image cleanup guard",
+    )
 
 
 def test_docker_backend_service_uses_logical_workspace_references() -> None:
@@ -62,7 +76,11 @@ def test_docker_backend_service_uses_logical_workspace_references() -> None:
     assert "Workspaces are logical references" in text
     assert "callerProvidesHostPath: false" in text
     assert "visibilityProbeBeforeProvisioning: true" in text
-    assert "A failed probe stops the job before expensive image provisioning" in text
+    assert_semantic_present(
+        text,
+        ("failed probe stops the job", "image provisioning"),
+        context="backend visibility-probe gate",
+    )
 
 
 def test_omnigent_uses_mcp_without_receiving_docker_authority() -> None:
@@ -86,10 +104,20 @@ def test_canonical_backend_doc_has_no_migration_or_compatibility_checklist() -> 
 def test_sidecar_document_is_only_a_removed_design_tombstone() -> None:
     text = _normalized(SIDECAR_DOC)
 
-    assert "Removed from desired state" in text
-    assert "not a supported MoonMind desired state or compatibility path" in text
-    assert "only a tombstone for old links" in text
-    assert "does not define a runtime mode" in text
+    assert_semantic_present(
+        text, ("removed from desired state",), context="sidecar tombstone status"
+    )
+    assert_semantic_present(
+        text,
+        ("not a supported", "desired state", "compatibility path"),
+        context="sidecar tombstone scope",
+    )
+    assert_semantic_present(
+        text, ("only a tombstone for old links",), context="sidecar tombstone purpose"
+    )
+    assert_semantic_present(
+        text, ("does not define a runtime mode",), context="sidecar tombstone limit"
+    )
     assert "may remain temporarily" not in text
 
 
@@ -120,7 +148,13 @@ def test_related_architecture_docs_do_not_reinstate_sidecar_as_default() -> None
 def test_backend_doc_remains_domain_agnostic() -> None:
     text = _read(BACKEND_DOC)
 
-    assert "The core remains workload-agnostic" in text
+    assert_semantic_present(
+        text, ("core remains workload-agnostic",), context="backend domain scope"
+    )
     assert "not backend" in text
-    assert "branches for Python, .NET, Unreal, Unity, or Node" in text
+    assert_semantic_present(
+        text,
+        ("branches for python", ".net", "unreal", "unity", "or node"),
+        context="backend toolchain neutrality",
+    )
     assert "specialized worker pool" in text

--- a/tests/unit/docs/test_final_docs_cleanup_policy.py
+++ b/tests/unit/docs/test_final_docs_cleanup_policy.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -91,11 +94,17 @@ def test_temp_plan_cleanup_guard_removes_plan_after_final_dod_closes() -> None:
 
 
 def test_docs_do_not_inline_secrets_or_raw_evidence() -> None:
+    from moonmind.omnigent.conformance import SECRET_PATTERN as SHARED_SECRET_PATTERN
+
     checked_paths = [*CANONICAL_DOCS, ROADMAP_DOC]
     for path in checked_paths:
         text = _read(path)
         for pattern in SECRET_PATTERNS:
             assert pattern.search(text) is None, path
+        # Production shared-scanner twin (#3964): the canonical credential
+        # guardrail must agree, so deleting this doc assertion cannot hide a
+        # leak from the owning redaction boundary.
+        assert SHARED_SECRET_PATTERN.search(text) is None, path
         assert "BEGIN_PROVIDER_PAYLOAD" not in text, path
         assert "```diff" not in text, path
 

--- a/tests/unit/docs/test_normal_codex_product_path_reconciliation.py
+++ b/tests/unit/docs/test_normal_codex_product_path_reconciliation.py
@@ -14,7 +14,12 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -55,25 +60,51 @@ def test_universal_canonical_identity_named_in_every_consuming_doc() -> None:
 def test_no_caller_authored_host_or_daemon_authority() -> None:
     text = _read(RECONCILIATION)
     assert "caller-authored `session.hostId`" in text
-    assert "No caller authors host, daemon, session, path, or credential authority." in text
+    # No caller authors host/daemon/session/path/credential authority (#3964:
+    # exact sentence loosened; the production adapter twin in
+    # test_skill_contracts_3964.py rejects caller-provided hostId in code).
+    assert_semantic_present(
+        text,
+        ("no caller authors", "credential authority"),
+        context="reconciliation caller-authority prohibition",
+    )
 
 
 def test_no_silent_fallback_is_pinned() -> None:
     text = _read(RECONCILIATION)
-    invariant = (
-        "An explicit Omnigent selection never silently runs through direct Codex, "
-        "another Provider Profile, another host mode, an arbitrary static host, or "
-        "a broader network/mount policy."
+    # Explicit selection never silently substitutes another runtime path
+    # (#3964: the three-sentence invariant paragraph loosened to its semantic
+    # contract; the production failure taxonomy twin in
+    # test_skill_contracts_3964.py proves fail-closed behavior in code).
+    assert_semantic_present(
+        text,
+        ("explicit", "never silently", "direct codex"),
+        context="reconciliation no-silent-fallback invariant",
     )
-    assert invariant in text
-    assert "fail-closed with no silent fallback" in text
+    assert_semantic_present(
+        text,
+        ("fail-closed", "no silent fallback"),
+        context="reconciliation fail-closed summary",
+    )
 
 
 def test_release_last_ordering_is_pinned() -> None:
     text = _read(RECONCILIATION)
-    assert "Provider Profile capacity is released last" in text
-    assert "no release before cleanup" in text.lower() or "release before cleanup" in text
-    assert "auxiliary cleanup/publication failure never overwrites `primaryStatus`" in text
+    assert_semantic_present(
+        text,
+        ("provider profile capacity is released last",),
+        context="reconciliation release-last ordering",
+    )
+    assert_semantic_present(
+        text,
+        ("no release before cleanup",),
+        context="reconciliation no-release-before-cleanup",
+    )
+    assert_semantic_present(
+        text,
+        ("never overwrites", "primaryStatus"),
+        context="reconciliation auxiliary-failure precedence",
+    )
 
 
 def test_evidence_qualified_support_vocabulary_is_present() -> None:
@@ -90,7 +121,11 @@ def test_evidence_qualified_support_vocabulary_is_present() -> None:
     ):
         assert f"**{term}**" in text, term
     # Unproven rows are not promoted to supported by this reconciliation.
-    assert "must not imply completion of checkpoint resume/branching" in text
+    assert_semantic_present(
+        text,
+        ("must not imply completion", "checkpoint resume"),
+        context="reconciliation unproven-rows guard",
+    )
 
 
 def test_fail_closed_cutover_is_pinned() -> None:

--- a/tests/unit/docs/test_normal_codex_product_path_reconciliation.py
+++ b/tests/unit/docs/test_normal_codex_product_path_reconciliation.py
@@ -76,10 +76,21 @@ def test_no_silent_fallback_is_pinned() -> None:
     # (#3964: the three-sentence invariant paragraph loosened to its semantic
     # contract; the production failure taxonomy twin in
     # test_skill_contracts_3964.py proves fail-closed behavior in code).
+    # P2 (Codex review): scope the terms to the bounded §5 failure-matrix
+    # section so unrelated occurrences elsewhere (e.g. "never silently
+    # filled" in the projection table) cannot satisfy a removed contract.
+    section_start = text.index("## 5. Complete failure and evidence matrix")
+    section_end = text.index("## 6. Evidence-qualified support language")
+    section = text[section_start:section_end]
     assert_semantic_present(
-        text,
+        section,
         ("explicit", "never silently", "direct codex"),
         context="reconciliation no-silent-fallback invariant",
+    )
+    assert_semantic_present(
+        section,
+        ("denied or failed", "is an error"),
+        context="reconciliation denied-selection error invariant",
     )
     assert_semantic_present(
         text,

--- a/tests/unit/docs/test_omnigent_consolidation_3962.py
+++ b/tests/unit/docs/test_omnigent_consolidation_3962.py
@@ -54,11 +54,12 @@ def test_entrypoint_exists_with_startup_path_and_limitations() -> None:
     ):
         assert term in text, term
     # A shared image never authorizes every installed harness (#3964: exact
-    # "never authorizes every installed runtime" wording loosened to the
-    # authorization contract so rewording does not break the guard).
+    # "never authorizes every installed runtime" wording loosened to
+    # stem-level authorization-contract terms so every->all or
+    # authorizes->grant-authorization rewording does not break the guard).
     assert_semantic_present(
         text,
-        ("never", "authoriz", "every installed"),
+        ("never", "authoriz", "installed", "runtime"),
         context="entrypoint shared-image authorization limit",
     )
     # Credential ownership distinction is summarized, not merged (#3964:

--- a/tests/unit/docs/test_omnigent_consolidation_3962.py
+++ b/tests/unit/docs/test_omnigent_consolidation_3962.py
@@ -11,7 +11,12 @@ valid internal links/anchors.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -48,10 +53,21 @@ def test_entrypoint_exists_with_startup_path_and_limitations() -> None:
         "selected-by-default",
     ):
         assert term in text, term
-    # A shared image never authorizes every installed harness.
-    assert "never authorizes every installed runtime" in text
-    # Credential ownership distinction is summarized, not merged.
-    assert "detached but preserved" in text
+    # A shared image never authorizes every installed harness (#3964: exact
+    # "never authorizes every installed runtime" wording loosened to the
+    # authorization contract so rewording does not break the guard).
+    assert_semantic_present(
+        text,
+        ("never", "authoriz", "every installed"),
+        context="entrypoint shared-image authorization limit",
+    )
+    # Credential ownership distinction is summarized, not merged (#3964:
+    # exact "detached but preserved" loosened to the ownership contract).
+    assert_semantic_present(
+        text,
+        ("detached", "preserved"),
+        context="entrypoint credential ownership distinction",
+    )
     # ManagedAgents boundary is cross-linked, not copied.
     assert "ManagedAgents/DockerBackendService.md" in text
 
@@ -65,8 +81,14 @@ def test_ownership_map_covers_every_omnigent_file() -> None:
 
 def test_credential_ownership_contract_survives() -> None:
     shared = _read(OMNIGENT / "SharedHostImage.md")
-    assert "destroyed on cleanup" in shared
-    assert "detached but preserved on cleanup" in shared
+    assert_semantic_present(
+        shared, ("destroyed on cleanup",), context="shared host cleanup"
+    )
+    assert_semantic_present(
+        shared,
+        ("detached", "preserved on cleanup"),
+        context="shared host credential ownership",
+    )
     assert "generation-marker fenced" in shared or "generation" in shared
     oauth = _read(OMNIGENT / "OmnigentHostOAuth.md")
     assert "no Claude/OpenCode" in oauth or "credential attachments" in oauth
@@ -74,8 +96,14 @@ def test_credential_ownership_contract_survives() -> None:
 
 def test_exact_support_contract_survives() -> None:
     strategy = _read(OMNIGENT / "PrimaryRuntimeProviderStrategy.md")
-    assert "evidence-gated" in strategy
-    assert "never silently" in strategy or "No silent fallback" in strategy
+    assert_semantic_present(
+        strategy, ("evidence-gated",), context="primary strategy evidence gate"
+    )
+    assert_semantic_present(
+        strategy,
+        ("no silent fallback",),
+        context="primary strategy fallback prohibition",
+    )
     cutover = _read(OMNIGENT / "CodexSupportAndCutover.md")
     assert "## Support and conformance matrix v1" in cutover
     assert "REQUIRED_ROW_CATALOG" in cutover

--- a/tests/unit/docs/test_omnigent_create_to_host_contract.py
+++ b/tests/unit/docs/test_omnigent_create_to_host_contract.py
@@ -1,6 +1,11 @@
 import json
 import re
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
@@ -24,7 +29,11 @@ def test_identity_and_versioned_wire_contract_are_pinned() -> None:
     assert '"agentKind": "external"' in text
     assert '"agentId": "omnigent"' in text
     assert '"harnessOverride": "codex-native"' in text
-    assert "There is deliberately no `session.hostId`" in text
+    assert_semantic_present(
+        text,
+        ("deliberately no", "session.hostid"),
+        context="create-to-host hostId absence",
+    )
     assert text.count('"schemaVersion": "omnigent-create-host/v1"') >= 4
 
 
@@ -50,7 +59,11 @@ def test_launch_snapshot_and_terminal_authority_are_pinned() -> None:
     assert terminal["primaryStatus"] == "completed"
     assert terminal["cleanup"] == {"status": "completed", "janitorRequired": False}
     assert terminal["profileLease"] == {"releaseStatus": "released"}
-    assert "never replace or obscure `primaryStatus`" in text
+    assert_semantic_present(
+        text,
+        ("never replace or obscure", "primaryStatus"),
+        context="create-to-host terminal authority",
+    )
 
 
 def test_manual_host_id_is_rejected_by_both_canonical_contracts() -> None:
@@ -63,12 +76,13 @@ def test_manual_host_id_is_rejected_by_both_canonical_contracts() -> None:
 
 def test_explicit_selection_is_fail_closed_without_substitution() -> None:
     text = CONTRACT.read_text(encoding="utf-8")
-    invariant = (
-        "An explicit Omnigent selection never silently runs through direct Codex, "
-        "another Provider Profile, another host mode, an arbitrary static host, or "
-        "a broader network/mount policy."
+    # Same invariant as the reconciliation doc (#3964: exact paragraph
+    # loosened to the substitution prohibition contract).
+    assert_semantic_present(
+        text,
+        ("explicit omnigent selection", "never silently"),
+        context="create-to-host no-substitution invariant",
     )
-    assert invariant in text
     for code in (
         "OMNIGENT_RUNTIME_UNSUPPORTED",
         "OMNIGENT_PROFILE_UNAVAILABLE",

--- a/tests/unit/docs/test_repository_access_slice0_reconciliation.py
+++ b/tests/unit/docs/test_repository_access_slice0_reconciliation.py
@@ -19,8 +19,10 @@ from pathlib import Path
 import pytest
 import yaml
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
+from _semantic_docs_3964 import assert_semantic_present
 from moonmind.omnigent.conformance import SECRET_PATTERN as SHARED_SECRET_PATTERN
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -90,16 +92,34 @@ def _repo_python_files() -> list[Path]:
 def test_design_remains_proposed_no_gate_relaxation() -> None:
     text = _read(DESIGN_DOC)
     assert "**Status:** Proposed" in text
-    # The design must keep stating its handoff is proposed, not permitted.
-    assert "may already be bypassed" in text
-    assert "proposed changes to the owning contracts and guidance" in text
+    # The design must keep stating its handoff is proposed, not permitted
+    # (#3964: exact prose loosened to the gate contract).
+    assert_semantic_present(
+        text, ("may already be bypassed",), context="design handoff gate"
+    )
+    assert_semantic_present(
+        text,
+        ("proposed changes to the owning contracts and guidance",),
+        context="design handoff scope",
+    )
     # Slice-0 enables no runtime path.
-    assert "No runtime qualification is claimed by this documentation task" in _read(PLAN_DOC)
+    assert_semantic_present(
+        _read(PLAN_DOC),
+        ("no runtime qualification is claimed",),
+        context="slice-0 runtime scope",
+    )
 
 
 def test_agents_recovery_gate_stays_mandatory() -> None:
     text = _read(AGENTS_DOC)
-    assert "publish a remotely verified recovery checkpoint before cleanup" in text
+    # Remote-checkpoint recovery gate (#3964: exact sentence loosened; the
+    # production behavior is owned by the recovery path, this pins the
+    # documented gate).
+    assert_semantic_present(
+        text,
+        ("remotely verified recovery checkpoint", "cleanup"),
+        context="AGENTS.md recovery gate",
+    )
 
 
 def test_plan_carries_complete_slice0_record() -> None:

--- a/tests/unit/docs/test_skill_contracts_3964.py
+++ b/tests/unit/docs/test_skill_contracts_3964.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 from _semantic_docs_3964 import (  # noqa: E402
     assert_semantic_absent,
     assert_semantic_present,
+    normalize,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -86,9 +87,9 @@ def test_every_skill_body_carries_executable_contract_sections() -> None:
             ("## ",),
             context=f"{skill_dir.name}/SKILL.md headed sections",
         )
-        lowered = text.lower()
-        assert ("workflow" in lowered or "inputs" in lowered), (
-            f"{skill_dir.name}/SKILL.md must define workflow/inputs semantics"
+        lowered = normalize(text)
+        assert any(term in lowered for term in ("workflow", "inputs", "output")), (
+            f"{skill_dir.name}/SKILL.md must define workflow/inputs/output semantics"
         )
 
 

--- a/tests/unit/docs/test_skill_contracts_3964.py
+++ b/tests/unit/docs/test_skill_contracts_3964.py
@@ -134,7 +134,7 @@ def test_semantic_helper_survives_harmless_rewording() -> None:
     original = "The shared image never authorizes every installed runtime."
     reworded = "A  shared\nimage   must NEVER grant authorization to all installed runtimes!"
     assert_semantic_present(
-        reworded, ("never", "authoriz", "every installed"), context="reword"
+        reworded, ("never", "authoriz", "installed", "runtime"), context="reword"
     )
     assert original != reworded  # the wordings genuinely differ
 
@@ -143,7 +143,9 @@ def test_semantic_helper_still_detects_concept_removal() -> None:
     mutated = "The shared image supports several installed runtimes."
     with pytest.raises(AssertionError, match="missing required concept"):
         assert_semantic_present(
-            mutated, ("never", "authoriz", "every installed"), context="mutated"
+            mutated,
+            ("never", "authoriz", "installed", "runtime"),
+            context="mutated",
         )
 
 

--- a/tests/unit/docs/test_skill_contracts_3964.py
+++ b/tests/unit/docs/test_skill_contracts_3964.py
@@ -31,7 +31,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 from _semantic_docs_3964 import (  # noqa: E402
     assert_semantic_absent,
     assert_semantic_present,
-    normalize,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -87,9 +86,13 @@ def test_every_skill_body_carries_executable_contract_sections() -> None:
             ("## ",),
             context=f"{skill_dir.name}/SKILL.md headed sections",
         )
-        lowered = normalize(text)
-        assert any(term in lowered for term in ("workflow", "inputs", "output")), (
-            f"{skill_dir.name}/SKILL.md must define workflow/inputs/output semantics"
+        # P1 (Codex review): the production frontmatter loader and canonical
+        # Skill contract do not require literal `workflow`/`inputs`/`output`
+        # prose. Validate declared frontmatter (covered by
+        # test_every_skill_frontmatter_parses_via_production_loader) plus a
+        # substantive headed body instead of an undocumented prose schema.
+        assert len(text.strip()) >= 200, (
+            f"{skill_dir.name}/SKILL.md must carry a substantive executable body"
         )
 
 
@@ -197,12 +200,16 @@ def test_no_silent_fallback_error_classes_exist_in_production() -> None:
         OMNIGENT_FAILURE_CLASS_TABLE,
         OmnigentFailureReason,
         classify_omnigent_failure,
+        failure_class_for_terminal_status,
     )
 
     # The production failure taxonomy must cover the fail-closed surface the
     # docs describe (auth, invalid payload, host timeout, ambiguous first
     # message): an explicit selection maps to a failure class, never to a
     # silent substitution.
+    # P2 (Codex review): exercise the production failure paths instead of
+    # only asserting enum keys exist, so a regression that silently routes
+    # through another runtime/profile/host cannot leave this twin green.
     assert OmnigentFailureReason.AUTH_FAILURE in OMNIGENT_FAILURE_CLASS_TABLE
     assert OmnigentFailureReason.INVALID_SESSION_PAYLOAD in (
         OMNIGENT_FAILURE_CLASS_TABLE
@@ -216,3 +223,15 @@ def test_no_silent_fallback_error_classes_exist_in_production() -> None:
         classify_omnigent_failure(OmnigentFailureReason.INVALID_SESSION_PAYLOAD)
         == "user_error"
     )
+    # Fail-closed: denied/failed explicit selections classify to an error,
+    # never to silent success (None) or a substituted authority.
+    for reason in (
+        OmnigentFailureReason.AUTH_FAILURE,
+        OmnigentFailureReason.INVALID_SESSION_PAYLOAD,
+        OmnigentFailureReason.SESSION_HOST_TIMEOUT,
+        OmnigentFailureReason.AMBIGUOUS_POSTING_RECONCILIATION,
+        OmnigentFailureReason.FIRST_MESSAGE_DIGEST_MISMATCH,
+    ):
+        assert classify_omnigent_failure(reason) is not None, reason
+    assert failure_class_for_terminal_status("failed") is not None
+    assert failure_class_for_terminal_status("timed_out") == "system_error"

--- a/tests/unit/docs/test_skill_contracts_3964.py
+++ b/tests/unit/docs/test_skill_contracts_3964.py
@@ -1,0 +1,215 @@
+"""Executable Skill-contract and production-boundary guards for #3964.
+
+``.agents/skills/**/SKILL.md`` files are executable portable contracts, not
+narrative documentation: resolution, materialization, and workflow selection
+consume their frontmatter (``name``/``description``). This suite validates
+them through the production frontmatter loader
+(``moonmind.services.skill_resolution._load_skill_frontmatter``) rather than
+a test-only parser, so a bug or drift in the shared implementation is caught
+by negative cases instead of comparing the implementation to itself.
+
+Production-boundary twins (secret redaction, caller-authored hostId
+rejection, no-silent-fallback error codes) prove the semantic guards hold in
+code, so deleting a documentation assertion cannot let an authority or
+security change pass silently.
+
+Mutation/regression proof for the ``_semantic_docs_3964`` helpers lives here:
+reworded prose carrying the same concepts passes, while text with a concept
+removed fails.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from _semantic_docs_3964 import (  # noqa: E402
+    assert_semantic_absent,
+    assert_semantic_present,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_ROOT = REPO_ROOT / ".agents" / "skills"
+
+
+def _production_skill_loader():
+    """Lazy import: production resolution pulls settings; keep collection light."""
+    from moonmind.services.skill_resolution import (  # noqa: E402
+        _AGENT_SKILL_NAME_RE,
+        _load_skill_frontmatter,
+    )
+
+    return _AGENT_SKILL_NAME_RE, _load_skill_frontmatter
+
+
+def _skill_dirs() -> list[Path]:
+    return sorted(
+        p for p in SKILLS_ROOT.iterdir() if p.is_dir() and (p / "SKILL.md").exists()
+    )
+
+
+def test_skill_snapshot_root_resolves() -> None:
+    assert SKILLS_ROOT.is_dir()
+    assert _skill_dirs(), "no skills found under .agents/skills"
+
+
+def test_every_skill_frontmatter_parses_via_production_loader() -> None:
+    _AGENT_SKILL_NAME_RE, _load_skill_frontmatter = _production_skill_loader()
+    for skill_dir in _skill_dirs():
+        if skill_dir.name == "local":
+            continue
+        frontmatter = _load_skill_frontmatter(skill_dir)
+        assert isinstance(frontmatter, dict), skill_dir.name
+        assert frontmatter, f"{skill_dir.name}: empty frontmatter"
+        assert _AGENT_SKILL_NAME_RE.fullmatch(skill_dir.name), skill_dir.name
+        assert frontmatter.get("name") == skill_dir.name, (
+            f"{skill_dir.name}: frontmatter name must match directory"
+        )
+        description = frontmatter.get("description")
+        assert isinstance(description, str) and description.strip(), (
+            f"{skill_dir.name}: non-empty description required"
+        )
+
+
+def test_every_skill_body_carries_executable_contract_sections() -> None:
+    for skill_dir in _skill_dirs():
+        if skill_dir.name == "local":
+            continue
+        text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert_semantic_present(
+            text,
+            ("## ",),
+            context=f"{skill_dir.name}/SKILL.md headed sections",
+        )
+        lowered = text.lower()
+        assert ("workflow" in lowered or "inputs" in lowered), (
+            f"{skill_dir.name}/SKILL.md must define workflow/inputs semantics"
+        )
+
+
+def test_production_frontmatter_loader_rejects_malformed_input(tmp_path: Path) -> None:
+    """Negative case against the shared loader (not a test-only duplicate)."""
+    _, _load_skill_frontmatter = _production_skill_loader()
+    bad = tmp_path / "bad-skill"
+    bad.mkdir()
+    (bad / "SKILL.md").write_text(
+        "---\nname: [unclosed\n description: x\n---\n\n# Bad\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="invalid YAML frontmatter"):
+        _load_skill_frontmatter(bad)
+
+    non_mapping = tmp_path / "list-skill"
+    non_mapping.mkdir()
+    (non_mapping / "SKILL.md").write_text(
+        "---\n- just\n- a\n- list\n---\n\n# Bad\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must be a mapping"):
+        _load_skill_frontmatter(non_mapping)
+
+    missing = tmp_path / "missing-skill"
+    missing.mkdir()
+    with pytest.raises(ValueError, match="failed to read skill frontmatter"):
+        _load_skill_frontmatter(missing)
+
+
+def test_skill_name_pattern_rejects_invalid_names() -> None:
+    _AGENT_SKILL_NAME_RE, _ = _production_skill_loader()
+    assert _AGENT_SKILL_NAME_RE.fullmatch("fix-ci") is not None
+    assert _AGENT_SKILL_NAME_RE.fullmatch("moonspec-verify") is not None
+    assert _AGENT_SKILL_NAME_RE.fullmatch("Bad Name!") is None
+    assert _AGENT_SKILL_NAME_RE.fullmatch("") is None
+
+
+# --- Mutation/regression proof for the semantic helpers ---
+
+
+def test_semantic_helper_survives_harmless_rewording() -> None:
+    original = "The shared image never authorizes every installed runtime."
+    reworded = "A  shared\nimage   must NEVER grant authorization to all installed runtimes!"
+    assert_semantic_present(
+        reworded, ("never", "authoriz", "every installed"), context="reword"
+    )
+    assert original != reworded  # the wordings genuinely differ
+
+
+def test_semantic_helper_still_detects_concept_removal() -> None:
+    mutated = "The shared image supports several installed runtimes."
+    with pytest.raises(AssertionError, match="missing required concept"):
+        assert_semantic_present(
+            mutated, ("never", "authoriz", "every installed"), context="mutated"
+        )
+
+
+def test_semantic_absent_helper_detects_reintroduced_concept() -> None:
+    clean = "The directory is an ownership surface."
+    assert_semantic_absent(clean, ("bounded context",), context="clean")
+    mutated = "The directory is a Bounded Context."
+    with pytest.raises(AssertionError, match="forbidden concept"):
+        assert_semantic_absent(mutated, ("bounded context",), context="mutated")
+
+
+# --- Production-boundary twins: security/authority holds in code ---
+
+
+def test_secret_redaction_boundary_catches_credential_shapes() -> None:
+    from moonmind.omnigent.conformance import SECRET_PATTERN
+
+    for sample in (
+        "token ghp_abc123def456",
+        "key github_pat_xyz789",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "password = hunter2",
+    ):
+        assert SECRET_PATTERN.search(sample) is not None, sample
+    assert SECRET_PATTERN.search("ordinary prose about authentication") is None
+
+
+def test_caller_authored_host_id_rejected_in_production_adapter() -> None:
+    from moonmind.workflows.adapters.omnigent_agent_adapter import (
+        OmnigentAdapterError,
+        OmnigentSessionSelection,
+    )
+
+    selection = OmnigentSessionSelection(
+        host_type="managed",
+        host_id="caller-picks-this",
+        workspace=None,
+        allow_empty_workspace=True,
+    )
+    from moonmind.workflows.adapters.omnigent_agent_adapter import _validate_session
+
+    with pytest.raises(OmnigentAdapterError, match="reject caller-provided hostId"):
+        _validate_session(selection)
+
+
+def test_no_silent_fallback_error_classes_exist_in_production() -> None:
+    from moonmind.omnigent.failure_classification import (
+        OMNIGENT_FAILURE_CLASS_TABLE,
+        OmnigentFailureReason,
+        classify_omnigent_failure,
+    )
+
+    # The production failure taxonomy must cover the fail-closed surface the
+    # docs describe (auth, invalid payload, host timeout, ambiguous first
+    # message): an explicit selection maps to a failure class, never to a
+    # silent substitution.
+    assert OmnigentFailureReason.AUTH_FAILURE in OMNIGENT_FAILURE_CLASS_TABLE
+    assert OmnigentFailureReason.INVALID_SESSION_PAYLOAD in (
+        OMNIGENT_FAILURE_CLASS_TABLE
+    )
+    assert OmnigentFailureReason.SESSION_HOST_TIMEOUT in OMNIGENT_FAILURE_CLASS_TABLE
+    assert (
+        classify_omnigent_failure(OmnigentFailureReason.AUTH_FAILURE)
+        == "integration_error"
+    )
+    assert (
+        classify_omnigent_failure(OmnigentFailureReason.INVALID_SESSION_PAYLOAD)
+        == "user_error"
+    )

--- a/tests/unit/docs/test_workflow_execution_product_model_docs.py
+++ b/tests/unit/docs/test_workflow_execution_product_model_docs.py
@@ -1,5 +1,11 @@
 from pathlib import Path
 
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _semantic_docs_3964 import assert_semantic_present
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PRODUCT_MODEL = REPO_ROOT / "docs" / "Temporal" / "WorkflowExecutionProductModel.md"
@@ -16,7 +22,13 @@ def _read(path: Path) -> str:
 def test_workflow_execution_product_model_defines_required_terms() -> None:
     text = _read(PRODUCT_MODEL)
 
-    assert "MoonMind does not define a separate product entity named Task." in text
+    # No separate product entity named Task (#3964: exact sentence loosened
+    # to the entity-denial contract).
+    assert_semantic_present(
+        text,
+        ("does not define a separate product entity named task",),
+        context="product model task-entity denial",
+    )
     assert "Workflow Execution" in text
     assert "`workflowId`" in text
     assert "`runId`" in text
@@ -31,7 +43,11 @@ def test_workflow_type_catalog_uses_workflow_native_user_workflow_language() -> 
     text = _read(TYPE_CATALOG)
 
     assert "`MoonMind.UserWorkflow`" in text
-    assert "User-submitted, Step-ledger-owning Workflow Execution" in text
+    assert_semantic_present(
+        text,
+        ("user-submitted, step-ledger-owning workflow execution",),
+        context="type catalog user-workflow language",
+    )
     assert "standard task execution" not in text
     assert "public APIs and UI flows may still use `task` terminology" not in text
 


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#3964: replaces brittle exact-prose assertions in the docs test suites with semantic/structural guards while retaining all meaningful verification.

- Adds `tests/unit/docs/_semantic_docs_3964.py` helpers (`assert_semantic_present`/`assert_semantic_absent`: case/whitespace-tolerant, stem-level matching) and converts 10 docs suites to use them; exact assertions retained only for short structural/metadata/ID/link terms (e.g. `**Document Class:**`, `MM-909`, `DOC-REQ-012`, `- [ ]` absence).
- Adds `tests/unit/docs/test_skill_contracts_3964.py`: validates every `.agents/skills/**/SKILL.md` as an executable portable contract through the production frontmatter loader with negative cases (malformed YAML, non-mapping, missing file) plus name-pattern checks and mutation/regression proof.
- Keeps link/anchor validation, registry-drift checks (#3959 catalog, #3960 reconciliation), executable JSON-example validation against production models, and production-boundary twins (SECRET_PATTERN credential shapes, fail-closed failure taxonomy, caller-authored managed hostId rejection).
- Follow-up fix aligns the reword fixture with stem-level terms (`never`, `authoriz`, `installed`, `runtime`) so harmless every->all / authorizes->grant-authorization rewording is tolerated while concept removal is still detected.

## Verification outcome

Controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (candidate `ddc6a9d33`, all five acceptance criteria VERIFIED, recommended action: advance). Prior verifier found one red mutation-proof test (literal `every installed` term vs `all` rewording); fixed in the follow-up commit and confirmed green by direct execution at HEAD.

## Tests run

- Direct execution of `_semantic_docs_3964.assert_semantic_present` on the reword fixture with stem terms: PASS (no raise).
- Concept-removed fixture and `assert_semantic_absent` reintroduction check: PASS (correctly raises / detects).
- Doc-side spot check of the entrypoint guard against `docs/Omnigent/README.md`: PASS.
- Production-boundary checks live where env permits (SECRET_PATTERN, OMNIGENT_FAILURE_CLASS_TABLE / classify): PASS; PyYAML frontmatter cross-check of all 35 skills: PASS.
- Full `tests/unit/docs` pytest suite: NOT RUN in this sandbox (no pytest module, no network); deferred to required CI on this PR.

## Remaining risks

- Full pytest suite green still needs CI confirmation on this PR.
- Adapter `_validate_session` managed-hostId rejection check was not executable in the sandbox (missing `fastapi_users`); the guard and its test are present and exercised in CI.

Closes MoonLadderStudios/MoonMind#3964