### PR TITLE
[Omnigent boundary] Simplify the existing upstream-native Workflow Chat integration without removing its security facade (MoonLadderStudios/MoonMind#3956)

### DIFF
--- a/docs/UI/WorkflowChatPanel.md
+++ b/docs/UI/WorkflowChatPanel.md
@@ -124,33 +124,6 @@ Startup has a finite deadline. Missing required assets, failed essential reads, 
 
 These are local presentation states, not new persisted Workflow or provider-session lifecycle states. Loading, retrying, or opening the full-page presentation must not create a session, replay a message, change credentials, or restart the workflow. The full-page action is a same-authority presentation alternative, not a workaround for shared bootstrap, capability, or transport defects.
 
-### 4.2 Upstream-native simplification decision (MoonLadderStudios/MoonMind#3956)
-
-The parent epic's duplication claim is corrected: `WorkflowChatNative` never
-reimplemented Omnigent's chat UI. The single ordinary interactive composer is
-the provider-maintained application mounted by `WorkflowNativeChatRoute`
-(Chat tab) through the server-issued, binding-scoped `chatUrl`; the Debug tab
-fallback (`WorkflowChatNative`) is a read-only diagnostic shell plus terminal
-workflow actions, not a second composer. No second composer was found on any
-reachable supported path, so none was removed; instead the duplicate
-fetch/iframe/readiness lifecycle in the fallback shell was deleted and the
-canonical behavior stays in `features/workflow-native-chat/` (`chatBindingModel`,
-`NativeChatFrame`, `NativeChatUnavailableState`, `useWorkflowChatBinding`).
-
-`native_ui.py` and `native_ui_compat.py` transforms were inventoried against the
-pinned `omnigent.server.v1` contract and all retained: bootstrap injection,
-scoped asset-URL rewriting, document/asset classification, version gating,
-security headers, and the route/transport allowlist remain load-bearing for the
-supported bundle. Removal criteria for any future deletion: the supported
-bundle demonstrably no longer needs the transform, the pinned contract fixture
-is updated in the same change, and no production caller remains. The
-method/route allowlist, ownership checks, expected-state checks, idempotency,
-secret scanning, header filtering, and bounds at the trusted boundary are never
-simplification targets.
-
-`embedded=1` is the presentation-only flag on the MoonMind-scoped `chatUrl`
-(§4) and is unrelated to the experimental embedded-host transport in #3955.
-
 ## 5. Workflow chat binding
 
 The Workflow Detail API exposes one authoritative binding for the session that the Chat route opens.

--- a/docs/UI/WorkflowChatPanel.md
+++ b/docs/UI/WorkflowChatPanel.md
@@ -124,6 +124,33 @@ Startup has a finite deadline. Missing required assets, failed essential reads, 
 
 These are local presentation states, not new persisted Workflow or provider-session lifecycle states. Loading, retrying, or opening the full-page presentation must not create a session, replay a message, change credentials, or restart the workflow. The full-page action is a same-authority presentation alternative, not a workaround for shared bootstrap, capability, or transport defects.
 
+### 4.2 Upstream-native simplification decision (MoonLadderStudios/MoonMind#3956)
+
+The parent epic's duplication claim is corrected: `WorkflowChatNative` never
+reimplemented Omnigent's chat UI. The single ordinary interactive composer is
+the provider-maintained application mounted by `WorkflowNativeChatRoute`
+(Chat tab) through the server-issued, binding-scoped `chatUrl`; the Debug tab
+fallback (`WorkflowChatNative`) is a read-only diagnostic shell plus terminal
+workflow actions, not a second composer. No second composer was found on any
+reachable supported path, so none was removed; instead the duplicate
+fetch/iframe/readiness lifecycle in the fallback shell was deleted and the
+canonical behavior stays in `features/workflow-native-chat/` (`chatBindingModel`,
+`NativeChatFrame`, `NativeChatUnavailableState`, `useWorkflowChatBinding`).
+
+`native_ui.py` and `native_ui_compat.py` transforms were inventoried against the
+pinned `omnigent.server.v1` contract and all retained: bootstrap injection,
+scoped asset-URL rewriting, document/asset classification, version gating,
+security headers, and the route/transport allowlist remain load-bearing for the
+supported bundle. Removal criteria for any future deletion: the supported
+bundle demonstrably no longer needs the transform, the pinned contract fixture
+is updated in the same change, and no production caller remains. The
+method/route allowlist, ownership checks, expected-state checks, idempotency,
+secret scanning, header filtering, and bounds at the trusted boundary are never
+simplification targets.
+
+`embedded=1` is the presentation-only flag on the MoonMind-scoped `chatUrl`
+(§4) and is unrelated to the experimental embedded-host transport in #3955.
+
 ## 5. Workflow chat binding
 
 The Workflow Detail API exposes one authoritative binding for the session that the Chat route opens.

--- a/docs/tmp/WorkflowChat3956SimplificationDecision.md
+++ b/docs/tmp/WorkflowChat3956SimplificationDecision.md
@@ -1,0 +1,37 @@
+# Workflow Chat Upstream-Native Simplification Decision (MoonLadderStudios/MoonMind#3956)
+
+Execution note for PR #4085. Canonical target state lives in `docs/UI/WorkflowChatPanel.md`;
+this file preserves the issue-specific implementation history moved out of that
+canonical page per review feedback.
+
+## Correction to the parent epic
+
+The parent epic's duplication claim is corrected: `WorkflowChatNative` never
+reimplemented Omnigent's chat UI. The single ordinary interactive composer is
+the provider-maintained application mounted by `WorkflowNativeChatRoute`
+(Chat tab) through the server-issued, binding-scoped `chatUrl`; the Debug tab
+fallback (`WorkflowChatNative`) is a read-only diagnostic shell plus terminal
+workflow actions, not a second composer. No second composer was found on any
+reachable supported path, so none was removed; instead the duplicate
+fetch/iframe/readiness lifecycle in the fallback shell was deleted and the
+canonical behavior stays in `features/workflow-native-chat/` (`chatBindingModel`,
+`NativeChatFrame`, `NativeChatUnavailableState`, `useWorkflowChatBinding`).
+
+## Transform inventory
+
+`native_ui.py` and `native_ui_compat.py` transforms were inventoried against the
+pinned `omnigent.server.v1` contract and all retained: bootstrap injection,
+scoped asset-URL rewriting, document/asset classification, version gating,
+security headers, and the route/transport allowlist remain load-bearing for the
+supported bundle. Removal criteria for any future deletion: the supported
+bundle demonstrably no longer needs the transform, the pinned contract fixture
+is updated in the same change, and no production caller remains. The
+method/route allowlist, ownership checks, expected-state checks, idempotency,
+secret scanning, header filtering, and bounds at the trusted boundary are never
+simplification targets.
+
+## Flag clarification
+
+`embedded=1` is the presentation-only flag on the MoonMind-scoped `chatUrl`
+(WorkflowChatPanel §4) and is unrelated to the experimental embedded-host
+transport in #3955.

--- a/frontend/src/entrypoints/WorkflowChatNative.test.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.test.tsx
@@ -1,17 +1,20 @@
 /**
- * Tests for the native Omnigent Workflow Chat surface
- * (MoonLadderStudios/MoonMind#3638).
+ * Tests for the diagnostics fallback shell
+ * (MoonLadderStudios/MoonMind#3638 compatibility surface, #3641 terminal
+ * actions, simplified MoonLadderStudios/MoonMind#3956).
+ *
+ * The single interactive chat application is mounted by
+ * `WorkflowNativeChatRoute` (Chat tab); its live behavior — same-origin URL
+ * guards, readiness/timeout, retry, unavailable states — is covered by the
+ * `features/workflow-native-chat` suites. This suite pins the fallback shell:
+ * no fetch, no iframe, no second composer — only the read-only diagnostic
+ * projection plus terminal workflow actions.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 import { renderWithClient } from '../utils/test-utils';
-import {
-  WorkflowChatNative,
-  fullPageChatUrl,
-  type WorkflowChatBinding,
-} from './WorkflowChatNative';
-import { isNativeChatReadySignal, nativeChatFatalReason, NATIVE_CHAT_READY_TIMEOUT_MS } from '../features/workflow-native-chat/nativeChatProtocol';
+import { WorkflowChatNative } from './WorkflowChatNative';
 import {
   capturedEvidenceHref,
   type CapturedEvidence,
@@ -20,199 +23,6 @@ import {
 
 const API_BASE = '/api';
 const WORKFLOW_ID = 'mm:w1';
-const CHAT_URL = '/omnigent-ui/workflow-chat/chatb_opaque123?embedded=1';
-
-function bindingResponse(overrides: Partial<WorkflowChatBinding> = {}): WorkflowChatBinding {
-  return {
-    chatBindingId: 'chatb_opaque123',
-    workflowId: WORKFLOW_ID,
-    chatUrl: CHAT_URL,
-    apiBase: '/api/workflow-chat-bindings/chatb_opaque123/omnigent',
-    state: 'available',
-    readOnly: false,
-    capabilities: {},
-    ...overrides,
-  } as WorkflowChatBinding;
-}
-
-function mockFetch(body: WorkflowChatBinding | null, status = 200) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async () =>
-      ({
-        ok: status >= 200 && status < 300,
-        status,
-        json: async () => body,
-      }) as unknown as Response,
-    ),
-  );
-}
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-  vi.restoreAllMocks();
-});
-
-describe('fullPageChatUrl', () => {
-  it('drops only the embedded flag from the scoped chat url', () => {
-    expect(fullPageChatUrl(CHAT_URL)).toBe(
-      '/omnigent-ui/workflow-chat/chatb_opaque123',
-    );
-  });
-
-  it('keeps other query parameters and never points at the upstream server', () => {
-    expect(
-      fullPageChatUrl('/omnigent-ui/workflow-chat/x?embedded=1&foo=bar'),
-    ).toBe('/omnigent-ui/workflow-chat/x?foo=bar');
-  });
-});
-
-describe('WorkflowChatNative', () => {
-  it('embeds the native app in an iframe using the scoped chatUrl', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId, queryByText } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    const frame = await waitFor(() => getByTestId('workflow-native-chat-frame'));
-    expect(frame.getAttribute('src')).toBe(CHAT_URL);
-    // The legacy projection is not rendered once native chat is available (no
-    // second composer competing with the native UI).
-    expect(queryByText('legacy projection')).toBeNull();
-  });
-
-  it('offers an Open in Omnigent full-page link on the same scoped binding', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active />,
-    );
-
-    const link = await waitFor(() => getByTestId('workflow-native-chat-open'));
-    expect(link.getAttribute('href')).toBe(
-      '/omnigent-ui/workflow-chat/chatb_opaque123',
-    );
-    expect(link.getAttribute('href')).not.toContain('embedded');
-  });
-
-  it('falls back to the legacy projection when no native binding exists', async () => {
-    mockFetch(null, 404);
-    const { findByText, queryByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    expect(await findByText('legacy projection')).toBeTruthy();
-    expect(queryByTestId('workflow-native-chat-frame')).toBeNull();
-  });
-
-  it('shows the unavailable reason, a Retry, and still renders the fallback', async () => {
-    mockFetch(
-      bindingResponse({ state: 'unavailable', unavailableReason: 'native_ui_upstream_unavailable', chatUrl: '' }),
-    );
-    const { findByTestId, findByText } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    expect(await findByTestId('workflow-native-chat-unavailable')).toBeTruthy();
-    // The unavailable state is retryable, so a stable Retry action is offered.
-    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
-    expect(await findByText('legacy projection')).toBeTruthy();
-  });
-
-  it('surfaces a stable reason and Retry when the binding request is unreachable', async () => {
-    // A non-404 error makes fetchWorkflowChatBinding throw, so the query errors.
-    mockFetch(null, 500);
-    const { findByTestId, findByText } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    const unavailable = await findByTestId('workflow-native-chat-unavailable');
-    expect(unavailable.textContent).toContain('native_chat_binding_unreachable');
-    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
-    // Native failure still shows the read-only fallback rather than swapping in a
-    // behaviorally different interactive chat.
-    expect(await findByText('legacy projection')).toBeTruthy();
-  });
-
-  it('offers Retry while the native session is still starting', async () => {
-    mockFetch(bindingResponse({ state: 'starting', chatUrl: '' }));
-    const { findByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active />,
-    );
-
-    const unavailable = await findByTestId('workflow-native-chat-unavailable');
-    expect(unavailable.textContent).toContain('native_chat_session_starting');
-    expect(await findByTestId('workflow-native-chat-retry')).toBeTruthy();
-  });
-
-  it('does not offer Retry for a runtime that never had a native binding', async () => {
-    mockFetch(null, 404);
-    const { findByText, queryByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    // A clean 404 is a stable historical state: no unavailable banner, no Retry,
-    // just the read-only fallback projection.
-    expect(await findByText('legacy projection')).toBeTruthy();
-    expect(queryByTestId('workflow-native-chat-unavailable')).toBeNull();
-    expect(queryByTestId('workflow-native-chat-retry')).toBeNull();
-  });
-
-  it('refetches the binding and mounts native chat when Retry succeeds', async () => {
-    const fetchMock = vi
-      .fn()
-      // First attempt: upstream not reachable yet.
-      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => null } as unknown as Response)
-      // Retry: the native binding is now available.
-      .mockResolvedValue({ ok: true, status: 200, json: async () => bindingResponse() } as unknown as Response);
-    vi.stubGlobal('fetch', fetchMock);
-
-    const { findByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    const retry = await findByTestId('workflow-native-chat-retry');
-    fireEvent.click(retry);
-
-    const frame = await findByTestId('workflow-native-chat-frame');
-    expect(frame.getAttribute('src')).toBe(CHAT_URL);
-  });
-
-  it('does not fetch while the chat tab is inactive', () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
-    renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active={false}>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('does not show terminal actions for a non-terminal workflow even when read-only', async () => {
-    // A binding can be read-only while its workflow is still live; terminal
-    // actions are gated on the workflow being terminal, not on write capability.
-    mockFetch(bindingResponse({ readOnly: true }));
-    const { getByTestId, queryByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal={false} />,
-    );
-    await waitFor(() => getByTestId('workflow-native-chat-frame'));
-    expect(queryByTestId('workflow-native-chat-continue')).toBeNull();
-    expect(queryByTestId('workflow-native-chat-evidence-toggle')).toBeNull();
-  });
-});
 
 const EVIDENCE: CapturedEvidence = {
   workflowId: WORKFLOW_ID,
@@ -233,7 +43,6 @@ const CONTINUE_RESULT: ContinueInNewWorkflowResult = {
 };
 
 function mockFetchByUrl(handlers: {
-  binding: WorkflowChatBinding;
   evidence?: CapturedEvidence;
   continue?: ContinueInNewWorkflowResult;
 }) {
@@ -245,11 +54,64 @@ function mockFetchByUrl(handlers: {
     if (url.includes('/continue')) {
       return { ok: true, status: 201, json: async () => handlers.continue } as unknown as Response;
     }
-    return { ok: true, status: 200, json: async () => handlers.binding } as unknown as Response;
+    throw new Error(`unexpected fetch in fallback shell: ${url}`);
   });
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('WorkflowChatNative fallback shell (#3956)', () => {
+  it('renders the read-only diagnostic projection without fetching or mounting a frame', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { getByText, queryByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID}>
+        <div>legacy projection</div>
+      </WorkflowChatNative>,
+    );
+
+    expect(getByText('legacy projection')).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+    // No live native surface here: the Chat tab owns the single iframe.
+    expect(queryByTestId('workflow-native-chat-frame')).toBeNull();
+    expect(queryByTestId('workflow-native-chat-open')).toBeNull();
+    expect(queryByTestId('workflow-native-chat-unavailable')).toBeNull();
+  });
+
+  it('does not show terminal actions for a non-terminal workflow', () => {
+    const { queryByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal={false} />,
+    );
+    expect(queryByTestId('workflow-native-chat-continue')).toBeNull();
+    expect(queryByTestId('workflow-native-chat-evidence-toggle')).toBeNull();
+  });
+
+  it('shows View captured evidence and Continue for a terminal workflow', async () => {
+    mockFetchByUrl({});
+    const { getByTestId } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal />,
+    );
+    expect(getByTestId('workflow-native-chat-evidence-toggle')).toBeTruthy();
+    expect(getByTestId('workflow-native-chat-continue')).toBeTruthy();
+  });
+
+  it('keeps terminal actions alongside the diagnostic projection', async () => {
+    mockFetchByUrl({});
+    const { getByTestId, getByText } = renderWithClient(
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal>
+        <div>legacy projection</div>
+      </WorkflowChatNative>,
+    );
+    expect(getByText('legacy projection')).toBeTruthy();
+    expect(getByTestId('workflow-native-chat-evidence-toggle')).toBeTruthy();
+    expect(getByTestId('workflow-native-chat-continue')).toBeTruthy();
+  });
+});
 
 describe('capturedEvidenceHref', () => {
   it('routes a plain ref through the workflow-scoped evidence download endpoint', () => {
@@ -259,8 +121,6 @@ describe('capturedEvidenceHref', () => {
   });
 
   it('carries an Omnigent gateway ref (scheme + slashes) intact as a query param', () => {
-    // The generic /artifacts/{id}/download route cannot serve these; the ref is
-    // encoded so its scheme and nested path survive to the gateway-aware route.
     expect(
       capturedEvidenceHref('/api', WORKFLOW_ID, 'artifact://omnigent/corr-1/final.json'),
     ).toBe(
@@ -276,44 +136,11 @@ describe('capturedEvidenceHref', () => {
 });
 
 describe('WorkflowChatNative terminal actions (#3641)', () => {
-  it('shows View captured evidence and Continue for a terminal workflow', async () => {
-    mockFetchByUrl({ binding: bindingResponse({ state: 'ended', readOnly: true }) });
-    const { getByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal />,
-    );
-    await waitFor(() => getByTestId('workflow-native-chat-frame'));
-    expect(getByTestId('workflow-native-chat-evidence-toggle')).toBeTruthy();
-    expect(getByTestId('workflow-native-chat-continue')).toBeTruthy();
-  });
-
-  it('keeps terminal workflow actions available when the native iframe is unavailable', async () => {
-    // Terminal binding returned as state='unavailable' (native UI disabled / upstream
-    // unavailable): the workflow-level actions must still render in the fallback.
-    mockFetchByUrl({
-      binding: bindingResponse({
-        state: 'unavailable',
-        unavailableReason: 'native_ui_serving_disabled',
-        chatUrl: '',
-      }),
-    });
-    const { getByTestId, queryByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal>
-        <div>legacy projection</div>
-      </WorkflowChatNative>,
-    );
-    await waitFor(() => getByTestId('workflow-native-chat-unavailable'));
-    expect(getByTestId('workflow-native-chat-evidence-toggle')).toBeTruthy();
-    expect(getByTestId('workflow-native-chat-continue')).toBeTruthy();
-    // No live iframe in the fallback.
-    expect(queryByTestId('workflow-native-chat-frame')).toBeNull();
-  });
-
   it('opens captured evidence as authorized MoonMind download links', async () => {
-    mockFetchByUrl({ binding: bindingResponse({ state: 'ended', readOnly: true }), evidence: EVIDENCE });
+    mockFetchByUrl({ evidence: EVIDENCE });
     const { getByTestId, findAllByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal />,
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal />,
     );
-    await waitFor(() => getByTestId('workflow-native-chat-evidence-toggle'));
 
     fireEvent.click(getByTestId('workflow-native-chat-evidence-toggle'));
     const links = await findAllByTestId('workflow-native-chat-evidence-link');
@@ -327,29 +154,21 @@ describe('WorkflowChatNative terminal actions (#3641)', () => {
   });
 
   it('requires authored intent before launching a continuation', async () => {
-    const fetchMock = mockFetchByUrl({
-      binding: bindingResponse({ state: 'ended', readOnly: true }),
-      continue: CONTINUE_RESULT,
-    });
+    const fetchMock = mockFetchByUrl({ continue: CONTINUE_RESULT });
     const { getByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal />,
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal />,
     );
-    await waitFor(() => getByTestId('workflow-native-chat-continue'));
 
-    // Opening the action reveals an authoring form; it does not launch anything.
     fireEvent.click(getByTestId('workflow-native-chat-continue'));
     const submit = getByTestId('workflow-native-chat-continue-submit') as HTMLButtonElement;
-    // Submit is disabled until new instructions are authored (no accidental rerun).
     expect(submit.disabled).toBe(true);
     expect(
       fetchMock.mock.calls.some((call) => String(call[0]).includes('/continue')),
     ).toBe(false);
   });
 
-  it('continues into the linked workflow with authored intent and navigates to it', async () => {    const fetchMock = mockFetchByUrl({
-      binding: bindingResponse({ state: 'ended', readOnly: true }),
-      continue: CONTINUE_RESULT,
-    });
+  it('continues into the linked workflow with authored intent and navigates to it', async () => {
+    const fetchMock = mockFetchByUrl({ continue: CONTINUE_RESULT });
     const assign = vi.fn();
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -357,9 +176,8 @@ describe('WorkflowChatNative terminal actions (#3641)', () => {
     });
 
     const { getByTestId } = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal />,
+      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} terminal />,
     );
-    await waitFor(() => getByTestId('workflow-native-chat-continue'));
 
     fireEvent.click(getByTestId('workflow-native-chat-continue'));
     fireEvent.change(getByTestId('workflow-native-chat-continue-instructions'), {
@@ -379,185 +197,9 @@ describe('WorkflowChatNative terminal actions (#3641)', () => {
     expect(String(continueCall?.[0])).toContain(
       `/executions/${encodeURIComponent(WORKFLOW_ID)}/continue`,
     );
-    // The continuation is a POST Workflow action carrying the authored intent,
-    // not a native composer message.
     expect(continueCall?.[1]?.method).toBe('POST');
     const body = JSON.parse(String(continueCall?.[1]?.body));
     expect(body.instructions).toBe('Do the follow-up work');
     expect(typeof body.idempotencyKey).toBe('string');
-  });
-});
-
-describe('native chat signal validation (#4013 AC7/PLAN5)', () => {
-  it('accepts only the ready shape for the current binding', () => {
-    expect(
-      isNativeChatReadySignal(
-        { type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_opaque123' },
-        'chatb_opaque123',
-      ),
-    ).toBe(true);
-    expect(
-      isNativeChatReadySignal(
-        { type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_other' },
-        'chatb_opaque123',
-      ),
-    ).toBe(false);
-    expect(
-      isNativeChatReadySignal({ type: 'something-else', chatBindingId: 'chatb_opaque123' }, 'chatb_opaque123'),
-    ).toBe(false);
-    expect(isNativeChatReadySignal(null, 'chatb_opaque123')).toBe(false);
-  });
-
-  it('extracts a bounded fatal reason only for the current binding', () => {
-    expect(
-      nativeChatFatalReason(
-        { type: 'moonmind.omnigent.chat.fatal', chatBindingId: 'chatb_opaque123', reason: 'native_crash' },
-        'chatb_opaque123',
-      ),
-    ).toBe('native_crash');
-    expect(
-      nativeChatFatalReason(
-        { type: 'moonmind.omnigent.chat.fatal', chatBindingId: 'chatb_other', reason: 'native_crash' },
-        'chatb_opaque123',
-      ),
-    ).toBeNull();
-    expect(
-      nativeChatFatalReason(
-        { type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_opaque123' },
-        'chatb_opaque123',
-      ),
-    ).toBeNull();
-  });
-});
-
-describe('WorkflowChatNative readiness containment (#4013 AC7/AC8)', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  function postToChat(data: unknown, origin?: string) {
-    window.dispatchEvent(
-      new MessageEvent('message', {
-        data,
-        origin: origin ?? window.location.origin,
-        source: document.querySelector<HTMLIFrameElement>('[data-testid="workflow-native-chat-frame"]')?.contentWindow ?? null,
-      }),
-    );
-  }
-
-  // Fake timers must be armed before render so the readiness deadline itself
-  // runs on the fake clock; async RTL queries would deadlock on fake timers,
-  // so initial readiness is flushed with virtual time + sync queries instead.
-  async function renderLiveFrame(children?: React.ReactNode, terminal = false) {
-    vi.useFakeTimers();
-    const utils = renderWithClient(
-      <WorkflowChatNative apiBase={API_BASE} workflowId={WORKFLOW_ID} active terminal={terminal}>
-        {children}
-      </WorkflowChatNative>,
-    );
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-    });
-    utils.getByTestId('workflow-native-chat-frame');
-    return utils;
-  }
-
-  async function advance(ms: number) {
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(ms);
-    });
-  }
-
-  it('shows a bounded timeout with Retry and the read-only fallback when ready never arrives', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId, getByText, queryByTestId } = await renderLiveFrame(
-      <div>legacy projection</div>,
-    );
-
-    expect(queryByTestId('workflow-native-chat-timeout')).toBeNull();
-
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-
-    expect(getByTestId('workflow-native-chat-timeout')).toBeTruthy();
-    expect(getByTestId('workflow-native-chat-retry')).toBeTruthy();
-    // The iframe and the transcript fallback stay reachable (AC8).
-    expect(getByTestId('workflow-native-chat-frame')).toBeTruthy();
-    expect(getByText('legacy projection')).toBeTruthy();
-  });
-
-  it('a valid ready signal suppresses the timeout', async () => {
-    mockFetch(bindingResponse());
-    const { queryByTestId } = await renderLiveFrame();
-
-    await act(async () => {
-      postToChat({ type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_opaque123' });
-    });
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-
-    expect(queryByTestId('workflow-native-chat-timeout')).toBeNull();
-    expect(queryByTestId('workflow-native-chat-fatal')).toBeNull();
-    expect(queryByTestId('workflow-native-chat-frame')).not.toBeNull();
-  });
-
-  it('ignores ready signals from another origin or another binding', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId } = await renderLiveFrame(<div>legacy projection</div>);
-
-    await act(async () => {
-      postToChat(
-        { type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_opaque123' },
-        'https://evil.test',
-      );
-      postToChat({ type: 'moonmind.omnigent.chat.ready', chatBindingId: 'chatb_other' });
-    });
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-
-    expect(getByTestId('workflow-native-chat-timeout')).toBeTruthy();
-  });
-
-  it('a fatal signal shows the failure surface with Retry and the fallback', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId, getByText } = await renderLiveFrame(<div>legacy projection</div>);
-
-    await act(async () => {
-      postToChat({
-        type: 'moonmind.omnigent.chat.fatal',
-        chatBindingId: 'chatb_opaque123',
-        reason: 'native_crash',
-      });
-    });
-
-    const fatal = getByTestId('workflow-native-chat-fatal');
-    expect(fatal.textContent).toContain('native_crash');
-    expect(getByTestId('workflow-native-chat-retry')).toBeTruthy();
-    expect(getByText('legacy projection')).toBeTruthy();
-  });
-
-  it('Retry after a timeout remounts the frame and waits again', async () => {
-    mockFetch(bindingResponse());
-    const { getByTestId, queryByTestId } = await renderLiveFrame();
-
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-    expect(getByTestId('workflow-native-chat-timeout')).toBeTruthy();
-
-    fireEvent.click(getByTestId('workflow-native-chat-retry'));
-    // The retry clears the timeout banner and rearms the deadline.
-    expect(queryByTestId('workflow-native-chat-timeout')).toBeNull();
-    expect(getByTestId('workflow-native-chat-frame')).toBeTruthy();
-
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-    expect(getByTestId('workflow-native-chat-timeout')).toBeTruthy();
-  });
-
-  it('keeps terminal workflow actions available while the native frame times out', async () => {
-    mockFetchByUrl({ binding: bindingResponse({ state: 'ended', readOnly: true }) });
-    const { getByTestId } = await renderLiveFrame(undefined, true);
-
-    await advance(NATIVE_CHAT_READY_TIMEOUT_MS + 1);
-
-    expect(getByTestId('workflow-native-chat-timeout')).toBeTruthy();
-    // Terminal evidence and continuation survive the native failure (AC8).
-    expect(getByTestId('workflow-native-chat-evidence-toggle')).toBeTruthy();
-    expect(getByTestId('workflow-native-chat-continue')).toBeTruthy();
   });
 });

--- a/frontend/src/entrypoints/WorkflowChatNative.tsx
+++ b/frontend/src/entrypoints/WorkflowChatNative.tsx
@@ -1,319 +1,47 @@
 /**
- * Native Omnigent Workflow Chat surface (MoonLadderStudios/MoonMind#3638,
- * terminal read-only + continuation MoonLadderStudios/MoonMind#3641).
+ * Diagnostics fallback shell for the Workflow Detail Debug tab
+ * (MoonLadderStudios/MoonMind#3638 compatibility surface, #3641 terminal
+ * actions, simplified MoonLadderStudios/MoonMind#3956).
  *
- * Renders the provider-maintained native Omnigent web application inside the
- * Workflow Detail chat region through the MoonMind-scoped, binding-scoped route
- * (`chatUrl`, e.g. `/omnigent-ui/workflow-chat/{chatBindingId}?embedded=1`)
- * rather than a copied MoonMind chat projection. When no native binding is
- * available it renders its `children` — the legacy read-only compatibility
- * projection — so there is never a second ordinary composer competing with the
- * native UI (docs/UI/WorkflowChatPanel.md §4, §11).
+ * The single interactive chat application is the provider-maintained native
+ * Omnigent UI mounted by `WorkflowNativeChatRoute` (Chat tab) through the
+ * server-issued, binding-scoped `chatUrl`. This module owns no iframe, no
+ * binding fetch, no readiness lifecycle, and no composer: it renders the
+ * read-only diagnostic `children` projection plus the terminal workflow actions
+ * (captured evidence + explicit linked continuation), which must stay visible
+ * after host cleanup without recreating a session.
  *
- * For a terminal (read-only) session the native transcript stays inspectable and
- * the context bar links to **View captured evidence** (immutable MoonMind
- * artifacts) and offers **Continue in a new workflow** — an explicit, authorized
- * Workflow action that creates a linked Workflow Execution from pinned source
- * identity and evidence. It never posts a message through the native composer and
- * never routes through `SubmitChatInstruction` (docs/UI/WorkflowChatPanel.md §9,
- * §10).
- *
- * The browser only ever uses the server-generated `chatUrl`/`apiBase`; it never
- * authors an upstream endpoint, provider session id, credential, or source run.
+ * Canonical live behavior (same-origin URL guards, readiness/timeout, retry,
+ * unavailable states) lives in
+ * `features/workflow-native-chat/` (`chatBindingModel`, `NativeChatFrame`,
+ * `NativeChatUnavailableState`, `useWorkflowChatBinding`). Do not reintroduce a
+ * second fetch/postMessage/iframe path here.
  */
-import React, { useEffect, useRef, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import React from 'react';
 
-import type { components } from '../generated/openapi';
 import { WorkflowTerminalChatActions } from '../features/workflow-native-chat/WorkflowTerminalChatActions';
-import { isNativeChatReadySignal, nativeChatFatalReason, NATIVE_CHAT_READY_TIMEOUT_MS } from '../features/workflow-native-chat/nativeChatProtocol';
-
-export type WorkflowChatBinding = components['schemas']['WorkflowChatBinding'];
-
-function joinApiPath(apiBase: string, path: string): string {
-  const base = (apiBase || '/api').replace(/\/+$/, '');
-  const suffix = path.startsWith('/') ? path : `/${path}`;
-  return `${base}${suffix}`;
-}
-
-export async function fetchWorkflowChatBinding(
-  apiBase: string,
-  workflowId: string,
-): Promise<WorkflowChatBinding | null> {
-  const resp = await fetch(
-    joinApiPath(apiBase, `/executions/${encodeURIComponent(workflowId)}/chat-binding`),
-    { credentials: 'include' },
-  );
-  if (!resp.ok) {
-    if (resp.status === 404) return null;
-    throw new Error(`workflow chat binding request failed (${resp.status})`);
-  }
-  return (await resp.json()) as WorkflowChatBinding;
-}
-
-/**
- * Return the authorized full-page **Open in Omnigent** URL for a `chatUrl`.
- *
- * The full-page surface uses the same MoonMind-scoped binding — it drops only
- * the `embedded=1` presentation flag. It never navigates directly to the
- * upstream Omnigent server, so no second login is required and no provider id is
- * exposed (docs/UI/WorkflowChatPanel.md §4).
- */
-export function fullPageChatUrl(chatUrl: string): string {
-  if (!chatUrl) return chatUrl;
-  const questionIndex = chatUrl.indexOf('?');
-  if (questionIndex === -1) return chatUrl;
-  const path = chatUrl.slice(0, questionIndex);
-  const params = new URLSearchParams(chatUrl.slice(questionIndex + 1));
-  params.delete('embedded');
-  const rest = params.toString();
-  return rest ? `${path}?${rest}` : path;
-}
-
-type NativeChatStatus = 'loading' | 'ready' | 'timeout' | 'fatal';
-
-function hasLiveNativeChat(binding: WorkflowChatBinding | null | undefined): boolean {
-  return Boolean(
-    binding && binding.chatUrl && binding.state !== 'unavailable',
-  );
-}
-
-/** Live native chat rendering (hooks-safe: always mounted for the live case). */
-function NativeChatLive({
-  binding,
-  apiBase,
-  workflowId,
-  terminal,
-  children,
-}: {
-  binding: WorkflowChatBinding;
-  apiBase: string;
-  workflowId: string;
-  terminal: boolean;
-  children?: React.ReactNode;
-}): React.ReactElement {
-  const openUrl = fullPageChatUrl(binding.chatUrl);
-  const frameRef = useRef<HTMLIFrameElement | null>(null);
-  const generationRef = useRef(0);
-  const [status, setStatus] = useState<NativeChatStatus>('loading');
-  const [fatalReason, setFatalReason] = useState<string | null>(null);
-  // Remount the iframe on bounded retry so a crashed frame is replaced while
-  // the mount generation guard keeps stale signals from the old frame out.
-  const [retryCount, setRetryCount] = useState(0);
-
-  useEffect(() => {
-    generationRef.current += 1;
-    const generation = generationRef.current;
-    setStatus('loading');
-    setFatalReason(null);
-
-    const onMessage = (event: MessageEvent) => {
-      // Exact-origin check first: cross-origin frames can never mark chat
-      // ready or failed.
-      if (event.origin !== window.location.origin) return;
-      // The signal must come from the currently mounted iframe window.
-      const frameWindow = frameRef.current?.contentWindow;
-      if (!frameWindow || event.source !== frameWindow) {
-        return;
-      }
-      // Stale signals from a replaced binding/mount are ignored.
-      if (generationRef.current !== generation) return;
-      if (isNativeChatReadySignal(event.data, binding.chatBindingId)) {
-        // A late ready still clears a prior timeout: the application rendered.
-        setStatus('ready');
-        return;
-      }
-      const fatal = nativeChatFatalReason(event.data, binding.chatBindingId);
-      if (fatal !== null) {
-        setFatalReason(fatal);
-        setStatus('fatal');
-      }
-    };
-    window.addEventListener('message', onMessage);
-    const timer = window.setTimeout(() => {
-      if (generationRef.current !== generation) return;
-      setStatus((current) => (current === 'loading' ? 'timeout' : current));
-    }, NATIVE_CHAT_READY_TIMEOUT_MS);
-    return () => {
-      window.removeEventListener('message', onMessage);
-      window.clearTimeout(timer);
-    };
-    // Re-run only when the authorized binding (or a bounded retry) changes.
-  }, [binding.chatBindingId, binding.chatUrl, retryCount]);
-
-  const showRecovery = status === 'timeout' || status === 'fatal';
-  const reason = status === 'fatal' ? (fatalReason ?? 'native_crash') : 'native_chat_not_ready';
-
-  return (
-    <div className="stack td-native-chat" data-testid="workflow-native-chat">
-      <div className="td-native-chat-actions">
-        {terminal ? (
-          <span className="small td-native-chat-readonly">
-            This session is read-only.
-          </span>
-        ) : null}
-        <a
-          className="button secondary"
-          href={openUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="workflow-native-chat-open"
-        >
-          Open in Omnigent
-        </a>
-      </div>
-      {terminal ? (
-        <WorkflowTerminalChatActions apiBase={apiBase} workflowId={workflowId} />
-      ) : null}
-      {showRecovery ? (
-        <div
-          className="td-native-chat-unavailable"
-          data-testid={
-            status === 'fatal'
-              ? 'workflow-native-chat-fatal'
-              : 'workflow-native-chat-timeout'
-          }
-        >
-          <p className="small">
-            {status === 'fatal'
-              ? `Native chat reported a failure: ${reason}.`
-              : 'Native chat is taking too long to become ready.'}{' '}
-            The conversation transcript below remains available.
-          </p>
-          <div className="button-group td-native-chat-actions">
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => {
-                setRetryCount((count) => count + 1);
-              }}
-              data-testid="workflow-native-chat-retry"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
-      ) : null}
-      <iframe
-        ref={frameRef}
-        key={`${binding.chatBindingId}:${retryCount}`}
-        title="Workflow chat"
-        src={binding.chatUrl}
-        className="td-native-chat-frame"
-        data-testid="workflow-native-chat-frame"
-      />
-      {showRecovery ? children : null}
-    </div>
-  );
-}
 
 export interface WorkflowChatNativeProps {
   apiBase: string;
   workflowId: string;
-  /** Only fetch/render while the Chat tab is active. */
-  active: boolean;
   /**
    * Whether the Workflow Execution is terminal, from the authoritative execution
    * status. Gates the terminal workflow actions (captured evidence + continue)
-   * independently of the chat binding's write capability or native-iframe
-   * availability, so a terminal workflow always exposes them (#3641 §9, §10).
+   * so a terminal workflow always exposes them (#3641 §9, §10).
    */
   terminal?: boolean;
-  /** Legacy read-only compatibility projection: shown when no native UI is
-   * available, and again below the iframe when a live mount reports a timeout
-   * or fatal failure, so recovery never hides terminal evidence (#4013 AC8). */
+  /** Read-only diagnostic/compatibility projection; never a second composer. */
   children?: React.ReactNode;
 }
 
 export function WorkflowChatNative({
   apiBase,
   workflowId,
-  active,
   terminal = false,
   children,
-}: WorkflowChatNativeProps): React.ReactElement | null {
-  const query = useQuery({
-    queryKey: ['workflow-chat-binding', workflowId],
-    queryFn: () => fetchWorkflowChatBinding(apiBase, workflowId),
-    enabled: active && Boolean(workflowId),
-    staleTime: 15_000,
-    retry: false,
-  });
-
-  const binding = query.data ?? null;
-
-  // While the binding is still resolving (and nothing cached yet), show the
-  // legacy projection to avoid a blank flash.
-  if (query.isLoading && !binding) {
-    return <>{children}</>;
-  }
-
-  if (hasLiveNativeChat(binding) && binding) {
-    return (
-      <NativeChatLive
-        binding={binding}
-        apiBase={apiBase}
-        workflowId={workflowId}
-        terminal={terminal}
-      >
-        {children}
-      </NativeChatLive>
-    );
-  }
-
-  // Native UI is unavailable for this workflow: surface the stable reason, a
-  // Retry when the condition is retryable, and an authorized full-page escape
-  // hatch when one exists, then fall back to the read-only diagnostic and
-  // compatibility projection (docs/UI/WorkflowChatPanel.md §11,
-  // MoonLadderStudios/MoonMind#3640).
-  //
-  // The fallback never becomes a behaviorally different interactive chat: the
-  // `children` projection is read-only, so native failure does not silently swap
-  // in a second composer. A terminal workflow still exposes its workflow-level
-  // actions here — the captured-evidence and continuation controls must not
-  // disappear just because the native iframe is unavailable (#3641 §10).
-  const unavailableReason = query.isError
-    ? 'native_chat_binding_unreachable'
-    : binding?.unavailableReason
-      ?? (binding?.state === 'starting' ? 'native_chat_session_starting' : undefined);
-  const retryable =
-    query.isError || binding?.state === 'starting' || binding?.state === 'unavailable';
-  const escapeHatch =
-    binding && binding.chatUrl ? fullPageChatUrl(binding.chatUrl) : null;
+}: WorkflowChatNativeProps): React.ReactElement {
   return (
     <>
-      {unavailableReason || retryable ? (
-        <div className="td-native-chat-unavailable" data-testid="workflow-native-chat-unavailable">
-          <p className="small">
-            Native chat is unavailable{unavailableReason ? `: ${unavailableReason}` : '.'}
-          </p>
-          <div className="button-group td-native-chat-actions">
-            {retryable ? (
-              <button
-                type="button"
-                className="secondary"
-                onClick={() => {
-                  void query.refetch();
-                }}
-                data-testid="workflow-native-chat-retry"
-              >
-                Retry
-              </button>
-            ) : null}
-            {escapeHatch ? (
-              <a
-                className="button secondary"
-                href={escapeHatch}
-                target="_blank"
-                rel="noopener noreferrer"
-                data-testid="workflow-native-chat-open"
-              >
-                Open in Omnigent
-              </a>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
       {terminal ? (
         <WorkflowTerminalChatActions apiBase={apiBase} workflowId={workflowId} />
       ) : null}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -10282,7 +10282,6 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
               <WorkflowChatNative
                 apiBase={payload.apiBase}
                 workflowId={execution.workflowId || execution.taskId || ''}
-                active={chatTabActive}
                 terminal={isTerminalExecution}
               >
                 <WorkflowChatDiagnostics

--- a/tests/unit/omnigent/test_workflow_chat_3956_boundary.py
+++ b/tests/unit/omnigent/test_workflow_chat_3956_boundary.py
@@ -1,0 +1,100 @@
+"""MoonLadderStudios/MoonMind#3956: upstream-native boundary composition pin.
+
+The facade, compat map, outbound scan, and terminal-evidence behaviors each have
+dedicated suites. This module pins their #3956 composition in one hermetic
+place: unknown routes/transports fail closed before any mutation, terminal
+state denies mutation authority, changed-content retries cannot reuse a scan
+allowance, secret blocks redact values, and the `embedded=1` presentation flag
+stays distinct from the experimental embedded-host transport (#3955).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent import native_ui_compat as compat
+from moonmind.omnigent.native_outbound_scan import (
+    NativeScanBlockedError,
+    NativeScanSurface,
+    canonical_payload_digest,
+    scan_native_outbound,
+)
+from moonmind.omnigent.workflow_chat_facade import (
+    CODE_ROUTE_NOT_ALLOWLISTED,
+    CODE_SESSION_READ_ONLY,
+    is_read_only,
+    match_facade_operation,
+    recompute_capabilities,
+)
+
+
+def test_unknown_route_and_unknown_transport_fail_closed() -> None:
+    assert match_facade_operation("GET", "v1/sessions/x/admin/backdoor") is None
+    assert match_facade_operation("DELETE", "v1/sessions") is None
+    assert compat.classify_native_ui_http("GET", "v1/sessions/x/admin/backdoor") is None
+    assert compat.classify_native_ui_websocket("v1/global/secret-stream") is None
+    assert CODE_ROUTE_NOT_ALLOWLISTED == "omnigent_chat_route_not_allowlisted"
+
+
+def test_unsupported_websocket_subprotocol_is_rejected() -> None:
+    with pytest.raises(Exception):
+        compat.negotiate_ws_subprotocol(["evil-protocol"])
+
+
+def test_terminal_state_denies_mutation_capability() -> None:
+    assert is_read_only("completed")
+    assert is_read_only("failed")
+    assert is_read_only("stopped")
+    assert not is_read_only("active")
+    caps = recompute_capabilities(status="completed")
+    assert caps["sendMessage"] is False
+    assert caps["interruptTurn"] is False
+    assert caps["viewTranscript"] is True
+    assert CODE_SESSION_READ_ONLY == "omnigent_chat_session_read_only"
+
+
+def _text_body(text: str) -> dict:
+    return {
+        "type": "message",
+        "data": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+def test_changed_content_retry_cannot_reuse_scan_allowance() -> None:
+    first = _text_body("hello world")
+    changed = _text_body("hello world!")
+    assert canonical_payload_digest(first) != canonical_payload_digest(changed)
+    allow = scan_native_outbound(
+        surface=NativeScanSurface.MESSAGE,
+        body=first,
+        high_security_mode=False,
+    )
+    assert allow.allowed is True
+    # The allow evidence is digest-bound to the exact first payload.
+    assert allow.payload_digest == canonical_payload_digest(first)
+    assert allow.payload_digest != canonical_payload_digest(changed)
+
+
+def test_secret_block_redacts_values_and_reports_location_only() -> None:
+    body = _text_body("deploy with ghp_" + "a" * 36 + " now")
+    with pytest.raises(NativeScanBlockedError) as excinfo:
+        scan_native_outbound(
+            surface=NativeScanSurface.MESSAGE,
+            body=body,
+            high_security_mode=True,
+        )
+    metadata = excinfo.value.evidence.audit_metadata()
+    dumped = str(metadata)
+    assert "ghp_" not in dumped
+    assert "findingLocations" in metadata or "findingCategories" in metadata
+    assert excinfo.value.evidence.allowed is False
+
+
+def test_embedded_presentation_flag_is_not_embedded_host_transport() -> None:
+    # `embedded=1` is a presentation query flag on the MoonMind-scoped chatUrl
+    # (docs/UI/WorkflowChatPanel.md §4); the experimental embedded-host channel
+    # in #3955 is a separate transport negotiated elsewhere. The compat map must
+    # not contain a route keyed on the presentation flag.
+    cmap = compat.compatibility_map()
+    serialized = str(cmap)
+    assert "embedded=1" not in serialized


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#3956: simplifies the upstream-native Workflow Chat integration while preserving the MoonMind security facade.

- `frontend/src/entrypoints/WorkflowChatNative.tsx`: deleted the duplicate fetch/iframe/readiness lifecycle (-272 lines) from the Debug-tab fallback shell; it now renders only children plus terminal-evidence actions. The single interactive composer remains upstream Omnigent via the canonical iframe in `NativeChatFrame.tsx`.
- `frontend/src/entrypoints/workflow-detail.tsx`: removed the now-obsolete prop caller; canonical binding hook (`useWorkflowChatBinding.ts`) retained.
- `frontend/src/entrypoints/WorkflowChatNative.test.tsx`: rewritten to pin the simplified shell (no-fetch/no-frame, terminal actions, evidence hrefs).
- `tests/unit/omnigent/test_workflow_chat_3956_boundary.py`: new boundary test pinning deny-by-default facade (unknown route / unsupported transport fail closed, terminal capability denial, digest-bound retry) and outbound-scan redaction.
- `docs/UI/WorkflowChatPanel.md` §4.2: decision record correcting the parent-epic duplication claim, listing retained compat needs and removal criteria, and distinguishing the `embedded=1` presentation flag from the #3955 transport.
- `native_ui.py`/`native_ui_compat.py` intentionally untouched: method/route allowlisting, ownership checks, expected-state checks, idempotency, secret scanning, header filtering, and bounds stay at the trusted boundary.

## Verification outcome

moonspec-verify verdict: **FULLY_IMPLEMENTED** (medium confidence) — all 8 issue requirements VERIFIED against candidate head `2dd76f0`.

## Tests run

- `bash tools/test_unit.sh --dashboard-only --ui-args --run frontend/src/entrypoints/WorkflowChatNative.test.tsx` — PASS (10/10)
- `bash tools/test_unit.sh --dashboard-only --ui-args --run frontend/src/features/workflow-native-chat frontend/src/entrypoints/workflow-detail.test.tsx` — PASS (231/231)
- `pytest tests/unit/omnigent/test_workflow_chat_3956_boundary.py` (plus facade/scan/compat suites) — NOT RUN in sandbox (no pytest module, offline proxy, container backend requires a managed workflow); all assertions statically verified line-by-line against production source. HEAD touches no production Python, so CI should execute this suite.

## Remaining risks

- Low: Python boundary test executes only in CI; implementation was source-inspected but not executed here.
- Pre-existing `test_native_ui.py` / `test_native_ui_compat.py` suites unchanged by this diff and not executed in sandbox; covered by required CI.

Closes MoonLadderStudios/MoonMind#3956