### PR TITLE
Preserve executable bits when restoring Omnigent checkpoints

### DIFF
--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -14,7 +14,7 @@ with the run rather than rewriting it after registry or credential changes.
 **Document Class:** Canonical declarative  
 **Status:** Current  
 **Owners:** MoonMind Platform  
-**Last updated:** 2026-08-17
+**Last updated:** 2026-09-07
 **Authority:** Unified Temporal lifecycle and ownership model for true agent execution, including profile-bound Codex execution through Omnigent hosts
 
 Implementation progress belongs in the roadmap, issues, and pull requests. This document defines durable product and runtime contracts.
@@ -814,8 +814,11 @@ Checkpoint capabilities remain distinct:
 
 Omnigent checkpoint extraction assigns restored files and their containing
 directories to the selected runtime identity before launch. Archive ownership is
-not runtime authority. Restored modes remain intact, and newly injected input
-artifacts retain their read-only projection contract.
+not runtime authority. Restore preserves ordinary executable bits so scripts
+remain runnable and unchanged Git candidates remain clean. Regular-file
+read/write access is owner-only; privilege bits and imported hooks are removed.
+Failure to apply these permissions aborts restore before readiness. Newly
+injected input artifacts retain their read-only projection contract.
 
 A session-state ref is not evidence of workspace capture or restore. `external_state_ref` can preserve Omnigent/provider continuity without being locally restorable.
 

--- a/moonmind/omnigent/workspace_artifacts.py
+++ b/moonmind/omnigent/workspace_artifacts.py
@@ -972,13 +972,14 @@ class WorkspaceArtifactProjector:
                             "archive member is sparse, truncated, or oversized",
                             "OMNIGENT_WORKSPACE_MATERIALIZATION_FAILED",
                         )
-                    # Normalize privileged metadata; content stays as data.
-                    try:
-                        os.chmod(target, 0o600, follow_symlinks=False)
-                    except OSError:
-                        # Mode normalization is best-effort: extraction
-                        # already created the file with restrictive bits.
-                        pass
+                    # Preserve ordinary executable bits: stripping them dirties
+                    # Git checkouts and breaks restored scripts before launch.
+                    # Keep read/write access owner-only and drop privilege bits;
+                    # imported hooks are removed before the tree is promoted.
+                    # A chmod failure must abort restore, never mark it ready.
+                    os.chmod(
+                        target, 0o600 | (member.mode & 0o111), follow_symlinks=False
+                    )
                 elif member.isdir():
                     target.mkdir(parents=True, exist_ok=True)
                 elif member.issym() or member.islnk():

--- a/tests/integration/reliability_journey/test_omnigent_checkpoint_ownership_journey.py
+++ b/tests/integration/reliability_journey/test_omnigent_checkpoint_ownership_journey.py
@@ -37,6 +37,11 @@ async def test_runtime_can_publish_beside_restored_verifier(
         member = tarfile.TarInfo("artifacts/verify.json")
         member.size = len(data)
         bundle.addfile(member, io.BytesIO(data))
+        script = b"#!/bin/sh\nprintf 'restored executable works\\n'\n"
+        member = tarfile.TarInfo("tools/verify.sh")
+        member.mode = 0o755
+        member.size = len(script)
+        bundle.addfile(member, io.BytesIO(script))
 
     class Artifacts:
         async def get_metadata(self, **_kwargs):
@@ -82,3 +87,13 @@ async def test_runtime_can_publish_beside_restored_verifier(
     )
     assert (workspace / "artifacts/pr.json").stat().st_uid == 1000
     assert (workspace / "artifacts/verify.json").read_bytes() == data
+    executed = subprocess.run(
+        [str(workspace / "tools/verify.sh")],
+        cwd=workspace,
+        user=1000,
+        group=1000,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert executed.stdout == "restored executable works\n"

--- a/tests/unit/omnigent/fixtures/checkpoint-executable-publication.json
+++ b/tests/unit/omnigent/fixtures/checkpoint-executable-publication.json
@@ -1,0 +1,33 @@
+{
+  "sourceWorkflowId": "mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T23:40:00Z",
+  "stepExecutionId": "tpl:github-issue-search-and-implement:08:094d273f:execution:1",
+  "request": {
+    "agentKind": "external",
+    "agentId": "omnigent",
+    "instructionRef": "Publish the verified candidate pull request.",
+    "workspaceSpec": {
+      "repository": "MoonLadderStudios/MoonMind",
+      "startingBranch": "main",
+      "branch": "moonmind-job-8372248e",
+      "workspaceCheckpointRestoreRef": "artifact://checkpoint"
+    },
+    "parameters": {
+      "publishMode": "pr",
+      "acceptedPublishedHead": {
+        "workflowId": "mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T23:40:00Z",
+        "repository": "MoonLadderStudios/MoonMind",
+        "branch": "moonmind-job-8372248e"
+      }
+    }
+  },
+  "pullRequest": {
+    "number": 4085,
+    "html_url": "https://github.com/MoonLadderStudios/MoonMind/pull/4085",
+    "draft": false,
+    "head": {
+      "ref": "moonmind-job-8372248e",
+      "repo": {"full_name": "MoonLadderStudios/MoonMind"}
+    },
+    "base": {"ref": "main"}
+  }
+}

--- a/tests/unit/omnigent/test_workspace_publication_base.py
+++ b/tests/unit/omnigent/test_workspace_publication_base.py
@@ -4,19 +4,23 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from moonmind.config.settings import settings
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
 from moonmind.omnigent.workspace_publication import OmnigentWorkspacePublicationService
 from moonmind.publish.service import PublishService
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.activity_runtime import TemporalSandboxActivities
 from moonmind.workflows.temporal.runtime.workspace_locators import (
     SandboxWorkspaceRecord,
     SandboxWorkspaceRecordStore,
@@ -27,6 +31,119 @@ def git(*args: str, cwd: Path) -> str:
     return subprocess.run(
         ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
     ).stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_restore_preserves_accepted_pr_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replay capture -> restore -> exact remote PR discovery, including retry."""
+    replay = json.loads(
+        (Path(__file__).parent / "fixtures/checkpoint-executable-publication.json")
+        .read_text()
+    )
+    monkeypatch.setattr(settings.security, "high_security_mode", False)
+    for prefix in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{prefix}_NAME", "Test")
+        monkeypatch.setenv(f"GIT_{prefix}_EMAIL", "test@example.invalid")
+    monkeypatch.setattr(
+        "moonmind.omnigent.workspace_publication.resolve_github_credential",
+        AsyncMock(return_value=SimpleNamespace(token="fixture-credential")),
+    )
+    source = tmp_path / "source"
+    source.mkdir()
+    origin = tmp_path / "origin.git"
+    git("init", "--bare", "--initial-branch=main", str(origin), cwd=tmp_path)
+    git("init", "--initial-branch=main", cwd=source)
+    (source / ".gitignore").write_text("artifacts/\n.moonmind/\n")
+    (source / "run.sh").write_text("#!/bin/sh\nprintf 'candidate works\\n'\n")
+    (source / "run.sh").chmod(0o755)
+    (source / "work.txt").write_text("base\n")
+    git("add", ".", cwd=source)
+    git("commit", "-m", "base", cwd=source)
+    git("remote", "add", "origin", str(origin), cwd=source)
+    git("push", "origin", "main", cwd=source)
+    candidate = replay["pullRequest"]["head"]["ref"]
+    git("checkout", "-b", candidate, cwd=source)
+    (source / "work.txt").write_text("completed work\n")
+    git("commit", "-am", "candidate", cwd=source)
+    head_sha = git("rev-parse", "HEAD", cwd=source)
+    git("push", "origin", candidate, cwd=source)
+    archive, _ = TemporalSandboxActivities(workspace_root=tmp_path)._build_worktree_archive(
+        source
+    )
+
+    class Artifacts:
+        async def get_metadata(self, **_kwargs):
+            return SimpleNamespace(size_bytes=len(archive)), []
+
+        async def read_chunks(self, **_kwargs):
+            return SimpleNamespace(), iter((archive,))
+
+    workflow_id, step_id = replay["sourceWorkflowId"], replay["stepExecutionId"]
+    workspace_id = hashlib.sha256(f"{workflow_id}:{step_id}".encode()).hexdigest()[:24]
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    workspace.parent.mkdir(parents=True)
+    git("clone", "--branch", candidate, str(origin), str(workspace), cwd=tmp_path)
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(workspace_id, workflow_id, step_id, "repo")
+    )
+    payload = replay["request"]
+    payload.update(correlationId=workflow_id, idempotencyKey=step_id)
+    payload["parameters"]["acceptedPublishedHead"]["headSha"] = head_sha
+    payload["workspaceSpec"]["workspaceLocator"] = {
+        "kind": "sandbox", "workspaceId": workspace_id, "relativePath": "repo"
+    }
+    request = AgentExecutionRequest.model_validate(payload)
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=AsyncMock(side_effect=AssertionError("must reuse checkout")),
+        workspace_root=tmp_path,
+        artifact_service=Artifacts(),
+    )
+    await materializer.materialize(
+        request, runtime_uid=os.getuid(), runtime_gid=os.getgid()
+    )
+    assert git("status", "--porcelain", cwd=workspace) == ""
+    assert subprocess.run(
+        [str(workspace / "run.sh")], check=True, capture_output=True, text=True
+    ).stdout == "candidate works\n"
+    assert not (workspace / "work.txt").stat().st_mode & 0o111
+
+    # The agent created this PR before the trusted publisher inspected the
+    # restored workspace. Exercise the real selector against its HTTP contract.
+    pull_request = replay["pullRequest"]
+    pull_request["head"]["sha"] = head_sha
+    lookups = []
+
+    def github(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/repos/MoonLadderStudios/MoonMind/pulls"
+        lookups.append(request.url.params["head"])
+        return httpx.Response(200, json=[pull_request])
+
+    client = httpx.AsyncClient
+    monkeypatch.setattr(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        lambda **kwargs: client(transport=httpx.MockTransport(github), **kwargs),
+    )
+    publisher = OmnigentWorkspacePublicationService(tmp_path)
+    for _attempt in range(2):
+        evidence = await publisher.publish_request_workspace(
+            request=request,
+            current_workflow_id=workflow_id,
+            current_step_execution_id=step_id,
+        )
+        assert evidence["pull_request_url"] == pull_request["html_url"]
+        assert evidence["push_branch"] == candidate
+        assert evidence["push_head_sha"] == head_sha
+        assert evidence["push_commit_count"] == 1
+        assert evidence["remote_verified"] is True
+        assert git("status", "--porcelain", cwd=workspace) == ""
+        assert git("rev-parse", "HEAD", cwd=workspace) == head_sha
+    assert lookups == [f"MoonLadderStudios:{candidate}"] * 2
+    assert git("branch", "--format=%(refname:short)", cwd=origin).splitlines() == [
+        "main", candidate
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_workspace_safe_sources.py
+++ b/tests/unit/omnigent/test_workspace_safe_sources.py
@@ -843,6 +843,70 @@ async def test_restored_git_is_usable_without_imported_authority(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("historical", [False, True])
+async def test_restore_preserves_execution_without_privileged_permissions(
+    tmp_path, historical
+):
+    archive = io.BytesIO()
+    modes = {"run.sh": 0o755, "data.txt": 0o644, "privileged.sh": 0o6777}
+    with tarfile.open(fileobj=archive, mode="w:gz") as bundle:
+        for name, mode in {**modes, ".git/hooks/pre-commit": 0o755}.items():
+            member = tarfile.TarInfo(name)
+            member.mode = mode
+            member.size = 2
+            bundle.addfile(member, io.BytesIO(b"ok"))
+    payload = archive.getvalue()
+    workspace_id = _workspace_id()
+    spec = (
+        _locator_spec(workspace_id, workspaceCheckpointRestoreRef="artifact://checkpoint")
+        if historical
+        else _authored_checkpoint_spec(workspace_id, payload)
+    )
+    await OmnigentWorkspaceMaterializer(
+        command_runner=_never_clone,
+        workspace_root=tmp_path,
+        artifact_service=FakeArtifactService({"checkpoint": payload}),
+    ).materialize(
+        _request(spec), runtime_uid=os.getuid(), runtime_gid=os.getgid()
+    )
+    workspace = tmp_path / "temporal_sandbox" / workspace_id / "repo"
+    for name, mode in modes.items():
+        restored_mode = (workspace / name).stat().st_mode
+        assert restored_mode & 0o111 == mode & 0o111
+        assert restored_mode & 0o666 == 0o600
+        assert restored_mode & 0o7000 == 0
+        assert (workspace / name).read_bytes() == b"ok"
+    assert not (workspace / ".git/hooks/pre-commit").exists()
+
+
+@pytest.mark.asyncio
+async def test_restore_permission_failure_does_not_promote_checkpoint(
+    tmp_path, monkeypatch
+):
+    payload = _tar_bytes([("run.sh", b"#!/bin/sh\n", "file")])
+    projector = WorkspaceArtifactProjector(FakeArtifactService({"checkpoint": payload}))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "existing.txt").write_text("preserve current workspace")
+
+    def fail_chmod(*_args, **_kwargs):
+        raise PermissionError("cannot apply restored permissions")
+
+    monkeypatch.setattr("moonmind.omnigent.workspace_artifacts.os.chmod", fail_chmod)
+    with pytest.raises(WorkspaceArtifactProjectionError, match="could not be applied"):
+        await projector.project(
+            workspace,
+            checkpoint_ref="artifact://checkpoint",
+            workflow_id="workflow-1",
+            runtime_uid=os.getuid(),
+            runtime_gid=os.getgid(),
+            strict_admission=True,
+        )
+    assert (workspace / "existing.txt").read_text() == "preserve current workspace"
+    assert not (workspace / "run.sh").exists()
+
+
+@pytest.mark.asyncio
 async def test_external_git_bindings_and_thin_bundles_fail_closed(tmp_path):
     workspace_id = _workspace_id()
     service = FakeArtifactService({})


### PR DESCRIPTION
## Related issue

N/A — regression from workflow `mm:7ecd83e1-f260-4d02-828d-fd9e59e1f8b8-2026-09-07T23:40:00Z`.

## Summary

Checkpoint extraction stripped executable bits from every restored file. The resulting 57 file-mode changes made an unchanged candidate appear dirty, so publication committed those changes on a new branch and lost the association with the agent-created PR #4085. GitHub issue finalization then failed because it had no authoritative PR URL.

Preserve ordinary executable bits while retaining owner-only read/write access and removing privileged permissions. Fail restore before promotion if permissions cannot be applied. In plain terms, restoring a saved checkout must not change which files Git considers executable.

Add a minimized incident fixture covering real checkpoint capture, restore, Git publication, HTTP PR discovery, and retry; cover imported-hook removal, historical/current restore inputs, and execution as UID 1000.

## Test Plan

```bash
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/omnigent/test_workspace_publication_base.py \
  tests/unit/omnigent/test_workspace_safe_sources.py \
  tests/unit/omnigent/test_workspace_materializer.py \
  tests/unit/workflows/temporal/workflows/test_run_publication_head_handoff.py
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local \
  MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-checkpoint-executable \
  ./tools/test_integration.sh
```

Results: **171 focused tests passed; all 721 hermetic integration tests passed.**

The new publication regression failed before the fix with `M run.sh` after restore. Ruff and `git diff --check` pass.

## Demo

N/A — no UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

The shared Omnigent restore boundary retains executable bits while stripping setuid/setgid/sticky bits and imported Git hooks. No workflow commands, serialized payloads, credentials, or publication authority change. Historical restore payloads remain supported and are tested. Completed restore generations and already-written damaged checkpoints are not retroactively repaired.

## Coverage notes

Inspected parent and publication-child Temporal histories, the durable agent transcript, and GitHub PR/head evidence. PR #4085 remains on the intended candidate; the publisher's extra commit contains 57 mode-only changes with no content additions or deletions. The regression uses local Git and a fake GitHub HTTP response; it does not claim a live provider rerun. Deployment and the original failed execution remain unchanged.

## Changelog

Omnigent checkpoint restores preserve executable files and keep unchanged candidates associated with their existing pull requests.
