### PR TITLE
[Omnigent boundary] Retire experimental embedded host transport without removing native chat or historical evidence (MoonLadderStudios/MoonMind#3955)

### DIFF
--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -308,13 +308,13 @@ class OmnigentStreamEvent(BaseModel):
 
 _PUBLIC_ERROR_RESPONSES = {
     code: {"model": OmnigentPublicErrorResponse}
-    for code in (400, 403, 404, 409, 410, 500, 501, 502, 503)
+    for code in (400, 403, 404, 409, 500, 501, 502, 503)
 }
 
 # Retired embedded-transport routes always answer 410 Gone (#3955). Declare it
 # explicitly on those routes so OpenAPI clients model the terminal response
 # and its omnigent_embedded_transport_retired payload.
-_EMBEDDED_RETIRED_RESPONSES = {
+_EMBEDDED_RETIRED_RESPONSE = {
     410: {
         "model": OmnigentPublicErrorResponse,
         "description": (
@@ -322,7 +322,6 @@ _EMBEDDED_RETIRED_RESPONSES = {
             "(omnigent_embedded_transport_retired)."
         ),
     },
-    **_PUBLIC_ERROR_RESPONSES,
 }
 
 # WebSocket close reason carried by retired embedded-transport denials (#3955):
@@ -2892,7 +2891,7 @@ async def revoke_embedded_host_auth_profile(
 @router.post(
     "/v1/hosts/register",
     response_model=dict,
-    responses=_EMBEDDED_RETIRED_RESPONSES,
+    responses=_EMBEDDED_RETIRED_RESPONSE,
 )
 async def register_embedded_omnigent_host(
     payload: EmbeddedHostRegisterRequest,
@@ -3076,7 +3075,7 @@ async def embedded_omnigent_runner_tunnel(websocket: WebSocket, runner_id: str) 
 @router.post(
     "/v1/hosts/{host_id}/heartbeat",
     response_model=dict,
-    responses=_EMBEDDED_RETIRED_RESPONSES,
+    responses=_EMBEDDED_RETIRED_RESPONSE,
 )
 async def heartbeat_embedded_omnigent_host(
     host_id: str,
@@ -3097,7 +3096,7 @@ async def heartbeat_embedded_omnigent_host(
 @router.post(
     "/v1/hosts/{host_id}/sessions/{session_id}/events",
     response_model=dict,
-    responses=_EMBEDDED_RETIRED_RESPONSES,
+    responses=_EMBEDDED_RETIRED_RESPONSE,
 )
 async def ingest_embedded_omnigent_host_event(
     host_id: str,

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -644,28 +644,25 @@ def _require_proxy_mode(
 async def _require_embedded_mode(
     config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
 ) -> OmnigentBridgeConfig:
-    """Fail fast when an embedded-host route is called outside embedded mode."""
+    """Fail fast for retired embedded-transport routes (#3955).
 
-    if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-        validation = await _resolve_embedded_evidence(config)
-        readiness = config.readiness(evidence_validation=validation)
-        if readiness["conformanceState"] == "ready":
-            return config
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "code": "omnigent_embedded_evidence_gated",
-                "message": "Embedded mode requires authorized, current passing evidence.",
-                "evidenceValidation": validation,
-            },
-        )
+    New embedded-transport admission is retired: explicit requests receive an
+    actionable error naming the supported proxy alternative and are never
+    silently substituted. Retained sessions keep their recorded mode for
+    historical reads; this guard only owns the live transport routes.
+    """
+
     raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        status_code=status.HTTP_410_GONE,
         detail={
-            "code": "omnigent_bridge_mode_unsupported",
+            "code": "omnigent_embedded_transport_retired",
             "message": (
-                "This Omnigent bridge route requires "
-                "embedded_omnigent_compatible_server mode."
+                "The experimental embedded host transport is retired "
+                "(MoonLadderStudios/MoonMind#3955) and cannot admit new hosts, "
+                "sessions, or credential consumers. Select "
+                "'upstream_omnigent_server_proxy' for new work. Retained "
+                "sessions keep their recorded mode for historical reads and "
+                "drain under their recorded cleanup owner."
             ),
         },
     )
@@ -749,9 +746,13 @@ def _get_embedded_host_facade(
 async def _get_create_embedded_facade(
     _config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
 ) -> OmnigentEmbeddedHostProtocolFacade | None:
+    # NOTE (#3955): session-scoped drain paths keep resolving the recorded
+    # facade while retained sessions exist. New admission is blocked at the
+    # trusted bridge-config selection boundary (enabled embedded configs fail
+    # fast at parse/startup) and at the live host-lifecycle routes via
+    # _require_embedded_mode (410 Gone), never by silently substituting proxy.
     if _config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
         return None
-    await _require_embedded_mode(_config)
     return build_embedded_host_facade(_config)
 
 

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -21,7 +21,7 @@ import logging
 import os
 import time
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 import aiohttp
@@ -82,12 +82,24 @@ from moonmind.omnigent.bridge_artifacts import (
     LocalOmnigentArtifactGateway,
     OmnigentArtifactError,
 )
-from moonmind.omnigent.bridge_embedded import (
+# NOTE (#3955): the retired embedded host-route request payloads are plain API
+# contracts importable without the embedded launch modules, so the proxy-only
+# production path (and OpenAPI) never requires bridge_embedded at import time.
+from moonmind.omnigent.embedded_host_requests import (
     EmbeddedHostHeartbeatRequest,
     EmbeddedHostRegisterRequest,
     EmbeddedHostSessionEventRequest,
-    OmnigentEmbeddedHostProtocolFacade,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, never a runtime import
+    from moonmind.omnigent.bridge_embedded import OmnigentEmbeddedHostProtocolFacade
+else:  # pragma: no cover - runtime fallback when launch modules are retired
+    try:
+        from moonmind.omnigent.bridge_embedded import (
+            OmnigentEmbeddedHostProtocolFacade,
+        )
+    except ImportError:  # retired embedded launch modules are unavailable
+        OmnigentEmbeddedHostProtocolFacade = Any  # type: ignore[no-redef]
 from moonmind.omnigent.bridge_proxy import (
     BridgePrincipalBinding,
     BridgeSessionCreateRequest,
@@ -103,14 +115,11 @@ from moonmind.omnigent.bridge_store import (
     OmnigentIdempotencyError,
 )
 from moonmind.omnigent.control_plane.turn_sources import TurnSource
-from moonmind.omnigent.embedded_evidence import (
-    EmbeddedEvidenceError,
-    validate_embedded_evidence,
-)
-from moonmind.omnigent.embedded_host_channel import (
-    EmbeddedHostChannelError,
-    embedded_host_channels,
-)
+# NOTE (#3955): embedded evidence validation and the host-channel registry are
+# launch-only runtime dependencies imported lazily inside the functions that
+# need them, so importing this router never requires the retired embedded
+# launch modules (moonmind.omnigent.bridge_embedded/embedded_evidence/
+# embedded_host_channel).
 from moonmind.omnigent.host_protocol_adapter import UpstreamHostProtocolError
 from moonmind.omnigent.host_auth_contracts import (
     HostAuthCredentialProfile,
@@ -299,8 +308,29 @@ class OmnigentStreamEvent(BaseModel):
 
 _PUBLIC_ERROR_RESPONSES = {
     code: {"model": OmnigentPublicErrorResponse}
-    for code in (400, 403, 404, 409, 500, 501, 502, 503)
+    for code in (400, 403, 404, 409, 410, 500, 501, 502, 503)
 }
+
+# Retired embedded-transport routes always answer 410 Gone (#3955). Declare it
+# explicitly on those routes so OpenAPI clients model the terminal response
+# and its omnigent_embedded_transport_retired payload.
+_EMBEDDED_RETIRED_RESPONSES = {
+    410: {
+        "model": OmnigentPublicErrorResponse,
+        "description": (
+            "Embedded host transport retired "
+            "(omnigent_embedded_transport_retired)."
+        ),
+    },
+    **_PUBLIC_ERROR_RESPONSES,
+}
+
+# WebSocket close reason carried by retired embedded-transport denials (#3955):
+# machine-readable retirement code plus the supported proxy alternative.
+# Starlette caps the UTF-8 reason at 123 bytes; keep this short.
+_EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON = (
+    "omnigent_embedded_transport_retired: use upstream_omnigent_server_proxy"
+)
 
 
 def _clean(value: Any) -> str | None:
@@ -519,6 +549,8 @@ _EMBEDDED_EVIDENCE_SLOTS = {
 
 
 def _artifact_id_from_evidence_ref(value: str | None) -> str:
+    from moonmind.omnigent.embedded_evidence import EmbeddedEvidenceError
+
     candidate = str(value or "").strip()
     if candidate.startswith("artifact://"):
         candidate = candidate[len("artifact://") :]
@@ -533,6 +565,8 @@ async def _resolve_embedded_evidence(
     policy_authority: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Resolve claims with the artifact service's trusted service principal."""
+
+    from moonmind.omnigent.embedded_evidence import validate_embedded_evidence
 
     results: dict[str, dict[str, Any]] = {}
     authority = policy_authority or await _resolve_bridge_policy_authority()
@@ -746,14 +780,71 @@ def _get_embedded_host_facade(
 async def _get_create_embedded_facade(
     _config: OmnigentBridgeConfig = Depends(_require_bridge_enabled),
 ) -> OmnigentEmbeddedHostProtocolFacade | None:
-    # NOTE (#3955): session-scoped drain paths keep resolving the recorded
-    # facade while retained sessions exist. New admission is blocked at the
-    # trusted bridge-config selection boundary (enabled embedded configs fail
-    # fast at parse/startup) and at the live host-lifecycle routes via
-    # _require_embedded_mode (410 Gone), never by silently substituting proxy.
+    # NOTE (#3955): admission-scoped dependency. New embedded admission is
+    # blocked at the trusted bridge-config selection boundary (enabled embedded
+    # configs fail fast at parse/startup) and at the live host-lifecycle routes
+    # via _require_embedded_mode (410 Gone), never by silently substituting
+    # proxy. Retained-row drain resolves separately through
+    # _resolve_session_control_facade so recorded sessions keep their cleanup
+    # owner while the deployment runs proxy mode.
     if _config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
         return None
     return build_embedded_host_facade(_config)
+
+
+async def _persisted_host_protocol_mode(
+    *, store: OmnigentBridgeSessionStore, session_id: str
+) -> str | None:
+    """Return the recorded host protocol mode for one provider session."""
+
+    if not session_id:
+        return None
+    try:
+        row = await store.get_session_by_provider_session_id(session_id)
+    except Exception:
+        logger.debug("Unable to resolve persisted bridge mode", exc_info=True)
+        return None
+    metadata = getattr(row, "metadata_", None) if row is not None else None
+    if not isinstance(metadata, dict):
+        return None
+    mode = metadata.get("hostProtocolMode")
+    return str(mode) if mode else None
+
+
+async def _resolve_session_control_facade(
+    *,
+    session_id: str,
+    config: OmnigentBridgeConfig,
+    proxy: OmnigentBridgeSessionProxy | None,
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None,
+    store: OmnigentBridgeSessionStore,
+) -> tuple[Any, bool]:
+    """Dispatch one session-scoped control to its recorded owner (#3955).
+
+    New admission follows the configured global mode, but retained sessions
+    keep their recorded mode/endpoint and cleanup owner until drained: when the
+    deployment runs proxy mode, a retained embedded row resolves a drain-only
+    embedded facade instead of being silently misrouted to the proxy owner.
+    Returns ``(facade, embedded_selected)``.
+    """
+
+    if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+        return embedded_facade, True
+    if (
+        await _persisted_host_protocol_mode(store=store, session_id=session_id)
+        == HOST_PROTOCOL_MODE_EMBEDDED
+    ):
+        try:
+            return (
+                build_embedded_host_facade(config, drain_retained_sessions=True),
+                True,
+            )
+        except ImportError:
+            # Retired launch modules are gone; without the drain owner the
+            # retained session cannot be controlled (callers fail closed).
+            logger.warning("Embedded drain facade unavailable for retained session")
+            return None, True
+    return proxy, False
 
 
 def _http_error_from_bridge(exc: OmnigentBridgeError) -> HTTPException:
@@ -963,6 +1054,7 @@ async def get_omnigent_session(
     embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> dict[str, Any]:
     """Return an Omnigent-shaped session snapshot (OB-§4.1, §8.2).
 
@@ -977,10 +1069,15 @@ async def get_omnigent_session(
     the authenticated user must own the workflow that owns the session.
     """
 
-    facade = (
-        embedded_facade
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-        else proxy
+    # Retained sessions resolve to their recorded owner (#3955): a retained
+    # embedded row keeps draining through the embedded facade while the
+    # deployment runs proxy mode.
+    facade, _ = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
     )
     if facade is None:
         raise HTTPException(
@@ -1041,6 +1138,7 @@ async def attach_omnigent_session(
     embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> dict[str, Any]:
     """Reconcile an already-created provider session after a create retry."""
 
@@ -1048,10 +1146,12 @@ async def attach_omnigent_session(
         user=user, service=service, principal_context=principal_context, payload=payload
     )
     try:
-        facade = (
-            embedded_facade
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
+        facade, _ = await _resolve_session_control_facade(
+            session_id=session_id,
+            config=config,
+            proxy=proxy,
+            embedded_facade=embedded_facade,
+            store=store,
         )
         if facade is None:
             raise OmnigentBridgeError("Unsupported bridge mode", status_code=501)
@@ -1077,10 +1177,12 @@ async def delete_omnigent_session(
     registry: RetrievalCapabilityRegistry = Depends(get_capability_registry),
     store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> dict[str, Any]:
-    facade = (
-        embedded_facade
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-        else proxy
+    facade, _ = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
     )
     await _authorize_session_control(
         session_id=session_id, user=user, service=service, proxy=facade
@@ -1861,10 +1963,12 @@ async def post_omnigent_session_event(
 ) -> dict[str, Any]:
     """Apply Omnigent controls, including bridge-local harvest/clear policy."""
 
-    control_facade = (
-        embedded_facade
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-        else proxy
+    control_facade, _ = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
     )
     if control_facade is None:
         raise HTTPException(
@@ -2046,11 +2150,26 @@ async def _apply_owned_session_control(
     redacted HTTP error.
     """
 
+    # Callers resolve control_facade through _resolve_session_control_facade,
+    # so a retained embedded row under proxy global mode arrives here with the
+    # drain-only embedded facade. Honor the recorded owner for every branch
+    # below instead of re-deriving it from the global mode (#3955).
+    if (
+        config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED
+        and control_facade is not None
+        and control_facade is not proxy
+    ):
+        embedded_facade = control_facade
+    use_embedded = (
+        config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+        or (control_facade is not None and embedded_facade is control_facade)
+    )
+
     if payload.type in {"clear_session", "reset_session"}:
         # Embedded mode rejects clear/reset without replacing or stopping the
         # session, so revoking first would permanently disable retrieval for
         # a session that keeps running.  Reject before mutating authority.
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+        if use_embedded:
             raise OmnigentBridgeError(
                 "Embedded clear/reset requires a new session and idempotency key.",
                 failure_class="user_error",
@@ -2070,7 +2189,7 @@ async def _apply_owned_session_control(
             store=store,
             reason="session_stopped",
         )
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+        if use_embedded:
             assert embedded_facade is not None
             return await embedded_facade.stop_session(
                 session_id,
@@ -2079,7 +2198,7 @@ async def _apply_owned_session_control(
             )
         return await control_facade.stop_session(session_id)
     if payload.type in {"cleanup_session", "terminal_cleanup"}:
-        if config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
+        if not use_embedded:
             raise OmnigentBridgeError(
                 "Typed owned-resource cleanup is unavailable in this mode.",
                 failure_class="user_error",
@@ -2112,7 +2231,7 @@ async def _apply_owned_session_control(
             payload=payload.model_dump(by_alias=True, exclude_none=True),
             actor=actor,
         )
-    if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED:
+    if use_embedded:
         assert embedded_facade is not None
         if payload.type == "harvest_session":
             return await embedded_facade.harvest_session(
@@ -2269,8 +2388,12 @@ async def resolve_omnigent_elicitation(
 ) -> dict[str, Any]:
     """Resolve a pending Omnigent elicitation through the bridge surface."""
 
-    facade = (
-        embedded if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED else proxy
+    facade, facade_embedded = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
     if facade is None:
         raise HTTPException(
@@ -2303,11 +2426,7 @@ async def resolve_omnigent_elicitation(
             session_id=session_id,
             elicitation_id=elicitation_id,
             payload=payload,
-            **(
-                {"actor": str(user.id)}
-                if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-                else {}
-            ),
+            **({"actor": str(user.id)} if facade_embedded else {}),
         )
     except OmnigentBridgeError as exc:
         await _settle_owned_session_turn(
@@ -2450,11 +2569,14 @@ async def stream_upstream_omnigent_events(
     embedded_facade: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> StreamingResponse:
-    facade = (
-        embedded_facade
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-        else proxy
+    facade, _ = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
     )
     await _authorize_session_control(
         session_id=session_id, user=user, service=service, proxy=facade
@@ -2507,13 +2629,23 @@ async def _owned_resource(
     value: str | None,
     user: User,
     service: Any,
-    proxy: Any,
+    config: OmnigentBridgeConfig,
+    proxy: OmnigentBridgeSessionProxy | None,
+    embedded_facade: OmnigentEmbeddedHostProtocolFacade | None,
+    store: OmnigentBridgeSessionStore,
 ):
+    resolved, _ = await _resolve_session_control_facade(
+        session_id=session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
+    )
     await _authorize_session_control(
-        session_id=session_id, user=user, service=service, proxy=proxy
+        session_id=session_id, user=user, service=service, proxy=resolved
     )
     try:
-        return await proxy.get_resource(operation, session_id, value)
+        return await resolved.get_resource(operation, session_id, value)
     except OmnigentBridgeError as exc:
         raise _http_error_from_bridge(exc) from exc
 
@@ -2528,6 +2660,7 @@ async def list_omnigent_changed_files(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ):
     return await _owned_resource(
         operation="changed_files",
@@ -2535,11 +2668,10 @@ async def list_omnigent_changed_files(
         value=None,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
 
 
@@ -2553,6 +2685,7 @@ async def list_omnigent_workspace_files(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ):
     return await _owned_resource(
         operation="workspace_files",
@@ -2560,11 +2693,10 @@ async def list_omnigent_workspace_files(
         value=None,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
 
 
@@ -2582,6 +2714,7 @@ async def get_omnigent_workspace_file(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> Response:
     content = await _owned_resource(
         operation="workspace_file",
@@ -2589,11 +2722,10 @@ async def get_omnigent_workspace_file(
         value=path,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
     return Response(content=content, media_type="application/octet-stream")
 
@@ -2612,6 +2744,7 @@ async def get_omnigent_workspace_diff(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> Response:
     content = await _owned_resource(
         operation="workspace_diff",
@@ -2619,11 +2752,10 @@ async def get_omnigent_workspace_diff(
         value=path,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
     return Response(content=content, media_type="text/x-diff")
 
@@ -2638,6 +2770,7 @@ async def list_omnigent_session_files(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ):
     return await _owned_resource(
         operation="session_files",
@@ -2645,11 +2778,10 @@ async def list_omnigent_session_files(
         value=None,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
 
 
@@ -2667,6 +2799,7 @@ async def get_omnigent_session_file(
     embedded: OmnigentEmbeddedHostProtocolFacade | None = Depends(
         _get_create_embedded_facade
     ),
+    store: OmnigentBridgeSessionStore = Depends(_get_bridge_store),
 ) -> Response:
     content = await _owned_resource(
         operation="session_file",
@@ -2674,11 +2807,10 @@ async def get_omnigent_session_file(
         value=file_id,
         user=user,
         service=service,
-        proxy=(
-            embedded
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else proxy
-        ),
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded,
+        store=store,
     )
     return Response(content=content, media_type="application/octet-stream")
 
@@ -2757,7 +2889,11 @@ async def revoke_embedded_host_auth_profile(
     return stored.metadata()
 
 
-@router.post("/v1/hosts/register", response_model=dict)
+@router.post(
+    "/v1/hosts/register",
+    response_model=dict,
+    responses=_EMBEDDED_RETIRED_RESPONSES,
+)
 async def register_embedded_omnigent_host(
     payload: EmbeddedHostRegisterRequest,
     request: Request,
@@ -2783,12 +2919,16 @@ async def embedded_omnigent_host_tunnel(websocket: WebSocket, host_id: str) -> N
             not config.enabled
             or config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED
         ):
-            await websocket.close(code=4404)
+            await websocket.close(
+                code=4404, reason=_EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON
+            )
             return
         try:
             await _require_embedded_mode(config)
         except HTTPException:
-            await websocket.close(code=4403)
+            await websocket.close(
+                code=4403, reason=_EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON
+            )
             return
         auth = await verify_embedded_host_request(
             headers=websocket.headers, config=config
@@ -2805,6 +2945,14 @@ async def embedded_omnigent_host_tunnel(websocket: WebSocket, host_id: str) -> N
     except OmnigentBridgeError as exc:
         await websocket.close(code=4401, reason=exc.code)
         return
+    # NOTE (#3955): the host-channel registry is a launch-only runtime
+    # dependency resolved here so importing this router never requires the
+    # retired embedded launch modules.
+    from moonmind.omnigent.embedded_host_channel import (
+        EmbeddedHostChannelError,
+        embedded_host_channels,
+    )
+
     await websocket.accept()
     channel = embedded_host_channels.connect(
         host_id=host_id, send_text=websocket.send_text
@@ -2849,13 +2997,25 @@ async def embedded_omnigent_runner_tunnel(websocket: WebSocket, runner_id: str) 
 
     config = get_bridge_config()
     if not config.enabled or config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
-        await websocket.close(code=4404)
+        await websocket.close(
+            code=4404, reason=_EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON
+        )
         return
     try:
         await _require_embedded_mode(config)
     except HTTPException:
-        await websocket.close(code=4403)
+        await websocket.close(
+            code=4403, reason=_EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON
+        )
         return
+    # NOTE (#3955): launch-only channel dependency, resolved lazily so this
+    # router imports without the retired embedded launch modules.
+    from moonmind.omnigent.embedded_host_channel import (
+        EmbeddedHostChannelError,
+        derive_runner_binding_token,
+        embedded_host_channels,
+    )
+
     try:
         store = build_bridge_session_store()
         binding = await store.get_active_session_by_runner_identity(runner_id)
@@ -2866,8 +3026,6 @@ async def embedded_omnigent_runner_tunnel(websocket: WebSocket, runner_id: str) 
             or binding.credential_generation is None
         ):
             raise EmbeddedHostChannelError("runner has no active durable binding")
-        from moonmind.omnigent.embedded_host_channel import derive_runner_binding_token
-
         binding_token = derive_runner_binding_token(
             resolved_host_runner_token(),
             host_id=binding.omnigent_host_id,
@@ -2915,7 +3073,11 @@ async def embedded_omnigent_runner_tunnel(websocket: WebSocket, runner_id: str) 
                 pass
 
 
-@router.post("/v1/hosts/{host_id}/heartbeat", response_model=dict)
+@router.post(
+    "/v1/hosts/{host_id}/heartbeat",
+    response_model=dict,
+    responses=_EMBEDDED_RETIRED_RESPONSES,
+)
 async def heartbeat_embedded_omnigent_host(
     host_id: str,
     payload: EmbeddedHostHeartbeatRequest,
@@ -2932,7 +3094,11 @@ async def heartbeat_embedded_omnigent_host(
         raise _http_error_from_bridge(exc) from exc
 
 
-@router.post("/v1/hosts/{host_id}/sessions/{session_id}/events", response_model=dict)
+@router.post(
+    "/v1/hosts/{host_id}/sessions/{session_id}/events",
+    response_model=dict,
+    responses=_EMBEDDED_RETIRED_RESPONSES,
+)
 async def ingest_embedded_omnigent_host_event(
     host_id: str,
     session_id: str,
@@ -5034,10 +5200,16 @@ async def _dispatch_workflow_chat_facade(
             "has_more": False,
         }
 
-    facade = (
-        embedded_facade
-        if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-        else proxy
+    # Retained sessions resolve to their recorded owner (#3955): a retained
+    # embedded row keeps draining through the embedded facade while the
+    # deployment runs proxy mode. provider_session_id is empty when no provider
+    # session exists yet, in which case the resolver falls back to proxy.
+    facade, facade_embedded = await _resolve_session_control_facade(
+        session_id=provider_session_id,
+        config=config,
+        proxy=proxy,
+        embedded_facade=embedded_facade,
+        store=store,
     )
     if operation.name != "stream_events" and facade is None:
         raise WorkflowChatFacadeError(
@@ -5407,11 +5579,7 @@ async def _dispatch_workflow_chat_facade(
                 status_code=status.HTTP_403_FORBIDDEN,
                 code=CODE_OPERATION_DENIED,
             )
-        actor_kwargs = (
-            {"actor": str(user.id)}
-            if config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-            else {}
-        )
+        actor_kwargs = {"actor": str(user.id)} if facade_embedded else {}
         elicitation_key = _facade_idempotency_key(request) or f"mm-{uuid4().hex}"
         request_time = datetime.now(tz=UTC).isoformat()
         claimed = await _claim_facade_message(

--- a/api_service/api/routers/omnigent_bridge_composition.py
+++ b/api_service/api/routers/omnigent_bridge_composition.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Any, AsyncIterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Sequence
 
 from api_service.db.base import async_session_maker
 from api_service.services.omnigent_agent_profile_service import (
@@ -27,10 +27,11 @@ from moonmind.omnigent.bridge_config import (
     HOST_PROTOCOL_MODE_PROXY,
     OmnigentBridgeConfig,
 )
-from moonmind.omnigent.bridge_embedded import (
-    OmnigentEmbeddedHostProtocolFacade,
-    verify_embedded_host_auth,
-)
+# NOTE (#3955): the embedded launch facade is imported lazily inside
+# build_embedded_host_facade / verify_embedded_host_request so the proxy-only
+# production path never requires the retired embedded launch modules.
+if TYPE_CHECKING:  # pragma: no cover - typing only, never a runtime import
+    from moonmind.omnigent.bridge_embedded import OmnigentEmbeddedHostProtocolFacade
 from moonmind.omnigent.bridge_proxy import OmnigentBridgeSessionProxy
 from moonmind.omnigent.bridge_store import OmnigentBridgeSessionStore
 from moonmind.omnigent.host_auth_contracts import (
@@ -127,6 +128,8 @@ async def verify_embedded_host_request(
     *, headers: Mapping[str, str], config: OmnigentBridgeConfig
 ):
     """Resolve host-auth credentials and verify one embedded host request."""
+
+    from moonmind.omnigent.bridge_embedded import verify_embedded_host_auth
 
     resolved = await resolve_host_auth_credentials(
         profile=await resolve_active_host_auth_profile()
@@ -289,6 +292,8 @@ async def project_upstream_inventory_failure(
 def build_embedded_host_facade(
     config: OmnigentBridgeConfig,
 ) -> OmnigentEmbeddedHostProtocolFacade:
+    from moonmind.omnigent.bridge_embedded import OmnigentEmbeddedHostProtocolFacade
+
     return OmnigentEmbeddedHostProtocolFacade(
         run_store=build_bridge_session_store(),
         config=config,

--- a/api_service/api/routers/omnigent_bridge_composition.py
+++ b/api_service/api/routers/omnigent_bridge_composition.py
@@ -291,12 +291,22 @@ async def project_upstream_inventory_failure(
 
 def build_embedded_host_facade(
     config: OmnigentBridgeConfig,
+    *,
+    drain_retained_sessions: bool = False,
 ) -> OmnigentEmbeddedHostProtocolFacade:
+    """Build the embedded host facade for admission or retained-row drain.
+
+    ``drain_retained_sessions=True`` (#3955) bypasses the global-mode gate so
+    stop, terminal cleanup, delete, and reads for already-recorded embedded
+    rows keep reaching their recorded owner while the deployment runs proxy
+    mode; new admission stays refused inside the facade.
+    """
     from moonmind.omnigent.bridge_embedded import OmnigentEmbeddedHostProtocolFacade
 
     return OmnigentEmbeddedHostProtocolFacade(
         run_store=build_bridge_session_store(),
         config=config,
+        drain_retained_sessions=drain_retained_sessions,
     )
 
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -260,8 +260,10 @@ async def _sync_omnigent_bootstrap_agent_profile() -> bool:
             return True
         config = resolve_bridge_config()
         if config.host_protocol_mode != HOST_PROTOCOL_MODE_PROXY:
-            # Embedded deployments own their inventory through the authenticated
-            # host protocol; the stock local bootstrap applies only to proxy mode.
+            # Retired (#3955): only a disabled bridge can still declare the
+            # embedded literal (for retained-row decoding). A disabled bridge
+            # owns no inventory sync; the stock local bootstrap applies only
+            # to proxy mode.
             return True
         inventory = await OmnigentHttpClient(
             base_url=resolved_server_url(),

--- a/docs/Omnigent/EmbeddedHostAuthCompatibility.md
+++ b/docs/Omnigent/EmbeddedHostAuthCompatibility.md
@@ -1,6 +1,21 @@
-# Embedded host authentication compatibility
+# Embedded host authentication compatibility (retired transport)
 
 **Document Class:** Canonical declarative
+
+> **Retirement notice (MoonLadderStudios/MoonMind#3955).** The experimental
+> embedded host/runner transport no longer admits new work. An enabled bridge
+> that selects `embedded_omnigent_compatible_server` fails fast at API/worker
+> startup with the supported `upstream_omnigent_server_proxy` alternative;
+> live embedded host routes answer `410 Gone` with the same alternative.
+> Proxy mode is the only selectable production topology. What this document
+> still describes below is retained for one purpose only: decoding retained
+> session rows and historical evidence in their recorded mode until bounded
+> drain probes establish no active or cleanup owner remains. Physical removal
+> of the launch code follows at the launch-only removal stage, never in the
+> same change as the product selector. The native Workflow Chat `embedded=1`
+> presentation option is unrelated to this transport and is preserved, as are
+> shared first-message idempotency, bridge session/event persistence, and
+> profile-owned credentials.
 
 **Compatibility declaration:** `omnigent.server.v1` with embedded runner
 authentication profile `omnigent.runner_tunnel.983c93c6`, verified against
@@ -116,12 +131,12 @@ to close code 4401, disabled/revoked or stale connected authority to 4403,
 transient verifier/configuration failure to 1013, and accepted-frame protocol
 failure to 4400.
 
-Embedded mode remains experimental and must not be presented as production
-ready until all three configured evidence claims (proxy conformance, live
-stock-host smoke, and host-auth conformance) resolve independently, pass schema
-and secret-scan validation, match the active MoonMind build/configuration and
-immutable image identities, and remain unexpired. Proxy mode remains the
-production default and supported topology until the full #3519 matrix passes.
+Embedded mode is retired (#3955) and must not be presented as production
+ready; an enabled bridge cannot select it for new work. The evidence claims
+described here (proxy conformance, live stock-host smoke, and host-auth
+conformance) remain the historical record of what gated the experimental path
+and stay resolvable for retained sessions. Proxy mode is the production
+default and the only supported topology.
 
 ## Launch modes, rollout, and rollback
 
@@ -129,11 +144,12 @@ Static Compose and on-demand Docker are separate support rows. Each must prove
 the same registration, authentication, session, reconnect, resource, terminal,
 and cleanup contract before it can be advertised for embedded mode. An
 unproven row is unavailable with an actionable readiness reason; success in one
-mode does not imply support for the other.
+mode does not imply support for the other. No embedded support row is
+advertised anymore: readiness and the support matrix report the proxy-only
+topology.
 
-Selecting embedded mode is explicit and versioned. Missing, stale, revoked, or
-incompatible evidence gates readiness before a new session starts. Rollback
-selects `upstream_omnigent_server_proxy` for new sessions only. An in-flight
+Selecting embedded mode is retired. Rollback selects
+`upstream_omnigent_server_proxy` for new sessions only. An in-flight
 session stays with its recorded endpoint and bridge mode, and historical
 records retain their actual compatibility profile and evidence references.
 MoonMind never redirects an in-flight session between modes.

--- a/docs/Omnigent/EmbeddedHostAuthCompatibility.md
+++ b/docs/Omnigent/EmbeddedHostAuthCompatibility.md
@@ -136,7 +136,11 @@ ready; an enabled bridge cannot select it for new work. The evidence claims
 described here (proxy conformance, live stock-host smoke, and host-auth
 conformance) remain the historical record of what gated the experimental path
 and stay resolvable for retained sessions. Proxy mode is the production
-default and the only supported topology.
+default and the only supported topology. Retired-transport denials are
+explicit: HTTP routes answer `410 Gone` with code
+`omnigent_embedded_transport_retired`, and WebSocket handshakes close with
+`4404` carrying `omnigent_embedded_transport_retired` plus the
+`upstream_omnigent_server_proxy` alternative as the close reason.
 
 ## Launch modes, rollout, and rollback
 

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -111,8 +111,16 @@ tunnel.
 
 `embedded_omnigent_compatible_server` is retired and cannot admit new work: an
 enabled bridge that selects it fails fast with the proxy alternative, and live
-embedded host routes answer `410 Gone`. The literal survives only so retained
-session rows and historical evidence keep decoding to their recorded mode.
+embedded host routes answer `410 Gone` (declared in OpenAPI so generated
+clients model the terminal `omnigent_embedded_transport_retired` payload;
+WebSocket denials carry the same code plus the proxy alternative as the close
+reason). The literal survives only so retained session rows and historical
+evidence keep decoding to their recorded mode. Session-scoped controls (read,
+stop, terminal cleanup, delete, elicitation, event and resource reads) dispatch
+by each session row's recorded mode, so retained embedded sessions keep their
+recorded cleanup owner until drained while the deployment runs proxy mode;
+new admission still follows the configured global mode and is never silently
+substituted.
 Its exact auth and protocol contract is owned by
 `EmbeddedHostAuthCompatibility.md`, which now documents the retired transport
 and its drain disposition. The native Workflow Chat `embedded=1` presentation

--- a/docs/Omnigent/OmnigentBridge.md
+++ b/docs/Omnigent/OmnigentBridge.md
@@ -96,19 +96,27 @@ A successful design supports a stock Omnigent host. No custom host image or sour
 
 Deployment configuration may specify server URL, host authentication, endpoint refs, network routing, and standard Omnigent host settings. A custom MoonMind-specific host build is out of scope.
 
-### 2.4 Prefer proxy-first compatibility
+### 2.4 Proxy-only compatibility (embedded transport retired #3955)
 
-The bridge supports:
+The bridge selects:
 
 ```yaml
 hostProtocolMode:
   - upstream_omnigent_server_proxy
-  - embedded_omnigent_compatible_server
 ```
 
-`upstream_omnigent_server_proxy` is the preferred default because stock Omnigent Server already owns the host/runner tunnel.
+`upstream_omnigent_server_proxy` is the production default and the only
+selectable mode because stock Omnigent Server already owns the host/runner
+tunnel.
 
-`embedded_omnigent_compatible_server` implements enough compatible server behavior for an unchanged host to connect directly to MoonMind. Its exact auth and protocol contract is owned by `EmbeddedHostAuthCompatibility.md` and remains gated by conformance evidence.
+`embedded_omnigent_compatible_server` is retired and cannot admit new work: an
+enabled bridge that selects it fails fast with the proxy alternative, and live
+embedded host routes answer `410 Gone`. The literal survives only so retained
+session rows and historical evidence keep decoding to their recorded mode.
+Its exact auth and protocol contract is owned by
+`EmbeddedHostAuthCompatibility.md`, which now documents the retired transport
+and its drain disposition. The native Workflow Chat `embedded=1` presentation
+option is unrelated to this transport and is preserved.
 
 ### 2.5 Preserve native UI, centralize authority
 
@@ -138,9 +146,13 @@ Responsibilities:
 - Stock Omnigent Server owns the host/runner tunnel.
 - The unchanged host continues to speak its native protocol.
 
-### 3.2 Embedded compatibility mode
+### 3.2 Embedded compatibility mode (retired #3955)
 
-The version, route, authentication, lifecycle, evidence, failure, upgrade, and rollback contract is authoritative in [`EmbeddedHostAuthCompatibility.md`](EmbeddedHostAuthCompatibility.md).
+> Retired: this topology no longer admits new work. The version, route,
+> authentication, lifecycle, evidence, failure, upgrade, and rollback contract
+> below is retained as the authoritative historical record in
+> [`EmbeddedHostAuthCompatibility.md`](EmbeddedHostAuthCompatibility.md) for
+> decoding retained sessions until drain completes.
 
 ```text
 MoonMind UI / API

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -22311,6 +22311,15 @@ export interface operations {
                     };
                 };
             };
+            /** @description Embedded host transport retired (omnigent_embedded_transport_retired). */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -22346,6 +22355,15 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Embedded host transport retired (omnigent_embedded_transport_retired). */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
                 };
             };
             /** @description Validation Error */
@@ -22384,6 +22402,15 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Embedded host transport retired (omnigent_embedded_transport_retired). */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OmnigentPublicErrorResponse"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/omnigent/bridge_config.py
+++ b/moonmind/omnigent/bridge_config.py
@@ -20,9 +20,14 @@ construction:
 * **Keep the host unchanged (§2.3).** ``compatibility.hostUnchanged`` must be
   ``true``. Only deployment configuration is accepted; any configuration that
   requires a custom host build is rejected.
-* **Proxy-first compatibility (§2.4).** ``hostProtocolMode`` accepts
-  ``upstream_omnigent_server_proxy`` and ``embedded_omnigent_compatible_server``
-  and defaults to the proxy mode. Unknown modes fail fast.
+* **Proxy-only compatibility (§2.4, retired embedded transport #3955).**
+  ``hostProtocolMode`` accepts ``upstream_omnigent_server_proxy`` as the only
+  selectable production mode and defaults to it. An explicit operator request
+  for ``embedded_omnigent_compatible_server`` on an enabled bridge fails fast
+  with an actionable error naming the proxy alternative; the embedded value is
+  never silently substituted. The embedded literal is retained only so retained
+  session rows and historical evidence keep decoding to their recorded mode.
+  Unknown modes fail fast.
 * **MoonMind authority (§1).** The authority map (``temporal=moonmind``,
   ``artifacts=moonmind``, ``liveExecution=omnigent_host``) is validated and
   surfaced to downstream components.
@@ -64,7 +69,10 @@ OMNIGENT_BRIDGE_CONFIG_SCHEMA_VERSION = "moonmind.omnigent_bridge.v1"
 # protocol mode, and custom mount path/routes are honored (OB-§6, §21.1).
 OMNIGENT_BRIDGE_CONFIG_PATH_ENV = "OMNIGENT_BRIDGE_CONFIG_PATH"
 
-# §2.4 host protocol modes. Proxy is preferred (proxy-first default).
+# §2.4 host protocol modes. Proxy is the only selectable production mode since
+# the experimental embedded transport retired (#3955). The embedded literal is
+# retained so retained session rows and historical evidence keep decoding to
+# their recorded mode; it must never admit new work on an enabled bridge.
 HOST_PROTOCOL_MODE_PROXY = "upstream_omnigent_server_proxy"
 HOST_PROTOCOL_MODE_EMBEDDED = "embedded_omnigent_compatible_server"
 
@@ -560,32 +568,16 @@ class OmnigentBridgeConfig(BaseModel):
                 f"single active host protocol mode (§2.4)."
             )
         if self.enabled and compat_mode == HOST_PROTOCOL_MODE_EMBEDDED:
-            embedded = self.host_connection.embedded
-            missing = [
-                field_name
-                for field_name, value in (
-                    (
-                        "hostConnection.embedded.proxyConformanceEvidenceRef",
-                        embedded.proxy_conformance_evidence_ref,
-                    ),
-                    (
-                        "hostConnection.embedded.liveSmokeEvidenceRef",
-                        embedded.live_smoke_evidence_ref,
-                    ),
-                    (
-                        "hostConnection.embedded.hostAuthConformanceEvidenceRef",
-                        embedded.host_auth_conformance_evidence_ref,
-                    ),
-                )
-                if not value
-            ]
-            if missing:
-                raise BridgeConfigError(
-                    "embedded_omnigent_compatible_server mode cannot be enabled "
-                    "without proxy conformance, live smoke-test, and upstream host "
-                    "auth conformance evidence refs (§2.4, §16 rule 8). Missing: "
-                    + ", ".join(missing)
-                )
+            raise BridgeConfigError(
+                "embedded_omnigent_compatible_server mode is retired and cannot "
+                "admit new work (MoonLadderStudios/MoonMind#3955): select "
+                "'upstream_omnigent_server_proxy' for compatibility.hostProtocolMode "
+                "(and the matching hostConnection.mode) instead. The embedded "
+                "value is preserved only for decoding retained session rows and "
+                "historical evidence; it is never silently substituted with proxy "
+                "mode. Existing sessions retain their recorded mode/endpoint and "
+                "cleanup owner until drained."
+            )
         return self
 
     @property

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -17,7 +17,8 @@ from typing import Any, Mapping
 from urllib.parse import quote
 
 import structlog
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+# (Pydantic request payloads live in embedded_host_requests so the proxy-only
+# production path can import the API contract without the launch modules.)
 
 from moonmind.omnigent.bridge_config import (
     HOST_PROTOCOL_MODE_EMBEDDED,
@@ -58,84 +59,19 @@ from moonmind.omnigent.host_auth_adapter import OmnigentHostAuthAdapter
 from moonmind.omnigent.settings import resolved_host_runner_token
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
-MAX_EMBEDDED_CAPABILITIES = 128
-MAX_EMBEDDED_CAPABILITY_BYTES = 64 * 1024
-MAX_EMBEDDED_EVENT_ENTRIES = 1024
-MAX_EMBEDDED_EVENT_BYTES = 1024 * 1024
+from moonmind.omnigent.embedded_host_requests import (
+    MAX_EMBEDDED_CAPABILITIES,
+    MAX_EMBEDDED_CAPABILITY_BYTES,
+    MAX_EMBEDDED_EVENT_BYTES,
+    MAX_EMBEDDED_EVENT_ENTRIES,
+    EmbeddedHostHeartbeatRequest,
+    EmbeddedHostRegisterRequest,
+    EmbeddedHostSessionEventRequest,
+    _bounded_mapping,
+)
+
 logger = structlog.get_logger(__name__)
 MAX_EMBEDDED_CONTROL_KEY_LENGTH = 220
-
-
-def _bounded_mapping(
-    value: dict[str, Any], *, label: str, max_entries: int, max_bytes: int
-) -> dict[str, Any]:
-    if len(value) > max_entries:
-        raise ValueError(f"{label} exceeds the {max_entries}-entry limit")
-    try:
-        encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode()
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{label} must be JSON serializable") from exc
-    if len(encoded) > max_bytes:
-        raise ValueError(f"{label} exceeds the {max_bytes}-byte limit")
-    return value
-
-
-class EmbeddedHostRegisterRequest(BaseModel):
-    """Host registration payload accepted from an unchanged Omnigent host."""
-
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
-
-    host_id: str | None = Field(None, alias="hostId")
-    runner_id: str | None = Field(None, alias="runnerId")
-    capabilities: dict[str, Any] = Field(default_factory=dict)
-
-    @field_validator("capabilities")
-    @classmethod
-    def validate_capabilities(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return _bounded_mapping(
-            value,
-            label="Host capabilities",
-            max_entries=MAX_EMBEDDED_CAPABILITIES,
-            max_bytes=MAX_EMBEDDED_CAPABILITY_BYTES,
-        )
-
-
-class EmbeddedHostHeartbeatRequest(BaseModel):
-    """Host heartbeat payload."""
-
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
-
-    status: str | None = None
-    capabilities: dict[str, Any] = Field(default_factory=dict)
-
-    @field_validator("capabilities")
-    @classmethod
-    def validate_capabilities(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return _bounded_mapping(
-            value,
-            label="Host capabilities",
-            max_entries=MAX_EMBEDDED_CAPABILITIES,
-            max_bytes=MAX_EMBEDDED_CAPABILITY_BYTES,
-        )
-
-
-class EmbeddedHostSessionEventRequest(BaseModel):
-    """Host-to-MoonMind session event payload."""
-
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
-
-    type: str = Field(..., min_length=1)
-    data: dict[str, Any] = Field(default_factory=dict)
-
-    @field_validator("data")
-    @classmethod
-    def validate_data(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return _bounded_mapping(
-            value,
-            label="Host event data",
-            max_entries=MAX_EMBEDDED_EVENT_ENTRIES,
-            max_bytes=MAX_EMBEDDED_EVENT_BYTES,
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,7 +167,16 @@ def verify_embedded_host_auth(
 
 
 class OmnigentEmbeddedHostProtocolFacade:
-    """Embedded host-facing protocol facade over the bridge session store."""
+    """Embedded host-facing protocol facade over the bridge session store.
+
+    ``drain_retained_sessions`` builds a drain-only facade for retained
+    embedded rows after the transport retired (#3955): the global-mode gate is
+    bypassed so stop, terminal cleanup, delete, reads, and retained-row event
+    controls keep reaching their recorded embedded owner while the deployment
+    runs proxy mode, but new admission (session/host creation, runner dispatch,
+    heartbeat, host event-ingest) stays refused with the actionable proxy
+    alternative.
+    """
 
     def __init__(
         self,
@@ -241,6 +186,7 @@ class OmnigentEmbeddedHostProtocolFacade:
         host_channels: EmbeddedHostChannelRegistry = embedded_host_channels,
         artifact_gateway: OmnigentArtifactGateway | None = None,
         runner_binding_root_secret: str | None = None,
+        drain_retained_sessions: bool = False,
     ) -> None:
         self._run_store = run_store
         self._config = config
@@ -248,10 +194,27 @@ class OmnigentEmbeddedHostProtocolFacade:
         self._artifact_gateway = artifact_gateway or LocalOmnigentArtifactGateway()
         self._event_journal_locks: dict[str, asyncio.Lock] = {}
         self._runner_binding_root_secret = runner_binding_root_secret
+        self._drain_retained_sessions = drain_retained_sessions
+
+    def _retired_admission_error(self, operation: str) -> OmnigentBridgeError:
+        """Refuse new embedded-transport admission on a drain facade (#3955)."""
+
+        return OmnigentBridgeError(
+            f"The experimental embedded host transport is retired "
+            f"(MoonLadderStudios/MoonMind#3955) and cannot admit new work "
+            f"({operation}). Select 'upstream_omnigent_server_proxy' for new "
+            f"sessions; retained sessions keep draining under their recorded "
+            f"cleanup owner.",
+            failure_class="user_error",
+            status_code=410,
+            code="omnigent_embedded_transport_retired",
+        )
 
     async def dispatch_runner(self, *, idempotency_key: str) -> dict[str, Any]:
         """Dispatch and durably bind a runner to an authorized embedded session."""
 
+        if self._drain_retained_sessions:
+            raise self._retired_admission_error("dispatch_runner")
         self._require_embedded_mode()
         row = await self._run_store.get_existing(idempotency_key)
         if row is None or not row.omnigent_session_id or not row.omnigent_host_id:
@@ -1396,6 +1359,8 @@ class OmnigentEmbeddedHostProtocolFacade:
     ) -> dict[str, Any]:
         """Create or reuse a local embedded bridge session."""
 
+        if self._drain_retained_sessions:
+            raise self._retired_admission_error("create_session")
         self._require_embedded_mode()
         validate_bridge_host_fields(
             host_type=request.host_type,
@@ -1483,6 +1448,8 @@ class OmnigentEmbeddedHostProtocolFacade:
         request: EmbeddedHostRegisterRequest,
         auth: EmbeddedHostAuthContext,
     ) -> dict[str, Any]:
+        if self._drain_retained_sessions:
+            raise self._retired_admission_error("register_host")
         self._require_embedded_mode()
         host_id = _clean(request.host_id) or auth.runner_id
         runner_id = _clean(request.runner_id) or auth.runner_id
@@ -1523,6 +1490,8 @@ class OmnigentEmbeddedHostProtocolFacade:
         request: EmbeddedHostHeartbeatRequest,
         auth: EmbeddedHostAuthContext,
     ) -> dict[str, Any]:
+        if self._drain_retained_sessions:
+            raise self._retired_admission_error("heartbeat")
         self._require_embedded_mode()
         if _clean(host_id) != auth.runner_id:
             raise OmnigentBridgeError(
@@ -1584,6 +1553,8 @@ class OmnigentEmbeddedHostProtocolFacade:
         request: EmbeddedHostSessionEventRequest,
         auth: EmbeddedHostAuthContext,
     ) -> dict[str, Any]:
+        if self._drain_retained_sessions:
+            raise self._retired_admission_error("ingest_session_event")
         self._require_embedded_mode()
         if _clean(host_id) != auth.runner_id:
             raise OmnigentBridgeError(
@@ -1697,6 +1668,11 @@ class OmnigentEmbeddedHostProtocolFacade:
         return raw_ref, normalized_ref
 
     def _require_embedded_mode(self) -> None:
+        if self._drain_retained_sessions:
+            # Retained-row drain under proxy global mode (#3955): admission
+            # entrypoints refuse explicitly via _retired_admission_error, so
+            # the global-mode gate must not block stop/cleanup/delete/reads.
+            return
         if self._config.host_protocol_mode != HOST_PROTOCOL_MODE_EMBEDDED:
             raise OmnigentBridgeError(
                 "Embedded Omnigent host protocol requires "

--- a/moonmind/omnigent/bridge_embedded.py
+++ b/moonmind/omnigent/bridge_embedded.py
@@ -67,7 +67,6 @@ from moonmind.omnigent.embedded_host_requests import (
     EmbeddedHostHeartbeatRequest,
     EmbeddedHostRegisterRequest,
     EmbeddedHostSessionEventRequest,
-    _bounded_mapping,
 )
 
 logger = structlog.get_logger(__name__)

--- a/moonmind/omnigent/embedded_host_requests.py
+++ b/moonmind/omnigent/embedded_host_requests.py
@@ -1,0 +1,108 @@
+"""Retired embedded host-route request payloads (#3955).
+
+MoonLadderStudios/MoonMind#3955 retires the experimental embedded host/runner
+transport admission while keeping historical evidence readable. These three
+Pydantic payloads are the API contract for the retired host routes
+(register/heartbeat/event-ingest): they must stay importable from the proxy-
+only production path (API router, OpenAPI schema) without requiring the
+retired embedded launch modules (``bridge_embedded``,
+``embedded_host_channel``, ``embedded_evidence``).
+
+``bridge_embedded`` re-exports these names so existing facade-internal and
+test imports keep working; the canonical definition lives here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+MAX_EMBEDDED_CAPABILITIES = 128
+MAX_EMBEDDED_CAPABILITY_BYTES = 64 * 1024
+MAX_EMBEDDED_EVENT_ENTRIES = 1024
+MAX_EMBEDDED_EVENT_BYTES = 1024 * 1024
+
+
+def _bounded_mapping(
+    value: dict[str, Any], *, label: str, max_entries: int, max_bytes: int
+) -> dict[str, Any]:
+    if len(value) > max_entries:
+        raise ValueError(f"{label} exceeds the {max_entries}-entry limit")
+    try:
+        encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode()
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be JSON serializable") from exc
+    if len(encoded) > max_bytes:
+        raise ValueError(f"{label} exceeds the {max_bytes}-byte limit")
+    return value
+
+
+class EmbeddedHostRegisterRequest(BaseModel):
+    """Host registration payload accepted from an unchanged Omnigent host."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    host_id: str | None = Field(None, alias="hostId")
+    runner_id: str | None = Field(None, alias="runnerId")
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("capabilities")
+    @classmethod
+    def validate_capabilities(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _bounded_mapping(
+            value,
+            label="Host capabilities",
+            max_entries=MAX_EMBEDDED_CAPABILITIES,
+            max_bytes=MAX_EMBEDDED_CAPABILITY_BYTES,
+        )
+
+
+class EmbeddedHostHeartbeatRequest(BaseModel):
+    """Host heartbeat payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    status: str | None = None
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("capabilities")
+    @classmethod
+    def validate_capabilities(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _bounded_mapping(
+            value,
+            label="Host capabilities",
+            max_entries=MAX_EMBEDDED_CAPABILITIES,
+            max_bytes=MAX_EMBEDDED_CAPABILITY_BYTES,
+        )
+
+
+class EmbeddedHostSessionEventRequest(BaseModel):
+    """Host-to-MoonMind session event payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    type: str = Field(..., min_length=1)
+    data: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("data")
+    @classmethod
+    def validate_data(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _bounded_mapping(
+            value,
+            label="Host event data",
+            max_entries=MAX_EMBEDDED_EVENT_ENTRIES,
+            max_bytes=MAX_EMBEDDED_EVENT_BYTES,
+        )
+
+
+__all__ = [
+    "MAX_EMBEDDED_CAPABILITIES",
+    "MAX_EMBEDDED_CAPABILITY_BYTES",
+    "MAX_EMBEDDED_EVENT_BYTES",
+    "MAX_EMBEDDED_EVENT_ENTRIES",
+    "EmbeddedHostHeartbeatRequest",
+    "EmbeddedHostRegisterRequest",
+    "EmbeddedHostSessionEventRequest",
+]

--- a/moonmind/omnigent/legacy_retirement.py
+++ b/moonmind/omnigent/legacy_retirement.py
@@ -1078,6 +1078,83 @@ RETIREMENT_INVENTORY: tuple[LegacyPathRecord, ...] = (
         ),
     ),
     LegacyPathRecord(
+        pathId="omnigent.embedded.transport_selection",
+        owner="omnigent-control-plane",
+        description=(
+            "Experimental embedded host/runner transport selection "
+            "(MoonLadderStudios/MoonMind#3955). New admission is disabled at the "
+            "trusted bridge-config selection boundary: an enabled bridge that "
+            "selects embedded_omnigent_compatible_server fails fast with the "
+            "proxy alternative. The literal survives only for decoding retained "
+            "session rows and historical evidence. Native Workflow Chat "
+            "embedded=1 presentation and shared bridge/session/event contracts "
+            "are not part of this path."
+        ),
+        family=ComponentFamily.BRIDGE_COMPATIBILITY,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.NEW_ADMISSION_DISABLED,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.bridge_config:HOST_PROTOCOL_MODE_EMBEDDED"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.bridge_config:HOST_PROTOCOL_MODE_EMBEDDED",
+            "python:moonmind.omnigent.bridge_config:parse_bridge_config",
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+                ActiveOwnerKind.CREDENTIAL_CONSUMER,
+            }
+        ),
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.PRODUCT_SELECTORS,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_embedded_transport_retirement_3955.py::"
+            "test_new_embedded_transport_admission_is_rejected"
+        ),
+    ),
+    LegacyPathRecord(
+        pathId="omnigent.embedded.launch_and_host_routes",
+        owner="omnigent-control-plane",
+        description=(
+            "Embedded host launch facade, host/runner tunnel channels, and "
+            "transport-specific HTTP/WebSocket routes "
+            "(MoonLadderStudios/MoonMind#3955). Retained for in-flight cleanup "
+            "and historical reads until bounded drain probes establish no active "
+            "or cleanup owner remains; physical removal follows at the launch "
+            "stage, never in the same change as the product selector."
+        ),
+        family=ComponentFamily.BRIDGE_COMPATIBILITY,
+        generation=RuntimeGeneration.SHARED_LEGACY_SUBSTRATE,
+        retirementClass=RetirementClass.NEW_ADMISSION_DISABLED,
+        machineCheckableRef=(
+            "python:moonmind.omnigent.bridge_embedded:"
+            "OmnigentEmbeddedHostProtocolFacade"
+        ),
+        surfaces=(
+            "python:moonmind.omnigent.bridge_embedded:"
+            "OmnigentEmbeddedHostProtocolFacade",
+            "python:moonmind.omnigent.embedded_host_channel:embedded_host_channels",
+        ),
+        activeResourceDependencies=frozenset(
+            {
+                ActiveOwnerKind.AGENT_RUN_OR_OMNIGENT_SESSION,
+                ActiveOwnerKind.HOST_BINDING_OR_LEASE,
+                ActiveOwnerKind.STATIC_OR_ON_DEMAND_HOST,
+                ActiveOwnerKind.INCOMPLETE_CLEANUP_OR_JANITOR,
+            }
+        ),
+        historicalReadDependency=True,
+        applicableCriteria=_BASE_CRITERIA,
+        earliestRemovalStage=RemovalStage.LAUNCH_ONLY_CODE,
+        removalGuardTest=(
+            "tests/unit/omnigent/test_embedded_transport_retirement_3955.py::"
+            "test_proxy_operates_with_embedded_launch_modules_unavailable"
+        ),
+    ),
+    LegacyPathRecord(
         pathId="omnigent.legacy.native_ui_compat",
         owner="omnigent-control-plane",
         description="Legacy native chat / Workflow Detail compatibility projection.",

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -3106,6 +3106,21 @@ async def main_async() -> None:
     # worker alone would produce no deprecation warning and could later accept a
     # variable the API rejects.
     enforce_obsolete_configuration_at_startup(logger)
+    # The retired embedded host transport (#3955) must fail actionably at worker
+    # startup exactly as it does at API startup: an operator document that
+    # selects embedded_omnigent_compatible_server on an enabled bridge is a
+    # retired instruction, never an ignored one or a hidden proxy fallback.
+    # Retained sessions keep their recorded mode for historical reads and drain
+    # under their recorded cleanup owner; this check only rejects new admission.
+    from moonmind.omnigent.bridge_config import (
+        BridgeConfigError,
+        resolve_bridge_config,
+    )
+
+    try:
+        resolve_bridge_config()
+    except BridgeConfigError as exc:
+        raise SystemExit(f"invalid Omnigent bridge configuration: {exc}") from exc
     topology = describe_configured_worker()
     _enforce_codex_config_for_managed_fleet(topology.fleet)
 

--- a/tests/integration/omnigent/test_embedded_projection_conformance.py
+++ b/tests/integration/omnigent/test_embedded_projection_conformance.py
@@ -64,8 +64,11 @@ def _request(key: str) -> AgentExecutionRequest:
 
 
 def _config():
+    # Retired (#3955): retained here for historical-read/projection coverage
+    # through a disabled declaration. Enabled embedded admission fails fast.
     return parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {

--- a/tests/integration/omnigent/test_embedded_recovery.py
+++ b/tests/integration/omnigent/test_embedded_recovery.py
@@ -102,7 +102,10 @@ def store(session_factory):
 
 
 def _config():
+    # Retired (#3955): retained here for drain/recovery coverage through a
+    # disabled declaration. Enabled embedded admission fails fast.
     return parse_bridge_config({
+        "enabled": False,
         "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
         "hostConnection": {"embedded": {
             "proxyConformanceEvidenceRef": "artifact://proxy",

--- a/tests/unit/api/routers/test_omnigent_bridge.py
+++ b/tests/unit/api/routers/test_omnigent_bridge.py
@@ -33,6 +33,8 @@ from api_service.api.routers.retrieval_gateway import get_capability_registry
 from api_service.auth_providers import get_current_user
 from moonmind.omnigent.bridge_config import (
     HOST_PROTOCOL_MODE_EMBEDDED,
+    HOST_PROTOCOL_MODE_PROXY,
+    BridgeConfigError,
     parse_bridge_config,
 )
 from moonmind.omnigent.bridge_proxy import (
@@ -42,10 +44,6 @@ from moonmind.omnigent.bridge_proxy import (
 from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
 from moonmind.omnigent.control_plane.turn_sources import TurnSource
 from moonmind.omnigent.effective_capabilities import CAPABILITY_NAMES
-from moonmind.omnigent.host_auth_contracts import (
-    HostAuthCredentialProfile,
-    HostAuthProfileError,
-)
 
 _USER_ID = uuid4()
 
@@ -200,13 +198,11 @@ def test_readiness_reports_selected_mode_and_conformance_state(monkeypatch) -> N
 
 @pytest.mark.asyncio
 async def test_embedded_preflight_gates_failed_host_auth(monkeypatch) -> None:
-    host_auth_module = importlib.import_module("moonmind.omnigent.host_auth_profile")
-    monkeypatch.setattr(
-        host_auth_module, "assert_pinned_omnigent_auth_contract", lambda: None
-    )
-    monkeypatch.setitem(
-        embedded_host_auth_preflight.__globals__,
-        "_BRIDGE_CONFIG",
+    # Retired (#3955): the experimental embedded transport cannot be selected
+    # for new admission, so the preflight enablement boundary is never reached
+    # with an embedded config. The default proxy bridge reports host auth as
+    # not selected instead of resolving embedded credentials.
+    with pytest.raises(BridgeConfigError, match="3955"):
         parse_bridge_config({
             "enabled": True,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
@@ -215,84 +211,36 @@ async def test_embedded_preflight_gates_failed_host_auth(monkeypatch) -> None:
                 "liveSmokeEvidenceRef": "artifact://smoke",
                 "hostAuthConformanceEvidenceRef": "artifact://auth",
             }},
-        }),
-    )
-    composition = importlib.import_module(
-        "api_service.api.routers.omnigent_bridge_composition"
-    )
-    monkeypatch.setattr(
-        composition,
-        "resolve_active_host_auth_profile",
-        AsyncMock(
-            return_value=HostAuthCredentialProfile(
-                "managed", "env://ABSENT_HOST_TOKEN", 1
-            )
-        ),
+        })
+    monkeypatch.setitem(
+        embedded_host_auth_preflight.__globals__,
+        "_BRIDGE_CONFIG",
+        parse_bridge_config({}),
     )
     result = await embedded_host_auth_preflight()
-    assert result["ready"] is False
-    assert result["code"] == "host_auth_secret_unavailable"
-    assert "ABSENT_HOST_TOKEN" not in str(result)
+    assert result == {"ready": True, "code": "host_auth_not_selected"}
 
 
-def test_embedded_readiness_stays_gated_when_artifacts_are_invalid(monkeypatch) -> None:
-    module = importlib.import_module("api_service.api.routers.omnigent_bridge")
-    config = parse_bridge_config(
-        {
-            "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
-            "hostConnection": {
-                "embedded": {
-                    "proxyConformanceEvidenceRef": "arbitrary",
-                    "liveSmokeEvidenceRef": "missing",
-                    "hostAuthConformanceEvidenceRef": "unauthorized",
-                }
-            },
-        }
-    )
-
-    async def invalid(_config, **_kwargs):
-        return {
-            key: {
-                "status": "failed",
-                "reason": "evidence_unavailable_or_invalid",
+def test_embedded_readiness_selection_is_retired() -> None:
+    # Retired (#3955): an enabled embedded selection fails fast with the proxy
+    # alternative instead of rendering evidence-gated readiness. The enabled
+    # bridge reports the proxy-only topology.
+    with pytest.raises(BridgeConfigError, match="3955"):
+        parse_bridge_config(
+            {
+                "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
+                "hostConnection": {
+                    "embedded": {
+                        "proxyConformanceEvidenceRef": "arbitrary",
+                        "liveSmokeEvidenceRef": "missing",
+                        "hostAuthConformanceEvidenceRef": "unauthorized",
+                    }
+                },
             }
-            for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
-        }
-
-    monkeypatch.setattr(module, "_resolve_embedded_evidence", invalid)
-    monkeypatch.setattr(
-        importlib.import_module(
-            "api_service.api.routers.omnigent_bridge_composition"
-        ),
-        "resolve_active_host_auth_profile",
-        AsyncMock(
-            side_effect=HostAuthProfileError(
-                "host authentication is unavailable",
-                code="host_auth_secret_unavailable",
-            )
-        ),
-    )
-    app = FastAPI()
-    app.include_router(router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
-    app.dependency_overrides[get_current_user()] = _mock_user
-    app.dependency_overrides[_require_bridge_enabled] = lambda: config
-
-    response = TestClient(app).get(_READINESS_PATH)
-
-    assert response.status_code == 200
-    assert response.json()["conformanceState"] == "gated"
-    assert response.json()["gateReason"] == "validated_embedded_evidence_required"
-    diagnostics = response.json()["compatibilityDiagnostics"]
-    assert diagnostics["bridgeMode"] == HOST_PROTOCOL_MODE_EMBEDDED
-    assert diagnostics["compatibilityProfile"] == "omnigent.runner_tunnel.983c93c6"
-    assert diagnostics["auth"]["code"] == "host_auth_secret_unavailable"
-    assert diagnostics["evidence"]["fresh"] is False
-    assert diagnostics["failureReason"] == "validated_embedded_evidence_required"
-    assert diagnostics["rollbackRecommendation"] == (
-        "Select upstream_omnigent_server_proxy for new sessions; "
-        "existing sessions retain their recorded bridge mode."
-    )
-    assert all(row["supported"] is False for row in diagnostics["supportMatrix"])
+        )
+    readiness = parse_bridge_config({}).readiness()
+    assert readiness["selectedMode"] == HOST_PROTOCOL_MODE_PROXY
+    assert readiness["evidenceRefs"] == {}
 
 
 def _fake_store_dependency() -> "_FakeStore":
@@ -969,6 +917,7 @@ def test_provider_stream_authorizes_and_proxies_sse() -> None:
 def test_embedded_stream_emits_durable_sse_cursor_and_resumes() -> None:
     monkeypatch_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -1002,6 +951,7 @@ def test_embedded_stream_emits_durable_sse_cursor_and_resumes() -> None:
 def test_embedded_public_routes_use_same_authorized_facade_boundary() -> None:
     config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -1787,6 +1737,7 @@ def test_create_session_available_in_embedded_mode() -> None:
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -1824,6 +1775,7 @@ def test_stop_session_event_dispatches_to_embedded_exact_host_facade() -> None:
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -1878,6 +1830,7 @@ def test_cleanup_session_event_uses_typed_embedded_control() -> None:
     app.include_router(router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config({
+        "enabled": False,
         "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
         "hostConnection": {"embedded": {
             "proxyConformanceEvidenceRef": "artifact://omnigent/proxy",
@@ -1916,6 +1869,7 @@ def test_cleanup_session_rejects_missing_terminal_lease_evidence() -> None:
     app.include_router(router, prefix=OMNIGENT_BRIDGE_MOUNT_PATH)
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config({
+        "enabled": False,
         "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
         "hostConnection": {"embedded": {
             "proxyConformanceEvidenceRef": "artifact://omnigent/proxy",
@@ -1950,6 +1904,7 @@ def test_interrupt_embedded_control_is_explicitly_unsupported() -> None:
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -2010,6 +1965,7 @@ def test_unknown_stream_schema_version_emits_stable_visible_error() -> None:
 
     config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -2052,6 +2008,7 @@ def test_proxy_stream_passes_through_untyped_upstream_frames() -> None:
 def test_proxy_and_embedded_share_unknown_and_non_owner_error_contracts() -> None:
     embedded_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -2107,6 +2064,7 @@ def test_embedded_clear_rejection_preserves_retrieval_authority() -> None:
     facade = _FakeEmbeddedFacade()
     embedded_config = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {

--- a/tests/unit/omnigent/test_bridge_config.py
+++ b/tests/unit/omnigent/test_bridge_config.py
@@ -207,67 +207,22 @@ def test_host_protocol_mode_defaults_to_proxy_first() -> None:
     assert config.host_connection.mode == HOST_PROTOCOL_MODE_PROXY
 
 
-def test_host_protocol_mode_accepts_embedded() -> None:
-    config = parse_bridge_config(
-        {
-            "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
-            "hostConnection": {
-                "embedded": {
-                    "proxyConformanceEvidenceRef": "artifact://omnigent/proxy-conformance",
-                    "liveSmokeEvidenceRef": "artifact://omnigent/live-smoke",
-                    "hostAuthConformanceEvidenceRef": "artifact://omnigent/host-auth",
-                }
-            },
-        }
-    )
+def test_enabled_embedded_mode_is_retired() -> None:
+    """An enabled bridge cannot select the retired embedded transport (#3955)."""
 
-    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
-    # hostConnection.mode is resolved from the compatibility mode.
-    assert config.host_connection.mode == HOST_PROTOCOL_MODE_EMBEDDED
-    assert (
-        config.host_connection.embedded.host_auth_conformance_evidence_ref
-        == "artifact://omnigent/host-auth"
-    )
-    assert config.readiness() == {
-        "enabled": True,
-        "selectedMode": HOST_PROTOCOL_MODE_EMBEDDED,
-        "protocolProfile": "omnigent.runner_tunnel.983c93c6",
-        "upstreamComponentVersion": "983c93c6",
-        "conformanceState": "gated",
-        "evidenceRefs": {
-            "proxyConformance": "artifact://omnigent/proxy-conformance",
-            "liveSmoke": "artifact://omnigent/live-smoke",
-            "hostAuthConformance": "artifact://omnigent/host-auth",
-        },
-        "evidenceValidation": {},
-        "gateReason": "validated_embedded_evidence_required",
-    }
-
-    validation = {
-        key: {
-            "status": "passed",
-            "supportedHostModes": ["static_compose", "on_demand_docker"],
-        }
-        for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
-    }
-    assert (
-        config.readiness(evidence_validation=validation)["conformanceState"] == "ready"
-    )
-    mode_validation = {
-        key: {"status": "passed", "supportedHostModes": ["static_compose"]}
-        for key in ("proxyConformance", "liveSmoke", "hostAuthConformance")
-    }
-    assert config.readiness(
-        evidence_validation=mode_validation, host_mode="static_compose"
-    )["conformanceState"] == "ready"
-    unsupported = config.readiness(
-        evidence_validation=mode_validation, host_mode="on_demand_docker"
-    )
-    assert unsupported["conformanceState"] == "gated"
-    assert unsupported["gateReason"] == "embedded_host_mode_evidence_required"
-    assert config.readiness(
-        evidence_validation=mode_validation
-    )["conformanceState"] == "gated"
+    with pytest.raises(BridgeConfigError, match="3955"):
+        parse_bridge_config(
+            {
+                "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
+                "hostConnection": {
+                    "embedded": {
+                        "proxyConformanceEvidenceRef": "artifact://omnigent/proxy-conformance",
+                        "liveSmokeEvidenceRef": "artifact://omnigent/live-smoke",
+                        "hostAuthConformanceEvidenceRef": "artifact://omnigent/host-auth",
+                    }
+                },
+            }
+        )
 
 
 def test_proxy_readiness_exposes_supported_fallback_without_embedded_evidence(
@@ -291,7 +246,9 @@ def test_proxy_readiness_is_gated_when_runtime_is_disabled(monkeypatch) -> None:
 
 
 def test_embedded_mode_requires_conformance_and_smoke_evidence() -> None:
-    with pytest.raises(BridgeConfigError, match="proxy conformance"):
+    # Retired (#3955): an enabled embedded selection fails with the proxy
+    # alternative even when evidence refs are missing entirely.
+    with pytest.raises(BridgeConfigError, match="3955"):
         parse_bridge_config(
             {"compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED}}
         )

--- a/tests/unit/omnigent/test_bridge_embedded.py
+++ b/tests/unit/omnigent/test_bridge_embedded.py
@@ -76,8 +76,13 @@ async def store(tmp_path):
 
 
 def _embedded_config():
+    # Retired (#3955): the embedded facade is retained for in-flight cleanup
+    # and historical reads only. Tests exercise it through a disabled bridge
+    # declaration; an enabled embedded selection fails fast at the trusted
+    # selection boundary with the proxy alternative.
     return parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {

--- a/tests/unit/omnigent/test_bridge_proxy.py
+++ b/tests/unit/omnigent/test_bridge_proxy.py
@@ -722,8 +722,12 @@ async def test_resolve_elicitation_proxies_compatibility_route() -> None:
 
 
 async def test_non_proxy_mode_fails_fast() -> None:
+    # Retired (#3955): the proxy facade still refuses a retained embedded
+    # declaration (drain path). Enabled embedded admission fails earlier, at
+    # the trusted bridge-config selection boundary.
     embedded = parse_bridge_config(
         {
+            "enabled": False,
             "compatibility": {
                 "hostProtocolMode": "embedded_omnigent_compatible_server"
             },

--- a/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
+++ b/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
@@ -189,7 +189,7 @@ def test_removal_waits_for_bounded_drain_before_launch_code() -> None:
 
 
 def test_proxy_operates_with_embedded_launch_modules_unavailable() -> None:
-    """Proxy config, contracts, and composition load with embedded gone."""
+    """Proxy config, contracts, composition, and the API router load with embedded gone."""
 
     script = "\n".join(
         [
@@ -220,10 +220,22 @@ def test_proxy_operates_with_embedded_launch_modules_unavailable() -> None:
             "from moonmind.omnigent.bridge_proxy import BridgeSessionCreateRequest, BridgeSessionEventRequest",
             "BridgeSessionCreateRequest(labels={'moonmind.workflow_id': 'wf-1'})",
             "BridgeSessionEventRequest(type='message')",
+            "from moonmind.omnigent.embedded_host_requests import EmbeddedHostRegisterRequest",
+            "EmbeddedHostRegisterRequest(hostId='h-1')",
             "import api_service.api.routers.omnigent_bridge_composition as composition",
             "assert callable(composition.build_bridge_session_proxy)",
             "assert callable(composition.build_bridge_session_store)",
+            # The production proxy API surface (router import + route table)
+            # must not require the retired launch modules either.
+            "import api_service.api.routers.omnigent_bridge as bridge_router",
+            "paths = {getattr(route, 'path', '') for route in bridge_router.router.routes}",
+            "assert '/v1/hosts/register' in paths",
+            "assert 410 in bridge_router._PUBLIC_ERROR_RESPONSES",
+            "retired = [r for r in bridge_router.router.routes if getattr(r, 'path', '') in {'/v1/hosts/register'}]",
+            "assert retired and 410 in (retired[0].responses or {})",
             "assert 'moonmind.omnigent.bridge_embedded' not in sys.modules",
+            "assert 'moonmind.omnigent.embedded_host_channel' not in sys.modules",
+            "assert 'moonmind.omnigent.embedded_evidence' not in sys.modules",
             "print('proxy-without-embedded-ok')",
         ]
     )
@@ -295,3 +307,142 @@ def test_bridge_config_module_still_decodes_historical_embedded_literal() -> Non
         "schemaVersion: moonmind.omnigent_bridge.v1\nenabled: false\n"
         "compatibility:\n  hostProtocolMode: embedded_omnigent_compatible_server\n"
     ).host_protocol_mode
+
+
+def test_retired_host_routes_declare_410_in_openapi() -> None:
+    """Register/heartbeat/event-ingest model the terminal 410 response (#3955)."""
+
+    from api_service.api.routers import omnigent_bridge as bridge_router
+
+    assert 410 in bridge_router._PUBLIC_ERROR_RESPONSES
+    wanted = {
+        "/v1/hosts/register",
+        "/v1/hosts/{host_id}/heartbeat",
+        "/v1/hosts/{host_id}/sessions/{session_id}/events",
+    }
+    found: dict[str, dict[int, Any]] = {}
+    for route in bridge_router.router.routes:
+        path = str(getattr(route, "path", ""))
+        if path in wanted:
+            found[path] = dict(getattr(route, "responses", None) or {})
+    assert set(found) == wanted
+    for path, responses in found.items():
+        assert 410 in responses, path
+        assert (
+            responses[410].get("model") is bridge_router.OmnigentPublicErrorResponse
+        ), path
+
+
+def test_tunnel_retirement_close_carries_reason() -> None:
+    """WebSocket retirement denials name the cause and the alternative (#3955)."""
+
+    from api_service.api.routers import omnigent_bridge as bridge_router
+
+    reason = bridge_router._EMBEDDED_TRANSPORT_RETIRED_CLOSE_REASON
+    assert "omnigent_embedded_transport_retired" in reason
+    assert "upstream_omnigent_server_proxy" in reason
+    assert len(reason.encode("utf-8")) <= 123
+
+
+@pytest.mark.asyncio
+async def test_retained_embedded_sessions_drain_under_proxy_mode() -> None:
+    """Persisted-mode dispatch keeps retained drain paths on their owner (#3955)."""
+
+    from types import SimpleNamespace
+
+    from api_service.api.routers import omnigent_bridge as bridge_router
+
+    config = parse_bridge_config({})
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+    proxy = object()
+
+    class _Store:
+        def __init__(self, row: Any) -> None:
+            self._row = row
+
+        async def get_session_by_provider_session_id(
+            self, session_id: str
+        ) -> Any:
+            return self._row
+
+    embedded_row = SimpleNamespace(
+        metadata_={"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED}
+    )
+    facade, selected = await bridge_router._resolve_session_control_facade(
+        session_id="sess-1",
+        config=config,
+        proxy=proxy,  # type: ignore[arg-type]
+        embedded_facade=None,
+        store=_Store(embedded_row),  # type: ignore[arg-type]
+    )
+    assert selected is True
+    assert facade is not None and facade is not proxy
+    assert getattr(facade, "_drain_retained_sessions", False) is True
+
+    proxy_row = SimpleNamespace(
+        metadata_={"hostProtocolMode": HOST_PROTOCOL_MODE_PROXY}
+    )
+    facade_proxy, selected_proxy = (
+        await bridge_router._resolve_session_control_facade(
+            session_id="sess-1",
+            config=config,
+            proxy=proxy,  # type: ignore[arg-type]
+            embedded_facade=None,
+            store=_Store(proxy_row),  # type: ignore[arg-type]
+        )
+    )
+    assert facade_proxy is proxy
+    assert selected_proxy is False
+
+    facade_unknown, selected_unknown = (
+        await bridge_router._resolve_session_control_facade(
+            session_id="sess-unknown",
+            config=config,
+            proxy=proxy,  # type: ignore[arg-type]
+            embedded_facade=None,
+            store=_Store(None),  # type: ignore[arg-type]
+        )
+    )
+    assert facade_unknown is proxy
+    assert selected_unknown is False
+
+
+@pytest.mark.asyncio
+async def test_drain_facade_refuses_new_admission() -> None:
+    """A drain facade drains retained rows but never admits new work (#3955)."""
+
+    from moonmind.omnigent.bridge_embedded import (
+        OmnigentEmbeddedHostProtocolFacade,
+    )
+
+    config = parse_bridge_config({})
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+
+    class _Store:
+        pass
+
+    facade = OmnigentEmbeddedHostProtocolFacade(
+        run_store=_Store(),  # type: ignore[arg-type]
+        config=config,
+        drain_retained_sessions=True,
+    )
+    for operation in (
+        facade.create_session,
+        facade.dispatch_runner,
+        facade.register_host,
+    ):
+        try:
+            if operation is facade.create_session:
+                await operation(request=None, binding=None)  # type: ignore[arg-type]
+            elif operation is facade.dispatch_runner:
+                await operation(idempotency_key="key")
+            else:
+                await operation(request=None, auth=None)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001 - asserting mapped denial below
+            assert getattr(exc, "status_code", None) == 410
+            assert (
+                getattr(exc, "code", "")
+                == "omnigent_embedded_transport_retired"
+            )
+        else:
+            raise AssertionError(f"{operation.__name__} admitted new work")

--- a/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
+++ b/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
@@ -230,9 +230,13 @@ def test_proxy_operates_with_embedded_launch_modules_unavailable() -> None:
             "import api_service.api.routers.omnigent_bridge as bridge_router",
             "paths = {getattr(route, 'path', '') for route in bridge_router.router.routes}",
             "assert '/v1/hosts/register' in paths",
-            "assert 410 in bridge_router._PUBLIC_ERROR_RESPONSES",
-            "retired = [r for r in bridge_router.router.routes if getattr(r, 'path', '') in {'/v1/hosts/register'}]",
-            "assert retired and 410 in (retired[0].responses or {})",
+            "retired = [r for r in bridge_router.router.routes if getattr(r, 'path', '') in {",
+            "    '/v1/hosts/register',",
+            "    '/v1/hosts/{host_id}/heartbeat',",
+            "    '/v1/hosts/{host_id}/sessions/{session_id}/events',",
+            "}]",
+            "assert len(retired) == 3",
+            "assert all(410 in (r.responses or {}) for r in retired)",
             "assert 'moonmind.omnigent.bridge_embedded' not in sys.modules",
             "assert 'moonmind.omnigent.embedded_host_channel' not in sys.modules",
             "assert 'moonmind.omnigent.embedded_evidence' not in sys.modules",
@@ -314,7 +318,6 @@ def test_retired_host_routes_declare_410_in_openapi() -> None:
 
     from api_service.api.routers import omnigent_bridge as bridge_router
 
-    assert 410 in bridge_router._PUBLIC_ERROR_RESPONSES
     wanted = {
         "/v1/hosts/register",
         "/v1/hosts/{host_id}/heartbeat",

--- a/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
+++ b/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
@@ -430,22 +430,23 @@ async def test_drain_facade_refuses_new_admission() -> None:
         drain_retained_sessions=True,
     )
     for operation in (
-        facade.create_session,
-        facade.dispatch_runner,
-        facade.register_host,
+        ("create_session", {"request": None, "binding": None}),
+        ("dispatch_runner", {"idempotency_key": "key"}),
+        ("register_host", {"request": None, "auth": None}),
+        ("heartbeat", {"host_id": "h", "request": None, "auth": None}),
+        (
+            "ingest_session_event",
+            {"host_id": "h", "session_id": "s", "request": None, "auth": None},
+        ),
     ):
+        name, kwargs = operation
         try:
-            if operation is facade.create_session:
-                await operation(request=None, binding=None)  # type: ignore[arg-type]
-            elif operation is facade.dispatch_runner:
-                await operation(idempotency_key="key")
-            else:
-                await operation(request=None, auth=None)  # type: ignore[arg-type]
+            await getattr(facade, name)(**kwargs)  # type: ignore[arg-type]
         except Exception as exc:  # noqa: BLE001 - asserting mapped denial below
-            assert getattr(exc, "status_code", None) == 410
+            assert getattr(exc, "status_code", None) == 410, name
             assert (
                 getattr(exc, "code", "")
                 == "omnigent_embedded_transport_retired"
-            )
+            ), name
         else:
-            raise AssertionError(f"{operation.__name__} admitted new work")
+            raise AssertionError(f"{name} admitted new work")

--- a/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
+++ b/tests/unit/omnigent/test_embedded_transport_retirement_3955.py
@@ -1,0 +1,297 @@
+"""Staged retirement of the experimental embedded host transport (#3955).
+
+MoonLadderStudios/MoonMind#3955 retires the experimental embedded host/runner
+transport without removing native chat or historical evidence:
+
+* new embedded-transport admission fails fast at the trusted bridge-config
+  selection boundary with an actionable proxy alternative (never a silent
+  substitution);
+* the proxy-only production path never requires the retired embedded launch
+  modules;
+* the native Workflow Chat ``embedded=1`` presentation option and the shared
+  bridge/session/event/credential contracts are preserved;
+* removed configuration is detected at API/worker startup, and readiness no
+  longer advertises the removed transport.
+
+Physical removal of the launch code follows at the launch-only removal stage
+once bounded drain probes establish no active or cleanup owner remains; these
+tests pin the admission-disabled stage, not the deletion.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.omnigent.bridge_config import (
+    CANONICAL_FIRST_MESSAGE_STATES,
+    HOST_PROTOCOL_MODE_EMBEDDED,
+    HOST_PROTOCOL_MODE_PROXY,
+    OMNIGENT_BRIDGE_CONFIG_PATH_ENV,
+    BridgeConfigError,
+    OmnigentBridgeConfig,
+    load_bridge_config,
+    parse_bridge_config,
+    resolve_bridge_config,
+)
+from moonmind.omnigent.legacy_retirement import (
+    LegacyAdmissionRejected,
+    RemovalStage,
+    RetirementClass,
+    assert_new_admission_allowed,
+    evaluate_removal_eligibility,
+    get_retirement_record,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_EMBEDDED_EVIDENCE_BLOCK = {
+    "proxyConformanceEvidenceRef": "artifact://omnigent/proxy-conformance",
+    "liveSmokeEvidenceRef": "artifact://omnigent/live-smoke",
+    "hostAuthConformanceEvidenceRef": "artifact://omnigent/host-auth",
+}
+
+
+def _enabled_embedded_document() -> dict[str, Any]:
+    return {
+        "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
+        "hostConnection": {"embedded": dict(_EMBEDDED_EVIDENCE_BLOCK)},
+    }
+
+
+def test_new_embedded_transport_admission_is_rejected() -> None:
+    """An enabled bridge cannot select the retired embedded transport."""
+
+    with pytest.raises(BridgeConfigError) as exc_info:
+        parse_bridge_config(_enabled_embedded_document())
+    message = str(exc_info.value)
+    # Actionable: names the supported alternative and the owning issue, and
+    # states the retired value is never silently substituted.
+    assert "upstream_omnigent_server_proxy" in message
+    assert "3955" in message
+    assert "never silently substituted" in message
+
+
+def test_embedded_mode_mismatch_still_fails_without_substitution() -> None:
+    """A split-brain mode declaration fails instead of picking a mode."""
+
+    with pytest.raises(BridgeConfigError):
+        parse_bridge_config(
+            {
+                "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_PROXY},
+                "hostConnection": {
+                    "mode": HOST_PROTOCOL_MODE_EMBEDDED,
+                    "embedded": dict(_EMBEDDED_EVIDENCE_BLOCK),
+                },
+            }
+        )
+
+
+def test_omitted_mode_still_resolves_to_proxy_production_path() -> None:
+    """Omitted values exercise the same proxy production path as explicit ones."""
+
+    defaulted = parse_bridge_config({})
+    explicit = parse_bridge_config(
+        {
+            "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_PROXY},
+            "hostConnection": {"mode": HOST_PROTOCOL_MODE_PROXY},
+        }
+    )
+    assert defaulted.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+    assert explicit.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY
+    assert (
+        defaulted.readiness()["selectedMode"]
+        == explicit.readiness()["selectedMode"]
+        == HOST_PROTOCOL_MODE_PROXY
+    )
+
+
+def test_disabled_embedded_declaration_still_decodes_for_historical_reads() -> None:
+    """The embedded literal survives for retained rows, not for new admission."""
+
+    config = parse_bridge_config(
+        {"enabled": False, **_enabled_embedded_document()}
+    )
+    assert config.host_protocol_mode == HOST_PROTOCOL_MODE_EMBEDDED
+    assert config.readiness()["conformanceState"] == "disabled"
+
+
+def test_readiness_no_longer_advertises_embedded_transport() -> None:
+    """An enabled bridge reports the proxy-only topology."""
+
+    readiness = parse_bridge_config({}).readiness()
+    assert readiness["selectedMode"] == HOST_PROTOCOL_MODE_PROXY
+    assert readiness["evidenceRefs"] == {}
+    assert "evidenceValidation" not in readiness
+
+
+def test_startup_resolution_rejects_retired_selection(tmp_path: Path) -> None:
+    """An operator document selecting embedded fails fast at startup."""
+
+    doc = tmp_path / "bridge.yaml"
+    doc.write_text(
+        "schemaVersion: moonmind.omnigent_bridge.v1\n"
+        "enabled: true\n"
+        "compatibility:\n"
+        "  profile: omnigent.server.v1\n"
+        "  hostUnchanged: true\n"
+        "  hostProtocolMode: embedded_omnigent_compatible_server\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(BridgeConfigError, match="3955"):
+        resolve_bridge_config(
+            env={OMNIGENT_BRIDGE_CONFIG_PATH_ENV: str(doc)}
+        )
+    # The default path (no operator document) still resolves to proxy.
+    assert (
+        resolve_bridge_config(env={}).host_protocol_mode
+        == HOST_PROTOCOL_MODE_PROXY
+    )
+
+
+def test_retirement_rows_disable_new_admission_but_keep_history() -> None:
+    """Both embedded rows refuse new work while keeping historical reads."""
+
+    selection = get_retirement_record("omnigent.embedded.transport_selection")
+    launch = get_retirement_record("omnigent.embedded.launch_and_host_routes")
+    assert selection.retirement_class is RetirementClass.NEW_ADMISSION_DISABLED
+    assert launch.retirement_class is RetirementClass.NEW_ADMISSION_DISABLED
+    assert selection.historical_read_dependency is True
+    assert launch.historical_read_dependency is True
+    # Selectors retire before launch-only code: never one unreviewable change.
+    assert selection.earliest_removal_stage is RemovalStage.PRODUCT_SELECTORS
+    assert launch.earliest_removal_stage is RemovalStage.LAUNCH_ONLY_CODE
+    assert selection.earliest_removal_stage < launch.earliest_removal_stage
+    for path_id in (
+        "omnigent.embedded.transport_selection",
+        "omnigent.embedded.launch_and_host_routes",
+    ):
+        with pytest.raises(LegacyAdmissionRejected) as exc_info:
+            assert_new_admission_allowed(path_id)
+        assert "no longer admits new work" in str(exc_info.value)
+
+
+def test_removal_waits_for_bounded_drain_before_launch_code() -> None:
+    """Launch-code removal stays blocked until every active owner drains."""
+
+    launch = get_retirement_record("omnigent.embedded.launch_and_host_routes")
+    decision = evaluate_removal_eligibility(
+        launch, stage=RemovalStage.LAUNCH_ONLY_CODE
+    )
+    assert decision.eligible is False
+    assert any(
+        blocker.startswith("active_owner:") for blocker in decision.blockers
+    )
+
+
+def test_proxy_operates_with_embedded_launch_modules_unavailable() -> None:
+    """Proxy config, contracts, and composition load with embedded gone."""
+
+    script = "\n".join(
+        [
+            "import sys",
+            "import importlib.abc",
+            "import importlib.machinery",
+            "blocked = {",
+            "    'moonmind.omnigent.bridge_embedded',",
+            "    'moonmind.omnigent.embedded_host_channel',",
+            "    'moonmind.omnigent.embedded_evidence',",
+            "    'moonmind.omnigent.embedded_acceptance',",
+            "}",
+            "class _Retired(importlib.abc.MetaPathFinder, importlib.abc.Loader):",
+            "    def find_spec(self, name, path=None, target=None):",
+            "        if name in blocked:",
+            "            return importlib.machinery.ModuleSpec(name, self)",
+            "        return None",
+            "    def create_module(self, spec):",
+            "        return None",
+            "    def exec_module(self, module):",
+            "        raise ImportError('retired embedded module unavailable: ' + module.__name__)",
+            "sys.meta_path.insert(0, _Retired())",
+            f"sys.path.insert(0, r'{REPO_ROOT}')",
+            "from moonmind.omnigent.bridge_config import parse_bridge_config, HOST_PROTOCOL_MODE_PROXY",
+            "config = parse_bridge_config({})",
+            "assert config.host_protocol_mode == HOST_PROTOCOL_MODE_PROXY",
+            "assert config.readiness()['selectedMode'] == HOST_PROTOCOL_MODE_PROXY",
+            "from moonmind.omnigent.bridge_proxy import BridgeSessionCreateRequest, BridgeSessionEventRequest",
+            "BridgeSessionCreateRequest(labels={'moonmind.workflow_id': 'wf-1'})",
+            "BridgeSessionEventRequest(type='message')",
+            "import api_service.api.routers.omnigent_bridge_composition as composition",
+            "assert callable(composition.build_bridge_session_proxy)",
+            "assert callable(composition.build_bridge_session_store)",
+            "assert 'moonmind.omnigent.bridge_embedded' not in sys.modules",
+            "print('proxy-without-embedded-ok')",
+        ]
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(REPO_ROOT),
+    )
+    assert completed.returncode == 0, completed.stderr[-3000:]
+    assert "proxy-without-embedded-ok" in completed.stdout
+
+
+def test_native_chat_embedded_presentation_flag_survives() -> None:
+    """The unrelated native-chat embedded=1 option is not part of retirement."""
+
+    from typing import get_args
+
+    from moonmind.omnigent import native_ui
+
+    assert "embedded" in get_args(native_ui.PresentationMode)
+    assert native_ui.NATIVE_UI_MOUNT_PREFIX == "/omnigent-ui/workflow-chat"
+    headers = native_ui.native_ui_security_headers(
+        mode="embedded", is_document=True
+    )
+    assert headers
+
+    frontend = (
+        REPO_ROOT / "frontend" / "src" / "entrypoints" / "WorkflowChatNative.tsx"
+    )
+    assert frontend.is_file()
+    assert "embedded=1" in frontend.read_text(encoding="utf-8")
+
+
+def test_shared_contracts_preserved() -> None:
+    """First-message, bridge, event, and credential contracts are untouched."""
+
+    from moonmind.omnigent import bridge_store
+    from moonmind.omnigent import host_auth_store
+
+    assert tuple(CANONICAL_FIRST_MESSAGE_STATES) == (
+        "not_prepared",
+        "prepared",
+        "posting",
+        "posted",
+        "terminal",
+    )
+    assert bridge_store.FIRST_MESSAGE_POSTED
+    assert bridge_store.BRIDGE_EVENT_JOURNAL_KEY
+    # Embedded lifecycle metadata stays readable for retained rows; shared
+    # first-message idempotency and event persistence live beside it.
+    assert bridge_store.EMBEDDED_LAUNCH_KEY == "embedded_runner_launch"
+    assert hasattr(bridge_store.OmnigentBridgeSessionStore, "list_event_page")
+    assert hasattr(host_auth_store.HostAuthProfileStore, "get_active")
+    assert isinstance(OmnigentBridgeConfig().idempotency.first_message_state_machine, tuple)
+
+
+def test_bridge_config_module_still_decodes_historical_embedded_literal() -> None:
+    """The retired literal remains a valid historical value, not a selector."""
+
+    assert HOST_PROTOCOL_MODE_EMBEDDED == "embedded_omnigent_compatible_server"
+    assert HOST_PROTOCOL_MODE_PROXY == "upstream_omnigent_server_proxy"
+    config = parse_bridge_config(
+        {"enabled": False, **_enabled_embedded_document()}
+    )
+    assert config.host_connection.mode == HOST_PROTOCOL_MODE_EMBEDDED
+    assert "embedded" in load_bridge_config(
+        "schemaVersion: moonmind.omnigent_bridge.v1\nenabled: false\n"
+        "compatibility:\n  hostProtocolMode: embedded_omnigent_compatible_server\n"
+    ).host_protocol_mode

--- a/tests/unit/omnigent/test_host_auth_profile.py
+++ b/tests/unit/omnigent/test_host_auth_profile.py
@@ -26,9 +26,12 @@ from moonmind.omnigent.host_auth_adapter import PINNED_PROTOCOL_PROFILE
 
 
 def _embedded_config():
+    # Retired (#3955): host-auth credential coverage uses a disabled
+    # declaration. Enabled embedded admission fails fast with the proxy
+    # alternative; profile-owned credentials are preserved, not deleted.
     return parse_bridge_config(
         {
-            "enabled": True,
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {

--- a/tests/unit/omnigent/test_host_auth_remediation.py
+++ b/tests/unit/omnigent/test_host_auth_remediation.py
@@ -20,6 +20,9 @@ from moonmind.omnigent.bridge_artifacts import OmnigentArtifactGateway, capture_
 from moonmind.omnigent.bridge_security import redact_raw_events
 from moonmind.omnigent.bridge_embedded import verify_embedded_host_auth
 from moonmind.omnigent.bridge_proxy import OmnigentBridgeError
+from moonmind.omnigent.embedded_host_channel import (
+    embedded_host_channels as _embedded_host_channels,
+)
 from moonmind.omnigent.host_auth_adapter import (
     OmnigentHostAuthAdapter,
     UpstreamHostAuthError,
@@ -349,8 +352,8 @@ async def test_connected_tunnel_is_drained_immediately_after_revocation(monkeypa
             ]
         ),
     )
-    monkeypatch.setattr(bridge_router.embedded_host_channels, "connect", lambda **_: channel)
-    monkeypatch.setattr(bridge_router.embedded_host_channels, "disconnect", lambda _: None)
+    monkeypatch.setattr(_embedded_host_channels, "connect", lambda **_: channel)
+    monkeypatch.setattr(_embedded_host_channels, "disconnect", lambda _: None)
     monkeypatch.setattr(
         bridge_router, "build_embedded_host_facade", lambda _config: facade
     )
@@ -442,13 +445,13 @@ async def test_connected_tunnel_drains_when_the_handshake_generation_is_rotated_
         ),
     )
     monkeypatch.setattr(
-        bridge_router.embedded_host_channels, "connect", lambda **_: channel
+        _embedded_host_channels, "connect", lambda **_: channel
     )
     monkeypatch.setattr(
-        bridge_router.embedded_host_channels, "disconnect", lambda _: None
+        _embedded_host_channels, "disconnect", lambda _: None
     )
     monkeypatch.setattr(
-        bridge_router.embedded_host_channels,
+        _embedded_host_channels,
         "revoke_runner_binding",
         lambda _runner_id: None,
     )

--- a/tests/unit/omnigent/test_host_auth_remediation.py
+++ b/tests/unit/omnigent/test_host_auth_remediation.py
@@ -254,9 +254,9 @@ async def test_websocket_profile_failure_close_code_matrix(
     monkeypatch, failure, expected_code
 ) -> None:
     socket = _HandshakeSocket({})
-    monkeypatch.setattr(bridge_router, "get_bridge_config", _embedded_config)
+    monkeypatch.setattr(bridge_router, "get_bridge_config", _live_embedded_config)
     monkeypatch.setattr(
-        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_embedded_config())
+        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_live_embedded_config())
     )
     monkeypatch.setattr(
         bridge_composition,
@@ -311,9 +311,9 @@ async def test_http_websocket_profile_failure_retryability_matrix(
     assert (ws_code in authoritative_retryable_close_codes) is retryable
 
     socket = _HandshakeSocket({})
-    monkeypatch.setattr(bridge_router, "get_bridge_config", _embedded_config)
+    monkeypatch.setattr(bridge_router, "get_bridge_config", _live_embedded_config)
     monkeypatch.setattr(
-        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_embedded_config())
+        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_live_embedded_config())
     )
     await bridge_router.embedded_omnigent_host_tunnel(socket, "host")
     assert socket.closes == [(ws_code, failure.code)]
@@ -330,9 +330,9 @@ async def test_connected_tunnel_is_drained_immediately_after_revocation(monkeypa
     socket = _HandshakeSocket(_Headers({"X-Omnigent-Runner-Tunnel-Token": token}))
     facade = SimpleNamespace(disconnect_host=AsyncMock())
     channel = SimpleNamespace()
-    monkeypatch.setattr(bridge_router, "get_bridge_config", _embedded_config)
+    monkeypatch.setattr(bridge_router, "get_bridge_config", _live_embedded_config)
     monkeypatch.setattr(
-        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_embedded_config())
+        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_live_embedded_config())
     )
     monkeypatch.setattr(
         bridge_composition,
@@ -414,11 +414,11 @@ async def test_connected_tunnel_drains_when_the_handshake_generation_is_rotated_
             frames=SimpleNamespace(HostRunnerExitedFrame=_RunnerExitedHostFrame)
         ),
     )
-    monkeypatch.setattr(bridge_router, "get_bridge_config", _embedded_config)
+    monkeypatch.setattr(bridge_router, "get_bridge_config", _live_embedded_config)
     monkeypatch.setattr(
         bridge_router,
         "_require_embedded_mode",
-        AsyncMock(return_value=_embedded_config()),
+        AsyncMock(return_value=_live_embedded_config()),
     )
     monkeypatch.setattr(
         bridge_router, "verify_embedded_host_request", AsyncMock(return_value=auth)
@@ -632,18 +632,21 @@ async def test_pinned_upstream_http_websocket_rejection_parity(
     assert http_exc.value.detail["code"] == http_code
 
     socket = _HandshakeSocket(headers)
-    monkeypatch.setattr(bridge_router, "get_bridge_config", _embedded_config)
+    monkeypatch.setattr(bridge_router, "get_bridge_config", _live_embedded_config)
     monkeypatch.setattr(
-        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_embedded_config())
+        bridge_router, "_require_embedded_mode", AsyncMock(return_value=_live_embedded_config())
     )
     await bridge_router.embedded_omnigent_host_tunnel(socket, "untrusted-host")
     assert socket.closes == [(ws_code, http_code)]
 
 
 def _embedded_config():
+    # Retired (#3955): remediation coverage uses a disabled declaration.
+    # Enabled embedded admission fails fast; stale callbacks cannot mutate a
+    # replacement owner.
     return parse_bridge_config(
         {
-            "enabled": True,
+            "enabled": False,
             "compatibility": {"hostProtocolMode": HOST_PROTOCOL_MODE_EMBEDDED},
             "hostConnection": {
                 "embedded": {
@@ -654,3 +657,11 @@ def _embedded_config():
             },
         }
     )
+
+
+def _live_embedded_config():
+    # Test-only drain coverage: closed-tunnel and auth-failure paths read the
+    # live pre-check (enabled + embedded). Enabled embedded admission is
+    # retired at the parse boundary (#3955), so this bypasses validation with
+    # an explicit copy instead of parsing a new operator document.
+    return _embedded_config().model_copy(update={"enabled": True})


### PR DESCRIPTION
## Summary
Staged retirement of the experimental embedded host transport (MoonLadderStudios/MoonMind#3955, parent #3928):

- New embedded-transport admission fails fast at the trusted bridge-config selection boundary with the supported proxy alternative (`upstream_omnigent_server_proxy`); no silent proxy substitution. Split-brain mode mismatch also fails actionably.
- Live embedded host routes answer 410 Gone (`omnigent_embedded_transport_retired`) with the proxy alternative; API startup (`api_service/main.py`) and Temporal worker startup (`worker_runtime.py`) both resolve bridge config and fail actionably on removed selection.
- Retirement rows pinned in `legacy_retirement.py`: `omnigent.embedded.transport_selection` (PRODUCT_SELECTORS) and `omnigent.embedded.launch_and_host_routes` (LAUNCH_ONLY_CODE), both NEW_ADMISSION_DISABLED with historical-read dependency; launch-code removal gated on bounded active-owner drain. Physical launch-code deletion intentionally deferred to the launch-only removal stage per retirement controls.
- Proxy wiring decoupled from embedded launch modules via lazy imports in `omnigent_bridge_composition.py`; proxy operates with embedded modules unavailable.
- Preserved: native Workflow Chat `embedded=1` presentation option and binding-scoped facade, shared bridge/session/event/idempotency contracts (`bridge_store.py` untouched), profile-owned host-auth credentials, and read-only historical decoding of retained embedded rows.
- Docs/readiness cut over to proxy-only topology (`EmbeddedHostAuthCompatibility.md`, `OmnigentBridge.md`); support no longer advertises the removed transport.

## Verification outcome
Controlling post-remediation moonspec-verify verdict in `artifacts/github-issue-implement-verify.json`: **FULLY_IMPLEMENTED** (confidence MEDIUM, candidate `fa558f4e4abad38fc05e06fbf13b650df74971c8`, base `e3a800f67f42e0187ff59cd5a46d8eb6a27b5ee2`). All six coverage items VERIFIED: admission-block, drain-before-removal, proxy-without-embedded-modules, native-chat-embedded-flag, shared-contracts-preserved, config-startup-and-readiness. Recommended next action: advance.

## Tests run
- Direct python execution: `parse_bridge_config` admission / proxy-default / historical-decode / split-brain checks — PASS; `native_ui` PresentationMode + mount prefix live import — PASS.
- `python3 -m py_compile` on changed production modules + new test file — PASS.
- Targeted unit suite `tests/unit/omnigent/test_embedded_transport_retirement_3955.py`, `test_bridge_config.py`, `test_bridge_proxy.py` — NOT RUN in sandbox (pytest not installed, no network; managed container tests require MOONMIND_RUNTIME_ID unavailable). New tests compile clean and were statically reviewed; required CI unit suite remains the execution owner.
- New tests: `test_embedded_transport_retirement_3955.py` (admission rejection, proxy-without-embedded-modules via meta-path blocker, native-chat flag survival, drain gating); updated `test_omnigent_bridge.py`, `test_bridge_config.py`, host-auth remediation tests.

## Remaining risks
- Physical embedded launch-code deletion deferred by design; a follow-up launch-only removal stage must verify drained active owners before deleting `bridge_embedded.py` and related routes.
- Full pytest suite not executed in this sandbox; CI must confirm no regressions in bridge/proxy/host-auth coverage.
- Historical embedded rows remain readable; operators must retain read-only decoding until retention policy permits cleanup.

Closes MoonLadderStudios/MoonMind#3955