### PR TITLE
[Omnigent boundary] Audit ownership and remove only demonstrated upstream duplication (#3954)

### DIFF
--- a/docs/Omnigent/ContractOwnership.md
+++ b/docs/Omnigent/ContractOwnership.md
@@ -41,6 +41,7 @@ work stays in its owning issue plan (`docs/tmp/OmnigentBridgeRollout.md`).
 | 22 | Policy authority, persistence, approvals | `PolicyAuthority.md` |
 | 23 | Embedded host-auth compatibility surface | `EmbeddedHostAuthCompatibility.md` |
 | 24 | Combined-stack validation and rollback runbook | `CombinedStackValidationAndRollback.md` |
+| 25 | Upstream-duplication audit (caller-backed ownership vs pinned upstream) | `UpstreamDuplicationAudit.md` |
 
 ## Duplicated sections and their surviving owners
 
@@ -103,6 +104,7 @@ Deliberately *not* merged (distinct responsibilities, per #3962):
 | `PolicyAuthority.md` | Owner: policy authority | Canonical desired state; #3515 |
 | `EmbeddedHostAuthCompatibility.md` | Owner: embedded compat surface | Experimental, not default |
 | `CombinedStackValidationAndRollback.md` | Owner: validation/rollback runbook | Current; #3564 |
+| `UpstreamDuplicationAudit.md` | Owner: caller-backed upstream-duplication audit | Current; #3954 |
 
 ## Reduction report
 

--- a/docs/Omnigent/UpstreamDuplicationAudit.md
+++ b/docs/Omnigent/UpstreamDuplicationAudit.md
@@ -1,0 +1,78 @@
+# Upstream Duplication Audit
+
+**Document Class:** Canonical declarative
+**Status:** Current
+**Owners:** MoonMind Platform
+**Last updated:** 2026-09-08
+**Authority:** Caller-backed ownership audit of suspected MoonMind/Omnigent
+duplication: which side owns each mutation or decision, and what must be
+proven before anything is removed.
+**Issue:** [MoonLadderStudios/MoonMind#3954](https://github.com/MoonLadderStudios/MoonMind/issues/3954).
+
+Parent: #3928. Coordinates with #3925 (runtime convergence), #3935 (session
+ownership), #3946 (projection writes), and #3956 (native UI).
+
+## Related documents
+
+- [`OmnigentAdapter.md`](./OmnigentAdapter.md) — ownership boundary principle
+- [`ContractOwnership.md`](./ContractOwnership.md) — per-file ownership map
+- [`OmnigentModuleArchitecture.md`](./OmnigentModuleArchitecture.md) — retirement inventory
+- [`OmnigentBridge.md`](./OmnigentBridge.md) — transport and native UI contract
+
+## Scope correction
+
+Reviewed against `63bce9852ffa33e33cb0b416bc24a654b1b6f92b`. Module and table
+counts are candidates for investigation, not a deletion list. A MoonMind
+workflow binding, immutable profile snapshot, credential lease, event journal,
+catalog projection, or artifact manifest is not redundant simply because
+Omnigent also has a session, agent, provider, or event object.
+
+The code-owned record is
+`moonmind/omnigent/upstream_duplication_audit.py` (`OWNERSHIP_TABLE`,
+fail-closed `check_*` guards, `evaluate_removal_eligibility`). This document
+states the durable disposition; the module enforces it in CI.
+
+## Ownership table
+
+| Suspected duplicate | Production entrypoint | State/decision owned | Surviving owner | Upstream replacement at pinned commit |
+| --- | --- | --- | --- | --- |
+| Workflow binding vs upstream session | `bridge_store.py` + `bridge_proxy.py` | Bridge authorization, idempotency ownership, attach ordering, session.created journal | MoonMind binding | None demonstrated: audit baseline differs from implementation pin, submodule not checked out |
+| Immutable profile snapshot vs launch args | `execution_adapters.py` + `profile_bound_execution.py` | Profile selection, policy snapshot, effectiveLaunch evidence | MoonMind adapters | None demonstrated: no audited upstream policy/snapshot API |
+| Credential lease vs runner token | `provider_leases.py` + `host_auth_adapter.py` | Profile lease, OAuth-home exclusivity, generation fencing, release-last | MoonMind lease | Pinned verifier proves host identity only, not lease ownership |
+| Event journal vs provider stream | `bridge_store.py` event index + `execute.py` | Durable pages, normalized events, raw bounded journal | MoonMind journal | None demonstrated: provider SSE has no durable cursors |
+| Catalog projection vs agent inventory | `harness_platform/catalog.py` + `omnigent_catalog.py` router | Trust classification, profile support evidence, readiness gating | MoonMind projection | None demonstrated: stock inventory carries no trust semantics |
+| Artifact manifest vs session files | `bridge_artifacts.py` + `workspace_publication.py` | Terminal result, capture manifests, redacted diagnostics, ArtifactRefs | MoonMind manifest | None demonstrated: upstream files lack provenance/retention |
+| Native UI facade vs upstream app | `native_ui.py` + `workflow_chat_facade.py` | Binding-scoped routes, allowlist, bootstrap contract, version gate | MoonMind facade | Version-gated only; unknown versions fail closed, never proxied directly |
+| Wire transport vs host protocol | `omnigent_client.py` + `bridge_proxy.py` | Facade validation, bounds, redacted codes, harvest-before-delete | MoonMind facade | None demonstrated: raw wire handling has no idempotency/ordering |
+
+Every row's persisted consumers, removal criteria, and proving test live in
+`OWNERSHIP_TABLE`. Disposition for all eight rows is **preserve**.
+
+## Boundary rule
+
+Upstream owns runtime mechanics (live runner, harness protocol, raw
+inventory/stream observations). MoonMind owns orchestration and governance
+(authorization, immutable policy, bounded evidence, canonical mutation
+identity, credential ownership). Cached projections and immutable evidence are
+downstream read models with provenance, freshness, and retention; only
+independently mutable duplicate authority is ever removed, never every local
+representation.
+
+## Fail-closed rejections
+
+Upstream drift, wrong owner, stale generation, unknown route, missing
+evidence, and credential mismatch are rejected with stable audit codes by the
+`check_*` guards. Unknown upstream fields, routes, and incompatible
+capabilities fail closed. No unrestricted proxy or direct upstream browser
+path replaces the binding-scoped facade.
+
+## Removals and residual dependencies
+
+No table or field is removed by this audit: no verified replacement contract
+exists, so every `evaluate_removal_eligibility` verdict is blocked with its
+persisted-consumer and removal-criteria blockers. Residual dependencies are
+the eight preserved candidates above; each names its removal criteria in the
+code-owned row rather than in a generic compatibility framework. Reduction is
+measured after preserving behavior (`audit_reduction_summary`: 8 examined, 8
+preserved, 0 removed); no LOC or table quota forces removal of the governance
+layer.

--- a/docs/Omnigent/UpstreamDuplicationAudit.md
+++ b/docs/Omnigent/UpstreamDuplicationAudit.md
@@ -68,11 +68,14 @@ path replaces the binding-scoped facade.
 
 ## Removals and residual dependencies
 
-No table or field is removed by this audit: no verified replacement contract
-exists, so every `evaluate_removal_eligibility` verdict is blocked with its
-persisted-consumer and removal-criteria blockers. Residual dependencies are
-the eight preserved candidates above; each names its removal criteria in the
-code-owned row rather than in a generic compatibility framework. Reduction is
-measured after preserving behavior (`audit_reduction_summary`: 8 examined, 8
-preserved, 0 removed); no LOC or table quota forces removal of the governance
-layer.
+No table or field is removed except under a verified replacement contract
+with drained consumers: every `evaluate_removal_eligibility` verdict is
+blocked until its persisted-consumer and removal-criteria blockers clear,
+and each row names its own removal criteria rather than deferring to a
+generic compatibility framework. Reduction is measured after preserving
+behavior via the code-owned `audit_reduction_summary()`, which derives its
+counts from row dispositions. The point-in-time outcome of this audit pass
+(examined/preserved/removed counts and residual dependencies at the review
+baseline) lives in
+[`../tmp/OmnigentUpstreamDuplication3954ReductionReport.md`](../tmp/OmnigentUpstreamDuplication3954ReductionReport.md),
+not here, so this document cannot go stale when the pin or consumers change.

--- a/docs/tmp/OmnigentUpstreamDuplication3954ReductionReport.md
+++ b/docs/tmp/OmnigentUpstreamDuplication3954ReductionReport.md
@@ -1,0 +1,26 @@
+# Upstream Duplication Audit Reduction Report (MoonLadderStudios/MoonMind#3954)
+
+Point-in-time outcome of the #3954 audit pass that produced
+`moonmind/omnigent/upstream_duplication_audit.py` and
+`docs/Omnigent/UpstreamDuplicationAudit.md`. Kept here (not in canonical
+docs) so the audit document stays a durable ownership contract instead of a
+stale snapshot tied to one upstream pin.
+
+- Audit baseline: `63bce9852ffa33e33cb0b416bc24a654b1b6f92b`, reviewed
+  without the upstream submodule checked out. The baseline differs from the
+  implementation pin owned by `host_auth_adapter.PINNED_OMNIGENT_COMMIT`, so
+  no supported upstream replacement contract is demonstrated.
+- Candidates examined: 8. Preserved: 8. Removed tables/fields: 0.
+- Residual dependencies: the eight preserved candidates
+  (`workflow-binding-vs-upstream-session`,
+  `immutable-profile-snapshot-vs-launch-args`, `credential-lease-vs-runner-token`,
+  `event-journal-vs-provider-stream`, `catalog-projection-vs-agent-inventory`,
+  `artifact-manifest-vs-session-files`, `native-ui-facade-vs-upstream-app`,
+  `wire-transport-vs-host-protocol`); each names its removal criteria in its
+  code-owned `OWNERSHIP_TABLE` row.
+- Every `evaluate_removal_eligibility` verdict is blocked: no verified
+  replacement contract at the implementation pin, persisted consumers not
+  drained, removal criteria unmet.
+- Live counts are code-owned: `audit_reduction_summary()` derives them from
+  row dispositions, so this note is history and the module is the current
+  evidence.

--- a/moonmind/omnigent/upstream_duplication_audit.py
+++ b/moonmind/omnigent/upstream_duplication_audit.py
@@ -332,9 +332,16 @@ def check_upstream_pin(
     *,
     supported_commits: frozenset[str] | None = None,
 ) -> str:
-    """Accept only a known-compatible upstream commit; reject drift fail-closed."""
+    """Accept only a known-compatible upstream commit; reject drift fail-closed.
 
-    supported = supported_commits or frozenset({PINNED_OMNIGENT_COMMIT})
+    ``supported_commits=None`` selects the default implementation-pin set;
+    an explicitly empty set is a deny-all policy and rejects every commit.
+    """
+
+    if supported_commits is None:
+        supported = frozenset({PINNED_OMNIGENT_COMMIT})
+    else:
+        supported = supported_commits
     candidate = str(reported_commit or "").strip()
     if not candidate:
         raise UpstreamDuplicationAuditError(
@@ -365,14 +372,34 @@ def check_audit_baseline_current() -> None:
         )
 
 
+# The binding-scoped facade operations this audit validates. The single
+# authority is ``workflow_chat_facade.FACADE_OPERATIONS``; this literal mirrors
+# it instead of importing it so the audit module stays importable without the
+# facade's dependency chain (bridge store / API models). CI pins the mirror:
+# ``test_facade_route_allowlist_matches_canonical`` fails on any drift.
 _ALLOWED_FACADE_ROUTES: frozenset[str] = frozenset(
     {
         "changed_files",
-        "workspace_files",
-        "workspace_file",
-        "workspace_diff",
-        "session_files",
+        "get_session",
+        "get_session_agent",
+        "get_session_environment",
+        "list_agents",
+        "list_child_sessions",
+        "list_harnesses",
+        "list_projects",
+        "list_sessions",
+        "liveness",
+        "native_current_user",
+        "native_server_info",
+        "post_event",
+        "resolve_elicitation",
         "session_file",
+        "session_files",
+        "stream_events",
+        "stream_events_websocket",
+        "workspace_diff",
+        "workspace_file",
+        "workspace_files",
     }
 )
 
@@ -415,20 +442,32 @@ def check_generation_match(*, observed: str, authorized: str) -> str:
     return seen
 
 
+# Terminal evidence refs every caller must supply. Presence alone is not
+# enough: a required ref that is absent or blank fails closed so callers
+# cannot omit evidence by passing ``{}`` or a partial mapping.
+REQUIRED_EVIDENCE_REFS: frozenset[str] = frozenset({"terminalRef", "captureRef"})
+
+
 def check_evidence_present(refs: Mapping[str, Any]) -> dict[str, Any]:
     """Accept only complete terminal evidence; missing refs fail closed."""
 
+    provided = dict(refs or {})
     missing = sorted(
         str(key)
-        for key, value in dict(refs or {}).items()
-        if str(value or "").strip() == ""
+        for key in REQUIRED_EVIDENCE_REFS
+        if str(provided.get(key) or "").strip() == ""
+    )
+    missing.extend(
+        str(key)
+        for key, value in provided.items()
+        if key not in REQUIRED_EVIDENCE_REFS and str(value or "").strip() == ""
     )
     if missing:
         raise UpstreamDuplicationAuditError(
-            f"Missing terminal evidence: {', '.join(missing)}",
+            f"Missing terminal evidence: {', '.join(sorted(set(missing)))}",
             code="omnigent_audit_missing_evidence",
         )
-    return dict(refs or {})
+    return dict(provided)
 
 
 def check_credential_scope(
@@ -506,9 +545,25 @@ class AuditReductionSummary:
 
 
 def audit_reduction_summary() -> AuditReductionSummary:
-    """Report the measured reduction: behavior preserved, nothing removed."""
+    """Report the measured reduction, derived from audited dispositions.
 
-    return AuditReductionSummary()
+    ``preserved``/``removed_tables_or_fields``/``residual_dependencies`` are
+    computed from each row's ``disposition`` (``"removed"`` counts as removed)
+    so the evidence stays true on the first successful reduction; the examined
+    baseline is retained for comparison.
+    """
+
+    examined = len(OWNERSHIP_TABLE)
+    residual = tuple(
+        row.candidate_id for row in OWNERSHIP_TABLE if row.disposition != "removed"
+    )
+    removed = examined - len(residual)
+    return AuditReductionSummary(
+        candidates_examined=examined,
+        preserved=len(residual),
+        removed_tables_or_fields=removed,
+        residual_dependencies=residual,
+    )
 
 
 __all__ = [
@@ -517,6 +572,7 @@ __all__ = [
     "AUDIT_ISSUE",
     "OWNERSHIP_TABLE",
     "PRODUCTION_BOUNDARY_COVERAGE",
+    "REQUIRED_EVIDENCE_REFS",
     "AuditReductionSummary",
     "RemovalEligibility",
     "UpstreamDuplicationAuditError",

--- a/moonmind/omnigent/upstream_duplication_audit.py
+++ b/moonmind/omnigent/upstream_duplication_audit.py
@@ -1,0 +1,534 @@
+"""Caller-backed upstream-duplication audit for the Omnigent boundary.
+
+Source issue: MoonLadderStudios/MoonMind#3954 (parent #3928).
+
+The audit's module/table counts are candidates for investigation, not a
+deletion list. A MoonMind workflow binding, immutable profile snapshot,
+credential lease, event journal, catalog projection, or artifact manifest is
+not redundant simply because Omnigent also has a session, agent, provider, or
+event object. This module is the code-owned record of that audit:
+
+* ``OWNERSHIP_TABLE`` holds one row per suspected duplicate with the issue's
+  required columns: production entrypoint, state/decision owned, persisted
+  consumers, supported upstream API at the pinned commit, proposed surviving
+  owner, and the test proving equivalent behavior.
+* The fail-closed guards (``check_*``) reject upstream drift, wrong owner,
+  stale generation, unknown route, missing evidence, and credential mismatch
+  without substituting credentials, profiles, billing-relevant values, source
+  authority, or less-constrained execution paths.
+* ``evaluate_removal_eligibility`` refuses every table/field removal until a
+  verified replacement contract with drained consumers exists. No removal is
+  eligible today: the audited upstream commit predates the implementation pin
+  and the upstream submodule is not checked out, so no supported replacement
+  has been demonstrated.
+
+This module is deliberately pure (stdlib only, plus the one upstream pin
+imported from its single authority): decision vocabulary lives here, while
+live verification stays in the adapters and conformance suites that own it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from moonmind.omnigent.host_auth_adapter import PINNED_OMNIGENT_COMMIT
+
+AUDIT_ISSUE = "MoonLadderStudios/MoonMind#3954"
+
+# The upstream commit the #3954 audit was reviewed against. This is the audit
+# baseline, not the implementation pin: the implementation pin is owned by
+# ``host_auth_adapter.PINNED_OMNIGENT_COMMIT`` and imported above so there is
+# exactly one authority for it.
+AUDITED_UPSTREAM_COMMIT = "63bce9852ffa33e33cb0b416bc24a654b1b6f92b"
+
+AUDIT_CONTRACT_VERSION = "moonmind.omnigent-upstream-duplication-audit/v1"
+
+
+class UpstreamDuplicationAuditError(RuntimeError):
+    """Fail-closed rejection raised by the #3954 audit guards."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class UpstreamOwnershipRow:
+    """One audited suspected duplicate with its caller-backed disposition."""
+
+    candidate_id: str
+    production_entrypoint: str
+    state_decision_owned: str
+    persisted_consumers: tuple[str, ...]
+    upstream_api_at_pinned_commit: str
+    surviving_owner: str
+    evidence_test: str
+    disposition: str
+    removal_criteria: str = ""
+
+
+OWNERSHIP_TABLE: tuple[UpstreamOwnershipRow, ...] = (
+    UpstreamOwnershipRow(
+        candidate_id="workflow-binding-vs-upstream-session",
+        production_entrypoint=(
+            "moonmind/omnigent/bridge_store.py::OmnigentBridgeSessionStore + "
+            "moonmind/omnigent/bridge_proxy.py::OmnigentBridgeSessionProxy"
+        ),
+        state_decision_owned=(
+            "MoonMind bridge authorization, idempotency-key ownership, "
+            "provider-session attachment ordering, session.created journal"
+        ),
+        persisted_consumers=(
+            "omnigent_bridge_session rows keyed by idempotency key; "
+            "omnigent_bridge_session_events journal; Temporal supervisor "
+            "reattach/retry reads; Workflow Detail projection",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: upstream submodule not checked out and "
+            "implementation pin f04b03 differs from the audit baseline, so no "
+            "supported upstream replacement for durable binding ownership is "
+            "demonstrated"
+        ),
+        surviving_owner="MoonMind bridge binding (upstream owns only the live runner session)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_bridge_binding_rejects_cross_owner_reuse"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a verified upstream durable-binding contract plus drained "
+            "bridge rows, journal, supervisor, and projection consumers"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="immutable-profile-snapshot-vs-launch-args",
+        production_entrypoint=(
+            "moonmind/omnigent/execution_adapters.py + "
+            "moonmind/omnigent/profile_bound_execution.py"
+        ),
+        state_decision_owned=(
+            "Provider Profile selection, policy snapshot, effectiveLaunch "
+            "evidence, durable binding before host mutation"
+        ),
+        persisted_consumers=(
+            "bridge authorization refs (profile, lease, binding, host-lease); "
+            "effective-launch evidence; retry path reusing durable binding",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: no audited upstream API accepting "
+            "MoonMind authorization/policyEvidence in place of caller-supplied "
+            "launch args"
+        ),
+        surviving_owner="MoonMind execution adapters (upstream owns host realization mechanics)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_profile_snapshot_guard_rejects_credential_mismatch"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a supported upstream policy/snapshot API plus migration "
+            "of authorization, lease, and retry consumers"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="credential-lease-vs-runner-token",
+        production_entrypoint=(
+            "moonmind/omnigent/provider_leases.py::"
+            "OmnigentProviderLeaseCoordinator + "
+            "moonmind/omnigent/host_auth_adapter.py::OmnigentHostAuthAdapter"
+        ),
+        state_decision_owned=(
+            "Purpose-aware Provider Profile lease, exclusive OAuth-home "
+            "ownership, credential-generation fencing, release-last ordering"
+        ),
+        persisted_consumers=(
+            "provider-lease rows; credential-generation refs in bridge "
+            "authorization; host-lease refs; janitor cleanup evidence",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Pinned runner-tunnel verifier only (host_auth_adapter); it proves "
+            "host identity, not profile-lease ownership, capacity, or "
+            "release ordering"
+        ),
+        surviving_owner="MoonMind credential lease (upstream owns only token-bound runner identity proof)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_credential_scope_rejects_mismatch"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Never delete enrollment-owned credentials as duplication cleanup; "
+            "requires drained leases, generations, and janitor evidence"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="event-journal-vs-provider-stream",
+        production_entrypoint=(
+            "moonmind/omnigent/bridge_store.py::OmnigentBridgeSessionStore event index + "
+            "moonmind/omnigent/execute.py::run_omnigent_execution stream normalization"
+        ),
+        state_decision_owned=(
+            "Durable cursorable event pages, normalized conversation/tool/"
+            "lifecycle events, raw bounded event journal as artifact evidence"
+        ),
+        persisted_consumers=(
+            "omnigent_bridge_session_events; raw journal artifacts; terminal "
+            "and checkpoint external-state refs; Workflow Detail timeline",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: provider SSE is a live observation without "
+            "durable cursors (proxy rejects `after != 0`); no durable journal "
+            "replacement demonstrated"
+        ),
+        surviving_owner="MoonMind event journal (upstream owns live SSE transport)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_missing_terminal_evidence_is_rejected"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a supported durable upstream journal plus migration of "
+            "cursor, artifact, checkpoint, and timeline consumers"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="catalog-projection-vs-agent-inventory",
+        production_entrypoint=(
+            "moonmind/omnigent/harness_platform/catalog.py + "
+            "api_service/api/routers/omnigent_catalog.py"
+        ),
+        state_decision_owned=(
+            "Synchronized catalog projection with trust classification, Agent "
+            "Profile support evidence, and readiness gating"
+        ),
+        persisted_consumers=(
+            "catalog/projection rows; Agent Profile support evidence; "
+            "launch-policy compilation reads",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: the stock agent-inventory route is an observed "
+            "inventory without trust, profile, or readiness semantics"
+        ),
+        surviving_owner="MoonMind catalog projection (upstream owns raw agent inventory observation)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_unknown_catalog_route_is_rejected"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a supported upstream trust/profile/readiness contract "
+            "plus drained projection and policy consumers"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="artifact-manifest-vs-session-files",
+        production_entrypoint=(
+            "moonmind/omnigent/bridge_artifacts.py + "
+            "moonmind/omnigent/workspace_publication.py"
+        ),
+        state_decision_owned=(
+            "Terminal AgentRunResult assembly, capture manifests, redacted "
+            "diagnostics, ArtifactRef-backed evidence"
+        ),
+        persisted_consumers=(
+            "artifact refs; capture/resource manifests; checkpoint/remediation "
+            "reads; post-host-cleanup replay (host-local logs are gone)",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: upstream session/resource files are "
+            "provider observations, not ArtifactRef evidence with provenance "
+            "and retention"
+        ),
+        surviving_owner="MoonMind artifact manifest (upstream owns live resource observation)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_missing_terminal_evidence_is_rejected"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a supported upstream artifact/provenance contract plus "
+            "migration of manifest, checkpoint, and replay consumers"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="native-ui-facade-vs-upstream-app",
+        production_entrypoint=(
+            "moonmind/omnigent/native_ui.py + "
+            "moonmind/omnigent/workflow_chat_facade.py"
+        ),
+        state_decision_owned=(
+            "Binding-scoped browser boundary: opaque chatBindingId, scoped "
+            "API/SSE facade allowlist, bootstrap contract, version gate, "
+            "security headers; native UI supplied by upstream"
+        ),
+        persisted_consumers=(
+            "chat binding refs; scoped facade authorization; bootstrap "
+            "compatibility evidence; Workflow Chat acceptance manifest",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Native UI verified only against the implementation pin via "
+            "SUPPORTED_NATIVE_UI_VERSIONS; unknown/blank/unsupported versions "
+            "fail closed, never proxied directly"
+        ),
+        surviving_owner="MoonMind binding-scoped facade (upstream owns rendering/interaction semantics)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_native_ui_version_gate_rejects_drift"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "No unrestricted proxy or direct upstream browser path may replace "
+            "the facade; requires scoped-route equivalence proof"
+        ),
+    ),
+    UpstreamOwnershipRow(
+        candidate_id="wire-transport-vs-host-protocol",
+        production_entrypoint=(
+            "moonmind/workflows/adapters/omnigent_client.py::"
+            "OmnigentHttpClient + moonmind/omnigent/bridge_proxy.py"
+        ),
+        state_decision_owned=(
+            "Binding-scoped facade validation, bounded resource limits, stable "
+            "redacted error codes, harvest-before-delete ordering"
+        ),
+        persisted_consumers=(
+            "bridge rows written before first-message post; harvest-completion "
+            "markers gating provider-session deletion",
+        ),
+        upstream_api_at_pinned_commit=(
+            "Unverified at 63bce98: raw upstream wire handling without "
+            "idempotency ownership, bounds, or harvest ordering is not a "
+            "supported replacement"
+        ),
+        surviving_owner="MoonMind host-protocol facade (upstream owns the stock server/host protocol)",
+        evidence_test=(
+            "tests/unit/omnigent/test_upstream_duplication_audit_3954.py::"
+            "test_unknown_resource_operation_is_rejected"
+        ),
+        disposition="preserve",
+        removal_criteria=(
+            "Requires a verified upstream idempotency/bounds/ordering contract "
+            "plus drained bridge-row and harvest consumers"
+        ),
+    ),
+)
+
+
+def get_ownership_row(candidate_id: str) -> UpstreamOwnershipRow:
+    """Return the audit row for one suspected duplicate, failing closed."""
+
+    for row in OWNERSHIP_TABLE:
+        if row.candidate_id == candidate_id:
+            return row
+    raise UpstreamDuplicationAuditError(
+        f"Unknown duplication candidate: {candidate_id!r}",
+        code="omnigent_audit_unknown_candidate",
+    )
+
+
+def check_upstream_pin(
+    reported_commit: str | None,
+    *,
+    supported_commits: frozenset[str] | None = None,
+) -> str:
+    """Accept only a known-compatible upstream commit; reject drift fail-closed."""
+
+    supported = supported_commits or frozenset({PINNED_OMNIGENT_COMMIT})
+    candidate = str(reported_commit or "").strip()
+    if not candidate:
+        raise UpstreamDuplicationAuditError(
+            "Upstream commit is unknown",
+            code="omnigent_audit_upstream_drift",
+        )
+    if candidate not in supported:
+        raise UpstreamDuplicationAuditError(
+            f"Upstream commit {candidate!r} is not a supported replacement contract",
+            code="omnigent_audit_upstream_drift",
+        )
+    return candidate
+
+
+def check_audit_baseline_current() -> None:
+    """Fail when the audit baseline no longer matches the implementation pin.
+
+    The #3954 review baseline (``AUDITED_UPSTREAM_COMMIT``) differs from the
+    implementation pin, so no removal may proceed on audit evidence alone: the
+    audit must be re-verified against the current pin first.
+    """
+
+    if AUDITED_UPSTREAM_COMMIT != PINNED_OMNIGENT_COMMIT:
+        raise UpstreamDuplicationAuditError(
+            "Audit baseline 63bce98 differs from the implementation pin; "
+            "re-verify the replacement contract before any removal",
+            code="omnigent_audit_upstream_drift",
+        )
+
+
+_ALLOWED_FACADE_ROUTES: frozenset[str] = frozenset(
+    {
+        "changed_files",
+        "workspace_files",
+        "workspace_file",
+        "workspace_diff",
+        "session_files",
+        "session_file",
+    }
+)
+
+
+def check_route_allowed(operation: str) -> str:
+    """Accept only binding-scoped facade operations; unknown routes fail closed."""
+
+    candidate = str(operation or "").strip()
+    if candidate not in _ALLOWED_FACADE_ROUTES:
+        raise UpstreamDuplicationAuditError(
+            f"Unknown facade route: {candidate!r}",
+            code="omnigent_audit_unknown_route",
+        )
+    return candidate
+
+
+def check_owner_match(*, stored_workflow_id: str, calling_workflow_id: str) -> str:
+    """Accept only the owning workflow for a durable idempotency key."""
+
+    stored = str(stored_workflow_id or "").strip()
+    calling = str(calling_workflow_id or "").strip()
+    if not stored or not calling or stored != calling:
+        raise UpstreamDuplicationAuditError(
+            "Durable binding is owned by a different workflow",
+            code="omnigent_audit_wrong_owner",
+        )
+    return stored
+
+
+def check_generation_match(*, observed: str, authorized: str) -> str:
+    """Accept only the authorized credential/host generation; stale fails closed."""
+
+    seen = str(observed or "").strip()
+    want = str(authorized or "").strip()
+    if not seen or not want or seen != want:
+        raise UpstreamDuplicationAuditError(
+            "Stale credential/host generation",
+            code="omnigent_audit_stale_generation",
+        )
+    return seen
+
+
+def check_evidence_present(refs: Mapping[str, Any]) -> dict[str, Any]:
+    """Accept only complete terminal evidence; missing refs fail closed."""
+
+    missing = sorted(
+        str(key)
+        for key, value in dict(refs or {}).items()
+        if str(value or "").strip() == ""
+    )
+    if missing:
+        raise UpstreamDuplicationAuditError(
+            f"Missing terminal evidence: {', '.join(missing)}",
+            code="omnigent_audit_missing_evidence",
+        )
+    return dict(refs or {})
+
+
+def check_credential_scope(
+    *,
+    presented_profile_ref: str,
+    authorized_profile_ref: str,
+    generation_matches: bool,
+) -> str:
+    """Accept only the authorized enrollment-owned credential scope."""
+
+    presented = str(presented_profile_ref or "").strip()
+    authorized = str(authorized_profile_ref or "").strip()
+    if not presented or not authorized or presented != authorized or not generation_matches:
+        raise UpstreamDuplicationAuditError(
+            "Credential scope mismatch",
+            code="omnigent_audit_credential_mismatch",
+        )
+    return presented
+
+
+@dataclass(frozen=True, slots=True)
+class RemovalEligibility:
+    """Whether one candidate may be removed under the audit."""
+
+    candidate_id: str
+    eligible: bool
+    blockers: tuple[str, ...] = ()
+    contract_version: str = AUDIT_CONTRACT_VERSION
+
+
+def evaluate_removal_eligibility(candidate_id: str) -> RemovalEligibility:
+    """Refuse removal until a verified replacement with drained consumers exists."""
+
+    row = get_ownership_row(candidate_id)
+    blockers = [
+        "no verified upstream replacement contract at the implementation pin",
+        f"persisted consumers not drained: {row.persisted_consumers[0][:80]}...",
+        f"removal criteria unmet: {row.removal_criteria[:80]}...",
+    ]
+    try:
+        check_audit_baseline_current()
+    except UpstreamDuplicationAuditError as exc:
+        blockers.insert(0, str(exc))
+    return RemovalEligibility(
+        candidate_id=row.candidate_id, eligible=False, blockers=tuple(blockers)
+    )
+
+
+# Production-boundary coverage the audit must preserve (issue acceptance §3):
+# each boundary maps to the ownership row and production entrypoint that owns
+# it, so coverage is caller-backed rather than aspirational.
+PRODUCTION_BOUNDARY_COVERAGE: tuple[tuple[str, str], ...] = (
+    ("launch", "wire-transport-vs-host-protocol"),
+    ("auth/profile admission", "immutable-profile-snapshot-vs-launch-args"),
+    ("session/turn control", "workflow-binding-vs-upstream-session"),
+    ("retry/cancel", "workflow-binding-vs-upstream-session"),
+    ("terminal evidence", "artifact-manifest-vs-session-files"),
+    ("post-host-cleanup reads", "artifact-manifest-vs-session-files"),
+    ("publication", "artifact-manifest-vs-session-files"),
+    ("cleanup", "credential-lease-vs-runner-token"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReductionSummary:
+    """Behavior-preserving reduction measured after the audit (no quota)."""
+
+    candidates_examined: int = field(default=len(OWNERSHIP_TABLE))
+    preserved: int = field(default=len(OWNERSHIP_TABLE))
+    removed_tables_or_fields: int = 0
+    residual_dependencies: tuple[str, ...] = tuple(
+        row.candidate_id for row in OWNERSHIP_TABLE
+    )
+    contract_version: str = AUDIT_CONTRACT_VERSION
+
+
+def audit_reduction_summary() -> AuditReductionSummary:
+    """Report the measured reduction: behavior preserved, nothing removed."""
+
+    return AuditReductionSummary()
+
+
+__all__ = [
+    "AUDITED_UPSTREAM_COMMIT",
+    "AUDIT_CONTRACT_VERSION",
+    "AUDIT_ISSUE",
+    "OWNERSHIP_TABLE",
+    "PRODUCTION_BOUNDARY_COVERAGE",
+    "AuditReductionSummary",
+    "RemovalEligibility",
+    "UpstreamDuplicationAuditError",
+    "UpstreamOwnershipRow",
+    "audit_reduction_summary",
+    "check_audit_baseline_current",
+    "check_credential_scope",
+    "check_evidence_present",
+    "check_generation_match",
+    "check_owner_match",
+    "check_route_allowed",
+    "check_upstream_pin",
+    "evaluate_removal_eligibility",
+    "get_ownership_row",
+]

--- a/tests/unit/omnigent/test_upstream_duplication_audit_3954.py
+++ b/tests/unit/omnigent/test_upstream_duplication_audit_3954.py
@@ -1,0 +1,216 @@
+"""Caller-backed upstream-duplication audit boundary.
+
+Source issue: MoonLadderStudios/MoonMind#3954 (parent #3928).
+
+Proves the audit deliverable: every suspected duplicate carries production
+callers and a disposition, the boundary has one owner per mutation with
+evidence kept downstream, production paths retain coverage, fail-closed
+rejections hold for drift/wrong-owner/stale-generation/unknown-route/
+missing-evidence/credential-mismatch, no table/field is removed with
+unresolved consumers, and reduction is measured after preserving behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from moonmind.omnigent import upstream_duplication_audit as audit
+from moonmind.omnigent.bridge_proxy import (
+    OmnigentBridgeError,
+    validate_bridge_host_fields,
+)
+from moonmind.omnigent.host_auth_adapter import PINNED_OMNIGENT_COMMIT
+from moonmind.omnigent.native_ui import (
+    SUPPORTED_NATIVE_UI_VERSIONS,
+    evaluate_native_ui_compatibility,
+    is_valid_chat_binding_id,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+REQUIRED_PRODUCTION_BOUNDARIES = (
+    "launch",
+    "auth/profile admission",
+    "session/turn control",
+    "retry/cancel",
+    "terminal evidence",
+    "post-host-cleanup reads",
+    "publication",
+    "cleanup",
+)
+
+
+def test_every_row_carries_required_columns_and_real_callers() -> None:
+    assert len(audit.OWNERSHIP_TABLE) >= 8
+    for row in audit.OWNERSHIP_TABLE:
+        assert row.candidate_id.strip()
+        assert row.production_entrypoint.strip()
+        assert row.state_decision_owned.strip()
+        assert row.persisted_consumers and all(
+            consumer.strip() for consumer in row.persisted_consumers
+        )
+        assert row.upstream_api_at_pinned_commit.strip()
+        assert row.surviving_owner.strip()
+        assert row.evidence_test.strip()
+        assert row.disposition.strip()
+        # Production entrypoints are caller-backed: each names a real module.
+        modules = [
+            part.split("::")[0].strip()
+            for part in row.production_entrypoint.split("+")
+        ]
+        assert modules
+        for module in modules:
+            assert (REPO_ROOT / module).is_file(), module
+
+
+def test_one_owner_per_mutation_with_evidence_downstream() -> None:
+    candidate_ids = [row.candidate_id for row in audit.OWNERSHIP_TABLE]
+    assert len(set(candidate_ids)) == len(candidate_ids)
+    for row in audit.OWNERSHIP_TABLE:
+        # MoonMind governance is never surrendered as redundant: every
+        # surviving owner keeps the MoonMind side authoritative while upstream
+        # owns only runtime mechanics or raw observations.
+        assert "MoonMind" in row.surviving_owner, row.candidate_id
+        assert "upstream owns" in row.surviving_owner, row.candidate_id
+
+
+def test_production_boundary_coverage_is_caller_backed() -> None:
+    covered = dict(audit.PRODUCTION_BOUNDARY_COVERAGE)
+    for boundary in REQUIRED_PRODUCTION_BOUNDARIES:
+        assert boundary in covered, boundary
+        audit.get_ownership_row(covered[boundary])
+
+
+def test_unknown_candidate_fails_closed() -> None:
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.get_ownership_row("not-a-real-candidate")
+    assert exc_info.value.code == "omnigent_audit_unknown_candidate"
+
+
+def test_upstream_drift_is_rejected() -> None:
+    assert audit.check_upstream_pin(PINNED_OMNIGENT_COMMIT) == PINNED_OMNIGENT_COMMIT
+    for bad in ("", "  ", "deadbeef" * 5):
+        with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+            audit.check_upstream_pin(bad)
+        assert exc_info.value.code == "omnigent_audit_upstream_drift"
+    # The #3954 review baseline differs from the implementation pin, so audit
+    # evidence alone cannot authorize a removal.
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_audit_baseline_current()
+    assert exc_info.value.code == "omnigent_audit_upstream_drift"
+
+
+def test_native_ui_version_gate_rejects_drift() -> None:
+    pinned = sorted(SUPPORTED_NATIVE_UI_VERSIONS)[0]
+    assert evaluate_native_ui_compatibility(pinned).ready is True
+    assert (
+        evaluate_native_ui_compatibility("unverified-next-build").ready is False
+    )
+    assert evaluate_native_ui_compatibility("").reason == "native_ui_version_unknown"
+    assert is_valid_chat_binding_id("chatb_abc123") is True
+    assert is_valid_chat_binding_id("not-a-binding") is False
+
+
+def test_bridge_binding_rejects_cross_owner_reuse() -> None:
+    assert (
+        audit.check_owner_match(stored_workflow_id="wf-1", calling_workflow_id="wf-1")
+        == "wf-1"
+    )
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_owner_match(stored_workflow_id="wf-1", calling_workflow_id="wf-2")
+    assert exc_info.value.code == "omnigent_audit_wrong_owner"
+    # The production facade enforces the same ownership at the boundary.
+    validate_bridge_host_fields(host_type="managed", host_id=None, workspace=None)
+    with pytest.raises(OmnigentBridgeError):
+        validate_bridge_host_fields(host_type="managed", host_id="h-1", workspace=None)
+    with pytest.raises(OmnigentBridgeError):
+        validate_bridge_host_fields(
+            host_type="direct-upstream", host_id=None, workspace=None
+        )
+
+
+def test_stale_generation_is_rejected() -> None:
+    assert (
+        audit.check_generation_match(observed="gen-7", authorized="gen-7") == "gen-7"
+    )
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_generation_match(observed="gen-6", authorized="gen-7")
+    assert exc_info.value.code == "omnigent_audit_stale_generation"
+
+
+def test_unknown_catalog_route_is_rejected() -> None:
+    assert audit.check_route_allowed("changed_files") == "changed_files"
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_route_allowed("upstream-direct-proxy")
+    assert exc_info.value.code == "omnigent_audit_unknown_route"
+
+
+def test_unknown_resource_operation_is_rejected() -> None:
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_route_allowed("../escape")
+    assert exc_info.value.code == "omnigent_audit_unknown_route"
+
+
+def test_missing_terminal_evidence_is_rejected() -> None:
+    refs = {"terminalRef": "artifact:terminal", "captureRef": "artifact:capture"}
+    assert audit.check_evidence_present(refs) == refs
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_evidence_present({"terminalRef": "artifact:terminal", "captureRef": ""})
+    assert exc_info.value.code == "omnigent_audit_missing_evidence"
+
+
+def test_credential_scope_rejects_mismatch() -> None:
+    assert (
+        audit.check_credential_scope(
+            presented_profile_ref="codex_openai_oauth",
+            authorized_profile_ref="codex_openai_oauth",
+            generation_matches=True,
+        )
+        == "codex_openai_oauth"
+    )
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_credential_scope(
+            presented_profile_ref="other_profile",
+            authorized_profile_ref="codex_openai_oauth",
+            generation_matches=True,
+        )
+    assert exc_info.value.code == "omnigent_audit_credential_mismatch"
+    with pytest.raises(audit.UpstreamDuplicationAuditError):
+        audit.check_credential_scope(
+            presented_profile_ref="codex_openai_oauth",
+            authorized_profile_ref="codex_openai_oauth",
+            generation_matches=False,
+        )
+
+
+def test_profile_snapshot_guard_rejects_credential_mismatch() -> None:
+    # Profile admission never substitutes a different credential source: a
+    # presented profile outside the authorized scope fails closed even when a
+    # generation value is present.
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_credential_scope(
+            presented_profile_ref="",
+            authorized_profile_ref="codex_openai_oauth",
+            generation_matches=True,
+        )
+    assert exc_info.value.code == "omnigent_audit_credential_mismatch"
+
+
+def test_no_table_or_field_removal_with_unresolved_consumers() -> None:
+    for row in audit.OWNERSHIP_TABLE:
+        decision = audit.evaluate_removal_eligibility(row.candidate_id)
+        assert decision.eligible is False
+        assert decision.blockers, row.candidate_id
+        assert row.removal_criteria.strip(), row.candidate_id
+
+
+def test_reduction_measured_after_preserving_behavior() -> None:
+    summary = audit.audit_reduction_summary()
+    assert summary.candidates_examined == len(audit.OWNERSHIP_TABLE)
+    assert summary.preserved == len(audit.OWNERSHIP_TABLE)
+    assert summary.removed_tables_or_fields == 0
+    assert set(summary.residual_dependencies) == {
+        row.candidate_id for row in audit.OWNERSHIP_TABLE
+    }

--- a/tests/unit/omnigent/test_upstream_duplication_audit_3954.py
+++ b/tests/unit/omnigent/test_upstream_duplication_audit_3954.py
@@ -76,11 +76,33 @@ def test_one_owner_per_mutation_with_evidence_downstream() -> None:
         assert "upstream owns" in row.surviving_owner, row.candidate_id
 
 
-def test_production_boundary_coverage_is_caller_backed() -> None:
+def test_facade_route_allowlist_matches_canonical() -> None:
+    # The audit's route guard must accept the full binding-scoped facade
+    # authority, not just the resource subset: production operations such as
+    # post_event, stream_events, get_session, and resolve_elicitation are
+    # legitimate facade operations.
+    from moonmind.omnigent.workflow_chat_facade import FACADE_OPERATIONS
+
+    canonical = {operation.name for operation in FACADE_OPERATIONS}
+    assert set(audit._ALLOWED_FACADE_ROUTES) == canonical
+    for operation in ("post_event", "stream_events", "get_session", "resolve_elicitation"):
+        assert audit.check_route_allowed(operation) == operation
+
+
+def test_production_boundary_entrypoints_are_caller_backed() -> None:
+    # Every covered production boundary must resolve to a real module on disk
+    # so the coverage table cannot drift into aspirational entries.
     covered = dict(audit.PRODUCTION_BOUNDARY_COVERAGE)
-    for boundary in REQUIRED_PRODUCTION_BOUNDARIES:
-        assert boundary in covered, boundary
-        audit.get_ownership_row(covered[boundary])
+    assert set(REQUIRED_PRODUCTION_BOUNDARIES) <= set(covered)
+    for boundary, candidate_id in covered.items():
+        row = audit.get_ownership_row(candidate_id)
+        modules = [
+            part.split("::")[0].strip()
+            for part in row.production_entrypoint.split("+")
+        ]
+        assert modules, boundary
+        for module in modules:
+            assert (REPO_ROOT / module).is_file(), (boundary, module)
 
 
 def test_unknown_candidate_fails_closed() -> None:
@@ -95,6 +117,19 @@ def test_upstream_drift_is_rejected() -> None:
         with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
             audit.check_upstream_pin(bad)
         assert exc_info.value.code == "omnigent_audit_upstream_drift"
+    # An explicitly empty supported-commit set is a deny-all policy: even the
+    # implementation pin is rejected instead of falling back to the default.
+    with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+        audit.check_upstream_pin(PINNED_OMNIGENT_COMMIT, supported_commits=frozenset())
+    assert exc_info.value.code == "omnigent_audit_upstream_drift"
+    # An explicit non-empty set still authorizes its members.
+    assert (
+        audit.check_upstream_pin(
+            PINNED_OMNIGENT_COMMIT,
+            supported_commits=frozenset({PINNED_OMNIGENT_COMMIT}),
+        )
+        == PINNED_OMNIGENT_COMMIT
+    )
     # The #3954 review baseline differs from the implementation pin, so audit
     # evidence alone cannot authorize a removal.
     with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
@@ -159,6 +194,12 @@ def test_missing_terminal_evidence_is_rejected() -> None:
     with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
         audit.check_evidence_present({"terminalRef": "artifact:terminal", "captureRef": ""})
     assert exc_info.value.code == "omnigent_audit_missing_evidence"
+    # Required refs cannot be omitted entirely: an empty or partial mapping
+    # fails even though no present value is blank.
+    for omitted in ({}, {"terminalRef": "artifact:terminal"}, {"captureRef": "artifact:capture"}):
+        with pytest.raises(audit.UpstreamDuplicationAuditError) as exc_info:
+            audit.check_evidence_present(omitted)
+        assert exc_info.value.code == "omnigent_audit_missing_evidence"
 
 
 def test_credential_scope_rejects_mismatch() -> None:
@@ -214,3 +255,20 @@ def test_reduction_measured_after_preserving_behavior() -> None:
     assert set(summary.residual_dependencies) == {
         row.candidate_id for row in audit.OWNERSHIP_TABLE
     }
+
+
+def test_reduction_counts_derive_from_dispositions(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The summary must stay true on the first successful reduction: rows
+    # marked removed stop counting as preserved/residual while the examined
+    # baseline is retained.
+    import dataclasses
+
+    removed_row = dataclasses.replace(audit.OWNERSHIP_TABLE[0], disposition="removed")
+    monkeypatch.setattr(
+        audit, "OWNERSHIP_TABLE", (removed_row, *audit.OWNERSHIP_TABLE[1:])
+    )
+    summary = audit.audit_reduction_summary()
+    assert summary.candidates_examined == len(audit.OWNERSHIP_TABLE)
+    assert summary.removed_tables_or_fields == 1
+    assert summary.preserved == len(audit.OWNERSHIP_TABLE) - 1
+    assert removed_row.candidate_id not in summary.residual_dependencies


### PR DESCRIPTION
Summary: Adds a caller-backed upstream-duplication audit for issue #3954: moonmind/omnigent/upstream_duplication_audit.py with an 8-row OWNERSHIP_TABLE (production entrypoint, state/decision owned, persisted consumers, upstream API at pinned commit, surviving owner, evidence test), fail-closed guards (upstream pin/drift, owner, generation, route, evidence, credential scope), evaluate_removal_eligibility, PRODUCTION_BOUNDARY_COVERAGE for the 8 required boundaries, and audit_reduction_summary. Documents the audit in docs/Omnigent/UpstreamDuplicationAudit.md and registers it in docs/Omnigent/ContractOwnership.md. Outcome is preserve-only: all 8 candidates blocked with explicit removal criteria and residual dependencies; no tables/fields removed, no enrollment credentials or run evidence deleted.

Verification outcome: moonspec-verify verdict FULLY_IMPLEMENTED (medium confidence) against HEAD 414c9aa4a; all six acceptance criteria VERIFIED with zero gaps.

Tests run:
- python3 -m py_compile on implementation and test files: PASS
- Direct stdlib equivalence execution (8 ownership rows resolve, all evaluate_removal_eligibility blocked, reduction summary 8/8/0, boundary coverage resolves, all check_* guards fail closed): PASS
- tests/unit/omnigent/test_upstream_duplication_audit_3954.py (15 tests) via pytest: NOT RUN in this sandbox (no pytest module); required CI must run it before merge.

Remaining risks:
- Dedicated pytest suite not executed under a runner here; equivalence established via direct guard execution plus source inspection. CI must run the suite.

Closes MoonLadderStudios/MoonMind#3954