### PR TITLE
Fix container ownership inspection through restricted Docker proxy

### DIFF
--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -645,8 +645,15 @@ class DockerContainerJobBackend:
         those fail closed instead of reading as a vanished consumer.
         """
 
+        # Generic inspect searches other object families after a container 404.
+        # The restricted proxy denies plugins, masking absence with a 403 and
+        # blocking both first launch and idempotent cleanup. Query containers
+        # explicitly so only their existence/ownership controls this boundary.
         code, stdout, stderr = await self._runner(
-            ("inspect", "--format", "{{json .Config.Labels}}", name)
+            (
+                "inspect", "--format", "{{json .Config.Labels}}",
+                "--type", "container", name,
+            )
         )
         if code:
             detail = stderr.decode(errors="replace").strip()

--- a/tests/integration/reliability/replays/container-ownership-inspect/manifest.json
+++ b/tests/integration/reliability/replays/container-ownership-inspect/manifest.json
@@ -1,0 +1,11 @@
+{
+  "incidentWorkflowId": "mm:26abcfea-f8f4-418b-82c3-991e42843992",
+  "containerJobId": "container-job:1b298653633b4d798f3eb41718ec62a3",
+  "boundary": "container-job activity to Docker CLI to restricted Docker proxy",
+  "failureShape": "Generic inspect masks container absence with a forbidden plugins lookup, preventing test launch and cleanup.",
+  "missingObjectStatus": 404,
+  "missingContainerMessage": "No such container: {name}",
+  "forbiddenStatus": 403,
+  "forbiddenBody": "<html><body><h1>403 Forbidden</h1>\nRequest forbidden by administrative rules.\n</body></html>\n",
+  "expectedInvariant": "Only container inspection determines job ownership; missing containers permit creation, while denied or unavailable ownership never permits mutation or release."
+}

--- a/tests/integration/reliability/test_container_ownership_inspect_replay.py
+++ b/tests/integration/reliability/test_container_ownership_inspect_replay.py
@@ -1,0 +1,141 @@
+"""Exercise the real Docker CLI against a hermetic restricted-proxy replay."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+
+import pytest
+from temporalio.exceptions import ApplicationError
+
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def proxy_replay(tmp_path, monkeypatch):
+    replay = load_replay("container-ownership-inspect", "manifest.json")
+    state = {"container_status": 404, "paths": []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_HEAD(self):
+            assert self.path == "/_ping"
+            self.send_response(200)
+            self.send_header("API-Version", "1.45")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_GET(self):
+            path = re.sub(r"^/v[0-9.]+", "", self.path)
+            state["paths"].append(path)
+            if path.startswith("/containers/"):
+                status = state["container_status"]
+                name = path.split("/")[2]
+                body = json.dumps(
+                    {
+                        "message": replay["missingContainerMessage"].format(name=name)
+                        if status == 404
+                        else "ownership service unavailable"
+                    }
+                ).encode()
+            elif path.startswith(("/images/", "/networks/", "/volumes/")):
+                status = replay["missingObjectStatus"]
+                body = b'{"message":"No such object"}'
+            elif path == "/info":
+                status = 200
+                body = b'{"Swarm":{"LocalNodeState":"inactive"}}'
+            else:
+                status = replay["forbiddenStatus"]
+                body = replay["forbiddenBody"].encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    # The production test image includes Docker CLI; no socket or daemon is
+    # needed. A missing CLI is a test-environment failure, never a silent skip.
+    assert shutil.which("docker"), "Docker CLI is required for the proxy replay"
+    for key in (
+        "DOCKER_CONTEXT",
+        "DOCKER_TLS_VERIFY",
+        "DOCKER_CERT_PATH",
+        "MOONMIND_DOCKER_ACTIVATION_COMMAND",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path / "docker-config"))
+    monkeypatch.setenv("DOCKER_API_VERSION", "1.45")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        docker_host=f"tcp://127.0.0.1:{server.server_port}",
+    )
+    payload = {
+        "jobId": replay["containerJobId"],
+        "ownershipToken": replay["containerJobId"] + ":v1",
+        "request": {
+            "idempotencyKey": "ownership-inspect-replay",
+            "source": {
+                "source": "workflow",
+                "workflowId": replay["incidentWorkflowId"],
+            },
+            "spec": {
+                "image": "python:3.13",
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "workspace"},
+                "command": ["python", "-V"],
+                "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+            },
+        },
+    }
+    try:
+        yield (
+            TemporalAgentRuntimeActivities(container_job_backend=backend),
+            payload,
+            state,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize(
+    "operation", ["reconcile_container", "stop_container", "remove_container"]
+)
+async def test_missing_container_crosses_real_cli_without_probing_plugins(
+    proxy_replay, operation
+):
+    runtime, payload, state = proxy_replay
+    result = await getattr(runtime, f"container_job_{operation}")(payload)
+    if operation == "reconcile_container":
+        assert "containerRef" not in result
+    if operation != "remove_container":
+        assert result["running"] is False
+    assert len(state["paths"]) == 1
+    assert state["paths"][0].startswith("/containers/")
+
+
+@pytest.mark.parametrize("status", [403, 500])
+@pytest.mark.parametrize(
+    "operation", ["reconcile_container", "stop_container", "remove_container"]
+)
+async def test_unknown_ownership_still_fails_closed(proxy_replay, operation, status):
+    runtime, payload, state = proxy_replay
+    state["container_status"] = status
+    with pytest.raises(ApplicationError) as raised:
+        await getattr(runtime, f"container_job_{operation}")(payload)
+    assert raised.value.type == "infrastructure"
+    assert "ownership could not be read" in str(raised.value)
+    assert len(state["paths"]) == 1
+    assert state["paths"][0].startswith("/containers/")

--- a/tests/unit/workflows/temporal/test_container_job_workflow.py
+++ b/tests/unit/workflows/temporal/test_container_job_workflow.py
@@ -247,6 +247,13 @@ async def test_production_backend_makes_every_registered_activity_callable(
             return 0, b"", b""
         if args[:2] == ("inspect", "--format"):
             if args[2] == "{{json .Config.Labels}}":
+                # Generic inspect probes plugins after a missing container;
+                # the deployment proxy denies that unrelated object family.
+                if (
+                    "--type" not in args
+                    or args[args.index("--type") + 1] != "container"
+                ):
+                    return 1, b"", b"Error response from daemon: 403 Forbidden"
                 return 1, b"", b"Error: No such object: moonmind-container-job"
             if args[2] == "{{json .State}}":
                 return 0, b'{"Running":false,"ExitCode":0}', b""


### PR DESCRIPTION
## Related issue

Related to #4090 and #4038. Diagnosed from workflow `mm:26abcfea-f8f4-418b-82c3-991e42843992`.

## Summary

New container jobs failed before pytest because generic `docker inspect` searched other Docker object types after the container returned 404. The restricted proxy denied the later plugins lookup with 403, masking the expected absence and blocking both launch and cleanup.

Limit ownership inspection to `--type container`. Add an incident replay using the real Docker CLI against a hermetic HTTP proxy fixture, plus activity-lifecycle regression coverage. ELI5: ask Docker whether the container exists without searching unrelated objects.

## Test Plan

```bash
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/workflows/temporal/test_container_job_backend.py \
  tests/unit/workflows/temporal/test_container_job_workflow.py \
  tests/unit/workflows/temporal/test_container_job_gpu_resources.py \
  tests/unit/capacity/test_machine_capacity_boundaries.py \
  tests/integration/reliability/test_container_ownership_inspect_replay.py --tb=short
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local ./tools/test_integration.sh
```

223 targeted checks and 730 hermetic integration checks passed during diagnosis. Targeted checks were rerun after syncing the latest main. The replay covers missing-container reconciliation, stop/removal, and genuine HTTP 403/500 failures.

## Demo

N/A.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

The shared Docker ownership lookup governs container creation and cleanup. Actual authorization or infrastructure failures still fail closed; proxy permissions and capacity-release safeguards remain intact. Activity signatures, persisted payloads, and workflow branching are unchanged, preserving in-flight invocation compatibility.

## Coverage notes

Read-only reproduction through the deployed worker/proxy returned 403 for generic inspection and confirmed absence for container-specific inspection of the actual failed job name. Existing tests cover owned/foreign containers and capacity accounting; the new replay exercises the real CLI instead of mocking its object-family fallback.

## Changelog

Fix managed test jobs failing before launch when their container does not yet exist.
