### PR TITLE
Fix issue-workflow brief and container verification handoffs

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -563,6 +563,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip uv
           uv pip install --system -e .
+      - name: Verify scoped CLI through the pinned native runner
+        # Keep upstream's dependencies isolated from the application driver.
+        # This replay uses real native Codex filters and local subprocesses;
+        # its container API fixture is loopback-only and needs no provider.
+        run: |
+          uv sync --project omnigent --frozen --no-dev
+          omnigent/.venv/bin/python \
+            tests/integration/reliability/replays/issue-brief-verification-handoff/runner_boundary.py
       - name: Set up Node for the hosted-UI capture
         uses: actions/setup-node@v7
         with:

--- a/api_service/api/routers/mcp_tools.py
+++ b/api_service/api/routers/mcp_tools.py
@@ -735,6 +735,14 @@ def _enforce_container_capability_scope(
                 ),
             },
         )
+    if capability.workspace_read_only:
+        # The caller can request stricter access, but only the signed session
+        # authority can restrict its omitted or false workspace flag. Persist
+        # this decision before handing the job to Temporal or the Docker worker.
+        submission.spec.workspace_read_only = True
+        payload.arguments = submission.model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
 
 
 @router.post("/container/tools/call", response_model=ToolCallResponse)

--- a/api_service/data/presets/github-issue-implement.yaml
+++ b/api_service/data/presets/github-issue-implement.yaml
@@ -10,6 +10,7 @@ tags:
 requiredCapabilities:
 - git
 - gh
+- docker
 annotations:
   sourceSkill: github-issue-implement
   issueProvider: github

--- a/api_service/data/presets/github-issue-search-and-implement.yaml
+++ b/api_service/data/presets/github-issue-search-and-implement.yaml
@@ -13,6 +13,7 @@ tags:
 requiredCapabilities:
 - git
 - gh
+- docker
 annotations:
   implementsPreset: github-issue-implement
   issueProvider: github

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -46,6 +46,25 @@ workspace locator, workflow, Step Execution, runtime, and host lease to the
 session capability. Its bearer is transported on stdin into a read-only capability
 file; only the file selector crosses the host, runner, and harness environment
 boundaries. Missing or unsupported workspace authority fails before launch.
+The host persists non-sensitive correlation and bearer-file selectors in one
+run-owned shell profile used by login shells and the projected `moonmind`
+executable. The admitted `docker` tool binding delivers that executable even when
+the execution does not require `gh`.
+
+The materialized workspace attachment owns repository access mode. Container-job
+capabilities bind that mode as `workspaceReadOnly`; a read-only repository policy
+or existing-workspace grant therefore remains read-only inside submitted jobs.
+The scoped API applies the signed restriction before persistence, regardless of
+an omitted or false caller value, and the worker enforces it on both bind and
+volume-subpath mounts. A caller may request stricter access but cannot weaken the
+session restriction.
+
+Capability schema v3 requires the access claim. Pre-v3 session capabilities fail
+closed and require a fresh host lease or managed session after deployment; they
+cannot authorize a new job using an unknown repository access policy. Already
+admitted job histories retain their recorded behavior: an omitted
+`spec.workspaceReadOnly` preserves the historical writable workspace and exact
+serialized request, while newly scoped read-only jobs persist the restriction.
 
 The selected daemon owns a persistent image store. Pulled and locally provisioned
 images remain reusable by later jobs and workflows until deployment-level image

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -40,6 +40,13 @@ The requesting runtime never receives the Docker socket, a Docker API endpoint,
 The per-session Docker-in-Docker topology is not a supported desired state or
 compatibility path.
 
+Generic Omnigent hosts receive container-job authority only when the admitted
+execution requires `docker`. The host environment binds the existing sandbox
+workspace locator, workflow, Step Execution, runtime, and host lease to the
+session capability. Its bearer is transported on stdin into a read-only capability
+file; only the file selector crosses the host, runner, and harness environment
+boundaries. Missing or unsupported workspace authority fails before launch.
+
 The selected daemon owns a persistent image store. Pulled and locally provisioned
 images remain reusable by later jobs and workflows until deployment-level image
 retention removes them. Image lifetime is independent of workflow and session

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -36,10 +36,14 @@ Presets do not replace Skills, require per-preset React forms, grant execution r
 
 Trusted issue loaders persist the complete GitHub or Jira brief as a linked JSON
 artifact before returning to the workflow. The existing `briefArtifactRef` carries
-that source into the first assessment and subsequent implementation, remediation,
-and verification workspaces. Inline context may be shortened for history limits;
+that source into attachment-capable assessment, implementation, remediation,
+and verification workspaces. Direct managed Codex sessions retain their existing
+prepared-context path because their session adapter rejects raw input refs.
+Inline context may be shortened for prompt limits;
 the full attachment remains authoritative. Agent-generated copies do not replace
-the loader's brief. Artifact storage failure stops the handoff before assessment.
+the loader's brief. Loader authority comes from the dispatched native tool identity,
+never from an agent's `trustedSource` field. Artifact storage failure stops the
+handoff before assessment.
 
 GitHub implementation presets declare `docker` for their repository verification
 work. Admission validates Docker readiness; agents use the

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -34,6 +34,17 @@ The system preserves these properties:
 
 Presets do not replace Skills, require per-preset React forms, grant execution rights, or create a second publishing engine. Their expanded steps pass the normal policy, runtime, repository, and publication boundaries.
 
+Trusted issue loaders persist the complete GitHub or Jira brief as a linked JSON
+artifact before returning to the workflow. The existing `briefArtifactRef` carries
+that source into the first assessment and subsequent implementation, remediation,
+and verification workspaces. Inline context may be shortened for history limits;
+the full attachment remains authoritative. Agent-generated copies do not replace
+the loader's brief. Artifact storage failure stops the handoff before assessment.
+
+GitHub implementation presets declare `docker` for their repository verification
+work. Admission validates Docker readiness; agents use the
+scoped Docker Backend Service to execute tests.
+
 ## Core Concepts
 
 | Concept | Meaning |

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6843,6 +6843,8 @@ export interface components {
             imageSourceRef?: string | null;
             /** Workspaceref */
             workspaceRef: components["schemas"]["SandboxWorkspaceLocator"] | components["schemas"]["ManagedWorkspaceLocator"] | components["schemas"]["ExternalStateLocator"];
+            /** Workspacereadonly */
+            workspaceReadOnly?: boolean | null;
             /** Command */
             command?: string[];
             /** Entrypoint */

--- a/moonmind/omnigent/host_ports.py
+++ b/moonmind/omnigent/host_ports.py
@@ -201,6 +201,7 @@ class OmnigentRuntimeEnvironmentPort(Protocol):
         plan: OmnigentExecutionPlanEnvelope,
         host_lease_ref: str,
         launch_policy: LaunchPolicy,
+        workspace_attachment: Mapping[str, Any] | None = None,
     ) -> Mapping[str, str]:
         raise NotImplementedError
 

--- a/moonmind/omnigent/host_runtime.py
+++ b/moonmind/omnigent/host_runtime.py
@@ -247,6 +247,7 @@ class GenericOmnigentHostRuntime:
                 plan=plan,
                 host_lease_ref=host_lease_ref,
                 launch_policy=launch_policy,
+                workspace_attachment=prepared.workspace_attachment,
             )
         )
         spec = HostLaunchSpec.model_validate(

--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -159,7 +159,7 @@ async def _run_exact_host_opencode_command(
         "bridge_dir=Path('/tmp/moonmind-opencode-attestation'), "
         "auth_secret='moonmind-attestation'); "
         "result = subprocess.run("
-        "['/home/app/.omnigent/moonmind/bin/moonmind-opencode-context', "
+        "['/home/app/.omnigent/moonmind/bin/moonmind-context', "
         "*sys.argv[1:]], "
         "env=env, text=True, capture_output=True); "
         "sys.stdout.write(result.stdout); sys.stderr.write(result.stderr); "

--- a/moonmind/omnigent/host_services/launcher.py
+++ b/moonmind/omnigent/host_services/launcher.py
@@ -95,12 +95,16 @@ class DockerOmnigentHostLauncher:
             else ""
         )
         supplied_runtime_environment = dict(runtime_environment or {})
-        fanout_bearer = str(
-            supplied_runtime_environment.pop(
-                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", ""
+        capability_bearers = {
+            key: (
+                filename,
+                str(supplied_runtime_environment.pop(key, "") or "").strip(),
             )
-            or ""
-        ).strip()
+            for key, filename in {
+                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "execution-fanout",
+                "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "container-jobs",
+            }.items()
+        }
         allowed_runtime_environment = {
             "MOONMIND_URL",
             "MOONMIND_AGENT_RUN_ID",
@@ -108,15 +112,24 @@ class DockerOmnigentHostLauncher:
             "MOONMIND_STEP_ID",
             "MOONMIND_RUNTIME_ID",
             "MOONMIND_REPOSITORY_CONNECTION_REF",
+            "MOONMIND_CONTAINER_JOBS_MCP_URL",
+            "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
+            "MOONMIND_CONTAINER_JOBS_SESSION_ID",
+            "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
+            "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
+            "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH",
         }
         if set(supplied_runtime_environment) - allowed_runtime_environment:
             raise HarnessPlatformError(
                 "generic host received unsupported runtime environment names",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
-        if fanout_bearer and not control_volume:
+        if (
+            any(bearer for _, bearer in capability_bearers.values())
+            and not control_volume
+        ):
             raise HarnessPlatformError(
-                "execution fan-out requires a lease-owned capability mount",
+                "runtime capabilities require a lease-owned capability mount",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
         await self._backend.run(
@@ -170,7 +183,9 @@ class DockerOmnigentHostLauncher:
                         ],
                         input_bytes=self._host_api_token.encode("utf-8"),
                     )
-                if fanout_bearer:
+                for _key, (filename, bearer) in capability_bearers.items():
+                    if not bearer:
+                        continue
                     await self._backend.run(
                         [
                             "docker",
@@ -187,9 +202,9 @@ class DockerOmnigentHostLauncher:
                             "/bin/sh",
                             host_class.imageRef,
                             "-ceu",
-                            "umask 077; cat > /control/execution-fanout; chown 1000:1000 /control/execution-fanout; chmod 0400 /control/execution-fanout",
+                            f"umask 077; cat > /control/{filename}; chown 1000:1000 /control/{filename}; chmod 0400 /control/{filename}",
                         ],
-                        input_bytes=fanout_bearer.encode("utf-8"),
+                        input_bytes=bearer.encode("utf-8"),
                     )
             # Initialize the writable host-state volume before a read-only-root launch.
             await self._backend.run(
@@ -219,10 +234,11 @@ class DockerOmnigentHostLauncher:
                 ["docker", "volume", "rm", state_volume], check=False
             )
             raise
-        if fanout_bearer:
-            supplied_runtime_environment[
-                "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE"
-            ] = "/run/moonmind-host-auth/execution-fanout"
+        for key, (filename, bearer) in capability_bearers.items():
+            if bearer:
+                supplied_runtime_environment[key + "_FILE"] = (
+                    f"/run/moonmind-host-auth/{filename}"
+                )
         script, runtime_environment = self._scripts.build_entrypoint(
             credential_handles=credential_handles,
             skill_attachment=spec.skillAttachment,

--- a/moonmind/omnigent/host_services/runtime_environment.py
+++ b/moonmind/omnigent/host_services/runtime_environment.py
@@ -17,13 +17,18 @@ from moonmind.omnigent.workspace_intent import (
     authored_connection_ref,
     authored_required_capabilities,
 )
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.container_job_models import OwnerIdentity
+from moonmind.schemas.workspace_locator_models import SandboxWorkspaceLocator
+from moonmind.security.container_job_capabilities import (
+    mint_container_job_session_capability,
+)
 from moonmind.security.execution_fanout_capabilities import (
     EXECUTION_FANOUT_REQUIRED_CAPABILITY,
     ExecutionFanoutCapabilityError,
     mint_execution_fanout_capability,
     require_execution_fanout_authorization,
 )
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 
 
 class OmnigentRuntimeEnvironmentService:
@@ -60,7 +65,9 @@ class OmnigentRuntimeEnvironmentService:
         launch_policy: LaunchPolicy,
     ) -> Mapping[str, str]:
         required_capabilities = authored_required_capabilities(request)
-        if EXECUTION_FANOUT_REQUIRED_CAPABILITY not in required_capabilities:
+        needs_fanout = EXECUTION_FANOUT_REQUIRED_CAPABILITY in required_capabilities
+        needs_containers = "docker" in required_capabilities
+        if not needs_fanout and not needs_containers:
             return {}
         try:
             require_execution_fanout_authorization(
@@ -88,7 +95,7 @@ class OmnigentRuntimeEnvironmentService:
             or not self._moonmind_url
         ):
             raise HarnessPlatformError(
-                "execution fan-out runtime identity is incomplete",
+                "runtime capability identity is incomplete",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
         environment = {
@@ -97,7 +104,46 @@ class OmnigentRuntimeEnvironmentService:
             "MOONMIND_TASK_WORKFLOW_ID": workflow_id,
             "MOONMIND_STEP_ID": step_execution_id,
             "MOONMIND_RUNTIME_ID": runtime_id,
-            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": (
+        }
+        if needs_containers:
+            try:
+                locator = SandboxWorkspaceLocator.model_validate(
+                    (request.workspace_spec or {}).get("workspaceLocator")
+                )
+            except ValueError as exc:
+                raise HarnessPlatformError(
+                    "container jobs require an authoritative sandbox workspace locator",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+                ) from exc
+            environment.update(
+                {
+                    "MOONMIND_CONTAINER_JOBS_MCP_URL": self._moonmind_url.rstrip("/")
+                    + "/mcp/container",
+                    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": mint_container_job_session_capability(
+                        secret=self._signing_secret,
+                        owner=OwnerIdentity(
+                            principalId=step_execution_id, principalType="service"
+                        ),
+                        agent_run_id=step_execution_id,
+                        workflow_id=workflow_id,
+                        step_id=step_execution_id,
+                        session_id=host_lease_ref,
+                        runtime_id=runtime_id,
+                        source_kind="omnigent",
+                        workspace_kind="sandbox",
+                        workspace_id=locator.workspace_id,
+                        workspace_relative_path=locator.relative_path,
+                        lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
+                    ),
+                    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",
+                    "MOONMIND_CONTAINER_JOBS_SESSION_ID": host_lease_ref,
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "sandbox",
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": locator.workspace_id,
+                    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": locator.relative_path,
+                }
+            )
+        if needs_fanout:
+            environment["MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN"] = (
                 mint_execution_fanout_capability(
                     secret=self._signing_secret,
                     parent_workflow_id=workflow_id,
@@ -108,8 +154,7 @@ class OmnigentRuntimeEnvironmentService:
                     source_kind="omnigent",
                     lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
                 )
-            ),
-        }
+            )
         repository_connection_ref = authored_connection_ref(request)
         if repository_connection_ref:
             environment["MOONMIND_REPOSITORY_CONNECTION_REF"] = (

--- a/moonmind/omnigent/host_services/runtime_environment.py
+++ b/moonmind/omnigent/host_services/runtime_environment.py
@@ -63,6 +63,7 @@ class OmnigentRuntimeEnvironmentService:
         plan: OmnigentExecutionPlanEnvelope,
         host_lease_ref: str,
         launch_policy: LaunchPolicy,
+        workspace_attachment: Mapping[str, Any] | None = None,
     ) -> Mapping[str, str]:
         required_capabilities = authored_required_capabilities(request)
         needs_fanout = EXECUTION_FANOUT_REQUIRED_CAPABILITY in required_capabilities
@@ -115,6 +116,15 @@ class OmnigentRuntimeEnvironmentService:
                     "container jobs require an authoritative sandbox workspace locator",
                     code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
                 ) from exc
+            access_mode = (workspace_attachment or {}).get("accessMode")
+            if not isinstance(access_mode, str) or access_mode not in {
+                "read-only",
+                "read-write",
+            }:
+                raise HarnessPlatformError(
+                    "container jobs require authoritative workspace access mode",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+                )
             environment.update(
                 {
                     "MOONMIND_CONTAINER_JOBS_MCP_URL": self._moonmind_url.rstrip("/")
@@ -133,6 +143,7 @@ class OmnigentRuntimeEnvironmentService:
                         workspace_kind="sandbox",
                         workspace_id=locator.workspace_id,
                         workspace_relative_path=locator.relative_path,
+                        workspace_read_only=access_mode == "read-only",
                         lifetime_seconds=int(launch_policy.limits["timeoutSeconds"]),
                     ),
                     "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -79,6 +79,13 @@ _MOONMIND_RUNTIME_ENV_FILES = {
     "MOONMIND_RUNTIME_ID": "runtime-id",
     "MOONMIND_REPOSITORY_CONNECTION_REF": "repository-connection-ref",
     "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": "execution-fanout-file",
+    "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE": "container-jobs-file",
+    "MOONMIND_CONTAINER_JOBS_MCP_URL": "container-jobs-mcp-url",
+    "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "container-jobs-source-kind",
+    "MOONMIND_CONTAINER_JOBS_SESSION_ID": "container-jobs-session-id",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "container-jobs-workspace-kind",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": "container-jobs-workspace-id",
+    "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": "container-jobs-workspace-relative-path",
 }
 
 

--- a/moonmind/omnigent/host_services/runtime_scripts.py
+++ b/moonmind/omnigent/host_services/runtime_scripts.py
@@ -140,8 +140,7 @@ class OmnigentRuntimeScriptService:
             for item in tool_attachments
             if item.get("targetPath")
         ]
-        if opencode_runtime or github_credential_attachment is not None:
-            tool_bins.insert(0, _RUNTIME_BIN_DIR)
+        tool_bins.insert(0, _RUNTIME_BIN_DIR)
         # Always include the Omnigent venv so `docker exec` probes (attestation,
         # version checks) resolve the omnigent binary without a full PATH.
         environment["PATH"] = ":".join(
@@ -172,7 +171,8 @@ class OmnigentRuntimeScriptService:
         # tmpfs home. OpenCode needs to create repos/, cache/ etc. inside its
         # data directory, which a read-only credential mount would block.
         runtime_context_dir = _RUNTIME_CONTEXT_DIR
-        opencode_context_wrapper = f"{_RUNTIME_BIN_DIR}/moonmind-opencode-context"
+        context_wrapper = f"{_RUNTIME_BIN_DIR}/moonmind-context"
+        context_profile = f"{runtime_context_dir}/shell-profile"
         opencode_wrapper = f"{_RUNTIME_BIN_DIR}/opencode"
         if opencode_runtime:
             environment["MOONMIND_OPENCODE_RUNTIME"] = "1"
@@ -197,7 +197,7 @@ class OmnigentRuntimeScriptService:
                 sorted(passthrough_names)
             )
         runtime_context_writes = "".join(
-            f'printf \'%s\\n\' "${key}" > {runtime_context_dir}/{filename}; '
+            f"printf '%s\\n' \"${key}\" > {runtime_context_dir}/{filename}; "
             for key, filename in _MOONMIND_RUNTIME_ENV_FILES.items()
             if key in supplied_runtime_environment
         )
@@ -206,6 +206,46 @@ class OmnigentRuntimeScriptService:
             for key, filename in _MOONMIND_RUNTIME_ENV_FILES.items()
             if key in supplied_runtime_environment
         )
+        # Native harnesses filter their child environment after the runner
+        # passthrough. Restore the same run-owned, non-secret projection at
+        # both login-shell and executable boundaries. File selectors survive;
+        # the protected bearer files themselves never enter this projection.
+        context_setup = (
+            f"mkdir -p {runtime_context_dir} {_RUNTIME_BIN_DIR}; "
+            f"printf '%s\\n' \"$MOONMIND_ACTIVE_SKILLS_DIR\" > {runtime_context_dir}/active-skills-dir; "
+            f"printf '%s\\n' \"$MOONMIND_STEP_EXECUTION_ID\" > {runtime_context_dir}/step-execution-id; "
+            + runtime_context_writes
+            + f"printf '%s\\n' "
+            f"'export MOONMIND_ACTIVE_SKILLS_DIR=$(cat {runtime_context_dir}/active-skills-dir)' "
+            f"'export MOONMIND_STEP_EXECUTION_ID=$(cat {runtime_context_dir}/step-execution-id)' "
+            + runtime_context_exports
+            + f"'export PATH={':'.join(tool_bins)}:$PATH' "
+            + "'if [ -r /home/app/.config/gh/hosts.yml ]; then' "
+            "'  export GH_CONFIG_DIR=/home/app/.config/gh' "
+            "'  export GH_PROMPT_DISABLED=1' "
+            "'  export GH_NO_UPDATE_NOTIFIER=1' "
+            "'  export GH_NO_EXTENSION_UPDATE_NOTIFIER=1' "
+            "'  export GIT_CONFIG_COUNT=1' "
+            "'  export GIT_CONFIG_KEY_0=credential.https://github.com.helper' "
+            f"'  export GIT_CONFIG_VALUE_0=\"!{_RUNTIME_BIN_DIR}/gh auth git-credential\"' "
+            f"'fi' > {context_profile}; "
+            f"chmod 0600 {runtime_context_dir}/*; "
+            f"printf '%s\\n' '. {context_profile}' > /home/app/.bash_profile; "
+            "cp /home/app/.bash_profile /home/app/.profile; "
+            "chmod 0600 /home/app/.bash_profile /home/app/.profile; "
+            f"printf '%s\\n' '#!/bin/sh' '. {context_profile}' "
+            f"'exec \"$@\"' > {context_wrapper}; chmod 0700 {context_wrapper}; "
+        )
+        if any(
+            tool.get("path") == "bin/moonmind"
+            for attachment in tool_attachments
+            for tool in attachment.get("tools", [])
+        ):
+            context_setup += (
+                f"printf '%s\\n' '#!/bin/sh' '. {context_profile}' "
+                "'exec /opt/moonmind-tools/bin/moonmind \"$@\"' "
+                f"> {_RUNTIME_BIN_DIR}/moonmind; chmod 0700 {_RUNTIME_BIN_DIR}/moonmind; "
+            )
         script = (
             "set -eu; "
             "unset OPENAI_API_KEY ANTHROPIC_API_KEY OPENCODE_AUTH_CONTENT "
@@ -215,7 +255,8 @@ class OmnigentRuntimeScriptService:
             "path=${check%:*}; generation=${check##*:}; "
             'test -r "$path"; test "$(cat "$path")" = "$generation"; done; '
             'IFS=$oldifs; test -d "$MOONMIND_ACTIVE_SKILLS_DIR"; '
-            'if [ "${MOONMIND_OPENCODE_RUNTIME:-0}" = 1 ]; then '
+            + context_setup
+            + 'if [ "${MOONMIND_OPENCODE_RUNTIME:-0}" = 1 ]; then '
             "mkdir -p "
             + opencode_data
             + " "
@@ -251,40 +292,13 @@ class OmnigentRuntimeScriptService:
             '"' + staging_dir + '/auth.json" ' + opencode_data + "/auth.json; "
             "chown 1000:1000 " + opencode_data + "/auth.json; "
             "chmod 0600 " + opencode_data + "/auth.json; fi; "
-            "printf '%s\\n' \"$MOONMIND_ACTIVE_SKILLS_DIR\" > "
-            + runtime_context_dir
-            + "/active-skills-dir; "
-            "printf '%s\\n' \"$MOONMIND_STEP_EXECUTION_ID\" > "
-            + runtime_context_dir
-            + "/step-execution-id; "
-            + runtime_context_writes
-            + "chmod 0600 " + runtime_context_dir + "/*; "
-            "printf '%s\\n' '#!/bin/sh' "
-            "'export MOONMIND_ACTIVE_SKILLS_DIR=$(cat "
-            + runtime_context_dir
-            + "/active-skills-dir)' "
-            "'export MOONMIND_STEP_EXECUTION_ID=$(cat "
-            + runtime_context_dir
-            + "/step-execution-id)' "
-            + runtime_context_exports
-            + "'if [ -r /home/app/.config/gh/hosts.yml ]; then' "
-            "'  export GH_CONFIG_DIR=/home/app/.config/gh' "
-            "'  export GH_PROMPT_DISABLED=1' "
-            "'  export GH_NO_UPDATE_NOTIFIER=1' "
-            "'  export GH_NO_EXTENSION_UPDATE_NOTIFIER=1' "
-            "'  export GIT_CONFIG_COUNT=1' "
-            "'  export GIT_CONFIG_KEY_0=credential.https://github.com.helper' "
-            "'  export GIT_CONFIG_VALUE_0=\"!"
-            + _RUNTIME_BIN_DIR
-            + "/gh auth git-credential\"' "
-            "'fi' 'exec \"$@\"' > " + opencode_context_wrapper + "; "
             "printf '%s\\n' '#!/bin/sh' "
             "'exec "
-            + opencode_context_wrapper
+            + context_wrapper
             + ' /usr/local/bin/opencode "$@"\' > '
             + opencode_wrapper
             + "; "
-            "chmod 0700 " + opencode_context_wrapper + " " + opencode_wrapper + "; fi; "
+            "chmod 0700 " + opencode_wrapper + "; fi; "
             "if [ -d /run/mm-credentials/github ]; then "
             "mkdir -p /home/app/.config/gh; "
             "cp /run/mm-credentials/github/hosts.yml "

--- a/moonmind/schemas/container_job_models.py
+++ b/moonmind/schemas/container_job_models.py
@@ -254,6 +254,11 @@ class ContainerJobSpec(ContractModel):
         max_length=128,
     )
     workspace_ref: WorkspaceLocator = Field(alias="workspaceRef")
+    # None preserves the exact serialized shape of already-admitted v1 jobs.
+    # Scoped transports stamp True from signed read-only session authority.
+    workspace_read_only: bool | None = Field(
+        None, alias="workspaceReadOnly", strict=True
+    )
     command: list[str] = Field(default_factory=list, max_length=128)
     entrypoint: list[str] = Field(default_factory=list, max_length=32)
     workdir: str = Field("/workspace", pattern=r"^/workspace(?:/[^/]+)*$", max_length=512)

--- a/moonmind/security/container_job_capabilities.py
+++ b/moonmind/security/container_job_capabilities.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 from moonmind.schemas.container_job_models import OwnerIdentity
 
 _AUDIENCE = "moonmind-container-jobs"
-_VERSION = 2
+_VERSION = 3
 
 
 class ContainerJobCapabilityError(ValueError):
@@ -34,6 +34,7 @@ class ContainerJobSessionCapability:
     workspace_kind: Literal["managed_runtime", "sandbox"]
     workspace_id: str
     workspace_relative_path: str
+    workspace_read_only: bool
     expires_at: int
 
 
@@ -71,6 +72,7 @@ def mint_container_job_session_capability(
     workspace_kind: Literal["managed_runtime", "sandbox"] = "managed_runtime",
     workspace_id: str | None = None,
     workspace_relative_path: str = "repo",
+    workspace_read_only: bool = False,
     lifetime_seconds: int,
     now: int | None = None,
 ) -> str:
@@ -88,6 +90,10 @@ def mint_container_job_session_capability(
     if workspace_kind not in {"managed_runtime", "sandbox"}:
         raise ContainerJobCapabilityError(
             "unsupported container-job capability workspace kind"
+        )
+    if not isinstance(workspace_read_only, bool):
+        raise ContainerJobCapabilityError(
+            "container-job capability workspace access must be boolean"
         )
     issued_at = int(time.time() if now is None else now)
     normalized_workspace_id = _required_text(
@@ -110,6 +116,7 @@ def mint_container_job_session_capability(
             workspace_relative_path,
             field="workspaceRelativePath",
         ),
+        "workspaceReadOnly": workspace_read_only,
         "iat": issued_at,
         "exp": issued_at + lifetime_seconds,
     }
@@ -166,6 +173,11 @@ def verify_container_job_session_capability(
         raise ContainerJobCapabilityError("invalid container-job capability")
     if workspace_kind not in {"managed_runtime", "sandbox"}:
         raise ContainerJobCapabilityError("invalid container-job capability")
+    workspace_read_only = payload.get("workspaceReadOnly")
+    if not isinstance(workspace_read_only, bool):
+        raise ContainerJobCapabilityError(
+            "invalid container-job capability workspace access"
+        )
     return ContainerJobSessionCapability(
         owner=owner,
         agent_run_id=_required_text(payload.get("agentRunId"), field="agentRunId"),
@@ -183,6 +195,7 @@ def verify_container_job_session_capability(
             payload.get("workspaceRelativePath"),
             field="workspaceRelativePath",
         ),
+        workspace_read_only=workspace_read_only,
         expires_at=expires_at,
     )
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -23,7 +23,7 @@ import tempfile
 import threading
 import time
 import tarfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
 from pathlib import Path
@@ -2559,7 +2559,7 @@ class TemporalSkillActivities:
             )
 
         try:
-            return await execute_skill_activity(
+            result = await execute_skill_activity(
                 invocation_payload=invocation_payload,
                 registry_snapshot=resolved_snapshot,
                 dispatcher=self._dispatcher,
@@ -2567,6 +2567,53 @@ class TemporalSkillActivities:
             )
         except ToolFailure as exc:
             raise _tool_failure_application_error(exc) from exc
+
+        # The trusted loader owns the complete brief. Persist it before the
+        # workflow compacts inline context, rather than asking an assessment
+        # agent in a fresh workspace to reconstruct that source from a preview.
+        outputs = result.outputs
+        if (
+            result.status == "COMPLETED"
+            and outputs.get("trustedSource")
+            in {"moonmind.github.get_issue", "moonmind.jira.get_issue"}
+            and outputs.get("artifactPath")
+        ):
+            if resolved_artifact_service is None:
+                raise TemporalActivityRuntimeError(
+                    "Trusted issue brief requires durable artifact storage"
+                )
+            from temporalio import activity
+
+            try:
+                info = activity.info()
+            except RuntimeError:
+                info = None
+            brief_ref = await _write_json_artifact(
+                resolved_artifact_service,
+                principal=principal or "system:agent_runtime",
+                payload=dict(outputs),
+                execution_ref=(
+                    ExecutionRef(
+                        namespace=info.namespace,
+                        workflow_id=info.workflow_id,
+                        run_id=info.workflow_run_id,
+                        link_type="input.issue_brief_handoff",
+                    )
+                    if info is not None
+                    else None
+                ),
+                metadata_json={
+                    "name": "issue-brief.json",
+                    "path": outputs["artifactPath"],
+                    "producer": "activity:mm.tool.execute",
+                    "labels": ["issue_brief"],
+                },
+            )
+            result = replace(
+                result,
+                outputs={**outputs, "briefArtifactRef": brief_ref.artifact_id},
+            )
+        return result
 
     async def mm_tool_execute(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -249,6 +249,7 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
 )
 from moonmind.workflows.temporal.story_output_tools import (
+    ISSUE_BRIEF_LOADER_TOOL_NAMES,
     JIRA_CHECK_BLOCKERS_TOOL_NAME,
     JIRA_LOAD_PRESET_BRIEF_TOOL_NAME,
     JIRA_UPDATE_ISSUE_STATUS_TOOL_NAME,
@@ -2558,6 +2559,23 @@ class TemporalSkillActivities:
                 principal or "system:deployment",
             )
 
+        selector = invocation_payload.get("tool") or invocation_payload.get("skill")
+        selected_name = (
+            str(selector.get("name") or selector.get("id") or "").strip()
+            if isinstance(selector, Mapping)
+            else ""
+        )
+        is_issue_loader = selected_name in ISSUE_BRIEF_LOADER_TOOL_NAMES
+        if is_issue_loader:
+            definition = resolved_snapshot.get_tool(name=selected_name)
+            if definition.executor.activity_type not in {
+                "mm.tool.execute",
+                "mm.skill.execute",
+            }:
+                raise TemporalActivityRuntimeError(
+                    "Trusted issue loaders require their registered native handler"
+                )
+
         try:
             result = await execute_skill_activity(
                 invocation_payload=invocation_payload,
@@ -2574,8 +2592,7 @@ class TemporalSkillActivities:
         outputs = result.outputs
         if (
             result.status == "COMPLETED"
-            and outputs.get("trustedSource")
-            in {"moonmind.github.get_issue", "moonmind.jira.get_issue"}
+            and is_issue_loader
             and outputs.get("artifactPath")
         ):
             if resolved_artifact_service is None:

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -2145,6 +2145,8 @@ class DockerContainerJobBackend:
             workspace_mount = (
                 f"type=bind,src={request.resolved_workspace_ref},dst=/workspace"
             )
+        if spec.workspace_read_only:
+            workspace_mount += ",readonly"
         args = [
             "create",
             "--name",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -49,6 +49,9 @@ JIRA_CHECK_BLOCKERS_TOOL_NAME = "jira.check_blockers"
 JIRA_LOAD_PRESET_BRIEF_TOOL_NAME = "jira.load_preset_brief"
 JIRA_UPDATE_ISSUE_STATUS_TOOL_NAME = "jira.update_issue_status"
 GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME = "github.load_issue_preset_brief"
+ISSUE_BRIEF_LOADER_TOOL_NAMES = frozenset(
+    {JIRA_LOAD_PRESET_BRIEF_TOOL_NAME, GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME}
+)
 GITHUB_CHECK_ISSUE_BLOCKERS_TOOL_NAME = "github.check_issue_blockers"
 GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME = "github.update_issue_status"
 GITHUB_RESOLVE_PULL_REQUEST_TARGET_TOOL_NAME = "github.resolve_pull_request_target"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -95,6 +95,7 @@ with workflow.unsafe.imports_passed_through():
         JIRA_BACKED_AGENT_SKILLS,
     )
     from moonmind.workflows.temporal.story_output_tools import (
+        ISSUE_BRIEF_LOADER_TOOL_NAMES,
         JIRA_CHECK_BLOCKERS_TOOL_NAME,
     )
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
@@ -9688,9 +9689,7 @@ class MoonMindRunWorkflow:
         """Declare durable prior-step artifacts as fresh-workspace attachments."""
 
         merged = [str(ref).strip() for ref in input_refs if str(ref).strip()]
-        if agent_kind == "managed" and not self._patched_or_false_outside_workflow(
-            RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
-        ):
+        if agent_kind == "managed":
             return list(dict.fromkeys(merged))
         artifact_refs = [
             self._assessment_context.get("assessmentArtifactRef")
@@ -9789,6 +9788,7 @@ class MoonMindRunWorkflow:
         outputs: Mapping[str, Any],
         *,
         request: AgentExecutionRequest | None = None,
+        source_tool_name: str | None = None,
     ) -> None:
         record_aliases = self._patched_or_false_outside_workflow(
             RUN_JIRA_BLOCKER_RECHECK_ASSESSMENT_CONTEXT_ALIAS_PATCH
@@ -9804,8 +9804,7 @@ class MoonMindRunWorkflow:
                     RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
                 )
                 and self._assessment_context.get("briefArtifactRef")
-                and outputs.get("trustedSource")
-                not in {"moonmind.github.get_issue", "moonmind.jira.get_issue"}
+                and source_tool_name not in ISSUE_BRIEF_LOADER_TOOL_NAMES
             ):
                 # Agent-produced copies cannot replace the loader's source.
                 continue
@@ -9838,7 +9837,9 @@ class MoonMindRunWorkflow:
                 self._assessment_context.pop("assessedRepository", None)
                 self._assessment_context.pop("assessedBranch", None)
 
-    def _merge_assessment_context_into_result(self, execution_result: Any) -> Any:
+    def _merge_assessment_context_into_result(
+        self, execution_result: Any, *, source_tool_name: str | None = None
+    ) -> Any:
         if not self._assessment_context:
             return execution_result
         outputs = self._get_from_result(execution_result, "outputs")
@@ -9859,10 +9860,7 @@ class MoonMindRunWorkflow:
                 )
                 and self._assessment_context.get("briefArtifactRef")
             ):
-                if outputs.get("trustedSource") in {
-                    "moonmind.github.get_issue",
-                    "moonmind.jira.get_issue",
-                }:
+                if source_tool_name in ISSUE_BRIEF_LOADER_TOOL_NAMES:
                     # A new trusted load may select a different issue.
                     continue
                 for alias in aliases:
@@ -9938,6 +9936,18 @@ class MoonMindRunWorkflow:
                 if gate_result_ref:
                     merged["moonSpecVerifyArtifactRef"] = gate_result_ref
         if not self._trusted_issue_context:
+            return merged if merged != previous_outputs else previous_outputs
+        if self._patched_or_false_outside_workflow(
+            RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
+        ):
+            # The context recorded from the dispatched loader owns source
+            # fields even when a later tool copies or spoofs trustedSource.
+            copied_source = self._trusted_previous_outputs_context(
+                {**merged, "trustedSource": self._trusted_issue_context["trustedSource"]}
+            )
+            for key in copied_source or {}:
+                merged.pop(key, None)
+            merged.update(self._trusted_issue_context)
             return merged if merged != previous_outputs else previous_outputs
         if self._trusted_previous_outputs_context(previous_outputs):
             return merged if merged != previous_outputs else previous_outputs
@@ -14035,8 +14045,18 @@ class MoonMindRunWorkflow:
                 self._record_assessment_context(
                     outputs_for_story_output,
                     request=agent_request_for_context,
+                    source_tool_name=(
+                        tool_name if agent_request_for_context is None else None
+                    ),
                 )
-                self._record_trusted_issue_context(outputs_for_story_output)
+                if (
+                    not workflow.patched(RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH)
+                    or (
+                        agent_request_for_context is None
+                        and tool_name in ISSUE_BRIEF_LOADER_TOOL_NAMES
+                    )
+                ):
+                    self._record_trusted_issue_context(outputs_for_story_output)
                 previous_step_outputs = outputs_for_story_output
                 story_output_result = outputs_for_story_output.get("storyOutput")
                 if isinstance(story_output_result, Mapping):
@@ -15221,7 +15241,11 @@ class MoonMindRunWorkflow:
         if preserve_assessment_context:
             outputs = self._get_from_result(current_result, "outputs")
             if isinstance(outputs, Mapping):
-                self._record_assessment_context(outputs, request=agent_request)
+                self._record_assessment_context(
+                    outputs,
+                    request=agent_request,
+                    source_tool_name=tool_name if agent_request is None else None,
+                )
         while self._jira_blocker_waitable_result(
             current_result,
             tool_type=tool_type,
@@ -15390,11 +15414,16 @@ class MoonMindRunWorkflow:
                     break
             if preserve_assessment_context:
                 current_result = self._merge_assessment_context_into_result(
-                    current_result
+                    current_result,
+                    source_tool_name=tool_name if agent_request is None else None,
                 )
                 outputs = self._get_from_result(current_result, "outputs")
                 if isinstance(outputs, Mapping):
-                    self._record_assessment_context(outputs, request=agent_request)
+                    self._record_assessment_context(
+                        outputs,
+                        request=agent_request,
+                        source_tool_name=tool_name if agent_request is None else None,
+                    )
             self._record_step_result_evidence(
                 node_id,
                 execution_result=current_result,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -617,6 +617,7 @@ RUN_ASSESSMENT_PARAMETER_INJECTION_PATCH = "run-assessment-parameter-injection-v
 RUN_ASSESSMENT_CONSUMER_HANDOFF_PATCH = "run-assessment-consumer-handoff-v1"
 RUN_ASSESSMENT_ATTACHMENT_HANDOFF_PATCH = "run-assessment-attachment-handoff-v1"
 RUN_ISSUE_BRIEF_ATTACHMENT_HANDOFF_PATCH = "run-issue-brief-attachment-handoff-v1"
+RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH = "run-trusted-issue-brief-authority-v1"
 RUN_MOONSPEC_VERIFY_ATTACHMENT_HANDOFF_PATCH = (
     "run-moonspec-verify-attachment-handoff-v1"
 )
@@ -9687,7 +9688,9 @@ class MoonMindRunWorkflow:
         """Declare durable prior-step artifacts as fresh-workspace attachments."""
 
         merged = [str(ref).strip() for ref in input_refs if str(ref).strip()]
-        if agent_kind == "managed":
+        if agent_kind == "managed" and not self._patched_or_false_outside_workflow(
+            RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
+        ):
             return list(dict.fromkeys(merged))
         artifact_refs = [
             self._assessment_context.get("assessmentArtifactRef")
@@ -9795,6 +9798,17 @@ class MoonMindRunWorkflow:
             ("assessmentVerdict", "assessment_verdict"),
             ("briefArtifactRef", "brief_artifact_ref"),
         ):
+            if (
+                aliases[0] == "briefArtifactRef"
+                and self._patched_or_false_outside_workflow(
+                    RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
+                )
+                and self._assessment_context.get("briefArtifactRef")
+                and outputs.get("trustedSource")
+                not in {"moonmind.github.get_issue", "moonmind.jira.get_issue"}
+            ):
+                # Agent-produced copies cannot replace the loader's source.
+                continue
             for key in aliases:
                 value = outputs.get(key)
                 if value in (None, "", {}, []):
@@ -9838,6 +9852,25 @@ class MoonMindRunWorkflow:
             ("assessmentVerdict", "assessment_verdict"),
             ("briefArtifactRef", "brief_artifact_ref"),
         ):
+            if (
+                aliases[0] == "briefArtifactRef"
+                and self._patched_or_false_outside_workflow(
+                    RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
+                )
+                and self._assessment_context.get("briefArtifactRef")
+            ):
+                if outputs.get("trustedSource") in {
+                    "moonmind.github.get_issue",
+                    "moonmind.jira.get_issue",
+                }:
+                    # A new trusted load may select a different issue.
+                    continue
+                for alias in aliases:
+                    if alias == aliases[0] or alias in merged_outputs:
+                        value = self._assessment_context["briefArtifactRef"]
+                        changed = changed or merged_outputs.get(alias) != value
+                        merged_outputs[alias] = value
+                continue
             if any(
                 merged_outputs.get(alias) not in (None, "", {}, []) for alias in aliases
             ):
@@ -9880,7 +9913,14 @@ class MoonMindRunWorkflow:
         ):
             value = self._assessment_context.get(key)
             if value not in (None, "", {}, []):
-                merged.setdefault(key, value)
+                if key in {"briefArtifactRef", "brief_artifact_ref"} and (
+                    self._patched_or_false_outside_workflow(
+                        RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH
+                    )
+                ):
+                    merged[key] = value
+                else:
+                    merged.setdefault(key, value)
         if self._patched_or_false_outside_workflow(
             RUN_MOONSPEC_GATE_PREVIOUS_OUTPUTS_HANDOFF_PATCH
         ):

--- a/services/omnigent/scripts/init-mounted-tools.sh
+++ b/services/omnigent/scripts/init-mounted-tools.sh
@@ -22,6 +22,6 @@ case "$reported" in
   *" $version "*) ;;
   *) echo "gh version mismatch: expected $version" >&2; exit 65 ;;
 esac
-printf '{"schemaVersion":1,"bundleVersion":"gh-%s-container-v1","tools":[{"name":"gh","version":"%s","path":"bin/gh","versionProbe":["--version"]},{"name":"moonmind","version":"container-v1","path":"bin/moonmind","versionProbe":["--help"]}]}\n' \
+printf '{"schemaVersion":1,"bundleVersion":"gh-%s-container-v1","tools":[{"name":"gh","version":"%s","path":"bin/gh","versionProbe":["--version"]},{"name":"docker","version":"container-v1","path":"bin/moonmind","versionProbe":["--help"]}]}\n' \
   "$version" "$version" > "$output/manifest.json"
 chmod -R a-w "$output"

--- a/services/omnigent/tools/init_omnigent_tools.py
+++ b/services/omnigent/tools/init_omnigent_tools.py
@@ -157,11 +157,24 @@ def initialize(lock_path: Path, output_root: Path) -> None:
     try:
         for index, tool in enumerate(lock["tools"]):
             selected = tool["platforms"][platform_key]
-            archive = staging / f"artifact-{index}.tar.gz"
-            _download(selected["url"], archive, selected["sha256"])
             executable = staging / _safe_relative_path(tool["path"])
-            _extract_executable(archive, selected["archivePath"], executable)
-            archive.unlink()
+            if tool.get("sourcePath"):
+                source = lock_path.parent / tool["sourcePath"]
+                if (
+                    source.is_symlink()
+                    or not source.is_file()
+                    or hashlib.sha256(source.read_bytes()).hexdigest()
+                    != selected["executableSha256"]
+                ):
+                    raise RuntimeError(f"SHA-256 mismatch for {tool['name']} source")
+                executable.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, executable)
+                executable.chmod(0o555)
+            else:
+                archive = staging / f"artifact-{index}.tar.gz"
+                _download(selected["url"], archive, selected["sha256"])
+                _extract_executable(archive, selected["archivePath"], executable)
+                archive.unlink()
             subprocess.run(
                 [str(executable), *tool["versionProbe"]],
                 check=True,

--- a/services/omnigent/tools/manifest.lock.json
+++ b/services/omnigent/tools/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "bundleVersion": "gh-2.76.2-1",
+  "bundleVersion": "gh-2.76.2-container-v1",
   "tools": [
     {
       "name": "gh",
@@ -21,6 +21,21 @@
       },
       "path": "bin/gh",
       "versionProbe": ["--version"]
+    },
+    {
+      "name": "docker",
+      "version": "container-v1",
+      "sourcePath": "../scripts/moonmind-container-cli.py",
+      "platforms": {
+        "linux/amd64": {
+          "executableSha256": "8ce5b264451fc9b17c7db1f1dfa9cd19121ff37c9450911dd5d43dcdee1979e4"
+        },
+        "linux/arm64": {
+          "executableSha256": "8ce5b264451fc9b17c7db1f1dfa9cd19121ff37c9450911dd5d43dcdee1979e4"
+        }
+      },
+      "path": "bin/moonmind",
+      "versionProbe": ["--help"]
     }
   ]
 }

--- a/tests/integration/reliability/replays/issue-brief-verification-handoff/manifest.json
+++ b/tests/integration/reliability/replays/issue-brief-verification-handoff/manifest.json
@@ -1,0 +1,12 @@
+{
+  "incidentWorkflowId": "mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-08T04:20:00Z",
+  "invariant": "The loader persists the complete trusted issue before prompt compaction, and the first assessment receives it as an authorized attachment.",
+  "bodyPrefix": "Required journey A: exercise the production boundary.\n",
+  "repeatCount": 180,
+  "acceptanceTail": "\nRequired journey B and final acceptance must remain available to the verifier.",
+  "containerSubmission": {
+    "observedFailure": "MOONMIND_RUNTIME_ID is required; run this command inside a MoonMind managed workflow",
+    "requiredCapabilities": ["git", "gh", "docker"],
+    "testTargets": ["tests/unit/test_pytest_unit_workflow.py"]
+  }
+}

--- a/tests/integration/reliability/replays/issue-brief-verification-handoff/runner_boundary.py
+++ b/tests/integration/reliability/replays/issue-brief-verification-handoff/runner_boundary.py
@@ -1,0 +1,173 @@
+"""Exercise the projected CLI; executable inside a pinned Omnigent host image.
+
+The native entrypoint uses the actual host and Codex environment builders.
+The unit caller supplies an empty child environment to test the stricter case.
+No provider is contacted; the local HTTP fixture records container submission.
+"""
+
+from __future__ import annotations
+
+import json
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+
+def exercise_projection(root: Path, *, native: bool = False) -> None:
+    repository = next(
+        parent for parent in Path(__file__).parents if (parent / "moonmind").is_dir()
+    )
+    # The host deliberately has only Omnigent dependencies, so load this pure
+    # script builder without importing MoonMind's application service package.
+    module_spec = importlib.util.spec_from_file_location(
+        "moonmind_runtime_scripts",
+        repository / "moonmind/omnigent/host_services/runtime_scripts.py",
+    )
+    runtime_scripts = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(runtime_scripts)
+    home = root / "home"
+    skills = root / "skills"
+    tools = root / "tools"
+    control = root / "control"
+    runtime_bin = home / ".omnigent/moonmind/bin"
+    for directory in (home, skills, tools / "bin", control, runtime_bin):
+        directory.mkdir(parents=True, exist_ok=True)
+    # This is an inert host-launch sentinel, not a replacement runner.
+    (runtime_bin / "omnigent").write_text("#!/bin/sh\nexit 0\n")
+    (runtime_bin / "omnigent").chmod(0o700)
+    shutil.copyfile(
+        repository / "services/omnigent/scripts/moonmind-container-cli.py",
+        tools / "bin/moonmind",
+    )
+    (tools / "bin/moonmind").chmod(0o555)
+    (control / "container-jobs").write_text("fixture-scoped-capability")
+    (control / "container-jobs").chmod(0o400)
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            assert self.headers["Authorization"] == "Bearer fixture-scoped-capability"
+            requests.append(request)
+            if request["tool"] == "container.submit":
+                result = {"jobId": "job-1"}
+            elif request["tool"] == "container.status":
+                result = {"state": "succeeded", "terminal": {"exitCode": 0}}
+            else:
+                result = {"items": [], "nextCursor": None}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"result": result}).encode())
+
+        def log_message(self, *_args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}/mcp/container"
+    expected = {
+        "MOONMIND_URL": endpoint.removesuffix("/mcp/container"),
+        "MOONMIND_AGENT_RUN_ID": "agent-run-1",
+        "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
+        "MOONMIND_STEP_ID": "step-1",
+        "MOONMIND_RUNTIME_ID": "codex-native",
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE": str(control / "container-jobs"),
+        "MOONMIND_CONTAINER_JOBS_MCP_URL": endpoint,
+        "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",
+        "MOONMIND_CONTAINER_JOBS_SESSION_ID": "lease-1",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "sandbox",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": "sandbox-1",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": "repo",
+    }
+    (
+        script,
+        environment,
+    ) = runtime_scripts.OmnigentRuntimeScriptService().build_entrypoint(
+        credential_handles=[],
+        skill_attachment={"targetPath": str(skills)},
+        step_execution_id="workflow-1:run-1:node-1:execution:1",
+        tool_attachments=(
+            {
+                "targetPath": str(tools),
+                "tools": [{"name": "docker", "path": "bin/moonmind"}],
+            },
+        ),
+        runtime_environment=expected,
+    )
+    script = script.replace("/home/app", str(home)).replace(
+        "/opt/moonmind-tools", str(tools)
+    )
+    environment = {
+        key: value.replace("/home/app", str(home)) for key, value in environment.items()
+    }
+    environment["HOME"] = str(home)
+    try:
+        setup = subprocess.run(
+            ["/bin/sh", "-ceu", script, "--", "http://fixture"],
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert setup.returncode == 0, setup.stderr
+        if native:
+            from omnigent.host.connect import _build_runner_env
+            from omnigent.inner.codex_executor import _clean_codex_env
+
+            runner_environment = _build_runner_env(
+                environment,
+                server_url="http://fixture",
+                runner_id="fixture",
+                binding_token="fixture",
+                workspace=str(root),
+                parent_pid=os.getpid(),
+            )
+            with patch.dict(os.environ, runner_environment, clear=True):
+                child_environment = _clean_codex_env()
+        else:
+            child_environment = {"HOME": str(home), "PATH": environment["PATH"]}
+        assert not any(key.startswith("MOONMIND_") for key in child_environment)
+        # Login commands recover both correlation and capability context.
+        # The CLI wrapper also works when an explicit non-login shell is used.
+        for shell_args in (["/bin/bash", "-lc"], ["/bin/sh", "-c"]):
+            command = "moonmind container python-tests tests/unit/test_pytest_unit_workflow.py"
+            if shell_args[-1] == "-lc":
+                command = 'test "$MOONMIND_RUNTIME_ID" = codex-native && ' + command
+            result = subprocess.run(
+                [*shell_args, command],
+                env=child_environment,
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+        submissions = [
+            item["arguments"] for item in requests if item["tool"] == "container.submit"
+        ]
+        assert len(submissions) == 2
+        for submission in submissions:
+            assert submission["source"]["stepId"] == "step-1"
+            assert submission["source"]["workflowId"] == "workflow-1"
+            assert submission["spec"]["workspaceRef"] == {
+                "kind": "sandbox",
+                "workspaceId": "sandbox-1",
+                "relativePath": "repo",
+            }
+        for artifact in (home / ".omnigent/moonmind/runtime-context").iterdir():
+            assert "fixture-scoped-capability" not in artifact.read_text()
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory(prefix="moonmind-native-shell-") as directory:
+        exercise_projection(Path(directory), native=True)
+    print("Native Codex runner â†’ filtered child â†’ projected CLI boundary passed")

--- a/tests/integration/reliability/test_issue_search_publication.py
+++ b/tests/integration/reliability/test_issue_search_publication.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from api_service.db.models import Base
@@ -23,6 +24,11 @@ from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalSkillActivities,
     _default_registry_skill_payload,
+)
+from moonmind.workflows.temporal.artifacts import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
 )
 from moonmind.workflows.temporal.story_output_tools import (
     register_story_output_tool_handlers,
@@ -42,6 +48,21 @@ from .helpers import load_replay
 pytestmark = [pytest.mark.asyncio, pytest.mark.reliability_journey]
 
 
+@pytest_asyncio.fixture
+async def artifact_service(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/artifacts.db")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+            yield TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+    finally:
+        await engine.dispose()
+
+
 @pytest.mark.parametrize(
     "inputs,restart_count",
     [
@@ -53,7 +74,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.reliability_journey]
 )
 @pytest.mark.parametrize("pr_created", [True, False, "unavailable"])
 async def test_search_publication_recovers_missing_pr_before_status(
-    tmp_path, monkeypatch, inputs, restart_count, pr_created
+    tmp_path, monkeypatch, inputs, restart_count, pr_created, artifact_service
 ):
     evidence = load_replay("issue-search-publication-handoff", "manifest.json")
     repository = evidence["repository"]
@@ -65,7 +86,8 @@ async def test_search_publication_recovers_missing_pr_before_status(
         "number": number,
         "state": "open",
         "title": "Dispose of completed temporary plans",
-        "body": "Preserve active dependencies and durable evidence.",
+        "body": "Preserve active dependencies and durable evidence.\n" * 180
+        + "Keep the complete acceptance criteria.",
         "html_url": f"https://github.com/{repository}/issues/{number}",
         "labels": [],
     }
@@ -125,12 +147,7 @@ async def test_search_publication_recovers_missing_pr_before_status(
         ),
     )
     activities = TemporalSkillActivities(
-        dispatcher=dispatcher,
-        artifact_service=SimpleNamespace(
-            read=AsyncMock(
-                return_value=(None, {"verdict": evidence["assessmentVerdict"]})
-            )
-        ),
+        dispatcher=dispatcher, artifact_service=artifact_service
     )
 
     async def invoke(payload):
@@ -156,14 +173,28 @@ async def test_search_publication_recovers_missing_pr_before_status(
         }
     )
     assert selected.status == "COMPLETED"
+    brief_ref = selected.outputs["briefArtifactRef"]
+    _brief, brief_bytes = await artifact_service.read(
+        artifact_id=brief_ref, principal="test:search-publication"
+    )
+    assert json.loads(brief_bytes)["issue"]["body"] == issue["body"]
+    assessment, _upload = await artifact_service.create(
+        principal="test:search-publication", content_type="application/json"
+    )
+    assessment = await artifact_service.write_complete(
+        artifact_id=assessment.artifact_id,
+        principal="test:search-publication",
+        content_type="application/json",
+        payload=json.dumps({"verdict": evidence["assessmentVerdict"]}).encode(),
+    )
     parent = MoonMindRunWorkflow()
     parent._owner_id = "test:search-publication"
     parent._repo = repository
     parent._record_trusted_issue_context(selected.outputs)
     parent._assessment_context = {
         "assessmentVerdict": evidence["assessmentVerdict"],
-        "assessmentArtifactRef": "art_assessment",
-        "briefArtifactRef": "art_brief",
+        "assessmentArtifactRef": assessment.artifact_id,
+        "briefArtifactRef": brief_ref,
         "assessedRepository": repository,
         "assessedBranch": "main",
     }

--- a/tests/integration/temporal/test_compose_foundation.py
+++ b/tests/integration/temporal/test_compose_foundation.py
@@ -249,8 +249,11 @@ def test_omnigent_hosts_use_versioned_read_only_tool_bundle():
 
     configured_version = initializer["environment"]["MOONMIND_GH_VERSION"]
     compose_default_version = configured_version.removesuffix("}").rsplit(":-", 1)[1]
-    assert tool_manifest["bundleVersion"] == f"gh-{compose_default_version}-1"
-    assert tool_manifest["tools"][0]["version"] == compose_default_version
+    assert tool_manifest["bundleVersion"] == f"gh-{compose_default_version}-container-v1"
+    tools_by_name = {tool["name"]: tool for tool in tool_manifest["tools"]}
+    assert tools_by_name["gh"]["version"] == compose_default_version
+    assert tools_by_name["docker"]["version"] == "container-v1"
+    assert tools_by_name["docker"]["path"] == "bin/moonmind"
 
     assert initializer["image"] == (
         "${OMNIGENT_GH_IMAGE:-serversideup/github-cli:alpine-2.76.2}"

--- a/tests/unit/api/test_container_job_readonly_authority.py
+++ b/tests/unit/api/test_container_job_readonly_authority.py
@@ -1,0 +1,293 @@
+"""Repository access authority survives the scoped container-job handoff."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.api.routers import mcp_tools
+from api_service.db.models import Base
+from api_service.services.container_jobs import ContainerJobService
+from moonmind.omnigent.harness_platform.execution_plan import (
+    create_execution_plan_envelope,
+)
+from moonmind.omnigent.harness_platform.host_classes import get_launch_policy
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.host_services.runtime_environment import (
+    OmnigentRuntimeEnvironmentService,
+)
+from moonmind.omnigent.host_services.workspace import OmnigentWorkspaceMaterializer
+from moonmind.omnigent.workspace_sources import issue_existing_workspace_grant
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.container_job_models import ContainerJobActivityRequest
+from moonmind.security.container_job_capabilities import (
+    verify_container_job_session_capability,
+)
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
+from moonmind.workflows.temporal.runtime.workspace_locators import (
+    SandboxWorkspaceRecord,
+    SandboxWorkspaceRecordStore,
+)
+from moonmind.workflows.temporal.workflows.container_job import (
+    MoonMindContainerJobWorkflow,
+)
+from tests.unit.omnigent.test_generic_platform_production_services import _plan
+
+
+@pytest_asyncio.fixture
+async def job_sessions(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/jobs.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+@pytest.mark.parametrize(
+    "attachment", [None, {}, {"accessMode": "rw"}, {"accessMode": []}]
+)
+def test_container_capability_requires_materialized_access_mode(attachment):
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "workflow-1",
+            "idempotencyKey": "step-1",
+            "parameters": {"requiredCapabilities": ["docker"]},
+            "workspaceSpec": {
+                "workspaceLocator": {"kind": "sandbox", "workspaceId": "sandbox-1"}
+            },
+        }
+    )
+    with pytest.raises(HarnessPlatformError, match="workspace access mode"):
+        OmnigentRuntimeEnvironmentService(
+            moonmind_url="http://api:8000", signing_secret="test-container-secret"
+        ).build(
+            request=request,
+            plan=_plan("test/model"),
+            host_lease_ref="lease-1",
+            launch_policy=get_launch_policy("omnigent-on-demand@1"),
+            workspace_attachment=attachment,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "harness_id", ["codex-native", "claude-code-native", "opencode-native"]
+)
+@pytest.mark.parametrize(
+    "mutation,grant_mode,expected_read_only",
+    [
+        ("allowed", None, False),
+        ("read_only", None, True),
+        ("allowed", "read_only", True),
+    ],
+)
+@pytest.mark.parametrize("requested_read_only", [None, False, True])
+@pytest.mark.parametrize("volume_name", [None, "agent_workspaces"])
+async def test_workspace_authority_survives_api_persistence_and_worker_launch(
+    tmp_path,
+    monkeypatch,
+    job_sessions,
+    harness_id,
+    mutation,
+    grant_mode,
+    expected_read_only,
+    requested_read_only,
+    volume_name,
+):
+    workspace_root = tmp_path / "workspaces"
+    workspace_id = hashlib.sha256(b"workflow-1:step-1").hexdigest()[:24]
+    repository = workspace_root / "temporal_sandbox" / workspace_id / "repo"
+    repository.mkdir(parents=True)
+    (repository / "source.txt").write_text("authoritative source", encoding="utf-8")
+    monkeypatch.setenv("WORKFLOW_WORKSPACE_ROOT", str(workspace_root))
+    monkeypatch.setenv("WORKFLOW_DOCKER_DAEMON_MODE", "local")
+    monkeypatch.setenv("MOONMIND_WORKSPACE_GRANT_SECRET", "test-grant-secret")
+    SandboxWorkspaceRecordStore(workspace_root).ensure(
+        SandboxWorkspaceRecord(
+            workspace_id=workspace_id,
+            workflow_id="workflow-1",
+            step_execution_id="step-1",
+            relative_path="repo",
+        )
+    )
+    locator = {"kind": "sandbox", "workspaceId": workspace_id, "relativePath": "repo"}
+    workspace_spec = {"workspaceLocator": locator}
+    if grant_mode:
+        grant = issue_existing_workspace_grant(
+            workspace_id=workspace_id,
+            owner_workflow_id="workflow-1",
+            owner_step_execution_id="step-1",
+            grantee_workflow_id="workflow-1",
+            mode=grant_mode,
+            generation=1,
+            secret="test-grant-secret",
+        )
+        workspace_spec["workspaceSource"] = {
+            "kind": "existing_workspace",
+            "existingWorkspaceGrant": {
+                "workspaceId": grant.workspace_id,
+                "ownerWorkflowId": grant.owner_workflow_id,
+                "ownerStepExecutionId": grant.owner_step_execution_id,
+                "generation": grant.generation,
+                "mode": grant.mode,
+                "expiresAt": grant.expires_at.isoformat(),
+                "grantDigest": grant.grant_digest,
+            },
+        }
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "workflow-1",
+            "idempotencyKey": "step-1",
+            "parameters": {"requiredCapabilities": ["docker"]},
+            "workspaceSpec": workspace_spec,
+        }
+    )
+    plan = create_execution_plan_envelope(
+        {
+            **_plan("test/model").payload.model_dump(mode="json", by_alias=True),
+            "harnessId": harness_id,
+            "workspaceMutation": mutation,
+        }
+    )
+    materializer = OmnigentWorkspaceMaterializer(
+        command_runner=AsyncMock(return_value=(0, "", "")),
+        workspace_root=workspace_root,
+    )
+    attachment = await materializer.materialize(
+        request,
+        mutation=plan.payload.workspaceMutation,
+        runtime_uid=os.getuid(),
+        runtime_gid=os.getgid(),
+    )
+    environment = OmnigentRuntimeEnvironmentService(
+        moonmind_url="http://api:8000", signing_secret="test-container-secret"
+    ).build(
+        request=request,
+        plan=plan,
+        host_lease_ref="lease-1",
+        launch_policy=get_launch_policy("omnigent-on-demand@1"),
+        workspace_attachment=attachment,
+    )
+    token = environment["MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"]
+    capability = verify_container_job_session_capability(
+        token, secret="test-container-secret"
+    )
+    assert capability.workspace_read_only is expected_read_only
+    expected_mount_read_only = bool(expected_read_only or requested_read_only)
+
+    submission = {
+        "idempotencyKey": "test-readonly",
+        "source": {
+            "source": "omnigent",
+            "workflowId": capability.workflow_id,
+            "stepId": capability.step_id,
+            "agentRunId": capability.agent_run_id,
+            "omnigentConversationId": capability.session_id,
+        },
+        "spec": {
+            "image": "alpine",
+            "workspaceRef": locator,
+            "command": ["cat", "/workspace/source.txt"],
+            "resources": {"cpuMillis": 100, "memoryMiB": 64},
+        },
+    }
+    if requested_read_only is not None:
+        submission["spec"]["workspaceReadOnly"] = requested_read_only
+    temporal = AsyncMock()
+    monkeypatch.setattr(
+        mcp_tools.settings.security, "JWT_SECRET_KEY", "test-container-secret"
+    )
+    monkeypatch.setattr(mcp_tools, "container_jobs_ready", lambda: True)
+    monkeypatch.setattr(mcp_tools, "get_temporal_artifact_service", lambda _session: None)
+    monkeypatch.setattr(
+        mcp_tools,
+        "ContainerJobService",
+        lambda session, **_kwargs: ContainerJobService(session, temporal=temporal),
+    )
+    app = FastAPI()
+    app.include_router(mcp_tools.router, prefix="/api")
+    async with job_sessions() as session:
+
+        async def session_dependency():
+            yield session
+
+        app.dependency_overrides[mcp_tools.get_async_session] = session_dependency
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/mcp/container/tools/call",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"tool": "container.submit", "arguments": submission},
+            )
+        assert response.status_code == 200, response.text
+        workflow_input = temporal.start_container_job.await_args.args[0]
+        record = await ContainerJobService(session).repository.get_for_owner(
+            owner=capability.owner, job_id=workflow_input.job_id
+        )
+        assert (
+            bool(record.request_json["spec"].get("workspaceReadOnly"))
+            is expected_mount_read_only
+        )
+        assert (
+            bool(workflow_input.request.spec.workspace_read_only)
+            is expected_mount_read_only
+        )
+
+    commands = []
+
+    async def daemon(argv):
+        commands.append(tuple(argv))
+        if tuple(argv[:3]) == ("inspect", "--format", "{{json .Config.Labels}}"):
+            return 1, b"", b"No such container"
+        return 0, b"", b""
+
+    backend = DockerContainerJobBackend(
+        workspace_root=workspace_root,
+        workspace_volume_name=volume_name,
+        command_runner=daemon,
+    )
+    activities = TemporalAgentRuntimeActivities(container_job_backend=backend)
+
+    async def invoke_activity(name, payload, **_kwargs):
+        return await getattr(activities, name.replace(".", "_"))(payload)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.container_job.workflow.execute_activity",
+        invoke_activity,
+    )
+    activity_request = ContainerJobActivityRequest(
+        jobId=workflow_input.job_id,
+        owner=workflow_input.owner,
+        ownershipToken=workflow_input.ownership_token,
+        request=workflow_input.request,
+    )
+    workflow = MoonMindContainerJobWorkflow()
+    resolved = await workflow._activity(
+        "container_job.resolve_workspace", activity_request
+    )
+    activity_request.resolved_workspace_ref = resolved.resolved_workspace_ref
+    activity_request.resolved_workspace_volume_name = (
+        resolved.resolved_workspace_volume_name
+    )
+    activity_request.resolved_workspace_volume_subpath = (
+        resolved.resolved_workspace_volume_subpath
+    )
+    activity_request.resolved_image_ref = "sha256:" + "a" * 64
+    await workflow._activity("container_job.create_container", activity_request)
+    created = next(command for command in commands if command[0] == "create")
+    mount = created[created.index("--mount") + 1]
+    assert mount.endswith(",readonly") is expected_mount_read_only
+    assert mount.startswith("type=volume" if volume_name else "type=bind")

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
@@ -92,7 +94,17 @@ def activity_boundary(monkeypatch):
         ),
     )
     artifact_service = SimpleNamespace(
-        read=AsyncMock(return_value=(None, {"verdict": "NOT_IMPLEMENTED"}))
+        read=AsyncMock(return_value=(None, {"verdict": "NOT_IMPLEMENTED"})),
+        create=AsyncMock(return_value=(SimpleNamespace(artifact_id="art_brief"), None)),
+        write_complete=AsyncMock(
+            return_value=SimpleNamespace(
+                artifact_id="art_brief",
+                sha256="a" * 64,
+                size_bytes=100,
+                content_type="application/json",
+                encryption=SimpleNamespace(value="none"),
+            )
+        ),
     )
     activities = TemporalSkillActivities(
         dispatcher=dispatcher, artifact_service=artifact_service
@@ -117,9 +129,109 @@ def activity_boundary(monkeypatch):
         )
 
     return SimpleNamespace(
-        execute=execute, pages=pages, requests=requests, detail=detail,
+        execute=execute,
+        pages=pages,
+        requests=requests,
+        detail=detail,
         dependency_details=dependency_details,
+        activities=activities,
+        artifact_service=artifact_service,
     )
+
+
+@pytest.mark.asyncio
+async def test_full_issue_brief_reaches_fresh_assessment_workspace(
+    activity_boundary,
+    tmp_path,
+    monkeypatch,
+):
+    """Replay mm:6901d5c7 04:20: full provider body must survive prompt compaction."""
+    from moonmind.omnigent.workspace_artifacts import WorkspaceArtifactProjector
+    from moonmind.workflows.temporal.artifacts import (
+        LocalTemporalArtifactStore,
+        TemporalArtifactRepository,
+        TemporalArtifactService,
+    )
+    from moonmind.workflows.temporal.workflows import run as run_module
+    from tests.unit.workflows.temporal.test_activity_runtime import temporal_db
+
+    replay = json.loads(
+        (
+            Path(__file__).resolve().parents[2]
+            / "integration/reliability/replays/issue-brief-verification-handoff/manifest.json"
+        ).read_text()
+    )
+    body = replay["bodyPrefix"] * replay["repeatCount"] + replay["acceptanceTail"]
+    candidate = issue(number=3950, body=body)
+    activity_boundary.pages[:] = [[candidate]]
+    activity_boundary.detail.update(candidate)
+    info = SimpleNamespace(
+        namespace="default",
+        workflow_id="workflow-1",
+        workflow_run_id="run-1",
+        run_id="run-1",
+    )
+    monkeypatch.setattr("temporalio.activity.info", lambda: info)
+    monkeypatch.setattr(run_module.workflow, "info", lambda: info)
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch: True)
+
+    async with temporal_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activity_boundary.activities._artifact_service = service
+            result = await activity_boundary.execute(
+                "github.load_issue_preset_brief",
+                {"repository": REPOSITORY, "issueSearch": ""},
+            )
+            assert result.status == "COMPLETED"
+            wf = MoonMindRunWorkflow()
+            wf._record_assessment_context(result.outputs)
+            wf._record_trusted_issue_context(result.outputs)
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "omnigent",
+                    "repository": REPOSITORY,
+                    "instructions": "Assess the full issue.",
+                    "previousOutputs": result.outputs,
+                },
+                node_id="assessment",
+                tool_name="omnigent",
+            )
+            assert "contextTruncation" in request.instruction_ref
+            assert "...[truncated]" in request.instruction_ref
+            assert request.input_refs
+            workspace = tmp_path / "fresh-workspace"
+            workspace.mkdir()
+            await WorkspaceArtifactProjector(service).project(
+                workspace,
+                attachment_refs=tuple(request.input_refs),
+                workflow_id="workflow-1",
+                runtime_uid=os.getuid(),
+                runtime_gid=os.getgid(),
+            )
+            attachments = list((workspace / ".moonmind/attachments").iterdir())
+            assert len(attachments) == 1
+            restored = json.loads(attachments[0].read_text())
+            assert restored["issue"]["body"] == body
+            assert restored["issue"]["body"].endswith(replay["acceptanceTail"])
+            assert "contextTruncation" not in restored
+
+
+@pytest.mark.asyncio
+async def test_issue_loader_fails_before_handoff_when_brief_cannot_be_persisted(
+    activity_boundary,
+):
+    activity_boundary.artifact_service.write_complete.side_effect = RuntimeError(
+        "storage unavailable"
+    )
+    with pytest.raises(RuntimeError, match="storage unavailable"):
+        await activity_boundary.execute(
+            "github.load_issue_preset_brief",
+            {"repository": REPOSITORY, "issueSearch": ""},
+        )
 
 
 @pytest.mark.parametrize(
@@ -397,6 +509,7 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
     finally:
         await engine.dispose()
     steps = expanded["steps"]
+    assert "docker" in expanded["capabilities"]
     assert steps[0]["type"] == "tool"
     tool = steps[0]["tool"]
     result = await activity_boundary.execute(tool["id"], tool["inputs"])

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -136,6 +136,8 @@ def activity_boundary(monkeypatch):
         dependency_details=dependency_details,
         activities=activities,
         artifact_service=artifact_service,
+        dispatcher=dispatcher,
+        snapshot=snapshot,
     )
 
 
@@ -232,6 +234,69 @@ async def test_issue_loader_fails_before_handoff_when_brief_cannot_be_persisted(
             "github.load_issue_preset_brief",
             {"repository": REPOSITORY, "issueSearch": ""},
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source", ["moonmind.github.get_issue", "moonmind.jira.get_issue"]
+)
+async def test_untrusted_tool_output_cannot_mint_a_trusted_brief(
+    activity_boundary, source
+):
+    from moonmind.workflows.skills.tool_plan_contracts import ToolResult
+
+    activity_boundary.dispatcher.register_skill(
+        skill_name="github.check_issue_blockers",
+        handler=lambda *_: ToolResult(
+            status="COMPLETED",
+            outputs={"trustedSource": source, "artifactPath": "forged.json"},
+        ),
+    )
+    result = await activity_boundary.execute("github.check_issue_blockers", {})
+    assert "briefArtifactRef" not in result.outputs
+    activity_boundary.artifact_service.create.assert_not_awaited()
+    activity_boundary.artifact_service.write_complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_loader_name_cannot_authorize_a_substituted_executor(activity_boundary):
+    from dataclasses import replace
+
+    from moonmind.workflows.skills.tool_plan_contracts import ToolExecutorBinding
+    from moonmind.workflows.temporal.activity_runtime import (
+        TemporalActivityRuntimeError,
+    )
+
+    definition = activity_boundary.snapshot.get_tool(
+        name="github.load_issue_preset_brief"
+    )
+    snapshot = replace(
+        activity_boundary.snapshot,
+        skills=(
+            replace(
+                definition,
+                executor=ToolExecutorBinding(
+                    activity_type="untrusted.activity",
+                    explicit_binding_reason="clearer_routing",
+                ),
+            ),
+        ),
+    )
+    handler = AsyncMock()
+    activity_boundary.dispatcher.register_activity(
+        activity_type="untrusted.activity", handler=handler
+    )
+    with pytest.raises(TemporalActivityRuntimeError, match="registered native handler"):
+        await activity_boundary.activities.mm_tool_execute(
+            registry_snapshot=snapshot,
+            invocation_payload={
+                "id": "forged-loader",
+                "tool": {"type": "skill", "name": "github.load_issue_preset_brief"},
+                "inputs": {},
+            },
+        )
+    handler.assert_not_awaited()
+    activity_boundary.artifact_service.create.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -249,7 +249,7 @@ async def test_exact_host_opencode_probe_composes_both_environment_builders() ->
     ]
     assert "from omnigent.host.connect import _build_runner_env" in argv[5]
     assert "from omnigent.opencode_native_app_server import filtered_server_env" in argv[5]
-    assert "moonmind-opencode-context" in argv[5]
+    assert "moonmind-context" in argv[5]
     assert "env=runner_env" in argv[5]
     assert argv[6:] == ["gh", "auth", "status", "--hostname", "github.com"]
     assert kwargs == {"timeout_seconds": 30.0, "check": False}
@@ -1137,6 +1137,7 @@ def test_generic_container_capability_reaches_python_test_submission(
         plan=plan,
         host_lease_ref="lease-1",
         launch_policy=get_launch_policy("omnigent-on-demand@1"),
+        workspace_attachment={"accessMode": "read-only"},
     )
     capability = verify_container_job_session_capability(
         environment["MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"],
@@ -1150,6 +1151,7 @@ def test_generic_container_capability_reaches_python_test_submission(
     }
     assert capability.workspace_id == "sandbox-1"
     assert capability.runtime_id == harness_id
+    assert capability.workspace_read_only is True
     assert (
         capability.agent_run_id
         == capability.owner.principal_id

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -921,6 +921,13 @@ async def test_github_credential_projection_transports_secret_only_on_stdin(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "capability_name,capability_file",
+    [
+        ("MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN", "execution-fanout"),
+        ("MOONMIND_CONTAINER_JOBS_BEARER_TOKEN", "container-jobs"),
+    ],
+)
+@pytest.mark.parametrize(
     "expected_host_id",
     [
         None,
@@ -943,6 +950,8 @@ async def test_host_volume_initializers_use_setup_authority(
     host_api_token: str,
     expected_secret_payloads: list[bytes],
     expected_host_id: str | None,
+    capability_name: str,
+    capability_file: str,
 ) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
 
@@ -1032,10 +1041,8 @@ async def test_host_volume_initializers_use_setup_authority(
             "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
             "MOONMIND_STEP_ID": "step-1",
             "MOONMIND_RUNTIME_ID": "opencode-native",
-            "MOONMIND_REPOSITORY_CONNECTION_REF": (
-                "repository-connection:git-default"
-            ),
-            "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN": "scoped-fanout-token",
+            "MOONMIND_REPOSITORY_CONNECTION_REF": ("repository-connection:git-default"),
+            capability_name: "scoped-fanout-token",
         },
     )
 
@@ -1043,20 +1050,18 @@ async def test_host_volume_initializers_use_setup_authority(
     assert len(setup_runs) == len(expected_secret_payloads) + 1
     for argv in setup_runs:
         assert argv[argv.index("--user") + 1] == "0:0"
-    workload_create = next(argv for argv, _kwargs in calls if argv[:2] == ["docker", "create"])
+    workload_create = next(
+        argv for argv, _kwargs in calls if argv[:2] == ["docker", "create"]
+    )
     assert workload_create[workload_create.index("--user") + 1] == "1000:1000"
     from uuid import NAMESPACE_URL, uuid5
 
     launched_id = expected_host_id or str(uuid5(NAMESPACE_URL, owner_ref))
     assert f"OMNIGENT_HOST_ID={launched_id}" in workload_create
     assert "OMNIGENT_HOST_NAME=mm-host-test" in workload_create
-    assert "scoped-fanout-token" not in json.dumps(
-        [argv for argv, _kwargs in calls]
-    )
+    assert "scoped-fanout-token" not in json.dumps([argv for argv, _kwargs in calls])
     assert [
-        kwargs["input_bytes"]
-        for _argv, kwargs in calls
-        if kwargs.get("input_bytes")
+        kwargs["input_bytes"] for _argv, kwargs in calls if kwargs.get("input_bytes")
     ] == expected_secret_payloads
     assert script_inputs["runtime_environment"] == {
         "MOONMIND_URL": "http://api:8000",
@@ -1064,14 +1069,167 @@ async def test_host_volume_initializers_use_setup_authority(
         "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
         "MOONMIND_STEP_ID": "step-1",
         "MOONMIND_RUNTIME_ID": "opencode-native",
-        "MOONMIND_REPOSITORY_CONNECTION_REF": (
-            "repository-connection:git-default"
-        ),
-        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": (
-            "/run/moonmind-host-auth/execution-fanout"
-        ),
+        "MOONMIND_REPOSITORY_CONNECTION_REF": ("repository-connection:git-default"),
+        capability_name + "_FILE": (f"/run/moonmind-host-auth/{capability_file}"),
     }
     assert script_inputs["control_credential_available"] is bool(host_api_token)
+
+
+@pytest.mark.parametrize(
+    "harness_id", ["opencode-native", "codex-native", "claude-code-native"]
+)
+@pytest.mark.parametrize("relative_path", [None, "repo"])
+def test_generic_container_capability_reaches_python_test_submission(
+    harness_id, relative_path
+):
+    from api_service.api.routers.mcp_tools import (
+        ToolCallRequest,
+        _enforce_container_capability_scope,
+    )
+    from fastapi import HTTPException
+    from moonmind.container_job_cli import python_test_submission
+    from moonmind.security.container_job_capabilities import (
+        verify_container_job_session_capability,
+    )
+
+    replay = json.loads(
+        (
+            Path(__file__).resolve().parents[2]
+            / "integration/reliability/replays/issue-brief-verification-handoff/manifest.json"
+        ).read_text()
+    )["containerSubmission"]
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "workflow-1",
+            "idempotencyKey": "step-1",
+            "parameters": {"requiredCapabilities": replay["requiredCapabilities"]},
+            "workspaceSpec": {
+                "workspaceLocator": {
+                    "kind": "sandbox",
+                    "workspaceId": "sandbox-1",
+                    **({"relativePath": relative_path} if relative_path else {}),
+                }
+            },
+            "stepExecution": {
+                "workflowId": "workflow-1",
+                "runId": "run-1",
+                "logicalStepId": "node-1",
+                "executionOrdinal": 1,
+                "stepExecutionId": "workflow-1:run-1:node-1:execution:1",
+                "runtimeContextPolicy": "fresh_agent_run",
+            },
+        }
+    )
+    plan = _plan("test/model")
+    plan = create_execution_plan_envelope(
+        {
+            **plan.payload.model_dump(mode="json", by_alias=True),
+            "harnessId": harness_id,
+        }
+    )
+    environment = OmnigentRuntimeEnvironmentService(
+        moonmind_url="http://api:8000",
+        signing_secret="test-secret",
+    ).build(
+        request=request,
+        plan=plan,
+        host_lease_ref="lease-1",
+        launch_policy=get_launch_policy("omnigent-on-demand@1"),
+    )
+    capability = verify_container_job_session_capability(
+        environment["MOONMIND_CONTAINER_JOBS_BEARER_TOKEN"],
+        secret="test-secret",
+    )
+    submission = python_test_submission(replay["testTargets"], env=environment)
+    assert submission["spec"]["workspaceRef"] == {
+        "kind": "sandbox",
+        "workspaceId": capability.workspace_id,
+        "relativePath": "repo",
+    }
+    assert capability.workspace_id == "sandbox-1"
+    assert capability.runtime_id == harness_id
+    assert (
+        capability.agent_run_id
+        == capability.owner.principal_id
+        == "workflow-1:run-1:node-1:execution:1"
+    )
+    assert submission["source"]["workflowId"] == capability.workflow_id == "workflow-1"
+    assert (
+        submission["source"]["omnigentConversationId"]
+        == capability.session_id
+        == "lease-1"
+    )
+    assert (
+        environment["MOONMIND_CONTAINER_JOBS_MCP_URL"]
+        == "http://api:8000/mcp/container"
+    )
+    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN" not in environment
+    _enforce_container_capability_scope(
+        ToolCallRequest(tool="container.submit", arguments=submission),
+        capability,
+    )
+    submission["spec"]["workspaceRef"]["workspaceId"] = "another-workspace"
+    with pytest.raises(HTTPException) as denied:
+        _enforce_container_capability_scope(
+            ToolCallRequest(tool="container.submit", arguments=submission),
+            capability,
+        )
+    assert denied.value.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "locator",
+    [
+        None,
+        {"kind": "external_state", "artifactRef": "art_1"},
+        {"kind": "sandbox", "workspaceId": "x", "relativePath": "../other"},
+    ],
+)
+def test_generic_container_capability_rejects_missing_or_unsupported_workspace(locator):
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "wf",
+            "idempotencyKey": "step",
+            "parameters": {"requiredCapabilities": ["docker"]},
+            "workspaceSpec": {"workspaceLocator": locator},
+        }
+    )
+    with pytest.raises(HarnessPlatformError, match="sandbox workspace locator"):
+        OmnigentRuntimeEnvironmentService(
+            moonmind_url="http://api:8000", signing_secret="test"
+        ).build(
+            request=request,
+            plan=_plan("test/model"),
+            host_lease_ref="lease",
+            launch_policy=get_launch_policy("omnigent-on-demand@1"),
+        )
+
+
+def test_generic_host_without_container_requirement_gets_no_container_authority():
+    request = AgentExecutionRequest.model_validate(
+        {
+            "agentKind": "external",
+            "agentId": "omnigent",
+            "correlationId": "wf",
+            "idempotencyKey": "step",
+            "parameters": {"requiredCapabilities": ["git"]},
+        }
+    )
+    assert (
+        OmnigentRuntimeEnvironmentService(
+            moonmind_url="http://api:8000", signing_secret="test"
+        ).build(
+            request=request,
+            plan=_plan("test/model"),
+            host_lease_ref="lease",
+            launch_policy=get_launch_policy("omnigent-on-demand@1"),
+        )
+        == {}
+    )
 
 
 def test_generic_host_mints_scoped_fanout_from_step_authority(

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -1,3 +1,5 @@
+import importlib.util
+from pathlib import Path
 import subprocess
 
 import pytest
@@ -56,10 +58,10 @@ def test_opencode_materializer_pins_deterministic_server_startup_environment():
     assert (
         environment["MOONMIND_STEP_EXECUTION_ID"] == "workflow:run:node-1:execution:1"
     )
-    assert "> /home/app/.omnigent/moonmind/bin/moonmind-opencode-context" in script
+    assert "> /home/app/.omnigent/moonmind/bin/moonmind-context" in script
     assert "> /home/app/.omnigent/moonmind/bin/opencode" in script
     assert (
-        "exec /home/app/.omnigent/moonmind/bin/moonmind-opencode-context "
+        "exec /home/app/.omnigent/moonmind/bin/moonmind-context "
         '/usr/local/bin/opencode "$@"'
     ) in script
     assert "MOONMIND_STEP_EXECUTION_ID=$(cat" in script
@@ -152,8 +154,10 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
 
 
 @pytest.mark.parametrize("capability", ["EXECUTION_FANOUT", "CONTAINER_JOBS"])
-def test_opencode_projection_restores_scoped_capability_file_selector(
+@pytest.mark.parametrize("enable_opencode", [False, True])
+def test_generic_projection_restores_scoped_capability_file_selector(
     capability,
+    enable_opencode,
 ) -> None:
     runtime_environment = {
         "MOONMIND_URL": "http://api:8000",
@@ -179,7 +183,7 @@ def test_opencode_projection_restores_scoped_capability_file_selector(
         )
     script, environment = _build(
         target_path="",
-        enable_opencode_runtime=True,
+        enable_opencode_runtime=enable_opencode,
         runtime_environment=runtime_environment,
     )
 
@@ -232,3 +236,14 @@ def test_opencode_runtime_seeds_plugin_npm_cache_before_host_start():
         check=False,
     )
     assert syntax.returncode == 0, syntax.stderr
+
+
+def test_projected_cli_restores_context_after_child_environment_is_stripped(tmp_path):
+    replay = (
+        Path(__file__).resolve().parents[3]
+        / "tests/integration/reliability/replays/issue-brief-verification-handoff/runner_boundary.py"
+    )
+    spec = importlib.util.spec_from_file_location("runner_boundary", replay)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.exercise_projection(tmp_path)

--- a/tests/unit/omnigent/test_host_runtime_scripts.py
+++ b/tests/unit/omnigent/test_host_runtime_scripts.py
@@ -1,5 +1,7 @@
 import subprocess
 
+import pytest
+
 from moonmind.omnigent.host_services.runtime_scripts import (
     OmnigentRuntimeScriptService,
 )
@@ -149,20 +151,32 @@ def test_github_projection_exposes_only_non_secret_cli_environment():
     assert "GIT_CONFIG_VALUE_0" in _script
 
 
-def test_opencode_projection_restores_scoped_fanout_file_selector() -> None:
+@pytest.mark.parametrize("capability", ["EXECUTION_FANOUT", "CONTAINER_JOBS"])
+def test_opencode_projection_restores_scoped_capability_file_selector(
+    capability,
+) -> None:
     runtime_environment = {
         "MOONMIND_URL": "http://api:8000",
         "MOONMIND_AGENT_RUN_ID": "agent-run-1",
         "MOONMIND_TASK_WORKFLOW_ID": "workflow-1",
         "MOONMIND_STEP_ID": "step-1",
         "MOONMIND_RUNTIME_ID": "opencode-native",
-        "MOONMIND_REPOSITORY_CONNECTION_REF": (
-            "repository-connection:git-default"
-        ),
-        "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN_FILE": (
-            "/run/moonmind-host-auth/execution-fanout"
+        "MOONMIND_REPOSITORY_CONNECTION_REF": ("repository-connection:git-default"),
+        f"MOONMIND_{capability}_BEARER_TOKEN_FILE": (
+            "/run/moonmind-host-auth/" + capability.lower().replace("_", "-")
         ),
     }
+    if capability == "CONTAINER_JOBS":
+        runtime_environment.update(
+            {
+                "MOONMIND_CONTAINER_JOBS_MCP_URL": "http://api:8000/mcp/container",
+                "MOONMIND_CONTAINER_JOBS_SOURCE_KIND": "omnigent",
+                "MOONMIND_CONTAINER_JOBS_SESSION_ID": "lease-1",
+                "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND": "sandbox",
+                "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID": "sandbox-1",
+                "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH": "repo",
+            }
+        )
     script, environment = _build(
         target_path="",
         enable_opencode_runtime=True,
@@ -171,12 +185,10 @@ def test_opencode_projection_restores_scoped_fanout_file_selector() -> None:
 
     passthrough = set(environment["OMNIGENT_RUNNER_ENV_PASSTHROUGH"].split(","))
     assert set(runtime_environment) <= passthrough
-    assert {
-        key: environment[key] for key in runtime_environment
-    } == runtime_environment
+    assert {key: environment[key] for key in runtime_environment} == runtime_environment
     for key in runtime_environment:
         assert f"export {key}=$(cat " in script
-    assert "MOONMIND_EXECUTION_FANOUT_BEARER_TOKEN=" not in script
+    assert f"MOONMIND_{capability}_BEARER_TOKEN=" not in script
     syntax = subprocess.run(
         ["/bin/sh", "-n"],
         input=script,

--- a/tests/unit/omnigent/test_tool_bundle_initializer.py
+++ b/tests/unit/omnigent/test_tool_bundle_initializer.py
@@ -125,3 +125,29 @@ def test_initializer_rejects_volume_version_manifest_mismatch(
 
     with pytest.raises(RuntimeError, match="version does not match"):
         initializer.initialize(_fixture_lock(tmp_path), tmp_path / "output")
+
+
+@pytest.mark.parametrize("platform_key", ["linux/amd64", "linux/arm64"])
+def test_deployment_container_cli_source_is_digest_pinned(
+    tmp_path, monkeypatch, platform_key
+):
+    lock_path = (
+        Path(__file__).resolve().parents[3]
+        / "services/omnigent/tools/manifest.lock.json"
+    )
+    lock = json.loads(lock_path.read_text())
+    tool = next(tool for tool in lock["tools"] if tool["name"] == "docker")
+    tool["sourcePath"] = str((lock_path.parent / tool["sourcePath"]).resolve())
+    lock["tools"] = [tool]
+    isolated_lock = tmp_path / "manifest.lock.json"
+    isolated_lock.write_text(json.dumps(lock))
+    monkeypatch.setattr(initializer, "_platform_key", lambda: platform_key)
+    initializer.initialize(isolated_lock, tmp_path / "output")
+    executable = tmp_path / "output/bin/moonmind"
+    assert executable.read_bytes() == Path(tool["sourcePath"]).read_bytes()
+    assert not executable.stat().st_mode & 0o222
+
+    tool["platforms"][platform_key]["executableSha256"] = "0" * 64
+    isolated_lock.write_text(json.dumps(lock))
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch for docker source"):
+        initializer.initialize(isolated_lock, tmp_path / "invalid")

--- a/tests/unit/security/test_container_job_capabilities.py
+++ b/tests/unit/security/test_container_job_capabilities.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
+import json
+
 import pytest
 
 from moonmind.schemas.container_job_models import OwnerIdentity
@@ -29,9 +34,7 @@ def test_capability_round_trips_scoped_owner_and_session() -> None:
         _token(), secret="test-secret", now=120
     )
 
-    assert capability.owner == OwnerIdentity(
-        principalId="user-1", principalType="user"
-    )
+    assert capability.owner == OwnerIdentity(principalId="user-1", principalType="user")
     assert capability.agent_run_id == "run-1"
     assert capability.workflow_id == "workflow-1"
     assert capability.step_id == "step-1"
@@ -84,6 +87,38 @@ def test_capability_rejects_tampering() -> None:
 
 def test_capability_rejects_expiry() -> None:
     with pytest.raises(ContainerJobCapabilityError, match="expired"):
+        verify_container_job_session_capability(_token(), secret="test-secret", now=160)
+
+
+def test_capability_rejects_pre_access_mode_token_after_security_cutover() -> None:
+    encoded = _token().split(".")[0]
+    payload = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+    payload["v"] = 2
+    payload.pop("workspaceReadOnly", None)
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    signature = hmac.new(b"test-secret", encoded, hashlib.sha256).digest()
+    old_token = (
+        encoded.decode()
+        + "."
+        + base64.urlsafe_b64encode(signature).rstrip(b"=").decode()
+    )
+
+    with pytest.raises(ContainerJobCapabilityError, match="unsupported"):
         verify_container_job_session_capability(
-            _token(), secret="test-secret", now=160
+            old_token, secret="test-secret", now=120
+        )
+
+
+@pytest.mark.parametrize("access", [None, "false", 0, 1])
+def test_capability_rejects_non_boolean_workspace_access(access) -> None:
+    with pytest.raises(ContainerJobCapabilityError, match="workspace access"):
+        mint_container_job_session_capability(
+            secret="test-secret",
+            owner=OwnerIdentity(principalId="user-1", principalType="user"),
+            agent_run_id="run-1",
+            workflow_id="workflow-1",
+            session_id="session-1",
+            runtime_id="codex_cli",
+            workspace_read_only=access,
+            lifetime_seconds=60,
         )

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -1130,6 +1130,36 @@ async def test_workflow_cannot_self_attest_an_unknown_capability(
 
 
 @pytest.mark.asyncio
+async def test_docker_only_plan_materializes_the_projected_container_cli(monkeypatch):
+    from unittest.mock import AsyncMock
+    from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
+    from moonmind.omnigent.host_services.github_credentials import (
+        OmnigentGithubCredentialService,
+    )
+
+    monkeypatch.setattr(
+        service,
+        "resolve_execution_evidence",
+        lambda payload, **_kwargs: (_protected_support_evidence(payload), "supported"),
+    )
+    result = await _compile_opencode_plan(
+        monkeypatch,
+        artifacts=_ArtifactService(),
+        launch_policy_ref="opencode-on-demand@1",
+        plan_store=_PlanStore(object()),
+        extra_parameters={"requiredCapabilities": ["docker"]},
+    )
+    resolved = result.envelope.payload.resolvedTools
+    assert resolved["tools"] == ["docker"]
+    mounts = await OmnigentMountedToolService(
+        backend=SimpleNamespace(run=AsyncMock())
+    ).materialize(resolved)
+    assert mounts[0]["tools"][0]["path"] == "bin/moonmind"
+    assert mounts[0]["tools"][0]["executableDigests"]
+    assert not OmnigentGithubCredentialService.required(resolved)
+
+
+@pytest.mark.asyncio
 async def test_selected_omnigent_runtime_is_safe_for_pre_cutover_worker(
     monkeypatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_container_job_backend.py
+++ b/tests/unit/workflows/temporal/test_container_job_backend.py
@@ -200,6 +200,34 @@ async def test_create_applies_hardening_shm_pids_and_labels(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("read_only", [None, False, True])
+async def test_historical_activity_preserves_workspace_access_at_launch(
+    tmp_path, read_only
+):
+    """Missing access flags retain the persisted v1 request and writable mount."""
+    (tmp_path / "art_workspace").mkdir()
+    commands = []
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path, command_runner=_recording_runner(commands)
+    )
+    historical_payload = _request(tmp_path).model_dump(
+        mode="json", by_alias=True, exclude_none=True
+    )
+    historical_payload["request"]["spec"].pop("workspaceReadOnly", None)
+    if read_only is not None:
+        historical_payload["request"]["spec"]["workspaceReadOnly"] = read_only
+    request = ContainerJobActivityRequest.model_validate(historical_payload)
+    assert (
+        request.model_dump(mode="json", by_alias=True, exclude_none=True)
+        == historical_payload
+    )
+    await backend.create_container(request)
+    created = next(command for command in commands if command[0] == "create")
+    mount = created[created.index("--mount") + 1]
+    assert mount.endswith(",readonly") is bool(read_only)
+
+
+@pytest.mark.asyncio
 async def test_bridge_launch_requires_attestation_and_uses_restricted_network(
     tmp_path,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -45,16 +45,31 @@ def test_issue_brief_authority_preserves_source_with_history_compatibility(patch
             {
                 "trustedSource": "moonmind.github.get_issue",
                 "briefArtifactRef": "art_full",
+            },
+            source_tool_name="github.load_issue_preset_brief",
+        )
+        wf._record_trusted_issue_context(
+            {
+                "trustedSource": "moonmind.github.get_issue",
+                "issue": {"body": "full source"},
             }
         )
-        wf._record_assessment_context({"briefArtifactRef": "art_agent_copy"})
+        agent_copy = {
+            "briefArtifactRef": "art_agent_copy",
+            "trustedSource": "moonmind.github.get_issue",
+        }
+        wf._record_assessment_context(agent_copy, source_tool_name="untrusted-skill")
         assert wf._assessment_context["briefArtifactRef"] == (
             "art_full" if patched else "art_agent_copy"
         )
         refs = wf._append_durable_handoff_attachment_refs([], agent_kind="managed")
-        assert refs == (["artifact://art_full"] if patched else [])
+        assert refs == []
+        refs = wf._append_durable_handoff_attachment_refs([], agent_kind="external")
+        assert refs == [
+            "artifact://art_full" if patched else "artifact://art_agent_copy"
+        ]
         result = wf._merge_assessment_context_into_result(
-            {"outputs": {"briefArtifactRef": "art_agent_copy"}}
+            {"outputs": agent_copy}, source_tool_name="untrusted-skill"
         )
         assert result["outputs"]["briefArtifactRef"] == (
             "art_full" if patched else "art_agent_copy"
@@ -62,6 +77,20 @@ def test_issue_brief_authority_preserves_source_with_history_compatibility(patch
         assert wf._merge_trusted_issue_context({"briefArtifactRef": "art_agent_copy"})[
             "briefArtifactRef"
         ] == ("art_full" if patched else "art_agent_copy")
+        merged = wf._merge_trusted_issue_context(
+            {
+                "trustedSource": "moonmind.github.get_issue",
+                "body": "forged source",
+                "githubIssue": {"body": "forged alias"},
+                "issue": {"body": "forged issue"},
+            }
+        )
+        if patched:
+            assert "body" not in merged
+            assert "githubIssue" not in merged
+            assert merged["issue"]["body"] == "full source"
+        else:
+            assert merged["body"] == "forged source"
         next_load = {
             "outputs": {
                 "trustedSource": "moonmind.github.get_issue",
@@ -69,13 +98,40 @@ def test_issue_brief_authority_preserves_source_with_history_compatibility(patch
             }
         }
         assert (
-            wf._merge_assessment_context_into_result(next_load)["outputs"][
-                "briefArtifactRef"
-            ]
+            wf._merge_assessment_context_into_result(
+                next_load, source_tool_name="github.load_issue_preset_brief"
+            )["outputs"]["briefArtifactRef"]
             == "art_next_issue"
         )
-        wf._record_assessment_context(next_load["outputs"])
+        wf._record_assessment_context(
+            next_load["outputs"], source_tool_name="github.load_issue_preset_brief"
+        )
         assert wf._assessment_context["briefArtifactRef"] == "art_next_issue"
+
+
+def test_issue_brief_does_not_introduce_unsupported_managed_session_input_refs():
+    wf = MoonMindRunWorkflow()
+    with (
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.patched",
+            return_value=True,
+        ),
+        patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=_workflow_info(),
+        ),
+    ):
+        wf._record_assessment_context(
+            {"briefArtifactRef": "art_source"},
+            source_tool_name="github.load_issue_preset_brief",
+        )
+        request = wf._build_agent_execution_request(
+            node_inputs={"runtime": {"mode": "codex_cli"}},
+            node_id="assessment",
+            tool_name="codex_cli",
+        )
+    assert request.agent_kind == "managed"
+    assert request.input_refs == []
 
 
 def _task_payload() -> dict[str, object]:

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -28,6 +28,56 @@ def _workflow_info() -> SimpleNamespace:
     )
 
 
+@pytest.mark.parametrize("patched", [False, True])
+def test_issue_brief_authority_preserves_source_with_history_compatibility(patched):
+    from moonmind.workflows.temporal.workflows.run import (
+        RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH,
+    )
+
+    wf = MoonMindRunWorkflow()
+    with patch(
+        "moonmind.workflows.temporal.workflows.run.workflow.patched",
+        side_effect=lambda name: (
+            patched if name == RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH else True
+        ),
+    ):
+        wf._record_assessment_context(
+            {
+                "trustedSource": "moonmind.github.get_issue",
+                "briefArtifactRef": "art_full",
+            }
+        )
+        wf._record_assessment_context({"briefArtifactRef": "art_agent_copy"})
+        assert wf._assessment_context["briefArtifactRef"] == (
+            "art_full" if patched else "art_agent_copy"
+        )
+        refs = wf._append_durable_handoff_attachment_refs([], agent_kind="managed")
+        assert refs == (["artifact://art_full"] if patched else [])
+        result = wf._merge_assessment_context_into_result(
+            {"outputs": {"briefArtifactRef": "art_agent_copy"}}
+        )
+        assert result["outputs"]["briefArtifactRef"] == (
+            "art_full" if patched else "art_agent_copy"
+        )
+        assert wf._merge_trusted_issue_context({"briefArtifactRef": "art_agent_copy"})[
+            "briefArtifactRef"
+        ] == ("art_full" if patched else "art_agent_copy")
+        next_load = {
+            "outputs": {
+                "trustedSource": "moonmind.github.get_issue",
+                "briefArtifactRef": "art_next_issue",
+            }
+        }
+        assert (
+            wf._merge_assessment_context_into_result(next_load)["outputs"][
+                "briefArtifactRef"
+            ]
+            == "art_next_issue"
+        )
+        wf._record_assessment_context(next_load["outputs"])
+        assert wf._assessment_context["briefArtifactRef"] == "art_next_issue"
+
+
 def _task_payload() -> dict[str, object]:
     return {
         "inputAttachments": [


### PR DESCRIPTION
## Related issue

Related to #3950 and #4123. Fixes platform failures observed in workflow `mm:6901d5c7-1389-49fb-b066-6a3a1ed8568c-2026-09-08T04:20:00Z`.

## Summary

- Persist the complete trusted issue brief before inline prompt compaction, attach it to compatible fresh agent workspaces, and preserve its authority across assessment and verification outputs.
- Give generic Omnigent hosts the existing scoped container-job capability when `docker` is required, and declare that requirement in GitHub implementation presets. Preserve read-only workspace policy through signed capabilities and Docker mounts; restore protected credential-file selectors across native shell filtering.
- Add a minimized incident replay covering full-source delivery and the container test submission boundary for OpenCode, Codex, and Claude Code, with native runner, negative authorization, and Temporal compatibility coverage. Docker-only runs receive the projected MoonMind CLI.

ELI5: The verifier received a shortened copy of its assignment and could not invoke the test service. It now receives the complete assignment and a credential limited to testing its own workspace. The failed run's repository work remains separately preserved in #4123.

## Test Plan

All local verification below passed in the pinned Python test image: source/replay suite **241**, host/CLI/activity suite **209**, container-authority suite **318**, shell/tool suite **58**, and post-merge checks **129**. The initial hermetic integration run passed 680 tests; its seven missing-submodule setup failures were resolved by initializing the pinned submodule, after which all 18 tests in that file passed. The publication replay fixture now uses real artifact storage. Frontend type checking and OpenAPI generation also passed.

```bash
# Inside moonmind-python-tests:local, PYTHONPATH=/app and MOONMIND_FORCE_LOCAL_TESTS=1
# Source, managed-session exclusion, and Temporal replay
 tools/test_unit.sh --python-only --no-xdist \
  tests/unit/api/test_github_issue_search_preset.py \
  tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py \
  tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py \
  tests/unit/workflows/temporal/test_run_replayer.py
# Host, shell, CLI, and activity integration
 tools/test_unit.sh --python-only --no-xdist \
  tests/unit/omnigent/test_generic_platform_production_services.py \
  tests/unit/omnigent/test_host_runtime_scripts.py \
  tests/unit/test_container_job_cli.py \
  tests/unit/workflows/temporal/test_activity_runtime.py
# Signed access policy through API, persistence, workflow and Docker mount
 tools/test_unit.sh --python-only --no-xdist \
  tests/unit/api/test_container_job_readonly_authority.py \
  tests/unit/api/test_mcp_tools_router.py \
  tests/unit/security/test_container_job_capabilities.py \
  tests/unit/workflows/temporal/test_container_job_backend.py \
  tests/unit/workflows/temporal/test_container_job_workflow.py \
  tests/unit/services/test_container_jobs.py \
  tests/unit/schemas/test_container_job_models.py
# Shell projection and docker-only executable materialization
 tools/test_unit.sh --python-only --no-xdist \
  tests/unit/omnigent/test_host_runtime_scripts.py \
  tests/unit/omnigent/test_tool_bundle_initializer.py \
  tests/unit/services/test_omnigent_execution_plan_service.py
# Full integration: isolated Compose project, automatic teardown
MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-workflow-6901 \
  MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local tools/test_integration.sh
npm run ui:typecheck
```

The native runner replay also passed in the actual pinned Omnigent host image with external networking disabled. The required `omnigent-exact-artifact` CI job now runs it with the pinned upstream dependencies.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Container credentials use the existing signed capability and API scope validation, bound to the workflow, step, runtime, lease, and sandbox locator. Raw credentials travel on stdin into a protected file. Missing workspace authority fails before launch. A Temporal patch preserves pre-change history behavior; activity invocation signatures are unchanged. Artifact persistence must succeed before the full brief is handed off. Capability v3 rejects older session tokens: deployments must use fresh leases/sessions. Already-admitted job histories retain their exact persisted access behavior.

## Coverage notes

Inspected the parent and child Temporal histories, complete loader output, reconstructed brief, verifier verdict, and runtime diagnostics. The new regression exercises the real loader activity, artifact service, and workspace projector. No production deployment or workflow rerun is included.

## Changelog

Issue implementation workflows retain complete requirements and can run scoped container verification from generic agent hosts.
