### PR TITLE
Keep API startup available while Omnigent maintenance waits

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -656,10 +656,10 @@ async def _reconcile_omnigent_bootstrap_once(
     )
 
 
-async def _maintain_omnigent_bootstrap_reconciliation(*, initial_ready: bool) -> None:
-    """Retry with capped backoff and keep observed agent inventory fresh."""
+async def _maintain_omnigent_bootstrap_reconciliation() -> None:
+    """Own bootstrap and refresh work without blocking HTTP availability."""
 
-    ready = initial_ready
+    ready = False
     retry_delay_seconds = 5
     # Registry-acquiring image refresh is bound to image-policy readiness
     # alone. An unrelated catalog or schedule outage must not re-pull images
@@ -726,11 +726,7 @@ async def lifespan(app: FastAPI):
 
     if build_omnigent_gate().enabled:
         app.state.omnigent_bootstrap_reconciliation_task = asyncio.create_task(
-            _maintain_omnigent_bootstrap_reconciliation(
-                initial_ready=bool(
-                    getattr(app.state, "omnigent_bootstrap_initial_ready", False)
-                ),
-            ),
+            _maintain_omnigent_bootstrap_reconciliation(),
             name="omnigent-bootstrap-reconciliation",
         )
     try:
@@ -2479,12 +2475,10 @@ async def startup_event():
     # them before the first reconciliation pass so a fresh restart can validate
     # and advertise the credentialless OpenCode Zen route immediately.
     await _auto_seed_provider_profiles()
-    # Readiness uses only bounded local image inspection. Registry refresh runs
-    # in the lifespan-owned reconciler after the API can serve health checks.
-    omnigent_bootstrap_ready = (
-        await _reconcile_omnigent_bootstrap_once(refresh_images=False)
-    ).ready
-    app.state.omnigent_bootstrap_initial_ready = omnigent_bootstrap_ready
+    # Omnigent reconciliation belongs to the lifespan-owned background task.
+    # Image resolution, provider validation and qualification can wait on
+    # external services or leases held by active workflows. None may hold the
+    # HTTP listener closed; execution admission still requires their evidence.
     await _sync_env_managed_secrets()
     # MoonLadderStudios/MoonMind#3955 retired the experimental embedded host
     # transport: startup no longer runs an embedded host-auth preflight or

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -390,8 +390,13 @@ and `OMNIGENT_HOST_IMAGE_REF` values explicitly.
 
 Bootstrap-owned policy defaults advance through a new immutable version when
 those resolved repository digests move; operator-authored defaults are never
-rewritten by bootstrap. Registry refresh runs in the lifespan-owned background
-reconciler; API startup readiness performs only bounded local inspection. A
+rewritten by bootstrap. Image resolution, registry refresh, provider validation,
+and deployment qualification run in the lifespan-owned background reconciler.
+API startup does not wait for this runtime maintenance or for credential leases
+held by active workflows. The reconciler starts automatically after local
+startup, retries with bounded backoff, and is cancelled and awaited on shutdown.
+HTTP health reports API/database availability; execution admission continues to
+require the selected runtime's validated evidence. A
 server policy cutover uses the running Compose container's observed repository
 digest, never a newly pulled tag whose container is not running yet. Bindings
 with active host leases remain on their immutable prior authority and are

--- a/tests/integration/reliability/replays/api-startup-provider-maintenance/manifest.json
+++ b/tests/integration/reliability/replays/api-startup-provider-maintenance/manifest.json
@@ -1,0 +1,16 @@
+{
+  "incident": "LAN outage on API restart while OpenCode provider validation waited for an active workflow's credential lease",
+  "runtime": "omnigent",
+  "protocol": "ASGI lifespan over HTTP",
+  "events": [
+    "An existing workflow retains its provider lease across an API restart",
+    "Bootstrap reconciliation requests credential validation and waits",
+    "The API completes startup and serves HTTP while reconciliation waits",
+    "Reconciliation resumes when the resource becomes available or is cancelled during API shutdown"
+  ],
+  "expected": {
+    "healthStatus": 200,
+    "reconciliationOwnedByLifespan": true,
+    "providerLeasePreserved": true
+  }
+}

--- a/tests/integration/reliability/test_api_startup_provider_maintenance.py
+++ b/tests/integration/reliability/test_api_startup_provider_maintenance.py
@@ -1,0 +1,183 @@
+"""Replay a blocked bootstrap dependency through real Uvicorn startup and HTTP."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import socket
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import uvicorn
+import yaml
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service import main as api_main
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+@pytest.mark.parametrize(
+    ("blocked_stage", "enabled_setting", "release_wait"),
+    [
+        ("provider", None, True),
+        ("provider", "true", False),
+        ("qualification", None, False),
+        ("images", "true", False),
+        ("provider", "false", False),
+    ],
+)
+async def test_http_serves_while_bootstrap_waits_and_lifespan_owns_cleanup(
+    monkeypatch, tmp_path, blocked_stage, enabled_setting, release_wait
+):
+    replay = load_replay("api-startup-provider-maintenance", "manifest.json")
+    # Exercise Compose's omitted-value default and its explicit equivalent
+    # through the actual runtime gate, rather than forcing the gate open.
+    compose = yaml.safe_load(
+        (Path(__file__).resolve().parents[3] / "docker-compose.yaml").read_text()
+    )
+    declaration = next(
+        value
+        for value in compose["services"]["api"]["environment"]
+        if value.startswith("OMNIGENT_ENABLED=")
+    )
+    match = re.fullmatch(r"OMNIGENT_ENABLED=\$\{OMNIGENT_ENABLED:-(.+)\}", declaration)
+    assert match is not None
+    monkeypatch.setenv("OMNIGENT_ENABLED", enabled_setting or match[1])
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "http://unused.invalid")
+    monkeypatch.setattr(api_main.settings.oidc, "AUTH_PROVIDER", "keycloak")
+    monkeypatch.delattr(
+        api_main.app.state, "omnigent_bootstrap_reconciliation_task", raising=False
+    )
+    from moonmind.rag import service as rag_service
+
+    monkeypatch.setattr(rag_service, "ContextRetrievalService", lambda **_: object())
+
+    # Keep unrelated startup integrations hermetic. The production startup,
+    # lifespan, reconciliation ordering, health route and TCP server all run.
+    for name in (
+        "_initialize_oidc_provider",
+        "_sync_preset_seed_catalog",
+        "_auto_seed_provider_profiles",
+        "_sync_env_managed_secrets",
+        "ensure_provider_profile_managers_started",
+        "ensure_managed_session_reconcile_schedule_started",
+        "ensure_managed_runtime_workspace_cleanup_schedule_started",
+        "ensure_omnigent_oauth_host_janitor_schedule_started",
+        "ensure_recurring_workflow_schedules_reconciled",
+    ):
+        monkeypatch.setattr(api_main, name, AsyncMock())
+    monkeypatch.setattr(api_main, "_register_settings_change_subscribers", lambda: None)
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/health.db")
+    sessions = async_sessionmaker(engine)
+
+    @asynccontextmanager
+    async def db_session():
+        async with sessions() as session:
+            yield session
+
+    monkeypatch.setattr(api_main, "get_async_session_context", db_session)
+    entered = asyncio.Event()
+    available = asyncio.Event()
+    exited = asyncio.Event()
+    completed = asyncio.Event()
+    cancelled = False
+
+    async def ready(*_args, **_kwargs):
+        return True
+
+    async def blocked(*_args, **_kwargs):
+        nonlocal cancelled
+        entered.set()
+        try:
+            # Deterministic replay of the external maintenance lease wait.
+            # Availability belongs to the existing workflow, never startup.
+            await available.wait()
+            return True
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        finally:
+            exited.set()
+
+    async def qualify():
+        completed.set()
+        return True
+
+    for name in (
+        "_sync_omnigent_deployment_images",
+        "_sync_omnigent_bootstrap_policies",
+        "_sync_omnigent_bootstrap_agent_profile",
+        "_sync_omnigent_harness_catalog",
+        "_sync_managed_bootstrap_recurring_schedules",
+        "_sync_omnigent_provider_readiness",
+    ):
+        monkeypatch.setattr(api_main, name, ready)
+    monkeypatch.setattr(api_main, "_sync_omnigent_deployment_qualification", qualify)
+    monkeypatch.setattr(
+        api_main,
+        {
+            "provider": "_sync_omnigent_provider_readiness",
+            "qualification": "_sync_omnigent_deployment_qualification",
+            "images": "_sync_omnigent_deployment_images",
+        }[blocked_stage],
+        blocked,
+    )
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    server = uvicorn.Server(
+        uvicorn.Config(api_main.app, lifespan="on", log_level="error")
+    )
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    try:
+        async with asyncio.timeout(3):
+            while not server.started:
+                if server_task.done():
+                    await server_task
+                    pytest.fail("API stopped before opening its HTTP listener")
+                await asyncio.sleep(0.01)
+
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{listener.getsockname()[1]}", trust_env=False
+        ) as client:
+            assert (await client.get("/healthz")).status_code == 200
+            if enabled_setting == "false":
+                assert not hasattr(
+                    api_main.app.state, "omnigent_bootstrap_reconciliation_task"
+                )
+                assert not entered.is_set()
+                return
+            await asyncio.wait_for(entered.wait(), timeout=8)
+            task = api_main.app.state.omnigent_bootstrap_reconciliation_task
+            assert not task.done()
+            assert not available.is_set(), "Startup must preserve the active lease"
+            response = await client.get("/healthz")
+            assert response.status_code == replay["expected"]["healthStatus"]
+            assert response.json()["db"] == "connected"
+            assert (await client.get("/")).status_code == 307
+            if release_wait:
+                available.set()
+                await asyncio.wait_for(completed.wait(), timeout=2)
+                assert not task.done(), "Periodic reconciliation must remain active"
+    finally:
+        if server.started:
+            server.should_exit = True
+        else:
+            server_task.cancel()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(server_task, return_exceptions=True), 3
+            )
+        finally:
+            listener.close()
+            await engine.dispose()
+
+    assert task.done(), "API shutdown must own reconciliation cleanup"
+    assert exited.is_set()
+    assert cancelled == (not release_wait)

--- a/tests/integration/reliability/test_api_startup_provider_maintenance.py
+++ b/tests/integration/reliability/test_api_startup_provider_maintenance.py
@@ -139,7 +139,7 @@ async def test_http_serves_while_bootstrap_waits_and_lifespan_owns_cleanup(
         async with asyncio.timeout(3):
             while not server.started:
                 if server_task.done():
-                    await server_task
+                    server_task.result()
                     pytest.fail("API stopped before opening its HTTP listener")
                 await asyncio.sleep(0.01)
 

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -87,7 +87,7 @@ async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inve
     )
 
     with pytest.raises(asyncio.CancelledError):
-        await api_main._maintain_omnigent_bootstrap_reconciliation(initial_ready=False)
+        await api_main._maintain_omnigent_bootstrap_reconciliation()
 
     assert delays == [5, 10, 120, 120]
     assert reconciliations == [True, True, False]
@@ -511,7 +511,7 @@ async def test_catalog_outage_does_not_retry_registry_image_refresh(
     )
 
     with pytest.raises(asyncio.CancelledError):
-        await api_main._maintain_omnigent_bootstrap_reconciliation(initial_ready=False)
+        await api_main._maintain_omnigent_bootstrap_reconciliation()
 
     # Aggregate readiness stays false, so the loop keeps retrying with capped
     # backoff, but images are refreshed only on the first pass.
@@ -557,7 +557,7 @@ async def test_image_policy_outage_keeps_retrying_registry_refresh(
     )
 
     with pytest.raises(asyncio.CancelledError):
-        await api_main._maintain_omnigent_bootstrap_reconciliation(initial_ready=False)
+        await api_main._maintain_omnigent_bootstrap_reconciliation()
 
     assert image_refreshes == [True, True]
 


### PR DESCRIPTION
Restarting the API while an active OpenCode workflow holds its provider lease left Uvicorn waiting for bootstrap credential validation, so the dashboard and health endpoint were unreachable. Run Omnigent bootstrap and refresh work exclusively in the existing lifespan-owned background reconciler. Local startup completes before runtime maintenance, and execution readiness continues to require validated evidence.

Remove the obsolete initial-readiness handoff and document the lifecycle ownership. Add a minimized incident replay that starts the real Uvicorn server, serves HTTP against SQLite, and holds bootstrap dependencies pending. It covers Compose defaults, explicit enable/disable, recovery after contention clears, and cancellation on shutdown.

Validation:

- Reproduced four HTTP-startup failures with the new replay against the original code.
- 30 API/startup tests passed, including provider and secret seeding.
- 94 provider revalidation, qualification, and bootstrap tests passed.
- 9 targeted integration tests passed through `./tools/test_integration.sh` with an isolated `moonmind-test-api-startup` Compose project and automatic teardown.
- New replay passes Ruff; existing edited files introduce no new Ruff findings.
- Applied the minimal recovery change to the affected deployment and verified healthy API plus HTTP 200 from its LAN dashboard URL.
