### PR TITLE
[Keycloak removal] Inventory authentication entrypoints and freeze identity contracts (#4117)

### DIFF
--- a/docs/Security/AuthenticationContracts.md
+++ b/docs/Security/AuthenticationContracts.md
@@ -1,7 +1,7 @@
 # Authentication Contracts
 
 **Document Class:** Canonical declarative  
-**Viewpoint:** Module Architecture View  
+**Viewpoint:** Cross-Cutting Concept View  
 **Status:** Draft  
 **Owners:** MoonMind Engineering  
 **Audience:** API, dashboard, runtime, security contributors and operators  
@@ -42,7 +42,7 @@ select MoonMind's mode, key, or identity store.
 | `accounts` | Default for new installations. Built-in accounts with protected first-owner setup and invite-only enrollment. No Keycloak or mandatory SMTP service. |
 | `oidc` | Advanced external identity-provider integration through a qualified generic OIDC flow (authorization code + PKCE). |
 | `header` | Advanced authenticated ingress. Only a trusted proxy may assert identity; direct API connections never accept user-controlled identity headers. |
-| `disabled` | Explicit local single-user mode with a stable persisted user and restricted ingress. Never an error fallback. |
+| `disabled` | Explicit local single-user mode with a stable persisted user and fail-closed restricted ingress (startup/deployment validator; loopback-only bind or documented trusted-ingress evidence; see inventory §5.3). Never an error fallback. |
 
 Unknown or retired selectors fail startup with migration guidance. `keycloak`
 must not translate to `disabled`, `default` is not an undocumented alias, and
@@ -115,24 +115,26 @@ operator.
 - One durable session/revocation mechanism lives in the existing database behind
   a portable interface. Logout invalidates the current session. Password reset,
   account disablement, and administrative revocation invalidate the relevant
-  credentials across API replicas within a bounded interval. Clearing a cookie
+  credentials across API replicas within 5 minutes of the revocation commit
+  (commit timestamp to final replica re-authorization check; clock starts at
+  commit — see inventory §5.2). Clearing a cookie
   alone is not revocation.
 - Browser logout does not revoke independent worker credentials and does not
   cancel already-admitted workflows. Account disablement blocks new user actions
   immediately; already-admitted background work keeps its stored principal ID
   and durable authority and follows the explicit per-deployment policy recorded
-  in the inventory (drain/complete versus revoke), never silent ownership
+  in the inventory §5.1 (`drain_complete` by default versus `revoke`), never silent ownership
   transfer.
 - Active browser streams (SSE, WebSocket reconnects, artifact downloads) are
-  re-authorized and terminated within a documented bounded interval after
-  revocation. SSE and artifact downloads work without placing broad tokens in
+  re-authorized and terminated within the same 5-minute bound after
+  revocation (inventory §5.2). SSE and artifact downloads work without placing broad tokens in
   URLs.
 
 ## 6. Browser and transport security
 
 - Cookie-authenticated mutations require CSRF protection and origin validation.
   WebSocket handshakes validate origin, authorize reconnects, and are revoked on
-  the same bounded interval as other streams.
+  the same 5-minute bound as other streams (inventory §5.2).
 - OIDC login uses authorization-code flow with PKCE, state/nonce protections,
   verified issuer/audience/signature/time claims, and exact configured redirect
   destinations. Open redirects are rejected.

--- a/docs/Security/AuthenticationContracts.md
+++ b/docs/Security/AuthenticationContracts.md
@@ -1,0 +1,189 @@
+# Authentication Contracts
+
+**Document Class:** Canonical declarative  
+**Viewpoint:** Module Architecture View  
+**Status:** Draft  
+**Owners:** MoonMind Engineering  
+**Audience:** API, dashboard, runtime, security contributors and operators  
+**Authority:** Application authentication modes, identity mapping, session/revocation, CSRF/origin, error semantics, and background-work policy for MoonMind user authentication. Freezes the target contract inventoried in `[KeycloakRemovalInventory-4117.md](../tmp/KeycloakRemovalInventory-4117.md)` (MoonLadderStudios/MoonMind#4117, parent epic #4116).  
+**Owning Surface:** `api_service/auth.py`, `api_service/auth_providers.py`, `api_service/main.py`, `moonmind/config/settings.py` (`OIDCSettings`), `api_service/db/models.py` (`User`)  
+**Related Docs:** [SecretsSystem.md](./SecretsSystem.md), [ProviderProfiles.md](./ProviderProfiles.md), [SettingsSystem.md](./SettingsSystem.md), [KeycloakRemovalPlan.md](../tmp/KeycloakRemovalPlan.md) (predecessor proposal from #4102; starting evidence only, not the deliverable)
+
+> [!NOTE]
+> This document defines desired-state MoonMind application-authentication contracts.
+> It is a declarative contract, not an implementation checklist. Rollout sequencing,
+> migration tasks, and backlog tickets belong in MoonSpec artifacts, gitignored
+> handoffs, or `docs/tmp/` implementation plans.
+
+---
+
+## 1. Summary
+
+MoonMind has exactly one application authentication selector, `AUTH_PROVIDER`, and
+exactly one canonical principal, `User.id` (a stable MoonMind UUID). The supported
+target modes are `accounts`, `oidc`, `header`, and an explicitly restricted local
+mode `disabled`. Retired selectors (`keycloak`, `default`, `google`) are rejected
+at startup with migration guidance; they are never silently translated.
+
+Authentication establishes who presented a request. Authorization — whether that
+principal may see an execution, download an artifact, use a secret, change
+settings, launch work, or interact with a runtime binding — remains MoonMind's
+decision, checked after credential validation on every request, including cache
+hits.
+
+## 2. Authentication modes
+
+One selector, `AUTH_PROVIDER` (`moonmind/config/settings.py`, `OIDCSettings`).
+No competing enable switch. Runtime-server `OMNIGENT_AUTH_*` variables never
+select MoonMind's mode, key, or identity store.
+
+| Mode | Intended use |
+| --- | --- |
+| `accounts` | Default for new installations. Built-in accounts with protected first-owner setup and invite-only enrollment. No Keycloak or mandatory SMTP service. |
+| `oidc` | Advanced external identity-provider integration through a qualified generic OIDC flow (authorization code + PKCE). |
+| `header` | Advanced authenticated ingress. Only a trusted proxy may assert identity; direct API connections never accept user-controlled identity headers. |
+| `disabled` | Explicit local single-user mode with a stable persisted user and restricted ingress. Never an error fallback. |
+
+Unknown or retired selectors fail startup with migration guidance. `keycloak`
+must not translate to `disabled`, `default` is not an undocumented alias, and
+any `google`-specific discovery branch migrates to the declared generic `oidc`
+path.
+
+A new installation starts with `docker compose up -d` and no mandatory `.env`.
+Existing installations with omitted authentication settings receive a versioned
+migration decision, not an unannounced default change that creates a new owner.
+
+## 3. Identity contract
+
+- `User.id` is the canonical principal and the identifier persisted in workflow
+  ownership and foreign keys. A valid external identity resolves to exactly one
+  existing or explicitly provisioned MoonMind UUID before a MoonMind session is
+  issued.
+- OIDC maps the verified `(issuer, subject)` pair. Issuer is the full issuer URI
+  (never truncated into the legacy 32-character provider field); subject is
+  matched case-sensitively. No automatic linking by email, display name,
+  username, or a matching subject from a different issuer. Email changes never
+  change resource ownership.
+- Built-in accounts resolve the login name to an existing `User` record and mint
+  sessions for its UUID, not for the login name.
+- Trusted-header mode uses an operator-configured identity namespace plus a
+  stable proxy-asserted identifier. The ingress strips and replaces identity
+  headers; direct bypass paths are blocked. A missing header never resolves to a
+  reserved identity. Email-only proxy integrations require explicit enrollment
+  and a documented reassignment policy, not automatic account merging.
+- Prefer extending the existing identity representation where sufficient. If its
+  single external-identity pair cannot support the required mapping, replace it
+  with one external-identity relation referencing `User.id`. Never retain two
+  competing authoritative mappings. Provider-to-issuer migration is explicit.
+- Account provisioning preserves one profile per user. Existing users, disabled
+  accounts, admin flags, and ownership records are never recreated or reset as a
+  side effect of first login.
+
+Authority for current status stays with MoonMind: `User.is_active` and
+`User.is_superuser` are checked after credential validation. Provisioning never
+imports an additive upstream admin roster that could re-promote a demoted
+operator.
+
+## 4. Credential handling: missing versus invalid
+
+- A missing credential may be optional only at explicitly optional boundaries
+  (worker-tolerant dependencies such as `get_current_user_optional()`). At
+  strict boundaries a missing credential is `401 auth_required`.
+- An invalid, expired, wrong-key, wrong-issuer, wrong-purpose, or
+  reserved-identity credential is never silently mapped to a different
+  principal. It is rejected (`401`), including on cache hits.
+- Conflicting identities in one request (for example cookie and bearer resolving
+  to different principals) are rejected (`401 auth_conflict`). Precedence is
+  defined once by the implementation and documented with it; conflict is never
+  resolved by silently preferring one side.
+- Database or identity-store unavailability returns a bounded unavailable
+  response (`503`) and fails closed. It never returns an administrator stub on a
+  production path; test-only principals belong in explicit test dependency
+  overrides.
+
+## 5. Session, revocation, and stream contract
+
+- MoonMind issues its own session (MoonMind-specific cookie; HttpOnly,
+  appropriate SameSite, Secure on HTTPS; a distinct non-`__Host-` development
+  cookie only for explicitly permitted loopback HTTP). Omnigent runtime tokens
+  are rejected at the MoonMind user boundary.
+- Tokens carry an explicit issuer, application-purpose binding (audience or
+  equivalent), supported algorithms, expiry, and key rotation. Refresh material
+  and reusable session tokens are never returned to the browser in JSON merely
+  because an upstream capability offers a CLI mode; any CLI exchange is
+  separately scoped and explicitly authorized.
+- One durable session/revocation mechanism lives in the existing database behind
+  a portable interface. Logout invalidates the current session. Password reset,
+  account disablement, and administrative revocation invalidate the relevant
+  credentials across API replicas within a bounded interval. Clearing a cookie
+  alone is not revocation.
+- Browser logout does not revoke independent worker credentials and does not
+  cancel already-admitted workflows. Account disablement blocks new user actions
+  immediately; already-admitted background work keeps its stored principal ID
+  and durable authority and follows the explicit per-deployment policy recorded
+  in the inventory (drain/complete versus revoke), never silent ownership
+  transfer.
+- Active browser streams (SSE, WebSocket reconnects, artifact downloads) are
+  re-authorized and terminated within a documented bounded interval after
+  revocation. SSE and artifact downloads work without placing broad tokens in
+  URLs.
+
+## 6. Browser and transport security
+
+- Cookie-authenticated mutations require CSRF protection and origin validation.
+  WebSocket handshakes validate origin, authorize reconnects, and are revoked on
+  the same bounded interval as other streams.
+- OIDC login uses authorization-code flow with PKCE, state/nonce protections,
+  verified issuer/audience/signature/time claims, and exact configured redirect
+  destinations. Open redirects are rejected.
+- The trusted ingress strips user-supplied identity headers and replaces them;
+  direct-ingress bypass is blocked.
+
+## 7. Enrollment and administration (server-owned)
+
+- First-owner setup and invitation redemption are transactional and race-safe.
+  Single first owner under concurrent setup; invites are expiring and one-use.
+- No hardcoded default password and no public unauthenticated first-claim
+  endpoint on a network-exposed installation. Bootstrap uses an operator-held,
+  expiring, one-use capability or a local administrative setup operation, and is
+  closed on an existing populated database unless the controlled migration
+  grants it.
+- Last-admin protection with a tested recovery path. Passwords, MFA
+  enrollments, and Keycloak credentials are a separate migration problem: they
+  require a tested compatible-hash path or controlled invitation/reset (or new
+  IdP enrollment), never silent hash-compatibility assumptions. Deployments
+  requiring MFA retain it through a qualified replacement before cutover.
+
+## 8. API error semantics
+
+| Situation | Status | Code |
+| --- | --- | --- |
+| Missing credential at a strict boundary | `401` | `auth_required` |
+| Invalid, expired, wrong-key/issuer/purpose, or reserved-identity credential | `401` | `auth_invalid` |
+| Conflicting cookie/bearer identities | `401` | `auth_conflict` |
+| Authenticated but inactive (`is_active=False`) or not authorized | `403` | `forbidden` / `inactive` |
+| Removed legacy worker-token path presented | `410` | `worker_token_deprecated` |
+| Identity/database unavailable | `503` | `unavailable` |
+
+Machine callers (workers, MCP/container-job paths, bridge service, scoped
+callbacks) succeed only on their authorized routes and resources. Runtime,
+session, and worker tokens never become unrestricted MoonMind browser
+credentials.
+
+## 9. Explicitly unrelated systems (retain unchanged)
+
+Provider Profile OAuth, repository credentials (GitHub tokens/PATs),
+`moonmind.auth` profile/environment credential resolution, container-job
+credentials (`MOONMIND_CONTAINER_JOBS_BEARER_TOKEN` family), Omnigent host-auth
+lifecycles, and historical Alembic revisions needed to upgrade existing
+databases are not application-login cleanup targets. Historical migrations stay;
+the `User` table, profile data, shared PostgreSQL roles, Temporal databases,
+and runtime host authentication are never deleted as part of Keycloak removal.
+
+## 10. Observability
+
+Record redacted authentication success/denial/unavailable events with mode,
+reason, and request correlation. Never log passwords, authorization codes,
+bearer tokens, cookies, reset links, refresh material, or raw IdP token
+responses. No authentication material belongs in Temporal payloads, workflow
+artifacts, or runtime bridge evidence.

--- a/docs/tmp/KeycloakRemovalInventory-4117.md
+++ b/docs/tmp/KeycloakRemovalInventory-4117.md
@@ -36,7 +36,7 @@ machine path. Disposition key: **convert** (move to the new boundary),
 | E6 | `api_service/auth.py` FastAPI Users core [J] | `BearerTransport(tokenUrl="auth/jwt/login")`, `JWTStrategy(secret=JWT_SECRET_KEY, 3600s)`, `UserManager` + profile hooks | email+password in, bearer JWT out | `UserManager` / `SQLAlchemyUserDatabase(User)` | `current_active_user` (active check) | issues tokens; creates profile async on register/login | **convert** (replace issuance/validation; keep one-profile-per-user; JWT secret/purpose rebinding) — K2/K4 |
 | E7 | `api_service/auth.py::get_or_create_default_user()` [S] | startup seeding; reserved zero UUID `00000000-…-000000` default | `DEFAULT_USER_*` settings | direct `User` row create | n/a (bootstrap) | creates local owner row | **convert** (explicit operator claim; no silent owner creation) — K3 |
 | E8 | `api_service/api/routers/profile.py` [R] | `GET/PUT /me` (`Profile` router, no extra prefix) via `get_current_user()` | bearer / default user | E3 | `ProfileService` | reads/writes own profile | **convert** (preserve contract, replace implementation) — K4 |
-| E9 | `api_service/api/routers/worker_auth.py::_require_worker_auth()` [W] | `X-MoonMind-Worker-Token` header + `get_current_user_optional()` | OIDC principal only; legacy worker token → `410 worker_token_deprecated`; none → `401 auth_required` | OIDC user with non-null id | manifests router mutations | machine-authority gate | **convert** (keep OIDC-only; browser logout must not revoke worker creds) — K4 |
+| E9 | `api_service/api/routers/worker_auth.py::_require_worker_auth()` [W] | `X-MoonMind-Worker-Token` header + `get_current_user_optional()` | OIDC principal only; legacy worker token → `410 worker_token_deprecated`; none → `401 auth_required` | any non-`disabled` user with non-null id resolves `auth_source="oidc"` (pre-change baseline, traced) | manifests router mutations | machine-authority gate with a pre-change gap: ordinary browser principals satisfy the current check, so this disposition is NOT a frozen OIDC-only worker contract | **convert** (K4 mints an explicitly scoped machine credential independent of browser login, with allow/deny rejection rules; browser logout must not revoke worker creds; ordinary browser principals must not satisfy worker-only mutations) — K4 |
 | E10 | `api_service/api/routers/manifests.py` [R/W] | user routes via `get_current_user()`; mutation route via `_require_worker_auth` | bearer or worker auth | E3 / E9 | manifest ownership | mixed human/machine surface | **convert** — K4 |
 | E11 | `api_service/api/routers/temporal_artifacts.py` [R/T] | artifact endpoints via `get_current_user_optional()` | optional bearer | E4 | Temporal artifact owner checks | preview/download surface | **convert** (no URL-broad tokens; SSE/download re-auth) — K4 |
 | E12 | `moonmind/workflows/temporal/artifacts.py` owner checks [D] | `_assert_read_access` / `_assert_mutation_access` / `_raw_access_allowed`: bypass when `AUTH_PROVIDER == "disabled"`; `principal required` when non-disabled and empty | principal string | owner principal vs `service:` prefix | artifact repository | authorization bypass in `disabled` | **convert** (new modes must not inherit bypass; authenticated fixtures) — K4 |
@@ -44,12 +44,16 @@ machine path. Disposition key: **convert** (move to the new boundary),
 | E14 | `api_service/api/routers/omnigent_bridge.py` + workflow-chat router [T] | bridge mount + `WORKFLOW_CHAT_BINDINGS_MOUNT_PATH`; native Workflow Chat behind same-origin binding-scoped facade | MoonMind login (binding-scoped) | E3 | binding scope | proxied upstream sessions | **convert** (login ≠ unrestricted upstream access; no cookie/bearer forwarding) — K4 |
 | E15 | `api_service/api/routers/container_jobs.py` [W] | container-job routes via `get_current_user()` | bearer | E3 | job ownership | dispatches container work | **convert** (qualify without browser cookies) — K4 |
 | E16 | `api_service/api/routers/retrieval_gateway.py:468` [W] | one optional-user route; rest strict | optional/strict bearer | E4 / E3 | retrieval ownership | mixed surface | **convert** — K4 |
-| E17 | All other `get_current_user()` routers [R] | provider_profiles, secrets, sessions, agent_profiles, deployment_operations, settings, timelines, bootstrap, recurring/executions/catalog/mcp/console/jira/manifests/workflows/oauth_sessions/presets/automation/system/agent_runs/policies/migration/native_ui | bearer | E3 | per-router ownership | standard API | **convert** (audit for direct FastAPI Users deps bypassing E3) — K4 |
-| E18 | `frontend/src/lib/api/client.ts::fetchApi` [C] | same-origin `fetch`, JSON headers, no auth header | cookie (same-origin) | browser session | n/a (client) | all dashboard requests | **convert** (login/setup/logout UX, CSRF-aware requests, return-to-deep-link, expired-session handling) — K4 |
+| E17 | All other `get_current_user()` routers [R] | provider_profiles, secrets, sessions, agent_profiles, deployment_operations, settings, timelines, bootstrap, recurring/executions/catalog/mcp/console/jira/manifests/workflows/oauth_sessions/presets/automation/system/agent_runs/policies/migration/native_ui | bearer | E3 | per-router ownership | standard API | **convert** (audit for direct FastAPI Users deps bypassing E3; non-login machine credentials live in E23–E26, not this row) — K4 |
+| E18 | `frontend/src/lib/api/client.ts::fetchApi` [C] | same-origin `fetch`, JSON headers only, sends no `Authorization` header (traced pre-change gap) | no credential sent by the client; mounted FastAPI Users transport (`api_service/auth.py` E6) returns a bearer JWT that this client never attaches, and no session cookie is established by the current application | browser session (unestablished) | n/a (client) | all dashboard requests | current bearer gap: authenticated modes leave this client without any credential until the bearer-to-cookie transport transition lands | **convert** (login/setup/logout UX, bearer-to-cookie transport transition, CSRF-aware requests, return-to-deep-link, expired-session handling with regression coverage proving the client presents a credential) — K4 |
 | E19 | `moonmind/container_job_cli.py` + `MOONMIND_CONTAINER_JOBS_BEARER_TOKEN{,_FILE}` [W/C] | CLI/container file-based bearer | scoped bearer file | container-job minting (`runtime_environment.py`, `launcher.py`) | job scope | machine credential | **retain** (unrelated machine credential; qualify in K4 journey, do not delete) — K4 |
 | E20 | `moonmind/auth/` (`AuthProviderManager`, `EnvAuthProvider`, `ProfileAuthProvider`) [D] | profile/environment credential resolution for provider credentials | env/profile secrets | provider resolution | secret refs | model-credential supply | **retain** (not application login) — no owner change |
 | E21 | `api_service/api/routers/oauth_sessions.py`, provider-profile OAuth [R] | model Provider Profile OAuth flows | provider OAuth | provider oauth policy | profile ownership | model access | **retain** (not application login) — no owner change |
 | E22 | `api_service/api/routers/worker_auth.py` legacy token constant | `X-MoonMind-Worker-Token` → `410` | removed | n/a | n/a | documents removal | **retain-narrowly** (keep the `410` tombstone through cutover, then remove with callers) — K5 |
+| E23 | `api_service/api/routers/execution_integrations.py` integration-callback token [W] | `/api/integrations/*` callback routes; `X-Integration-Token` header or `Authorization: Bearer` compared against `IntegrationCallbackSettings.callback_token` / `JulesSettings.jules_callback_token` (constant-time compare, rate-limited, payload-capped) | shared integration-callback secret (operator-held, per-integration profile) | callback-profile match (no MoonMind user principal) | execution visibility/write-back | admitted-workflow write-back path independent of `get_current_user()` | **convert** (scope per-integration tokens, rotation plan, and cutover tests proving `JWT_SECRET_KEY` rebinding/rotation does not break admitted callbacks) — K4 |
+| E24 | `api_service/api/routers/proxy.py` provider-proxy token [W] | `/proxy/{provider}/{path}`; `Authorization: Bearer mm-proxy-token:<fernet>` or `x-api-key`, Fernet-decrypted via app encryption key, provider-bound, exp-checked | symmetric-encrypted proxy token carrying `secret_refs` (not a MoonMind login) | token `provider` field vs route provider | provider secret resolution | model-credential supply to agent runtimes | **convert** (qualify proxy-token issuance/rotation independently of the login JWT secret; cutover tests prove proxy tokens survive `JWT_SECRET_KEY` rotation) — K4 |
+| E25 | `api_service/api/routers/mcp_tools.py::call_managed_session_container_tool` managed-session capability [W] | `POST /container/tools/call`; `Authorization` bearer verified by `verify_container_job_session_capability(..., secret=JWT_SECRET_KEY)` | JWT-secret-backed managed-session capability (scoped: session id, tools, workspace flags) | capability `owner` | container tool dispatch | machine-scoped container execution | **convert** (explicit `JWT_SECRET_KEY` purpose binding + rotation/migration plan for managed-session capabilities; K4 regression coverage for rebinding) — K4 |
+| E26 | `api_service/api/execution_fanout.py` execution-fanout capability [W] | fanout create/describe routes via `EXECUTION_FANOUT_HEADER`, verified by `verify_execution_fanout_capability` | fanout capability marker (JWT-secret-backed) | capability parent/child binding | fanout child visibility | admitted-workflow fanout | **convert** (same secret-purpose binding and rotation plan as E25; K4 cutover tests) — K4 |
 
 Direct FastAPI Users dependencies outside E3/E4 (e.g. `websockets.py` importing
 `get_jwt_strategy`/`get_user_manager`) must be audited in K4 so no stale
@@ -163,6 +167,45 @@ principal), `service:worker` (service prefix principal). Executable form:
 | `get_auth_router()`, `AUTH_PROVIDER=keycloak` | empty router (Keycloak placeholder; login path unmounted) |
 | startup `AUTH_PROVIDER=google` without reachable issuer | `RuntimeError` from discovery |
 | DB outage on strict path | degraded/unavailable (must fail closed; no admin stub on production paths) |
+
+### 5.1 Background-work disablement policy (frozen selection surface)
+
+When a user account is disabled, new user actions are blocked immediately.
+Already-admitted background work (running Temporal workflows, queued jobs,
+container dispatches) keeps its stored principal ID and durable authority and
+follows exactly one per-deployment policy selected before K6 cutover:
+
+| Field | Frozen values |
+| --- | --- |
+| Policy selector | `drain_complete` (let admitted work finish; admit nothing new) or `revoke` (cancel admitted work). No silent ownership transfer either way. |
+| Default | `drain_complete`, recorded in the deployment runbook when the operator selects nothing. |
+| Owner | Deployment owner selects; K4 implements both paths with fixtures; K6 gates cutover on the recorded selection. |
+| Evidence | K4 negative matrix (disabled principal admits nothing new under both policies) + K6 smoke result naming the selected policy. |
+
+### 5.2 Revocation deadline (frozen acceptance threshold)
+
+"Bounded interval" in `docs/Security/AuthenticationContracts.md` §5 means:
+credential and session revocation (password reset, account disablement,
+administrative revocation, logout) is enforced on every API replica and
+terminates active browser streams (SSE, WebSocket reconnects, artifact
+downloads) within **5 minutes of the revocation commit**, measured from the
+database transaction commit timestamp to the replica's final re-authorization
+check. The clock starts at commit, not at cache expiry. K4 proves this with a
+replica-consistency test using a fixed short test bound; K6 verifies the
+production 5-minute bound on the deployed replica count.
+
+### 5.3 Disabled-mode ingress gate (fail-closed validator)
+
+`disabled` mode is an explicitly selected local single-user mode, never an
+error fallback. Its restricted-ingress requirement is enforced by a
+fail-closed startup/deployment validator (K4 implements, K2 qualifies the
+interface): at startup the API refuses to serve `disabled` mode on a
+non-loopback bind unless the operator provides explicit trusted-ingress
+evidence (loopback-only bind proof or a named trusted-proxy chain with TLS
+termination recorded in the deployment runbook). Accepted evidence is a
+loopback bind (`127.0.0.1`/`::1`) or a documented trusted-ingress declaration;
+anything else fails startup closed. The deployment owner records the bind,
+proxy chain, TLS termination, and replica count per §4 step 5.
 
 Escaped-regression policy: any production escape becomes a minimized required-CI
 fixture (unit where possible, `integration_ci` only for Docker/compose/DB seams

--- a/docs/tmp/KeycloakRemovalInventory-4117.md
+++ b/docs/tmp/KeycloakRemovalInventory-4117.md
@@ -1,0 +1,190 @@
+# Keycloak Removal Inventory — #4117
+
+Status: Discovery and boundary decisions for MoonLadderStudios/MoonMind#4117
+(parent epic #4116). Temporary execution scaffolding under `docs/tmp/` per
+AGENTS.md. Durable desired-state contracts live in
+`docs/Security/AuthenticationContracts.md`. This document changes no behavior,
+removes no services, and authorizes no production account changes.
+
+Revision traced: `main` at `984feb4f9` (assessment baseline). Predecessor
+proposal `KeycloakRemovalPlan.md` (#4102) is starting evidence, re-traced here —
+not the deliverable.
+
+Target contract freeze: `accounts` (default) / `oidc` (generic) / `header`
+(trusted proxy) / `disabled` (explicit restricted local). Canonical principal:
+`User.id` UUID. No email-based implicit linking. Full freeze in
+`docs/Security/AuthenticationContracts.md`.
+
+---
+
+## 1. Authentication entrypoint inventory (R1)
+
+Constructor key: **S** = startup, **R** = mounted router, **D** = direct
+FastAPI Users dependency, **J** = JWT issuance/validation, **C** = dashboard
+request client, **T** = stream (SSE/WebSocket/download/chat), **W** = worker /
+machine path. Disposition key: **convert** (move to the new boundary),
+**retain** (unrelated, unchanged), **remove-with-callers** (delete together),
+**retain-narrowly** (keep only for historical upgrade/recovery).
+
+| # | Surface (file) | Public path / constructor | Credential | Principal resolver | Resource authorization owner | Side effect | Disposition + owner |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| E1 | `api_service/main.py` lifespan + `_initialize_oidc_provider` [S] | startup; `google` discovery branch fetches `{OIDC_ISSUER_URL}/.well-known/openid-configuration` → `app.state.jwks_uri` | none (outbound fetch) | n/a | n/a | provider-dependent startup | **convert** (generic `oidc` discovery; reject retired literals) — K2/K4 |
+| E2 | `api_service/main.py` auth-router mounting [R] | `/api/v1/auth/*`, `/api/v1/auth/users/*`; skipped entirely when `AUTH_PROVIDER == "keycloak"` | JWT bearer / registration body | `fastapi_users` + `UserManager` | per-router `current_user` consumers | mounts login/register/reset/verify/users paths | **convert** (one vertical slice; no second registration/reset path left mounted) — K4 |
+| E3 | `api_service/auth_providers.py::get_current_user()` [D] | dependency factory used by ~30 routers; non-`disabled` returns `current_active_user`; `disabled` loads default user from DB with stub fallbacks | bearer JWT (non-disabled) / DB row or stub (`disabled`) | FastAPI Users `current_active_user` vs default-user lookup | each consuming router | central integration point to preserve | **convert** (keep as main integration point behind new resolver) — K4 |
+| E4 | `api_service/auth_providers.py::get_current_user_optional()` [D] | optional variant; non-`disabled` returns `current_active_user_optional`, else strict default user | optional bearer | same as E3, `optional=True` | worker-tolerant routers | missing credential stays optional here only | **convert** — K4 |
+| E5 | `api_service/auth_providers.py::get_auth_router()` [R] | helper router: `keycloak` → empty placeholder; `default` → `/auth/jwt` + `/auth` register routes | same as E2 | `fastapi_users` | callers (legacy prefix) |archived branch surface | **remove-with-callers** (`keycloak` placeholder and `default` branch) — K5 |
+| E6 | `api_service/auth.py` FastAPI Users core [J] | `BearerTransport(tokenUrl="auth/jwt/login")`, `JWTStrategy(secret=JWT_SECRET_KEY, 3600s)`, `UserManager` + profile hooks | email+password in, bearer JWT out | `UserManager` / `SQLAlchemyUserDatabase(User)` | `current_active_user` (active check) | issues tokens; creates profile async on register/login | **convert** (replace issuance/validation; keep one-profile-per-user; JWT secret/purpose rebinding) — K2/K4 |
+| E7 | `api_service/auth.py::get_or_create_default_user()` [S] | startup seeding; reserved zero UUID `00000000-…-000000` default | `DEFAULT_USER_*` settings | direct `User` row create | n/a (bootstrap) | creates local owner row | **convert** (explicit operator claim; no silent owner creation) — K3 |
+| E8 | `api_service/api/routers/profile.py` [R] | `GET/PUT /me` (`Profile` router, no extra prefix) via `get_current_user()` | bearer / default user | E3 | `ProfileService` | reads/writes own profile | **convert** (preserve contract, replace implementation) — K4 |
+| E9 | `api_service/api/routers/worker_auth.py::_require_worker_auth()` [W] | `X-MoonMind-Worker-Token` header + `get_current_user_optional()` | OIDC principal only; legacy worker token → `410 worker_token_deprecated`; none → `401 auth_required` | OIDC user with non-null id | manifests router mutations | machine-authority gate | **convert** (keep OIDC-only; browser logout must not revoke worker creds) — K4 |
+| E10 | `api_service/api/routers/manifests.py` [R/W] | user routes via `get_current_user()`; mutation route via `_require_worker_auth` | bearer or worker auth | E3 / E9 | manifest ownership | mixed human/machine surface | **convert** — K4 |
+| E11 | `api_service/api/routers/temporal_artifacts.py` [R/T] | artifact endpoints via `get_current_user_optional()` | optional bearer | E4 | Temporal artifact owner checks | preview/download surface | **convert** (no URL-broad tokens; SSE/download re-auth) — K4 |
+| E12 | `moonmind/workflows/temporal/artifacts.py` owner checks [D] | `_assert_read_access` / `_assert_mutation_access` / `_raw_access_allowed`: bypass when `AUTH_PROVIDER == "disabled"`; `principal required` when non-disabled and empty | principal string | owner principal vs `service:` prefix | artifact repository | authorization bypass in `disabled` | **convert** (new modes must not inherit bypass; authenticated fixtures) — K4 |
+| E13 | `api_service/api/websockets.py::get_current_user_ws()` [T] | `/ws/v1/*` + `/terminal/{session_id}`; `?token=` query → `strategy.read_token(token, user_manager)` | bearer JWT in query | `JWTStrategy.read_token` | per-socket DB + owner checks | long-lived streams | **convert** (origin check, re-auth, bounded termination) — K4 |
+| E14 | `api_service/api/routers/omnigent_bridge.py` + workflow-chat router [T] | bridge mount + `WORKFLOW_CHAT_BINDINGS_MOUNT_PATH`; native Workflow Chat behind same-origin binding-scoped facade | MoonMind login (binding-scoped) | E3 | binding scope | proxied upstream sessions | **convert** (login ≠ unrestricted upstream access; no cookie/bearer forwarding) — K4 |
+| E15 | `api_service/api/routers/container_jobs.py` [W] | container-job routes via `get_current_user()` | bearer | E3 | job ownership | dispatches container work | **convert** (qualify without browser cookies) — K4 |
+| E16 | `api_service/api/routers/retrieval_gateway.py:468` [W] | one optional-user route; rest strict | optional/strict bearer | E4 / E3 | retrieval ownership | mixed surface | **convert** — K4 |
+| E17 | All other `get_current_user()` routers [R] | provider_profiles, secrets, sessions, agent_profiles, deployment_operations, settings, timelines, bootstrap, recurring/executions/catalog/mcp/console/jira/manifests/workflows/oauth_sessions/presets/automation/system/agent_runs/policies/migration/native_ui | bearer | E3 | per-router ownership | standard API | **convert** (audit for direct FastAPI Users deps bypassing E3) — K4 |
+| E18 | `frontend/src/lib/api/client.ts::fetchApi` [C] | same-origin `fetch`, JSON headers, no auth header | cookie (same-origin) | browser session | n/a (client) | all dashboard requests | **convert** (login/setup/logout UX, CSRF-aware requests, return-to-deep-link, expired-session handling) — K4 |
+| E19 | `moonmind/container_job_cli.py` + `MOONMIND_CONTAINER_JOBS_BEARER_TOKEN{,_FILE}` [W/C] | CLI/container file-based bearer | scoped bearer file | container-job minting (`runtime_environment.py`, `launcher.py`) | job scope | machine credential | **retain** (unrelated machine credential; qualify in K4 journey, do not delete) — K4 |
+| E20 | `moonmind/auth/` (`AuthProviderManager`, `EnvAuthProvider`, `ProfileAuthProvider`) [D] | profile/environment credential resolution for provider credentials | env/profile secrets | provider resolution | secret refs | model-credential supply | **retain** (not application login) — no owner change |
+| E21 | `api_service/api/routers/oauth_sessions.py`, provider-profile OAuth [R] | model Provider Profile OAuth flows | provider OAuth | provider oauth policy | profile ownership | model access | **retain** (not application login) — no owner change |
+| E22 | `api_service/api/routers/worker_auth.py` legacy token constant | `X-MoonMind-Worker-Token` → `410` | removed | n/a | n/a | documents removal | **retain-narrowly** (keep the `410` tombstone through cutover, then remove with callers) — K5 |
+
+Direct FastAPI Users dependencies outside E3/E4 (e.g. `websockets.py` importing
+`get_jwt_strategy`/`get_user_manager`) must be audited in K4 so no stale
+entrypoint bypasses the new resolver.
+
+## 2. Reference classification (R2)
+
+Live application-login behavior: `api_service/auth.py`,
+`api_service/auth_providers.py`, `api_service/main.py` (E1/E2 branches),
+`moonmind/config/settings.py` (`OIDCSettings`: `AUTH_PROVIDER`,
+`OIDC_ISSUER_URL/CLIENT_ID/CLIENT_SECRET`, `DEFAULT_USER_*`,
+`SecuritySettings.JWT_SECRET_KEY`), `api_service/db/models.py`
+(`User.oidc_provider[32]/oidc_subject[255]`, `uq_oidc_identity`),
+`api_service/api/websockets.py` token-in-query, `init_db_scripts/01-create-dbs.sh`
+(keycloak role+db), `docker-compose.yaml` (`keycloak` service behind
+`keycloak` profile + `OIDC_ISSUER_URL` default pointing at it + `./keycloak`
+mounts), `keycloak/realm-export.json`, `tools/dev-keycloak.ps1`,
+`tools/dev-insecure.ps1` Keycloak comments.
+
+Test coverage (Keycloak-named, pre-cutover): `tests/conftest.py::keycloak_mode`
+fixture, `tests/integration/temporal/test_temporal_artifact_authorization.py`,
+`tests/integration/temporal/test_task_shaped_submission_normalization.py:658`,
+`tests/integration/reliability/test_api_startup_provider_maintenance.py:52`,
+`tests/unit/workflows/temporal/test_artifacts.py:1692`,
+`tests/unit/api/routers/test_executions.py:10407,10454`,
+`tests/unit/test_integration_test_taxonomy.py:326` (asserts literal `keycloak`
+in the authz test). K5 replaces these with authenticated-mode coverage that
+exercises the new production boundary; the taxonomy assertion is updated with
+the fixtures.
+
+Unrelated, retain unchanged: model Provider Profile OAuth (`oauth_sessions`
+router, `is_codex_oauth_profile`, provider `auth_state` fields in
+`provider_profiles.py`/`main.py` seed logic), repository credentials
+(`GITHUB_TOKEN/PAT`, `ATLASSIAN_API_KEY` managed-secret sync in `main.py`),
+`moonmind.auth` profile/env resolution, container-job bearer family,
+Omnigent host-auth lifecycles, `OMNIGENT_AUTH_*` runtime-server variables in
+`.env-template` (never reinterpreted as MoonMind control-plane config).
+
+Historical evidence, retain narrowly: Alembic revisions under
+`api_service/migrations/versions/` (needed to upgrade existing databases),
+`init_db` shared roles, Temporal databases. Never deleted for Keycloak removal.
+
+`keycloak-db` updater reconciliation: `.agents/skills/update-moonmind/scripts/run-update-moonmind.sh`
+maps `keycloak/*` to targets `keycloak` + `keycloak-db`, but the Compose
+inventory has one `keycloak` service and no `keycloak-db` service — the
+Keycloak data lives in the shared `postgres` database (`01-create-dbs.sh`
+creates role/database `keycloak` inside it). `keycloak-db` names no deployed
+service; K5 removes both updater targets after verifying no other consumer
+references `keycloak-db`.
+
+## 3. Persisted-authority dispositions (R7, part 1)
+
+| Authority | Disposition |
+| --- | --- |
+| `User.id` UUIDs + workflow/artifact/schedule ownership FKs | **convert** (preserve every retained id; migration is additive + idempotent dry-run/apply) — K3 |
+| `User.oidc_provider/oidc_subject` (+ `uq_oidc_identity`) | **convert** (explicit provider→issuer mapping; replace with one external-identity relation if the 32-char field cannot hold issuer URIs; never two competing mappings) — K3 |
+| `User` rows, profiles, `is_active`/`is_superuser` | **convert** (no recreate/reset on first login; server-owned admin, last-admin recovery) — K3 |
+| Zero/default UUID row (`00000000-…-000000`) | **convert** (explicit operator claim to protected owner; closed first-owner on populated DB) — K3 |
+| Password hashes / MFA enrollments / Keycloak credentials | **convert-via-reset** (separate problem; tested compatible-hash path or invitation/reset/new-IdP enrollment; MFA retained via qualified replacement before cutover) — K3 |
+| Provider Profile OAuth data, managed secrets, container-job creds, host auth | **retain** — no change |
+| Alembic history, shared PG roles, Temporal DBs | **retain-narrowly** (upgrade/recovery only) — K5 keeps |
+| `keycloak` Compose service/profile, realm assets, keycloak init, launch helpers, health references, updater targets, Keycloak docs | **remove-with-callers** after K2–K4 pass (reviewed removal manifest; no `down -v` on shared DB) — K5 |
+| `keycloak`/`default` auth branches, old token issuance/acceptance, `google` discovery branch | **remove-with-callers** (migrate `google` → generic `oidc`; no dual acceptance) — K5 |
+| Keycloak-named test fixtures | **remove-with-callers**, replaced by authenticated-mode boundary coverage — K5 |
+
+Concurrent work: coordinate with #4103 (removal) and #3939/#3940 without treating
+adjacent scope as a prerequisite; this issue owns the inventory and contracts,
+not the cutover itself.
+
+## 4. Operator inventory procedure (R5, protected)
+
+Deployment facts and secrets must never enter public issue bodies. The
+deployment owner runs these steps in a protected channel and records only
+pass/fail + unknowns (as explicit deployment gates) against the issue:
+
+1. Enumerate deployed users: count, `User.id` list, `is_active`/`is_superuser`
+   flags, and the `(issuer, subject)` or login-name mapping for each. Export
+   stays operator-held (encrypted, restore-tested backup before any cutover).
+2. List external identity pairs: Keycloak realm(s), issuer URIs, client IDs,
+   and which MoonMind UUID each `(issuer, subject)` maps to; flag duplicate
+   emails, orphaned profiles, and default/zero-UUID collisions for K3 preflight.
+3. List realm consumers beyond MoonMind (other apps sharing the realm) with
+   migration owners; no shared consumer is silently abandoned (K6 gate).
+4. List service accounts, password/hash algorithms in use, MFA/SSO
+   requirements, and active sessions/tokens outstanding.
+5. Record ingress and replica topology: public host ports, trusted-proxy chain,
+   TLS termination, API replica count, and whether `disabled` mode is exposed
+   beyond loopback (must be restricted).
+6. Unknown facts (user counts, realm consumers, hash portability, MFA path,
+   migration duration) remain explicit deployment gates in K6. They do not block
+   hermetic implementation (K1–K5), which proceeds on fixtures.
+
+## 5. Sanitized pre-change baseline (R6)
+
+Fixtures (no secrets; synthetic UUIDs/emails only):
+`owner` (resource owner), `non-owner` (other active user), `admin`
+(`is_superuser=True`), `zero` (default `00000000-…-000000` single-user
+principal), `service:worker` (service prefix principal). Executable form:
+`tests/unit/security/test_auth_inventory_4117.py`.
+
+| Path | Current behavior (traced, pre-change) |
+| --- | --- |
+| `disabled` mode, artifact read/mutation | bypass: any principal (including `None`/empty) passes `_assert_*` |
+| non-`disabled`, owner reads own artifact | pass |
+| non-`disabled`, non-owner reads/mutates foreign artifact | `TemporalArtifactAuthorizationError` |
+| non-`disabled`, empty principal on list path | `TemporalArtifactAuthorizationError("principal required")` |
+| non-`disabled`, `service:*` principal | passes owner checks (service bypass) |
+| worker auth, legacy `X-MoonMind-Worker-Token` presented | `410 worker_token_deprecated` |
+| worker auth, valid OIDC user, non-disabled | resolves `auth_source="oidc"` |
+| worker auth, no credential | `401 auth_required` |
+| `get_auth_router()`, `AUTH_PROVIDER=keycloak` | empty router (Keycloak placeholder; login path unmounted) |
+| startup `AUTH_PROVIDER=google` without reachable issuer | `RuntimeError` from discovery |
+| DB outage on strict path | degraded/unavailable (must fail closed; no admin stub on production paths) |
+
+Escaped-regression policy: any production escape becomes a minimized required-CI
+fixture (unit where possible, `integration_ci` only for Docker/compose/DB seams
+per the taxonomy); a broken behavior is never preserved as the target.
+
+## 6. Plan-section and verification-matrix ownership (R7, part 2)
+
+Plan sections (`KeycloakRemovalPlan.md`): §1 decision → K1 (this issue, frozen
+above); §2 baseline → K1 (this inventory); §3 target contracts → K1 canonical
+doc, implemented K2–K4; §4 packages K1–K6 → owners below; §5 verification matrix
+→ row owners below; §6 rollback → K6; §7 completion → K6 sign-off.
+
+| Package / matrix row | Owner (epic child) | Exit evidence |
+| --- | --- | --- |
+| K1 inventory + acceptance contract | #4117 (this issue) | this file + canonical contracts + baseline fixtures |
+| K2 upstream boundary qualification | epic child (auth adapter) | pinned commit, adapter conformance tests, supported-interface contract |
+| K3 migration + account lifecycle | epic child (identity/migration) | real-PG migration/rerun tests, UUID ownership assertions, bootstrap race tests |
+| K4 vertical slice (API+dashboard) | epic child (cutover slice) | two-user journey + negative matrix, old-token rejection, stream revocation, replica consistency, Keycloak-unreachable pass |
+| K5 removal manifest | #4103 (coordinate) | reviewed manifest, clean boot/journeys without Keycloak, no live dependency |
+| K6 deployment cutover | deployment owner + epic child | smoke results, ownership reconciliation, old-credential rejection, recovery retention |
+| Matrix: Authentication / Identity / Browser security / Account lifecycle | K2/K3/K4 per row | hermetic fixtures (local OIDC + trusted-proxy fixtures, real PG for concurrency seams) |
+| Matrix: Resource authorization / Machine authority / Durability / User journey / Removal | K4/K5/K6 per row | negative matrix, restart/replica tests, journey replay, removal manifest |
+
+No unowned deletion, migration, or security requirement remains: every inventoried
+path (§1) and persisted authority (§3) names a disposition and an owner above.

--- a/tests/unit/security/test_auth_inventory_4117.py
+++ b/tests/unit/security/test_auth_inventory_4117.py
@@ -18,6 +18,7 @@ semantics) are durable and move with docs/Security/AuthenticationContracts.md.
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -74,11 +75,17 @@ def test_canonical_principal_is_uuid_backed_user_id():
 
 def test_external_identity_pair_has_unique_pair_constraint():
     table = db_models.User.__table__
-    assert table.c["oidc_provider"].type.length == 32
+    # Pre-change baseline (owned for replacement by the K3 identity/migration
+    # child): the legacy `oidc_provider` column is 32 chars and cannot hold a
+    # full issuer URI. The frozen contract is uniqueness + full preservation
+    # of the `(issuer, subject)` pair, independently of the legacy layout —
+    # K3 replaces this with one external-identity relation when the field
+    # cannot hold issuer URIs, never two competing mappings.
     constraints = list(table.constraints)
     assert any(
         getattr(c, "name", "") == "uq_oidc_identity" for c in constraints
     ), "expected uq_oidc_identity unique pair constraint on (oidc_provider, oidc_subject)"
+    assert "oidc_subject" in table.c and table.c["oidc_subject"].type.length == 255
 
 
 def test_zero_uuid_default_is_reserved_single_user_principal():
@@ -87,10 +94,19 @@ def test_zero_uuid_default_is_reserved_single_user_principal():
 
 
 def test_target_modes_are_frozen_and_documented():
-    inventory = open("docs/tmp/KeycloakRemovalInventory-4117.md", encoding="utf-8").read()
-    contracts = open("docs/Security/AuthenticationContracts.md", encoding="utf-8").read()
+    inventory = Path("docs/tmp/KeycloakRemovalInventory-4117.md").read_text(encoding="utf-8")
+    contracts = Path("docs/Security/AuthenticationContracts.md").read_text(encoding="utf-8")
+    # Supported modes: asserted as structured table rows in the canonical
+    # contract (`| `accounts` |`), not incidental prose mentions — a removed
+    # mode row or an added retired-mode row fails even when the word appears
+    # elsewhere in the document.
     for mode in ("accounts", "oidc", "header", "disabled"):
-        assert mode in contracts
+        assert f"| `{mode}` |" in contracts, f"missing structured mode row for {mode}"
+    # Retired selectors: frozen as rejected-at-startup with migration guidance
+    # in the canonical contract, with dispositions tracked in the inventory.
+    for retired in ("keycloak", "default", "google"):
+        assert retired in contracts
+    assert "Rejected selectors" in contracts or "retired selectors" in contracts.lower()
     for retired in ("keycloak", "default", "google"):
         assert retired in inventory  # retired literals tracked with disposition
 
@@ -148,6 +164,7 @@ async def test_worker_auth_rejects_legacy_token_with_gone(monkeypatch):
             worker_token="legacy-token", user=_user(OWNER_PRINCIPAL)
         )
     assert exc_info.value.status_code == 410
+    assert exc_info.value.detail["code"] == "worker_token_deprecated"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/security/test_auth_inventory_4117.py
+++ b/tests/unit/security/test_auth_inventory_4117.py
@@ -1,0 +1,190 @@
+"""Sanitized pre-change baseline + frozen-contract guardrails for #4117.
+
+Covers MoonLadderStudios/MoonMind#4117 (parent epic #4116):
+caller/disposition inventory acceptance contract for Keycloak removal.
+
+These tests are hermetic (no DB, no network, no credentials) and use synthetic
+fixtures only: owner / non-owner / admin / zero-UUID / service principals.
+They exercise genuine public authorization boundaries (artifact owner checks,
+worker-auth gate, auth-router mounting, identity-model constraints), not
+provider-string assertions.
+
+Pre-change baselines asserted here are owned for replacement by the K4/K5
+cutover children (see docs/tmp/KeycloakRemovalInventory-4117.md); the frozen
+contract assertions (canonical UUID principal, no email linking, error
+semantics) are durable and move with docs/Security/AuthenticationContracts.md.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from api_service import auth as auth_module
+from api_service import auth_providers as auth_providers_module
+from api_service.api.routers import worker_auth as worker_auth_module
+from api_service.db import models as db_models
+from moonmind.config.settings import settings
+from moonmind.workflows.temporal import artifacts as artifact_module
+
+# ---------------------------------------------------------------------------
+# Sanitized fixtures (synthetic only — no secrets, no production data)
+# ---------------------------------------------------------------------------
+
+ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+OWNER_PRINCIPAL = "owner-user-4117"
+NON_OWNER_PRINCIPAL = "non-owner-user-4117"
+ADMIN_PRINCIPAL = "admin-user-4117"
+SERVICE_PRINCIPAL = "service:worker-4117"
+
+
+def _artifact_owned_by(owner: str):
+    return SimpleNamespace(artifact_id="artifact-4117", created_by_principal=owner)
+
+
+def _service():
+    # Bypass __init__ (needs repository/session); the access helpers under test
+    # only touch settings + _owner_principal.
+    return object.__new__(artifact_module.TemporalArtifactService)
+
+
+def _user(principal: str, *, is_superuser: bool = False):
+    return SimpleNamespace(
+        id=uuid.uuid4(), email=f"{principal}@example.invalid", is_superuser=is_superuser
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frozen identity contract (durable)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_principal_is_uuid_backed_user_id():
+    assert db_models.User.__tablename__ == "user"
+    id_col = db_models.User.__table__.c["id"]
+    # fastapi-users SQLAlchemyBaseUserTableUUID supplies a GUID/UUID id column;
+    # assert the contract (UUID principal), not one vendor type class.
+    assert "uuid" in type(id_col.type).__name__.lower() or "guid" in type(
+        id_col.type
+    ).__name__.lower()
+
+
+def test_external_identity_pair_has_unique_pair_constraint():
+    table = db_models.User.__table__
+    assert table.c["oidc_provider"].type.length == 32
+    constraints = list(table.constraints)
+    assert any(
+        getattr(c, "name", "") == "uq_oidc_identity" for c in constraints
+    ), "expected uq_oidc_identity unique pair constraint on (oidc_provider, oidc_subject)"
+
+
+def test_zero_uuid_default_is_reserved_single_user_principal():
+    assert auth_module._DEFAULT_USER_ID == ZERO_UUID
+    uuid.UUID(auth_module._DEFAULT_USER_ID)  # parses as a UUID
+
+
+def test_target_modes_are_frozen_and_documented():
+    inventory = open("docs/tmp/KeycloakRemovalInventory-4117.md", encoding="utf-8").read()
+    contracts = open("docs/Security/AuthenticationContracts.md", encoding="utf-8").read()
+    for mode in ("accounts", "oidc", "header", "disabled"):
+        assert mode in contracts
+    for retired in ("keycloak", "default", "google"):
+        assert retired in inventory  # retired literals tracked with disposition
+
+
+# ---------------------------------------------------------------------------
+# Sanitized pre-change baseline: artifact authorization boundary
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_mode_bypasses_artifact_authorization_for_any_principal(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled")
+    service = _service()
+    artifact = _artifact_owned_by(OWNER_PRINCIPAL)
+    for principal in (
+        OWNER_PRINCIPAL,
+        NON_OWNER_PRINCIPAL,
+        ADMIN_PRINCIPAL,
+        SERVICE_PRINCIPAL,
+        "",
+    ):
+        service._assert_read_access(artifact, principal=principal)
+        service._assert_mutation_access(artifact, principal=principal)
+
+
+def test_enabled_mode_owner_passes_non_owner_fails(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "oidc")
+    service = _service()
+    artifact = _artifact_owned_by(OWNER_PRINCIPAL)
+    service._assert_read_access(artifact, principal=OWNER_PRINCIPAL)
+    service._assert_mutation_access(artifact, principal=OWNER_PRINCIPAL)
+    with pytest.raises(artifact_module.TemporalArtifactAuthorizationError):
+        service._assert_read_access(artifact, principal=NON_OWNER_PRINCIPAL)
+    with pytest.raises(artifact_module.TemporalArtifactAuthorizationError):
+        service._assert_mutation_access(artifact, principal=NON_OWNER_PRINCIPAL)
+
+
+def test_enabled_mode_service_principal_passes_owner_checks(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "accounts")
+    service = _service()
+    artifact = _artifact_owned_by(OWNER_PRINCIPAL)
+    service._assert_read_access(artifact, principal=SERVICE_PRINCIPAL)
+    service._assert_mutation_access(artifact, principal=SERVICE_PRINCIPAL)
+
+
+# ---------------------------------------------------------------------------
+# Sanitized pre-change baseline: worker-auth gate error semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_auth_rejects_legacy_token_with_gone(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "oidc")
+    with pytest.raises(HTTPException) as exc_info:
+        await worker_auth_module._require_worker_auth(
+            worker_token="legacy-token", user=_user(OWNER_PRINCIPAL)
+        )
+    assert exc_info.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_worker_auth_resolves_oidc_principal(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "oidc")
+    resolved = await worker_auth_module._require_worker_auth(
+        worker_token=None, user=_user(OWNER_PRINCIPAL)
+    )
+    assert resolved.auth_source == "oidc"
+
+
+@pytest.mark.asyncio
+async def test_worker_auth_missing_credential_is_unauthorized(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "oidc")
+    with pytest.raises(HTTPException) as exc_info:
+        await worker_auth_module._require_worker_auth(worker_token=None, user=None)
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Sanitized pre-change baseline: router mounting branches
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_mode_mounts_no_legacy_auth_routes(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak")
+    router = auth_providers_module.get_auth_router()
+    assert router.routes == []
+
+
+def test_default_mode_mounts_legacy_jwt_routes(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "default")
+    router = auth_providers_module.get_auth_router()
+    assert len(router.routes) > 0
+
+
+def test_central_integration_points_exist():
+    assert callable(auth_providers_module.get_current_user)
+    assert callable(auth_providers_module.get_current_user_optional)
+    assert callable(auth_providers_module.get_default_user_from_db)


### PR DESCRIPTION
Summary
Implements MoonLadderStudios/MoonMind#4117 (parent epic #4116): complete caller/disposition inventory and frozen executable acceptance contract for replacing application authentication without deleting unrelated credential systems. Adds exactly three new files, no production behavior change:
- docs/tmp/KeycloakRemovalInventory-4117.md — 22-surface entrypoint inventory (E1-E22) with public path, credential type, principal resolver, authorization owner, side effect, disposition + owner; reference classification; persisted-authority dispositions; operator inventory procedure; plan/verification-matrix ownership map.
- docs/Security/AuthenticationContracts.md — canonical frozen mode/identity contract (accounts, generic OIDC, trusted header, restricted local mode), canonical MoonMind UUID, no email linking, active/admin authority, revocation/stream/CSRF/error semantics.
- tests/unit/security/test_auth_inventory_4117.py — 13 hermetic baseline/contract tests exercising genuine public API/authorization boundaries.

Verification outcome
moonspec-verify verdict: FULLY_IMPLEMENTED (medium confidence) at candidate HEAD f164da93f against assessment base 984feb4f9 (NOT_IMPLEMENTED). All 7 required-work items (R1-R7) and all 5 acceptance criteria verified against current source. Trusted brief: moonmind.github.get_issue for MoonLadderStudios/MoonMind#4117.

Tests run
- Targeted: ./tools/test_unit.sh --python-only -- tests/unit/security/test_auth_inventory_4117.py — could not execute in this sandbox (no pytest module installed; managed container test path requires MOONMIND_RUNTIME_ID, unavailable). Every test assertion was traced to verified production source lines and matches existing passing-test conventions. Required CI must execute the new test file.
- No other suites run; docs-only + new-test change, no production code changed.

Remaining risks
- New hermetic tests unexecuted locally; deferred to required CI (see residual risk in artifacts/github-issue-implement-verify.json).
- Operator inventory facts (deployed users, UUID mappings, issuer/subject pairs, realm consumers, sessions, topology) remain explicit K6 deployment gates; secrets never enter public bodies.

Closes MoonLadderStudios/MoonMind#4117