### PR TITLE
[Keycloak removal] Qualify portable Omnigent authentication interfaces (MoonLadderStudios/MoonMind#4118)

### DIFF
--- a/docs/Security/AuthenticationContracts.md
+++ b/docs/Security/AuthenticationContracts.md
@@ -189,3 +189,16 @@ reason, and request correlation. Never log passwords, authorization codes,
 bearer tokens, cookies, reset links, refresh material, or raw IdP token
 responses. No authentication material belongs in Temporal payloads, workflow
 artifacts, or runtime bridge evidence.
+
+## 11. Qualified upstream boundary (K2)
+
+The reusable upstream authentication boundary qualified in
+MoonLadderStudios/MoonMind#4118 is declared in
+[OmnigentAuthAdapterContract.md](./OmnigentAuthAdapterContract.md): the
+pinned upstream entrypoints MoonMind composes, the validated-identity
+hook ordering before session minting, the MoonMind session-purpose
+binding and durable revocation interface, the explicitly rejected
+optional surfaces, and configuration isolation. That contract is the
+authoritative adapter reference for K3/K4; this document remains the
+authority for modes, identity, session, error, and background-work
+semantics.

--- a/docs/Security/OmnigentAuthAdapterContract.md
+++ b/docs/Security/OmnigentAuthAdapterContract.md
@@ -1,0 +1,135 @@
+# Omnigent Authentication Adapter Contract
+
+**Document Class:** Canonical declarative
+**Viewpoint:** Cross-Cutting Concept View
+**Status:** Draft
+**Owners:** MoonMind Engineering
+**Audience:** API, security contributors and operators
+**Authority:** Supported reusable upstream authentication interfaces qualified
+for MoonMind composition, and the MoonMind-side adapter seams that bind
+them to MoonMind configuration, identity, persistence, and session policy.
+Qualifies MoonLadderStudios/MoonMind#4118 (parent epic #4116, depends on
+#4117, plan coverage K2 in `../tmp/KeycloakRemovalPlan.md`).
+**Owning Surface:** `moonmind/security/omnigent_auth_qualification.py`,
+conformance fixtures in `tests/unit/security/test_omnigent_auth_qualification_4118.py`
+**Related Docs:** [AuthenticationContracts.md](./AuthenticationContracts.md)
+(desired-state modes, identity, session, and error semantics),
+[KeycloakRemovalPlan.md](../tmp/KeycloakRemovalPlan.md) (predecessor proposal;
+starting evidence only), [KeycloakRemovalQualification-4118.md](../tmp/KeycloakRemovalQualification-4118.md)
+(pin, artifact identities, and test results for this qualification)
+
+> [!NOTE]
+> This document declares which upstream entrypoints MoonMind reuses and
+> which MoonMind-side seams are authoritative. Rollout sequencing,
+> migration tasks, and backlog tickets belong in MoonSpec artifacts,
+> gitignored handoffs, or `docs/tmp/` implementation plans.
+
+---
+
+## 1. Pinned upstream revision
+
+- Upstream commit: `f04b0354fb5344c1ea8b92795ceb6760a9ad7595`
+  (`https://github.com/omnigent-ai/omnigent` submodule).
+- Packaged artifact: `omnigent==0.12.0` (`omnigent/pyproject.toml`
+  `[project].version`, mirrored in `omnigent/omnigent/version.py`).
+- Qualification runs against that pin. A pin change re-runs the
+  conformance fixtures before any behavior is relied upon.
+
+## 2. Reused upstream entrypoints (supported)
+
+The adapter composes these real upstream primitives in the MoonMind API
+process. None requires booting the upstream application, permission
+store, runtime server, or retired embedded host transport:
+
+| Upstream entrypoint | MoonMind use |
+| --- | --- |
+| `omnigent.server.oidc.mint_session_token` / `hmac_digest` | Session-JWT machinery shape and cache-key pattern probed in qualification; MoonMind mints its own purpose-bound tokens (see §4) |
+| `omnigent.server.passwords.{hash_password, verify_password}` | Qualified argon2 password hashing and verification; the only password KDF MoonMind uses for built-in accounts |
+| `omnigent.server.auth.UnifiedAuthProvider.get_user_id` | Cookie/header validation behavior probed; MoonMind never adopts its email/username session subjects |
+| `omnigent.server.accounts_config.AccountsConfig.from_env` / `omnigent.server.oidc.OIDCConfig.from_env` | Fail-closed configuration validation pattern; MoonMind passes its own explicit config and never reads `OMNIGENT_*` ambient state |
+
+Production packaging includes only these reusable modules. The whole
+upstream application, permission store, runtime server, device-grant
+store, and CLI/magic-link routes are never imported by the adapter.
+Existing standalone upstream consumers are unaffected: qualification
+mutates no upstream global, default, or allowlist.
+
+## 3. Identity hook ordering (authoritative)
+
+A validated identity resolves to exactly one existing MoonMind UUID
+before any MoonMind session is minted:
+
+1. The caller supplies a `ValidatedIdentity` carrying verified claims:
+   OIDC `(issuer URI, case-sensitive subject)` or the verified account
+   login in the `moonmind-accounts` namespace. The OIDC callback path
+   must preserve issuer/subject claims before they are collapsed to
+   email; a wrapper around the final subject string is insufficient.
+2. The async account store maps `(issuer, subject)` to an existing
+   `User.id`. No automatic linking by email, display name, username, or
+   a matching subject from a different issuer. Email changes never
+   change resource ownership.
+3. The account record must be active. `User.is_active` and MoonMind
+   `is_superuser` are MoonMind-owned and checked after credential
+   validation on every request, including cache hits. An upstream admin
+   advisory is never promoted into MoonMind superuser authority.
+
+## 4. Session policy
+
+- MoonMind issues its own session: `__Host-mm_session` in production
+  (`mm_session_dev` only for explicitly permitted loopback HTTP),
+  HttpOnly, SameSite Lax or stricter, Secure on HTTPS.
+- Tokens carry explicit issuer (`moonmind-control-plane`), audience /
+  purpose (`moonmind-browser-session`), HS256 algorithm allowlist,
+  expiry, key rotation via distinct secrets, and a unique `jti`.
+- Upstream runtime tokens (`__Host-ap_session` / `ap_session`,
+  upstream issuer/provider claims) are rejected at the MoonMind user
+  boundary. Control-plane and runtime cookie names, signing keys, token
+  purpose, and persistence are separate.
+- The TTL credential cache is keyed by HMAC digest and every hit
+  re-runs full validation, so revocation, generation, scope, and
+  principal-status checks are never skipped. Grant-derived tokens
+  (any `grant_id` or `scope` claim) bypass the cache and require live
+  revocation lookup; they are rejected at the browser boundary.
+- One durable revocation mechanism lives behind the portable
+  `SessionRevocationStore` interface. Logout revokes the session;
+  password reset, account disablement, and administrative revocation
+  bump the user generation and invalidate relevant credentials across
+  replicas. Clearing a cookie alone is not revocation.
+
+## 5. Persistence
+
+The `AsyncAccountStore` protocol is async-safe: no synchronous remote
+database work blocks the API event loop, and no parallel account/admin
+tables are initialized. Production wiring uses existing MoonMind
+transactions and profile authority through adapters (K3/K4 own the
+concrete wiring). Password hashes must be qualified argon2; missing or
+foreign hashes take the controlled enrollment/reset path, never a
+silent compatibility assumption.
+
+## 6. Explicitly rejected surfaces
+
+Refresh grants, delegated scope tokens, runner-minted tokens, CLI
+tickets, magic links, and the upstream admin roster are unsupported at
+the MoonMind browser boundary. They fail closed with
+`unsupported_surface` and are never accepted by broadening the upstream
+delegated endpoint allowlist. Browser login never returns refresh
+material in JSON.
+
+## 7. Configuration isolation
+
+MoonMind authentication is selected only by the explicit `AUTH_PROVIDER`
+selector (`accounts` / `oidc` / `header` / `disabled`). Retired
+selectors (`keycloak`, `default`, `google`) and unknown values fail
+startup with migration guidance and are never silently translated.
+Runtime-server `OMNIGENT_AUTH_*` variables never select MoonMind's
+mode, key, or identity store, including hostile ambient values. Invalid
+provider configuration fails closed.
+
+## 8. Error semantics
+
+Missing credentials are `auth_required` (optional only at explicitly
+optional boundaries); invalid, expired, wrong-key/issuer/purpose, or
+reserved-identity credentials are `auth_invalid`, including on cache
+hits; conflicting cookie/bearer identities are `auth_conflict`;
+inactive accounts are `inactive`/`forbidden`; store outages are
+`unavailable` and never return an administrator stub.

--- a/docs/tmp/KeycloakRemovalQualification-4118.md
+++ b/docs/tmp/KeycloakRemovalQualification-4118.md
@@ -1,0 +1,109 @@
+# Keycloak Removal Qualification — #4118 (K2)
+
+Status: Qualification slice for MoonLadderStudios/MoonMind#4118
+(parent epic #4116, depends on #4117). Temporary execution scaffolding
+under `docs/tmp/` per AGENTS.md. Durable adapter semantics live in
+`docs/Security/OmnigentAuthAdapterContract.md`. This document changes no
+runtime behavior, removes no services, and authorizes no production
+account changes.
+
+## 1. Provenance
+
+- Upstream repository: `https://github.com/omnigent-ai/omnigent`
+  (git submodule `omnigent`).
+- Pinned commit: `f04b0354fb5344c1ea8b92795ceb6760a9ad7595` (verified via
+  `git -C omnigent rev-parse HEAD` in the working tree).
+- Packaged artifact: `omnigent==0.12.0` (`omnigent/pyproject.toml`
+  `[project].version`, mirrored in `omnigent/omnigent/version.py`).
+- No mutable-main pin and no private monkey-patch: qualification imports
+  only the reusable modules
+  (`omnigent.server.{auth,oidc,passwords,accounts_config}`) and never
+  the whole application, permission store, runtime server, device-grant
+  store, or CLI/magic-link routes. No `sys.modules` entry for
+  `omnigent.server.app`, `omnigent.server.permissions`, or
+  `omnigent.stores.permission_store` is created (asserted in
+  `test_production_packaging_excludes_irrelevant_runtime_modules`).
+- Image provenance: no new always-on auth container is introduced by
+  this slice; deployment image changes (if any) are owned by the K4/K6
+  cutover, not by qualification.
+
+## 2. What was built
+
+- Adapter: `moonmind/security/omnigent_auth_qualification.py` — explicit
+  `MoonmindAuthConfig` (no ambient `OMNIGENT_*` reads), `ValidatedIdentity`
+  hook resolved before minting, async `AsyncAccountStore` /
+  `SessionRevocationStore` protocols with hermetic in-memory fixtures,
+  MoonMind purpose-bound sessions (`moonmind-control-plane` /
+  `moonmind-browser-session`, distinct cookies/keys), a TTL cache that
+  re-validates every hit, and fail-closed rejection of refresh,
+  delegated, runner, CLI-ticket, magic-link, and upstream-admin-roster
+  surfaces.
+- Conformance fixtures:
+  `tests/unit/security/test_omnigent_auth_qualification_4118.py` (27
+  tests covering all six acceptance criteria; hermetic — no DB, no
+  network, no credentials).
+- Canonical contract: `docs/Security/OmnigentAuthAdapterContract.md`,
+  referenced from `docs/Security/AuthenticationContracts.md` §11.
+  The K1 inventory (`docs/tmp/KeycloakRemovalInventory-4117.md`) and
+  its fixtures are untouched.
+
+## 3. Reuse evidence (real upstream entrypoints, pinned revision)
+
+`collect_upstream_probe_evidence()` (exercised by
+`test_upstream_probes_pass_on_pinned_revision`) confirms against the
+pinned commit:
+
+- `mint_session_token` + `hmac_digest` + `UnifiedAuthProvider`
+  cookie round-trip, including `None` for missing/malformed tokens.
+- Argon2 password hash/verify round-trip through
+  `omnigent.server.passwords`.
+- `AccountsConfig.from_env` and `OIDCConfig.from_env` fail loud on
+  missing configuration.
+- Upstream defaults intact (`local` reserved identity, default header
+  name, header-mode fail-closed without the single-user marker), so
+  existing standalone upstream consumers remain supported.
+
+## 4. Test results
+
+pytest is unavailable in the execution sandbox (no `pytest` module, no
+network for installs, and the MoonMind managed container backend
+requires a workflow runtime ID), so the conformance suite could not be
+executed via the canonical `./tools/test_unit.sh` runner here.
+Instead, every behavior the suite asserts was executed directly with
+the system interpreter against the real pinned upstream sources:
+
+- All five `UpstreamProbeEvidence` probes pass on the pinned revision
+  (see §3).
+- All adapter flows pass: minimal accounts/OIDC issuance, email-only
+  rejection, cross-issuer distinction, case-sensitive subjects,
+  reserved-identity rejection, argon2 round-trip, enrollment-required
+  path, admin-advisory non-promotion, inactive blocking, cross-replica
+  revocation, generation invalidation, cache-bypass resistance,
+  grant/delegated/malformed/wrong-key rejection,
+  missing/invalid/conflict semantics, unsupported-surface rejection,
+  selector fail-closed behavior, hostile ambient `OMNIGENT_*`
+  isolation, control-plane/runtime cookie/key/purpose separation, and
+  upstream-token rejection at the MoonMind boundary.
+- K1 regression risk: `docs/Security/AuthenticationContracts.md` keeps
+  all frozen structured mode rows and retired-selector coverage and
+  gains only an additive §11 pointer; `api_service/auth.py`,
+  `api_service/auth_providers.py`, and `pyproject.toml` are unmodified
+  (cutover and packaging advances belong to K4/K5). Downstream
+  verification must rerun `./tools/test_unit.sh --python-only
+  tests/unit/security/` including `test_auth_inventory_4117.py`.
+
+## 5. Known limits / handoff to K3/K4
+
+- Production persistence wiring (existing MoonMind transactions and
+  profile authority behind the new protocols) is defined but not
+  connected; K3/K4 own the concrete adapters and migration.
+- API/route cutover is explicitly out of scope: no FastAPI Users path
+  was changed or removed here.
+- No upstream code changes were required for this slice, so no upstream
+  PR is referenced. If K3/K4 need a natively supported
+  validated-claims hook inside the upstream OIDC callback (rather than
+  the MoonMind-side `ValidatedIdentity` contract defined here), that
+  upstream extension must land through the reviewed upstream process
+  before the cutover relies on it; this issue must not be read as
+  permission to substitute an insecure local copy or to call Omnigent
+  Server remotely.

--- a/moonmind/security/omnigent_auth_qualification.py
+++ b/moonmind/security/omnigent_auth_qualification.py
@@ -113,6 +113,8 @@ def _observed_omnigent_commit() -> str:
         if completed.returncode == 0 and revision:
             return revision
     except Exception:
+        # Fail closed to "unknown" so provenance never claims a revision
+        # that was not actually observed from the submodule checkout.
         pass
     return "unknown"
 
@@ -126,6 +128,8 @@ def _observed_omnigent_package() -> str:
         if _observed_version:
             return f"omnigent=={_observed_version}"
     except Exception:
+        # Fail closed to "unknown" so evidence never reports a package
+        # version that was not actually imported from the pinned bundle.
         pass
     return "unknown"
 

--- a/moonmind/security/omnigent_auth_qualification.py
+++ b/moonmind/security/omnigent_auth_qualification.py
@@ -38,9 +38,12 @@ from __future__ import annotations
 import hashlib
 import hmac
 import secrets
+import subprocess
+import sys
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol
 
 import jwt
@@ -68,6 +71,64 @@ MOONMIND_SESSION_PURPOSE = "moonmind-browser-session"
 MOONMIND_PROD_COOKIE = "__Host-mm_session"
 MOONMIND_DEV_COOKIE = "mm_session_dev"
 _SUPPORTED_ALGORITHMS = ("HS256",)
+
+# Pinned upstream revision this qualification targets. Observed provenance in
+# ``UpstreamProbeEvidence`` is derived from the checked-out submodule and the
+# imported package at runtime (see ``_observed_omnigent_*``); these constants
+# are the expected values, never the reported observation.
+PINNED_OMNIGENT_COMMIT = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
+PINNED_OMNIGENT_PACKAGE = "omnigent==0.12.0"
+
+
+def _ensure_omnigent_bundle_on_path() -> None:
+    """Put the pinned omnigent submodule bundle root on ``sys.path``.
+
+    The submodule lives at ``<repo_root>/omnigent`` and contains the
+    importable ``omnigent/`` package one level down
+    (``<repo_root>/omnigent/omnigent/server/...``). From the repository root
+    ``import omnigent.server`` would otherwise resolve the submodule root as
+    a namespace package and fail. CI's ``unit-fast`` job only runs
+    ``git submodule update --init -- omnigent`` plus
+    ``uv pip install --system -e .[tests]``; no separate Omnigent install is
+    required once this bundle root is visible.
+    """
+    bundle_root = Path(__file__).resolve().parents[2] / "omnigent"
+    bundle_text = str(bundle_root)
+    if bundle_text not in sys.path:
+        sys.path.insert(0, bundle_text)
+
+
+def _observed_omnigent_commit() -> str:
+    """Return the checked-out omnigent submodule revision, or ``"unknown"``."""
+    try:
+        bundle_root = Path(__file__).resolve().parents[2] / "omnigent"
+        completed = subprocess.run(
+            ["git", "-C", str(bundle_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        revision = (completed.stdout or "").strip()
+        if completed.returncode == 0 and revision:
+            return revision
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _observed_omnigent_package() -> str:
+    """Return the imported omnigent package version, or ``"unknown"``."""
+    try:
+        _ensure_omnigent_bundle_on_path()
+        from omnigent.version import VERSION as _observed_version
+
+        if _observed_version:
+            return f"omnigent=={_observed_version}"
+    except Exception:
+        pass
+    return "unknown"
+
 
 # Upstream cookie names observed at the pinned revision; MoonMind never uses
 # them so control-plane and runtime credentials cannot be confused.
@@ -242,33 +303,39 @@ class AsyncAccountStore(Protocol):
 
     async def resolve_identity_to_user_id(self, identity: ValidatedIdentity) -> uuid.UUID | None:
         """Map a validated (issuer, subject) pair to an existing UUID."""
-        ...
+        raise NotImplementedError
 
     async def get_account(self, user_id: uuid.UUID) -> AccountRecord | None:
-        ...
+        """Return the MoonMind account for a UUID, if any."""
+        raise NotImplementedError
 
     async def get_password_hash_by_login(self, login: str) -> str | None:
-        ...
+        """Return the stored password hash for a login, if any."""
+        raise NotImplementedError
 
     async def record_login(self, user_id: uuid.UUID, when_epoch_seconds: int) -> None:
-        ...
+        """Record a successful login; fixture implementations may no-op."""
+        raise NotImplementedError
 
 
 class SessionRevocationStore(Protocol):
     """Durable session/revocation mechanism behind a portable interface."""
 
     async def revoke_session(self, jti: str) -> None:
-        ...
+        """Durably revoke one session by JTI."""
+        raise NotImplementedError
 
     async def is_session_revoked(self, jti: str) -> bool:
-        ...
+        """Return whether a JTI was revoked."""
+        raise NotImplementedError
 
     async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
         """Invalidate all sessions for a user; returns the new generation."""
-        ...
+        raise NotImplementedError
 
     async def generation_for_user(self, user_id: uuid.UUID) -> int:
-        ...
+        """Return the current revocation generation for a user."""
+        raise NotImplementedError
 
 
 class InMemoryAsyncAccountStore:
@@ -335,6 +402,7 @@ class InMemoryRevocationStore:
 
 def qualify_password_hash(plaintext: str) -> str:
     """Hash a password with the qualified upstream argon2 implementation."""
+    _ensure_omnigent_bundle_on_path()
     from omnigent.server.passwords import hash_password
 
     return hash_password(plaintext)
@@ -342,6 +410,7 @@ def qualify_password_hash(plaintext: str) -> str:
 
 def verify_account_password(plaintext: str, password_hash: str) -> bool:
     """Verify against a stored hash; ``False`` on any mismatch or malformed hash."""
+    _ensure_omnigent_bundle_on_path()
     from omnigent.server.passwords import InvalidPasswordError, verify_password
 
     try:
@@ -377,6 +446,7 @@ async def mint_moonmind_session(
     config: MoonmindAuthConfig,
     *,
     now: int | None = None,
+    revocation: SessionRevocationStore | None = None,
 ) -> tuple[str, uuid.UUID]:
     """Mint a MoonMind-bound session for a validated identity.
 
@@ -385,6 +455,11 @@ async def mint_moonmind_session(
     A wrapper around a final subject string is insufficient; the caller
     must supply the verified claims. Email-only mappings are rejected:
     the identity must already resolve to a UUID in the store.
+
+    When ``revocation`` is supplied, the current revocation generation is
+    captured into the ``gen`` claim so every later validation can compare
+    the minted generation against the live generation even when the caller
+    does not pin ``expected_generation``.
     """
     now = now if now is not None else _now_seconds()
     user_id = await account_store.resolve_identity_to_user_id(identity)
@@ -395,7 +470,7 @@ async def mint_moonmind_session(
         raise ForbiddenError("inactive", "account inactive")
     # Upstream admin advisory is recorded nowhere privileged: MoonMind
     # superuser authority comes only from the MoonMind account record.
-    payload = {
+    payload: dict[str, Any] = {
         "sub": str(account.user_id),
         "iss": config.token_issuer,
         "aud": config.token_audience,
@@ -405,6 +480,11 @@ async def mint_moonmind_session(
         "exp": now + config.session_ttl_seconds,
         "id_issuer": identity.issuer,
     }
+    if revocation is not None:
+        try:
+            payload["gen"] = await revocation.generation_for_user(account.user_id)
+        except Exception as exc:
+            raise UnavailableError("revocation store unavailable") from exc
     token = jwt.encode(payload, config.cookie_secret, algorithm="HS256")
     await account_store.record_login(account.user_id, now)
     return token, account.user_id
@@ -455,6 +535,7 @@ async def validate_moonmind_session(
             algorithms=list(_SUPPORTED_ALGORITHMS),
             issuer=config.token_issuer,
             audience=config.token_audience,
+            options={"require": ["exp", "iss", "aud", "sub", "jti"]},
         )
     except jwt.InvalidTokenError as exc:
         raise AuthInvalidError("auth_invalid", f"invalid session: {exc}") from exc
@@ -475,15 +556,23 @@ async def validate_moonmind_session(
         raise UnavailableError("revocation store unavailable") from exc
     if revoked:
         raise AuthInvalidError("auth_invalid", "session revoked")
-    generation = await revocation.generation_for_user(user_id)
+    try:
+        generation = await revocation.generation_for_user(user_id)
+    except Exception as exc:
+        raise UnavailableError("revocation store unavailable") from exc
     if expected_generation is not None and generation != expected_generation:
         raise AuthInvalidError("auth_invalid", "stale session generation")
-    # A generation bump invalidates sessions minted before it even when the
-    # caller does not pin a generation: compare against the token's issue
-    # time is out of scope for the hermetic fixture, so any bump revokes
-    # previously observed sessions tracked via expected_generation, and
-    # revoke_all_for_user callers must re-resolve. Direct per-session
+    # Every session is compared against its minted revocation generation,
+    # even when the caller does not pin one: tokens minted with a ``gen``
+    # claim must match the live generation, and legacy tokens without the
+    # claim are rejected once any generation bump exists. Direct per-session
     # revocation covers logout; generation covers password/account events.
+    token_generation = payload.get("gen")
+    if token_generation is not None:
+        if token_generation != generation:
+            raise AuthInvalidError("auth_invalid", "stale session generation")
+    elif generation != 0:
+        raise AuthInvalidError("auth_invalid", "stale session generation")
     try:
         account = await account_store.get_account(user_id)
     except Exception as exc:
@@ -573,8 +662,8 @@ async def resolve_current_user(
 class UpstreamProbeEvidence:
     """Redacted qualification evidence for the pinned upstream revision."""
 
-    commit: str = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
-    package: str = "omnigent==0.12.0"
+    commit: str = PINNED_OMNIGENT_COMMIT
+    package: str = PINNED_OMNIGENT_PACKAGE
     session_roundtrip: bool = False
     password_roundtrip: bool = False
     accounts_config_fail_closed: bool = False
@@ -585,6 +674,7 @@ class UpstreamProbeEvidence:
 
 def probe_upstream_session_roundtrip(cookie_secret: bytes | None = None) -> bool:
     """Mint and validate a session JWT through real upstream helpers."""
+    _ensure_omnigent_bundle_on_path()
     from omnigent.server.oidc import hmac_digest, mint_session_token
 
     secret = cookie_secret or secrets.token_bytes(32)
@@ -621,6 +711,7 @@ def probe_upstream_config_fail_closed() -> tuple[bool, bool]:
     """Upstream config constructors fail loud on invalid configuration."""
     import os
 
+    _ensure_omnigent_bundle_on_path()
     from omnigent.server.accounts_config import AccountsConfig
     from omnigent.server.oidc import OIDCConfig
 
@@ -653,6 +744,7 @@ def probe_upstream_config_fail_closed() -> tuple[bool, bool]:
 
 def probe_upstream_defaults_intact() -> bool:
     """The pinned upstream default behavior is unchanged by qualification."""
+    _ensure_omnigent_bundle_on_path()
     from omnigent.server.auth import (
         RESERVED_USER_LOCAL,
         UnifiedAuthProvider,
@@ -673,8 +765,15 @@ def probe_upstream_defaults_intact() -> bool:
 
 
 def collect_upstream_probe_evidence() -> UpstreamProbeEvidence:
-    """Run all reuse probes and return redacted evidence (no secrets)."""
-    evidence = UpstreamProbeEvidence()
+    """Run all reuse probes and return redacted evidence (no secrets).
+
+    Provenance is observed from the checked-out submodule and the imported
+    package, never reported from hard-coded constants alone.
+    """
+    evidence = UpstreamProbeEvidence(
+        commit=_observed_omnigent_commit(),
+        package=_observed_omnigent_package(),
+    )
     try:
         evidence.session_roundtrip = probe_upstream_session_roundtrip()
     except Exception as exc:

--- a/moonmind/security/omnigent_auth_qualification.py
+++ b/moonmind/security/omnigent_auth_qualification.py
@@ -1,0 +1,696 @@
+"""K2 qualification adapter: portable Omnigent authentication interfaces.
+
+Source issue: MoonLadderStudios/MoonMind#4118 (parent #4116, depends on #4117).
+Plan coverage: K2 in ``docs/tmp/KeycloakRemovalPlan.md``.
+
+This module is the MoonMind-side qualification slice. It composes small,
+real upstream primitives (session-JWT machinery, argon2 password helpers,
+fail-closed config validation) inside the MoonMind API process using
+explicit MoonMind configuration and injected persistence. It does not
+import or boot the whole upstream application, permission store, runtime
+server, or retired embedded host transport.
+
+Reusable upstream entrypoints probed here (pinned commit
+``f04b0354fb5344c1ea8b92795ceb6760a9ad7595``, package ``omnigent==0.12.0``):
+
+- ``omnigent.server.oidc.mint_session_token`` / ``hmac_digest``
+- ``omnigent.server.passwords.{hash_password, verify_password}``
+- ``omnigent.server.auth.UnifiedAuthProvider`` cookie/header validation
+- ``omnigent.server.accounts_config.AccountsConfig.from_env`` /
+  ``omnigent.server.oidc.OIDCConfig.from_env`` fail-closed validation
+
+MoonMind binds its own session policy on top (application issuer/audience
+purpose, supported algorithms, expiry, distinct cookies/keys, live
+revocation, current-user checks). Upstream runtime tokens are rejected at
+the MoonMind boundary. Unsupported upstream surfaces (refresh grants,
+delegated scope tokens, runner minting, CLI tickets, magic links) are
+explicitly rejected, never accepted by broadening upstream allowlists.
+
+Non-goals (owned by later issues): API cutover wiring (K4), schema
+migration and account lifecycle (K3), removal manifest (K5), deployment
+cutover (K6). No new auth microservice, no copied OIDC/password
+implementation, no whole-server embedding, no promotion of upstream admin
+flags into MoonMind superuser authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import jwt
+
+# ---------------------------------------------------------------------------
+# Mode selector and fail-closed validation
+# ---------------------------------------------------------------------------
+
+SUPPORTED_MODES = ("accounts", "oidc", "header", "disabled")
+RETIRED_SELECTORS = ("keycloak", "default", "google")
+
+_RETIRED_GUIDANCE = {
+    "keycloak": "AUTH_PROVIDER='keycloak' was removed. Choose 'accounts', 'oidc', "
+    "'header', or explicit 'disabled' local mode per "
+    "docs/Security/AuthenticationContracts.md and re-run migration preflight.",
+    "default": "AUTH_PROVIDER='default' was removed. It is not an alias for any "
+    "supported mode. Choose an explicit supported mode.",
+    "google": "AUTH_PROVIDER='google' was removed. Use generic 'oidc' with explicit "
+    "issuer/client configuration.",
+}
+
+MOONMIND_TOKEN_ISSUER = "moonmind-control-plane"
+MOONMIND_TOKEN_AUDIENCE = "moonmind-browser-session"
+MOONMIND_SESSION_PURPOSE = "moonmind-browser-session"
+MOONMIND_PROD_COOKIE = "__Host-mm_session"
+MOONMIND_DEV_COOKIE = "mm_session_dev"
+_SUPPORTED_ALGORITHMS = ("HS256",)
+
+# Upstream cookie names observed at the pinned revision; MoonMind never uses
+# them so control-plane and runtime credentials cannot be confused.
+UPSTREAM_SESSION_COOKIES = frozenset({"__Host-ap_session", "ap_session"})
+
+# Surfaces the upstream package offers that MoonMind does not expose to the
+# browser. Presenting any of them is a fail-closed rejection, never a grant
+# of MoonMind authority.
+UNSUPPORTED_SURFACES = (
+    "refresh",
+    "delegated",
+    "runner_token",
+    "cli_ticket",
+    "magic_link",
+    "upstream_admin_roster",
+)
+
+
+class AuthConfigError(ValueError):
+    """Fail-closed configuration error with migration guidance."""
+
+
+class AuthInvalidError(Exception):
+    """Invalid, expired, wrong-key/issuer/purpose, or reserved credential."""
+
+    def __init__(self, code: str = "auth_invalid", message: str = "invalid credential"):
+        super().__init__(message)
+        self.code = code
+
+
+class AuthRequiredError(Exception):
+    """Missing credential at a strict boundary."""
+
+    def __init__(self, message: str = "authentication required"):
+        super().__init__(message)
+        self.code = "auth_required"
+
+
+class AuthConflictError(Exception):
+    """Conflicting cookie/bearer identities in one request."""
+
+    def __init__(self, message: str = "conflicting identities"):
+        super().__init__(message)
+        self.code = "auth_conflict"
+
+
+class ForbiddenError(Exception):
+    """Authenticated but inactive or not authorized."""
+
+    def __init__(self, code: str = "forbidden", message: str = "forbidden"):
+        super().__init__(message)
+        self.code = code
+
+
+class UnavailableError(Exception):
+    """Identity/database unavailable; fail closed, never an admin stub."""
+
+    def __init__(self, message: str = "identity store unavailable"):
+        super().__init__(message)
+        self.code = "unavailable"
+
+
+class UnsupportedSurfaceError(Exception):
+    """An upstream optional surface was presented to the MoonMind boundary."""
+
+    def __init__(self, surface: str):
+        super().__init__(f"unsupported authentication surface: {surface}")
+        self.surface = surface
+        self.code = "unsupported_surface"
+
+
+def validate_mode_selector(mode: str) -> str:
+    """Validate a MoonMind ``AUTH_PROVIDER`` selector, failing closed.
+
+    Unknown and retired selectors raise :class:`AuthConfigError` with
+    migration guidance; they are never silently translated.
+    """
+    normalized = (mode or "").strip().lower()
+    if normalized in SUPPORTED_MODES:
+        return normalized
+    if normalized in _RETIRED_GUIDANCE:
+        raise AuthConfigError(_RETIRED_GUIDANCE[normalized])
+    raise AuthConfigError(
+        f"Unknown AUTH_PROVIDER={mode!r}. Supported: "
+        f"{', '.join(SUPPORTED_MODES)}. See "
+        "docs/Security/AuthenticationContracts.md."
+    )
+
+
+@dataclass(frozen=True)
+class MoonmindAuthConfig:
+    """Explicit control-plane authentication configuration.
+
+    All values are passed explicitly by the caller. This object never reads
+    ``OMNIGENT_AUTH_*`` (or any other ambient environment state); hostile
+    ambient values cannot select MoonMind behavior. Upstream's independent
+    default behavior is left intact.
+    """
+
+    mode: str
+    cookie_name: str
+    cookie_secret: bytes
+    session_ttl_seconds: int = 8 * 3600
+    token_issuer: str = MOONMIND_TOKEN_ISSUER
+    token_audience: str = MOONMIND_TOKEN_AUDIENCE
+    require_secure_cookies: bool = True
+
+    def __post_init__(self) -> None:
+        validate_mode_selector(self.mode)
+        if not isinstance(self.cookie_secret, (bytes, bytearray)) or len(self.cookie_secret) < 32:
+            raise AuthConfigError("cookie_secret must be at least 32 bytes")
+        if self.cookie_name in UPSTREAM_SESSION_COOKIES:
+            raise AuthConfigError(
+                f"cookie_name={self.cookie_name!r} collides with the upstream "
+                "runtime session cookie; control-plane and runtime cookies "
+                "must be distinct."
+            )
+        if not self.token_issuer or not self.token_audience:
+            raise AuthConfigError("token_issuer and token_audience must be non-empty")
+        if self.session_ttl_seconds <= 0:
+            raise AuthConfigError("session_ttl_seconds must be positive")
+
+
+# ---------------------------------------------------------------------------
+# Validated identity: resolved before any session is minted
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidatedIdentity:
+    """Identity verified before session minting.
+
+    For OIDC, ``issuer`` is the full verified issuer URI and ``subject`` is
+    the case-sensitive verified subject claim. For built-in accounts,
+    ``issuer`` names the local account namespace (``"moonmind-accounts"``)
+    and ``subject`` is the verified login name. ``email`` is informational
+    only and never used as the identity key.
+
+    ``upstream_is_admin`` is advisory from the upstream roster (if any) and
+    is never promoted into MoonMind superuser authority by this adapter.
+    """
+
+    issuer: str
+    subject: str
+    email: str | None = None
+    upstream_is_admin: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.issuer or not self.subject:
+            raise AuthConfigError("ValidatedIdentity requires non-empty issuer and subject")
+        for reserved in ("local", "__public__"):
+            if self.subject == reserved or (self.email or "") == reserved:
+                raise AuthInvalidError("auth_invalid", f"reserved identity {reserved!r}")
+
+
+@dataclass(frozen=True)
+class AccountRecord:
+    """MoonMind-owned account state. ``is_superuser`` stays server-owned."""
+
+    user_id: uuid.UUID
+    is_active: bool = True
+    is_superuser: bool = False
+    email: str | None = None
+
+
+class AsyncAccountStore(Protocol):
+    """Async-safe persistence boundary for identity resolution.
+
+    Production wiring uses existing MoonMind transactions and profile
+    authority through adapters (K3/K4). No parallel account/admin tables.
+    """
+
+    async def resolve_identity_to_user_id(self, identity: ValidatedIdentity) -> uuid.UUID | None:
+        """Map a validated (issuer, subject) pair to an existing UUID."""
+        ...
+
+    async def get_account(self, user_id: uuid.UUID) -> AccountRecord | None:
+        ...
+
+    async def get_password_hash_by_login(self, login: str) -> str | None:
+        ...
+
+    async def record_login(self, user_id: uuid.UUID, when_epoch_seconds: int) -> None:
+        ...
+
+
+class SessionRevocationStore(Protocol):
+    """Durable session/revocation mechanism behind a portable interface."""
+
+    async def revoke_session(self, jti: str) -> None:
+        ...
+
+    async def is_session_revoked(self, jti: str) -> bool:
+        ...
+
+    async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
+        """Invalidate all sessions for a user; returns the new generation."""
+        ...
+
+    async def generation_for_user(self, user_id: uuid.UUID) -> int:
+        ...
+
+
+class InMemoryAsyncAccountStore:
+    """Hermetic fixture store: no second database, no network."""
+
+    def __init__(self) -> None:
+        self._identity_map: dict[tuple[str, str], uuid.UUID] = {}
+        self._accounts: dict[uuid.UUID, AccountRecord] = {}
+        self._password_hashes: dict[str, str] = {}
+        self.login_calls: list[tuple[str, str]] = []
+
+    def enroll(
+        self,
+        identity: ValidatedIdentity,
+        account: AccountRecord,
+        *,
+        password_hash: str | None = None,
+        login: str | None = None,
+    ) -> None:
+        self._identity_map[(identity.issuer, identity.subject)] = account.user_id
+        self._accounts[account.user_id] = account
+        if password_hash is not None and login is not None:
+            self._password_hashes[login.strip().lower()] = password_hash
+
+    async def resolve_identity_to_user_id(self, identity: ValidatedIdentity) -> uuid.UUID | None:
+        self.login_calls.append((identity.issuer, identity.subject))
+        return self._identity_map.get((identity.issuer, identity.subject))
+
+    async def get_account(self, user_id: uuid.UUID) -> AccountRecord | None:
+        return self._accounts.get(user_id)
+
+    async def get_password_hash_by_login(self, login: str) -> str | None:
+        return self._password_hashes.get(login.strip().lower())
+
+    async def record_login(self, user_id: uuid.UUID, when_epoch_seconds: int) -> None:
+        return None
+
+
+class InMemoryRevocationStore:
+    """Hermetic durable-revocation fixture shared across validator replicas."""
+
+    def __init__(self) -> None:
+        self._revoked: set[str] = set()
+        self._generations: dict[uuid.UUID, int] = {}
+
+    async def revoke_session(self, jti: str) -> None:
+        self._revoked.add(jti)
+
+    async def is_session_revoked(self, jti: str) -> bool:
+        return jti in self._revoked
+
+    async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
+        self._generations[user_id] = self._generations.get(user_id, 0) + 1
+        return self._generations[user_id]
+
+    async def generation_for_user(self, user_id: uuid.UUID) -> int:
+        return self._generations.get(user_id, 0)
+
+
+# ---------------------------------------------------------------------------
+# Password-hash qualification via the reusable upstream implementation
+# ---------------------------------------------------------------------------
+
+
+def qualify_password_hash(plaintext: str) -> str:
+    """Hash a password with the qualified upstream argon2 implementation."""
+    from omnigent.server.passwords import hash_password
+
+    return hash_password(plaintext)
+
+
+def verify_account_password(plaintext: str, password_hash: str) -> bool:
+    """Verify against a stored hash; ``False`` on any mismatch or malformed hash."""
+    from omnigent.server.passwords import InvalidPasswordError, verify_password
+
+    try:
+        verify_password(plaintext, password_hash)
+        return True
+    except InvalidPasswordError:
+        return False
+
+
+def password_enrollment_required(password_hash: str | None) -> bool:
+    """Whether login must take the controlled enrollment/reset path.
+
+    Unknown, missing, or non-argon2 hashes are never assumed compatible;
+    the caller must require enrollment or reset instead of logging in.
+    """
+    if not password_hash:
+        return True
+    return not password_hash.startswith("$argon2")
+
+
+# ---------------------------------------------------------------------------
+# Session issuance and validation with MoonMind purpose binding
+# ---------------------------------------------------------------------------
+
+
+def _now_seconds() -> int:
+    return int(time.time())
+
+
+async def mint_moonmind_session(
+    identity: ValidatedIdentity,
+    account_store: AsyncAccountStore,
+    config: MoonmindAuthConfig,
+    *,
+    now: int | None = None,
+) -> tuple[str, uuid.UUID]:
+    """Mint a MoonMind-bound session for a validated identity.
+
+    Resolution order (observed by conformance fixtures): validated
+    (issuer, subject) -> existing MoonMind UUID -> active account -> mint.
+    A wrapper around a final subject string is insufficient; the caller
+    must supply the verified claims. Email-only mappings are rejected:
+    the identity must already resolve to a UUID in the store.
+    """
+    now = now if now is not None else _now_seconds()
+    user_id = await account_store.resolve_identity_to_user_id(identity)
+    if user_id is None:
+        raise AuthInvalidError("auth_invalid", "unknown identity: enrollment required")
+    account = await account_store.get_account(user_id)
+    if account is None or not account.is_active:
+        raise ForbiddenError("inactive", "account inactive")
+    # Upstream admin advisory is recorded nowhere privileged: MoonMind
+    # superuser authority comes only from the MoonMind account record.
+    payload = {
+        "sub": str(account.user_id),
+        "iss": config.token_issuer,
+        "aud": config.token_audience,
+        "purpose": MOONMIND_SESSION_PURPOSE,
+        "jti": secrets.token_hex(16),
+        "iat": now,
+        "exp": now + config.session_ttl_seconds,
+        "id_issuer": identity.issuer,
+    }
+    token = jwt.encode(payload, config.cookie_secret, algorithm="HS256")
+    await account_store.record_login(account.user_id, now)
+    return token, account.user_id
+
+
+def assert_surface_not_used(surface: str) -> None:
+    """Fail closed when an unsupported upstream surface is presented."""
+    if surface in UNSUPPORTED_SURFACES:
+        raise UnsupportedSurfaceError(surface)
+    raise AuthConfigError(f"unknown surface {surface!r}")
+
+
+def reject_unsupported_token_shape(payload: dict[str, Any]) -> None:
+    """Reject grant-derived and delegated token shapes at the boundary.
+
+    Any ``grant_id`` (login/device grant) or ``scope`` (delegated) claim
+    marks a token the MoonMind browser boundary never accepts. Refresh
+    material is never accepted here either. MoonMind does not broaden the
+    upstream delegated endpoint allowlist to admit these.
+    """
+    if payload.get("grant_id") is not None:
+        raise UnsupportedSurfaceError("refresh")
+    if payload.get("scope") is not None:
+        raise UnsupportedSurfaceError("delegated")
+    if payload.get("refresh_token") is not None:
+        raise UnsupportedSurfaceError("refresh")
+
+
+async def validate_moonmind_session(
+    token: str,
+    account_store: AsyncAccountStore,
+    revocation: SessionRevocationStore,
+    config: MoonmindAuthConfig,
+    *,
+    expected_generation: int | None = None,
+) -> AccountRecord:
+    """Validate a MoonMind session token, failing closed.
+
+    Every call checks signature, algorithm, issuer, audience/purpose,
+    expiry, live revocation, generation, and current principal status --
+    including cache-mediated callers, which must route through this
+    function rather than trusting a cached subject.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            config.cookie_secret,
+            algorithms=list(_SUPPORTED_ALGORITHMS),
+            issuer=config.token_issuer,
+            audience=config.token_audience,
+        )
+    except jwt.InvalidTokenError as exc:
+        raise AuthInvalidError("auth_invalid", f"invalid session: {exc}") from exc
+    if payload.get("purpose") != MOONMIND_SESSION_PURPOSE:
+        raise AuthInvalidError("auth_invalid", "wrong token purpose")
+    reject_unsupported_token_shape(payload)
+    jti = payload.get("jti")
+    sub = payload.get("sub")
+    if not isinstance(jti, str) or not jti:
+        raise AuthInvalidError("auth_invalid", "session without jti")
+    try:
+        user_id = uuid.UUID(str(sub))
+    except (ValueError, TypeError) as exc:
+        raise AuthInvalidError("auth_invalid", "session without UUID subject") from exc
+    try:
+        revoked = await revocation.is_session_revoked(jti)
+    except Exception as exc:
+        raise UnavailableError("revocation store unavailable") from exc
+    if revoked:
+        raise AuthInvalidError("auth_invalid", "session revoked")
+    generation = await revocation.generation_for_user(user_id)
+    if expected_generation is not None and generation != expected_generation:
+        raise AuthInvalidError("auth_invalid", "stale session generation")
+    # A generation bump invalidates sessions minted before it even when the
+    # caller does not pin a generation: compare against the token's issue
+    # time is out of scope for the hermetic fixture, so any bump revokes
+    # previously observed sessions tracked via expected_generation, and
+    # revoke_all_for_user callers must re-resolve. Direct per-session
+    # revocation covers logout; generation covers password/account events.
+    try:
+        account = await account_store.get_account(user_id)
+    except Exception as exc:
+        raise UnavailableError("account store unavailable") from exc
+    if account is None or not account.is_active:
+        raise ForbiddenError("inactive", "account inactive")
+    return account
+
+
+class SessionValidationCache:
+    """TTL credential cache that cannot bypass request-specific checks.
+
+    The cache stores only (jti, user_id, expiry) keyed by HMAC digest and
+    every hit re-runs :func:`validate_moonmind_session`, so revocation,
+    generation, scope, and principal-status checks are never skipped.
+    Grant-derived tokens are never inserted.
+    """
+
+    def __init__(self, config: MoonmindAuthConfig) -> None:
+        self._config = config
+        self._entries: dict[str, tuple[str, float]] = {}
+        self.hits = 0
+        self.misses = 0
+
+    def _key(self, token: str) -> str:
+        return hmac.new(self._config.cookie_secret, token.encode(), hashlib.sha256).hexdigest()
+
+    async def validate(
+        self,
+        token: str,
+        account_store: AsyncAccountStore,
+        revocation: SessionRevocationStore,
+    ) -> AccountRecord:
+        key = self._key(token)
+        cached = self._entries.get(key)
+        account = await validate_moonmind_session(token, account_store, revocation, self._config)
+        now_mono = time.monotonic()
+        if cached is not None and cached[1] > now_mono:
+            self.hits += 1
+        else:
+            self.misses += 1
+        # Never cache grant-derived shapes: validation already rejected
+        # them, so reaching here means a plain session token.
+        try:
+            payload = jwt.decode(token, options={"verify_signature": False})
+            remaining = float(payload.get("exp", 0)) - time.time()
+        except Exception:
+            remaining = 0
+        if remaining > 0:
+            self._entries[key] = (str(account.user_id), now_mono + remaining)
+        return account
+
+
+async def resolve_current_user(
+    *,
+    cookie_token: str | None,
+    bearer_token: str | None,
+    account_store: AsyncAccountStore,
+    revocation: SessionRevocationStore,
+    config: MoonmindAuthConfig,
+    optional: bool = False,
+) -> AccountRecord | None:
+    """Resolve the current user with missing-vs-invalid and conflict semantics."""
+    if not cookie_token and not bearer_token:
+        if optional:
+            return None
+        raise AuthRequiredError()
+    if cookie_token and bearer_token and cookie_token != bearer_token:
+        # Two presented credentials must resolve to the same principal;
+        # conflicting identities are rejected, never silently preferred.
+        first = await validate_moonmind_session(cookie_token, account_store, revocation, config)
+        second = await validate_moonmind_session(bearer_token, account_store, revocation, config)
+        if first.user_id != second.user_id:
+            raise AuthConflictError()
+        return first
+    token = cookie_token or bearer_token
+    assert token is not None
+    return await validate_moonmind_session(token, account_store, revocation, config)
+
+
+# ---------------------------------------------------------------------------
+# Upstream reuse probes: evidence that pinned entrypoints are reusable
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UpstreamProbeEvidence:
+    """Redacted qualification evidence for the pinned upstream revision."""
+
+    commit: str = "f04b0354fb5344c1ea8b92795ceb6760a9ad7595"
+    package: str = "omnigent==0.12.0"
+    session_roundtrip: bool = False
+    password_roundtrip: bool = False
+    accounts_config_fail_closed: bool = False
+    oidc_config_fail_closed: bool = False
+    upstream_defaults_intact: bool = False
+    notes: list[str] = field(default_factory=list)
+
+
+def probe_upstream_session_roundtrip(cookie_secret: bytes | None = None) -> bool:
+    """Mint and validate a session JWT through real upstream helpers."""
+    from omnigent.server.oidc import hmac_digest, mint_session_token
+
+    secret = cookie_secret or secrets.token_bytes(32)
+
+    class _Conn:
+        def __init__(self, cookies: dict[str, str], headers: dict[str, str], path: str = "/"):
+            self.cookies = cookies
+            self.headers = headers
+            self.url = type("U", (), {"path": path})()
+
+    from omnigent.server.auth import UnifiedAuthProvider
+
+    token = mint_session_token("probe-user-4118", secret, 3600, "accounts")
+    assert hmac_digest(token, secret)
+
+    class _Cfg:
+        def __init__(self, s: bytes) -> None:
+            self.cookie_secret = s
+            self.session_cookie_name = "ap_session"
+
+    provider = UnifiedAuthProvider(source="accounts", accounts_config=_Cfg(secret))  # type: ignore[arg-type]
+    assert provider.get_user_id(_Conn({"ap_session": token}, {})) == "probe-user-4118"  # type: ignore[arg-type]
+    assert provider.get_user_id(_Conn({}, {})) is None  # type: ignore[arg-type]
+    assert provider.get_user_id(_Conn({"ap_session": "malformed"}, {})) is None  # type: ignore[arg-type]
+    return True
+
+
+def probe_upstream_password_roundtrip() -> bool:
+    """Hash and verify through the real upstream argon2 implementation."""
+    return verify_account_password("correct horse 4118", qualify_password_hash("correct horse 4118"))
+
+
+def probe_upstream_config_fail_closed() -> tuple[bool, bool]:
+    """Upstream config constructors fail loud on invalid configuration."""
+    import os
+
+    from omnigent.server.accounts_config import AccountsConfig
+    from omnigent.server.oidc import OIDCConfig
+
+    saved = dict(os.environ)
+    try:
+        for var in (
+            "OMNIGENT_ACCOUNTS_COOKIE_SECRET",
+            "OMNIGENT_ACCOUNTS_BASE_URL",
+            "OMNIGENT_OIDC_ISSUER",
+            "OMNIGENT_OIDC_CLIENT_ID",
+            "OMNIGENT_OIDC_CLIENT_SECRET",
+            "OMNIGENT_OIDC_COOKIE_SECRET",
+        ):
+            os.environ.pop(var, None)
+        try:
+            AccountsConfig.from_env()
+            accounts_failed = False
+        except RuntimeError:
+            accounts_failed = True
+        try:
+            OIDCConfig.from_env()
+            oidc_failed = False
+        except RuntimeError:
+            oidc_failed = True
+        return accounts_failed, oidc_failed
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def probe_upstream_defaults_intact() -> bool:
+    """The pinned upstream default behavior is unchanged by qualification."""
+    from omnigent.server.auth import (
+        RESERVED_USER_LOCAL,
+        UnifiedAuthProvider,
+        resolve_auth_header,
+    )
+
+    assert RESERVED_USER_LOCAL == "local"
+    assert resolve_auth_header() == "X-Forwarded-Email" or isinstance(resolve_auth_header(), str)
+
+    class _Conn:
+        headers: dict[str, str] = {}
+        cookies: dict[str, str] = {}
+        url = type("U", (), {"path": "/"})()
+
+    header_provider = UnifiedAuthProvider(source="header", local_single_user=False)
+    assert header_provider.get_user_id(_Conn()) is None  # type: ignore[arg-type]
+    return True
+
+
+def collect_upstream_probe_evidence() -> UpstreamProbeEvidence:
+    """Run all reuse probes and return redacted evidence (no secrets)."""
+    evidence = UpstreamProbeEvidence()
+    try:
+        evidence.session_roundtrip = probe_upstream_session_roundtrip()
+    except Exception as exc:
+        evidence.notes.append(f"session_roundtrip failed: {type(exc).__name__}")
+    try:
+        evidence.password_roundtrip = probe_upstream_password_roundtrip()
+    except Exception as exc:
+        evidence.notes.append(f"password_roundtrip failed: {type(exc).__name__}")
+    try:
+        accounts_failed, oidc_failed = probe_upstream_config_fail_closed()
+        evidence.accounts_config_fail_closed = accounts_failed
+        evidence.oidc_config_fail_closed = oidc_failed
+    except Exception as exc:
+        evidence.notes.append(f"config_fail_closed failed: {type(exc).__name__}")
+    try:
+        evidence.upstream_defaults_intact = probe_upstream_defaults_intact()
+    except Exception as exc:
+        evidence.notes.append(f"defaults_intact failed: {type(exc).__name__}")
+    return evidence

--- a/tests/unit/security/test_omnigent_auth_qualification_4118.py
+++ b/tests/unit/security/test_omnigent_auth_qualification_4118.py
@@ -1,0 +1,476 @@
+"""K2 conformance fixtures for MoonLadderStudios/MoonMind#4118.
+
+Hermetic qualification of the portable Omnigent authentication boundary:
+real upstream primitives (session-JWT machinery, argon2 passwords,
+fail-closed config validation) composed in the MoonMind process with
+explicit config and injected persistence. No second account database, no
+remote runtime request, no private monkey-patches, no network, no DB.
+
+Consumed by later Keycloak-removal issues (K3/K4) as the adapter
+conformance contract.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+import uuid
+
+import jwt
+import pytest
+
+from moonmind.security import omnigent_auth_qualification as q
+
+
+def _config(mode: str = "accounts", **overrides) -> q.MoonmindAuthConfig:
+    base = {
+        "mode": mode,
+        "cookie_name": q.MOONMIND_DEV_COOKIE,
+        "cookie_secret": secrets.token_bytes(32),
+        "session_ttl_seconds": 3600,
+        "require_secure_cookies": False,
+    }
+    base.update(overrides)
+    return q.MoonmindAuthConfig(**base)  # type: ignore[arg-type]
+
+
+def _identity(
+    issuer: str = "moonmind-accounts",
+    subject: str = "alice",
+    **overrides,
+) -> q.ValidatedIdentity:
+    base = {"issuer": issuer, "subject": subject}
+    base.update(overrides)
+    return q.ValidatedIdentity(**base)  # type: ignore[arg-type]
+
+
+def _enrolled(store: q.InMemoryAsyncAccountStore, identity, user_id=None, **kw):
+    account = q.AccountRecord(user_id=user_id or uuid.uuid4(), **kw)
+    store.enroll(identity, account)
+    return account
+
+
+# ---------------------------------------------------------------------------
+# 1. Minimal real authentication flow in the MoonMind process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minimal_accounts_flow_with_explicit_config_and_injected_persistence():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=True, is_superuser=False)
+
+    token, user_id = await q.mint_moonmind_session(identity, store, config)
+    assert user_id == account.user_id
+    # Session subject is the MoonMind UUID, not the login name.
+    assert jwt.decode(token, options={"verify_signature": False})["sub"] == str(account.user_id)
+
+    resolved = await q.resolve_current_user(
+        cookie_token=token,
+        bearer_token=None,
+        account_store=store,
+        revocation=revocation,
+        config=config,
+    )
+    assert resolved is not None and resolved.user_id == account.user_id
+    # Identity hook ran before minting: exactly one store resolution call.
+    assert store.login_calls == [(identity.issuer, identity.subject)]
+
+
+@pytest.mark.asyncio
+async def test_oidc_flow_resolves_verified_issuer_subject_before_minting():
+    config = _config("oidc")
+    store = q.InMemoryAsyncAccountStore()
+    identity = _identity(
+        issuer="https://idp.example.invalid",
+        subject="UserA-123",
+        email="alice@example.invalid",
+    )
+    account = _enrolled(store, identity)
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    claims = jwt.decode(token, options={"verify_signature": False})
+    assert claims["id_issuer"] == "https://idp.example.invalid"
+    assert claims["sub"] == str(account.user_id)
+    assert claims["sub"] != "alice@example.invalid"
+
+
+# ---------------------------------------------------------------------------
+# 2. No email/username-only UUID mapping; case-sensitive, issuer-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_email_only_match_does_not_resolve_identity():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    enrolled_identity = _identity(subject="alice")
+    account = _enrolled(store, enrolled_identity, email="alice@example.invalid")
+    assert account.email == "alice@example.invalid"
+    # Same email, different subject: enrollment required, not auto-linked.
+    with pytest.raises(q.AuthInvalidError):
+        await q.mint_moonmind_session(
+            _identity(subject="alice2", email="alice@example.invalid"), store, config
+        )
+
+
+@pytest.mark.asyncio
+async def test_same_email_across_issuers_resolves_distinct_uuids():
+    config = _config("oidc")
+    store = q.InMemoryAsyncAccountStore()
+    id_a = _identity(issuer="https://a.example.invalid", subject="sub-1", email="x@y.invalid")
+    id_b = _identity(issuer="https://b.example.invalid", subject="sub-1", email="x@y.invalid")
+    acc_a = _enrolled(store, id_a)
+    acc_b = _enrolled(store, id_b)
+    assert acc_a.user_id != acc_b.user_id
+    _, uid_a = await q.mint_moonmind_session(id_a, store, config)
+    _, uid_b = await q.mint_moonmind_session(id_b, store, config)
+    assert uid_a == acc_a.user_id and uid_b == acc_b.user_id
+
+
+@pytest.mark.asyncio
+async def test_subject_matching_is_case_sensitive():
+    store = q.InMemoryAsyncAccountStore()
+    config = _config("oidc")
+    lower = _identity(issuer="https://idp.example.invalid", subject="usera")
+    _enrolled(store, lower)
+    with pytest.raises(q.AuthInvalidError):
+        await q.mint_moonmind_session(
+            _identity(issuer="https://idp.example.invalid", subject="UserA"), store, config
+        )
+
+
+def test_reserved_identities_rejected_before_minting():
+    with pytest.raises(q.AuthInvalidError):
+        _identity(subject="local")
+    with pytest.raises(q.AuthInvalidError):
+        _identity(subject="__public__")
+
+
+# ---------------------------------------------------------------------------
+# 3. Async-safe persistence, passwords, admin policy, durable revocation
+# ---------------------------------------------------------------------------
+
+
+def test_password_roundtrip_uses_qualified_upstream_argon2():
+    hashed = q.qualify_password_hash("correct horse 4118")
+    assert hashed.startswith("$argon2")
+    assert q.verify_account_password("correct horse 4118", hashed) is True
+    assert q.verify_account_password("wrong password", hashed) is False
+    assert q.verify_account_password("anything", "not-a-hash") is False
+
+
+def test_password_enrollment_required_for_missing_or_foreign_hashes():
+    assert q.password_enrollment_required(None) is True
+    assert q.password_enrollment_required("") is True
+    assert q.password_enrollment_required("$2b$12$bcrypt-hash") is True
+    assert q.password_enrollment_required(q.qualify_password_hash("x" * 12)) is False
+
+
+@pytest.mark.asyncio
+async def test_upstream_admin_advisory_never_promotes_to_superuser():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity(upstream_is_admin=True)
+    _enrolled(store, identity, is_superuser=False)
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    resolved = await q.validate_moonmind_session(token, store, revocation, config)
+    assert resolved.is_superuser is False
+
+
+@pytest.mark.asyncio
+async def test_inactive_account_blocked_at_mint_and_at_validation():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=False)
+    with pytest.raises(q.ForbiddenError):
+        await q.mint_moonmind_session(identity, store, config)
+    # Even a minted-shaped token for a demoted operator fails validation.
+    store._accounts[account.user_id] = q.AccountRecord(
+        user_id=account.user_id, is_active=True
+    )
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    store._accounts[account.user_id] = q.AccountRecord(
+        user_id=account.user_id, is_active=False
+    )
+    with pytest.raises(q.ForbiddenError):
+        await q.validate_moonmind_session(token, store, revocation, config)
+
+
+@pytest.mark.asyncio
+async def test_logout_revocation_is_durable_across_validator_replicas():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    replica_a = q.SessionValidationCache(config)
+    replica_b = q.SessionValidationCache(config)
+    identity = _identity()
+    _enrolled(store, identity)
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    await replica_a.validate(token, store, revocation)
+    jti = jwt.decode(token, options={"verify_signature": False})["jti"]
+    await revocation.revoke_session(jti)
+    with pytest.raises(q.AuthInvalidError):
+        await replica_b.validate(token, store, revocation)
+
+
+@pytest.mark.asyncio
+async def test_password_reset_generation_invalidates_sessions():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity)
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    generation = await revocation.generation_for_user(account.user_id)
+    await q.validate_moonmind_session(
+        token, store, revocation, config, expected_generation=generation
+    )
+    new_generation = await revocation.revoke_all_for_user(account.user_id)
+    assert new_generation == generation + 1
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(
+            token, store, revocation, config, expected_generation=generation
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Cache, grant-derived, malformed, and unsupported-surface rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_cannot_bypass_revocation_or_status():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    cache = q.SessionValidationCache(config)
+    identity = _identity()
+    account = _enrolled(store, identity)
+    token, _ = await q.mint_moonmind_session(identity, store, config)
+    await cache.validate(token, store, revocation)
+    assert cache.misses == 1
+    jti = jwt.decode(token, options={"verify_signature": False})["jti"]
+    await revocation.revoke_session(jti)
+    with pytest.raises(q.AuthInvalidError):
+        await cache.validate(token, store, revocation)
+
+
+@pytest.mark.asyncio
+async def test_grant_derived_token_rejected_despite_valid_signature():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity)
+    now = int(time.time())
+    grant_token = jwt.encode(
+        {
+            "sub": str(account.user_id),
+            "iss": config.token_issuer,
+            "aud": config.token_audience,
+            "purpose": q.MOONMIND_SESSION_PURPOSE,
+            "jti": secrets.token_hex(16),
+            "iat": now,
+            "exp": now + 3600,
+            "grant_id": "grant-4118",
+        },
+        config.cookie_secret,
+        algorithm="HS256",
+    )
+    with pytest.raises(q.UnsupportedSurfaceError):
+        await q.validate_moonmind_session(grant_token, store, revocation, config)
+    scoped = jwt.encode(
+        {
+            "sub": str(account.user_id),
+            "iss": config.token_issuer,
+            "aud": config.token_audience,
+            "purpose": q.MOONMIND_SESSION_PURPOSE,
+            "jti": secrets.token_hex(16),
+            "iat": now,
+            "exp": now + 3600,
+            "scope": "sessions:read",
+        },
+        config.cookie_secret,
+        algorithm="HS256",
+    )
+    with pytest.raises(q.UnsupportedSurfaceError):
+        await q.validate_moonmind_session(scoped, store, revocation, config)
+
+
+@pytest.mark.asyncio
+async def test_malformed_and_wrong_key_tokens_rejected():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session("malformed", store, revocation, config)
+    other = _config("accounts")
+    identity = _identity()
+    _enrolled(store, identity)
+    foreign, _ = await q.mint_moonmind_session(identity, store, other)
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(foreign, store, revocation, config)
+
+
+@pytest.mark.asyncio
+async def test_missing_vs_invalid_vs_conflict_semantics():
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    with pytest.raises(q.AuthRequiredError):
+        await q.resolve_current_user(
+            cookie_token=None,
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+    assert (
+        await q.resolve_current_user(
+            cookie_token=None,
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+            optional=True,
+        )
+        is None
+    )
+    with pytest.raises(q.AuthInvalidError):
+        await q.resolve_current_user(
+            cookie_token="bogus",
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+    id_a = _identity(subject="alice")
+    id_b = _identity(subject="bob")
+    acc_a = _enrolled(store, id_a)
+    acc_b = _enrolled(store, id_b)
+    assert acc_a.user_id != acc_b.user_id
+    tok_a, _ = await q.mint_moonmind_session(id_a, store, config)
+    tok_b, _ = await q.mint_moonmind_session(id_b, store, config)
+    with pytest.raises(q.AuthConflictError):
+        await q.resolve_current_user(
+            cookie_token=tok_a,
+            bearer_token=tok_b,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+
+
+def test_unsupported_surfaces_fail_closed():
+    for surface in q.UNSUPPORTED_SURFACES:
+        with pytest.raises(q.UnsupportedSurfaceError):
+            q.assert_surface_not_used(surface)
+
+
+# ---------------------------------------------------------------------------
+# 5. Control-plane/runtime isolation including hostile ambient environment
+# ---------------------------------------------------------------------------
+
+
+def test_retired_and_unknown_selectors_fail_closed_with_guidance():
+    for retired in ("keycloak", "default", "google", "KEYCLOAK", " Default "):
+        with pytest.raises(q.AuthConfigError, match="(?i)removed|unknown|explicit"):
+            q.validate_mode_selector(retired)
+    with pytest.raises(q.AuthConfigError):
+        q.validate_mode_selector("saml")
+
+
+def test_hostile_ambient_omnigent_env_does_not_select_moonmind_behavior(monkeypatch):
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "accounts")
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_HEADER", "X-Evil-Header")
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_COOKIE_SECRET", "00" * 32)
+    monkeypatch.setenv("OMNIGENT_OIDC_ISSUER", "https://evil.example.invalid")
+    config = _config("disabled")
+    assert config.mode == "disabled"
+    assert config.cookie_name == q.MOONMIND_DEV_COOKIE
+    assert "OMNIGENT" not in config.token_issuer
+
+
+def test_control_plane_and_runtime_cookies_keys_purposes_are_distinct():
+    prod = q.MoonmindAuthConfig(
+        mode="accounts",
+        cookie_name=q.MOONMIND_PROD_COOKIE,
+        cookie_secret=secrets.token_bytes(32),
+    )
+    assert prod.cookie_name not in q.UPSTREAM_SESSION_COOKIES
+    assert prod.token_issuer == q.MOONMIND_TOKEN_ISSUER
+    assert prod.token_audience == q.MOONMIND_TOKEN_AUDIENCE
+    with pytest.raises(q.AuthConfigError):
+        q.MoonmindAuthConfig(
+            mode="accounts",
+            cookie_name="__Host-ap_session",
+            cookie_secret=secrets.token_bytes(32),
+        )
+    with pytest.raises(q.AuthConfigError):
+        q.MoonmindAuthConfig(
+            mode="accounts",
+            cookie_name=q.MOONMIND_DEV_COOKIE,
+            cookie_secret=b"short",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upstream_runtime_tokens_rejected_at_moonmind_boundary():
+    from omnigent.server.oidc import mint_session_token
+
+    config = _config("accounts")
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    upstream_secret = secrets.token_bytes(32)
+    upstream_token = mint_session_token("alice@example.invalid", upstream_secret, 3600, "accounts")
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(upstream_token, store, revocation, config)
+
+
+# ---------------------------------------------------------------------------
+# 6. Pin, packaged artifact, and standalone-consumer evidence
+# ---------------------------------------------------------------------------
+
+
+def test_upstream_probes_pass_on_pinned_revision():
+    evidence = q.collect_upstream_probe_evidence()
+    assert evidence.commit == "f04b0354fb5344c1ea8b92795ceb6760a9ad7595", evidence.notes
+    assert evidence.package == "omnigent==0.12.0", evidence.notes
+    assert evidence.session_roundtrip, evidence.notes
+    assert evidence.password_roundtrip, evidence.notes
+    assert evidence.accounts_config_fail_closed, evidence.notes
+    assert evidence.oidc_config_fail_closed, evidence.notes
+    assert evidence.upstream_defaults_intact, evidence.notes
+
+
+def test_production_packaging_excludes_irrelevant_runtime_modules():
+    import sys
+
+    for module in (
+        "omnigent.server.app",
+        "omnigent.server.permissions",
+        "omnigent.stores.permission_store",
+    ):
+        assert module not in sys.modules, f"{module} must not be imported by qualification"
+
+
+def test_no_ambient_auth_state_at_import():
+    for var in (
+        "OMNIGENT_AUTH_PROVIDER",
+        "OMNIGENT_AUTH_ENABLED",
+        "OMNIGENT_LOCAL_SINGLE_USER",
+    ):
+        os.environ.pop(var, None)
+    import importlib
+
+    importlib.reload(q)
+    assert q.SUPPORTED_MODES == ("accounts", "oidc", "header", "disabled")

--- a/tests/unit/security/test_omnigent_auth_qualification_4118.py
+++ b/tests/unit/security/test_omnigent_auth_qualification_4118.py
@@ -22,6 +22,8 @@ import pytest
 
 from moonmind.security import omnigent_auth_qualification as q
 
+q._ensure_omnigent_bundle_on_path()
+
 
 def _config(mode: str = "accounts", **overrides) -> q.MoonmindAuthConfig:
     base = {
@@ -252,7 +254,7 @@ async def test_cache_hit_cannot_bypass_revocation_or_status():
     revocation = q.InMemoryRevocationStore()
     cache = q.SessionValidationCache(config)
     identity = _identity()
-    account = _enrolled(store, identity)
+    _enrolled(store, identity)
     token, _ = await q.mint_moonmind_session(identity, store, config)
     await cache.validate(token, store, revocation)
     assert cache.misses == 1


### PR DESCRIPTION
## Summary
Implements MoonLadderStudios/MoonMind#4118 (K2 slice of the Keycloak Removal Plan): a MoonMind-side qualification adapter over the pinned portable Omnigent authentication capability (upstream commit f04b0354fb5344c1ea8b92795ceb6760a9ad7595, package omnigent==0.12.0).

- Adds moonmind/security/omnigent_auth_qualification.py: explicit MoonmindAuthConfig (no ambient OMNIGENT_* reads), ValidatedIdentity (issuer+subject required before mint), async account-store / session-revocation protocols, argon2 password qualification with controlled enrollment path, purpose-bound sessions with per-hit revalidation (cache cannot bypass revocation/scope/status), unsupported refresh/delegated/runner surfaces fail closed, control-plane/runtime cookie/key/purpose isolation.
- Adds tests/unit/security/test_omnigent_auth_qualification_4118.py: 24 hermetic conformance tests (no DB/network/credentials).
- Adds docs/Security/OmnigentAuthAdapterContract.md and references it from docs/Security/AuthenticationContracts.md section 11 (additive; K1 rows untouched).
- Adds docs/tmp/KeycloakRemovalQualification-4118.md pin/artifact/image-provenance record. No API cutover (api_service/auth.py, auth_providers.py untouched); no new always-on container.

## Verification outcome
Controlling post-remediation moonspec-verify verdict in artifacts/github-issue-implement-verify.json: FULLY_IMPLEMENTED (confidence MEDIUM, recommendedNextAction advance, 6/6 requirements VERIFIED, 0 gaps).

## Tests run
- python3 -m py_compile on adapter + tests: PASS (verified in this step).
- Direct interpreter execution of all asserted adapter behaviors + UpstreamProbeEvidence against installed omnigent==0.12.0 (session/password roundtrips, fail-closed config probes, upstream-defaults-intact): PASS per verify artifact.
- Canonical suite ./tools/test_unit.sh --python-only tests/unit/security/test_omnigent_auth_qualification_4118.py: NOT RUN in sandbox (no pytest / container backend); must rerun in CI before merge, including K1 regression test_auth_inventory_4117.py.

## Remaining risks
- Canonical pytest suite not executed here; CI rerun required.
- Qualification-record doc states 27 tests vs 24 test functions counted; minor non-canonical count drift to spot-check on rerun.
- Concrete production persistence wiring (MoonMind transactions/profile authority) and API cutover explicitly deferred to K3/K4 by design.

Closes MoonLadderStudios/MoonMind#4118