### PR TITLE
[Qdrant removal] Retire vector capabilities at admission and remove authoring controls (#4105)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -321,8 +321,10 @@ from moonmind.workflows.executions.execution_contract import (
     is_non_repository_side_effect_skill,
     is_self_managed_publish_skill,
     reject_removed_follow_up_fields,
+    reject_retired_vector_fields,
     reject_workflow_capability_identity_versions,
     resolve_publish_mode_for_skill,
+    strip_absent_vector_fields,
 )
 from moonmind.workflows.executions.repository_contract import (
     RepositoryContractError,
@@ -10803,6 +10805,14 @@ async def _create_execution_from_workflow_request(
     try:
         reject_removed_follow_up_fields(payload, field_path="payload")
         reject_removed_follow_up_fields(task_payload, field_path="workflow")
+        reject_retired_vector_fields(payload, field_path="payload")
+        reject_retired_vector_fields(task_payload, field_path="workflow")
+        for candidate_path, candidate in (
+            ("payload.initialParameters", payload.get("initialParameters")),
+            ("payload.initial_parameters", payload.get("initial_parameters")),
+        ):
+            if isinstance(candidate, dict):
+                reject_retired_vector_fields(candidate, field_path=candidate_path)
     except WorkflowContractError as exc:
         raise _invalid_workflow_request(str(exc)) from exc
     _reject_submit_version_identity(task_payload)
@@ -11359,13 +11369,19 @@ async def _create_execution_from_workflow_request(
         initial_parameters["parentWorkflowId"] = principal.workflow_id
     if isinstance(payload.get("omnigent"), Mapping):
         initial_parameters["omnigent"] = dict(payload["omnigent"])
-    # Context retrieval (RAG) authoring: initial ContextPack overrides (#3513)
-    # and in-session follow-up retrieval policy (#3514). Lifted here next to the
-    # omnigent block so the authored values reach the run's initial parameters.
-    if isinstance(payload.get("rag"), Mapping):
-        initial_parameters["rag"] = dict(payload["rag"])
-    if isinstance(payload.get("followUpRetrieval"), Mapping):
-        initial_parameters["followUpRetrieval"] = dict(payload["followUpRetrieval"])
+    # Built-in vector retrieval authoring retired (#4105): explicit `rag` /
+    # `followUpRetrieval` requirements fail before scheduling with an
+    # actionable validation result. Absent/empty/disabled values are stripped
+    # so stale drafts cannot reintroduce retired authority; they are never
+    # silently dropped with changed semantics when explicit.
+    try:
+        reject_retired_vector_fields(payload, field_path="payload")
+    except WorkflowContractError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
+    payload.pop("rag", None)
+    payload.pop("followUpRetrieval", None)
+    payload.pop("follow_up_retrieval", None)
+    strip_absent_vector_fields(initial_parameters)
     if "modelTier" in runtime_payload:
         initial_parameters["modelTier"] = runtime_payload.get("modelTier")
     if "tierFallback" in runtime_payload:
@@ -12248,6 +12264,13 @@ def _build_recurring_target(
             if "initialParameters" in target_payload
             else target_payload.get("initial_parameters")
         )
+        if isinstance(initial_parameters, Mapping):
+            try:
+                reject_retired_vector_fields(
+                    dict(initial_parameters), field_path="payload.initialParameters"
+                )
+            except WorkflowContractError as exc:
+                raise _invalid_workflow_request(str(exc)) from exc
         target: dict[str, Any] = {
             "workflowType": workflow_type,
             "initialParameters": (

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10244,6 +10244,21 @@ async def _exact_rerun_parameters_from_snapshot(
         publish_mode = str(publish.get("mode") or "").strip()
         if publish_mode:
             parameters["publishMode"] = publish_mode
+    # Retired (#4105): an exact rerun restores historical authority verbatim,
+    # so explicit `rag` / `followUpRetrieval` blocks must surface the promised
+    # resubmit-without guidance instead of being accepted as new work and
+    # silently stripped downstream.
+    try:
+        reject_retired_vector_fields(parameters, field_path="parameters")
+        reject_retired_vector_fields(workflow_payload, field_path="workflow")
+    except WorkflowContractError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "retired_vector_retrieval",
+                "message": str(exc),
+            },
+        ) from exc
     return parameters
 
 
@@ -12309,11 +12324,21 @@ def _build_recurring_target(
         task_payload.pop("propose_tasks", None)
         task_payload.pop("proposalPolicy", None)
         task_payload.pop("proposal_policy", None)
+        try:
+            reject_retired_vector_fields(
+                task_payload, field_path=f"payload.{task_key}"
+            )
+        except WorkflowContractError as exc:
+            raise _invalid_workflow_request(str(exc)) from exc
         target_payload[task_key] = task_payload
     target_payload.pop("proposeTasks", None)
     target_payload.pop("propose_tasks", None)
     target_payload.pop("proposalPolicy", None)
     target_payload.pop("proposal_policy", None)
+    try:
+        reject_retired_vector_fields(target_payload, field_path="payload")
+    except WorkflowContractError as exc:
+        raise _invalid_workflow_request(str(exc)) from exc
     _stamp_recurring_runtime_metadata(target_payload, runtime_metadata)
     return {
         "workflowType": workflow_type,

--- a/api_service/api/routers/retrieval_gateway.py
+++ b/api_service/api/routers/retrieval_gateway.py
@@ -149,6 +149,16 @@ def _bridge_authoritative_issue(
 
     launch = dict(row.effective_launch_snapshot_json or {})
     policy = launch.get("followUpRetrieval")
+    if isinstance(policy, dict) and policy.get("enabled") is True:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Built-in vector retrieval has been retired "
+                "(MoonLadderStudios/MoonMind#4105). Remove followUpRetrieval "
+                "and use explicit attachments, artifact refs, or scoped "
+                "workspace access instead. Historical details remain readable."
+            ),
+        )
     if not isinstance(policy, dict) or policy.get("enabled") is not True:
         raise HTTPException(
             403, detail="Follow-up retrieval is not enabled by the launch snapshot."

--- a/api_service/services/checkpoint_branches.py
+++ b/api_service/services/checkpoint_branches.py
@@ -71,6 +71,22 @@ async def prepare_checkpoint_branch_workspace(
 ) -> CheckpointBranchWorkspacePreparation:
     """Validate, emit artifacts, and persist a checkpoint branch git binding."""
 
+    if follow_up_retrieval is not None:
+        # Retired (#4105): explicit vector authority fails before any
+        # artifact write or persistence; absent values are dropped downstream.
+        from moonmind.workflows.executions.execution_contract import (
+            WorkflowContractError,
+            reject_retired_vector_fields,
+        )
+
+        try:
+            reject_retired_vector_fields(
+                {"followUpRetrieval": dict(follow_up_retrieval)},
+                field_path="payload",
+            )
+        except WorkflowContractError as exc:
+            raise ValueError(str(exc)) from exc
+
     try:
         validated_input = CheckpointBranchGitBindingInput.model_validate(binding_input)
     except ValueError as exc:
@@ -326,8 +342,9 @@ async def _persist_branch_turn(
     turn = await session.get(WorkflowCheckpointBranchTurn, binding.branch_turn_id)
     diagnostics = dict(prepared.branch_turn_metadata or {})
     diagnostics["gitBinding"] = prepared.diagnostics["gitBinding"]
-    if follow_up_retrieval is not None:
-        diagnostics["followUpRetrieval"] = dict(follow_up_retrieval)
+    # Entry validation rejected explicit retired authority; any residue
+    # reaching here is absent/empty/disabled and carries no authority, so new
+    # turns persist no vector retrieval state (retired #4105).
     if turn is None:
         turn = WorkflowCheckpointBranchTurn(
             branch_turn_id=binding.branch_turn_id,

--- a/docs/tmp/QdrantRemovalInventory-4105.md
+++ b/docs/tmp/QdrantRemovalInventory-4105.md
@@ -1,0 +1,74 @@
+# Qdrant / Built-in Vector Retrieval Consumer Inventory — #4105
+
+Parent: MoonLadderStudios/MoonMind#4103. This issue (#4105) owns the
+**admission + authoring + plan-compilation** contract. Execution/cutover,
+Compose deletion, ManifestIngest redesign, docs migration, and worker/CLI
+removal belong to sibling children of #4103 (referenced below as
+“sibling-execution/cutover”) and are explicitly out of scope here
+(#3948 owns ManifestIngest public compile/execute semantics).
+
+Dispositions: **delete** (remove in owning change), **retain-without-vector**
+(new writes carry no vector behavior; historical reads stay), **external-only**
+(already-supported explicitly-external integration with a surviving
+implementation, not native vector).
+
+## A. Shared admission boundary — owned by #4105 (this change)
+
+| Consumer | Disposition | Notes |
+|---|---|---|
+| `moonmind/workflows/executions/execution_contract.py` — `reject_retired_vector_fields` / `strip_absent_vector_fields` | retain-without-vector | New: explicit `rag` / `followUpRetrieval` rejected with actionable message; absent/empty/disabled stripped, never silently weakened. Wired into `WorkflowExecutionSpec` + `CanonicalWorkflowExecutionPayload`. |
+| `api_service/api/routers/executions.py` submit validation + create lift + recurring target builder | retain-without-vector | Explicit retired fields → 422 before Temporal start; absent residue stripped. Historical detail projections (`retrieval` read block) untouched. |
+| `moonmind/schemas/agent_runtime_models.py` `AgentExecutionRequest` | retain-without-vector | Explicit `parameters.rag` / `followUpRetrieval` → validation error before host launch. |
+| `moonmind/schemas/checkpoint_branch_models.py` create/continue/fork | retain-without-vector | Explicit `followUpRetrieval` → validation error; absent parses for history. |
+| `api_service/api/routers/retrieval_gateway.py` `_bridge_authoritative_issue` | retain-without-vector | New capability issuance from an enabled launch snapshot → 410 retired (no mint, no event write). Diagnostics/result reads unchanged (historical). |
+
+## B. Authoring surfaces — owned by #4105 (this change)
+
+| Consumer | Disposition | Notes |
+|---|---|---|
+| `frontend/src/lib/contextRetrievalAuthoring.ts` | retain-without-vector | `compile…` returns `{}`; `hasAuthored…` false (no draft/hidden persistence); `parse…` kept for historical reads; new `hasRetiredRetrievalParameters` surfaces “resubmit without” guidance. |
+| `frontend/src/components/ContextRetrievalControls.tsx` | delete (controls) / retain notice | All inputs/hidden state removed; retired notice only. Callers keep mounting it so no invisible form state survives. |
+| `frontend/src/entrypoints/workflow-start.tsx` (create/edit/rerun) | retain-without-vector | Submit/draft paths now send no retrieval fields (`compile {}` + `hasAuthored false`). Historical parse kept for reading source payloads. `buildEditParametersPatch` strips inherited + submitted `rag` / `followUpRetrieval` unconditionally. |
+| `frontend/src/entrypoints/schedules.tsx` | retain-without-vector | Read/write helpers strip `rag` / `followUpRetrieval` on save; raw JSON remains the editor. |
+| `frontend/src/entrypoints/workflow-detail.tsx` (rerun/branch diagnostics) | retain-without-vector | Rerun compiles to `{}`; follow-up diagnostics query kept for historical evidence. |
+| `frontend/src/lib/remediationCreateDraft.ts` | retain-without-vector | Drafts no longer persist `contextRetrieval`; type kept optional for reading old drafts. |
+| `frontend/src/entrypoints/omnigent-inventory.tsx`, `WorkflowRowActionsMenu.tsx` (references) | retain-without-vector | No authoring authority; left readable. |
+| `frontend/src/generated/openapi.ts` retrieval schemas | retain-without-vector | Regenerate from retired backend schemas in the owning regeneration change; no hand edits here. |
+
+## C. Plan compilation — owned by #4105 (this change)
+
+| Consumer | Disposition | Notes |
+|---|---|---|
+| `moonmind/omnigent/codex_execution_decisions.py` `compile_follow_up_retrieval_policy` / `enforce_required_follow_up_retrieval` | retain-without-vector | Compile always `{"enabled": false}` (no vector descriptors in new plans); any explicit authored request raises `OMNIGENT_RETIRED_VECTOR_RETRIEVAL` before launch. Unrelated profile/credential/qualification/approval/publication/artifact authority untouched. |
+| `moonmind/omnigent/profile_bound_execution.py` effective-launch builder + coordinator | retain-without-vector | Persists `{"enabled": false}` snapshot; explicit requests fail via (C) before launch. |
+| `api_service/services/omnigent_execution_plan_service.py` plan compiler | retain-without-vector | Inherits (C); no new vector policy materialized. |
+| `moonmind/workflows/checkpoint_branches.py` bundle builder | retain-without-vector | Historical bundle read kept; new branch-turn admission enforced by request models (A). |
+| `moonmind/workflows/temporal/workflows/run.py` agent-request forwarding | retain-without-vector | `rag` / `followUpRetrieval` no longer forwarded into request parameters (no-op post-admission; keeps pre-retirement in-flight replay deterministic — cutover child coordinates in-flight decoding/retirement). |
+| `api_service/services/checkpoint_branch_turn_execution.py`, `checkpoint_branches.py`, `checkpoint_branches_service.py` | retain-without-vector | Stored diagnostics readable; new launches validate via `AgentExecutionRequest` (A). |
+
+## D. Execution / runtime / storage — sibling of #4103 (NOT this change)
+
+Native Qdrant/embedding execution, collection/overlay administration, index
+health, CLI, workers, Compose, packaging, and ManifestIngest-adjacent names
+that do not contain `qdrant` are inventoried here and explicitly deferred to
+the sibling execution/cutover child. This change does not delete them, invent
+a replacement provider registry, or redesign generic ManifestIngest.
+
+| Consumer | Disposition | Owner |
+|---|---|---|
+| `moonmind/rag/*` (service, qdrant_client, embedding, settings, guardrails, context_injection, context_pack, planning, overlay, overlay_cleanup, long_term_memory, telemetry, cli) | delete (sibling) | sibling-execution/cutover |
+| `api_service/api/routers/retrieval_gateway.py` query/index-health execution paths (`POST /context`, `GET /index-health`, session-result budget) | delete (sibling) | sibling-execution/cutover |
+| `api_service/retrieval_capabilities.py` live capability registry + evidence store | delete (sibling) | sibling-execution/cutover |
+| `moonmind/agents/codex_worker/worker.py`, `moonmind/workflows/temporal/activities/omnigent_session_activities.py`, `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/artifacts.py`, `moonmind/workflows/skills/ops_diagnostics_execution.py` (retrieval wiring) | delete/retain-without-vector per file (sibling decides) | sibling-execution/cutover |
+| `moonmind/config/settings.py` RAG/Qdrant settings, `docker-compose.yaml` + `tools/get-qdrant.py`, `.env-template` retrieval env | delete (sibling) | sibling-execution/cutover |
+| `moonmind/cli.py`, `moonmind/rag/cli.py`, `moonmind/manifest/*` CLI/registration paths carrying embedding/collection/overlay flags | delete (sibling) | sibling-execution/cutover |
+| `api_service/services/omnigent_agent_*`, `provider_profile_creation.py`, `profile_execution_selection.py`, `presets/catalog.py`, `remediation_actions.py`, `settings_change_*`, `execution_integrations.py`, `workflow_console*.py`, `agent_runs.py`, `omnigent_bootstrap/bridge/native_ui.py` collection/overlay-adjacent handling | audit + delete vector-only branches (sibling) | sibling-execution/cutover |
+| `docs/**` (`Rag/*`, `Memory/*`, `ManagedAgents/WorkerVectorEmbedding.md`, `MoonMindArchitecture.md`, `MoonMindRoadmap.md`, `UI/CreatePage.md`), `README.md`, `examples/*`, `memory/omnigent-3514-followup-retrieval-authoring.md` | docs migration (sibling) | sibling-execution/cutover |
+| `tests/**` rag/retrieval/manifest suites, `frontend/src/**/*.test.*` retrieval suites | update alongside owning code change | #4105 updates admission/authoring/plan tests only; execution-suite deletion with sibling |
+
+## E. Truthful-error / no-rescue rules (this change + sibling)
+
+- Absent optional enrichment (no/empty/disabled vector fields) → normal admission, no vector behavior.
+- Explicit unsupported retrieval → actionable field/capability validation (422 / model validation / `OMNIGENT_RETIRED_VECTOR_RETRIEVAL` / 410 on gateway issuance) **before** Temporal start, host launch, paid calls, or external writes. No silent field-drop with changed semantics.
+- Authorization failures keep their existing codes; no scope-widening scan, substitute credential, or invented external backend rescues an invalid request.
+- In-flight decoding and schedule retirement coordination belong to the cutover sibling; this change never mutates immutable admitted snapshots and retains no indefinite new-write alias.

--- a/frontend/src/components/ContextRetrievalControls.test.tsx
+++ b/frontend/src/components/ContextRetrievalControls.test.tsx
@@ -1,62 +1,28 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ContextRetrievalControls } from './ContextRetrievalControls';
-import {
-  ContextRetrievalAuthoring,
-  defaultContextRetrievalAuthoring,
-} from '../lib/contextRetrievalAuthoring';
+import { defaultContextRetrievalAuthoring } from '../lib/contextRetrievalAuthoring';
 
-function renderControls(overrides?: Partial<ContextRetrievalAuthoring>) {
-  let value: ContextRetrievalAuthoring = {
-    ...defaultContextRetrievalAuthoring(),
-    ...overrides,
-  };
-  const onChange = vi.fn((next: ContextRetrievalAuthoring) => {
-    value = next;
-  });
-  const utils = render(
-    <ContextRetrievalControls value={value} onChange={onChange} />,
-  );
-  return { ...utils, onChange, getValue: () => value };
-}
-
-describe('ContextRetrievalControls', () => {
-  it('renders policy ceilings so the operator sees the boundary', () => {
-    renderControls();
-    expect(
-      screen.getByText(/Policy ceilings/i).textContent,
-    ).toContain('top_k ≤ 50');
-  });
-
-  it('enables follow-up retrieval through the toggle', () => {
-    const { onChange } = renderControls();
-    fireEvent.click(
-      screen.getByLabelText(/request additional context during the run/i),
-    );
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        followUp: expect.objectContaining({ enabled: true }),
-      }),
-    );
-  });
-
-  it('warns when follow-up retrieval is enabled without collections', () => {
-    const value = defaultContextRetrievalAuthoring();
-    value.followUp.enabled = true;
-    render(<ContextRetrievalControls value={value} onChange={vi.fn()} />);
-    expect(screen.getByText(/no collections are selected/i)).toBeTruthy();
-  });
-
-  it('hides initial-injection controls when showInitialControls is false', () => {
-    render(
+describe('ContextRetrievalControls (retired #4105)', () => {
+  it('renders the retirement notice with no editable inputs', () => {
+    const { container } = render(
       <ContextRetrievalControls
         value={defaultContextRetrievalAuthoring()}
         onChange={vi.fn()}
-        showInitialControls={false}
       />,
     );
-    expect(screen.queryByText(/Initial context injection/i)).toBeNull();
-    expect(screen.getByText(/In-session follow-up retrieval/i)).toBeTruthy();
+    expect(screen.getByText(/retired/i)).toBeTruthy();
+    expect(container.querySelectorAll('input, select, textarea').length).toBe(0);
+  });
+
+  it('renders no hidden retrieval state', () => {
+    const { container } = render(
+      <ContextRetrievalControls
+        value={defaultContextRetrievalAuthoring()}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('input[type="hidden"]')).toBeNull();
   });
 });

--- a/frontend/src/components/ContextRetrievalControls.tsx
+++ b/frontend/src/components/ContextRetrievalControls.tsx
@@ -1,13 +1,8 @@
-import { JSX, useId } from 'react';
+import { JSX } from 'react';
 
 import {
   ContextRetrievalAuthoring,
-  DEFAULT_RETRIEVAL_CEILINGS,
-  FollowUpRetrievalAuthoring,
-  RetrievalBudgetPreset,
   RetrievalCeilings,
-  applyBudgetPreset,
-  explainRetrievalDenials,
 } from '../lib/contextRetrievalAuthoring';
 
 interface ContextRetrievalControlsProps {
@@ -18,344 +13,37 @@ interface ContextRetrievalControlsProps {
   description?: string;
   disabled?: boolean;
   /**
-   * When false, hide the automatic initial-injection collection controls
-   * (surfaces that only govern follow-up retrieval, e.g. a branch turn).
+   * Retained for caller compatibility; retired surfaces render no
+   * initial-injection controls.
    */
   showInitialControls?: boolean;
   idPrefix?: string;
 }
 
-const BUDGET_PRESET_OPTIONS: Array<{ value: RetrievalBudgetPreset; label: string }> = [
-  { value: 'conservative', label: 'Conservative' },
-  { value: 'balanced', label: 'Balanced' },
-  { value: 'generous', label: 'Generous' },
-  { value: 'custom', label: 'Custom' },
-];
-
 /**
- * Coherent, policy-bounded RAG authoring controls shared by every MoonMind
- * authoring surface (GitHub issue MoonLadderStudios/MoonMind#3514, item 6).
+ * Retired built-in vector retrieval authoring
+ * (MoonLadderStudios/MoonMind#4105).
  *
- * The controls only NARROW within the policy ceilings; the visible ceilings and
- * denial notices make that boundary explicit rather than failing silently.
+ * Renders no editable inputs, hidden fields, or cached form state: new writes
+ * must not advertise or accept a built-in vector capability. Historical
+ * payloads remain readable in detail views through
+ * `parseContextRetrievalParameters`; this surface only explains the retirement
+ * and points at supported alternatives.
  */
 export function ContextRetrievalControls({
-  value,
-  onChange,
-  ceilings = DEFAULT_RETRIEVAL_CEILINGS,
   description,
-  disabled = false,
-  showInitialControls = true,
-  idPrefix,
 }: ContextRetrievalControlsProps): JSX.Element {
-  const generatedId = useId();
-  const prefix = idPrefix ?? generatedId;
-  const denials = explainRetrievalDenials(value, ceilings);
-  const followUp = value.followUp;
-
-  const setFollowUp = (patch: Partial<FollowUpRetrievalAuthoring>): void => {
-    onChange({ ...value, followUp: { ...followUp, ...patch } });
-  };
-
-  const toggleCollection = (
-    scope: 'initial' | 'followUp',
-    collection: string,
-  ): void => {
-    if (scope === 'initial') {
-      const has = value.initial.collections.includes(collection);
-      const collections = has
-        ? value.initial.collections.filter((item) => item !== collection)
-        : [...value.initial.collections, collection];
-      onChange({ ...value, initial: { ...value.initial, collections } });
-      return;
-    }
-    const has = followUp.collections.includes(collection);
-    const collections = has
-      ? followUp.collections.filter((item) => item !== collection)
-      : [...followUp.collections, collection];
-    setFollowUp({ collections });
-  };
-
-  const onPresetChange = (preset: RetrievalBudgetPreset): void => {
-    onChange({ ...value, followUp: applyBudgetPreset(followUp, preset) });
-  };
-
-  const onCustomNumber = (
-    field: 'topK' | 'maxContextTokens' | 'maxQueries' | 'latencyMs' | 'maxLifetimeSeconds',
-    raw: string,
-  ): void => {
-    const parsed = Number(raw);
-    setFollowUp({
-      budgetPreset: 'custom',
-      [field]: Number.isFinite(parsed) ? parsed : followUp[field],
-    } as Partial<FollowUpRetrievalAuthoring>);
-  };
-
-  const budgetsDisabled = disabled || !followUp.enabled;
-
   return (
     <div className="context-retrieval-controls stack" data-testid="context-retrieval-controls">
       {description ? <p className="small">{description}</p> : null}
-
-      {showInitialControls ? (
-        <fieldset className="context-retrieval-section" disabled={disabled}>
-          <legend>Initial context injection</legend>
-          <p className="small">
-            The initial ContextPack is injected automatically. Choose which
-            collections it may draw from and whether a stale overlay is allowed.
-          </p>
-          <CollectionChips
-            name={`${prefix}-initial-collections`}
-            allowed={ceilings.collections}
-            selected={value.initial.collections}
-            onToggle={(collection) => toggleCollection('initial', collection)}
-            disabled={disabled}
-          />
-          <label className="checkbox">
-            <input
-              type="checkbox"
-              checked={value.initial.allowStale}
-              disabled={disabled}
-              onChange={(event) =>
-                onChange({
-                  ...value,
-                  initial: { ...value.initial, allowStale: event.target.checked },
-                })
-              }
-            />
-            Allow a stale overlay for initial injection
-          </label>
-          <label className="checkbox">
-            <input
-              type="checkbox"
-              checked={value.initial.required}
-              disabled={disabled}
-              onChange={(event) =>
-                onChange({
-                  ...value,
-                  initial: { ...value.initial, required: event.target.checked },
-                })
-              }
-            />
-            Require initial context (fail the step if unavailable)
-          </label>
-        </fieldset>
-      ) : null}
-
-      <fieldset className="context-retrieval-section" disabled={disabled}>
-        <legend>In-session follow-up retrieval</legend>
-        <label className="checkbox">
-          <input
-            type="checkbox"
-            checked={followUp.enabled}
-            disabled={disabled}
-            onChange={(event) => setFollowUp({ enabled: event.target.checked })}
-          />
-          Allow the session to request additional context during the run
-        </label>
-        <label className="checkbox">
-          <input
-            type="checkbox"
-            checked={followUp.required}
-            disabled={budgetsDisabled}
-            onChange={(event) => setFollowUp({ required: event.target.checked })}
-          />
-          Follow-up retrieval is required (not optional)
-        </label>
-
-        <div className="context-retrieval-field">
-          <span className="context-retrieval-label">Collections the session may query</span>
-          <CollectionChips
-            name={`${prefix}-followup-collections`}
-            allowed={ceilings.collections}
-            selected={followUp.collections}
-            onToggle={(collection) => toggleCollection('followUp', collection)}
-            disabled={budgetsDisabled}
-          />
-        </div>
-
-        <label className="context-retrieval-field">
-          <span className="context-retrieval-label">Budget preset</span>
-          <select
-            value={followUp.budgetPreset}
-            disabled={budgetsDisabled}
-            onChange={(event) => onPresetChange(event.target.value as RetrievalBudgetPreset)}
-          >
-            {BUDGET_PRESET_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className="grid-2">
-          <NumberField
-            label="top_k"
-            value={followUp.topK}
-            ceilingMax={ceilings.topK.max}
-            min={ceilings.topK.min}
-            disabled={budgetsDisabled}
-            onChange={(raw) => onCustomNumber('topK', raw)}
-          />
-          <NumberField
-            label="Max context tokens"
-            value={followUp.maxContextTokens}
-            ceilingMax={ceilings.maxContextTokens.max}
-            min={ceilings.maxContextTokens.min}
-            disabled={budgetsDisabled}
-            onChange={(raw) => onCustomNumber('maxContextTokens', raw)}
-          />
-          <NumberField
-            label="Max queries per run"
-            value={followUp.maxQueries}
-            ceilingMax={ceilings.maxQueries.max}
-            min={ceilings.maxQueries.min}
-            disabled={budgetsDisabled}
-            onChange={(raw) => onCustomNumber('maxQueries', raw)}
-          />
-          <NumberField
-            label="Latency budget (ms)"
-            value={followUp.latencyMs}
-            ceilingMax={ceilings.latencyMs.max}
-            min={ceilings.latencyMs.min}
-            disabled={budgetsDisabled}
-            onChange={(raw) => onCustomNumber('latencyMs', raw)}
-          />
-          <NumberField
-            label="Capability lifetime (s)"
-            value={followUp.maxLifetimeSeconds}
-            ceilingMax={ceilings.maxLifetimeSeconds.max}
-            min={ceilings.maxLifetimeSeconds.min}
-            disabled={budgetsDisabled}
-            onChange={(raw) => onCustomNumber('maxLifetimeSeconds', raw)}
-          />
-        </div>
-
-        <label className="context-retrieval-field">
-          <span className="context-retrieval-label">Overlay policy</span>
-          <select
-            value={followUp.overlayPolicy}
-            disabled={budgetsDisabled}
-            onChange={(event) =>
-              setFollowUp({ overlayPolicy: event.target.value === 'skip' ? 'skip' : 'include' })
-            }
-          >
-            <option value="include">Include workspace overlay</option>
-            <option value="skip">Skip overlay (indexed content only)</option>
-          </select>
-        </label>
-
-        <label className="checkbox">
-          <input
-            type="checkbox"
-            checked={followUp.staleOverlayAllowed}
-            disabled={budgetsDisabled || !ceilings.allowStaleOverlay}
-            onChange={(event) => setFollowUp({ staleOverlayAllowed: event.target.checked })}
-          />
-          Allow a stale overlay
-          {!ceilings.allowStaleOverlay ? ' (blocked by policy)' : ''}
-        </label>
-        <label className="checkbox">
-          <input
-            type="checkbox"
-            checked={followUp.fallbackAllowed}
-            disabled={budgetsDisabled || !ceilings.allowFallback}
-            onChange={(event) => setFollowUp({ fallbackAllowed: event.target.checked })}
-          />
-          Allow local-search fallback
-          {!ceilings.allowFallback ? ' (blocked by policy)' : ''}
-        </label>
-      </fieldset>
-
-      <p className="small context-retrieval-ceilings">
-        Policy ceilings — collections: {ceilings.collections.join(', ') || 'none'}; top_k ≤{' '}
-        {ceilings.topK.max}; context tokens ≤ {ceilings.maxContextTokens.max}; queries ≤{' '}
-        {ceilings.maxQueries.max}; latency ≤ {ceilings.latencyMs.max}ms; lifetime ≤{' '}
-        {ceilings.maxLifetimeSeconds.max}s. Values above a ceiling are clamped server-side.
-      </p>
-
-      {denials.length > 0 ? (
-        <div className="notice error context-retrieval-denials" role="note">
-          <p className="small">The current selection will be adjusted or denied by policy:</p>
-          <ul className="small">
-            {denials.map((denial) => (
-              <li key={denial}>{denial}</li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
+      <div className="notice warning" role="note">
+        <p className="small">
+          Built-in vector retrieval has been retired
+          (MoonLadderStudios/MoonMind#4105). New runs use explicit attachments,
+          artifact refs, or scoped workspace access instead. Historical details
+          remain readable; resubmit without retrieval settings to start new work.
+        </p>
+      </div>
     </div>
-  );
-}
-
-interface CollectionChipsProps {
-  name: string;
-  allowed: readonly string[];
-  selected: string[];
-  onToggle: (collection: string) => void;
-  disabled?: boolean;
-}
-
-function CollectionChips({
-  name,
-  allowed,
-  selected,
-  onToggle,
-  disabled,
-}: CollectionChipsProps): JSX.Element {
-  if (allowed.length === 0) {
-    return <p className="small">No collections are available in this deployment.</p>;
-  }
-  return (
-    <div className="context-retrieval-collections">
-      {allowed.map((collection) => (
-        <label key={collection} className="checkbox context-retrieval-collection">
-          <input
-            type="checkbox"
-            name={name}
-            value={collection}
-            checked={selected.includes(collection)}
-            disabled={disabled}
-            onChange={() => onToggle(collection)}
-          />
-          {collection}
-        </label>
-      ))}
-    </div>
-  );
-}
-
-interface NumberFieldProps {
-  label: string;
-  value: number;
-  min: number;
-  ceilingMax: number;
-  disabled?: boolean;
-  onChange: (raw: string) => void;
-}
-
-function NumberField({
-  label,
-  value,
-  min,
-  ceilingMax,
-  disabled,
-  onChange,
-}: NumberFieldProps): JSX.Element {
-  return (
-    <label className="context-retrieval-field">
-      <span className="context-retrieval-label">
-        {label} <span className="context-retrieval-ceiling-hint">(≤ {ceilingMax})</span>
-      </span>
-      <input
-        type="number"
-        min={min}
-        max={ceilingMax}
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-      />
-    </label>
   );
 }

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -28,11 +28,12 @@ import {
 const SCHEDULES_MOBILE_MEDIA_QUERY = '(max-width: 720px)';
 
 /**
- * Sync context-retrieval authoring into a schedule's raw target JSON
- * (MoonMind#3514). The target's `initialParameters` carries the run params, so
- * `rag` / `followUpRetrieval` live there. Returns the parsed authoring value and
- * a writer that produces an updated target-JSON string, or null when the JSON
- * cannot be parsed (the raw textarea then remains the sole editor).
+ * Retired context-retrieval schedule sync (MoonLadderStudios/MoonMind#4105).
+ * Historical schedule targets remain readable via
+ * `parseContextRetrievalParameters`; writes always strip `rag` /
+ * `followUpRetrieval` so saved schedules cannot reactivate the removed
+ * feature. Returns the parsed authoring value and a writer that produces an
+ * updated target-JSON string, or null when the JSON cannot be parsed.
  */
 function readScheduleContextRetrieval(
   targetJson: string,

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -235,7 +235,7 @@ describe("buildEditParametersPatch", () => {
     expect("followUpRetrieval" in patch).toBe(false);
   });
 
-  it("keeps rag/followUpRetrieval when the submission carries them", () => {
+  it("strips retired rag/followUpRetrieval even when the submission carries them", () => {
     const patch = buildEditParametersPatch({
       execution: {
         workflowId: "mm:edit-retrieval-keep",
@@ -255,11 +255,10 @@ describe("buildEditParametersPatch", () => {
       },
     });
 
-    expect(patch.rag).toEqual({ collections: ["docs"] });
-    expect(patch.followUpRetrieval).toEqual({
-      enabled: true,
-      collections: ["docs"],
-    });
+    // Retired (#4105): neither inherited nor submitted retrieval authority may
+    // reach a new submission.
+    expect("rag" in patch).toBe(false);
+    expect("followUpRetrieval" in patch).toBe(false);
   });
 
   it("strips retired follow-up fields from a historical canonical workflow", () => {
@@ -1710,13 +1709,15 @@ describe("MoonLadderStudios/MoonMind#3451 Omnigent readiness", () => {
           providerProfileRef: "oauth-1",
           launchPolicyRef: "on-demand-v1",
         },
-        rag: { collections: ["docs"], required: true },
-        followUpRetrieval: { enabled: true, collections: ["docs"] },
         task: {
           remediation: draft.remediation,
         },
       },
     });
+    // Retired (#4105): the imported draft's retrieval authoring is not
+    // resubmitted.
+    expect("rag" in request.payload).toBe(false);
+    expect("followUpRetrieval" in request.payload).toBe(false);
   });
 
   it("adopts the active default policy version without requiring a host-policy choice", async () => {
@@ -16059,7 +16060,7 @@ describe("Task Create MM-641 authoring validation", () => {
     ).toBeNull();
   });
 
-  it("submits authored Context retrieval (RAG) values while Advanced mode is on", async () => {
+  it("shows the retired retrieval notice and submits no vector fields while Advanced mode is on", async () => {
     renderWithClient(<WorkflowStartPage payload={withAttachmentPolicy()} />);
 
     fireEvent.change(await screen.findByLabelText("Instructions"), {
@@ -16075,16 +16076,10 @@ describe("Task Create MM-641 authoring validation", () => {
     expect(controls).not.toBeNull();
 
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
-    fireEvent.click(
-      screen.getByLabelText(
-        "Require initial context (fail the step if unavailable)",
-      ),
-    );
-    fireEvent.click(
-      screen.getByLabelText(
-        "Allow the session to request additional context during the run",
-      ),
-    );
+    // Retired (#4105): no editable retrieval inputs remain, only the notice.
+    expect(
+      screen.getByText(/Built-in vector retrieval has been retired/i),
+    ).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
 
@@ -16096,8 +16091,8 @@ describe("Task Create MM-641 authoring validation", () => {
     });
 
     const payload = latestCreateRequest().payload as Record<string, unknown>;
-    expect(payload.rag).toEqual({ required: true });
-    expect(payload.followUpRetrieval).toMatchObject({ enabled: true });
+    expect("rag" in payload).toBe(false);
+    expect("followUpRetrieval" in payload).toBe(false);
   });
 
   it("ignores hidden Context retrieval (RAG) authoring when Advanced mode is off", async () => {
@@ -16211,7 +16206,7 @@ describe("Task Create MM-641 authoring validation", () => {
     expect("rag" in payload).toBe(false);
     expect("followUpRetrieval" in payload).toBe(false);
   });
-  it("reveals Advanced mode so an inherited rerun retrieval policy stays visible and resubmitted", async () => {
+  it("reveals Advanced mode and strips the inherited retired rerun retrieval policy", async () => {
     window.history.pushState(
       {},
       "Task Rerun",
@@ -16233,11 +16228,19 @@ describe("Task Create MM-641 authoring validation", () => {
       '[data-canonical-create-section="Execution controls"]',
     ) as HTMLElement;
     expect(controls).not.toBeNull();
-    expect(
-      (within(controls).getByLabelText("Advanced mode") as HTMLInputElement)
-        .checked,
-    ).toBe(true);
+    // Retired (#4105): an inherited rerun retrieval policy no longer forces
+    // Advanced mode open. Enable it explicitly to confirm the retired notice
+    // renders instead of editable controls.
+    const advancedToggle = within(controls).getByLabelText(
+      "Advanced mode",
+    ) as HTMLInputElement;
+    if (!advancedToggle.checked) {
+      fireEvent.click(advancedToggle);
+    }
     expect(within(controls).getByText("Context retrieval (RAG)")).toBeTruthy();
+    expect(
+      screen.getByText(/Built-in vector retrieval has been retired/i),
+    ).toBeTruthy();
 
     fireEvent.change(instructions, {
       target: { value: "Rerun with the inherited retrieval policy." },
@@ -16260,14 +16263,10 @@ describe("Task Create MM-641 authoring validation", () => {
     const request = JSON.parse(String(updateCall?.[1]?.body)) as {
       parametersPatch: Record<string, unknown>;
     };
-    expect(request.parametersPatch.rag).toEqual({
-      collections: ["docs"],
-      required: true,
-    });
-    expect(request.parametersPatch.followUpRetrieval).toMatchObject({
-      enabled: true,
-      collections: ["docs"],
-    });
+    // Retired (#4105): the inherited rerun retrieval policy is stripped, never
+    // resubmitted.
+    expect("rag" in request.parametersPatch).toBe(false);
+    expect("followUpRetrieval" in request.parametersPatch).toBe(false);
   });
 
   it("does not serialize the primary Skill onto blank added steps", async () => {

--- a/frontend/src/entrypoints/workflow-start.test.tsx
+++ b/frontend/src/entrypoints/workflow-start.test.tsx
@@ -16110,19 +16110,18 @@ describe("Task Create MM-641 authoring validation", () => {
     ) as HTMLElement;
     expect(controls).not.toBeNull();
 
-    // Author retrieval in Advanced mode, then hide the controls again before
-    // submitting.
+    // Retired (#4105): no editable retrieval inputs remain. Opening Advanced
+    // mode shows the retired notice, then hiding the controls again before
+    // submitting still sends no vector fields.
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
-    fireEvent.click(
-      screen.getByLabelText(
+    expect(
+      screen.getByText(/Built-in vector retrieval has been retired/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByLabelText(
         "Require initial context (fail the step if unavailable)",
       ),
-    );
-    fireEvent.click(
-      screen.getByLabelText(
-        "Allow the session to request additional context during the run",
-      ),
-    );
+    ).toBeNull();
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
     expect(
       document.querySelector('[data-testid="context-retrieval-controls"]'),
@@ -16159,38 +16158,30 @@ describe("Task Create MM-641 authoring validation", () => {
     ) as HTMLElement;
     expect(controls).not.toBeNull();
 
-    // Author retrieval, turn Advanced mode off to clear it, then turn it back
-    // on to adjust an unrelated advanced control.
+    // Retired (#4105): toggling Advanced mode off and on never restores
+    // editable retrieval inputs; only the retired notice renders.
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
-    fireEvent.click(
-      screen.getByLabelText(
-        "Require initial context (fail the step if unavailable)",
-      ),
-    );
-    fireEvent.click(
-      screen.getByLabelText(
-        "Allow the session to request additional context during the run",
-      ),
-    );
+    expect(
+      screen.getByText(/Built-in vector retrieval has been retired/i),
+    ).toBeTruthy();
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
     fireEvent.click(within(controls).getByLabelText("Advanced mode"));
 
-    // The reopened controls are unauthored again instead of showing the values
-    // the operator already cleared.
+    // The reopened controls show the retired notice instead of editable
+    // retrieval authoring.
     expect(
-      (
-        screen.getByLabelText(
-          "Require initial context (fail the step if unavailable)",
-        ) as HTMLInputElement
-      ).checked,
-    ).toBe(false);
+      screen.getByText(/Built-in vector retrieval has been retired/i),
+    ).toBeTruthy();
     expect(
-      (
-        screen.getByLabelText(
-          "Allow the session to request additional context during the run",
-        ) as HTMLInputElement
-      ).checked,
-    ).toBe(false);
+      screen.queryByLabelText(
+        "Require initial context (fail the step if unavailable)",
+      ),
+    ).toBeNull();
+    expect(
+      screen.queryByLabelText(
+        "Allow the session to request additional context during the run",
+      ),
+    ).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Start Workflow" }));
 

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -1801,16 +1801,14 @@ export function buildEditParametersPatch({
   if (!("mergeAutomation" in submittedPayload)) {
     delete parametersPatch.mergeAutomation;
   }
-  // Context retrieval authority (#3514) is an operator-cleared control. When the
-  // submission does not carry `rag` / `followUpRetrieval` the operator disabled
-  // that authoring, so the inherited base value must be explicitly removed
-  // rather than silently preserved (mirrors the `mergeAutomation` clear above).
-  if (!("rag" in submittedPayload)) {
-    delete parametersPatch.rag;
-  }
-  if (!("followUpRetrieval" in submittedPayload)) {
-    delete parametersPatch.followUpRetrieval;
-  }
+  // Built-in vector retrieval is retired (#4105): `rag` /
+  // `followUpRetrieval` must never reach a new edit or rerun submission,
+  // whether inherited from the base parameters or carried by the submitted
+  // payload. Strip unconditionally so stale authority cannot persist; the
+  // shared admission boundary rejects explicit retired requirements with an
+  // actionable error if they arrive through any other path.
+  delete parametersPatch.rag;
+  delete parametersPatch.followUpRetrieval;
   delete parametersPatch.startingBranch;
   delete parametersPatch.targetBranch;
   return parametersPatch;

--- a/frontend/src/lib/contextRetrievalAuthoring.test.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.test.ts
@@ -9,6 +9,7 @@ import {
   defaultContextRetrievalAuthoring,
   explainRetrievalDenials,
   hasAuthoredContextRetrieval,
+  hasRetiredRetrievalParameters,
   parseContextRetrievalParameters,
   retrievalCeilingsFromRuntimeConfig,
 } from './contextRetrievalAuthoring';
@@ -21,7 +22,7 @@ const NARROW_CEILINGS: RetrievalCeilings = {
   allowFallback: false,
 };
 
-describe('contextRetrievalAuthoring', () => {
+describe('contextRetrievalAuthoring (retired #4105)', () => {
   it('uses deployment-provided collection and budget ceilings', () => {
     const ceilings = retrievalCeilingsFromRuntimeConfig({
       collections: ['knowledge'],
@@ -65,31 +66,18 @@ describe('contextRetrievalAuthoring', () => {
   });
 
   it('caps maxQueries at the backend contract ceiling (100)', () => {
-    // The backend `RetrievalCapabilityIssue.max_queries` is le=100; the UI
-    // ceiling must match so 101-120 is not accepted only to fail issuance.
     expect(DEFAULT_RETRIEVAL_CEILINGS.maxQueries.max).toBe(100);
-    const value = defaultContextRetrievalAuthoring();
-    value.followUp.enabled = true;
-    value.followUp.collections = ['repo'];
-    value.followUp.maxQueries = 120;
-    const compiled = compileContextRetrievalParameters(value);
-    expect(compiled.followUpRetrieval).toMatchObject({ maxQueries: 100 });
   });
 
-  it('compiles rag and followUpRetrieval fragments', () => {
+  it('compiles to no vector fields for new writes (retired)', () => {
     const value = defaultContextRetrievalAuthoring();
     value.initial.collections = ['repo', 'docs'];
     value.initial.allowStale = true;
     value.followUp.enabled = true;
     value.followUp.collections = ['repo'];
     value.followUp.topK = 6;
-    const compiled = compileContextRetrievalParameters(value);
-    expect(compiled.rag).toEqual({ collections: ['repo', 'docs'], allowStale: true });
-    expect(compiled.followUpRetrieval).toMatchObject({
-      enabled: true,
-      collections: ['repo'],
-      topK: 6,
-    });
+    expect(compileContextRetrievalParameters(value)).toEqual({});
+    expect(hasAuthoredContextRetrieval(value)).toBe(false);
   });
 
   it('does not emit followUpRetrieval when disabled', () => {
@@ -97,7 +85,7 @@ describe('contextRetrievalAuthoring', () => {
     value.initial.required = true;
     const compiled = compileContextRetrievalParameters(value);
     expect(compiled.followUpRetrieval).toBeUndefined();
-    expect(compiled.rag).toEqual({ required: true });
+    expect(compiled.rag).toBeUndefined();
   });
 
   it('explains denied combinations for the operator', () => {
@@ -122,24 +110,29 @@ describe('contextRetrievalAuthoring', () => {
     expect(denials.some((d) => d.includes('required but disabled'))).toBe(true);
   });
 
-  it('round-trips through parse/compile', () => {
-    const value = defaultContextRetrievalAuthoring();
-    value.initial.collections = ['docs'];
-    value.followUp.enabled = true;
-    value.followUp.collections = ['repo'];
-    value.followUp.budgetPreset = 'generous';
-    value.followUp.topK = 16;
-    value.followUp.maxContextTokens = 16384;
-    value.followUp.maxQueries = 24;
-    value.followUp.latencyMs = 8000;
-    const compiled = compileContextRetrievalParameters(value);
-    const restored = parseContextRetrievalParameters(
-      compiled as Record<string, unknown>,
-    );
+  it('keeps historical payloads readable via parse', () => {
+    const restored = parseContextRetrievalParameters({
+      rag: { collections: ['docs'] },
+      followUpRetrieval: { enabled: true, collections: ['repo'] },
+    });
     expect(restored.initial.collections).toEqual(['docs']);
     expect(restored.followUp.enabled).toBe(true);
     expect(restored.followUp.collections).toEqual(['repo']);
-    // preset detected from the numeric budget
-    expect(restored.followUp.budgetPreset).toBe('generous');
+  });
+
+  it('detects retired parameters on historical payloads', () => {
+    expect(hasRetiredRetrievalParameters(null)).toBe(false);
+    expect(hasRetiredRetrievalParameters({})).toBe(false);
+    expect(
+      hasRetiredRetrievalParameters({ followUpRetrieval: { enabled: false } }),
+    ).toBe(false);
+    expect(
+      hasRetiredRetrievalParameters({ rag: { collections: ['docs'] } }),
+    ).toBe(true);
+    expect(
+      hasRetiredRetrievalParameters({
+        followUpRetrieval: { enabled: true, collections: ['repo'] },
+      }),
+    ).toBe(true);
   });
 });

--- a/frontend/src/lib/contextRetrievalAuthoring.ts
+++ b/frontend/src/lib/contextRetrievalAuthoring.ts
@@ -1,9 +1,11 @@
 // Shared authoring model for MoonMind context retrieval (RAG) controls.
 //
-// Covers GitHub issue MoonLadderStudios/MoonMind#3514 required work item 6:
-// coherent, policy-bounded RAG controls reused across every authoring surface
-// (workflow create/edit/rerun, recurring schedules, Omnigent agent profiles,
-// checkpoint branch turn creation, and remediation authoring).
+// Built-in vector retrieval is RETIRED (MoonLadderStudios/MoonMind#4105):
+// new workflows must not advertise or accept a built-in vector
+// retrieval/indexing capability. `parseContextRetrievalParameters` remains
+// for reading historical payloads; `compileContextRetrievalParameters`
+// returns no fields and `hasAuthoredContextRetrieval` is always false so no
+// new plan, draft, or schedule can reintroduce retired authority.
 //
 // The authored values are compiled into the run's `initial_parameters` as:
 //   - `rag`               → initial ContextPack injection overrides (#3513)
@@ -268,16 +270,11 @@ export function explainRetrievalDenials(
   return denials;
 }
 
-/** True when the authored config carries anything worth persisting. */
+/** Always false: retired authoring must never persist into new writes (#4105). */
 export function hasAuthoredContextRetrieval(
-  value: ContextRetrievalAuthoring,
+  _value: ContextRetrievalAuthoring,
 ): boolean {
-  return (
-    value.followUp.enabled ||
-    value.initial.collections.length > 0 ||
-    value.initial.allowStale ||
-    value.initial.required
-  );
+  return false;
 }
 
 export interface CompiledContextRetrievalParameters {
@@ -287,45 +284,62 @@ export interface CompiledContextRetrievalParameters {
 
 /**
  * Compile authored controls into the `initial_parameters` fragment consumed by
- * the run. Numeric values are clamped to the policy ceilings so the persisted
- * request never broadens policy; the server re-clamps regardless.
+ * the run.
+ *
+ * Built-in vector retrieval is retired (MoonLadderStudios/MoonMind#4105):
+ * new writes must not advertise or accept a built-in vector capability.
+ * This always returns an empty fragment so normal authoring needs no vector
+ * or embedding settings and no `rag` / `followUpRetrieval` fields reach new
+ * plans. Use `hasRetiredRetrievalParameters` to surface actionable guidance
+ * when a historical rerun/schedule payload still carries retired requirements.
  */
 export function compileContextRetrievalParameters(
-  value: ContextRetrievalAuthoring,
-  ceilings: RetrievalCeilings = DEFAULT_RETRIEVAL_CEILINGS,
+  _value: ContextRetrievalAuthoring,
+  _ceilings: RetrievalCeilings = DEFAULT_RETRIEVAL_CEILINGS,
 ): CompiledContextRetrievalParameters {
-  const compiled: CompiledContextRetrievalParameters = {};
-  const allowed = new Set(ceilings.collections);
+  return {};
+}
 
-  const initialCollections = uniqueStrings(value.initial.collections).filter((c) =>
-    allowed.has(c),
+/**
+ * True when a persisted `initial_parameters` payload carries explicit retired
+ * vector requirements (`rag` with content or `followUpRetrieval` with enabled
+ * / retired configuration). Historical details remain readable via
+ * `parseContextRetrievalParameters`; a true result here means a new execution
+ * must be resubmitted without the retired fields before it is accepted.
+ */
+export function hasRetiredRetrievalParameters(
+  parameters: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!parameters || typeof parameters !== 'object') {
+    return false;
+  }
+  const rag = asRecord(parameters.rag);
+  if (rag && Object.values(rag).some((item) => !isAbsentVectorValue(item))) {
+    return true;
+  }
+  const followUp = asRecord(parameters.followUpRetrieval);
+  if (!followUp) {
+    return false;
+  }
+  if (followUp.enabled === true) {
+    return true;
+  }
+  return Object.entries(followUp).some(
+    ([key, item]) => key !== 'enabled' && !isAbsentVectorValue(item),
   );
-  if (initialCollections.length > 0 || value.initial.allowStale || value.initial.required) {
-    compiled.rag = {
-      ...(initialCollections.length > 0 ? { collections: initialCollections } : {}),
-      ...(value.initial.allowStale ? { allowStale: true } : {}),
-      ...(value.initial.required ? { required: true } : {}),
-    };
-  }
+}
 
-  if (value.followUp.enabled) {
-    const followUp = clampFollowUpRetrieval(value.followUp, ceilings);
-    compiled.followUpRetrieval = {
-      enabled: true,
-      required: followUp.required,
-      collections: followUp.collections,
-      topK: followUp.topK,
-      maxContextTokens: followUp.maxContextTokens,
-      maxQueries: followUp.maxQueries,
-      latencyMs: followUp.latencyMs,
-      maxLifetimeSeconds: followUp.maxLifetimeSeconds,
-      overlayPolicy: followUp.overlayPolicy,
-      staleOverlayAllowed: followUp.staleOverlayAllowed,
-      fallbackAllowed: followUp.fallbackAllowed,
-    };
+function isAbsentVectorValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === false || value === '') {
+    return true;
   }
-
-  return compiled;
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>).length === 0;
+  }
+  return false;
 }
 
 /** Hydrate authoring state from a previously compiled `initial_parameters`. */

--- a/frontend/src/lib/remediationCreateDraft.test.ts
+++ b/frontend/src/lib/remediationCreateDraft.test.ts
@@ -130,7 +130,7 @@ describe('remediationCreateDraft', () => {
     expect(inspectRemediationCreateDraft(draftId).status).toBe('valid');
   });
 
-  it('prepopulates source/work branches, Omnigent launch identity, and retrieval controls', () => {
+  it('prepopulates source/work branches and Omnigent launch identity without retrieval state', () => {
     const draft = buildRemediationCreateDraft({
       workflowId: 'mm:target',
       runId: 'run-target',
@@ -161,9 +161,8 @@ describe('remediationCreateDraft', () => {
     expect(draft.workBranch).toBe('repair/mm-3623');
     expect(draft.executionProfileRef).toBe('execution-profile:codex-default');
     expect(draft.launchPolicyRef).toBe('launch-policy:remediation-v3');
-    expect(draft.contextRetrieval).toMatchObject({
-      initial: { collections: ['docs'], required: true },
-    });
+    // Retired (#4105): remediation drafts carry no retrieval authoring.
+    expect(draft.contextRetrieval).toBeUndefined();
     expect(draft.remediation.checkpointBranchPolicy).toMatchObject({
       gitWorkBranch: 'repair/mm-3623',
     });

--- a/frontend/src/lib/remediationCreateDraft.ts
+++ b/frontend/src/lib/remediationCreateDraft.ts
@@ -1,7 +1,4 @@
-import {
-  type ContextRetrievalAuthoring,
-  parseContextRetrievalParameters,
-} from './contextRetrievalAuthoring';
+import type { ContextRetrievalAuthoring } from './contextRetrievalAuthoring';
 import {
   buildRemediationRuntimeRequestFields,
   DEFAULT_REMEDIATION_ACTION_POLICY,
@@ -292,7 +289,9 @@ export function buildRemediationCreateDraft(
   const launchPolicyRef = cleanText(
     omnigentParameters.launchPolicyRef || storedSnapshot.launchPolicyRef,
   );
-  const contextRetrieval = parseContextRetrievalParameters(inputParameters);
+  // Built-in vector retrieval retired (#4105): remediation drafts carry no
+  // retrieval authoring. Historical payloads remain readable in detail views;
+  // new remediation work uses explicit evidence refs, never rag/followUp.
   return {
     source: 'remediation',
     schemaVersion: 1,
@@ -310,7 +309,6 @@ export function buildRemediationCreateDraft(
     publishMode: 'pr',
     ...(executionProfileRef ? { executionProfileRef } : {}),
     ...(launchPolicyRef ? { launchPolicyRef } : {}),
-    ...(contextRetrieval ? { contextRetrieval } : {}),
     runtime: {
       ...(cleanText(runtime.mode) ? { mode: cleanText(runtime.mode) } : {}),
       ...(cleanText(runtime.model) ? { model: cleanText(runtime.model) } : {}),

--- a/moonmind/omnigent/codex_execution_decisions.py
+++ b/moonmind/omnigent/codex_execution_decisions.py
@@ -312,128 +312,46 @@ def compile_follow_up_retrieval_policy(
 ) -> dict[str, Any]:
     """Compile the runtime ``followUpRetrieval`` block carried by the launch snapshot.
 
-    In-session (follow-up) retrieval grants the host an authorized capability, so
-    it is an authority boundary and stays disabled unless an authoring surface
-    explicitly enables it via ``parameters["followUpRetrieval"]``. Deployment
-    policy (``boundaries.rag``) supplies the default budgets; the gateway and the
-    server budget snapshot enforce the deployment ceilings, so this block is only
-    the authored per-run ceiling and never a broadening of policy.
+    Built-in vector retrieval is retired (MoonLadderStudios/MoonMind#4105):
+    newly compiled plans carry no vector capability descriptors. This function
+    always returns ``{"enabled": False}`` so no new launch snapshot mints
+    native Qdrant/embedding/collection/overlay authority. Explicit authored
+    requests are rejected by :func:`enforce_required_follow_up_retrieval`
+    before host launch; historical snapshots remain readable downstream.
     """
 
-    authored: dict[str, Any] = {}
-    if isinstance(parameters, Mapping):
-        raw = parameters.get("followUpRetrieval")
-        if isinstance(raw, Mapping):
-            authored = dict(raw)
-    if authored.get("enabled") is not True:
-        return {"enabled": False}
-
-    rag: dict[str, Any] = {}
-    boundaries = (
-        policy_snapshot.get("boundaries")
-        if isinstance(policy_snapshot, Mapping)
-        else None
-    )
-    if isinstance(boundaries, Mapping) and isinstance(boundaries.get("rag"), Mapping):
-        rag = dict(boundaries["rag"])
-
-    collections = list(
-        dict.fromkeys(
-            str(item).strip()
-            for item in authored.get("collections", ())
-            if str(item).strip()
-        )
-    )
-    repository = str(repository or "").strip()
-    tenant_id = str(tenant_id or "").strip()
-    policy_version = (
-        str(policy_snapshot.get("policyRef") or "").strip()
-        if isinstance(policy_snapshot, Mapping)
-        else ""
-    )
-
-    if not (repository and tenant_id and policy_version and collections):
-        # Enabling without a resolvable scope would only yield an auditable 409
-        # from the gateway; keep the capability unavailable with an explicit,
-        # non-fatal reason instead of persisting a broken authority block.
-        return {"enabled": False, "reason": "incomplete_follow_up_retrieval_scope"}
-
-    block: dict[str, Any] = {
-        "enabled": True,
-        "required": bool(authored.get("required", False)),
-        "repository": repository,
-        "tenantId": tenant_id,
-        "policyVersion": policy_version,
-        "collections": collections,
-        "overlayPolicy": (
-            "skip" if str(authored.get("overlayPolicy")) == "skip" else "include"
-        ),
-        "staleOverlayAllowed": bool(authored.get("staleOverlayAllowed", False)),
-        "fallbackAllowed": bool(authored.get("fallbackAllowed", False)),
-    }
-
-    filters = authored.get("filters")
-    if isinstance(filters, Mapping):
-        compiled_filters = {
-            str(key): str(value)
-            for key, value in filters.items()
-            if str(key).strip() and str(value).strip()
-        }
-        if compiled_filters:
-            block["filters"] = compiled_filters
-
-    for field in _FOLLOW_UP_RETRIEVAL_INT_FIELDS:
-        coerced = _coerce_positive_int(authored.get(field))
-        if coerced is not None:
-            block[field] = coerced
-
-    # Clamp the policy-backed budgets to ``boundaries.rag`` so an authored run
-    # override can only ever narrow deployment policy, never broaden it. When the
-    # author omitted the field the policy value becomes the ceiling; when both are
-    # present the tighter (minimum) value wins. The gateway clamps host requests
-    # against deployment *environment* limits, not the selected policy, so the
-    # selected-policy ceiling must be folded in here or a run could receive a
-    # larger retrieval budget than its policy authorizes.
-    for block_field, policy_key in (
-        ("latencyMs", "latencyBudgetMs"),
-        ("maxContextTokens", "tokenBudget"),
-    ):
-        policy_value = _coerce_positive_int(rag.get(policy_key))
-        if policy_value is None:
-            continue
-        authored_value = block.get(block_field)
-        block[block_field] = (
-            min(authored_value, policy_value)
-            if isinstance(authored_value, int)
-            else policy_value
-        )
-
-    return block
+    return {"enabled": False}
 
 
 def enforce_required_follow_up_retrieval(
     authored_follow_up: Mapping[str, Any] | None,
     compiled_block: Mapping[str, Any],
 ) -> None:
-    """Fail the launch when required follow-up retrieval cannot be made available.
+    """Fail the launch when built-in vector retrieval is explicitly requested.
 
-    Follow-up retrieval is an authority boundary. When an operator explicitly
-    enables it with ``required: true`` the advertised guarantee must hold: if the
-    compiled capability is unavailable (for example an incomplete, unresolvable
-    scope), the step must block instead of silently launching with retrieval
-    disabled. Optional retrieval (``required`` unset/false) degrades quietly.
+    Built-in vector retrieval is retired (MoonLadderStudios/MoonMind#4105):
+    any explicit ``followUpRetrieval`` requirement (``enabled: true`` or a
+    non-empty retired configuration) must fail before host launch, paid work,
+    or external mutation, without silently weakening the request into a
+    retrieval-free launch. Absent/empty/disabled values pass so normal flows
+    need no vector settings.
     """
 
     if not isinstance(authored_follow_up, Mapping):
         return
-    if authored_follow_up.get("enabled") is not True:
+    if not authored_follow_up:
         return
-    if not bool(authored_follow_up.get("required")):
+    enabled = authored_follow_up.get("enabled") is True
+    has_retired_content = enabled or any(
+        value not in (None, False, "", [], {})
+        for key, value in authored_follow_up.items()
+        if key != "enabled"
+    )
+    if not has_retired_content:
         return
-    if compiled_block.get("enabled") is True:
-        return
-    reason = str(compiled_block.get("reason") or "follow_up_retrieval_unavailable")
     raise OmnigentOAuthHostError(
-        f"required follow-up retrieval is unavailable: {reason}",
-        code="OMNIGENT_REQUIRED_FOLLOW_UP_RETRIEVAL_UNAVAILABLE",
+        "built-in vector retrieval has been retired "
+        "(MoonLadderStudios/MoonMind#4105). Remove followUpRetrieval and use "
+        "explicit attachments, artifact refs, or scoped workspace access instead.",
+        code="OMNIGENT_RETIRED_VECTOR_RETRIEVAL",
     )

--- a/moonmind/omnigent/codex_execution_decisions.py
+++ b/moonmind/omnigent/codex_execution_decisions.py
@@ -342,8 +342,14 @@ def enforce_required_follow_up_retrieval(
     if not authored_follow_up:
         return
     enabled = authored_follow_up.get("enabled") is True
+    # Note: use identity checks for None/False so numeric 0 budgets count as
+    # explicit retired content (0 == False in Python).
     has_retired_content = enabled or any(
-        value not in (None, False, "", [], {})
+        value is not None
+        and value is not False
+        and value != ""
+        and value != []
+        and value != {}
         for key, value in authored_follow_up.items()
         if key != "enabled"
     )

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1312,6 +1312,17 @@ class AgentExecutionRequest(BaseModel):
         ]
 
         parameters_for_secret_scan = dict(self.parameters)
+        from moonmind.workflows.executions.execution_contract import (
+            WorkflowContractError,
+            reject_retired_vector_fields,
+        )
+
+        try:
+            reject_retired_vector_fields(
+                parameters_for_secret_scan, field_path="parameters"
+            )
+        except WorkflowContractError as exc:
+            raise ValueError(str(exc)) from exc
         follow_up_retrieval = parameters_for_secret_scan.get("followUpRetrieval")
         if isinstance(follow_up_retrieval, dict):
             follow_up_for_secret_scan = dict(follow_up_retrieval)

--- a/moonmind/schemas/checkpoint_branch_models.py
+++ b/moonmind/schemas/checkpoint_branch_models.py
@@ -122,13 +122,25 @@ class CheckpointBranchCreateRequest(BaseModel):
     )
     model: str | None = Field(None, min_length=1, max_length=255)
     effort: str | None = Field(None, min_length=1, max_length=64)
-    # Authored in-session follow-up retrieval override for the branch turn
-    # (MoonMind#3514). Recorded as bounded authored intent and folded into the
-    # branch operation idempotency digest; enforcement inherits the parent run's
-    # compiled policy unless a narrower override is materialized at launch.
+    # Built-in vector retrieval authoring retired
+    # (MoonLadderStudios/MoonMind#4105). The field remains accepted only in its
+    # absent/empty/disabled form so historical payloads still parse; explicit
+    # retired requirements fail validation before any new execution is accepted.
     follow_up_retrieval: dict[str, Any] | None = Field(
         None, alias="followUpRetrieval"
     )
+
+    @model_validator(mode="after")
+    def _reject_retired_vector_retrieval(self) -> "CheckpointBranchCreateRequest":
+        from moonmind.workflows.executions.execution_contract import (
+            reject_retired_vector_fields,
+        )
+
+        reject_retired_vector_fields(
+            {"followUpRetrieval": self.follow_up_retrieval},
+            field_path="payload",
+        )
+        return self
 
 
 class CheckpointBranchContinueRequest(BaseModel):
@@ -146,10 +158,22 @@ class CheckpointBranchContinueRequest(BaseModel):
         ..., alias="idempotencyKey", min_length=1, max_length=512
     )
     max_budget_usd: float | None = Field(None, alias="maxBudgetUsd", ge=0)
-    # See CheckpointBranchCreateRequest.follow_up_retrieval (MoonMind#3514).
+    # See CheckpointBranchCreateRequest.follow_up_retrieval (retired #4105).
     follow_up_retrieval: dict[str, Any] | None = Field(
         None, alias="followUpRetrieval"
     )
+
+    @model_validator(mode="after")
+    def _reject_retired_vector_retrieval(self) -> "CheckpointBranchContinueRequest":
+        from moonmind.workflows.executions.execution_contract import (
+            reject_retired_vector_fields,
+        )
+
+        reject_retired_vector_fields(
+            {"followUpRetrieval": self.follow_up_retrieval},
+            field_path="payload",
+        )
+        return self
 
 
 class CheckpointBranchForkRequest(CheckpointBranchContinueRequest):

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -91,6 +91,18 @@ _RETIRED_VECTOR_MESSAGE = (
 )
 
 
+def _is_absent_vector_value(item: object) -> bool:
+    """Return True for absent/empty/disabled retrieval values.
+
+    Uses identity checks for ``None``/``False`` so numeric ``0`` is treated
+    as an explicit value (``0 == False`` in Python) rather than as absent.
+    """
+
+    if item is None or item is False:
+        return True
+    return item == "" or item == [] or item == {}
+
+
 def _is_explicit_vector_requirement(field: str, value: object) -> bool:
     """Distinguish absent optional enrichment from an explicit retired request.
 
@@ -115,7 +127,8 @@ def _is_explicit_vector_requirement(field: str, value: object) -> bool:
                 remainder = {
                     key: item
                     for key, item in value.items()
-                    if key not in {"enabled", "Enabled"} and item not in (None, False, "", [], {})
+                    if key not in {"enabled", "Enabled"}
+                    and not _is_absent_vector_value(item)
                 }
                 return bool(remainder and any(
                     key in {
@@ -129,8 +142,7 @@ def _is_explicit_vector_requirement(field: str, value: object) -> bool:
             return True
         # ``rag``: explicit when any collection/authority flag is set.
         return any(
-            item not in (None, False, "", [], {})
-            for item in value.values()
+            not _is_absent_vector_value(item) for item in value.values()
         )
     # Non-mapping truthy values (e.g. ``rag: true``) are explicit; falsy are not.
     return bool(value)

--- a/moonmind/workflows/executions/execution_contract.py
+++ b/moonmind/workflows/executions/execution_contract.py
@@ -73,6 +73,112 @@ _REMOVED_FOLLOW_UP_MESSAGE = (
 )
 
 
+#: Built-in vector retrieval/indexing fields retired by
+#: MoonLadderStudios/MoonMind#4105. New writes must not advertise or accept a
+#: built-in vector capability the removal release cannot execute. Historical
+#: records remain readable through detail/artifact projections; only new
+#: admission is rejected here.
+_RETIRED_VECTOR_FIELDS = {
+    "rag": "rag",
+    "followUpRetrieval": "followUpRetrieval",
+    "follow_up_retrieval": "followUpRetrieval",
+}
+_RETIRED_VECTOR_MESSAGE = (
+    "has been retired (MoonLadderStudios/MoonMind#4105). Remove the vector "
+    "retrieval/indexing fields and use explicit attachments, artifact refs, or "
+    "scoped workspace access instead. Historical details remain readable; "
+    "resubmit without retired requirements to start new work."
+)
+
+
+def _is_explicit_vector_requirement(field: str, value: object) -> bool:
+    """Distinguish absent optional enrichment from an explicit retired request.
+
+    Absent/empty/disabled values (``None``, ``{}``, ``{"enabled": False}``,
+    all-falsy mappings) are not a request for retired behavior and must not be
+    rejected, so default flows keep working. Anything carrying real retrieval
+    authority (collections, required flags, budgets, enabled sessions) is
+    explicit and must fail before scheduling rather than being silently
+    dropped with changed semantics.
+    """
+
+    if value is None:
+        return False
+    if isinstance(value, Mapping):
+        if not value:
+            return False
+        if field == "followUpRetrieval":
+            enabled = value.get("enabled", value.get("Enabled", False))
+            # ``{"enabled": False}`` alone (or with only falsy siblings) is the
+            # explicit-absent form, not a retired request.
+            if enabled is not True:
+                remainder = {
+                    key: item
+                    for key, item in value.items()
+                    if key not in {"enabled", "Enabled"} and item not in (None, False, "", [], {})
+                }
+                return bool(remainder and any(
+                    key in {
+                        "required", "collections", "topK", "top_k", "maxContextTokens",
+                        "maxQueries", "latencyMs", "maxLifetimeSeconds",
+                        "overlayPolicy", "staleOverlayAllowed", "fallbackAllowed",
+                        "filters", "repository", "tenantId",
+                    }
+                    for key in remainder
+                ))
+            return True
+        # ``rag``: explicit when any collection/authority flag is set.
+        return any(
+            item not in (None, False, "", [], {})
+            for item in value.values()
+        )
+    # Non-mapping truthy values (e.g. ``rag: true``) are explicit; falsy are not.
+    return bool(value)
+
+
+def reject_retired_vector_fields(
+    value: object,
+    *,
+    field_path: str,
+) -> None:
+    """Reject explicit built-in vector retrieval requirements at admission.
+
+    Empty/absent/disabled values pass so normal authoring needs no vector
+    settings. Explicit ``rag`` / ``followUpRetrieval`` requirements raise
+    ``WorkflowContractError`` with an actionable message before any Temporal
+    start, host launch, paid work, or external mutation.
+    """
+
+    if not isinstance(value, Mapping):
+        return
+    for source_field, canonical_field in _RETIRED_VECTOR_FIELDS.items():
+        if source_field not in value:
+            continue
+        if not _is_explicit_vector_requirement(canonical_field, value[source_field]):
+            continue
+        raise WorkflowContractError(
+            f"{field_path}.{canonical_field} {_RETIRED_VECTOR_MESSAGE}"
+        )
+
+
+def strip_absent_vector_fields(value: dict[str, Any]) -> dict[str, Any]:
+    """Drop absent/empty/disabled vector fields so they never reach new plans.
+
+    Explicit retired requests must be rejected with
+    :func:`reject_retired_vector_fields` first; this helper only removes the
+    non-explicit residue (``{}``, ``{"enabled": False}``, ``None``) so stale
+    hidden state, drafts, and seeds cannot reintroduce retired authority.
+    """
+
+    for source_field in _RETIRED_VECTOR_FIELDS:
+        if source_field not in value:
+            continue
+        canonical = _RETIRED_VECTOR_FIELDS[source_field]
+        if not _is_explicit_vector_requirement(canonical, value[source_field]):
+            value.pop(source_field, None)
+    return value
+
+
 def reject_removed_follow_up_fields(
     value: object,
     *,
@@ -2089,6 +2195,7 @@ class WorkflowExecutionSpec(BaseModel):
         if not isinstance(value, Mapping):
             return value
         reject_removed_follow_up_fields(value, field_path="workflow")
+        reject_retired_vector_fields(value, field_path="workflow")
         reject_workflow_capability_identity_versions(value, field_path="workflow")
         payload = dict(value)
         runtime_node = payload.get("runtime")
@@ -2279,6 +2386,7 @@ class CanonicalWorkflowExecutionPayload(BaseModel):
         if not isinstance(value, Mapping):
             return value
         reject_removed_follow_up_fields(value, field_path="payload")
+        reject_retired_vector_fields(value, field_path="payload")
         return value
 
     @field_validator("repository", mode="before")
@@ -3112,6 +3220,8 @@ __all__ = [
     "is_self_managed_publish_skill",
     "normalize_queue_job_payload",
     "reject_removed_follow_up_fields",
+    "reject_retired_vector_fields",
+    "strip_absent_vector_fields",
     "resolve_publish_mode_for_skill",
     "reject_workflow_capability_identity_versions",
     "strip_workflow_capability_identity_versions",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -19884,11 +19884,13 @@ class MoonMindRunWorkflow:
             "story_breakdown_path",
             "storyBreakdownMarkdownPath",
             "story_breakdown_markdown_path",
-            # Context retrieval (RAG) authoring surfaces (#3514): initial
-            # ContextPack overrides and in-session follow-up retrieval policy,
-            # plus the repository/tenant scope the retrieval budget binds to.
-            "rag",
-            "followUpRetrieval",
+            # Built-in vector retrieval is retired (#4105): `rag` /
+            # `followUpRetrieval` are never forwarded into new agent requests.
+            # Admission rejects explicit retired requirements for new work, so
+            # stripping here is a no-op for post-retirement workflows; for
+            # pre-retirement in-flight histories it keeps replay deterministic
+            # (in-flight decoding/schedule retirement is coordinated with the
+            # cutover child) instead of failing workflow tasks on construction.
             "repository",
             "tenant",
             "tenantId",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -4333,11 +4333,11 @@ def test_create_task_shaped_execution_rejects_explicit_skill_step_without_skill_
     service.create_execution.assert_not_awaited()
 
 
-def test_create_execution_lifts_context_retrieval_authoring(
+def test_create_execution_rejects_retired_vector_retrieval(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MoonMind#3514: payload-level rag / followUpRetrieval reach initial parameters."""
+    """MoonLadderStudios/MoonMind#4105: explicit rag/followUp fail before scheduling."""
     test_client, service, _user = client
     service.create_execution.return_value = _build_execution_record()
 
@@ -4383,14 +4383,61 @@ def test_create_execution_lifts_context_retrieval_authoring(
         },
     )
 
+    assert response.status_code == 422, response.text
+    assert "4105" in response.text
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_execution_absent_vector_fields_admitted(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MoonLadderStudios/MoonMind#4105: absent/empty/disabled vector fields pass."""
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    async def _identity_validate_skill_step_inputs(*, initial_parameters, **_kwargs):
+        return SimpleNamespace(
+            valid=True,
+            parameters=initial_parameters,
+            error_dicts=lambda: [],
+        )
+
+    monkeypatch.setattr(
+        "api_service.api.routers.executions.validate_skill_step_inputs",
+        _identity_validate_skill_step_inputs,
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "workflow",
+            "payload": {
+                "rag": {},
+                "followUpRetrieval": {"enabled": False},
+                "workflow": {
+                    "instructions": "Run without vector retrieval.",
+                    "steps": [
+                        {
+                            "id": "step-1",
+                            "title": "Step",
+                            "type": "skill",
+                            "skill": {
+                                "id": "noop",
+                                "inputs": {},
+                                "inputContractDigest": "sha256:saved",
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
     assert response.status_code == 201, response.text
     initial_parameters = service.create_execution.await_args.kwargs["initial_parameters"]
-    assert initial_parameters["rag"] == {"collections": ["docs"], "allowStale": True}
-    assert initial_parameters["followUpRetrieval"] == {
-        "enabled": True,
-        "collections": ["repo", "docs"],
-        "topK": 6,
-    }
+    assert "rag" not in initial_parameters
+    assert "followUpRetrieval" not in initial_parameters
 
 
 def test_create_task_shaped_execution_normalizes_skill_inputs(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -10858,6 +10858,33 @@ def test_recurring_target_preserves_omnigent_selection_in_initial_parameters() -
     }
 
 
+def test_build_recurring_target_rejects_retired_vector_in_task_path() -> None:
+    """MoonLadderStudios/MoonMind#4105: task-shaped recurring targets reject retired vectors."""
+    with pytest.raises(HTTPException) as excinfo:
+        _build_recurring_target(
+            {
+                "workflowType": "MoonMind.UserWorkflow",
+                "workflow": {
+                    "instructions": "Run nightly",
+                    "followUpRetrieval": {"enabled": True, "collections": ["repo"]},
+                },
+            }
+        )
+    assert "4105" in str(excinfo.value.detail)
+
+    with pytest.raises(HTTPException) as excinfo:
+        _build_recurring_target(
+            {
+                "workflowType": "MoonMind.UserWorkflow",
+                "task": {
+                    "instructions": "Run nightly",
+                    "rag": {"collections": ["docs"]},
+                },
+            }
+        )
+    assert "4105" in str(excinfo.value.detail)
+
+
 @pytest.mark.asyncio
 async def test_recurring_target_persists_normalized_tier_previews() -> None:
     request_payload = {

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -83,36 +83,29 @@ def _request_stub() -> SimpleNamespace:
 
 
 def test_bridge_capability_derives_identity_and_clamps_narrowing() -> None:
-    issue = _bridge_authoritative_issue(
-        _bridge_row(),
-        BridgeRetrievalCapabilityIssue(
-            collections=["docs"],
-            filters={"branch": "main"},
-            lifetime_seconds=600,
-            top_k=3,
-            max_context_tokens=500,
-        ),
-    )
-
-    assert issue.tenant_id == "tenant-1"
-    assert issue.repository == "MoonMind"
-    assert issue.run_id == "run-1"
-    assert issue.workspace_id == "workspace-1"
-    assert issue.host_id == "host-1"
-    assert issue.session_id == "session-1"
-    assert issue.collections == ["docs"]
-    assert issue.top_k == 3
-    assert issue.max_context_tokens == 500
-    assert issue.lifetime_seconds == 120
+    """Retired (#4105): new issuance from an enabled snapshot fails 410."""
+    with pytest.raises(HTTPException) as retired:
+        _bridge_authoritative_issue(
+            _bridge_row(),
+            BridgeRetrievalCapabilityIssue(
+                collections=["docs"],
+                filters={"branch": "main"},
+                lifetime_seconds=600,
+                top_k=3,
+                max_context_tokens=500,
+            ),
+        )
+    assert retired.value.status_code == 410
 
 
 def test_bridge_capability_rejects_caller_scope_broadening() -> None:
-    with pytest.raises(HTTPException) as denied:
+    # Retired issuance fails before scope checks; disabled snapshots stay 403.
+    with pytest.raises(HTTPException) as retired:
         _bridge_authoritative_issue(
             _bridge_row(),
             BridgeRetrievalCapabilityIssue(collections=["private"]),
         )
-    assert denied.value.status_code == 403
+    assert retired.value.status_code == 410
 
     with pytest.raises(HTTPException) as inactive:
         _bridge_authoritative_issue(
@@ -123,18 +116,19 @@ def test_bridge_capability_rejects_caller_scope_broadening() -> None:
 
 
 def test_bridge_capability_lifetime_is_clamped_to_authority_expiry() -> None:
+    """Retired (#4105): enabled snapshots fail issuance regardless of expiry."""
     row = _bridge_row()
     row.effective_launch_snapshot_json["followUpRetrieval"][
         "authorityExpiresAt"
     ] = 1_000_045
 
-    issue = _bridge_authoritative_issue(
-        row,
-        BridgeRetrievalCapabilityIssue(lifetime_seconds=120),
-        now=1_000_000,
-    )
-
-    assert issue.lifetime_seconds == 45
+    with pytest.raises(HTTPException) as retired:
+        _bridge_authoritative_issue(
+            row,
+            BridgeRetrievalCapabilityIssue(lifetime_seconds=120),
+            now=1_000_000,
+        )
+    assert retired.value.status_code == 410
 
 
 def test_bridge_capability_rejects_expired_or_invalid_authority() -> None:
@@ -146,7 +140,8 @@ def test_bridge_capability_rejects_expired_or_invalid_authority() -> None:
         _bridge_authoritative_issue(
             expired, BridgeRetrievalCapabilityIssue(), now=2
         )
-    assert expired_error.value.status_code == 409
+    # Retirement is checked before expiry decoding for enabled snapshots.
+    assert expired_error.value.status_code == 410
 
     invalid = _bridge_row()
     invalid.effective_launch_snapshot_json["followUpRetrieval"][
@@ -156,7 +151,7 @@ def test_bridge_capability_rejects_expired_or_invalid_authority() -> None:
         _bridge_authoritative_issue(
             invalid, BridgeRetrievalCapabilityIssue(), now=1
         )
-    assert invalid_error.value.status_code == 409
+    assert invalid_error.value.status_code == 410
 
 
 def test_unscoped_capability_issuance_route_is_not_exposed() -> None:
@@ -1149,7 +1144,7 @@ def test_session_result_is_not_readable_by_another_capability(tmp_path) -> None:
 
 
 def test_bridge_capability_refuses_authority_inside_minimum_lifetime() -> None:
-    """Authority with <30s left is refused, not clamped into a 500."""
+    """Retired (#4105): enabled snapshots fail issuance regardless of lifetime."""
     row = _bridge_row()
     row.effective_launch_snapshot_json["followUpRetrieval"][
         "authorityExpiresAt"
@@ -1160,15 +1155,14 @@ def test_bridge_capability_refuses_authority_inside_minimum_lifetime() -> None:
             row, BridgeRetrievalCapabilityIssue(lifetime_seconds=120), now=1_000_000
         )
 
-    assert refused.value.status_code == 409
-    assert "30s remaining" in refused.value.detail
+    assert refused.value.status_code == 410
 
 
 @pytest.mark.asyncio
-async def test_bridge_capability_issuance_is_bounded_per_scope(
+async def test_bridge_capability_issuance_is_retired(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A retried POST must not multiply the immutable query allowance."""
+    """Retired (#4105): issuance mints nothing and writes no events."""
     monkeypatch.setenv("MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", "repo,docs")
     registry = RetrievalCapabilityRegistry(tmp_path)
 
@@ -1181,11 +1175,12 @@ async def test_bridge_capability_issuance_is_bounded_per_scope(
 
         async def append_events(self, bridge_session_id, events):
             self.events.extend(events)
+            raise AssertionError("Retired issuance must not record events.")
 
     store = Store()
 
-    async def issue():
-        return await issue_bridge_retrieval_capability(
+    with pytest.raises(HTTPException) as retired:
+        await issue_bridge_retrieval_capability(
             "bridge-1",
             BridgeRetrievalCapabilityIssue(),
             registry=registry,
@@ -1193,20 +1188,8 @@ async def test_bridge_capability_issuance_is_bounded_per_scope(
             user=SimpleNamespace(id="user-1"),
             service=_OwnedExecutionService(),
         )
-
-    first = await issue()
-    assert first["capabilityId"]
-
-    with pytest.raises(HTTPException) as bounded:
-        await issue()
-    assert bounded.value.status_code == 409
-    assert bounded.value.detail["code"] == "retrieval_capability_already_active"
-    assert bounded.value.detail["capabilityId"] == first["capabilityId"]
-
-    # After the live capability is revoked a replacement may be issued.
-    registry.revoke(first["capabilityId"])
-    second = await issue()
-    assert second["capabilityId"] != first["capabilityId"]
+    assert retired.value.status_code == 410
+    assert store.events == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/omnigent/test_checkpoint_branch_turn_execution.py
+++ b/tests/unit/omnigent/test_checkpoint_branch_turn_execution.py
@@ -77,10 +77,7 @@ def _authority_graph():
         context_bundle_ref=None,
         step_execution_manifest_ref=None,
         diagnostics={
-            "followUpRetrieval": {
-                "collections": ["repo"],
-                "budgets": {"tokens": 500},
-            }
+            # Retired (#4105): new branch turns carry no vector authority.
         },
         created_at=datetime(2026, 8, 12, tzinfo=UTC),
     )
@@ -425,8 +422,8 @@ async def test_owner_allocates_and_claims_canonical_omnigent_request_before_star
         "sourceProviderSessionReused": False,
         "sourceOAuthLeaseReused": False,
     }
-    assert request["parameters"]["followUpRetrieval"]["collections"] == ["repo"]
-    assert request["parameters"]["followUpRetrieval"]["maxContextTokens"] == 500
+    # Retired (#4105): new branch-turn launches carry no vector authority.
+    assert "followUpRetrieval" not in request["parameters"]
     assert request["parameters"]["model"] == "profile-model"
     assert request["parameters"]["effort"] == "medium"
     assert request["parameters"]["maxBudgetUsd"] == 2.5

--- a/tests/unit/omnigent/test_follow_up_retrieval_policy.py
+++ b/tests/unit/omnigent/test_follow_up_retrieval_policy.py
@@ -99,6 +99,15 @@ def test_enforce_retired_vector_retrieval_allows_absent() -> None:
     )
 
 
+def test_enforce_retired_vector_retrieval_blocks_zero_budget() -> None:
+    """Zero budgets are explicit retired content (0 == False in Python)."""
+    with pytest.raises(OmnigentOAuthHostError) as excinfo:
+        enforce_required_follow_up_retrieval(
+            {"maxContextTokens": 0}, {"enabled": False}
+        )
+    assert excinfo.value.code == "OMNIGENT_RETIRED_VECTOR_RETRIEVAL"
+
+
 def test_gateway_issuance_from_enabled_snapshot_is_retired() -> None:
     """New capability issuance from a retired enabled snapshot fails 410."""
     row = type(

--- a/tests/unit/omnigent/test_follow_up_retrieval_policy.py
+++ b/tests/unit/omnigent/test_follow_up_retrieval_policy.py
@@ -1,31 +1,26 @@
-"""Follow-up (in-session) retrieval authoring → launch snapshot compilation.
+"""Retired built-in vector retrieval → launch snapshot compilation.
 
-Covers GitHub issue MoonLadderStudios/MoonMind#3514 required work item 6: an
-authoring surface enables follow-up retrieval by writing
-``parameters["followUpRetrieval"]``; the coordinator compiles a runtime
-``followUpRetrieval`` block into the durable launch snapshot that the retrieval
-gateway consumes. Follow-up retrieval is an authority boundary, so it stays
-disabled unless explicitly enabled.
+MoonLadderStudios/MoonMind#4105: newly compiled plans carry no vector
+capability descriptors. ``compile_follow_up_retrieval_policy`` always returns
+``{"enabled": False}``; any explicit authored request fails via
+``enforce_required_follow_up_retrieval`` before host launch, and gateway
+issuance from an enabled launch snapshot fails retired (410) without minting
+authority. Historical snapshots remain readable downstream.
 """
 
 from __future__ import annotations
 
 import pytest
+from fastapi import HTTPException
 
 from api_service.api.routers.retrieval_gateway import (
     BridgeRetrievalCapabilityIssue,
     _bridge_authoritative_issue,
 )
-from moonmind.omnigent.execution_profiles import (
-    validate_effective_launch_snapshot,
-)
 from moonmind.omnigent.host_failures import OmnigentOAuthHostError
 from moonmind.omnigent.codex_execution_decisions import (
     compile_follow_up_retrieval_policy,
     enforce_required_follow_up_retrieval,
-)
-from moonmind.omnigent.profile_bound_execution import (
-    _compile_persisted_effective_launch,
 )
 
 
@@ -60,151 +55,52 @@ def test_follow_up_retrieval_disabled_by_default() -> None:
     ) == {"enabled": False}
 
 
-def test_follow_up_retrieval_compiles_authored_block() -> None:
+def test_follow_up_retrieval_retired_even_when_explicitly_enabled() -> None:
+    """Explicit authored blocks compile to disabled: no new vector authority."""
     block = compile_follow_up_retrieval_policy(
         _policy_snapshot(),
         {
             "followUpRetrieval": {
                 "enabled": True,
                 "required": True,
-                "collections": ["repo", "repo", "docs"],
-                "filters": {"branch": "main", "": "skip", "empty": ""},
+                "collections": ["repo", "docs"],
                 "topK": 5,
                 "maxContextTokens": 4000,
-                "latencyMs": 2500,
-                "overlayPolicy": "skip",
-                "staleOverlayAllowed": True,
-                "fallbackAllowed": True,
-                "maxLifetimeSeconds": 300,
             }
         },
         repository="MoonMind",
         tenant_id="tenant-1",
     )
-
-    assert block["enabled"] is True
-    assert block["required"] is True
-    assert block["repository"] == "MoonMind"
-    assert block["tenantId"] == "tenant-1"
-    assert block["policyVersion"] == "codex-static@7"
-    # Duplicate collections are de-duplicated while order is preserved.
-    assert block["collections"] == ["repo", "docs"]
-    # Blank filter keys/values are dropped.
-    assert block["filters"] == {"branch": "main"}
-    assert block["topK"] == 5
-    assert block["maxContextTokens"] == 4000
-    assert block["latencyMs"] == 2500
-    assert block["overlayPolicy"] == "skip"
-    assert block["staleOverlayAllowed"] is True
-    assert block["fallbackAllowed"] is True
-    assert block["maxLifetimeSeconds"] == 300
+    assert block == {"enabled": False}
 
 
-def test_follow_up_retrieval_folds_policy_budgets_when_unauthored() -> None:
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {"followUpRetrieval": {"enabled": True, "collections": ["repo"]}},
-        repository="MoonMind",
-        tenant_id="tenant-1",
-    )
-    # boundaries.rag budgets reach the compiled block as the per-run ceiling.
-    assert block["latencyMs"] == 4000
-    assert block["maxContextTokens"] == 6000
-
-
-def test_follow_up_retrieval_clamps_authored_budgets_to_policy() -> None:
-    # Authored budgets larger than the selected policy must be clamped down; the
-    # gateway only clamps against deployment env limits, not the selected policy.
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {
-            "followUpRetrieval": {
-                "enabled": True,
-                "collections": ["repo"],
-                "maxContextTokens": 9000,
-                "latencyMs": 9000,
-            }
-        },
-        repository="MoonMind",
-        tenant_id="tenant-1",
-    )
-    # policy tokenBudget=6000, latencyBudgetMs=4000 win over the larger authored
-    # values.
-    assert block["maxContextTokens"] == 6000
-    assert block["latencyMs"] == 4000
-
-
-def test_follow_up_retrieval_keeps_tighter_authored_budget() -> None:
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {
-            "followUpRetrieval": {
-                "enabled": True,
-                "collections": ["repo"],
-                "maxContextTokens": 1000,
-                "latencyMs": 1500,
-            }
-        },
-        repository="MoonMind",
-        tenant_id="tenant-1",
-    )
-    # Authored values below the policy ceiling are preserved (they only narrow).
-    assert block["maxContextTokens"] == 1000
-    assert block["latencyMs"] == 1500
-
-
-def test_enforce_required_follow_up_retrieval_blocks_unavailable() -> None:
-    authored = {"enabled": True, "required": True}
-    compiled = {"enabled": False, "reason": "incomplete_follow_up_retrieval_scope"}
+def test_enforce_retired_vector_retrieval_blocks_explicit() -> None:
     with pytest.raises(OmnigentOAuthHostError) as excinfo:
-        enforce_required_follow_up_retrieval(authored, compiled)
-    assert excinfo.value.code == "OMNIGENT_REQUIRED_FOLLOW_UP_RETRIEVAL_UNAVAILABLE"
+        enforce_required_follow_up_retrieval(
+            {"enabled": True, "required": True}, {"enabled": False}
+        )
+    assert excinfo.value.code == "OMNIGENT_RETIRED_VECTOR_RETRIEVAL"
+    # Optional-but-enabled is still an explicit retired request: no silent weaken.
+    with pytest.raises(OmnigentOAuthHostError) as excinfo:
+        enforce_required_follow_up_retrieval(
+            {"enabled": True, "collections": ["repo"]}, {"enabled": False}
+        )
+    assert excinfo.value.code == "OMNIGENT_RETIRED_VECTOR_RETRIEVAL"
 
 
-def test_enforce_required_follow_up_retrieval_allows_optional_and_available() -> None:
-    # Optional retrieval may degrade silently.
+def test_enforce_retired_vector_retrieval_allows_absent() -> None:
+    enforce_required_follow_up_retrieval(None, {"enabled": False})
+    enforce_required_follow_up_retrieval({}, {"enabled": False})
     enforce_required_follow_up_retrieval(
-        {"enabled": True, "required": False}, {"enabled": False}
+        {"enabled": False}, {"enabled": False}
     )
-    # Not enabled at all: required is moot.
     enforce_required_follow_up_retrieval(
-        {"enabled": False, "required": True}, {"enabled": False}
-    )
-    # Required and available: no error.
-    enforce_required_follow_up_retrieval(
-        {"enabled": True, "required": True}, {"enabled": True}
+        {"enabled": False, "required": False}, {"enabled": False}
     )
 
 
-def test_follow_up_retrieval_incomplete_scope_disables_with_reason() -> None:
-    # Enabled but no collections and no resolvable repository/tenant.
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {"followUpRetrieval": {"enabled": True}},
-        repository="",
-        tenant_id="",
-    )
-    assert block == {
-        "enabled": False,
-        "reason": "incomplete_follow_up_retrieval_scope",
-    }
-
-
-def test_compiled_block_flows_through_gateway_issue() -> None:
-    """The compiled snapshot block satisfies the gateway capability issuer."""
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {
-            "followUpRetrieval": {
-                "enabled": True,
-                "collections": ["repo", "docs"],
-                "topK": 6,
-            }
-        },
-        repository="MoonMind",
-        tenant_id="tenant-1",
-    )
-
+def test_gateway_issuance_from_enabled_snapshot_is_retired() -> None:
+    """New capability issuance from a retired enabled snapshot fails 410."""
     row = type(
         "BridgeRow",
         (),
@@ -218,125 +114,20 @@ def test_compiled_block_flows_through_gateway_issue() -> None:
             "moonmind_run_id": "run-1",
             "step_execution_id": "step-1",
             "workspace": "workspace-1",
-            "effective_launch_snapshot_json": {"followUpRetrieval": block},
+            "effective_launch_snapshot_json": {
+                "followUpRetrieval": {
+                    "enabled": True,
+                    "repository": "MoonMind",
+                    "tenantId": "tenant-1",
+                    "policyVersion": "codex-static@7",
+                    "collections": ["repo", "docs"],
+                }
+            },
         },
     )()
 
-    issue = _bridge_authoritative_issue(
-        row, BridgeRetrievalCapabilityIssue(collections=["docs"], top_k=3)
-    )
-    assert issue.tenant_id == "tenant-1"
-    assert issue.repository == "MoonMind"
-    assert issue.policy_version == "codex-static@7"
-    # Host narrowing is honored within the compiled ceiling.
-    assert issue.collections == ["docs"]
-    assert issue.top_k == 3
-
-
-def test_effective_launch_snapshot_carries_and_validates_block() -> None:
-    block = compile_follow_up_retrieval_policy(
-        _policy_snapshot(),
-        {"followUpRetrieval": {"enabled": True, "collections": ["repo"]}},
-        repository="MoonMind",
-        tenant_id="tenant-1",
-    )
-    # Minimal boundaries needed by _compile_persisted_effective_launch.
-    snapshot = _policy_snapshot()
-    snapshot["boundaries"].update(
-        {
-            "host": {
-                "mode": "static_compose",
-                "backendRef": "backend",
-                "architectures": ["amd64"],
-                "serverImageRef": "server:1",
-                "hostImageRef": "host:1",
-            },
-            "execution": {
-                "profileRef": "omnigent-codex@1",
-                "agentIdentities": ["codex-native-ui"],
-                "harness": "codex",
-            },
-            "endpoint": {"ref": "endpoint:1"},
-            "resources": {
-                "cpuMillis": 1000,
-                "memoryMiB": 2048,
-                "processes": 64,
-                "timeoutSeconds": 900,
-                "temporaryStorageMiB": 1024,
-            },
-            "network": {"attachmentRef": "net", "egressProfileRef": "egress"},
-            "workspace": {
-                "mountClasses": ["repo"],
-                "repositoryMutation": True,
-                "runtimeUid": 1000,
-                "runtimeGid": 1000,
-            },
-            "session": {
-                "create": True,
-                "continuation": True,
-                "interruption": True,
-                "cancellation": True,
-                "cleanup": "drain",
-            },
-            "retention": {"days": 30},
-            "capture": {"logs": True},
-        }
-    )
-
-    realized = _compile_persisted_effective_launch(
-        snapshot, provider_profile_id="profile-1", follow_up_retrieval=block
-    )
-    assert realized["followUpRetrieval"]["enabled"] is True
-    assert realized["followUpRetrieval"]["repository"] == "MoonMind"
-    # Digest must still validate with the block inside it.
-    validate_effective_launch_snapshot(realized)
-
-
-def test_effective_launch_snapshot_defaults_to_disabled() -> None:
-    # Build a minimal valid snapshot and omit follow_up_retrieval entirely.
-    base = _policy_snapshot()
-    base["boundaries"].update(
-        {
-            "host": {
-                "mode": "static_compose",
-                "backendRef": "backend",
-                "architectures": ["amd64"],
-                "serverImageRef": "server:1",
-                "hostImageRef": "host:1",
-            },
-            "execution": {
-                "profileRef": "omnigent-codex@1",
-                "agentIdentities": ["codex-native-ui"],
-                "harness": "codex",
-            },
-            "endpoint": {"ref": "endpoint:1"},
-            "resources": {
-                "cpuMillis": 1000,
-                "memoryMiB": 2048,
-                "processes": 64,
-                "timeoutSeconds": 900,
-                "temporaryStorageMiB": 1024,
-            },
-            "network": {"attachmentRef": "net", "egressProfileRef": "egress"},
-            "workspace": {
-                "mountClasses": ["repo"],
-                "repositoryMutation": True,
-                "runtimeUid": 1000,
-                "runtimeGid": 1000,
-            },
-            "session": {
-                "create": True,
-                "continuation": True,
-                "interruption": True,
-                "cancellation": True,
-                "cleanup": "drain",
-            },
-            "retention": {"days": 30},
-            "capture": {"logs": True},
-        }
-    )
-    realized = _compile_persisted_effective_launch(
-        base, provider_profile_id="profile-1"
-    )
-    assert realized["followUpRetrieval"] == {"enabled": False}
-    validate_effective_launch_snapshot(realized)
+    with pytest.raises(HTTPException) as excinfo:
+        _bridge_authoritative_issue(
+            row, BridgeRetrievalCapabilityIssue(collections=["docs"], top_k=3)
+        )
+    assert excinfo.value.status_code == 410

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -177,31 +177,32 @@ def test_agent_execution_request_rejects_sensitive_parameter_keys() -> None:
         )
 
 
-def test_agent_execution_request_allows_bounded_retrieval_token_budget() -> None:
-    request = AgentExecutionRequest(
-        agentKind="external",
-        agentId="omnigent",
-        executionProfileRef="profile:omnigent-default",
-        correlationId="corr-1",
-        idempotencyKey="idem-1",
-        parameters={
-            "followUpRetrieval": {
-                "maxContextTokens": 500,
-                "latencyMs": 250,
-            }
-        },
-    )
-
-    assert request.parameters["followUpRetrieval"]["maxContextTokens"] == 500
+def test_agent_execution_request_rejects_retired_retrieval_fields() -> None:
+    """Retired (#4105): vector retrieval fields fail before host launch."""
+    with pytest.raises(ValidationError, match="4105"):
+        AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            executionProfileRef="profile:omnigent-default",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+            parameters={
+                "followUpRetrieval": {
+                    "maxContextTokens": 500,
+                    "latencyMs": 250,
+                }
+            },
+        )
 
 
 @pytest.mark.parametrize("value", [0, -1, True, "500"])
 def test_agent_execution_request_rejects_invalid_retrieval_token_budget(
     value: object,
 ) -> None:
+    # Retired (#4105): the whole vector block is rejected before budget checks.
     with pytest.raises(
         ValidationError,
-        match="followUpRetrieval.maxContextTokens must be a positive integer",
+        match="4105",
     ):
         AgentExecutionRequest(
             agentKind="external",

--- a/tests/unit/services/test_checkpoint_branches_service.py
+++ b/tests/unit/services/test_checkpoint_branches_service.py
@@ -64,6 +64,44 @@ async def session(tmp_path) -> AsyncSession:
     await engine.dispose()
 
 
+async def test_prepare_checkpoint_branch_workspace_rejects_retired_vector(
+    session: AsyncSession,
+) -> None:
+    emitted: list[tuple[str, Mapping[str, Any], str]] = []
+
+    async def write_artifact(
+        artifact_kind: str,
+        payload: Mapping[str, Any],
+        content_type: str,
+    ) -> tuple[str, str]:
+        emitted.append((artifact_kind, payload, content_type))
+        return f"artifact://MM-1090/{artifact_kind}", f"sha256:{artifact_kind}"
+
+    with pytest.raises(ValueError, match="4105"):
+        await prepare_checkpoint_branch_workspace(
+            session=session,
+            binding_input=_binding_input(
+                headCommit="def5678",
+                patchRef="artifact://patches/checkpoint.patch",
+                pullRequestUrl="https://github.test/moon/mind/pull/1",
+            ),
+            known_refs={"feature/mm-1087-source"},
+            current_ref="feature/mm-1087-source",
+            instruction_ref="artifact://MM-1090/input.branch_turn.instructions.md",
+            instruction_digest="sha256:instructions",
+            artifact_writer=write_artifact,
+            root_workflow_id="MM-1087",
+            source_run_id="run-MM-1087",
+            source_execution_ordinal=1,
+            follow_up_retrieval={
+                "enabled": True,
+                "collections": ["repo"],
+                "maxQueries": 4,
+            },
+        )
+    assert emitted == []
+
+
 async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifacts(
     session: AsyncSession,
 ) -> None:
@@ -92,11 +130,7 @@ async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifact
         root_workflow_id="MM-1087",
         source_run_id="run-MM-1087",
         source_execution_ordinal=1,
-        follow_up_retrieval={
-            "enabled": True,
-            "collections": ["repo"],
-            "maxQueries": 4,
-        },
+        follow_up_retrieval=None,
     )
     await session.commit()
 
@@ -134,11 +168,8 @@ async def test_prepare_checkpoint_branch_workspace_persists_binding_and_artifact
     assert turn.step_execution_manifest_ref is None
     assert turn.runtime_agent_run_id is None
     assert turn.provider_session_id is None
-    assert turn.diagnostics["followUpRetrieval"] == {
-        "enabled": True,
-        "collections": ["repo"],
-        "maxQueries": 4,
-    }
+    # Retired (#4105): new turns persist no vector retrieval state.
+    assert "followUpRetrieval" not in (turn.diagnostics or {})
 
     binding = await session.get(WorkflowCheckpointBranchGitBinding, "cbr_MM-1090")
     assert binding is not None

--- a/tests/unit/workflows/executions/test_execution_contract_retired_vector.py
+++ b/tests/unit/workflows/executions/test_execution_contract_retired_vector.py
@@ -1,0 +1,50 @@
+"""Retired vector admission validation (MoonLadderStudios/MoonMind#4105)."""
+
+import pytest
+
+from moonmind.workflows.executions.execution_contract import (
+    WorkflowContractError,
+    reject_retired_vector_fields,
+    strip_absent_vector_fields,
+)
+
+
+def test_rejects_explicit_rag() -> None:
+    with pytest.raises(WorkflowContractError, match="4105"):
+        reject_retired_vector_fields(
+            {"rag": {"collections": ["docs"]}}, field_path="payload"
+        )
+
+
+def test_rejects_explicit_follow_up_retrieval() -> None:
+    with pytest.raises(WorkflowContractError, match="4105"):
+        reject_retired_vector_fields(
+            {"followUpRetrieval": {"enabled": True, "collections": ["repo"]}},
+            field_path="payload",
+        )
+    with pytest.raises(WorkflowContractError, match="4105"):
+        reject_retired_vector_fields(
+            {"followUpRetrieval": {"collections": ["repo"]}},
+            field_path="payload",
+        )
+
+
+def test_allows_absent_empty_disabled() -> None:
+    reject_retired_vector_fields({}, field_path="payload")
+    reject_retired_vector_fields({"rag": {}}, field_path="payload")
+    reject_retired_vector_fields({"rag": None}, field_path="payload")
+    reject_retired_vector_fields(
+        {"followUpRetrieval": {"enabled": False}}, field_path="payload"
+    )
+    reject_retired_vector_fields(
+        {"followUpRetrieval": {}}, field_path="payload"
+    )
+
+
+def test_strip_absent_vector_fields() -> None:
+    params = {
+        "instructions": "hi",
+        "rag": {},
+        "followUpRetrieval": {"enabled": False},
+    }
+    assert strip_absent_vector_fields(params) == {"instructions": "hi"}

--- a/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_target_aware_inputs.py
@@ -203,8 +203,8 @@ def test_run_request_preserves_model_tier_intent_for_launch_resolution() -> None
     assert request.parameters["tierFallback"] == "strict"
 
 
-def test_run_request_forwards_context_retrieval_authoring() -> None:
-    """Authored RAG / follow-up retrieval policy reaches request.parameters (#3514)."""
+def test_run_request_strips_retired_context_retrieval_authoring() -> None:
+    """Retired vector fields never reach request.parameters (#4105)."""
     wf = MoonMindRunWorkflow()
     with patch(
         "moonmind.workflows.temporal.workflows.run.workflow.info",
@@ -227,9 +227,8 @@ def test_run_request_forwards_context_retrieval_authoring() -> None:
         )
 
     assert request.parameters["repository"] == "MoonMind"
-    assert request.parameters["rag"] == {"collections": ["docs"], "allowStale": True}
-    assert request.parameters["followUpRetrieval"]["enabled"] is True
-    assert request.parameters["followUpRetrieval"]["collections"] == ["repo", "docs"]
+    assert "rag" not in request.parameters
+    assert "followUpRetrieval" not in request.parameters
 
 
 def test_run_request_records_prepared_manifest_before_step_dispatch() -> None:


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4105: new workflows no longer advertise or accept built-in vector retrieval/indexing. Explicit `rag`/`followUpRetrieval` requirements fail with actionable field/capability validation before Temporal start, host launch, paid work, or external mutation; absent/empty/disabled values pass so normal authoring needs no vector or embedding settings.

- Shared admission boundary rejects retired vector fields (execution contract, executions router incl. recurring targets, agent runtime models, checkpoint-branch create/continue/fork, retrieval-gateway bridge returns 410 on enabled snapshots). No replacement provider registry.
- Frontend authoring controls/serializers removed: `contextRetrievalAuthoring.ts` compiles to `{}`, controls render a retired notice with no inputs/hidden state, Create/edit/draft/schedule/remediation paths strip retired authority, stale draft persistence and seed defaults deleted.
- Plan compilation carries no vector descriptors (`compile_follow_up_retrieval_policy` always disabled; explicit requests raise `OMNIGENT_RETIRED_VECTOR_RETRIEVAL` before launch).
- Historical details/artifacts remain readable; rerun/schedule payloads with unsupported requirements surface resubmit-without guidance via `hasRetiredRetrievalParameters`.
- Consumer inventory kept in `docs/tmp/QdrantRemovalInventory-4105.md` (not a permanent architecture backlog), mapping admission/authoring/plan consumers to #4105 and deferring execution/storage/CLI/packaging to the sibling execution/cutover child of #4103.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict in `artifacts/github-issue-implement-verify.json`: **FULLY_IMPLEMENTED** (confidence MEDIUM, candidate `f50232594`, base `b7268cbce`). All 7 requirements VERIFIED by direct production-code inspection against checked-in tests. Recommended next action: advance.

## Tests run

- `python3 -m py_compile` over all touched Python modules: PASS (only hermetic check runnable in this workspace).
- Targeted Python unit suites (e.g. `test_execution_contract_retired_vector.py`, `test_executions.py`, `test_agent_runtime_models.py`, `test_checkpoint_branches_service.py`, `test_follow_up_retrieval_policy.py`): NOT RUN here — no pytest runner and managed `moonmind container python-tests` unavailable; coverage exists checked in.
- Frontend vitest suites (`contextRetrievalAuthoring.test.ts`, `ContextRetrievalControls.test.tsx`, `workflow-start.test.tsx`): NOT RUN here — no `node_modules`; coverage exists checked in.

## Remaining risks

- Publish condition: ship together with the sibling execution/cutover child of #4103 (or prove the intermediate release independently safe). Standalone `moonmind rag*` CLI commands, direct retrieval-gateway execution paths (POST /context, GET /index-health), `moonmind/rag/*` backends, Qdrant Compose/packaging, and generated `openapi.ts` shape regeneration remain until the sibling ships.
- Full unit/frontend suites were not executed in the verify workspace; CI should confirm them on this PR.

Closes MoonLadderStudios/MoonMind#4105