### PR TITLE
Fix API startup with empty Compose session secret settings

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -845,8 +845,11 @@ async def _initialize_oidc_provider(app: FastAPI):
     is_remote = bool(public_base) and not public_base_url_is_loopback(public_base)
     try:
         session_secret = resolve_session_secret(
+            # Compose renders omitted secret settings as empty strings.
+            # Preserve omission so the durable key owner can load or generate.
             explicit_secret=os.environ.get("MOONMIND_SESSION_SECRET")
-            or os.environ.get("JWT_SECRET"),
+            or os.environ.get("JWT_SECRET")
+            or None,
             key_path=default_session_key_path(),
             allow_generate=not is_remote,
             for_remote_production=is_remote,

--- a/tests/unit/api_service/test_auth_startup_session_secret.py
+++ b/tests/unit/api_service/test_auth_startup_session_secret.py
@@ -1,0 +1,71 @@
+"""Replay the API startup failure caused by Compose's empty secret defaults."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from api_service import main as api_main
+from api_service.auth_providers import build_moonmind_control_plane_config
+from moonmind.security import auth_modes_4120 as auth_modes
+
+
+@pytest.fixture
+def session_key_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTH_PROVIDER", "disabled")
+    monkeypatch.setattr(api_main.settings.oidc, "AUTH_PROVIDER", "disabled")
+    monkeypatch.setenv("MOONMIND_API_PUBLISH_HOST", "127.0.0.1")
+    monkeypatch.delenv("MOONMIND_AUTH_MIGRATION_DECISION", raising=False)
+    monkeypatch.delenv("MOONMIND_PUBLIC_BASE_URL", raising=False)
+    monkeypatch.delenv("MOONMIND_SESSION_SECRET", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    # Restore the process-level mode after exercising the real startup owner.
+    monkeypatch.setattr(auth_modes, "_ACTIVE_PRODUCTION_MODE", None)
+    path = tmp_path / "session-keys" / "moonmind_session_key"
+    monkeypatch.setenv("MOONMIND_SESSION_KEY_PATH", str(path))
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("secret_env", [None, ""], ids=["omitted", "compose-empty"])
+async def test_startup_generates_durable_key_and_request_reuses_it(
+    monkeypatch, session_key_path: Path, secret_env
+):
+    if secret_env is not None:
+        monkeypatch.setenv("MOONMIND_SESSION_SECRET", secret_env)
+        monkeypatch.setenv("JWT_SECRET", secret_env)
+
+    app = FastAPI()
+    await api_main._initialize_oidc_provider(app)
+    first_key = session_key_path.read_bytes()
+    assert len(first_key) >= 32
+    assert session_key_path.stat().st_mode & 0o777 == 0o600
+    assert app.state.auth_production_mode == "disabled"
+    assert build_moonmind_control_plane_config().cookie_secret == first_key
+
+    await api_main._initialize_oidc_provider(FastAPI())
+    assert session_key_path.read_bytes() == first_key
+    assert build_moonmind_control_plane_config().cookie_secret == first_key
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("env_name", ["MOONMIND_SESSION_SECRET", "JWT_SECRET"])
+async def test_startup_rejects_explicit_placeholder_without_generating_key(
+    monkeypatch, session_key_path: Path, env_name
+):
+    monkeypatch.setenv(env_name, "devsecret")
+    with pytest.raises(RuntimeError, match="insecure placeholder"):
+        await api_main._initialize_oidc_provider(FastAPI())
+    assert not session_key_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_remote_startup_empty_secrets_still_require_provisioned_key(
+    monkeypatch, session_key_path: Path
+):
+    monkeypatch.setenv("MOONMIND_SESSION_SECRET", "")
+    monkeypatch.setenv("JWT_SECRET", "")
+    monkeypatch.setenv("MOONMIND_PUBLIC_BASE_URL", "https://moonmind.example.com")
+    with pytest.raises(RuntimeError, match="remote production"):
+        await api_main._initialize_oidc_provider(FastAPI())
+    assert not session_key_path.exists()


### PR DESCRIPTION
## Related issue

Related to #4120 and #4142.

## Summary

Compose renders omitted session-secret settings as empty strings. API startup passed that empty string to the secret resolver, which rejected it as an explicit placeholder and caused a restart loop. Normalize empty settings to omission so startup loads or generates the durable deployment-owned key.

Add startup-boundary regression coverage for omitted and Compose-empty settings, key reuse across initialization and requests, placeholder rejection, and remote deployments requiring provisioned material.

## Test Plan

```bash
./tools/test_unit.sh --python-only --no-xdist tests/unit/api_service/test_auth_startup_session_secret.py tests/unit/security/test_auth_modes_4120.py tests/unit/security/test_auth_compose_rendered_4120.py tests/unit/api/test_auth_providers.py --tb=short -p no:cacheprovider
```

31 passed. The new Compose-empty regression reproduced the startup failure before the fix.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Secret validation still rejects explicit placeholders and requires provisioned key material for remote deployments. The change is confined to normalization of empty environment settings at API startup.

## Coverage notes

Restarted the affected deployment with the fix and verified HTTP 200 responses for the dashboard, execution-list API, and health endpoint. The deployed dashboard asset-coherence check passed.

## Changelog

Fix API startup crashes when Compose uses the default empty session-secret settings.
