### PR TITLE
Fix deployment registry authentication and terminal workflow status

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -294,13 +294,19 @@ MOONMIND_WORKER_CAPABILITIES="codex,git,gh,docker,execution.fanout"
 # `never` only when policy requires an explicit operator prewarm.
 MOONMIND_UNREAL_ENGINE_IMAGE="ghcr.io/moonladderstudios/tactics-ue-base:5.8"
 MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY="if-missing"
+# Private images need an encrypted managed secret containing registry username
+# and password/token as JSON, plus an explicit grant for its repository.
+# A host `docker login` is not available inside the trusted worker container.
+MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF=""
+# MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF="db://tactics-ghcr-pull"
+# MOONMIND_REGISTRY_CREDENTIAL_GRANTS=[{"credentialRef":"db://tactics-ghcr-pull","registry":"ghcr.io","repositories":["moonladderstudios/tactics-ue-base"],"principals":["*"]}]
 MOONMIND_UNREAL_CCACHE_VOLUME_NAME="unreal_ccache_volume"
 MOONMIND_UNREAL_UBT_VOLUME_NAME="unreal_ubt_volume"
 
 # Container-job image and cache sources this deployment approves. MoonMind
 # carries no project image, volume, or in-container path of its own: a caller
 # selects a source by its opaque ref, and an undeclared ref fails closed.
-# docker-compose.yaml derives these from the four variables above. Setting
+# docker-compose.yaml derives these from the variables above. Setting
 # either variable replaces that derived default outright -- declarations are
 # consumed exactly as supplied and are never merged -- so repeat every source
 # you intend to keep alongside any source you add. Unknown keys are rejected at

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -512,6 +512,7 @@ async def mutate_execution_projection(
     if latest is not None:
         records = [latest, *(record for record in records if record is not latest)]
     stale = False
+    closes_current_run = False
     if latest is not None and not patch_only:
         previous_time = _projection_semantic_time(latest.updated_at, latest.search_attributes)
         incoming_time = _semantic_time(incoming.get("updated_at"))
@@ -524,10 +525,7 @@ async def mutate_execution_projection(
             and not latest.close_status
             and latest.run_id == incoming.get("run_id")
         )
-        stale = bool(
-            previous_time and incoming_time and incoming_time < previous_time
-            and not closes_current_run
-        )
+        stale = bool(previous_time and incoming_time and incoming_time < previous_time)
         # A stale RUNNING describe with no semantic timestamp cannot reopen a
         # terminal execution in the same run.
         stale = stale or bool(latest.close_status and not incoming.get("close_status") and latest.run_id == incoming.get("run_id"))
@@ -539,6 +537,18 @@ async def mutate_execution_projection(
         if not patch_only and not stale:
             merged = {column.name: getattr(latest, column.name) for column in TemporalExecutionCanonicalRecord.__table__.columns if hasattr(TemporalExecutionRecord, column.name)}
             merged.update({key: value for key, value in incoming.items() if key in CORE_TEMPORAL_SYNC_FIELDS})
+    if stale and closes_current_run:
+        # Closure can advance lifecycle without making an older memo current.
+        # Keep the stored metadata and semantic timestamp, including API-owned
+        # counters, attention flags, parameters, and pending integration work.
+        merged.update({
+            key: value for key, value in incoming.items()
+            if key in CORE_TEMPORAL_SYNC_FIELDS and key != "updated_at"
+        })
+        merged["search_attributes"] = {
+            **(merged.get("search_attributes") or {}),
+            "mm_state": [incoming["state"]],
+        }
     merged["workflow_id"] = workflow_id
     merged["updated_at"] = (
         _projection_semantic_time(merged.get("updated_at"), merged.get("search_attributes"))

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -515,7 +515,19 @@ async def mutate_execution_projection(
     if latest is not None and not patch_only:
         previous_time = _projection_semantic_time(latest.updated_at, latest.search_attributes)
         incoming_time = _semantic_time(incoming.get("updated_at"))
-        stale = bool(previous_time and incoming_time and incoming_time < previous_time)
+        # DB-only finalization writes can occur after the last mm_updated_at.
+        # Temporal closure is authoritative for this run even when that metadata
+        # timestamp is newer; otherwise detail reads retain EXECUTING forever.
+        closes_current_run = bool(
+            owner == "temporal"
+            and incoming.get("close_status")
+            and not latest.close_status
+            and latest.run_id == incoming.get("run_id")
+        )
+        stale = bool(
+            previous_time and incoming_time and incoming_time < previous_time
+            and not closes_current_run
+        )
         # A stale RUNNING describe with no semantic timestamp cannot reopen a
         # terminal execution in the same run.
         stale = stale or bool(latest.close_status and not incoming.get("close_status") and latest.run_id == incoming.get("run_id"))

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -846,7 +846,8 @@ async def _initialize_oidc_provider(app: FastAPI):
     try:
         session_secret = resolve_session_secret(
             explicit_secret=os.environ.get("MOONMIND_SESSION_SECRET")
-            or os.environ.get("JWT_SECRET"),
+            or os.environ.get("JWT_SECRET")
+            or None,
             key_path=default_session_key_path(),
             allow_generate=not is_remote,
             for_remote_production=is_remote,

--- a/api_service/services/container_jobs.py
+++ b/api_service/services/container_jobs.py
@@ -26,6 +26,7 @@ from api_service.services.registry_authorization import (
 from moonmind.config.container_backend_settings import (
     ContainerBackendConfigError,
     ContainerBackendSettings,
+    RegistryImageSource,
     resolve_container_backend_settings,
 )
 from moonmind.schemas.container_job_models import (
@@ -252,11 +253,25 @@ class ContainerJobService:
             # Public requests select only an opaque deployment-approved alias.
             # Recipe paths and registry references remain worker-side policy.
             try:
-                self._backend_settings.image_source(
+                source = self._backend_settings.image_source(
                     request.spec.image_source_ref or ""
                 )
             except ContainerBackendConfigError as exc:
                 raise ValueError("container image source is not configured") from exc
+            if isinstance(source, RegistryImageSource):
+                authorization = self._authorizer.authorize(
+                    owner=owner,
+                    spec=request.spec.model_copy(
+                        update={
+                            "image_source_ref": None,
+                            "image": source.image,
+                            "pull_policy": source.pull_policy,
+                            "registry_credential_ref": source.registry_credential_ref,
+                        }
+                    ),
+                )
+                if not authorization.authorized:
+                    raise ContainerJobAuthorizationError(authorization)
         existing = await self.repository.find_exact_replay(owner=owner, request=request)
         if existing is not None:
             record, replayed = existing, True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       # values identical to `temporal-worker-agent-runtime`: a ref declared only
       # on the worker is rejected as unconfigured before the request ever
       # reaches Temporal.
-      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}"}]}
+      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}","registryCredentialRef":"${MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF:-}"}]}
       - MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=${MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES:-[{"cacheRef":"unreal-ccache","volumeName":"${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]}
       # Omnigent is a normal local runtime. Operators can still disable or
       # redirect it explicitly, but the canonical Compose path needs no hidden
@@ -858,7 +858,7 @@ services:
       - MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY=${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}
       - MOONMIND_UNREAL_CCACHE_VOLUME_NAME=${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}
       - MOONMIND_UNREAL_UBT_VOLUME_NAME=${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}
-      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}"}]}
+      - MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES=${MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES:-[{"sourceRef":"tactics-unreal","image":"${MOONMIND_UNREAL_ENGINE_IMAGE:-ghcr.io/moonladderstudios/tactics-ue-base:5.8}","pullPolicy":"${MOONMIND_UNREAL_ENGINE_IMAGE_PULL_POLICY:-if-missing}","registryCredentialRef":"${MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF:-}"}]}
       - MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES=${MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES:-[{"cacheRef":"unreal-ccache","volumeName":"${MOONMIND_UNREAL_CCACHE_VOLUME_NAME:-unreal_ccache_volume}","target":"/home/ue4/.ccache"},{"cacheRef":"unreal-ubt","volumeName":"${MOONMIND_UNREAL_UBT_VOLUME_NAME:-unreal_ubt_volume}","target":"/home/ue4/.config/Epic/UnrealBuildTool"}]}
       # Non-secret deployment values portable Skills may read from a managed
       # session. Secret-looking names are refused; secrets use credentials.

--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -309,7 +309,8 @@ dockerBackendService:
 
     # Every other image source is declared by the deployment through
     # MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES, a JSON array of
-    # {"sourceRef", "image", "pullPolicy"} objects. MoonMind ships no project
+    # {"sourceRef", "image", "pullPolicy", "registryCredentialRef"} objects.
+    # registryCredentialRef is optional. MoonMind ships no project
     # image default of its own.
     <deployment-declared>:
       kind: registry
@@ -658,6 +659,41 @@ Compose profile for operators who want prewarming. It must call the same
 provisioner and must never be a dependency of ordinary API or worker startup.
 
 ### 11.6 Private images
+
+A deployment registry image declaration may carry an optional opaque
+`registryCredentialRef`. The API authorizes the resolved image and credential
+through `MOONMIND_REGISTRY_CREDENTIAL_GRANTS` before persisting a job, and the
+worker checks that both still match that authorization before inspecting or
+pulling. Callers continue to submit only `imageSourceRef`; they cannot override
+the source's image, pull policy, or credential. Missing grants fail at admission.
+Existing declarations without a credential retain their anonymous pull behavior.
+If a credential or image declaration changes while a job is in flight, an
+authorization mismatch fails closed; a new submission obtains a new decision.
+
+For the Compose Unreal source, set
+`MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF` to a managed secret such as
+`db://tactics-ghcr-pull` and declare a grant scoped to
+`ghcr.io/moonladderstudios/tactics-ue-base`. Store the registry username and
+password/token as a JSON object in that encrypted secret. A host's Docker Desktop
+credential helper is client-local and is not inherited by the worker container.
+The worker never substitutes the agent's GitHub source-control token.
+
+Registry enrollment is a deployment operation, not a per-job or per-container
+step. With a `db://` reference, preserving the application database, its managed
+secret encryption key, and deployment configuration makes worker recreations
+and application updates reuse the credential automatically. The API's separate
+session-key volume likewise preserves its generated local signing key across
+API recreations; empty Compose defaults select that durable key path.
+
+Fresh deployments with empty databases can instead use an `env://`, `vault://`,
+or approved `exec://` registry credential reference. Their deployment provisioner
+supplies access to that selected source; no dashboard enrollment or database
+copy is required. For example, `env://TACTICS_REGISTRY_AUTH` resolves a JSON
+username/password pair injected into the trusted worker by the deployment's
+secret manager. Both the image declaration and its repository-scoped grant must
+name that same reference. Secret values do not belong in the image declaration
+or grant. Missing or unauthorized references fail closed instead of searching
+other credentials.
 
 A job request carries a non-sensitive `registryCredentialRef` only; it never
 carries a username, token, password, or Docker auth blob. Private-image

--- a/moonmind/config/container_backend_settings.py
+++ b/moonmind/config/container_backend_settings.py
@@ -23,7 +23,7 @@ from typing import Any, Final, Mapping
 
 from pydantic import ValidationError
 
-from moonmind.schemas.container_job_models import CacheMount
+from moonmind.schemas.container_job_models import CacheMount, ContainerJobSpec
 
 #: The only backend kind this deployment supports. A second backend kind
 #: (Podman, containerd, Kubernetes, endpoint pools) is explicitly out of scope.
@@ -41,7 +41,7 @@ PYTHON_TEST_LOCAL_IMAGE: Final[str] = "moonmind-python-tests:local"
 PYTHON_TEST_RECIPE_VERSION: Final[str] = "v1"
 
 #: Deployment-declared registry image sources, as a JSON array of
-#: ``{"sourceRef", "image", "pullPolicy"}`` objects.
+#: ``{"sourceRef", "image", "pullPolicy", "registryCredentialRef"}`` objects.
 IMAGE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES"
 
 #: Deployment-declared named-volume cache sources, as a JSON array of
@@ -52,7 +52,7 @@ CACHE_SOURCES_ENV_KEY: Final[str] = "MOONMIND_CONTAINER_BACKEND_CACHE_SOURCES"
 #: is a configuration error rather than an ignored field, because every omitted
 #: key falls back to the permissive default.
 _IMAGE_SOURCE_KEYS: Final[frozenset[str]] = frozenset(
-    {"sourceRef", "image", "pullPolicy"}
+    {"sourceRef", "image", "pullPolicy", "registryCredentialRef"}
 )
 _CACHE_SOURCE_KEYS: Final[frozenset[str]] = frozenset(
     {"cacheRef", "volumeName", "target", "readOnly"}
@@ -120,6 +120,7 @@ class RegistryImageSource:
     source_ref: str
     image: str
     pull_policy: str = "if-missing"
+    registry_credential_ref: str | None = None
 
 
 @dataclass(frozen=True)
@@ -333,10 +334,28 @@ def _declared_image_sources(
                 f"{field} declares duplicate sourceRef {source_ref!r}"
             )
         seen.add(source_ref)
+        # Reuse the public credential-reference validator; secret values never
+        # belong in deployment image declarations either. Empty interpolation
+        # has the same meaning as an omitted optional credential reference.
+        credential_ref = item.get("registryCredentialRef") or None
+        try:
+            credential_ref = ContainerJobSpec.model_validate(
+                {
+                    "image": image,
+                    "registryCredentialRef": credential_ref,
+                    "workspaceRef": {"kind": "sandbox", "workspaceId": "declaration"},
+                    "resources": {"cpuMillis": 100, "memoryMiB": 64},
+                }
+            ).registry_credential_ref
+        except ValidationError as exc:
+            raise ContainerBackendConfigError(
+                f"{field} requires a valid image and opaque registryCredentialRef"
+            ) from exc
         sources.append(
             RegistryImageSource(
                 source_ref=source_ref,
                 image=image,
+                registry_credential_ref=credential_ref,
                 # First use is cold-start provisioning, not an operator-only
                 # prewarm requirement. Private registries still fail through
                 # the normal credential-aware pull contract when authorization

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -1613,6 +1613,7 @@ class DockerContainerJobBackend:
             image = source.image
             policy = source.pull_policy
             image_source_ref = source.source_ref
+            credential_ref = source.registry_credential_ref
         else:
             if spec.image is None:  # schema validation is the public guard
                 raise ImageAcquisitionError(
@@ -1622,8 +1623,14 @@ class DockerContainerJobBackend:
             image = spec.image
             policy = spec.pull_policy
             image_source_ref = None
+            credential_ref = spec.registry_credential_ref
 
-        credential_ref = spec.registry_credential_ref
+        authorization = request.registry_authorization
+        if authorization is not None and authorization.credential_ref != credential_ref:
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.IMAGE_USE_DENIED,
+                "registry credential does not match the authorized reference",
+            )
         if credential_ref is not None:
             return await self._acquire_private_image(
                 request, image, policy, credential_ref
@@ -1792,6 +1799,14 @@ class DockerContainerJobBackend:
             )
         normalized = normalize_image_reference(image)
         self._enforce_authorized_scope(normalized, authorization)
+        if (
+            normalize_image_reference(authorization.reference).identity
+            != normalized.identity
+        ):
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                "resolved image does not match the authorized reference",
+            )
 
         # A local inspect needs no registry authentication.
         inspect_code, stdout, _ = await self._runner(

--- a/moonmind/workflows/temporal/container_job_backend.py
+++ b/moonmind/workflows/temporal/container_job_backend.py
@@ -1631,6 +1631,14 @@ class DockerContainerJobBackend:
                 ContainerJobFailureClass.IMAGE_USE_DENIED,
                 "registry credential does not match the authorized reference",
             )
+        if authorization is not None and (
+            normalize_image_reference(authorization.reference).identity
+            != normalize_image_reference(image).identity
+        ):
+            raise ContainerJobBackendError(
+                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
+                "resolved image does not match the authorized reference",
+            )
         if credential_ref is not None:
             return await self._acquire_private_image(
                 request, image, policy, credential_ref
@@ -1799,15 +1807,6 @@ class DockerContainerJobBackend:
             )
         normalized = normalize_image_reference(image)
         self._enforce_authorized_scope(normalized, authorization)
-        if (
-            normalize_image_reference(authorization.reference).identity
-            != normalized.identity
-        ):
-            raise ContainerJobBackendError(
-                ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH,
-                "resolved image does not match the authorized reference",
-            )
-
         # A local inspect needs no registry authentication.
         inspect_code, stdout, _ = await self._runner(
             ("image", "inspect", "--format", "{{.Id}}", image)

--- a/tests/integration/reliability/replays/registry-source-credential-handoff/manifest.json
+++ b/tests/integration/reliability/replays/registry-source-credential-handoff/manifest.json
@@ -1,0 +1,7 @@
+{
+  "failureShapeId": "registry-source-credential-handoff",
+  "incidentWorkflowId": "mm:2c280690-b10b-4a4c-a17d-1fc42662dec5",
+  "image": "ghcr.io/moonladderstudios/tactics-ue-base@sha256:9251c83b0ef1da2b5c1c13568c21b7852dddf5124904b0a3f96297a8990f35b4",
+  "observedFailure": "Caller submitted a private image without registryCredentialRef; missing cache followed by anonymous pull failed image_pull_auth_failed. Deployment image aliases had no credential field.",
+  "invariant": "The selected deployment image and credential are authorized at API admission, checked at the worker boundary, and resolved only into per-job ephemeral Docker auth."
+}

--- a/tests/integration/reliability/replays/session-secret-compose-default/manifest.json
+++ b/tests/integration/reliability/replays/session-secret-compose-default/manifest.json
@@ -1,0 +1,6 @@
+{
+  "failureShapeId": "session-secret-compose-default",
+  "observedFailure": "Local Compose API startup rejects its empty default as an insecure explicit session secret, even though the documented default owns durable key generation",
+  "composeEnvironment": {"MOONMIND_SESSION_SECRET": "", "JWT_SECRET": ""},
+  "invariant": "Empty Compose defaults use one durable local key across recreations; nonempty placeholders and unprovisioned remote deployments still fail closed"
+}

--- a/tests/integration/reliability/replays/terminal-projection-metadata-skew/manifest.json
+++ b/tests/integration/reliability/replays/terminal-projection-metadata-skew/manifest.json
@@ -1,0 +1,10 @@
+{
+  "failureShapeId": "terminal-projection-metadata-skew",
+  "incidentWorkflowId": "mm:2c280690-b10b-4a4c-a17d-1fc42662dec5",
+  "startedAt": "2026-09-08T16:57:55.413543+00:00",
+  "terminalUpdatedAt": "2026-09-08T17:14:26.020500+00:00",
+  "metadataUpdatedAt": "2026-09-08T17:14:26.303185+00:00",
+  "closedAt": "2026-09-08T17:14:26.823404+00:00",
+  "observedFailure": "Temporal list reports failed while the persisted detail rejects terminal evidence as stale and reports executing",
+  "invariant": "Temporal closure advances an open projection of the same run regardless of metadata write timestamps; stale running snapshots cannot reopen it"
+}

--- a/tests/integration/test_registry_source_credential_handoff.py
+++ b/tests/integration/test_registry_source_credential_handoff.py
@@ -1,0 +1,285 @@
+"""Replay the private-image incident across API, workflow, Activity and Docker."""
+
+import json
+import stat
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db.models import Base
+from api_service.services.container_jobs import (
+    ContainerJobAuthorizationError,
+    ContainerJobService,
+)
+from api_service.services.registry_authorization import (
+    PrivateImageAuthorizationPolicy,
+    PrivateImageAuthorizationService,
+)
+from moonmind.config.container_backend_settings import (
+    resolve_container_backend_settings,
+)
+from moonmind.schemas.container_job_models import (
+    ContainerJobSubmitRequest,
+    OwnerIdentity,
+)
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.container_job_backend import DockerContainerJobBackend
+from moonmind.workflows.temporal.runtime.registry_auth_resolve import RegistryCredential
+from moonmind.workflows.temporal.workflows.container_job import (
+    MoonMindContainerJobWorkflow,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+REPLAY = json.loads(
+    (
+        Path(__file__).parent
+        / "reliability/replays/registry-source-credential-handoff/manifest.json"
+    ).read_text()
+)
+IMAGE = REPLAY["image"]
+CREDENTIAL = "db://registry-pull"
+DIGEST = "sha256:" + "a" * 64
+
+
+def backend_settings(*, pull_policy=None, credential=CREDENTIAL, image=IMAGE):
+    source = {
+        "sourceRef": "build-image",
+        "image": image,
+        "registryCredentialRef": credential,
+    }
+    if pull_policy is not None:
+        source["pullPolicy"] = pull_policy
+    return resolve_container_backend_settings(
+        {"MOONMIND_CONTAINER_BACKEND_IMAGE_SOURCES": json.dumps([source])}
+    )
+
+
+def authorizer(credential_ref=CREDENTIAL):
+    return PrivateImageAuthorizationService(
+        PrivateImageAuthorizationPolicy.model_validate(
+            {
+                "grants": [
+                    {
+                        "credentialRef": credential_ref,
+                        "registry": "ghcr.io",
+                        "repositories": ["moonladderstudios/tactics-ue-base"],
+                        "principals": ["service:agent"],
+                    }
+                ]
+            }
+        )
+    )
+
+
+@pytest_asyncio.fixture
+async def session(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/jobs.db")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    try:
+        async with async_sessionmaker(engine, expire_on_commit=False)() as db:
+            yield db
+    finally:
+        await engine.dispose()
+
+
+async def submit(
+    session, *, config, principal="agent", direct=False, credential_ref=CREDENTIAL
+):
+    temporal = AsyncMock()
+    spec = (
+        {"image": IMAGE, "registryCredentialRef": CREDENTIAL}
+        if direct
+        else {"imageSourceRef": "build-image"}
+    )
+    request = ContainerJobSubmitRequest.model_validate(
+        {
+            "idempotencyKey": "registry-handoff",
+            "source": {"source": "workflow"},
+            "spec": {
+                **spec,
+                "workspaceRef": {"kind": "sandbox", "workspaceId": "run"},
+                "command": ["true"],
+                "resources": {"cpuMillis": 100, "memoryMiB": 64},
+            },
+        }
+    )
+    await ContainerJobService(
+        session,
+        temporal=temporal,
+        authorizer=authorizer(credential_ref),
+        backend_settings=config,
+    ).submit(
+        owner=OwnerIdentity(principalId=principal, principalType="service"),
+        request=request,
+    )
+    return temporal.start_container_job.await_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "policy,direct,credential_backend",
+    [
+        (None, False, "stub"),
+        ("if-missing", False, "stub"),
+        (None, True, "stub"),
+        (None, False, "env"),
+        (None, False, "db"),
+    ],
+)
+async def test_authorized_cold_pull_and_cache_cross_production_handoff(
+    session, tmp_path, monkeypatch, policy, direct, credential_backend
+):
+    credential_ref = CREDENTIAL
+    material = json.dumps({"username": "fixture-user", "password": "fixture-secret"})
+    if credential_backend == "env":
+        # A new deployment can use its provisioner's secret without a DB import.
+        credential_ref = "env://FIXTURE_REGISTRY_AUTH"
+        monkeypatch.setenv("FIXTURE_REGISTRY_AUTH", material)
+    elif credential_backend == "db":
+        from api_service.services.secrets import SecretsService
+        from moonmind.auth.resolvers import db_resolver
+
+        await SecretsService.create_secret(session, "registry-pull", material)
+        # Resolve through a separate session, as a recreated worker does.
+        monkeypatch.setattr(
+            db_resolver, "async_session_maker", async_sessionmaker(session.bind)
+        )
+    config = backend_settings(pull_policy=policy, credential=credential_ref)
+    inp = await submit(
+        session, config=config, direct=direct, credential_ref=credential_ref
+    )
+    assert inp.registry_authorization.credential_ref == credential_ref
+    assert inp.request.spec.registry_credential_ref == (CREDENTIAL if direct else None)
+    (tmp_path / "temporal_sandbox/run/repo").mkdir(parents=True)
+    commands, auth_dirs = [], []
+    cached = False
+
+    async def runner(raw):
+        nonlocal cached
+        args = tuple(raw)
+        commands.append(args)
+        if args[:2] == ("image", "inspect"):
+            return (0, DIGEST.encode(), b"") if cached else (1, b"", b"No such image")
+        if "pull" in args:
+            assert args[0] == "--config", "must not silently retry anonymously"
+            auth_dir = Path(args[1])
+            auth_dirs.append(auth_dir)
+            config_path = auth_dir / "config.json"
+            assert stat.S_IMODE(auth_dir.stat().st_mode) == 0o700
+            assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+            auth = json.loads(config_path.read_text())["auths"]
+            assert auth == {
+                "ghcr.io": {"username": "fixture-user", "password": "fixture-secret"}
+            }
+            assert args[-1] == IMAGE
+            cached = True
+        if args[0] == "info":
+            return 0, f"{10 * 1024**3}\t16".encode(), b""
+        if args[:2] == ("inspect", "--format"):
+            if args[2] == "{{json .State}}":
+                return 0, b'{"Running":false,"ExitCode":0}', b""
+            return 1, b"", b"Error: No such object: moonmind-container-job"
+        return 0, b"", b""
+
+    resolver = AsyncMock(
+        return_value=RegistryCredential(
+            username="fixture-user", secret="fixture-secret"
+        )
+    )
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=config,
+        command_runner=runner,
+        registry_auth_resolver=resolver if credential_backend == "stub" else None,
+        auth_root=tmp_path / "auth",
+        evidence_publisher=AsyncMock(return_value="art:evidence"),
+        projection_writer=AsyncMock(),
+    )
+    runtime = TemporalAgentRuntimeActivities(container_job_backend=backend)
+
+    async def dispatch(name, payload, **kwargs):
+        return await getattr(runtime, name.replace(".", "_"))(payload)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.workflows.container_job.workflow.execute_activity",
+        dispatch,
+    )
+    for _ in range(2):
+        result = await MoonMindContainerJobWorkflow().run(
+            inp.model_dump(mode="json", by_alias=True)
+        )
+        assert result["state"] == "succeeded", result
+        assert result["terminal"]["exitCode"] == 0
+        assert result["cleanup"]["state"] == "succeeded"
+    if credential_backend == "stub":
+        resolver.assert_awaited_once_with(CREDENTIAL)
+    else:
+        resolver.assert_not_awaited()
+    assert len(auth_dirs) == 1 and not auth_dirs[0].exists()
+    assert all("fixture-secret" not in str(command) for command in commands)
+
+
+@pytest.mark.parametrize(
+    "principal,credential", [("other", CREDENTIAL), ("agent", None)]
+)
+async def test_unauthorized_source_fails_before_workflow(
+    session, principal, credential
+):
+    with pytest.raises(ContainerJobAuthorizationError):
+        await submit(
+            session, config=backend_settings(credential=credential), principal=principal
+        )
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["credential", "removed_credential", "image", "missing_decision", "unknown_source"],
+)
+async def test_changed_or_legacy_authority_fails_before_docker(
+    session, tmp_path, monkeypatch, change
+):
+    inp = await submit(session, config=backend_settings())
+    config = backend_settings()
+    if change == "credential":
+        config = backend_settings(credential="db://different")
+    elif change == "removed_credential":
+        config = backend_settings(credential=None)
+    elif change == "image":
+        config = backend_settings(image=IMAGE.split("@")[0] + ":different")
+    elif change == "unknown_source":
+        config = resolve_container_backend_settings({})
+    else:
+        # Previously persisted source submissions had no authorization payload.
+        inp.registry_authorization = None
+    runner = AsyncMock()
+    resolver = AsyncMock()
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=config,
+        command_runner=runner,
+        registry_auth_resolver=resolver,
+        auth_root=tmp_path / "auth",
+    )
+    runtime = TemporalAgentRuntimeActivities(container_job_backend=backend)
+    from temporalio.exceptions import ApplicationError
+
+    with pytest.raises(ApplicationError) as error:
+        await runtime.container_job_acquire_image(
+            {
+                "jobId": inp.job_id,
+                "ownershipToken": inp.ownership_token,
+                "request": inp.request.model_dump(mode="json", by_alias=True),
+                "registryAuthorization": inp.registry_authorization.model_dump(
+                    by_alias=True
+                )
+                if inp.registry_authorization
+                else None,
+                "resolvedWorkspaceRef": str(tmp_path),
+            }
+        )
+    assert error.value.non_retryable
+    runner.assert_not_awaited()
+    resolver.assert_not_awaited()

--- a/tests/integration/test_registry_source_credential_handoff.py
+++ b/tests/integration/test_registry_source_credential_handoff.py
@@ -236,12 +236,20 @@ async def test_unauthorized_source_fails_before_workflow(
 
 @pytest.mark.parametrize(
     "change",
-    ["credential", "removed_credential", "image", "missing_decision", "unknown_source"],
+    [
+        "credential", "removed_credential", "image", "missing_decision",
+        "unknown_source", "public_image", "public_protected_image",
+    ],
 )
 async def test_changed_or_legacy_authority_fails_before_docker(
     session, tmp_path, monkeypatch, change
 ):
-    inp = await submit(session, config=backend_settings())
+    initial = (
+        backend_settings(credential=None, image="alpine:3.22")
+        if change.startswith("public_")
+        else backend_settings()
+    )
+    inp = await submit(session, config=initial)
     config = backend_settings()
     if change == "credential":
         config = backend_settings(credential="db://different")
@@ -251,6 +259,10 @@ async def test_changed_or_legacy_authority_fails_before_docker(
         config = backend_settings(image=IMAGE.split("@")[0] + ":different")
     elif change == "unknown_source":
         config = resolve_container_backend_settings({})
+    elif change == "public_image":
+        config = backend_settings(credential=None, image="alpine:3.23")
+    elif change == "public_protected_image":
+        config = backend_settings(credential=None, image=IMAGE)
     else:
         # Previously persisted source submissions had no authorization payload.
         inp.registry_authorization = None
@@ -282,4 +294,34 @@ async def test_changed_or_legacy_authority_fails_before_docker(
         )
     assert error.value.non_retryable
     runner.assert_not_awaited()
+    resolver.assert_not_awaited()
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+async def test_public_alias_reuses_equivalent_admitted_image(session, tmp_path, legacy):
+    inp = await submit(
+        session, config=backend_settings(credential=None, image="alpine:3.22")
+    )
+    runner = AsyncMock(return_value=(0, DIGEST.encode(), b""))
+    resolver = AsyncMock()
+    runtime = TemporalAgentRuntimeActivities(container_job_backend=DockerContainerJobBackend(
+        workspace_root=tmp_path,
+        settings=backend_settings(
+            credential=None, image="docker.io/library/alpine:3.22"
+        ),
+        command_runner=runner,
+        registry_auth_resolver=resolver,
+    ))
+    result = await runtime.container_job_acquire_image({
+        "jobId": inp.job_id,
+        "ownershipToken": inp.ownership_token,
+        "request": inp.request.model_dump(mode="json", by_alias=True),
+        # Credential-free jobs persisted before alias authorization remain valid.
+        "registryAuthorization": None if legacy else inp.registry_authorization.model_dump(
+            by_alias=True
+        ),
+        "resolvedWorkspaceRef": str(tmp_path),
+    })
+    assert result["imageObservation"]["cacheHit"] is True
+    runner.assert_awaited_once()
     resolver.assert_not_awaited()

--- a/tests/integration/test_startup_session_secret_defaults.py
+++ b/tests/integration/test_startup_session_secret_defaults.py
@@ -1,0 +1,67 @@
+"""Compose's omitted session secret must create one durable local generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from api_service import main
+from moonmind.security import auth_modes_4120 as auth_modes
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+REPLAY = json.loads(
+    (
+        Path(__file__).parent
+        / "reliability/replays/session-secret-compose-default/manifest.json"
+    ).read_text()
+)
+
+
+@pytest.fixture
+def local_startup(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTH_PROVIDER", "disabled")
+    monkeypatch.setattr(main.settings.oidc, "AUTH_PROVIDER", "disabled")
+    monkeypatch.setenv("MOONMIND_API_PUBLISH_HOST", "127.0.0.1")
+    monkeypatch.setenv("MOONMIND_PUBLIC_BASE_URL", "")
+    monkeypatch.setenv("MOONMIND_SESSION_KEY_PATH", str(tmp_path / "session-key"))
+    monkeypatch.delenv("MOONMIND_AUTH_MIGRATION_DECISION", raising=False)
+    monkeypatch.setattr(auth_modes, "_ACTIVE_PRODUCTION_MODE", None)
+    yield tmp_path / "session-key"
+
+
+@pytest.mark.parametrize("compose_empty", [False, True])
+async def test_local_startup_reuses_generated_key(
+    local_startup, monkeypatch, compose_empty
+):
+    for key, value in REPLAY["composeEnvironment"].items():
+        if compose_empty:
+            monkeypatch.setenv(key, value)
+        else:
+            monkeypatch.delenv(key, raising=False)
+    await main._initialize_oidc_provider(FastAPI())
+    first = local_startup.read_bytes()
+    assert len(first) >= 32
+    await main._initialize_oidc_provider(FastAPI())
+    assert local_startup.read_bytes() == first
+
+
+@pytest.mark.parametrize("key", ["MOONMIND_SESSION_SECRET", "JWT_SECRET"])
+async def test_nonempty_placeholder_still_fails_closed(local_startup, monkeypatch, key):
+    monkeypatch.setenv("MOONMIND_SESSION_SECRET", "")
+    monkeypatch.setenv("JWT_SECRET", "")
+    monkeypatch.setenv(key, "devsecret")
+    with pytest.raises(RuntimeError, match="insecure placeholder"):
+        await main._initialize_oidc_provider(FastAPI())
+    assert not local_startup.exists()
+
+
+async def test_remote_startup_still_requires_provisioned_key(
+    local_startup, monkeypatch
+):
+    monkeypatch.setenv("MOONMIND_SESSION_SECRET", "")
+    monkeypatch.setenv("JWT_SECRET", "")
+    monkeypatch.setenv("MOONMIND_PUBLIC_BASE_URL", "https://moonmind.example.com")
+    with pytest.raises(RuntimeError, match="remote production"):
+        await main._initialize_oidc_provider(FastAPI())
+    assert not local_startup.exists()

--- a/tests/integration/test_terminal_projection_replay.py
+++ b/tests/integration/test_terminal_projection_replay.py
@@ -140,7 +140,8 @@ async def test_terminal_describe_repairs_metadata_skew(
         assert detail["state"] == detail["rawState"] == expected
         assert detail["closeStatus"] == expected
         assert detail["closedAt"]
-        assert detail["summary"] == "Terminal result"
+        # The older Temporal memo cannot replace newer database metadata.
+        assert detail["summary"] == "Launching agent..."
         listing = await client.get("/api/executions")
         assert listing.status_code == 200, listing.text
         assert listing.json()["items"][0]["state"] == detail["state"]
@@ -160,6 +161,53 @@ async def test_terminal_describe_repairs_metadata_skew(
         assert record.state.value == expected
         assert record.close_status.value == expected
         assert record.finish_outcome_code == expected.upper()
+
+
+async def test_older_closure_preserves_newer_database_metadata(session):
+    updated = datetime.fromisoformat(REPLAY["metadataUpdatedAt"])
+    workflow_id = REPLAY["incidentWorkflowId"]
+    source = TemporalExecutionCanonicalRecord(
+        workflow_id=workflow_id, run_id="current-run", namespace="default",
+        workflow_type="MoonMind.UserWorkflow", owner_id="owner", owner_type="user",
+        entry="user_workflow", state="executing", close_status=None,
+        memo={"summary": "Newer outcome", "parameters": {"version": "new"}},
+        parameters={"version": "new"}, artifact_refs=[],
+        search_attributes={"mm_state": ["executing"], "custom": ["preserve"]},
+        updated_at=updated, integration_state={"pr": "published"},
+        pending_parameters_patch={"version": "pending"}, attention_required=True,
+        step_count=12, wait_cycle_count=3, rerun_count=2,
+    )
+    session.add(source)
+    await session.commit()
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id, desc.run_id = workflow_id, "current-run"
+    desc.namespace, desc.workflow_type = "default", "MoonMind.UserWorkflow"
+    desc.status = WorkflowExecutionStatus.FAILED
+    desc.start_time = desc.execution_time = datetime.fromisoformat(REPLAY["startedAt"])
+    desc.close_time = datetime.fromisoformat(REPLAY["closedAt"])
+    desc.search_attributes = {
+        "mm_state": ["failed"],
+        "mm_updated_at": [datetime.fromisoformat(REPLAY["terminalUpdatedAt"])],
+    }
+    desc.memo = AsyncMock(return_value={
+        "summary": "Older outcome", "parameters": {"version": "old"},
+        "integration_state": {"pr": "pending"}, "step_count": 1,
+    })
+    await sync_execution_projection(session, desc)
+    await session.commit()
+    for model in (TemporalExecutionCanonicalRecord, TemporalExecutionRecord):
+        record = await session.get(model, workflow_id, populate_existing=True)
+        assert record.state.value == record.close_status.value == "failed"
+        assert record.closed_at is not None
+        assert record.updated_at.replace(tzinfo=updated.tzinfo) == updated
+        assert record.memo["summary"] == "Newer outcome"
+        assert record.parameters == {"version": "new"}
+        assert record.integration_state == {"pr": "published"}
+        assert record.pending_parameters_patch == {"version": "pending"}
+        assert record.attention_required is True
+        assert (record.step_count, record.wait_cycle_count, record.rerun_count) == (12, 3, 2)
+        assert record.search_attributes["custom"] == ["preserve"]
+        assert record.search_attributes["mm_state"] == ["failed"]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_terminal_projection_replay.py
+++ b/tests/integration/test_terminal_projection_replay.py
@@ -1,0 +1,208 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from temporalio.client import WorkflowExecutionDescription, WorkflowExecutionStatus
+
+from api_service.core.sync import sync_execution_projection
+from api_service.db.models import (
+    Base,
+    TemporalExecutionCanonicalRecord,
+    TemporalExecutionRecord,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+REPLAY = json.loads(
+    (
+        Path(__file__).parent
+        / "reliability/replays/terminal-projection-metadata-skew/manifest.json"
+    ).read_text()
+)
+
+
+@pytest_asyncio.fixture
+async def session(tmp_path, monkeypatch):
+    from moonmind.config.settings import settings
+
+    monkeypatch.setattr(settings.workflow, "temporal_artifact_backend", "local_fs")
+    monkeypatch.setattr(
+        settings.workflow, "temporal_artifact_root", str(tmp_path / "artifacts")
+    )
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent-runs"))
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/projection.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with async_sessionmaker(engine, expire_on_commit=False)() as db:
+            yield db
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.parametrize("query", ["", "?source=temporal"])
+@pytest.mark.parametrize(
+    "terminal_status,expected",
+    [
+        (WorkflowExecutionStatus.FAILED, "failed"),
+        (WorkflowExecutionStatus.COMPLETED, "completed"),
+        (WorkflowExecutionStatus.CANCELED, "canceled"),
+    ],
+)
+async def test_terminal_describe_repairs_metadata_skew(
+    session, monkeypatch, query, terminal_status, expected
+):
+    from api_service.api.routers import executions
+    from api_service.db.base import get_async_session
+    from moonmind.config.settings import settings
+    from moonmind.workflows.temporal.service import TemporalExecutionService
+
+    started = datetime.fromisoformat(REPLAY["startedAt"])
+    updated = datetime.fromisoformat(REPLAY["terminalUpdatedAt"])
+    metadata_updated = datetime.fromisoformat(REPLAY["metadataUpdatedAt"])
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = REPLAY["incidentWorkflowId"]
+    desc.run_id = "incident-run"
+    desc.namespace = "default"
+    desc.workflow_type = "MoonMind.UserWorkflow"
+    desc.status = terminal_status
+    desc.start_time = desc.execution_time = started
+    desc.close_time = datetime.fromisoformat(REPLAY["closedAt"])
+    desc.search_attributes = {"mm_state": [expected], "mm_updated_at": [updated]}
+    desc.memo = AsyncMock(
+        return_value={
+            "summary": "Terminal result",
+            "owner_id": "owner",
+            "owner_type": "user",
+        }
+    )
+    source = TemporalExecutionCanonicalRecord(
+        workflow_id=desc.id,
+        run_id=desc.run_id,
+        namespace="default",
+        workflow_type=desc.workflow_type,
+        owner_id="owner",
+        owner_type="user",
+        entry="user_workflow",
+        state="executing",
+        close_status=None,
+        memo={"summary": "Launching agent..."},
+        parameters={},
+        artifact_refs=[],
+        search_attributes={"mm_state": ["executing"]},
+        started_at=started,
+        updated_at=metadata_updated,
+        finish_outcome_code=expected.upper(),
+    )
+    session.add(source)
+    await session.commit()
+    adapter = SimpleNamespace(describe_workflow=AsyncMock(return_value=desc))
+    service = TemporalExecutionService(session, client_adapter=adapter)
+    await service._sync_projection_best_effort(source)
+    handle = SimpleNamespace(
+        describe=AsyncMock(return_value=desc),
+        query=AsyncMock(side_effect=RuntimeError("no live query")),
+    )
+    temporal = SimpleNamespace(get_workflow_handle=Mock(return_value=handle))
+    user = SimpleNamespace(id="owner", is_superuser=True)
+    app = FastAPI()
+    app.include_router(executions.router)
+
+    async def session_dependency():
+        yield session
+
+    app.dependency_overrides[get_async_session] = session_dependency
+    app.dependency_overrides[executions._get_service] = lambda: service
+    app.dependency_overrides[executions.get_temporal_client] = lambda: temporal
+    routes = list(app.routes)
+    while routes:
+        route = routes.pop()
+        routes.extend(getattr(getattr(route, "original_router", route), "routes", ()))
+        for dependency in getattr(
+            getattr(route, "dependant", None), "dependencies", ()
+        ):
+            if getattr(dependency.call, "__name__", "") == "_current_user_fallback":
+                app.dependency_overrides[dependency.call] = lambda: user
+    monkeypatch.setattr(settings.temporal, "temporal_authoritative_read_enabled", True)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/api/executions/{desc.id}{query}")
+        assert response.status_code == 200, response.text
+        detail = response.json()
+        assert detail["state"] == detail["rawState"] == expected
+        assert detail["closeStatus"] == expected
+        assert detail["closedAt"]
+        assert detail["summary"] == "Terminal result"
+        listing = await client.get("/api/executions")
+        assert listing.status_code == 200, listing.text
+        assert listing.json()["items"][0]["state"] == detail["state"]
+
+    # A later metadata timestamp on a delayed RUNNING snapshot is no authority
+    # to reopen this same run, even on a subsequent request/transaction.
+    desc.status = WorkflowExecutionStatus.RUNNING
+    desc.close_time = None
+    desc.search_attributes = {
+        "mm_state": ["executing"],
+        "mm_updated_at": [metadata_updated + timedelta(seconds=1)],
+    }
+    await sync_execution_projection(session, desc)
+    await session.commit()
+    for model in (TemporalExecutionCanonicalRecord, TemporalExecutionRecord):
+        record = await session.get(model, desc.id, populate_existing=True)
+        assert record.state.value == expected
+        assert record.close_status.value == expected
+        assert record.finish_outcome_code == expected.upper()
+
+
+@pytest.mark.parametrize(
+    "incoming_run,status",
+    [
+        ("previous-run", WorkflowExecutionStatus.FAILED),
+        ("current-run", WorkflowExecutionStatus.RUNNING),
+        ("current-run", None),
+        ("current-run", 999),
+    ],
+)
+async def test_stale_or_unknown_evidence_cannot_close_current_run(
+    session, incoming_run, status
+):
+    updated = datetime.fromisoformat(REPLAY["metadataUpdatedAt"])
+    desc = Mock(spec=WorkflowExecutionDescription)
+    desc.id = REPLAY["incidentWorkflowId"]
+    desc.run_id = "current-run"
+    desc.namespace = "default"
+    desc.workflow_type = "MoonMind.UserWorkflow"
+    desc.status = WorkflowExecutionStatus.RUNNING
+    desc.start_time = desc.execution_time = datetime.fromisoformat(REPLAY["startedAt"])
+    desc.close_time = None
+    desc.search_attributes = {"mm_state": ["executing"], "mm_updated_at": [updated]}
+    desc.memo = AsyncMock(return_value={"summary": "Current run"})
+    await sync_execution_projection(session, desc)
+    await session.commit()
+
+    desc.run_id = incoming_run
+    desc.status = status
+    desc.close_time = (
+        datetime.fromisoformat(REPLAY["closedAt"])
+        if status == WorkflowExecutionStatus.FAILED
+        else None
+    )
+    desc.search_attributes = {
+        "mm_state": ["unknown"],
+        "mm_updated_at": [datetime.fromisoformat(REPLAY["terminalUpdatedAt"])],
+    }
+    desc.memo = AsyncMock(return_value={"summary": "Stale evidence"})
+    record = await sync_execution_projection(session, desc)
+    await session.commit()
+    assert record.run_id == "current-run"
+    assert record.state.value == "executing"
+    assert record.close_status is None
+    assert record.memo["summary"] == "Current run"

--- a/tests/unit/config/test_container_backend_compose_declarations.py
+++ b/tests/unit/config/test_container_backend_compose_declarations.py
@@ -97,3 +97,15 @@ def test_compose_declares_identical_sources_for_api_and_worker() -> None:
     api, worker = (_service_environment(name) for name in _DECLARING_SERVICES)
     for key in (IMAGE_SOURCES_ENV_KEY, CACHE_SOURCES_ENV_KEY):
         assert api[key] == worker[key]
+
+
+@pytest.mark.parametrize("service", _DECLARING_SERVICES)
+def test_compose_passes_registry_credential_reference_to_api_and_worker(service: str) -> None:
+    environment = _service_environment(service)
+    declaration = environment[IMAGE_SOURCES_ENV_KEY].replace(
+        "${MOONMIND_UNREAL_ENGINE_REGISTRY_CREDENTIAL_REF:-}", "db://registry-pull"
+    )
+    settings = resolve_container_backend_settings({
+        IMAGE_SOURCES_ENV_KEY: _interpolate(declaration)
+    })
+    assert settings.image_source(_SKILL_IMAGE_SOURCE_REF).registry_credential_ref == "db://registry-pull"

--- a/tests/unit/config/test_container_backend_settings.py
+++ b/tests/unit/config/test_container_backend_settings.py
@@ -291,6 +291,25 @@ def test_declarations_reject_keys_outside_their_documented_schema() -> None:
     assert settings.cache_source(DECLARED_CACHE_REF).read_only is True
 
 
+@pytest.mark.parametrize("credential_ref", [None, "", "db://registry-pull"])
+def test_registry_source_accepts_optional_opaque_credential(credential_ref) -> None:
+    declaration = {"sourceRef": "private", "image": DECLARED_IMAGE}
+    if credential_ref is not None:
+        declaration["registryCredentialRef"] = credential_ref
+    settings = resolve_container_backend_settings(
+        {IMAGE_SOURCES_ENV_KEY: json.dumps([declaration])}
+    )
+    assert settings.image_source("private").registry_credential_ref == (credential_ref or None)
+
+
+def test_registry_source_rejects_plaintext_credential() -> None:
+    with pytest.raises(ContainerBackendConfigError, match="opaque registryCredentialRef"):
+        resolve_container_backend_settings({IMAGE_SOURCES_ENV_KEY: json.dumps([
+            {"sourceRef": "private", "image": DECLARED_IMAGE,
+             "registryCredentialRef": "username:password"}
+        ])})
+
+
 def test_shared_memory_default_must_fit_under_its_ceiling() -> None:
     # ``_enforce_resource_ceilings`` only inspects caller-supplied shmSize, so a
     # default above the ceiling would launch every omitted request above the


### PR DESCRIPTION
## Related issue

N/A â€” production incident investigation.

## Summary

- Private deployment image aliases now carry an opaque registry credential reference. API admission authorizes it, and the worker verifies the exact image and credential before resolving a temporary Docker login. Recreated services reuse the configured secret; fresh deployments can use the existing environment or external secret backends.
- A terminal Temporal result now closes the current run's projection even when a later metadata write would otherwise leave workflow detail showing executing.
- Empty local Compose session-secret defaults select the existing durable key-generation path, so API startup succeeds and reuses that key.

ELI5: Configure the image credential once at deployment level, and each authorized job receives it automatically. Finished workflows also stop looking active.

## Test Plan

After review fixes: **182 targeted unit tests, 34 integration cases, and 13 conformance cases passed**. Architecture audits and changed-test lint passed.

The broader local run had 16,253 unit passes and 23 failures: 18 depend on Git metadata unavailable through the Windows worktree mount; the other five reproduce unchanged on base revision `b7268cbce` (root-mode runner mocks and the Compose janitor override). The full integration run had 710 passes and three failures; its two missing-host configuration cases and interrupted conformance case passed on corrected isolated reruns. All GitHub checks passed for the review-fix head `113f8c7ee`; the resolver merged the PR after rechecking the exact remote head and review inventory.

```bash
bash tools/test_unit.sh --python-only \
  tests/unit/test_sync.py \
  tests/unit/security/test_auth_modes_4120.py \
  tests/unit/config/test_container_backend_settings.py \
  tests/unit/config/test_container_backend_compose_declarations.py \
  tests/unit/services/test_container_jobs.py \
  tests/unit/services/test_registry_authorization.py \
  tests/unit/workflows/temporal/test_container_job_backend_registry_auth.py \
  tests/unit/workflows/temporal/test_registry_auth_resolve.py \
  tests/unit/workflows/temporal/test_container_image_acquisition.py \
  tests/unit/workflows/temporal/test_container_job_workflow.py
python -m pytest -q -m integration_ci \
  tests/integration/test_registry_source_credential_handoff.py \
  tests/integration/test_terminal_projection_replay.py \
  tests/integration/test_startup_session_secret_defaults.py \
  tests/integration/temporal/test_system_operations_api.py
python -m pytest -q -m integration_ci tests/integration/temporal/test_step_execution_conformance.py
```

## Demo

N/A â€” no visual styling changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Registry access still requires an explicit repository-scoped grant. No credentials are committed or carried in workflow payloads. Image or credential changes between admission and execution fail closed. Existing anonymous declarations remain supported; no workflow payload schema changes. Projection reconciliation accepts closure only for the same run, preserves newer database metadata, and protects against stale runs and reopening terminal runs. Remote session-key provisioning and placeholder rejection remain enforced.

## Coverage notes

Added minimized incident fixtures covering the API â†’ workflow â†’ Activity â†’ Docker credential handoff, real database/environment secret resolution, projection reconciliation through HTTP reads, and repeated session startup. A live job using only the configured image alias pulled the expected private GHCR digest, verified the Unreal build tool, exited successfully, published its logs, and removed its temporary auth directory. The affected workflow detail now reports failed consistently with its list entry. The live check did not execute an Unreal build.

## Changelog

Reuse deployment registry credentials automatically and keep terminal workflow status and local API startup reliable.
