### PR TITLE
Fix workflow dependencies being skipped before execution

### DIFF
--- a/docs/Workflows/WorkflowDependencies.md
+++ b/docs/Workflows/WorkflowDependencies.md
@@ -4,7 +4,7 @@
 **Viewpoint:** Module Contract Specification  
 **Status:** Draft  
 **Owners:** MoonMind Engineering  
-**Updated:** 2026-09-06  
+**Updated:** 2026-09-08
 **Audience:** Workflow lifecycle, API, orchestration, and dashboard contributors  
 **Authority:** Inter-UserWorkflow dependency declaration, successful-completion waiting, signaling, bypass, and durable outcome semantics. Publication inheritance and code-transfer proof remain with their providing owners.  
 **Owning Surface:** Workflow dependency admission and durable wait/notification boundary  
@@ -20,7 +20,7 @@ The single-policy batch contract is defined in [Workflow Publishing](WorkflowPub
 
 ## 2. Contract Summary
 
-Create requests may declare prerequisite workflow IDs in `payload.task.dependsOn`, normalized to `initialParameters.task.dependsOn`. Targets are existing MoonMind.UserWorkflow executions. WorkflowId is the durable target; runId is diagnostic/evidence identity, not a dependency target. Compatibility taskId equals workflowId for Temporal-backed work.
+Create requests may declare prerequisite workflow IDs in `payload.workflow.dependsOn`, normalized to `initialParameters.workflow.dependsOn`. Targets are existing MoonMind.UserWorkflow executions. WorkflowId is the durable target; runId is diagnostic/evidence identity, not a dependency target. Compatibility taskId equals workflowId for Temporal-backed work.
 
 A prerequisite is satisfied only when it reaches MoonMind terminal state completed. Failed, canceled, terminated, timed_out, or runtime-unresolvable outcomes keep the dependent in waiting_on_dependencies until that same workflowId later completes or an operator cancels/bypasses the wait. A prerequisite failure does not automatically fail the dependent.
 
@@ -36,7 +36,7 @@ The contract supports create-time declaration, UserWorkflow-to-UserWorkflow edge
 {
   "type": "task",
   "payload": {
-    "task": {
+    "workflow": {
       "instructions": "Run integration tests",
       "dependsOn": ["mm:01ABC...", "mm:01DEF..."]
     }
@@ -63,6 +63,8 @@ Persist forward/reverse edges, startup resolution state, notification ownership,
 ### 4.1 Lifecycle
 
 The normal order is scheduled when applicable, initializing, waiting_on_dependencies, then the ordinary planning/executing lifecycle. No declared dependencies means the gate is skipped.
+
+The gate reads the same admitted workflow parameters used for dependency visibility. It precedes planning, tool execution, and child launch for every runtime and preset, including the Fix and Review Loop.
 
 ### 4.2 Dependency resolution model
 

--- a/docs/Workflows/WorkflowDependenciesOperatorGuide.md
+++ b/docs/Workflows/WorkflowDependenciesOperatorGuide.md
@@ -6,7 +6,7 @@ This document describes operational behavior, limits, diagnostics, and remediati
 
 ## 1. What Are Workflow Dependencies?
 
-A `MoonMind.UserWorkflow` execution can declare up to **10 prerequisite `workflowId` values** at create time via `payload.task.dependsOn`. The dependent run:
+A `MoonMind.UserWorkflow` execution can declare up to **10 prerequisite `workflowId` values** at create time via `payload.workflow.dependsOn`. The dependent run:
 
 1. Initializes normally.
 2. Enters `waiting_on_dependencies` state.
@@ -146,7 +146,7 @@ Workflows that started **before** `dependency-wait-through-rerun-v1` was deploye
 Dependents are stored in the `execution_dependencies` durable edge table. If reverse lookup returns empty:
 
 1. Verify the prerequisite's `workflowId` matches the `prerequisite_workflow_id` column.
-2. Check that the dependency edges were persisted at create time (both `initialParameters.task.dependsOn` and the edge table must be written).
+2. Check that the dependency edges were persisted at create time (both `initialParameters.workflow.dependsOn` and the edge table must be written).
 
 ---
 
@@ -155,6 +155,7 @@ Dependents are stored in the `execution_dependencies` durable edge table. If rev
 The dependency gate is deployed under cooperating Temporal patches:
 
 - **`dependency-gate-v1`** — installs the dependency gate itself. Workflows started before this patch was deployed skip the gate entirely (backward compatible).
+- **`run-canonical-dependency-parameters-v1`** — reads dependencies from the admitted `workflow` envelope. Histories that already passed initialization without this marker retain their recorded command sequence; restarting a worker does not retroactively gate work that already launched. Cancel and recreate an affected dependent with its prerequisites to enforce the wait.
 - **`dependency-wait-through-rerun-v1`** — installs the unified wait-through-rerun behavior. The first time a workflow under this patch records a prerequisite outcome, Temporal records a marker that pins the workflow to the new behavior across replays.
   - Workflows started **after** `dependency-wait-through-rerun-v1` was deployed never auto-fail on a prerequisite failure.
   - Workflows whose history predates `dependency-wait-through-rerun-v1` continue to use the legacy fail-fast code path until they terminate. Their `_dependency_failure` paths and `dependency_gate_failed` events remain accurate for those runs only.

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -599,6 +599,8 @@ RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH = (
 )
 RUN_MEMO_RUNTIME_INHERITANCE_PATCH = "run-memo-runtime-inheritance-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
+# Older canonical-payload histories skipped the gate; preserve their commands.
+RUN_CANONICAL_DEPENDENCY_PARAMETERS_PATCH = "run-canonical-dependency-parameters-v1"
 # Replay-stable patch id for unified wait-through-rerun dependency behavior.
 # Under this patch, a non-success prerequisite terminal outcome (failed,
 # canceled, terminated, timed_out, unresolvable) keeps the dependent run
@@ -10156,25 +10158,32 @@ class MoonMindRunWorkflow:
     def _dependency_ids_from_parameters(
         self, parameters: Mapping[str, Any]
     ) -> list[str]:
-        task_payload = parameters.get("task")
+        parameter_key = "task"
+        if "workflow" in parameters and workflow.patched(
+            RUN_CANONICAL_DEPENDENCY_PARAMETERS_PATCH
+        ):
+            parameter_key = "workflow"
+        task_payload = parameters.get(parameter_key)
         if task_payload is None:
             return []
         if not isinstance(task_payload, Mapping):
-            raise ValueError("initialParameters.task must be an object when provided")
+            raise ValueError(
+                f"initialParameters.{parameter_key} must be an object when provided"
+            )
 
         depends_on = task_payload.get("dependsOn")
         if depends_on is None:
             return []
         if not isinstance(depends_on, list):
             raise ValueError(
-                "initialParameters.task.dependsOn must be a list when provided"
+                f"initialParameters.{parameter_key}.dependsOn must be a list when provided"
             )
 
         normalized: list[str] = []
         for dep_id in depends_on:
             if not isinstance(dep_id, str):
                 raise ValueError(
-                    "initialParameters.task.dependsOn entries must be strings"
+                    f"initialParameters.{parameter_key}.dependsOn entries must be strings"
                 )
             candidate = dep_id.strip()
             if candidate and candidate not in normalized:

--- a/tests/fixtures/temporal/workflow_dependencies/canonical_start.json
+++ b/tests/fixtures/temporal/workflow_dependencies/canonical_start.json
@@ -1,0 +1,23 @@
+{
+  "workflow_type": "MoonMind.UserWorkflow",
+  "initial_parameters": {
+    "requestType": "task",
+    "workflow": {
+      "dependsOn": ["prerequisite"],
+      "instructions": "Resolve the target pull request before the fix and review loop.",
+      "publish": {
+        "mode": "none",
+        "mergeAutomation": {"enabled": true, "finishMode": "fix_only"}
+      },
+      "appliedStepTemplates": [{"slug": "pr-review-resolve"}],
+      "steps": [{
+        "id": "resolve-target",
+        "type": "tool",
+        "tool": {
+          "id": "github.resolve_pull_request_target",
+          "inputs": {"repository": "example/repository", "pullRequest": "feature/example"}
+        }
+      }]
+    }
+  }
+}

--- a/tests/unit/workflows/temporal/test_run_dependency_pause_boundary.py
+++ b/tests/unit/workflows/temporal/test_run_dependency_pause_boundary.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import json
 from contextlib import asynccontextmanager
 from datetime import timedelta
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -17,6 +19,7 @@ from moonmind.schemas.temporal_activity_models import DependencyStatusSnapshotIn
 from moonmind.workflows.temporal.workflows.run import (
     DEFAULT_ACTIVITY_CATALOG,
     DEPENDENCY_RECONCILE_INTERVAL,
+    RUN_CANONICAL_DEPENDENCY_PARAMETERS_PATCH,
     RUN_DEPENDENCY_PAUSE_SAFE_BOUNDARY_PATCH,
     MoonMindUserWorkflow,
 )
@@ -71,7 +74,7 @@ async def _wait_for_query(handle, query: str, **expected):
 
 
 @asynccontextmanager
-async def _dependency_workflow(state: str):
+async def _dependency_workflow(state: str, *, input_payload=None, wait_for_gate=True):
     """Keep the production workflow and activity invocation; supply only the snapshot."""
     queue = f"dependency-pause-{uuid4()}"
     snapshot = DependencySnapshot(state)
@@ -96,7 +99,7 @@ async def _dependency_workflow(state: str):
             ):
                 handle = await env.client.start_workflow(
                     MoonMindUserWorkflow.run,
-                    {
+                    input_payload or {
                         "workflow_type": "MoonMind.UserWorkflow",
                         "initial_parameters": {"task": {"dependsOn": ["prerequisite"]}},
                     },
@@ -112,12 +115,13 @@ async def _dependency_workflow(state: str):
                     ]),
                 )
                 try:
-                    await _wait_for_query(
-                        handle, "get_status", state="waiting_on_dependencies"
-                    )
-                    async with asyncio.timeout(5):
-                        while not snapshot.calls:
-                            await asyncio.sleep(0.01)
+                    if wait_for_gate:
+                        await _wait_for_query(
+                            handle, "get_status", state="waiting_on_dependencies"
+                        )
+                        async with asyncio.timeout(5):
+                            while not snapshot.calls:
+                                await asyncio.sleep(0.01)
                     yield env, handle, snapshot
                 finally:
                     await handle.terminate(reason="Dependency pause boundary test complete")
@@ -171,6 +175,56 @@ async def test_dependency_wait_confirms_pause_and_replays(state, system_control)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["", "new_provider_state", "failed", "canceled", "timed_out"])
+async def test_canonical_dependencies_keep_non_success_waiting(state):
+    async with _dependency_workflow(
+        state, input_payload=_canonical_dependency_input()
+    ) as (_env, handle, _snapshot):
+        history = await handle.fetch_history()
+        assert _scheduled_activities(history) == ["execution.dependency_status_snapshot"]
+        assert (await handle.query("get_status"))["state"] == "waiting_on_dependencies"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dependencies", [None, [], ["prerequisite"]])
+async def test_canonical_dependencies_ready_at_start(dependencies):
+    payload = _canonical_dependency_input()
+    if dependencies is None:
+        payload["initial_parameters"]["workflow"].pop("dependsOn")
+    else:
+        payload["initial_parameters"]["workflow"]["dependsOn"] = dependencies
+    async with _dependency_workflow(
+        "completed", input_payload=payload, wait_for_gate=False
+    ) as (_env, handle, snapshot):
+        await _wait_for_query(handle, "get_status", state="planning")
+        assert snapshot.calls == ([["prerequisite"]] if dependencies else [])
+        assert _scheduled_activities(await handle.fetch_history())[-1] == "plan.generate"
+
+
+@pytest.mark.asyncio
+async def test_canonical_dependency_history_before_fix_replays(monkeypatch):
+    """Do not insert dependency commands into histories that already began work."""
+    patched = workflow.patched
+    with monkeypatch.context() as legacy:
+        legacy.setattr(workflow, "patched", lambda patch_id: (
+            False if patch_id == RUN_CANONICAL_DEPENDENCY_PARAMETERS_PATCH
+            else patched(patch_id)
+        ))
+        async with _dependency_workflow(
+            "executing", input_payload=_canonical_dependency_input(), wait_for_gate=False
+        ) as (_env, handle, snapshot):
+            await _wait_for_query(handle, "get_status", state="planning")
+            assert snapshot.calls == []
+            history = await handle.fetch_history()
+            assert _scheduled_activities(history) == ["plan.generate"]
+
+    await Replayer(
+        workflows=[MoonMindUserWorkflow],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    ).replay_workflow(history)
+
+
+@pytest.mark.asyncio
 async def test_dependency_pause_history_before_safe_boundary_patch_replays(monkeypatch):
     """Replay a minimal old dependency timer history with actual no-argument Updates."""
     patched = workflow.patched
@@ -196,3 +250,57 @@ async def test_dependency_pause_history_before_safe_boundary_patch_replays(monke
         workflows=[MoonMindUserWorkflow],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ).replay_workflow(history)
+
+
+def _canonical_dependency_input():
+    """Minimized worker input from the Fix and Review Loop dependency incident."""
+    return json.loads((
+        Path(__file__).parents[3]
+        / "fixtures/temporal/workflow_dependencies/canonical_start.json"
+    ).read_text())
+
+
+def _scheduled_activities(history):
+    return [
+        event.activity_task_scheduled_event_attributes.activity_type.name
+        for event in history.events
+        if event.HasField("activity_task_scheduled_event_attributes")
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime", [None, "omnigent", "codex_cli", "claude_code", "jules", "openclaw"]
+)
+async def test_canonical_dependencies_block_planning_and_child_launch(runtime):
+    payload = _canonical_dependency_input()
+    parameters = payload["initial_parameters"]
+    if runtime is not None:
+        parameters["targetRuntime"] = runtime
+        parameters["workflow"]["runtime"] = {"mode": runtime}
+    async with _dependency_workflow("executing", input_payload=payload) as (
+        _env, handle, snapshot
+    ):
+        assert snapshot.calls == [["prerequisite"]]
+        history = await handle.fetch_history()
+        assert _scheduled_activities(history) == ["execution.dependency_status_snapshot"]
+        assert not any(
+            event.HasField("start_child_workflow_execution_initiated_event_attributes")
+            for event in history.events
+        )
+
+        await handle.signal("DependencyResolved", {
+            "prerequisiteWorkflowId": "prerequisite",
+            "terminalState": "completed",
+            "closeStatus": "completed",
+            "resolvedAt": "2026-09-08T23:02:00Z",
+        })
+        await _wait_for_query(handle, "get_status", state="planning")
+        history = await handle.fetch_history()
+        assert _scheduled_activities(history)[:2] == [
+            "execution.dependency_status_snapshot", "plan.generate"
+        ]
+        await Replayer(
+            workflows=[MoonMindUserWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ).replay_workflow(history)

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1291,6 +1291,14 @@ async def test_create_execution_persists_dependency_edges_and_supports_lookups(
         assert source is not None
         assert source.parameters["workflow"]["dependsOn"] == [dep1.workflow_id, dep2.workflow_id]
 
+        # The worker must receive the same canonical dependency envelope that
+        # admission persists and the dashboard displays.
+        start_args = mock_client_adapter.start_workflow.await_args.kwargs["input_args"]
+        assert "task" not in start_args["initial_parameters"]
+        assert start_args["initial_parameters"]["workflow"]["dependsOn"] == [
+            dep1.workflow_id, dep2.workflow_id
+        ]
+
         prerequisites = await service.list_prerequisites(dependent.workflow_id)
         assert [edge.prerequisite_workflow_id for edge in prerequisites] == [
             dep1.workflow_id,


### PR DESCRIPTION
Workflow submissions store prerequisites in `workflow.dependsOn`, but the dependency gate still read only `task.dependsOn`. The dashboard showed the prerequisite while the Fix and Review Loop immediately resolved its PR and launched merge automation before that prerequisite completed.

Read the canonical workflow envelope before planning or child launch for all runtimes. A Temporal patch preserves command ordering for existing histories that already skipped the gate. Update the dependency contract and operator guidance; affected runs that already launched must be canceled and recreated to enforce waiting.

Validation:
- Reproduced the failure with a minimized incident payload before applying the fix.
- Passed targeted dependency, scheduling, signal, admission, and replay tests, including default runtime and all five runtime families, non-success prerequisites, completion signals, and pre-fix histories.
- Passed all 264 hermetic reliability journey tests.
