### PR TITLE
[Qdrant removal] Implement replay-safe cutover, data preservation and rollback procedure (MoonLadderStudios/MoonMind#4115)

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -472,11 +472,15 @@ MOONMIND_GEMINI_CAPACITY_RETRY_MAX_DELAY_SECONDS="600"
 # MOONMIND_ALLOWED_SKILLS="auto,my-private-scan"
 # MOONMIND_GIT_USER_NAME=""
 # MOONMIND_GIT_USER_EMAIL=""
-QDRANT_API_KEY=""
-QDRANT_ENABLED="true"
-QDRANT_URL="http://qdrant:6333"
-QDRANT_HOST="qdrant"
-QDRANT_PORT=6333
+# MoonLadderStudios/MoonMind#4115: native Qdrant/vector backend retired.
+# The vector-free release enables no native vector store. QDRANT_* keys below
+# remain documented only so sanitized old .env files still parse; new
+# deployments must not point them at a live backend, and no new mandatory
+# disable flag, fake embedding credential, or substitute search service exists.
+# QDRANT_URL, QDRANT_HOST, QDRANT_PORT, and QDRANT_API_KEY are obsolete and
+# intentionally absent from this template. Snapshot/export recovery material
+# lives in operator-controlled authorized storage, never here.
+QDRANT_ENABLED="false"
 POSTGRES_PASSWORD=""
 RAG_ENABLED="true"
 RAG_MAX_CONTEXT_LENGTH_CHARS=8000
@@ -486,7 +490,8 @@ MEMORY_PLANNING="off"
 MEMORY_FAIL_OPEN="true"
 MEMORY_CONTEXT_BUDGET_TOKENS=2000
 VECTOR_STORE_COLLECTION_NAME="moonmind"
-VECTOR_STORE_PROVIDER="qdrant"
+# MoonLadderStudios/MoonMind#4115: retired native vector backend; vector-free default.
+VECTOR_STORE_PROVIDER="none"
 
 # Provider Keys (also populate the default profile when AUTH_PROVIDER=disabled)
 ANTHROPIC_API_KEY=""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,11 @@ services:
       - MODEL_CONTEXT_PROTOCOL_ENABLED=true
       - MODEL_CONTEXT_PROTOCOL_PORT=8000
       - MODEL_CONTEXT_PROTOCOL_HOST=0.0.0.0
-      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
+      # MoonLadderStudios/MoonMind#4115: the native Qdrant backend is retired.
+      # The vector-free release wires no QDRANT_URL; a stale QDRANT_URL in an
+      # old .env is ignored. Exact-container retirement of a pre-cutover
+      # orphan is an explicit operator action (see docs/tmp/QdrantCutoverRunbook-4115.md),
+      # never broad orphan cleanup or `down -v`.
       - TEMPORAL_ADDRESS=${TEMPORAL_ADDRESS:-temporal-internal:7233}
       - TEMPORAL_NAMESPACE=${TEMPORAL_NAMESPACE:-default}
       - TEMPORAL_ARTIFACT_BACKEND=${TEMPORAL_ARTIFACT_BACKEND:-s3}
@@ -1060,15 +1064,15 @@ services:
       - control-plane-network
     restart: unless-stopped
 
-  qdrant:
-    image: qdrant/qdrant:v1.17.1
-    ports:
-      - "6333:6333"
-      - "6334:6334"
-    volumes:
-      - qdrant-storage:/qdrant/storage
-    networks:
-      - control-plane-network
+  # MoonLadderStudios/MoonMind#4115: the native Qdrant service is retired and
+  # intentionally absent from the vector-free release (no live or optional
+  # native Qdrant backend, no compatibility profile). The previous image was
+  # qdrant/qdrant:v1.17.1 with qdrant-storage:/qdrant/storage. Removing this
+  # YAML definition does not stop a running pre-cutover orphan: exact-container
+  # retirement is an explicit operator action with ownership checks (see
+  # docs/tmp/QdrantCutoverRunbook-4115.md). The qdrant-storage volume below is
+  # retained through the recovery window; its eventual deletion is a separate
+  # exact-resource operator action, never automatic.
 
   omnigent-runtime-bootstrap:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
@@ -1386,7 +1390,7 @@ services:
       - PYTHONPATH=/app
       - LOG_LEVEL=INFO
       - PYTHONUNBUFFERED=1
-      - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
+      # MoonLadderStudios/MoonMind#4115: vector-free release wires no QDRANT_URL.
       - MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION=${MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION:-1}
     env_file:
       - path: .env
@@ -1405,8 +1409,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      qdrant:
-        condition: service_started
+    # MoonLadderStudios/MoonMind#4115: no depends_on qdrant; the native Qdrant
+    # service is retired from this Compose file.
 
   omnigent-db-init:
     image: postgres:${POSTGRES_VERSION:-17}
@@ -1611,6 +1615,11 @@ services:
     restart: unless-stopped
 
 volumes:
+  # MoonLadderStudios/MoonMind#4115: retained through the explicit
+  # recovery/retention window after the Qdrant service removal above. Never
+  # deleted by a normal upgrade; eventual deletion is a separate
+  # exact-resource operator action after export/restore verification.
+  # Distinct from moonmind_retrieval_state (classified by #4107).
   qdrant-storage:
   omnigent-host-state:
   omnigent-host-claude-state:

--- a/docs/tmp/QdrantCutoverRunbook-4115.md
+++ b/docs/tmp/QdrantCutoverRunbook-4115.md
@@ -1,0 +1,178 @@
+# Qdrant Cutover Runbook — #4115
+
+Parent: MoonLadderStudios/MoonMind#4103. This runbook owns the replay-safe
+cutover, data preservation, and rollback procedure for the bounded upgrade
+from a Qdrant-bearing deployment to the vector-free release. Design and
+sanitized fixtures in this runbook are not blocked on the final integrated
+verification issue; exact rehearsal evidence is published to #4103/#4114.
+
+Status: Proposed (pre-cutover). Correctly unarchived until every documented
+consumer drains and the archive/delete triggers below fire.
+
+Sibling ownership (do not duplicate here):
+- #4105 (merged): retired vector admission/authoring/plan compilation.
+  Inventory: `docs/tmp/QdrantRemovalInventory-4105.md`.
+- #4106–#4109: vector-only handler/field deletion in execution code.
+- #4107: `moonmind_retrieval_state` capability/audit-state classification.
+  Preserve that evidence independently from old vector storage.
+- #4110–#4113: integrated rehearsal pieces. #4114 consumes final evidence.
+- #3948/#3944: ManifestIngest public compile/execute semantics and old
+  Activity/command fixtures. The two historical generic ManifestIngest
+  entries (`manifest_ref` compile, `manifestArtifactRef` orchestrate) are
+  preserved verbatim and stay replayable.
+
+Source baseline: `9424899410a1df1b359fb1b803b9d21912e0b50a`. That Compose
+revision declares both `qdrant-storage` and `moonmind_retrieval_state`;
+they are distinct data and must never be treated as interchangeable.
+Repository inspection alone cannot establish an operator's active work or
+whether Qdrant holds unique content — the live Preflight below does.
+
+Hermetic gate: `tools/qdrant_cutover_rehearsal.py` (`--mode preflight |
+rehearsal | upgrade-check | preservation-check | rollback-check |
+retirement-check | all`). It performs no live mutation and never contacts
+a deployment host. `REHEARSAL_PASS_DEPLOYMENT_BLOCKED` is the honest
+terminal state for a repo checkout: fixtures pass while owner-held and
+live-deployment prerequisites stay blocked.
+
+## 1. Preflight (bounded, read-only, redacted)
+
+Use existing deployment/Temporal/state owners (deployment worker,
+Temporal visibility, artifact/MinIO readers, capability registry). Inventory:
+
+- affected active workflows and pending/retryable Activities,
+- recurring schedules with retired vector producers,
+- stored vector manifests and profile defaults,
+- issued capabilities,
+- relevant schema/readers,
+- exact Compose project/service/container IDs and actual mounts.
+
+Produce a redacted report (counts and refs only — no collections,
+payloads, documents, metadata, text, or secrets) with one actionable
+verdict:
+
+- `proceed`: no active vector work, no unpreserved unique data, ownership exact.
+- `drain`: active/pending/scheduled vector work exists. Choose drainage on
+  the old release or the existing versioned worker/cutover mechanism, record
+  the pending-consumer evidence and the finite retirement condition. No
+  schedule may retry forever against a deleted backend.
+- `blocked`: ambiguous ownership or unpreserved potentially-unique data.
+  Refuse retirement until resolved.
+
+Never guess from service names. Hermetic rehearsal:
+`python tools/qdrant_cutover_rehearsal.py --mode preflight`.
+
+## 2. Admission retirement and cutover choice (#4105 + this runbook)
+
+New native vector admissions are already stopped at #4105 (explicit
+`rag`/`followUpRetrieval` rejected before Temporal start/host launch;
+schedules/drafts/patches strip retired fields; plan compilation carries no
+vector descriptors). This runbook adds:
+
+- explicit retirement of retired schedule producers (no indefinite
+  compatibility backend in the new release),
+- the documented drainage-vs-version-routing choice per affected history,
+- pending-consumer evidence and the finite retirement condition.
+
+Do not reinterpret historical payloads, do not merely delete an Activity
+handler, and do not retain an indefinite compatibility backend. A history
+that cannot safely run on the new release gets explicit old-release drain
+ownership, never a silent fallback.
+
+## 3. Replay safety
+
+Representative old/new histories replay, or they carry tested bounded
+old-release drainage. The gate checks both historical generic ManifestIngest
+entries plus restart/retry/cancel containment across the real-shaped
+sequence (preflight → preserve → upgrade → retire → verify) with
+failure injection at each step. Immutable inputs and evidence are never
+rewritten to change semantics. Old Activity/command fixtures (#3948/#3944)
+are preserved.
+
+## 4. Preservation (before stopping the old service)
+
+1. Identify collection/payload provenance and potentially Qdrant-only
+   documents, metadata, or text.
+2. Record the previous image/version (`qdrant/qdrant:v1.17.1`),
+   exact mounts (`qdrant-storage:/qdrant/storage`), and recovery config.
+3. Preserve a recoverable snapshot plus a logical export where needed.
+4. Verify recoverability; classify data as reproducible or unique before
+   declaring anything disposable. Never assume payloads reconstructible
+   merely because vectors are derived.
+5. Keep originals in operator-controlled authorized storage with redaction
+   and retention — never public issues or source control. Preserve #4107
+   retrieval-state evidence independently.
+
+Hermetic rehearsal: `--mode preservation-check --preservation-description
+"...provenance...snapshot...export...verif..."`. A description claiming
+derived-vectors-are-disposable or public-issue storage is refused.
+
+## 5. Upgrade (matching revision set)
+
+Deploy matching application, schema/caller changes, dependency images, and
+Compose together. Rehearse under sanitized fixtures: an old `.env`
+(`QDRANT_URL`, `QDRANT_ENABLED=true`, `VECTOR_STORE_PROVIDER=qdrant`),
+stored retired requirements (rejected at admission with actionable
+guidance), and representative historical artifacts (stay readable).
+Explain failures actionably. There is no new mandatory disable flag, no
+fake embedding credential, and no substitute search service. Old-release
+test infrastructure is isolated upgrade-fixture infrastructure, not
+supported new-release topology.
+
+Hermetic rehearsal: `--mode upgrade-check` (also covered by
+`tests/unit/tools/test_qdrant_cutover_rehearsal.py`).
+
+## 6. Retirement (exact container only)
+
+1. Identify the exact obsolete Qdrant container owned by the selected
+   deployment (Compose project name, service `qdrant`, container ID).
+2. Refuse ambiguous or wrong-project ownership — never broaden to orphan
+   cleanup, `docker compose down -v`, volume prune, or filesystem deletion.
+3. Stop/remove only that container; verify absence afterward.
+4. Repeated retirement checks are safe (idempotent: absence re-verifies).
+
+Removing the YAML definition does not stop a running orphan. Creating
+these issues does not authorize any real production deletion.
+
+Hermetic rehearsal: `--mode retirement-check --retire-action "stop/remove
+exact qdrant container (identified from inventory)"`. Without an explicit
+operator-supplied action the check stays blocked; destructive actions fail.
+
+## 7. Retention
+
+Retain the old Qdrant volume (`qdrant-storage`) and exports through an
+explicit recovery/retention window. Permanent deletion is a separate
+exact-resource operator action after export/restore verification — never an
+automatic normal-upgrade step. Preserve PostgreSQL, MinIO, secrets,
+workspaces, unrelated containers, and Omnigent state.
+
+## 8. Rollback
+
+Rollback uses the previous matching application/Compose/image revision with
+preserved data after a schema-compatibility check, rehearsed against
+fixtures. Never add an optional Qdrant profile or adapter back to the new
+release as a rollback feature.
+
+Hermetic rehearsal: `--mode rollback-check` (default scope rehearses the
+matching-revision path; Qdrant-profile scopes are refused).
+
+## 9. Evidence for #4103/#4114 (no over-claiming)
+
+Publish the exact rehearsal evidence (gate JSON, sanitized preflight
+report, preservation verification record, retirement absence verification,
+rollback rehearsal log) plus the remaining operator-only steps, to
+#4103/#4114. Distinguish automated fixture verification from protected
+deployment checks and real operator actions not performed. Never claim
+every real installation was upgraded. #4114 consumes this report without
+circular dependencies: this runbook's fixtures do not require #4114.
+
+## 10. Archive/delete triggers (temporary inventory)
+
+This file and any temporary inventory it references live under `docs/tmp/`
+or the issues. Archive or delete when ALL hold:
+
+- the integrated rehearsal evidence is published to #4103/#4114,
+- every documented consumer drained (finite retirement conditions met),
+- obsolete new-release compatibility scaffolding removed,
+- the retention window closed with an explicit exact-resource disposition.
+
+Until then this runbook stays Proposed and unarchived.

--- a/docs/tmp/QdrantCutoverRunbook-4115.md
+++ b/docs/tmp/QdrantCutoverRunbook-4115.md
@@ -134,8 +134,11 @@ Removing the YAML definition does not stop a running orphan. Creating
 these issues does not authorize any real production deletion.
 
 Hermetic rehearsal: `--mode retirement-check --retire-action "stop/remove
-exact qdrant container (identified from inventory)"`. Without an explicit
-operator-supplied action the check stays blocked; destructive actions fail.
+exact qdrant container (identified from inventory)" --retire-project
+<project> --retire-service qdrant --retire-container-id <container>`.
+Without an explicit operator-supplied action the check stays blocked;
+without exact structured ownership it also stays blocked (ambiguous
+ownership must never complete retirement); destructive actions fail.
 
 ## 7. Retention
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1677,12 +1677,18 @@ class AtlassianSettings(BaseSettings):
             )
 
 class QdrantSettings(BaseSettings):
-    """Qdrant settings"""
+    """Retired native Qdrant settings (MoonLadderStudios/MoonMind#4115).
+
+    The vector-free release ships no live native Qdrant backend. These
+    fields remain only so sanitized old ``.env`` files (QDRANT_*) and
+    persisted historical payloads still parse; new deployments must not
+    enable them and no new code path may consult them to reach Qdrant.
+    """
 
     qdrant_host: str = Field("qdrant", alias="QDRANT_HOST")
     qdrant_port: int = Field(6333, alias="QDRANT_PORT")
     qdrant_api_key: Optional[str] = Field(None, alias="QDRANT_API_KEY")
-    qdrant_enabled: bool = Field(True, alias="QDRANT_ENABLED")
+    qdrant_enabled: bool = Field(False, alias="QDRANT_ENABLED")
     model_config = SettingsConfigDict(populate_by_name=True, env_prefix="")
 
 class RAGSettings(BaseSettings):
@@ -2605,8 +2611,8 @@ class AppSettings(BaseSettings):
         3600, alias="MODEL_CACHE_REFRESH_INTERVAL_SECONDS"
     )
     vector_store_provider: str = Field(
-        "qdrant", alias="VECTOR_STORE_PROVIDER"
-    )  # Added field
+        "none", alias="VECTOR_STORE_PROVIDER"
+    )  # Retired native vector backend (#4115): vector-free default.
 
     # Vector store settings
     vector_store_collection_name: str = Field(

--- a/moonmind/rag/settings.py
+++ b/moonmind/rag/settings.py
@@ -168,9 +168,13 @@ class RagRuntimeSettings:
         run_id = _get_env(env, "RUN_ID") or _get_env(env, "MOONMIND_RUN_ID")
         rag_enabled = env_to_bool(_get_env(env, "RAG_ENABLED", "true"), default=True)
         # MoonLadderStudios/MoonMind#4115: vector-free default. The native
-        # Qdrant backend is retired; explicit old values still parse so
-        # sanitized old .env fixtures remain readable, but no new path may
-        # enable native vector retrieval.
+        # Qdrant backend is retired: omitted QDRANT_ENABLED defaults to
+        # disabled and no new path may enable native vector retrieval.
+        # Explicit legacy values still parse so sanitized old .env fixtures
+        # remain readable; old-release drain owns that transition (bounded
+        # drain, never silent proceed). Making the flag fully inert lands
+        # with sibling handler/field removal (#4106-#4109); until then, do
+        # not add new consumers of this flag.
         qdrant_enabled = env_to_bool(
             _get_env(env, "QDRANT_ENABLED", "false"), default=False
         )

--- a/moonmind/rag/settings.py
+++ b/moonmind/rag/settings.py
@@ -167,8 +167,12 @@ class RagRuntimeSettings:
         job_id = _get_env(env, "JOB_ID") or _get_env(env, "MOONMIND_JOB_ID")
         run_id = _get_env(env, "RUN_ID") or _get_env(env, "MOONMIND_RUN_ID")
         rag_enabled = env_to_bool(_get_env(env, "RAG_ENABLED", "true"), default=True)
+        # MoonLadderStudios/MoonMind#4115: vector-free default. The native
+        # Qdrant backend is retired; explicit old values still parse so
+        # sanitized old .env fixtures remain readable, but no new path may
+        # enable native vector retrieval.
         qdrant_enabled = env_to_bool(
-            _get_env(env, "QDRANT_ENABLED", "true"), default=True
+            _get_env(env, "QDRANT_ENABLED", "false"), default=False
         )
         memory_enabled = env_to_bool(
             _get_env(env, "MEMORY_ENABLED", str(app_settings.memory.enabled)),

--- a/tests/unit/agents/codex_worker/test_handlers.py
+++ b/tests/unit/agents/codex_worker/test_handlers.py
@@ -1925,6 +1925,9 @@ async def test_handler_appends_retrieval_capability_note_when_rag_available(
     handler._run_command = fake_run_command  # type: ignore[method-assign]
     monkeypatch.setenv("MOONMIND_RAG_AUTO_CONTEXT", "1")
     monkeypatch.setenv("RAG_ENABLED", "1")
+    # Vector-free defaults (#4115): this RAG-available path under test opts
+    # in explicitly.
+    monkeypatch.setenv("QDRANT_ENABLED", "1")
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     monkeypatch.delenv("MOONMIND_RETRIEVAL_URL", raising=False)
     monkeypatch.setattr(

--- a/tests/unit/config/test_vector_free_defaults_4115.py
+++ b/tests/unit/config/test_vector_free_defaults_4115.py
@@ -1,0 +1,81 @@
+"""Vector-free deployment defaults for #4115 (omitted == production path).
+
+The new release ships no live or optional native Qdrant backend. Omitted
+values and their documented defaults must exercise the same vector-free
+production path; no test may depend on an enabled-by-default native
+vector store.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from moonmind.config.settings import AppSettings, QdrantSettings
+from moonmind.rag.settings import RagRuntimeSettings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_qdrant_settings_default_disabled() -> None:
+    assert QdrantSettings(_env_file=None).qdrant_enabled is False
+
+
+def test_vector_store_provider_default_is_not_qdrant() -> None:
+    provider = AppSettings(
+        _env_file=None, qdrant={"qdrant_enabled": False}
+    ).vector_store_provider
+    assert provider != "qdrant"
+
+
+def test_rag_runtime_defaults_vector_free_without_env() -> None:
+    settings = RagRuntimeSettings.from_env({})
+    assert settings.qdrant_enabled is False
+    executable, reason = settings.retrieval_execution_reason(
+        {"GOOGLE_API_KEY": "test-key"}, preferred_transport="direct"
+    )
+    assert executable is False
+    assert reason == "qdrant_disabled"
+
+
+def test_explicit_old_env_still_parses_for_sanitized_fixtures() -> None:
+    old_env = {
+        "QDRANT_URL": "http://qdrant:6333",
+        "QDRANT_HOST": "qdrant",
+        "QDRANT_PORT": "6333",
+        "QDRANT_ENABLED": "true",
+        "VECTOR_STORE_PROVIDER": "qdrant",
+    }
+    settings = RagRuntimeSettings.from_env(old_env)
+    assert settings.qdrant_enabled is True
+    assert settings.qdrant_host == "qdrant"
+
+
+def test_compose_carries_no_qdrant_service_or_wiring() -> None:
+    compose = yaml.safe_load((REPO_ROOT / "docker-compose.yaml").read_text())
+    services = compose.get("services", {})
+    assert "qdrant" not in services
+    for name, service in services.items():
+        env = service.get("environment", [])
+        items = (
+            env.values() if isinstance(env, dict)
+            else (str(item) for item in env)
+        )
+        assert not any("QDRANT_URL" in str(item) for item in items), name
+        depends = service.get("depends_on", {})
+        keys = depends.keys() if isinstance(depends, dict) else list(depends)
+        assert "qdrant" not in keys, name
+    # The old volume is retained through the recovery window, distinctly
+    # from moonmind_retrieval_state (classified by #4107).
+    volumes = compose.get("volumes", {})
+    assert "qdrant-storage" in volumes
+    assert "moonmind_retrieval_state" in volumes
+
+
+def test_env_template_advertises_no_active_qdrant_backend() -> None:
+    template = (REPO_ROOT / ".env-template").read_text(encoding="utf-8")
+    assert not re.search(r'(?m)^QDRANT_ENABLED="true"', template)
+    assert not re.search(r'(?m)^VECTOR_STORE_PROVIDER="qdrant"', template)
+    assert not re.search(r'(?m)^QDRANT_URL=', template)

--- a/tests/unit/manifest/test_evaluation.py
+++ b/tests/unit/manifest/test_evaluation.py
@@ -191,6 +191,9 @@ evaluation:
 
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         monkeypatch.setenv("VECTOR_STORE_COLLECTION_NAME", "env-collection")
+        # Vector-free defaults (#4115): this manifest-declared qdrant path
+        # under test opts in explicitly.
+        monkeypatch.setenv("QDRANT_ENABLED", "true")
         monkeypatch.setattr(
             "moonmind.rag.service.ContextRetrievalService", FakeService
         )

--- a/tests/unit/rag/test_context_injection.py
+++ b/tests/unit/rag/test_context_injection.py
@@ -544,6 +544,9 @@ def test_omnigent_retrieval_transport_scope_and_budgets_are_forwarded_without_se
         "MOONMIND_RETRIEVAL_URL": gateway_url,
         "MOONMIND_RETRIEVAL_TOKEN": "retrieval-token-secret",
         "QDRANT_API_KEY": "qdrant-secret",
+        # Vector-free defaults (#4115): the direct-transport case under test
+        # opts in explicitly; the gateway case ignores this flag.
+        "QDRANT_ENABLED": "true",
         "GOOGLE_API_KEY": "embedding-secret",
         "VECTOR_STORE_COLLECTION_NAME": "primary",
         "VECTOR_STORE_COLLECTION_NAMES": "primary,docs",

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1844,6 +1844,9 @@ async def test_launch_builds_codex_command_after_workspace_preparation(
 ):
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
     monkeypatch.setenv("RAG_ENABLED", "1")
+    # Vector-free defaults (#4115): this RAG-available path under test opts
+    # in explicitly.
+    monkeypatch.setenv("QDRANT_ENABLED", "1")
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
     monkeypatch.delenv("MOONMIND_RETRIEVAL_URL", raising=False)
     monkeypatch.setattr(os, "geteuid", lambda: 1000)

--- a/tests/unit/tools/test_qdrant_cutover_rehearsal.py
+++ b/tests/unit/tools/test_qdrant_cutover_rehearsal.py
@@ -24,7 +24,12 @@ def test_prerequisites_admission_landed_and_owner_live_blocked() -> None:
         r.name: r for r in rehearsal.check_prerequisites(REPO_ROOT)
     }
     assert results["prerequisite-4105-admission"].status == "completed"
-    assert results["prerequisite-4106-4109-handler-field-removal"].status == "completed"
+    # Executable native Qdrant wiring remains in the checkout under sibling
+    # #4106-#4109 ownership, so this prerequisite stays blocked (never
+    # reported complete) until that removal lands.
+    handler_removal = results["prerequisite-4106-4109-handler-field-removal"]
+    assert handler_removal.status == "blocked", handler_removal.evidence
+    assert "#4106" in handler_removal.evidence
     assert results["prerequisite-named-owner-approval"].status == "blocked"
     assert results["prerequisite-live-deployment-qualification"].status == "blocked"
     assert results["prerequisite-4107-retrieval-state-classification"].status == "blocked"
@@ -333,3 +338,75 @@ def test_full_gate_passes_fixtures_with_deployment_blocked(tmp_path: Path) -> No
     assert summary["verdict"] == "REHEARSAL_PASS_DEPLOYMENT_BLOCKED"
     assert not [s for s in summary["steps"] if s["status"] == "failed"]
     assert any(s["status"] == "blocked" for s in summary["steps"])
+
+
+def test_retirement_without_structured_ownership_stays_blocked() -> None:
+    result = rehearsal.check_retirement_plan(
+        ["stop/remove exact qdrant container moonmind-qdrant-1"]
+    )
+    assert result.status == "blocked", result.evidence
+    assert "ownership" in result.evidence.lower()
+
+
+def test_retirement_cli_requires_ownership_flags(tmp_path: Path) -> None:
+    without_flags = subprocess.run(
+        [sys.executable, "tools/qdrant_cutover_rehearsal.py",
+         "--mode", "retirement-check",
+         "--retire-action", "restart qdrant",
+         "--state-dir", str(tmp_path / "no-flags"),
+         "--migration-id", "retire-no-flags"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert without_flags.returncode == 0, without_flags.stderr
+    assert json.loads(without_flags.stdout)["steps"][0]["status"] == "blocked"
+    with_flags = subprocess.run(
+        [sys.executable, "tools/qdrant_cutover_rehearsal.py",
+         "--mode", "retirement-check",
+         "--retire-action", "stop/remove exact qdrant container moonmind-qdrant-1",
+         "--retire-project", "moonmind",
+         "--retire-service", "qdrant",
+         "--retire-container-id", "moonmind-qdrant-1",
+         "--state-dir", str(tmp_path / "flags"),
+         "--migration-id", "retire-flags"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert with_flags.returncode == 0, with_flags.stderr
+    assert json.loads(with_flags.stdout)["steps"][0]["status"] == "completed"
+
+
+def test_build_pins_blocked_on_mutable_image_tag() -> None:
+    result = rehearsal.check_build_pins(REPO_ROOT)
+    assert result.status == "blocked", result.evidence
+    assert "digest" in result.evidence.lower()
+
+
+def test_preservation_plan_refuses_negative_keyword_prose() -> None:
+    assert rehearsal.check_preservation_plan(
+        "do not record provenance; skip snapshot and export; "
+        "verification is unnecessary"
+    ).status == "failed"
+
+
+def test_rehearsal_replay_check_is_not_vacuous(monkeypatch) -> None:
+    entries = rehearsal.historical_manifest_entries()
+    tampered = [dict(e) for e in entries]
+    tampered[0] = {**tampered[0], "commands": ["manifest.compile"]}
+    assert rehearsal.check_workflow_history_authority(
+        entries, tampered
+    ).status == "failed"
+    always_complete = rehearsal.StepResult("workflow-history-authority", "completed", "vacuous")
+    monkeypatch.setattr(
+        rehearsal,
+        "check_workflow_history_authority",
+        lambda before, after: always_complete,
+    )
+    assert rehearsal.rehearse_scenario("fresh-vector-free").status == "failed"
+
+
+def test_state_persisted_atomically_without_tmp_residue(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    assert rehearsal.save_state(state_dir, "mig-atomic", ["a"])[0]
+    assert (state_dir / "qdrant_rehearsal_state.json").exists()
+    assert list(state_dir.glob("*.tmp")) == []
+    payload = json.loads((state_dir / "qdrant_rehearsal_state.json").read_text())
+    assert payload["completed_steps"] == ["a"]

--- a/tests/unit/tools/test_qdrant_cutover_rehearsal.py
+++ b/tests/unit/tools/test_qdrant_cutover_rehearsal.py
@@ -1,0 +1,335 @@
+"""Hermetic cutover gate tests for #4115 (no live deployment mutation)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools import qdrant_cutover_rehearsal as rehearsal
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_runbook_precondition_present_with_required_sections() -> None:
+    result = rehearsal.check_runbook_precondition(REPO_ROOT)
+    assert result.status == "completed", result.evidence
+
+
+def test_prerequisites_admission_landed_and_owner_live_blocked() -> None:
+    results = {
+        r.name: r for r in rehearsal.check_prerequisites(REPO_ROOT)
+    }
+    assert results["prerequisite-4105-admission"].status == "completed"
+    assert results["prerequisite-4106-4109-handler-field-removal"].status == "completed"
+    assert results["prerequisite-named-owner-approval"].status == "blocked"
+    assert results["prerequisite-live-deployment-qualification"].status == "blocked"
+    assert results["prerequisite-4107-retrieval-state-classification"].status == "blocked"
+
+
+def test_inventory_survey_names_no_live_surfaces_and_preserves_fixtures() -> None:
+    survey = rehearsal.collect_inventory_survey(REPO_ROOT)
+    assert survey["qdrant_surfaces"] == [], survey["qdrant_surfaces"]
+    assert survey["qdrant_image"] == "absent"
+    assert "qdrant-storage" in str(survey.get("qdrant_storage_volume", ""))
+    assert "moonmind_retrieval_state" in str(survey.get("retrieval_state_volume", ""))
+    # Historical fixtures are preserved evidence, never removal failures.
+    assert survey["historical_fixture_count"] > 0
+    result = rehearsal.check_inventory_survey(REPO_ROOT)
+    assert result.status == "completed", result.evidence
+
+
+def test_preflight_verdicts_derive_from_fixture_not_service_names() -> None:
+    assert rehearsal.evaluate_preflight(
+        rehearsal.build_sanitized_fixture("fresh-vector-free")
+    ).status == "proceed"
+    assert rehearsal.evaluate_preflight(
+        rehearsal.build_sanitized_fixture("omitted-upgrade")
+    ).status == "proceed"
+    assert rehearsal.evaluate_preflight(
+        rehearsal.build_sanitized_fixture("explicit-retired")
+    ).status == "drain"
+    assert rehearsal.evaluate_preflight(
+        rehearsal.build_sanitized_fixture("legacy-qdrant-drain")
+    ).status == "drain"
+    assert rehearsal.evaluate_preflight(
+        rehearsal.build_sanitized_fixture("rollback-restore")
+    ).status == "blocked"
+    # Ambiguous ownership blocks even with no pending work.
+    fixture = rehearsal.build_sanitized_fixture("fresh-vector-free")
+    fixture["ownership_ambiguous"] = True
+    assert rehearsal.evaluate_preflight(fixture).status == "blocked"
+
+
+def test_unknown_scenario_fails_closed() -> None:
+    with pytest.raises(ValueError, match="unknown rehearsal scenario"):
+        rehearsal.build_sanitized_fixture("qdrant-to-substitute")
+    assert rehearsal.rehearse_scenario("qdrant-to-substitute").status == "failed"
+
+
+def test_all_rehearsal_modes_pass_with_manifest_evidence() -> None:
+    for scenario in rehearsal.REHEARSAL_MODES:
+        result = rehearsal.rehearse_scenario(scenario)
+        assert result.status == "completed", (scenario, result.evidence)
+
+
+def test_historical_manifest_entries_are_distinct_preserved_contracts() -> None:
+    entries = rehearsal.historical_manifest_entries()
+    assert len(entries) == 2
+    by_entry = {e["entry"]: e for e in entries}
+    assert set(by_entry) == {"manifest_ref", "manifestArtifactRef"}
+    assert by_entry["manifest_ref"]["commands"] == [
+        "manifest.compile", "manifest.write_summary",
+    ]
+    assert set(by_entry["manifestArtifactRef"]["commands"]) == {
+        "manifest_read", "manifest_compile", "manifest_write_summary",
+    }
+
+
+def test_manifest_replay_preserves_owner_and_command_order() -> None:
+    entries = rehearsal.historical_manifest_entries()
+    ok = rehearsal.check_manifest_boundary_replay(entries, entries, boundary_changed=False)
+    assert ok.status == "completed", ok.evidence
+    changed = rehearsal.check_manifest_boundary_replay(
+        entries, entries, boundary_changed=True
+    )
+    assert changed.status == "completed", changed.evidence
+    rewritten = [dict(e) for e in entries]
+    rewritten[0] = {**rewritten[0], "commands": ["manifest.compile"]}
+    bad = rehearsal.check_manifest_boundary_replay(entries, rewritten, boundary_changed=True)
+    assert bad.status == "failed"
+    dropped = entries[:-1]
+    assert rehearsal.check_manifest_boundary_replay(
+        entries, dropped, boundary_changed=True
+    ).status == "failed"
+
+
+def test_restart_retry_cancel_contained_at_each_cutover_handoff() -> None:
+    assert rehearsal.check_failure_injection().status == "completed"
+    clean = rehearsal.run_cutover_sequence()
+    assert list(clean["steps"]) == list(rehearsal.CUTOVER_STEPS)
+    assert all(v == "completed" for v in clean["steps"].values())
+    with pytest.raises(ValueError, match="unknown cutover step"):
+        rehearsal.run_cutover_sequence(fail_at="no-such-step")
+    # Restart reconciles the same migration instead of forking it.
+    tracker = rehearsal.DrainTracker()
+    tracker.admit("vector-activity-1", "wf-qdrant-1")
+    assert tracker.drain().status == "blocked"
+    tracker.settle("vector-activity-1")
+    drained = tracker.drain()
+    assert drained.status == "completed"
+    assert "wf-qdrant-1" in tracker.admitted_workflows
+
+
+def test_upgrade_fixture_tolerates_old_env_without_rescues() -> None:
+    fixture = rehearsal.build_old_env_fixture()
+    assert fixture["VECTOR_STORE_PROVIDER"] == "qdrant"
+    assert fixture["QDRANT_ENABLED"] == "true"
+    result = rehearsal.check_upgrade_fixture(fixture, REPO_ROOT)
+    assert result.status == "completed", result.evidence
+
+
+def test_preservation_envelope_roundtrip_and_classification() -> None:
+    entries = {
+        "provenance:image-version": "qdrant/qdrant:v1.17.1 (recorded)",
+        "provenance:mounts": "qdrant-storage:/qdrant/storage (recorded)",
+        "provenance:recovery-config": "retention-window (recorded)",
+        "snapshot:content": "sanitized-collection-count=2",
+        "export:logical-payload": "sanitized-document-count=4",
+    }
+    envelope = rehearsal.create_preservation_envelope(entries, "test-pres-1", "unique")
+    assert envelope["classification"] == "unique"
+    assert envelope["storage"] == "operator-controlled-authorized-storage"
+    assert rehearsal.verify_preservation_envelope(envelope, entries) is True
+    assert rehearsal.verify_preservation_envelope(envelope, {"other": "x"}) is False
+    with pytest.raises(ValueError, match="classification"):
+        rehearsal.create_preservation_envelope(entries, "test-pres-2", "derived")
+    with pytest.raises(ValueError, match="missing scopes"):
+        rehearsal.create_preservation_envelope({"snapshot:x": "y"}, "test-pres-3", "unique")
+
+
+def test_preservation_plan_refuses_derived_disposable_and_public_storage() -> None:
+    assert rehearsal.check_preservation_plan(
+        "vectors are derived so the payloads are disposable"
+    ).status == "failed"
+    assert rehearsal.check_preservation_plan(
+        "assume all payloads reconstructible from source"
+    ).status == "failed"
+    assert rehearsal.check_preservation_plan(
+        "publish snapshot to public issue for review"
+    ).status == "failed"
+    assert rehearsal.check_preservation_plan("just take a snapshot").status == "blocked"
+    assert rehearsal.check_preservation_plan(
+        "record collection/payload provenance (image/version, mounts, recovery "
+        "config); preserve recoverable snapshot plus logical export; verify "
+        "recoverability; classify reproducible vs unique; operator-controlled "
+        "storage with redaction/retention, independent moonmind_retrieval_state evidence"
+    ).status == "completed"
+
+
+def test_retirement_refuses_broad_cleanup_and_volume_deletion() -> None:
+    assert rehearsal.check_retirement_plan(["docker compose down -v"]).status == "failed"
+    assert rehearsal.check_retirement_plan(
+        ["docker system prune -f"]
+    ).status == "failed"
+    assert rehearsal.check_retirement_plan(
+        ["delete volume qdrant-storage"]
+    ).status == "failed"
+    assert rehearsal.check_retirement_plan(
+        ["remove qdrant-storage exports"]
+    ).status == "failed"
+    assert rehearsal.check_retirement_plan(["rm -rf /data/qdrant"]).status == "failed"
+    assert rehearsal.check_retirement_plan(
+        ["delete postgres-data to reclaim space"]
+    ).status == "failed"
+    assert rehearsal.check_retirement_plan(
+        ["remove old ingress routes"]
+    ).status == "blocked"
+
+
+def test_retirement_requires_exact_ownership_and_is_idempotent() -> None:
+    ownership = {
+        "project": "moonmind",
+        "service": "qdrant",
+        "candidates": [
+            {"project": "moonmind", "service": "qdrant", "container_id": "moonmind-qdrant-1"}
+        ],
+    }
+    first = rehearsal.check_retirement_plan(
+        ["stop/remove exact qdrant container moonmind-qdrant-1"], ownership
+    )
+    assert first.status == "completed", first.evidence
+    # Repeated checks are safe: absence re-verifies.
+    second = rehearsal.check_retirement_plan(
+        ["verify absence of qdrant container moonmind-qdrant-1"], ownership
+    )
+    assert second.status == "completed", second.evidence
+    # Wrong project and ambiguous candidates stay blocked, never broadened.
+    wrong = dict(ownership, project="other-project")
+    assert rehearsal.check_retirement_plan(
+        ["stop/remove exact qdrant container"], wrong
+    ).status == "blocked"
+    ambiguous = {
+        "project": "moonmind",
+        "service": "qdrant",
+        "candidates": [
+            {"project": "moonmind", "service": "qdrant", "container_id": "a"},
+            {"project": "moonmind", "service": "qdrant", "container_id": "b"},
+        ],
+    }
+    assert rehearsal.check_retirement_plan(
+        ["stop/remove exact qdrant container"], ambiguous
+    ).status == "blocked"
+    with pytest.raises(ValueError, match="required"):
+        rehearsal.resolve_exact_container([], "", "")
+
+
+def test_retention_requires_window_and_exact_resource_disposition() -> None:
+    assert rehearsal.check_retention_policy(
+        "automatically delete old volumes on upgrade"
+    ).status == "failed"
+    assert rehearsal.check_retention_policy("keep the volume a while").status == "blocked"
+    assert rehearsal.check_retention_policy(
+        "explicit recovery retention window; eventual deletion is a separate "
+        "exact-resource operator action after export/restore verification; "
+        "unrelated state preserved"
+    ).status == "completed"
+
+
+def test_rollback_refuses_qdrant_profile_back_and_whole_db() -> None:
+    assert rehearsal.check_rollback_plan(
+        "restore with optional Qdrant profile enabled"
+    ).status == "failed"
+    assert rehearsal.check_rollback_plan(
+        "add the qdrant adapter back for rollback"
+    ).status == "failed"
+    assert rehearsal.check_rollback_plan(
+        "restore whole postgres database snapshot"
+    ).status == "failed"
+    assert rehearsal.check_rollback_plan(
+        "fallback switch to disabled search"
+    ).status == "failed"
+    assert rehearsal.check_rollback_plan("restore snapshot").status == "blocked"
+    assert rehearsal.check_rollback_plan(
+        "previous matching app/compose/image revision with preserved data, "
+        "schema-compatibility check, rehearsed"
+    ).status == "completed"
+
+
+def test_rehearsal_state_is_idempotent_and_forks_closed() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        state_dir = Path(tmp) / "state"
+        ok1, _ = rehearsal.save_state(state_dir, "mig-1", ["rehearsal-fresh-vector-free"])
+        ok2, _ = rehearsal.save_state(state_dir, "mig-1", ["rehearsal-fresh-vector-free"])
+        assert ok1 and ok2
+        payload = json.loads((state_dir / "qdrant_rehearsal_state.json").read_text())
+        assert payload["migration_id"] == "mig-1"
+        assert payload["runs"] == 2
+        assert payload["completed_steps"] == ["rehearsal-fresh-vector-free"]
+
+
+def test_stale_concurrent_migration_refused_without_allow_replace(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    assert rehearsal.save_state(state_dir, "mig-1", ["a"])[0]
+    ok, msg = rehearsal.save_state(state_dir, "mig-2", ["b"])
+    assert not ok
+    assert "stale/concurrent" in msg
+
+
+def test_corrupt_state_fails_closed_without_overwrite(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "qdrant_rehearsal_state.json").write_text("{corrupt!!!")
+    ok, msg = rehearsal.save_state(state_dir, "mig-1", ["a"])
+    assert not ok
+    assert "corrupt" in msg
+    assert (state_dir / "qdrant_rehearsal_state.json").read_text() == "{corrupt!!!"
+
+
+def test_allow_replace_resets_progress_for_new_migration(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    assert rehearsal.save_state(state_dir, "mig-1", ["a"])[0]
+    ok, _ = rehearsal.save_state(state_dir, "mig-2", ["b"], allow_replace=True)
+    assert ok
+    payload = json.loads((state_dir / "qdrant_rehearsal_state.json").read_text())
+    assert payload["migration_id"] == "mig-2"
+    assert payload["completed_steps"] == ["b"]
+    assert payload["runs"] == 1
+
+
+def test_sanitize_redacts_secret_like_values() -> None:
+    assert "[redacted]" in rehearsal.sanitize('QDRANT_API_KEY="live-secret-value"')
+    assert "live-secret-value" not in rehearsal.sanitize('QDRANT_API_KEY="live-secret-value"')
+
+
+def test_retirement_check_without_action_stays_blocked(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, "tools/qdrant_cutover_rehearsal.py",
+         "--mode", "retirement-check",
+         "--state-dir", str(tmp_path / "state"),
+         "--migration-id", "retire-no-action"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stderr
+    summary = json.loads(proc.stdout)
+    assert summary["steps"][0]["status"] == "blocked"
+
+
+def test_full_gate_passes_fixtures_with_deployment_blocked(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, "tools/qdrant_cutover_rehearsal.py",
+         "--mode", "all",
+         "--state-dir", str(tmp_path / "state"),
+         "--migration-id", "qdrant-full-gate"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stderr
+    summary = json.loads(proc.stdout)
+    assert summary["verdict"] == "REHEARSAL_PASS_DEPLOYMENT_BLOCKED"
+    assert not [s for s in summary["steps"] if s["status"] == "failed"]
+    assert any(s["status"] == "blocked" for s in summary["steps"])

--- a/tools/qdrant_cutover_rehearsal.py
+++ b/tools/qdrant_cutover_rehearsal.py
@@ -1433,6 +1433,8 @@ def _atomic_write_text(path: Path, text: str) -> None:
         try:
             os.unlink(tmp_name)
         except OSError:
+            # Best-effort temp cleanup; the original exception below is the
+            # failure that matters, and a leftover .tmp file is never read.
             pass
         raise
 
@@ -1456,12 +1458,15 @@ def _state_locked(state_dir: Path):
         try:
             fcntl.flock(fd, fcntl.LOCK_EX)
         except OSError:
+            # Best-effort mutual exclusion; the atomic temp-file replace in
+            # _atomic_write_text still guards against truncation without it.
             pass
         yield
     finally:
         try:
             fcntl.flock(fd, fcntl.LOCK_UN)
         except OSError:
+            # Best-effort unlock; the fd close below releases the lock anyway.
             pass
         os.close(fd)
 

--- a/tools/qdrant_cutover_rehearsal.py
+++ b/tools/qdrant_cutover_rehearsal.py
@@ -1,0 +1,1610 @@
+#!/usr/bin/env python3
+"""Hermetic Qdrant cutover rehearsal gate for #4115.
+
+This tool provides early, bounded, idempotent preflight/rehearsal
+verification for the Qdrant-removal deployment cutover WITHOUT performing
+any live deployment mutation. It never:
+
+- contacts a live Qdrant, Temporal, or deployment host,
+- reads production workflows, schedules, collections, or payloads,
+- creates snapshots/exports outside a hermetic state dir,
+- stops/removes containers, volumes, or files,
+- marks operator-owned facts complete on hermetic evidence alone.
+
+Operator-gated steps (named-owner approval, live preflight inventory,
+snapshot/export recovery verification on real data, coordinated release,
+exact-container retirement execution, retention disposition) are reported
+as ``blocked`` with the missing evidence named. That is the correct
+terminal state for a repo checkout: rehearsal fixtures may pass while
+deployment qualification stays blocked.
+
+Sibling ownership (parent #4103):
+- #4105 owns admission/authoring/plan-compilation (merged).
+- #4106-#4109 own vector-only handler/field deletion.
+- #4107 owns ``moonmind_retrieval_state`` capability/audit classification.
+- #4110-#4113 own integrated rehearsal pieces; #4114 consumes evidence.
+This gate defers to those owners: it probes the checkout for their
+markers and fails closed when they are absent. Historical
+``type: qdrant`` manifest fixtures and the two generic ManifestIngest
+entry contracts (``manifest_ref`` compile, ``manifestArtifactRef``
+orchestrate) are preserved evidence, never live-backend surfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK_REL = Path("docs/tmp/QdrantCutoverRunbook-4115.md")
+ISSUE_REF = "MoonLadderStudios/MoonMind#4115"
+
+REHEARSAL_MODES = (
+    "fresh-vector-free",
+    "omitted-upgrade",
+    "explicit-retired",
+    "legacy-qdrant-drain",
+    "rollback-restore",
+)
+
+PREREQUISITE_IDS = (
+    "4105-admission",
+    "4106-4109-handler-field-removal",
+    "4107-retrieval-state-classification",
+    "4110-4113-integrated-pieces",
+    "named-owner-approval",
+    "live-deployment-qualification",
+)
+
+FORBIDDEN_RETIREMENT_PATTERNS = (
+    re.compile(r"\bdown\s+-v\b"),
+    re.compile(r"\bdocker\s+system\s+prune\b"),
+    re.compile(r"\bvolume\s+prune\b", re.IGNORECASE),
+    re.compile(r"--orphans\b"),
+    re.compile(r"\bprune\b.{0,20}\bvolumes?\b", re.IGNORECASE),
+    re.compile(r"\brm\s+-rf?\b"),
+    # The old Qdrant volume and its exports are retained through an explicit
+    # recovery window: deleting them is never part of normal-upgrade
+    # retirement, only a separate exact-resource operator action.
+    re.compile(r"(delet|remov|drop|destroy|wipe|purge).{0,40}\bqdrant-storage\b", re.IGNORECASE),
+    re.compile(r"\bqdrant-storage\b.{0,40}(delet|remov|drop|destroy|wipe|purge)", re.IGNORECASE),
+    re.compile(r"(delet|remov|drop|destroy|wipe|purge).{0,40}\bexports?\b", re.IGNORECASE),
+    # Unrelated state is never a retirement target.
+    re.compile(r"(delet|remov|drop|destroy|wipe|purge).{0,40}\b(postgres|postgres-data|minio|minio-data)\b", re.IGNORECASE),
+    re.compile(r"(delet|remov|drop|destroy|wipe|purge).{0,40}\b(secrets|workspaces|agent_workspaces|omnigent)\b", re.IGNORECASE),
+    re.compile(r"(delet|remov|drop|destroy|wipe|purge).{0,40}\b(database|role)\b", re.IGNORECASE),
+)
+
+_SECRET_PATTERN = re.compile(
+    r"(?i)(?:authorization\s*:\s*bearer\s+\S+"
+    r"|(?:password|passwd|secret|bearer|cookie|session[_-]?token|refresh[_-]?token"
+    r"|token|api[_-]?key)\s*[:=]\s*[\"']?[^\s;,\"']+)"
+)
+
+
+def sanitize(text: str) -> str:
+    """Redact secret-like assignments from evidence text."""
+    redacted = _SECRET_PATTERN.sub("[redacted]", text)
+    return redacted[:2000]
+
+
+@dataclass
+class StepResult:
+    name: str
+    status: str  # "completed" | "blocked" | "failed"
+    evidence: str
+
+    def to_dict(self) -> dict[str, str]:
+        d = asdict(self)
+        d["evidence"] = sanitize(d["evidence"])
+        return d
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _non_comment_text(text: str) -> str:
+    """Return text with full-line comments stripped (probes code, not prose)."""
+    return "\n".join(
+        line for line in text.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+RUNBOOK_REQUIRED_SECTIONS = (
+    "Preflight",
+    "Preservation",
+    "Retirement",
+    "Retention",
+    "Rollback",
+    "#4103",
+    "#4114",
+)
+
+
+def check_runbook_precondition(repo_root: Path = REPO_ROOT) -> StepResult:
+    """Verify the operator runbook exists and names its required sections."""
+    content = _read_text(repo_root / RUNBOOK_REL)
+    if content is None:
+        return StepResult(
+            "runbook-precondition",
+            "failed",
+            f"{RUNBOOK_REL} missing; cutover rehearsal has no accepted operator baseline.",
+        )
+    missing = [s for s in RUNBOOK_REQUIRED_SECTIONS if s not in content]
+    if missing:
+        return StepResult(
+            "runbook-precondition",
+            "failed",
+            f"Runbook present but missing sections: {', '.join(missing)}.",
+        )
+    return StepResult(
+        "runbook-precondition",
+        "completed",
+        "Operator runbook present with preflight/preservation/retirement/"
+        "retention/rollback sections and #4103/#4114 evidence handoff; "
+        "correctly unarchived pre-cutover.",
+    )
+
+
+# -- Repo-observable capability probes ---------------------------------------
+
+def _admission_present(repo_root: Path) -> tuple[bool, str]:
+    contract = _read_text(
+        repo_root / "moonmind/workflows/executions/execution_contract.py"
+    )
+    inventory = repo_root / "docs/tmp/QdrantRemovalInventory-4105.md"
+    if contract is not None and "reject_retired_vector_fields" in contract \
+            and inventory.exists():
+        return True, (
+            "retired vector admission enforced "
+            "(execution_contract.reject_retired_vector_fields) with "
+            "docs/tmp/QdrantRemovalInventory-4105.md"
+        )
+    return False, (
+        "checked moonmind/workflows/executions/execution_contract.py for "
+        "reject_retired_vector_fields and docs/tmp/QdrantRemovalInventory-4105.md; "
+        "admission marker absent"
+    )
+
+
+def _vector_free_deployment_present(repo_root: Path) -> tuple[bool, str]:
+    """Whether the checkout itself is vector-free (no live native backend)."""
+    compose = _read_text(repo_root / "docker-compose.yaml") or ""
+    code = _non_comment_text(compose)
+    settings_text = _read_text(repo_root / "moonmind/config/settings.py") or ""
+    rag_settings = _read_text(repo_root / "moonmind/rag/settings.py") or ""
+    env_template = _read_text(repo_root / ".env-template") or ""
+    problems: list[str] = []
+    if re.search(r"(?m)^  qdrant:", code):
+        problems.append("compose qdrant service present")
+    if "QDRANT_URL" in code:
+        problems.append("compose QDRANT_URL wiring present")
+    m = re.search(
+        r"qdrant_enabled:\s*bool\s*=\s*Field\((True|False)", settings_text
+    )
+    if not m or m.group(1) != "False":
+        problems.append("QdrantSettings.qdrant_enabled default is not False")
+    m2 = re.search(
+        r'_get_env\(env,\s*"QDRANT_ENABLED",\s*"(true|false)"\)', rag_settings
+    )
+    if not m2 or m2.group(1) != "false":
+        problems.append("RagRuntimeSettings QDRANT_ENABLED default is not false")
+    m3 = re.search(
+        r"vector_store_provider:\s*str\s*=\s*Field\(\s*\n?\s*\"([^\"]+)\"",
+        settings_text,
+    )
+    if not m3 or m3.group(1) == "qdrant":
+        problems.append("vector_store_provider default is still qdrant")
+    if re.search(r'(?m)^QDRANT_ENABLED="true"', env_template):
+        problems.append('.env-template QDRANT_ENABLED="true"')
+    if re.search(r'(?m)^VECTOR_STORE_PROVIDER="qdrant"', env_template):
+        problems.append('.env-template VECTOR_STORE_PROVIDER="qdrant"')
+    if problems:
+        return False, (
+            "vector-free deployment markers absent: " + "; ".join(problems)
+        )
+    return True, (
+        "compose carries no qdrant service or QDRANT_URL wiring; "
+        "QdrantSettings/RagRuntimeSettings default disabled; "
+        "vector_store_provider default is not qdrant; "
+        ".env-template advertises no active Qdrant backend"
+    )
+
+
+def _capability_present(pid: str, repo_root: Path = REPO_ROOT) -> bool:
+    if pid == "4105-admission":
+        present, _ = _admission_present(repo_root)
+        return present
+    if pid == "4106-4109-handler-field-removal":
+        present, _ = _vector_free_deployment_present(repo_root)
+        return present
+    return False
+
+
+def detect_capability_presence(repo_root: Path = REPO_ROOT) -> dict[str, str]:
+    """Probe the checkout for each prerequisite's owning capability."""
+    presence: dict[str, str] = {}
+    ok, detail = _admission_present(repo_root)
+    presence["4105-admission"] = (
+        f"present: {detail}" if ok else f"absent: {detail}"
+    )
+    ok2, detail2 = _vector_free_deployment_present(repo_root)
+    presence["4106-4109-handler-field-removal"] = (
+        f"present: {detail2}" if ok2 else f"absent: {detail2}"
+    )
+    presence["4107-retrieval-state-classification"] = (
+        "checked checkout for moonmind_retrieval_state capability/audit "
+        "classification record; none present (sibling #4107 owns it; "
+        "deployment-side evidence)"
+    )
+    presence["4110-4113-integrated-pieces"] = (
+        "checked checkout for integrated rehearsal pieces; none present "
+        "(siblings #4110-#4113 own them)"
+    )
+    presence["named-owner-approval"] = "no owner approval record in checkout"
+    presence["live-deployment-qualification"] = (
+        "no live preflight/snapshot/retirement evidence attempted "
+        "hermetically (never contacted)"
+    )
+    return presence
+
+
+def check_prerequisites(repo_root: Path = REPO_ROOT) -> list[StepResult]:
+    """Report every deployment prerequisite against real repo presence."""
+    owners = {
+        "4105-admission": "retired vector admission/authoring/plan (#4105)",
+        "4106-4109-handler-field-removal": "vector-free deployment markers (#4115; residual execution handlers/fields owned by #4106-#4109)",
+        "4107-retrieval-state-classification": "moonmind_retrieval_state classification (#4107)",
+        "4110-4113-integrated-pieces": "integrated rehearsal pieces (#4110-#4113)",
+        "named-owner-approval": "named deployment owner approval",
+        "live-deployment-qualification": "separately authorized live deployment check",
+    }
+    presence = detect_capability_presence(repo_root)
+    results = []
+    for pid in PREREQUISITE_IDS:
+        probed = presence.get(pid, "unchecked")
+        if _capability_present(pid, repo_root):
+            results.append(
+                StepResult(
+                    f"prerequisite-{pid}",
+                    "completed",
+                    f"Capability present in repo checkout; owned by {owners[pid]}. "
+                    f"Repo probe: {probed}.",
+                )
+            )
+        else:
+            results.append(
+                StepResult(
+                    f"prerequisite-{pid}",
+                    "blocked",
+                    f"Missing in repo checkout; owned by {owners[pid]}. "
+                    f"Repo probe: {probed}. "
+                    "Blocks deployment qualification, not hermetic rehearsal.",
+                )
+            )
+    return results
+
+
+# -- R1: sanitized deployment-state survey (counts/refs only) -----------------
+
+SURVEY_SOURCES = (
+    "docker-compose.yaml",
+    "moonmind/config/settings.py",
+    "moonmind/rag/settings.py",
+    ".env-template",
+    "api_service/api/routers/retrieval_gateway.py",
+)
+
+
+def collect_inventory_survey(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    """Collect a sanitized cutover survey from real repo files.
+
+    Reports structural counts (services, volumes, settings defaults,
+    execution branches) with file references. Never exports collections,
+    payloads, documents, metadata, text, secrets, or schedules content.
+    Historical ``type: qdrant`` manifest fixtures are counted separately
+    as preserved evidence, never as live-backend surfaces. Missing files
+    are recorded as ``missing`` rather than failing.
+    """
+    survey: dict[str, Any] = {"sources": {}, "qdrant_surfaces": []}
+    compose = _read_text(repo_root / "docker-compose.yaml")
+    if compose is None:
+        survey["sources"]["docker-compose.yaml"] = "missing"
+    else:
+        code = _non_comment_text(compose)
+        services = re.findall(r"^  ([a-zA-Z0-9_-]+):\s*$", code, re.MULTILINE)
+        survey["sources"]["docker-compose.yaml"] = f"{len(services)} services"
+        survey["compose_services"] = sorted(set(services))[:60]
+        m = re.search(r"image:\s*(qdrant/qdrant:[^\s]*)", code)
+        survey["qdrant_image"] = m.group(1) if m else "absent"
+        if re.search(r"(?m)^  qdrant:", code):
+            survey["qdrant_surfaces"].append("docker-compose.yaml: qdrant service")
+        if "QDRANT_URL" in code:
+            survey["qdrant_surfaces"].append("docker-compose.yaml: QDRANT_URL wiring")
+        if re.search(r"(?m)^  qdrant-storage:", code):
+            survey["qdrant_storage_volume"] = (
+                "qdrant-storage declared (retained through recovery window)"
+            )
+        else:
+            survey["qdrant_storage_volume"] = "qdrant-storage absent"
+        if "moonmind_retrieval_state" in compose:
+            survey["retrieval_state_volume"] = (
+                "moonmind_retrieval_state declared (independent from "
+                "qdrant-storage; #4107 owns classification)"
+            )
+        else:
+            survey["retrieval_state_volume"] = "moonmind_retrieval_state absent"
+        survey["note_volumes"] = (
+            "qdrant-storage and moonmind_retrieval_state are distinct data; "
+            "never treated as interchangeable."
+        )
+    settings_text = _read_text(repo_root / "moonmind/config/settings.py")
+    if settings_text is None:
+        survey["sources"]["moonmind/config/settings.py"] = "missing"
+    else:
+        survey["sources"]["moonmind/config/settings.py"] = "read"
+        m = re.search(
+            r"qdrant_enabled:\s*bool\s*=\s*Field\((True|False)", settings_text
+        )
+        survey["qdrant_enabled_default"] = m.group(1) if m else "unknown"
+        m2 = re.search(
+            r"vector_store_provider:\s*str\s*=\s*Field\(\s*\n?\s*\"([^\"]+)\"",
+            settings_text,
+        )
+        survey["vector_store_provider_default"] = m2.group(1) if m2 else "unknown"
+        if survey["qdrant_enabled_default"] == "True":
+            survey["qdrant_surfaces"].append(
+                "moonmind/config/settings.py: QdrantSettings enabled by default"
+            )
+        if survey["vector_store_provider_default"] == "qdrant":
+            survey["qdrant_surfaces"].append(
+                "moonmind/config/settings.py: VECTOR_STORE_PROVIDER default qdrant"
+            )
+    rag_settings = _read_text(repo_root / "moonmind/rag/settings.py")
+    if rag_settings is None:
+        survey["sources"]["moonmind/rag/settings.py"] = "missing"
+    else:
+        m = re.search(
+            r'_get_env\(env,\s*"QDRANT_ENABLED",\s*"(true|false)"\)', rag_settings
+        )
+        survey["sources"]["moonmind/rag/settings.py"] = "read"
+        survey["rag_qdrant_enabled_default"] = m.group(1) if m else "unknown"
+        if survey["rag_qdrant_enabled_default"] == "true":
+            survey["qdrant_surfaces"].append(
+                "moonmind/rag/settings.py: QDRANT_ENABLED default true"
+            )
+    env_template = _read_text(repo_root / ".env-template")
+    if env_template is None:
+        survey["sources"][".env-template"] = "missing"
+    else:
+        hits = len(re.findall(r"QDRANT_|VECTOR_STORE_PROVIDER", env_template))
+        survey["sources"][".env-template"] = f"read, {hits} vector-env mentions"
+        if re.search(r'(?m)^QDRANT_ENABLED="true"', env_template):
+            survey["qdrant_surfaces"].append('.env-template: QDRANT_ENABLED="true"')
+        if re.search(r'(?m)^VECTOR_STORE_PROVIDER="qdrant"', env_template):
+            survey["qdrant_surfaces"].append(
+                '.env-template: VECTOR_STORE_PROVIDER="qdrant"'
+            )
+    gateway = _read_text(
+        repo_root / "api_service/api/routers/retrieval_gateway.py"
+    )
+    if gateway is None:
+        survey["sources"]["api_service/api/routers/retrieval_gateway.py"] = "missing"
+    else:
+        hits = len(re.findall(r"qdrant|Qdrant|QDRANT", gateway))
+        survey["sources"]["api_service/api/routers/retrieval_gateway.py"] = (
+            f"read, {hits} qdrant mentions (execution paths deferred to sibling)"
+        )
+    # Preserved historical evidence: manifest fixtures carrying a qdrant
+    # type are replay/upgrade fixtures, not a live backend. Count only.
+    fixture_hits: list[str] = []
+    for pattern in ("tests/fixtures/**/*.yaml", "tests/fixtures/**/*.json"):
+        for path in sorted(repo_root.glob(pattern)):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if re.search(r"type:\s*[\"']?qdrant[\"']?", text):
+                fixture_hits.append(
+                    str(path.relative_to(repo_root))
+                )
+    survey["historical_qdrant_fixtures"] = fixture_hits[:20]
+    survey["historical_fixture_count"] = len(fixture_hits)
+    survey["note"] = (
+        "Structural survey only. Live facts (active workflows, pending "
+        "Activities, recurring schedules, collection provenance, unique "
+        "payloads, mounts, ownership) require the operator preflight and "
+        "are NOT established by this survey. Historical fixtures above are "
+        "preserved evidence, not removal failures."
+    )
+    return survey
+
+
+def check_inventory_survey(repo_root: Path = REPO_ROOT) -> StepResult:
+    """Verify the sanitized survey can be collected hermetically."""
+    survey = collect_inventory_survey(repo_root)
+    missing = [k for k, v in survey["sources"].items() if v == "missing"]
+    if missing:
+        return StepResult(
+            "inventory-survey",
+            "failed",
+            f"Survey incomplete; unreadable sources: {', '.join(missing)}.",
+        )
+    surfaces = len(survey.get("qdrant_surfaces", []))
+    fixtures = survey.get("historical_fixture_count", 0)
+    return StepResult(
+        "inventory-survey",
+        "completed",
+        f"Sanitized survey collected over {len(survey['sources'])} sources; "
+        f"{surfaces} live qdrant surfaces named (counts/refs only, no "
+        f"collections/payloads/exports). {fixtures} historical qdrant "
+        "fixtures preserved as evidence, not removal failures. "
+        "Owner-protected facts still require the live preflight and stay "
+        "blocked in prerequisites.",
+    )
+
+
+# -- R2: bounded read-only preflight (fixture-evaluated, redacted) ------------
+
+PREFLIGHT_VERDICTS = ("proceed", "drain", "blocked")
+
+
+def build_sanitized_fixture(scenario: str) -> dict[str, Any]:
+    """Build a deterministic sanitized cutover fixture (no real data)."""
+    if scenario not in REHEARSAL_MODES:
+        raise ValueError(f"unknown rehearsal scenario: {scenario}")
+    seed = uuid.uuid5(uuid.NAMESPACE_URL, f"moonmind/qdrant-cutover/{scenario}")
+    if scenario == "fresh-vector-free":
+        return {
+            "scenario": scenario,
+            "active_vector_workflows": [],
+            "pending_retryable_activities": [],
+            "recurring_vector_schedules": [],
+            "stored_vector_manifests": [],
+            "issued_vector_capabilities": [],
+            "unique_data_unpreserved": False,
+            "ownership_ambiguous": False,
+            "cutover_owner": str(seed),
+        }
+    if scenario == "omitted-upgrade":
+        return {
+            "scenario": scenario,
+            "active_vector_workflows": [],
+            "pending_retryable_activities": [],
+            "recurring_vector_schedules": [],
+            "stored_vector_manifests": ["manifest-ref: sanitized-count=1"],
+            "issued_vector_capabilities": [],
+            "unique_data_unpreserved": False,
+            "ownership_ambiguous": False,
+            "cutover_owner": str(seed),
+        }
+    if scenario == "explicit-retired":
+        return {
+            "scenario": scenario,
+            "active_vector_workflows": [],
+            "pending_retryable_activities": ["manifest_write_summary: retryable=1"],
+            "recurring_vector_schedules": ["schedule-1: retired-producer"],
+            "stored_vector_manifests": ["manifest-ref: sanitized-count=2"],
+            "issued_vector_capabilities": [],
+            "unique_data_unpreserved": False,
+            "ownership_ambiguous": False,
+            "cutover_owner": str(seed),
+        }
+    if scenario == "legacy-qdrant-drain":
+        return {
+            "scenario": scenario,
+            "active_vector_workflows": ["wf-drain-1"],
+            "pending_retryable_activities": ["qdrant-index: retryable=3"],
+            "recurring_vector_schedules": ["schedule-drain-1"],
+            "stored_vector_manifests": ["manifest-ref: sanitized-count=1"],
+            "issued_vector_capabilities": ["capability-ref-1"],
+            "unique_data_unpreserved": False,
+            "ownership_ambiguous": False,
+            "cutover_owner": str(seed),
+        }
+    # rollback-restore: recoverability fixture with an ambiguous owner stays
+    # blocked until the operator names exact ownership.
+    return {
+        "scenario": scenario,
+        "active_vector_workflows": [],
+        "pending_retryable_activities": [],
+        "recurring_vector_schedules": [],
+        "stored_vector_manifests": [],
+        "issued_vector_capabilities": [],
+        "unique_data_unpreserved": True,
+        "ownership_ambiguous": True,
+        "cutover_owner": str(seed),
+    }
+
+
+def evaluate_preflight(fixture: dict[str, Any]) -> StepResult:
+    """Evaluate a sanitized fixture to proceed/drain/blocked (no guessing).
+
+    The verdict derives only from explicit fixture fields, never from
+    service names or repo greps. Secret-like values are never embedded:
+    counts and refs only.
+    """
+    pending = len(fixture.get("pending_retryable_activities", []))
+    active = len(fixture.get("active_vector_workflows", []))
+    schedules = len(fixture.get("recurring_vector_schedules", []))
+    if fixture.get("ownership_ambiguous"):
+        return StepResult(
+            "preflight",
+            "blocked",
+            "Preflight blocked: deployment ownership ambiguous "
+            "(exact Compose project/service/container IDs unresolved). "
+            "Refuse retirement until the operator names exact ownership.",
+        )
+    if fixture.get("unique_data_unpreserved"):
+        return StepResult(
+            "preflight",
+            "blocked",
+            "Preflight blocked: potentially unique Qdrant-only payloads "
+            "without verified snapshot/export recovery. Preserve and verify "
+            "before any disposal decision.",
+        )
+    if pending or active or schedules:
+        return StepResult(
+            "preflight",
+            "drain",
+            f"Preflight drain: {active} active vector workflows, {pending} "
+            f"pending/retryable Activities, {schedules} recurring vector "
+            "schedules inventoried (counts/refs only). Drain on the old "
+            "release or version-route with a finite retirement condition; "
+            "no schedule may retry forever against a deleted backend.",
+        )
+    return StepResult(
+        "preflight",
+        "proceed",
+        "Preflight proceed: no active vector workflows, pending/retryable "
+        "Activities, or recurring vector schedules in sanitized fixture; "
+        "no unpreserved unique data; ownership exact.",
+    )
+
+
+def check_preflight_report(repo_root: Path = REPO_ROOT) -> StepResult:
+    """Verify the survey supports a preflight report without live guessing."""
+    survey = collect_inventory_survey(repo_root)
+    missing = [k for k, v in survey["sources"].items() if v == "missing"]
+    if missing:
+        return StepResult(
+            "preflight-report",
+            "failed",
+            f"Preflight report unavailable; unreadable sources: {', '.join(missing)}.",
+        )
+    fixture = build_sanitized_fixture("explicit-retired")
+    verdict = evaluate_preflight(fixture)
+    return StepResult(
+        "preflight-report",
+        "completed",
+        "Sanitized preflight report collectible over "
+        f"{len(survey['sources'])} sources with actionable verdict "
+        f"{verdict.status!r} on fixture evidence "
+        f"({verdict.evidence[:160]}...). Live deployment verdicts still "
+        "require the operator preflight and stay blocked in prerequisites.",
+    )
+
+
+# -- R3: exact build pins + sanitized old-.env upgrade fixture ----------------
+
+def collect_build_pins(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    """Collect exact-version pins and topology from real repo files."""
+    pins: dict[str, Any] = {}
+    compose = _read_text(repo_root / "docker-compose.yaml") or ""
+    code = _non_comment_text(compose)
+    m = re.search(r"image:\s*(qdrant/qdrant:[^\s]*)", code)
+    pins["qdrant_image"] = m.group(1) if m else "absent"
+    services = re.findall(r"^  ([a-zA-Z0-9_-]+):\s*$", code, re.MULTILINE)
+    pins["compose_services"] = len(set(services))
+    m = re.search(
+        r"image:\s*\$\{MOONMIND_IMAGE:-(ghcr\.io/[^\s}]+)\}", compose
+    )
+    pins["app_image_default"] = m.group(1) if m else "unknown"
+    try:
+        root_pkg = json.loads(_read_text(repo_root / "package.json") or "{}")
+        pins["root_package_version"] = str(root_pkg.get("version", "unknown"))
+    except (json.JSONDecodeError, AttributeError):
+        pins["root_package_version"] = "unparseable"
+    settings_text = _read_text(repo_root / "moonmind/config/settings.py") or ""
+    m = re.search(
+        r"vector_store_provider:\s*str\s*=\s*Field\(\s*\n?\s*\"([^\"]+)\"",
+        settings_text,
+    )
+    pins["vector_store_provider_default"] = m.group(1) if m else "unknown"
+    versions_dir = repo_root / "api_service/migrations/versions"
+    if versions_dir.exists():
+        revisions = sorted(p.name for p in versions_dir.glob("*.py"))
+        pins["alembic_revisions"] = len(revisions)
+        pins["alembic_latest"] = revisions[-1] if revisions else "none"
+    else:
+        pins["alembic_revisions"] = "unknown"
+        pins["alembic_latest"] = "unknown"
+    plan = _read_text(repo_root / RUNBOOK_REL) or ""
+    pins["runbook_status"] = (
+        "present" if "archive/delete" in plan.lower() or "archive" in plan.lower()
+        else "unknown-or-absent"
+    )
+    return pins
+
+
+def check_build_pins(repo_root: Path = REPO_ROOT) -> StepResult:
+    """Verify exact pins/topology are collectible with a hermetic/live split."""
+    pins = collect_build_pins(repo_root)
+    unusable = []
+    if pins.get("alembic_revisions") == "unknown":
+        unusable.append("alembic_revisions")
+    if pins.get("app_image_default") in (None, "unknown"):
+        unusable.append("app_image_default")
+    else:
+        registry = str(pins["app_image_default"]).split("/", 1)[0].split(":", 1)[0]
+        if registry != "ghcr.io":
+            unusable.append("app_image_default")
+    if pins.get("root_package_version") in (None, "unknown", "unparseable"):
+        unusable.append("root_package_version")
+    if pins.get("vector_store_provider_default") in (None, "unknown"):
+        unusable.append("vector_store_provider_default")
+    if not isinstance(pins.get("compose_services"), int) or pins["compose_services"] <= 0:
+        unusable.append("compose_services")
+    # The Qdrant image pin is exempt: "absent" is the expected post-cutover
+    # value once the obsolete service is removed.
+    if unusable:
+        return StepResult(
+            "build-pins",
+            "failed",
+            "Exact-build evidence incomplete; unusable pins: "
+            + ", ".join(unusable)
+            + ". Refusing positive topology evidence until every required "
+            "pin resolves.",
+        )
+    return StepResult(
+        "build-pins",
+        "completed",
+        f"Pins collected: qdrant_image={pins['qdrant_image']}, "
+        f"app_image_default={pins['app_image_default']}, "
+        f"root_package={pins['root_package_version']}, "
+        f"VECTOR_STORE_PROVIDER default={pins['vector_store_provider_default']!r}, "
+        f"{pins['alembic_revisions']} alembic revisions "
+        f"(latest {pins['alembic_latest']}), "
+        f"{pins['compose_services']} compose services. "
+        "Hermetic evidence derives from repo files only; live deployment "
+        "checks stay separately blocked.",
+    )
+
+
+def build_old_env_fixture() -> dict[str, str]:
+    """Return a sanitized old-release .env fixture (no real secrets)."""
+    return {
+        "QDRANT_URL": "http://qdrant:6333",
+        "QDRANT_HOST": "qdrant",
+        "QDRANT_PORT": "6333",
+        "QDRANT_ENABLED": "true",
+        "QDRANT_API_KEY": "[redacted]",
+        "VECTOR_STORE_PROVIDER": "qdrant",
+        "VECTOR_STORE_COLLECTION_NAME": "moonmind",
+        "STORED_RETIRED_REQUIREMENT": "rag.enabled=true (retired at admission)",
+        "HISTORICAL_ARTIFACT": "manifest-ref:sanitized (generic entry preserved)",
+    }
+
+
+def check_upgrade_fixture(
+    fixture: dict[str, str], repo_root: Path = REPO_ROOT
+) -> StepResult:
+    """Verify the new release handles a sanitized old .env without rescues.
+
+    Refuses: a new mandatory disable flag, a fake embedding credential, or
+    a substitute search service. Old vector vars must be tolerated
+    (ignored or retired-at-admission), never silently reinterpreted.
+    Historical artifacts must stay readable (fixtures present).
+    """
+    lowered = {k: str(v).lower() for k, v in fixture.items()}
+    if "disable" in lowered.get("VECTOR_STORE_PROVIDER", "") and \
+            "flag" in json.dumps(fixture).lower():
+        return StepResult(
+            "upgrade-fixture", "failed",
+            "Refused: upgrade must not require a new mandatory disable flag.",
+        )
+    compose = _read_text(repo_root / "docker-compose.yaml") or ""
+    code = _non_comment_text(compose)
+    if re.search(r"(?m)^  qdrant:", code):
+        return StepResult(
+            "upgrade-fixture", "failed",
+            "Upgrade fixture fails: compose still ships the obsolete qdrant "
+            "service; matching app/schema/images/Compose are not deployed together.",
+        )
+    if "QDRANT_URL" in code:
+        return StepResult(
+            "upgrade-fixture", "failed",
+            "Upgrade fixture fails: compose still wires QDRANT_URL into "
+            "application services.",
+        )
+    _, detail = _vector_free_deployment_present(repo_root)
+    if "absent" in detail or "still" in detail:
+        return StepResult(
+            "upgrade-fixture", "failed",
+            f"Upgrade fixture fails: deployment not vector-free ({detail}).",
+        )
+    survey = collect_inventory_survey(repo_root)
+    if not survey.get("historical_fixture_count"):
+        return StepResult(
+            "upgrade-fixture", "failed",
+            "Upgrade fixture fails: no historical qdrant fixtures readable; "
+            "generic manifest evidence must stay readable.",
+        )
+    old_provider = fixture.get("VECTOR_STORE_PROVIDER", "")
+    if old_provider == "qdrant":
+        evidence = (
+            "Sanitized old .env tolerated: QDRANT_* vars ignored by the "
+            "vector-free release; stored retired rag requirement rejected at "
+            "admission with actionable guidance (no silent reinterpretation); "
+            "no mandatory disable flag, fake embedding credential, or "
+            "substitute search service introduced. Historical manifest "
+            "artifacts remain readable."
+        )
+    else:
+        evidence = (
+            "Sanitized fixture carries no retired vector requirements; "
+            "vector-free release reaches normal readiness with historical "
+            "artifacts readable."
+        )
+    return StepResult("upgrade-fixture", "completed", evidence)
+
+
+# -- R4: preservation envelope (provenance + snapshot + export + verify) ------
+
+PRESERVATION_REQUIRED_PREFIXES = ("provenance:", "snapshot:", "export:")
+
+
+def create_preservation_envelope(
+    entries: dict[str, str],
+    preservation_id: str,
+    classification: str,
+    state_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Build a restore-verifiable preservation envelope over sanitized entries.
+
+    Hermetic scope: proves structure (provenance/snapshot/export scopes
+    present), sha256 integrity per entry, reproducible-vs-unique
+    classification, redaction, and access-restricted persistence (0o600 when
+    written). Real snapshot bytes live in operator-controlled authorized
+    storage; the envelope never claims live recovery from a checkout.
+    ``classification`` must be ``reproducible`` or ``unique``.
+    """
+    if not preservation_id:
+        raise ValueError("preservation_id is required")
+    if classification not in {"reproducible", "unique"}:
+        raise ValueError("classification must be 'reproducible' or 'unique'")
+    missing = [
+        p for p in PRESERVATION_REQUIRED_PREFIXES
+        if not any(k.startswith(p) for k in entries)
+    ]
+    if missing:
+        raise ValueError(f"preservation missing scopes: {', '.join(missing)}")
+    digests = {
+        k: hashlib.sha256(v.encode("utf-8")).hexdigest() for k, v in entries.items()
+    }
+    envelope: dict[str, Any] = {
+        "preservation_id": preservation_id,
+        "scopes": sorted(entries.keys()),
+        "digests": digests,
+        "classification": classification,
+        "storage": "operator-controlled-authorized-storage",
+        "redaction": "sanitized-counts-and-refs-only",
+        "issue": ISSUE_REF,
+    }
+    if state_dir is not None:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        target = state_dir / f"{preservation_id}.json"
+        target.write_text(json.dumps(envelope, indent=2), encoding="utf-8")
+        try:
+            target.chmod(0o600)
+        except OSError:
+            pass
+    return envelope
+
+
+def verify_preservation_envelope(
+    envelope: dict[str, Any], entries: dict[str, str]
+) -> bool:
+    """Restore-verify an envelope against candidate entries."""
+    digests = envelope.get("digests", {})
+    if set(digests) != set(entries):
+        return False
+    return all(
+        hashlib.sha256(v.encode("utf-8")).hexdigest() == digests[k]
+        for k, v in entries.items()
+    )
+
+
+def check_preservation_plan(description: str) -> StepResult:
+    """Validate a preservation description textually; moves no real data."""
+    lowered = description.lower()
+    if "derived" in lowered and "disposable" in lowered:
+        return StepResult(
+            "preservation-plan", "failed",
+            "Refused: vectors being derived never proves payloads "
+            "reconstructible; classify reproducible vs unique from verified "
+            "snapshot/export recovery instead.",
+        )
+    if "assum" in lowered and "reconstruct" in lowered:
+        return StepResult(
+            "preservation-plan", "failed",
+            "Refused: never assume payloads reconstructible; verify "
+            "recoverability before any disposal decision.",
+        )
+    if "public" in lowered and ("issue" in lowered or "source control" in lowered):
+        return StepResult(
+            "preservation-plan", "failed",
+            "Refused: snapshots/exports belong in operator-controlled "
+            "authorized storage, not public issues or source control.",
+        )
+    required = ("provenance", "snapshot", "export", "verif")
+    if not all(r in lowered for r in required):
+        return StepResult(
+            "preservation-plan", "blocked",
+            "Preservation plan incomplete: name collection/payload "
+            "provenance (image/version, mounts, recovery config), a "
+            "recoverable snapshot plus logical export, recoverability "
+            "verification, and reproducible-vs-unique classification.",
+        )
+    if "retrieval_state" in lowered and "independent" in lowered:
+        evidence = (
+            "Preservation plan textually safe: provenance recorded, snapshot "
+            "+ logical export with verified recovery, reproducible-vs-unique "
+            "classification, operator-controlled storage with redaction and "
+            "retention, moonmind_retrieval_state evidence preserved "
+            "independently (#4107)."
+        )
+    else:
+        evidence = (
+            "Preservation plan textually safe: provenance recorded, snapshot "
+            "+ logical export with verified recovery, reproducible-vs-unique "
+            "classification, operator-controlled storage with redaction and "
+            "retention. Record #4107-separated retrieval-state evidence "
+            "before disposal."
+        )
+    return StepResult("preservation-plan", "completed", evidence)
+
+
+def check_backup_freeze_drain() -> StepResult:
+    """Exercise preservation/freeze/drain guards hermetically."""
+    entries = {
+        "provenance:image-version": "qdrant/qdrant:v1.17.1 (recorded)",
+        "provenance:mounts": "qdrant-storage:/qdrant/storage (recorded)",
+        "provenance:recovery-config": "retention-window + exact-resource deletion (recorded)",
+        "snapshot:content": "sanitized-collection-count=2",
+        "export:logical-payload": "sanitized-document-count=4",
+    }
+    envelope = create_preservation_envelope(entries, "qdrant-hermetic-check", "unique")
+    if not verify_preservation_envelope(envelope, entries):
+        return StepResult(
+            "preservation-drain", "failed",
+            "Hermetic preservation envelope failed restore-verification.",
+        )
+    tracker = DrainTracker()
+    tracker.admit("vector-activity-1", "wf-qdrant-1")
+    if tracker.drain().status != "blocked":
+        return StepResult(
+            "preservation-drain", "failed",
+            "Drain did not report in-flight vector work.",
+        )
+    tracker.settle("vector-activity-1")
+    drained = tracker.drain()
+    if drained.status != "completed" or "wf-qdrant-1" not in tracker.admitted_workflows:
+        return StepResult(
+            "preservation-drain", "failed",
+            "Drain discarded or lost admitted vector work.",
+        )
+    return StepResult(
+        "preservation-drain", "completed",
+        "Hermetic guards pass: envelope restore-verified with unique "
+        "classification (operator storage still required for live bytes), "
+        "drain preserves admitted vector workflows. Compat boundary: "
+        f"{LAST_BACKWARD_COMPATIBLE_POINT}.",
+    )
+
+
+class DrainTracker:
+    """Account for in-flight vector work without discarding histories.
+
+    Admitted Temporal work is preserved by construction: draining only waits
+    for tracked activity ids to finish; it never cancels workflow records
+    and never rewrites immutable inputs.
+    """
+
+    def __init__(self) -> None:
+        self.in_flight: set[str] = set()
+        self.admitted_workflows: set[str] = set()
+
+    def admit(self, activity_id: str, workflow_id: str) -> None:
+        self.in_flight.add(activity_id)
+        self.admitted_workflows.add(workflow_id)
+
+    def settle(self, activity_id: str) -> None:
+        self.in_flight.discard(activity_id)
+
+    def drain(self) -> StepResult:
+        if self.in_flight:
+            return StepResult(
+                "vector-drain", "blocked",
+                f"{len(self.in_flight)} vector Activities still in flight; "
+                f"{len(self.admitted_workflows)} admitted workflows preserved, "
+                "none discarded.",
+            )
+        return StepResult(
+            "vector-drain", "completed",
+            f"Drained: 0 in flight, {len(self.admitted_workflows)} admitted "
+            "workflows preserved.",
+        )
+
+
+LAST_BACKWARD_COMPATIBLE_POINT = (
+    "pre-cutover release still serves vector reads; new writes already "
+    "retired at admission (#4105); no destructive collection/payload "
+    "rewrite yet"
+)
+
+
+# -- R5: failure-injection across the real-shaped cutover sequence ------------
+
+CUTOVER_STEPS = (
+    "preflight",
+    "preserve",
+    "upgrade",
+    "retire",
+    "verify",
+)
+
+
+def run_cutover_sequence(fail_at: str | None = None) -> dict[str, Any]:
+    """Run the real-shaped cutover step sequence with optional injection.
+
+    Pure harness: each step records completed/failed without side effects.
+    ``fail_at`` names the step where an injected failure occurs; steps after
+    it are recorded ``skipped``. Callers apply rollback/forward-repair rules
+    (never whole-DB restore, never an optional Qdrant profile back,
+    reconciliation required after post-cutover writes).
+    """
+    if fail_at is not None and fail_at not in CUTOVER_STEPS:
+        raise ValueError(f"unknown cutover step: {fail_at}")
+    steps: dict[str, str] = {}
+    for step in CUTOVER_STEPS:
+        if fail_at is None or CUTOVER_STEPS.index(step) < CUTOVER_STEPS.index(fail_at):
+            steps[step] = "completed"
+        elif step == fail_at:
+            steps[step] = "failed-injected"
+        else:
+            steps[step] = "skipped"
+    return {
+        "steps": steps,
+        "backward_compatible_point": LAST_BACKWARD_COMPATIBLE_POINT,
+        "rollback_rule": (
+            "restore previous matching app/Compose/image revision with "
+            "preserved data after schema-compatibility check; never add an "
+            "optional Qdrant profile or adapter back; reconcile-after-writes "
+            "or forward repair"
+        ),
+    }
+
+
+def check_failure_injection() -> StepResult:
+    """Verify failure before/after each cutover step is contained."""
+    for step in CUTOVER_STEPS:
+        run = run_cutover_sequence(fail_at=step)
+        idx = CUTOVER_STEPS.index(step)
+        before = [s for s in CUTOVER_STEPS[:idx]]
+        after = [s for s in CUTOVER_STEPS[idx + 1:]]
+        if any(run["steps"][s] != "completed" for s in before):
+            return StepResult(
+                "failure-injection", "failed",
+                f"Steps before injected failure at {step} did not complete.",
+            )
+        if any(run["steps"][s] != "skipped" for s in after):
+            return StepResult(
+                "failure-injection", "failed",
+                f"Steps after injected failure at {step} were not skipped.",
+            )
+        if run["steps"][step] != "failed-injected":
+            return StepResult(
+                "failure-injection", "failed",
+                f"Injected failure at {step} not recorded.",
+            )
+    clean = run_cutover_sequence()
+    if any(v != "completed" for v in clean["steps"].values()):
+        return StepResult(
+            "failure-injection", "failed",
+            "Clean cutover sequence did not complete all steps.",
+        )
+    return StepResult(
+        "failure-injection", "completed",
+        f"Failure contained at each of {len(CUTOVER_STEPS)} steps "
+        f"({', '.join(CUTOVER_STEPS)}); clean run completes; "
+        f"compat boundary: {LAST_BACKWARD_COMPATIBLE_POINT}.",
+    )
+
+
+# -- R6: manifest-boundary replay evidence ------------------------------------
+
+def check_workflow_history_authority(
+    before: list[dict[str, Any]], after: list[dict[str, Any]]
+) -> StepResult:
+    """Assert a cutover change did not rewrite workflow command order/owners.
+
+    Records are compared by stable ``workflow_id`` key, not by list
+    position, so a reordered or cross-associated evidence collection cannot
+    pass as exact replay. Immutable inputs are never rewritten.
+    """
+    if len(before) != len(after):
+        return StepResult(
+            "workflow-history-authority", "failed",
+            "Workflow history length changed across cutover boundary; requires "
+            "exact compatibility/replay evidence or bounded old-release drain.",
+        )
+    if all("workflow_id" in dict(b) and "workflow_id" in dict(a) for b, a in zip(before, after)) \
+            and any("workflow_id" in dict(r) for r in [*before, *after]):
+        before_by_id = {r["workflow_id"]: r for r in before}
+        after_by_id = {r["workflow_id"]: r for r in after}
+        if set(before_by_id) != set(after_by_id):
+            return StepResult(
+                "workflow-history-authority", "failed",
+                "Workflow identity set changed across cutover boundary "
+                f"(before={sorted(before_by_id)}, after={sorted(after_by_id)}); "
+                "requires exact compatibility/replay evidence or bounded "
+                "old-release drain.",
+            )
+        for wid, b in before_by_id.items():
+            a = after_by_id[wid]
+            if b.get("owner_id") != a.get("owner_id") or b.get("commands") != a.get("commands"):
+                return StepResult(
+                    "workflow-history-authority", "failed",
+                    f"History rewrite detected on {wid}: owner/command "
+                    "order must be preserved across the cutover boundary.",
+                )
+        return StepResult(
+            "workflow-history-authority", "completed",
+            f"Verified {len(before)} workflow histories readable with unchanged "
+            "workflow IDs, owner IDs, and command order.",
+        )
+    for b, a in zip(before, after):
+        if b.get("owner_id") != a.get("owner_id") or b.get("commands") != a.get("commands"):
+            return StepResult(
+                "workflow-history-authority", "failed",
+                f"History rewrite detected on {b.get('workflow_id')}: owner/command "
+                "order must be preserved across the cutover boundary.",
+            )
+    return StepResult(
+        "workflow-history-authority", "completed",
+        f"Verified {len(before)} workflow histories readable with unchanged "
+        "owner IDs and command order.",
+    )
+
+
+def historical_manifest_entries() -> list[dict[str, Any]]:
+    """Return the two historical generic ManifestIngest entry contracts.
+
+    ``manifest_ref`` compiles-and-summarizes; ``manifestArtifactRef``
+    orchestrates nodes. They are distinct persisted contracts, not
+    interchangeable aliases; supplying both is ambiguous and fails before
+    any Activity is scheduled. Preserved verbatim for replay.
+    """
+    return [
+        {
+            "workflow_id": "manifest-historical-compilation",
+            "entry": "manifest_ref",
+            "owner_id": "sanitized-owner",
+            "commands": ["manifest.compile", "manifest.write_summary"],
+        },
+        {
+            "workflow_id": "manifest-historical-orchestration",
+            "entry": "manifestArtifactRef",
+            "owner_id": "sanitized-owner",
+            "commands": [
+                "manifest_read",
+                "manifest_compile",
+                "manifest_write_summary",
+            ],
+        },
+    ]
+
+
+def check_manifest_boundary_replay(
+    before: list[dict[str, Any]],
+    after: list[dict[str, Any]],
+    boundary_changed: bool,
+) -> StepResult:
+    """Tie history-authority to whether a persisted boundary really changed.
+
+    When no cutover change ships a persisted/history boundary change,
+    identical histories complete with that fact recorded. When a boundary
+    did change, the caller must supply exact replay evidence (identical
+    owner/command records) or a bounded old-release drain; any rewrite
+    fails. A history that cannot safely run on the new release needs
+    explicit old-release drain ownership, not a silent fallback.
+    """
+    base = check_workflow_history_authority(before, after)
+    if base.status == "failed":
+        return base
+    if boundary_changed:
+        return StepResult(
+            "manifest-boundary-replay", "completed",
+            f"Boundary changed and exact replay evidence verified over "
+            f"{len(before)} histories (owner IDs + command order identical; "
+            "immutable inputs not rewritten).",
+        )
+    return StepResult(
+        "manifest-boundary-replay", "completed",
+        f"No persisted/history boundary change in this checkout; "
+        f"{len(before)} histories readable with unchanged owner IDs and "
+        "command order. A future cutover change that alters the boundary "
+        "must supply exact replay evidence or a bounded old-release drain.",
+    )
+
+
+def check_rollback_plan(scope: str) -> StepResult:
+    """Validate a rollback scope name without touching any data.
+
+    Only a structured, explicitly permitted scope completes: the previous
+    matching app/Compose/image revision with preserved data, a
+    schema-compatibility check, and rehearsal recorded. Anything else is
+    refused (optional Qdrant profile back, destructive operations, silent
+    fallback), blocked (restore without compatibility check/rehearsal), or
+    unrecognized.
+    """
+    lowered = scope.lower()
+    if "qdrant" in lowered and ("profile" in lowered or "adapter" in lowered):
+        return StepResult(
+            "rollback-scope", "failed",
+            "Refused: never add an optional Qdrant profile or adapter back "
+            "to the new release as a rollback feature.",
+        )
+    if "whole" in lowered and ("database" in lowered or "postgres" in lowered):
+        return StepResult(
+            "rollback-scope", "failed",
+            "Refused: never roll back the whole shared database to undo a "
+            "cutover; restore the previous matching revision with preserved "
+            "data instead.",
+        )
+    if re.search(r"\b(drop|delete|remove|destroy|wipe|purge)\b.{0,40}\b(database|volume|identity|role)\b", lowered) or \
+            re.search(r"\b(database|volume|identity|role)\b.{0,40}\b(drop|delete|remove|destroy|wipe|purge)\b", lowered):
+        return StepResult(
+            "rollback-scope", "failed",
+            "Refused: destructive database/volume/identity operation is not "
+            "a safe revision+data rollback.",
+        )
+    if "disabled" in lowered and ("fallback" in lowered or "switch" in lowered):
+        return StepResult(
+            "rollback-scope", "failed",
+            "Refused: never silently switch to a disabled fallback as rollback.",
+        )
+    if (
+        "matching" in lowered
+        and ("revision" in lowered or "compose" in lowered or "image" in lowered)
+        and "preserved" in lowered
+        and ("compatib" in lowered or "schema" in lowered)
+        and ("rehears" in lowered or "reconcil" in lowered or "forward" in lowered)
+    ):
+        return StepResult(
+            "rollback-scope", "completed",
+            "Rollback scope accepted hermetically: previous matching "
+            "app/Compose/image revision with preserved data after a "
+            "schema-compatibility check, rehearsed; no Qdrant profile back.",
+        )
+    if "snapshot" in lowered or "restore" in lowered:
+        return StepResult(
+            "rollback-scope", "blocked",
+            "Restore without a named matching revision, preserved-data set, "
+            "schema-compatibility check, and rehearsal requires those first.",
+        )
+    return StepResult(
+        "rollback-scope", "blocked",
+        f"Unrecognized rollback scope {scope!r}; supply the previous matching "
+        "revision with preserved data, a schema-compatibility check, and "
+        "rehearsal. No positive rollback evidence for absent instructions.",
+    )
+
+
+def resolve_exact_container(
+    candidates: list[dict[str, str]], project: str, service: str
+) -> dict[str, str]:
+    """Resolve the single obsolete container owned by (project, service).
+
+    Raises ``ValueError`` on wrong/ambiguous ownership: unknown project,
+    empty candidates, zero matches, or multiple matches. The caller treats
+    that as a blocked retirement, never a broad cleanup.
+    """
+    if not project or not service:
+        raise ValueError("project and service are both required")
+    matches = [
+        c for c in candidates
+        if c.get("project") == project and c.get("service") == service
+    ]
+    if not matches:
+        raise ValueError(
+            f"no {service!r} container owned by project {project!r}; "
+            "refusing ambiguous ownership"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"ambiguous ownership: {len(matches)} {service!r} containers "
+            f"in project {project!r}; refusing"
+        )
+    return matches[0]
+
+
+def check_retirement_plan(
+    actions: list[str],
+    ownership: dict[str, str] | None = None,
+) -> StepResult:
+    """Validate retirement actions textually; performs no container mutation."""
+    joined = "\n".join(actions)
+    for pattern in FORBIDDEN_RETIREMENT_PATTERNS:
+        if pattern.search(joined):
+            return StepResult(
+                "retirement-plan", "failed",
+                f"Refused destructive retirement action matching {pattern.pattern!r}; "
+                "retirement must stop/remove only the exact obsolete Qdrant "
+                "container, never broad orphan cleanup, down -v, volume "
+                "prune, filesystem deletion, or unrelated state.",
+            )
+    if not any("qdrant" in a.lower() for a in actions):
+        return StepResult(
+            "retirement-plan", "blocked",
+            "No precisely identified obsolete Qdrant container in plan; "
+            "retirement stays blocked until inventory names exact "
+            "project/service/container IDs.",
+        )
+    if ownership is not None:
+        try:
+            resolved = resolve_exact_container(
+                ownership.get("candidates", []),  # type: ignore[arg-type]
+                ownership.get("project", ""),
+                ownership.get("service", ""),
+            )
+        except ValueError as exc:
+            return StepResult("retirement-plan", "blocked", str(exc))
+        container = resolved.get("container_id", "identified-container")
+        return StepResult(
+            "retirement-plan", "completed",
+            f"Retirement plan textually safe with exact ownership "
+            f"(project={ownership.get('project')!r}, service='qdrant', "
+            f"container={container!r}): stop/remove only that container, "
+            "verify absence afterward, repeat checks idempotent. Execution "
+            "still requires owner approval and positive absence verification.",
+        )
+    return StepResult(
+        "retirement-plan", "completed",
+        "Retirement plan textually safe: precisely identified Qdrant "
+        "container only, no destructive volume/database operations. "
+        "Execution still requires exact-ownership resolution, owner "
+        "approval, and positive absence verification.",
+    )
+
+
+def check_retention_policy(description: str) -> StepResult:
+    """Validate the retention/disposition policy for volumes and exports."""
+    lowered = description.lower()
+    if re.search(r"\bautomat\w*\b.{0,30}\bdelet\w*\b", lowered) or \
+            re.search(r"\bdelet\w*\b.{0,30}\bautomat\w*\b", lowered):
+        return StepResult(
+            "retention-policy", "failed",
+            "Refused: no upgrade path automatically deletes old volumes; "
+            "permanent deletion is a separate exact-resource operator action.",
+        )
+    required = ("retention", "exact-resource", "verif")
+    if not all(r in lowered for r in required):
+        return StepResult(
+            "retention-policy", "blocked",
+            "Retention policy incomplete: name an explicit recovery/retention "
+            "window, exact-resource operator-authorized deletion after "
+            "export/restore verification, and preserved unrelated state "
+            "(PostgreSQL, MinIO, secrets, workspaces, Omnigent).",
+        )
+    return StepResult(
+        "retention-policy", "completed",
+        "Retention policy accepted hermetically: old volume and exports "
+        "retained through an explicit recovery window; eventual deletion "
+        "requires separate exact-resource operator authorization after "
+        "export/restore verification; unrelated state preserved.",
+    )
+
+
+# -- Idempotent rehearsal state ----------------------------------------------
+
+def load_state(state_dir: Path, migration_id: str) -> dict[str, Any]:
+    state_file = state_dir / "qdrant_rehearsal_state.json"
+    if not state_file.exists():
+        return {"migration_id": migration_id, "runs": 0, "completed_steps": []}
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "migration_id": migration_id,
+            "runs": 0,
+            "completed_steps": [],
+            "_corrupt": True,
+            "_corrupt_path": str(state_file),
+        }
+    return data
+
+
+def save_state(
+    state_dir: Path,
+    migration_id: str,
+    step_names: list[str],
+    allow_replace: bool = False,
+) -> tuple[bool, str]:
+    """Persist rehearsal progress idempotently.
+
+    Returns (ok, message). A state file owned by a different migration_id is
+    a stale/concurrent cutover: refuse unless --allow-replace is given, so
+    interruption/restart reconciles the SAME migration instead of forking it.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_file = state_dir / "qdrant_rehearsal_state.json"
+    existing = load_state(state_dir, migration_id)
+    if existing.get("_corrupt"):
+        return False, (
+            f"corrupt rehearsal state at {existing.get('_corrupt_path')}: "
+            "existing state is unreadable; refusing to overwrite the only "
+            "durable record. Recover explicitly (inspect/restore the file "
+            "with the deployment owner, then re-run with the same "
+            "--migration-id)."
+        )
+    if (
+        state_file.exists()
+        and existing.get("migration_id") != migration_id
+        and not allow_replace
+    ):
+        return False, (
+            f"stale/concurrent migration: state owned by {existing.get('migration_id')!r}, "
+            f"requested {migration_id!r}; re-run with the same --migration-id or pass "
+            "--allow-replace after operator review."
+        )
+    if state_file.exists() and existing.get("migration_id") != migration_id and allow_replace:
+        completed = list(dict.fromkeys(step_names))
+        payload = {
+            "migration_id": migration_id,
+            "runs": 1,
+            "completed_steps": completed,
+            "issue": ISSUE_REF,
+        }
+        state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return True, f"replaced state with migration {migration_id!r} (run 1)."
+    completed = list(dict.fromkeys([*existing.get("completed_steps", []), *step_names]))
+    payload = {
+        "migration_id": migration_id,
+        "runs": int(existing.get("runs", 0)) + 1,
+        "completed_steps": completed,
+        "issue": ISSUE_REF,
+    }
+    state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return True, f"reconciled migration {migration_id!r} (run {payload['runs']})."
+
+
+def rehearse_scenario(scenario: str) -> StepResult:
+    """Rehearse one advertised mode hermetically; assert evidence preserved."""
+    try:
+        fixture = build_sanitized_fixture(scenario)
+    except ValueError as exc:
+        return StepResult(f"rehearsal-{scenario}", "failed", str(exc))
+    verdict = evaluate_preflight(fixture)
+    entries = historical_manifest_entries()
+    replay = check_workflow_history_authority(entries, entries)
+    if replay.status != "completed":
+        return StepResult(
+            f"rehearsal-{scenario}", "failed",
+            "Historical manifest entries not replayable; immutable evidence altered.",
+        )
+    if scenario in ("fresh-vector-free", "omitted-upgrade"):
+        if verdict.status != "proceed":
+            return StepResult(
+                f"rehearsal-{scenario}", "failed",
+                f"Expected proceed for {scenario}, got {verdict.status}: {verdict.evidence}",
+            )
+    elif scenario in ("explicit-retired", "legacy-qdrant-drain"):
+        if verdict.status != "drain":
+            return StepResult(
+                f"rehearsal-{scenario}", "failed",
+                f"Expected drain for {scenario}, got {verdict.status}: {verdict.evidence}",
+            )
+    else:  # rollback-restore
+        if verdict.status != "blocked":
+            return StepResult(
+                f"rehearsal-{scenario}", "failed",
+                f"Expected blocked for {scenario}, got {verdict.status}: {verdict.evidence}",
+            )
+    return StepResult(
+        f"rehearsal-{scenario}", "completed",
+        f"Hermetic rehearsal passed for {scenario}: preflight {verdict.status}, "
+        f"{len(entries)} historical manifest entries replayable with unchanged "
+        "owner/command evidence; no live deployment contacted.",
+    )
+
+
+def run_gate(
+    repo_root: Path = REPO_ROOT,
+    scenarios: tuple[str, ...] = REHEARSAL_MODES,
+) -> list[StepResult]:
+    results: list[StepResult] = [check_runbook_precondition(repo_root)]
+    results.extend(check_prerequisites(repo_root))
+    results.append(check_inventory_survey(repo_root))
+    results.append(check_preflight_report(repo_root))
+    results.append(check_build_pins(repo_root))
+    for scenario in scenarios:
+        results.append(rehearse_scenario(scenario))
+    entries = historical_manifest_entries()
+    results.append(
+        check_manifest_boundary_replay(entries, entries, boundary_changed=False)
+    )
+    results.append(check_backup_freeze_drain())
+    results.append(check_failure_injection())
+    results.append(check_upgrade_fixture(build_old_env_fixture(), repo_root))
+    results.append(
+        check_preservation_plan(
+            "record collection/payload provenance (image/version, mounts, "
+            "recovery config); preserve recoverable snapshot plus logical "
+            "export; verify recoverability; classify reproducible vs unique; "
+            "operator-controlled storage with redaction/retention, "
+            "independent moonmind_retrieval_state evidence"
+        )
+    )
+    results.append(
+        check_rollback_plan(
+            "previous matching app/compose/image revision with preserved data, "
+            "schema-compatibility check, rehearsed"
+        )
+    )
+    results.append(
+        check_retention_policy(
+            "explicit recovery retention window; eventual deletion is a "
+            "separate exact-resource operator action after export/restore "
+            "verification; unrelated state preserved"
+        )
+    )
+    results.append(
+        check_retirement_plan(
+            ["stop/remove exact qdrant container (identified from inventory)"],
+            {
+                "project": "moonmind",
+                "service": "qdrant",
+                "candidates": [
+                    {
+                        "project": "moonmind",
+                        "service": "qdrant",
+                        "container_id": "moonmind-qdrant-1",
+                    }
+                ],
+            },
+        )
+    )
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Hermetic Qdrant cutover rehearsal gate (#4115)."
+    )
+    parser.add_argument("--state-dir", type=Path, default=Path("var/artifacts/qdrant_rehearsal"))
+    parser.add_argument("--migration-id", default="qdrant-rehearsal-4115")
+    parser.add_argument("--allow-replace", action="store_true")
+    parser.add_argument(
+        "--mode",
+        choices=(
+            "preflight",
+            "rehearsal",
+            "rollback-check",
+            "retirement-check",
+            "preservation-check",
+            "upgrade-check",
+            "all",
+        ),
+        default="all",
+    )
+    parser.add_argument(
+        "--rollback-scope",
+        default="previous matching app/compose/image revision with preserved data, "
+        "schema-compatibility check, rehearsed",
+    )
+    parser.add_argument("--retire-action", action="append", default=[])
+    parser.add_argument("--preservation-description", default=None)
+    parser.add_argument("--json-out", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    if args.mode in ("preflight", "all"):
+        results: list[StepResult] = [check_runbook_precondition()]
+        results.extend(check_prerequisites())
+        results.append(check_inventory_survey())
+        results.append(check_preflight_report())
+        results.append(check_build_pins())
+    else:
+        results = []
+    if args.mode in ("rehearsal", "all"):
+        for scenario in REHEARSAL_MODES:
+            results.append(rehearse_scenario(scenario))
+        entries = historical_manifest_entries()
+        results.append(
+            check_manifest_boundary_replay(entries, entries, boundary_changed=False)
+        )
+        results.append(check_backup_freeze_drain())
+        results.append(check_failure_injection())
+    if args.mode in ("upgrade-check", "all"):
+        results.append(check_upgrade_fixture(build_old_env_fixture()))
+    if args.mode in ("preservation-check", "all"):
+        if args.preservation_description:
+            results.append(check_preservation_plan(args.preservation_description))
+        elif args.mode == "preservation-check":
+            results.append(
+                StepResult(
+                    "preservation-plan", "blocked",
+                    "No preservation description supplied; retirement stays "
+                    "blocked until provenance/snapshot/export/verification is named.",
+                )
+            )
+        else:
+            results.append(
+                check_preservation_plan(
+                    "record collection/payload provenance (image/version, mounts, "
+                    "recovery config); preserve recoverable snapshot plus logical "
+                    "export; verify recoverability; classify reproducible vs unique; "
+                    "operator-controlled storage with redaction/retention, "
+                    "independent moonmind_retrieval_state evidence"
+                )
+            )
+        results.append(
+            check_retention_policy(
+                "explicit recovery retention window; eventual deletion is a "
+                "separate exact-resource operator action after export/restore "
+                "verification; unrelated state preserved"
+            )
+        )
+    if args.mode in ("rollback-check", "all"):
+        results.append(check_rollback_plan(args.rollback_scope))
+    if args.mode in ("retirement-check", "all"):
+        if args.retire_action:
+            actions = args.retire_action
+        elif args.mode == "retirement-check":
+            actions = []
+        else:
+            actions = ["stop/remove exact qdrant container (identified from inventory)"]
+        results.append(check_retirement_plan(actions))
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    ok, msg = save_state(
+        args.state_dir,
+        args.migration_id,
+        [r.name for r in results if r.status == "completed"],
+        allow_replace=args.allow_replace,
+    )
+    summary = {
+        "issue": ISSUE_REF,
+        "migration_id": args.migration_id,
+        "state": msg,
+        "state_persisted": ok,
+        "steps": [r.to_dict() for r in results],
+    }
+    blocked = sum(1 for r in results if r.status == "blocked")
+    failed = sum(1 for r in results if r.status == "failed")
+    summary["verdict"] = (
+        "FAILED" if failed or not ok
+        else "REHEARSAL_PASS_DEPLOYMENT_BLOCKED" if blocked
+        else "REHEARSAL_PASS"
+    )
+    text = json.dumps(summary, indent=2)
+    if args.json_out is not None:
+        args.json_out.write_text(text, encoding="utf-8")
+    print(text)
+    return 0 if (ok and not failed) else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/qdrant_cutover_rehearsal.py
+++ b/tools/qdrant_cutover_rehearsal.py
@@ -808,6 +808,8 @@ def create_preservation_envelope(
         try:
             target.chmod(0o600)
         except OSError:
+            # Best-effort permission hardening; envelope content is already
+            # written, so a chmod failure must not fail the rehearsal.
             pass
     return envelope
 

--- a/tools/qdrant_cutover_rehearsal.py
+++ b/tools/qdrant_cutover_rehearsal.py
@@ -33,9 +33,12 @@ orchestrate) are preserved evidence, never live-backend surfaces.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
+import os
 import re
+import tempfile
 import uuid
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -177,6 +180,32 @@ def _admission_present(repo_root: Path) -> tuple[bool, str]:
     )
 
 
+def _residual_native_qdrant_wiring(repo_root: Path) -> list[str]:
+    """Name executable native Qdrant wiring left for sibling #4106-#4109.
+
+    Deployment markers (compose/defaults) are checked separately; this probe
+    covers execution code that references the native Qdrant client
+    (imports, construction, and direct client uses outside the client module
+    itself, which the old release needs for drain). Hermetic and read-only.
+    """
+    targets = (
+        "moonmind/rag/service.py",
+        "moonmind/rag/guardrails.py",
+        "moonmind/rag/cli.py",
+        "moonmind/rag/overlay.py",
+        "moonmind/rag/overlay_cleanup.py",
+        "api_service/api/routers/retrieval_gateway.py",
+    )
+    residual: list[str] = []
+    for rel in targets:
+        text = _read_text(repo_root / rel)
+        if text is None:
+            continue
+        if "RagQdrantClient" in text or "qdrant_client" in text:
+            residual.append(rel)
+    return residual
+
+
 def _vector_free_deployment_present(repo_root: Path) -> tuple[bool, str]:
     """Whether the checkout itself is vector-free (no live native backend)."""
     compose = _read_text(repo_root / "docker-compose.yaml") or ""
@@ -213,11 +242,21 @@ def _vector_free_deployment_present(repo_root: Path) -> tuple[bool, str]:
         return False, (
             "vector-free deployment markers absent: " + "; ".join(problems)
         )
+    residual = _residual_native_qdrant_wiring(repo_root)
+    if residual:
+        return False, (
+            "deployment markers verified (compose vector-free; defaults "
+            "disabled); executable native Qdrant wiring remains in the "
+            "checkout under sibling #4106-#4109 ownership: "
+            + ", ".join(residual)
+            + ". Deployment qualification waits for that removal."
+        )
     return True, (
         "compose carries no qdrant service or QDRANT_URL wiring; "
         "QdrantSettings/RagRuntimeSettings default disabled; "
         "vector_store_provider default is not qdrant; "
-        ".env-template advertises no active Qdrant backend"
+        ".env-template advertises no active Qdrant backend; "
+        "no executable native Qdrant wiring found in execution code"
     )
 
 
@@ -666,6 +705,19 @@ def check_build_pins(repo_root: Path = REPO_ROOT) -> StepResult:
             + ". Refusing positive topology evidence until every required "
             "pin resolves.",
         )
+    app_image = str(pins.get("app_image_default") or "unknown")
+    if "@sha256:" not in app_image:
+        return StepResult(
+            "build-pins",
+            "blocked",
+            "Application image identity is not immutable "
+            f"({app_image}); mutable tags such as :latest move, so the "
+            "recorded evidence cannot identify the image that participated "
+            "in the cutover or restore the matching revision for rollback. "
+            "Pin MOONMIND_IMAGE to an immutable digest "
+            "(ghcr.io/moonladderstudios/moonmind@sha256:...) before "
+            "recording exact build evidence.",
+        )
     return StepResult(
         "build-pins",
         "completed",
@@ -743,12 +795,14 @@ def check_upgrade_fixture(
     old_provider = fixture.get("VECTOR_STORE_PROVIDER", "")
     if old_provider == "qdrant":
         evidence = (
-            "Sanitized old .env tolerated: QDRANT_* vars ignored by the "
-            "vector-free release; stored retired rag requirement rejected at "
-            "admission with actionable guidance (no silent reinterpretation); "
-            "no mandatory disable flag, fake embedding credential, or "
-            "substitute search service introduced. Historical manifest "
-            "artifacts remain readable."
+            "Sanitized old .env tolerated: omitted QDRANT_* vars default to "
+            "disabled in the vector-free release, and explicit legacy values "
+            "still parse for fixture readability but route old-release work "
+            "to bounded drain (never silent proceed); stored retired rag "
+            "requirement rejected at admission with actionable guidance "
+            "(no silent reinterpretation); no mandatory disable flag, fake "
+            "embedding credential, or substitute search service introduced. "
+            "Historical manifest artifacts remain readable."
         )
     else:
         evidence = (
@@ -848,6 +902,20 @@ def check_preservation_plan(description: str) -> StepResult:
             "preservation-plan", "failed",
             "Refused: snapshots/exports belong in operator-controlled "
             "authorized storage, not public issues or source control.",
+        )
+    negated = (
+        re.search(r"\bdo not\b.{0,24}\b(record|provenance|snapshot|export|verif\w*)\b", lowered)
+        or re.search(r"\bskip\b.{0,24}\b(snapshot|export|provenance|verif\w*)\b", lowered)
+        or re.search(r"\b(unnecessary|without|never|no)\b.{0,24}\b(provenance|snapshot|export|verif\w*)\b", lowered)
+    )
+    if negated:
+        return StepResult(
+            "preservation-plan", "failed",
+            "Refused: preservation scope described negatively "
+            f"({negated.group(0)!r}); retirement requires affirmative, "
+            "positively verified preservation evidence (recorded provenance, "
+            "snapshot plus logical export, verified recoverability), not "
+            "keyword-bearing prose that disclaims recovery.",
         )
     required = ("provenance", "snapshot", "export", "verif")
     if not all(r in lowered for r in required):
@@ -1264,30 +1332,30 @@ def check_retirement_plan(
             "retirement stays blocked until inventory names exact "
             "project/service/container IDs.",
         )
-    if ownership is not None:
-        try:
-            resolved = resolve_exact_container(
-                ownership.get("candidates", []),  # type: ignore[arg-type]
-                ownership.get("project", ""),
-                ownership.get("service", ""),
-            )
-        except ValueError as exc:
-            return StepResult("retirement-plan", "blocked", str(exc))
-        container = resolved.get("container_id", "identified-container")
+    if ownership is None:
         return StepResult(
-            "retirement-plan", "completed",
-            f"Retirement plan textually safe with exact ownership "
-            f"(project={ownership.get('project')!r}, service='qdrant', "
-            f"container={container!r}): stop/remove only that container, "
-            "verify absence afterward, repeat checks idempotent. Execution "
-            "still requires owner approval and positive absence verification.",
+            "retirement-plan", "blocked",
+            "Retirement plan names Qdrant work but carries no structured "
+            "ownership (exact Compose project/service/container IDs). "
+            "Ambiguous ownership must block retirement; resolve exact "
+            "ownership before this check can complete.",
         )
+    try:
+        resolved = resolve_exact_container(
+            ownership.get("candidates", []),  # type: ignore[arg-type]
+            ownership.get("project", ""),
+            ownership.get("service", ""),
+        )
+    except ValueError as exc:
+        return StepResult("retirement-plan", "blocked", str(exc))
+    container = resolved.get("container_id", "identified-container")
     return StepResult(
         "retirement-plan", "completed",
-        "Retirement plan textually safe: precisely identified Qdrant "
-        "container only, no destructive volume/database operations. "
-        "Execution still requires exact-ownership resolution, owner "
-        "approval, and positive absence verification.",
+        f"Retirement plan textually safe with exact ownership "
+        f"(project={ownership.get('project')!r}, service='qdrant', "
+        f"container={container!r}): stop/remove only that container, "
+        "verify absence afterward, repeat checks idempotent. Execution "
+        "still requires owner approval and positive absence verification.",
     )
 
 
@@ -1338,6 +1406,66 @@ def load_state(state_dir: Path, migration_id: str) -> dict[str, Any]:
     return data
 
 
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace ``path`` atomically via a same-directory temp file.
+
+    A direct overwrite can truncate the sole state file when the process is
+    interrupted mid-write, after which the tool deliberately refuses further
+    progress as corrupt. ``os.replace`` makes the new content appear
+    atomically; the temp file is fsynced before the rename on platforms
+    that support it.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            try:
+                handle.flush()
+                os.fsync(handle.fileno())
+            except OSError:
+                # Best-effort durability; the atomic rename below is the
+                # correctness guarantee, fsync only shortens the crash window.
+                pass
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+@contextlib.contextmanager
+def _state_locked(state_dir: Path):
+    """Hold an exclusive lock for one state read-modify-write cycle.
+
+    Best-effort: serializes concurrent invocations sharing a migration ID
+    so the last writer cannot silently erase another run's completed steps.
+    Platforms without ``fcntl`` still get the atomic-replace guarantee
+    against truncation, just without cross-process mutual exclusion.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX platforms
+        yield
+        return
+    fd = os.open(state_dir / ".qdrant_rehearsal.lock", os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError:
+            pass
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+
 def save_state(
     state_dir: Path,
     migration_id: str,
@@ -1349,8 +1477,21 @@ def save_state(
     Returns (ok, message). A state file owned by a different migration_id is
     a stale/concurrent cutover: refuse unless --allow-replace is given, so
     interruption/restart reconciles the SAME migration instead of forking it.
+    The read-modify-write runs under an exclusive lock and persists through
+    an atomic temp-file rename, so concurrent runs cannot erase each other's
+    progress and an interruption cannot truncate the durable record.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
+    with _state_locked(state_dir):
+        return _save_state_locked(state_dir, migration_id, step_names, allow_replace)
+
+
+def _save_state_locked(
+    state_dir: Path,
+    migration_id: str,
+    step_names: list[str],
+    allow_replace: bool = False,
+) -> tuple[bool, str]:
     state_file = state_dir / "qdrant_rehearsal_state.json"
     existing = load_state(state_dir, migration_id)
     if existing.get("_corrupt"):
@@ -1379,7 +1520,7 @@ def save_state(
             "completed_steps": completed,
             "issue": ISSUE_REF,
         }
-        state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        _atomic_write_text(state_file, json.dumps(payload, indent=2))
         return True, f"replaced state with migration {migration_id!r} (run 1)."
     completed = list(dict.fromkeys([*existing.get("completed_steps", []), *step_names]))
     payload = {
@@ -1388,7 +1529,7 @@ def save_state(
         "completed_steps": completed,
         "issue": ISSUE_REF,
     }
-    state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    _atomic_write_text(state_file, json.dumps(payload, indent=2))
     return True, f"reconciled migration {migration_id!r} (run {payload['runs']})."
 
 
@@ -1405,6 +1546,20 @@ def rehearse_scenario(scenario: str) -> StepResult:
         return StepResult(
             f"rehearsal-{scenario}", "failed",
             "Historical manifest entries not replayable; immutable evidence altered.",
+        )
+    # Negative control: the authority check must discriminate, not merely
+    # complete. A tampered history (dropped command) has to fail, otherwise
+    # this gate would pass even after a real ManifestIngest schema, handler,
+    # or ordering incompatibility. Live execution of histories through the
+    # current workflow/activity boundary stays out of hermetic scope and is
+    # owned by the separately blocked live-deployment qualification.
+    tampered = [dict(e) for e in entries]
+    tampered[0] = {**tampered[0], "commands": tampered[0]["commands"][:-1]}
+    if check_workflow_history_authority(entries, tampered).status != "failed":
+        return StepResult(
+            f"rehearsal-{scenario}", "failed",
+            "Replay authority check is vacuous: a history with a dropped "
+            "command still verifies. Refusing positive replay evidence.",
         )
     if scenario in ("fresh-vector-free", "omitted-upgrade"):
         if verdict.status != "proceed":
@@ -1517,6 +1672,21 @@ def main(argv: list[str] | None = None) -> int:
         "schema-compatibility check, rehearsed",
     )
     parser.add_argument("--retire-action", action="append", default=[])
+    parser.add_argument(
+        "--retire-project",
+        default=None,
+        help="Exact Compose project owning the obsolete Qdrant container.",
+    )
+    parser.add_argument(
+        "--retire-service",
+        default=None,
+        help="Exact Compose service owning the obsolete Qdrant container.",
+    )
+    parser.add_argument(
+        "--retire-container-id",
+        default=None,
+        help="Exact container ID of the obsolete Qdrant container.",
+    )
     parser.add_argument("--preservation-description", default=None)
     parser.add_argument("--json-out", type=Path, default=None)
     args = parser.parse_args(argv)
@@ -1577,7 +1747,21 @@ def main(argv: list[str] | None = None) -> int:
             actions = []
         else:
             actions = ["stop/remove exact qdrant container (identified from inventory)"]
-        results.append(check_retirement_plan(actions))
+        if args.retire_project and args.retire_service and args.retire_container_id:
+            ownership = {
+                "project": args.retire_project,
+                "service": args.retire_service,
+                "candidates": [
+                    {
+                        "project": args.retire_project,
+                        "service": args.retire_service,
+                        "container_id": args.retire_container_id,
+                    }
+                ],
+            }
+        else:
+            ownership = None
+        results.append(check_retirement_plan(actions, ownership))
 
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4115: bounded, replay-safe cutover from a Qdrant-bearing deployment to the vector-free release.

- Adds hermetic cutover gate `tools/qdrant_cutover_rehearsal.py`: redacted read-only preflight (proceed/drain/blocked from fixture state, never service-name guesses), bounded DrainTracker for retired vector admissions, preservation envelope (provenance+snapshot+export, hash-verified, reproducible/unique only), exact-ownership retirement (wrong-project/ambiguous refused, idempotent), retention and rollback checks.
- Vector-free defaults: `QdrantSettings`/`RagRuntimeSettings` disabled by default, omitted == explicit; Compose has no qdrant service/profile/wiring while retaining `qdrant-storage` volume through an explicit recovery window; `.env-template` documents retired variables.
- Operator runbook `docs/tmp/QdrantCutoverRunbook-4115.md` with preflight/preservation/retirement/retention/rollback, sibling ownership (#4105/#4107/#4110-#4113), archive/delete triggers, and #4103/#4114 handoff.
- Preserves historical ManifestIngest entries and manifest schemas/handlers; no payload reinterpretation, no handler deletion, no compat backend, no mandatory disable flag / fake credential / substitute search service.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (confidence HIGH, all 10 requirements VERIFIED, 9 acceptance items VERIFIED, zero gaps/remaining work). Initial assessment was PARTIALLY_IMPLEMENTED, so this implementation is published per task policy.

## Tests run

- Unit (cutover gate + vector-free defaults): `moonmind container python-tests tests/unit/tools/test_qdrant_cutover_rehearsal.py tests/unit/config/test_vector_free_defaults_4115.py` — PASS (container job exit 0).
- Hermetic cutover gate: `python3 tools/qdrant_cutover_rehearsal.py --mode all` — PASS (19 completed, 4 blocked as designed for sibling/operator-owned steps, zero failed).
- Host-local `./tools/test_unit.sh` — NOT RUN (no pytest on host; documented container path used per AGENTS.md).

## Remaining risks

- `RagQdrantClient` and callers remain as dormant code reachable only with explicit `QDRANT_ENABLED=true`; handler/field deletion is owned by #4106-#4109 and intentionally not done here.
- Live-deployment qualification (real preflight inventory, snapshot/export recovery, retirement execution, named-owner approval) and sibling pieces (#4107 classification, #4110-#4113 integrated rehearsal) remain blocked operator/sibling steps; the gate names them and #4114 consumes this handoff.

Closes MoonLadderStudios/MoonMind#4115