### PR TITLE
Fix review loop completion barrier and clean Codex responses

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -189,7 +189,9 @@ metadata flag.
      owning gate owns that side effect and the durable wait for its result.
    - `automated_review_wait`: a request for this head already exists and its
      result has not arrived. Return control to the owning gate with
-     `reenter_gate`.
+     `reenter_gate`. This wait takes precedence over every remediation,
+     including CI failures, merge conflicts, and older actionable comments.
+     Do not edit, commit, push, or start a fix Skill while it is pending.
    - `deferred_comments`: the comment ledger deferred or could not fix at least
      one comment that is still present. Publish `manual_review` and stop; a
      repeated remediation pass cannot clear a deferred disposition.
@@ -200,6 +202,14 @@ metadata flag.
      publish `manual_review` or `failed` evidence and stop without merging.
 4. After every remediation, verify the exact local `HEAD` is visible on the PR
    branch, then return to step 2. Never reuse a pre-remediation snapshot.
+   Completion accepts a submitted provider review, a provider-authored clean
+   response (`Codex Review: Didn't find any major issues. 🚀`) after the request
+   on its unchanged head, or the provider's qualified clean-review reaction.
+   A PR-level reaction must be newer than the request; an eyes reaction is
+   never completion. Read all pages and refresh the comment inventory after
+   observing completion. A clean response satisfies review freshness; it does
+   not erase independent actionable findings, CI failures, or conflicts. When
+   those gates are clear, finish on the same head without another request.
 5. Enforce `maxIterations`, `finalizeMaxRetries`, and
    `finalizeMaxElapsedSeconds`. Retryable/no-progress states receive at least five
    finalize checks unless the elapsed-time limit or a hard failure is reached.

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -191,6 +191,7 @@ metadata flag.
      result has not arrived. Return control to the owning gate with
      `reenter_gate`. This wait takes precedence over every remediation,
      including CI failures, merge conflicts, and older actionable comments.
+     Terminal evidence and deferred-comment blockers still take precedence.
      Do not edit, commit, push, or start a fix Skill while it is pending.
    - `deferred_comments`: the comment ledger deferred or could not fix at least
      one comment that is still present. Publish `manual_review` and stop; a
@@ -207,7 +208,9 @@ metadata flag.
    on its unchanged head, or the provider's qualified clean-review reaction.
    A PR-level reaction must be newer than the request; an eyes reaction is
    never completion. Read all pages and refresh the comment inventory after
-   observing completion. A clean response satisfies review freshness; it does
+   observing completion and revalidate the remote head before accepting the
+   snapshot. Merge with the verified head as an expected-head guard. A clean
+   response satisfies review freshness; it does
    not erase independent actionable findings, CI failures, or conflicts. When
    those gates are clear, finish on the same head without another request.
 5. Enforce `maxIterations`, `finalizeMaxRetries`, and

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -163,9 +163,21 @@ def _read_snapshot(path: Path) -> dict[str, Any]:
         raise RuntimeError(f"snapshot must be a JSON object: {path}")
     return payload
 
-def _merge_pr(pr_selector: str, merge_method: str) -> None:
-    cmd = ["gh", "pr", "merge", pr_selector, f"--{merge_method}"]
+
+def _merge_pr(pr_selector: str, merge_method: str, expected_head: str) -> None:
+    if not expected_head:
+        raise RuntimeError("Cannot merge without the verified PR head")
+    cmd = [
+        "gh",
+        "pr",
+        "merge",
+        pr_selector,
+        f"--{merge_method}",
+        "--match-head-commit",
+        expected_head,
+    ]
     subprocess.run(cmd, check=True)
+
 
 def _write_result(
     result_path: Path,
@@ -356,7 +368,7 @@ def main() -> None:
                         file=sys.stderr,
                     )
                     sys.exit(EXIT_CODE_FAILED if args.strict_exit_codes else 0)
-                
+
                 # Snapshot refresh can fail transiently (network/auth/API blips).
                 # Treat as blocked so orchestrate can retry with backoff.
                 _write_result(
@@ -418,7 +430,9 @@ def main() -> None:
                 )
                 print("Merge gate passed (dry-run).")
                 sys.exit(EXIT_CODE_BLOCKED if args.strict_exit_codes else 0)
-            _merge_pr(pr_selector, args.merge_method)
+            _merge_pr(
+                pr_selector, args.merge_method, normalize_text(pr.get("headRefOid"))
+            )
             if not _check_pr_merged(pr_selector):
                 _write_result(
                     result_path,

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -1411,6 +1411,18 @@ def main():
         )
         if not isinstance(comments, list):
             comments = []
+        # Comments/reactions have no reviewed commit. Revalidate the remote
+        # head after completion and inventory collection before publishing them.
+        completed_pr, _, _ = fetch_pr_data(args.pr)
+        if (
+            not head_sha
+            or str(completed_pr.get("headRefOid") or "").strip() != head_sha
+        ):
+            print(
+                "PR head changed during review collection; refresh the snapshot.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     addressed_ids = _load_addressed_comment_ids()
     deferred_ids = _load_deferred_comment_ids()
     comments_summary = summarize_comments(

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -25,6 +25,7 @@ for _package_root in (SCRIPT_DIR.parent / "lib", *SCRIPT_DIR.parents):
         break
 
 from pr_resolver_core.review_providers import (  # noqa: E402
+    is_clean_review_comment,
     resolve_automated_review_provider,
 )
 
@@ -743,11 +744,23 @@ def _fetch_pull_request_reviews(*, pr_repo: str | None, pr_number: object) -> li
     if not repo or not number:
         return []
     payload = run_command_optional(
-        ["gh", "api", f"repos/{repo}/pulls/{number}/reviews?per_page=100"]
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/pulls/{number}/reviews?per_page=100",
+        ]
     )
     if not isinstance(payload, list):
         return []
-    return [item for item in payload if isinstance(item, dict)]
+    return [
+        item
+        for page in payload
+        if isinstance(page, list)
+        for item in page
+        if isinstance(item, dict)
+    ]
 
 
 def _fetch_comment_reactions(*, pr_repo: str | None, comment_id: object) -> list[dict]:
@@ -759,12 +772,43 @@ def _fetch_comment_reactions(*, pr_repo: str | None, comment_id: object) -> list
         [
             "gh",
             "api",
+            "--paginate",
+            "--slurp",
             f"repos/{repo}/issues/comments/{identifier}/reactions?per_page=100",
         ]
     )
     if not isinstance(payload, list):
         return []
-    return [item for item in payload if isinstance(item, dict)]
+    return [
+        item
+        for page in payload
+        if isinstance(page, list)
+        for item in page
+        if isinstance(item, dict)
+    ]
+
+
+def _fetch_pr_reactions(*, pr_repo: str | None, pr_number: object) -> list[dict]:
+    if not pr_repo or not pr_number:
+        return []
+    payload = run_command_optional(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{pr_repo}/issues/{pr_number}/reactions?per_page=100",
+        ]
+    )
+    if not isinstance(payload, list):
+        return []
+    return [
+        item
+        for page in payload
+        if isinstance(page, list)
+        for item in page
+        if isinstance(item, dict)
+    ]
 
 
 def build_automated_review_evidence(
@@ -778,12 +822,14 @@ def build_automated_review_evidence(
     reviews: list[dict] | None = None,
     head_committed_at: datetime | None = None,
     reactions_for_request: list[dict] | None = None,
+    reactions_for_pr: list[dict] | None = None,
 ) -> dict:
     """Collect portable evidence about the configured automated reviewer.
 
     The Skill owns this decision in every host: a review only counts for the
     current head when the provider identity submitted it against that exact
-    commit, or reacted to the request comment that was posted for that head.
+    commit, or answered the request for the unchanged head with a qualified
+    clean comment or reaction. PR-level results must postdate the request.
     """
 
     record = resolve_automated_review_provider(provider)
@@ -826,6 +872,14 @@ def build_automated_review_evidence(
         user = review.get("user") if isinstance(review.get("user"), dict) else {}
         if _strip_bot_suffix(user.get("login")) not in provider_logins:
             continue
+        if str(review.get("state") or "").upper() not in {
+            "APPROVED",
+            "COMMENTED",
+            "CHANGES_REQUESTED",
+        }:
+            continue
+        if _parse_utc_timestamp(review.get("submitted_at")) is None:
+            continue
         provider_reviews.append(
             (_parse_utc_timestamp(review.get("submitted_at")), review)
         )
@@ -834,6 +888,8 @@ def build_automated_review_evidence(
 
     fresh_review = None
     for submitted_at, review in provider_reviews:
+        if request_at is not None and submitted_at <= request_at:
+            continue
         commit_id = str(review.get("commit_id") or "").strip()
         if commit_id:
             if normalized_head and commit_id == normalized_head:
@@ -857,6 +913,16 @@ def build_automated_review_evidence(
         completed_at = str(fresh_review.get("submitted_at") or "").strip() or None
 
     if fresh_review is None and request_comment is not None:
+        for comment in comments:
+            if comment.get("type") == "issue_comment" and is_clean_review_comment(
+                record, comment, requested_at=request_at, head_sha=normalized_head
+            ):
+                completion_kind = "issue_comment"
+                completion_id = comment.get("id")
+                completed_at = comment.get("created_at")
+                break
+
+    if not completion_kind and request_comment is not None:
         if reactions_for_request is None:
             reactions_for_request = _fetch_comment_reactions(
                 pr_repo=pr_repo, comment_id=request_comment.get("id")
@@ -871,6 +937,31 @@ def build_automated_review_evidence(
             completion_id = reaction.get("id")
             completed_at = str(reaction.get("created_at") or "").strip() or None
             break
+
+        if not completion_kind:
+            if reactions_for_pr is None:
+                reactions_for_pr = _fetch_pr_reactions(
+                    pr_repo=pr_repo, pr_number=pr_number
+                )
+            for reaction in reactions_for_pr:
+                user = (
+                    reaction.get("user")
+                    if isinstance(reaction.get("user"), dict)
+                    else {}
+                )
+                created_at = _parse_utc_timestamp(reaction.get("created_at"))
+                if (
+                    _strip_bot_suffix(user.get("login")) in provider_logins
+                    and str(reaction.get("content") or "")
+                    in record.clean_review_reactions
+                    and created_at is not None
+                    and request_at is not None
+                    and created_at > request_at
+                ):
+                    completion_kind = "reaction"
+                    completion_id = reaction.get("id")
+                    completed_at = reaction.get("created_at")
+                    break
 
     fresh = bool(completion_kind)
     evidence: dict = {
@@ -1300,6 +1391,26 @@ def main():
     )
     if not isinstance(comments, list):
         comments = []
+    automated_review = build_automated_review_evidence(
+        provider=args.review_provider,
+        require_fresh_review=bool(args.require_fresh_review),
+        pr_repo=pr_repo,
+        pr_number=pr_data.get("number"),
+        head_sha=head_sha,
+        comments=comments,
+    )
+    if automated_review.get("freshReviewForHead") is True:
+        # GitHub publishes the review summary and inline findings separately.
+        # Fetch the full inventory after observing completion, so a snapshot
+        # collected while the review was running cannot authorize a clean exit.
+        comments_data = run_command(
+            comments_cmd, "Failed to retrieve completed review comments."
+        )
+        comments = (
+            comments_data.get("comments", []) if isinstance(comments_data, dict) else []
+        )
+        if not isinstance(comments, list):
+            comments = []
     addressed_ids = _load_addressed_comment_ids()
     deferred_ids = _load_deferred_comment_ids()
     comments_summary = summarize_comments(
@@ -1316,22 +1427,14 @@ def main():
         previous_grace=_load_previous_codex_review_grace(snapshot_path),
     )
 
-    automated_review = build_automated_review_evidence(
-        provider=args.review_provider,
-        require_fresh_review=bool(args.require_fresh_review),
-        pr_repo=pr_repo,
-        pr_number=pr_data.get("number"),
-        head_sha=head_sha,
-        comments=comments,
-    )
-
     # 4. Construct Snapshot
     snapshot = {
         "repository": pr_repo or "",
         "pr": pr_data,
         "ci": ci_summary,
         "commentsFetch": {
-            "succeeded": True,
+            "succeeded": isinstance(comments_data, dict)
+            and isinstance(comments_data.get("comments"), list),
             "source": str(comments_script),
         },
         "comments": comments,

--- a/api_service/data/presets/pr-review-resolve.yaml
+++ b/api_service/data/presets/pr-review-resolve.yaml
@@ -1,7 +1,8 @@
 slug: pr-review-resolve
 title: Fix and Review Loop
-description: Request an automated review for every new head, fix every actionable
-  comment, and repeat until the pull request is clean. Optionally finish with a
+description: Request an automated review for every new head, wait for its complete
+  result before fixing comments, CI, or conflicts, and repeat until the pull request
+  is clean. Optionally finish with a
   final pr-resolver pass that merges the pull request.
 scope: global
 tags:

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -226,6 +226,23 @@ Without an active request, the automated-review gate may allow the first resolve
 
 A changed head invalidates the pending request and requires the governed head-update/re-entry path. Record per-cycle provider/head, request key/comment/time, completion identity/kind/time, and outcome. Never reuse another cycle's evidence merely because it is recent.
 
+An active request owns the unchanged head until review completion. CI failures,
+merge conflicts, and older actionable comments do not bypass that wait. Review
+evidence is collected independently of these repairable conditions; missing or
+unknown completion evidence keeps the gate closed. The portable Skill gives
+the same wait precedence over remediation. A head changed externally invalidates
+the request and re-enters the gate for the new revision.
+
+Completion includes the provider's submitted review, its request-bound clean
+comment (for Codex, `Codex Review: Didn't find any major issues. 🚀`), or its
+qualified clean-review reaction. Ordinary clean comments and PR-level reactions
+must be newer than the request on its unchanged head. Pending, unknown, blank,
+or dismissed review states, eyes reactions, quoted clean messages, and stale
+responses are not completion. The Skill reads every page of review/reaction
+evidence and refreshes the full comment inventory after observing completion.
+Once that head has a completed review and no remaining blockers, it finishes
+according to finishMode without requesting another review for the same head.
+
 ### 11.3.5 No-progress and termination rules
 
 The Skill emits a signature of head plus sorted outstanding actionable/deferred comment IDs. Repeated signatures, unchanged actionable comments, deferred/unfixable comments, exhausted cycle budget, unprovable review request, ownership/expected-head conflict, and expiry stop through explicit reasons such as review_loop_no_progress, deferred_comments, review_cycle_budget_exhausted, automated_review_request_failed, or expired.

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -230,7 +230,8 @@ An active request owns the unchanged head until review completion. CI failures,
 merge conflicts, and older actionable comments do not bypass that wait. Review
 evidence is collected independently of these repairable conditions; missing or
 unknown completion evidence keeps the gate closed. The portable Skill gives
-the same wait precedence over remediation. A head changed externally invalidates
+the same wait precedence over remediation, after terminal evidence validation
+and deferred-comment blockers. A head changed externally invalidates
 the request and re-enters the gate for the new revision.
 
 Completion includes the provider's submitted review, its request-bound clean
@@ -239,7 +240,10 @@ qualified clean-review reaction. Ordinary clean comments and PR-level reactions
 must be newer than the request on its unchanged head. Pending, unknown, blank,
 or dismissed review states, eyes reactions, quoted clean messages, and stale
 responses are not completion. The Skill reads every page of review/reaction
-evidence and refreshes the full comment inventory after observing completion.
+evidence and refreshes the full comment inventory after observing completion,
+then revalidates the remote head. Merge operations require that verified head
+to still match. When a request has multiple provider response comments, the
+latest authoritative response takes precedence over an earlier failure or clean result.
 Once that head has a completed review and no remaining blockers, it finishes
 according to finishMode without requesting another review for the same head.
 

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from pr_resolver_core.review_providers import (
     automated_review_provider_or_raise,
+    is_clean_review_comment,
     normalize_reviewer_login,
 )
 
@@ -115,8 +116,6 @@ class PullRequestSelectorResult(BaseModel):
     selector_type: str = Field(..., alias="selectorType")
     reason_code: str = Field(..., alias="reasonCode")
     summary: str
-
-
 
 
 @dataclass(frozen=True, slots=True)
@@ -1467,7 +1466,13 @@ class GitHubService:
                     }
                 )
 
-            if pr_open is True and pr_merged is not True and merge_conflicted:
+            active_review = bool(review_loop_enabled and review_request)
+            if (
+                pr_open is True
+                and pr_merged is not True
+                and merge_conflicted
+                and not active_review
+            ):
                 return PullRequestReadinessResult(
                     headSha=observed_head_sha,
                     baseSha=observed_base_sha,
@@ -1488,6 +1493,16 @@ class GitHubService:
                     ],
                 )
 
+            if pr_open is True and pr_merged is not True and merge_conflicted:
+                blockers.append(
+                    {
+                        "kind": "merge_conflict",
+                        "summary": "Pull request has merge conflicts.",
+                        "retryable": False,
+                        "source": "github",
+                    }
+                )
+
             if checks_required and pr_merged is not True and not blockers:
                 check_evidence = await self._evaluate_github_checks(
                     client=client,
@@ -1499,7 +1514,10 @@ class GitHubService:
                 checks_passing = check_evidence["passing"]
                 blockers.extend(check_evidence["blockers"])
 
-            if review_required and pr_merged is not True and not blockers:
+            if pr_merged is not True and (
+                (review_required and not blockers)
+                or (active_review and pr_open is True)
+            ):
                 if review_loop_enabled:
                     # The review loop makes every review request explicit and
                     # head-bound: with no active request the gate must open so
@@ -1829,6 +1847,14 @@ class GitHubService:
             ):
                 continue
             submitted_at = _parse_github_timestamp(review.get("submitted_at"))
+            if str(review.get("state") or "").upper() not in {
+                "APPROVED",
+                "COMMENTED",
+                "CHANGES_REQUESTED",
+            }:
+                continue
+            if submitted_at is None:
+                continue
             if requested_at is not None and (
                 submitted_at is None or submitted_at <= requested_at
             ):
@@ -1868,14 +1894,25 @@ class GitHubService:
                 "blockers": [],
             }
 
-        provider_failure = await self._find_request_provider_failure(
+        comment_result = await self._find_request_review_comment(
             client=client,
             repo=repo,
             pr_number=pr_number,
             headers=headers,
             provider=record,
             requested_at=requested_at,
+            head_sha=requested_head_sha,
         )
+        if isinstance(comment_result, dict):
+            return {
+                "complete": True,
+                "completionKind": "issue_comment",
+                "completionId": comment_result.get("id"),
+                "completedAt": comment_result.get("created_at"),
+                "stale": False,
+                "blockers": [],
+            }
+        provider_failure = comment_result
         if provider_failure is not None:
             summary = "Automated review provider failed to process the request."
             if (
@@ -1902,7 +1939,7 @@ class GitHubService:
             }
         return pending
 
-    async def _find_request_provider_failure(
+    async def _find_request_review_comment(
         self,
         *,
         client: httpx.AsyncClient,
@@ -1911,8 +1948,9 @@ class GitHubService:
         headers: dict[str, str],
         provider: Any,
         requested_at: datetime | None,
-    ) -> ProviderFailureEvent | None:
-        """Return a sanitized provider failure posted after this request."""
+        head_sha: str,
+    ) -> dict[str, Any] | ProviderFailureEvent | None:
+        """Read a request's clean response or sanitized provider failure."""
 
         comments_url: str | None = (
             f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
@@ -1943,6 +1981,10 @@ class GitHubService:
                         created_at is None or created_at <= requested_at
                     ):
                         continue
+                    if is_clean_review_comment(
+                        provider, comment, requested_at=requested_at, head_sha=head_sha
+                    ):
+                        return comment
                     failure = build_provider_failure_event(
                         reason=comment.get("body")
                     )

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -1956,6 +1956,7 @@ class GitHubService:
             f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
             "?per_page=100"
         )
+        latest: tuple[datetime, dict[str, Any] | ProviderFailureEvent] | None = None
         try:
             while comments_url:
                 response = await client.get(comments_url, headers=headers)
@@ -1977,19 +1978,22 @@ class GitHubService:
                     ):
                         continue
                     created_at = _parse_github_timestamp(comment.get("created_at"))
-                    if requested_at is not None and (
-                        created_at is None or created_at <= requested_at
+                    if created_at is None or (
+                        requested_at is not None and created_at <= requested_at
                     ):
                         continue
                     if is_clean_review_comment(
                         provider, comment, requested_at=requested_at, head_sha=head_sha
                     ):
-                        return comment
-                    failure = build_provider_failure_event(
-                        reason=comment.get("body")
-                    )
-                    if failure is not None:
-                        return failure
+                        candidate = comment
+                    else:
+                        candidate = build_provider_failure_event(
+                            reason=comment.get("body")
+                        )
+                    if candidate is not None and (
+                        latest is None or created_at >= latest[0]
+                    ):
+                        latest = (created_at, candidate)
                 comments_url = response.links.get("next", {}).get("url")
         except (
             httpx.HTTPStatusError,
@@ -1997,7 +2001,7 @@ class GitHubService:
             httpx.TimeoutException,
         ):
             return None
-        return None
+        return latest[1] if latest is not None else None
 
     async def _find_request_clean_review_reaction(
         self,

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -1149,6 +1149,17 @@ class MoonMindMergeAutomationWorkflow:
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
         if self._review_loop_active():
+            if (
+                self._active_review_request
+                and workflow.patched("merge-automation-active-review-barrier-v1")
+                and isinstance(evaluation, Mapping)
+                and evaluation.get("automatedReviewComplete") is not True
+                and evaluation.get("automatedReviewRequestStale") is not True
+            ):
+                # Older/in-flight activity results can omit review evidence
+                # when CI fails or conflicts are actionable. Unknown cannot
+                # release a resolver while this request still owns the head.
+                evaluation = {**evaluation, "automatedReviewComplete": False}
             self._settle_active_review_request(
                 evaluation if isinstance(evaluation, Mapping) else {}
             )

--- a/moonmind/workflows/temporal/workflows/pr_resolver.py
+++ b/moonmind/workflows/temporal/workflows/pr_resolver.py
@@ -110,7 +110,10 @@ def pr_resolver_identity_selector(
 
 def classify_pr_resolver_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     """Deterministically classify a captured GitHub snapshot."""
-    decision = classify_snapshot(normalize_temporal_snapshot(snapshot))
+    # This retired workflow only replays pre-cutover resolver histories.
+    decision = classify_snapshot(
+        normalize_temporal_snapshot(snapshot), pending_review_precedes_remediation=False
+    )
     return {
         "classification": decision.classification,
         "reasonCode": decision.reason_code,
@@ -529,6 +532,7 @@ class MoonMindPRResolverWorkflow:
                         known_ci_failures_precede_degraded=_workflow_patch_enabled(
                             PR_RESOLVER_CI_FAILURE_PRECEDENCE_PATCH
                         ),
+                        pending_review_precedes_remediation=False,
                     )
                     self._classification = transition.decision.classification
                 transition_reason = (

--- a/pr_resolver_core/classify.py
+++ b/pr_resolver_core/classify.py
@@ -54,18 +54,13 @@ def classify_snapshot(
         return _decision(
             "manual_review", "publish_unavailable", ResolverAction.STOP_MANUAL_REVIEW
         )
-    if (
+    review_pending = (
         pending_review_precedes_remediation
         and snapshot.review_loop_enabled
         and snapshot.automated_review_requested
         and not snapshot.fresh_automated_review
-    ):
-        # Preserve the reviewed head until the outstanding request completes,
-        # including when CI, conflicts, or older comments need remediation.
-        return _decision(
-            "automated_review_wait", "automated_review_wait", ResolverAction.WAIT
-        )
-    if snapshot.merge_conflict:
+    )
+    if snapshot.merge_conflict and not review_pending:
         return _decision(
             "merge_conflicts", "merge_conflicts", ResolverAction.RUN_REMEDIATION
         )
@@ -99,6 +94,12 @@ def classify_snapshot(
         # instead of burning the review-cycle budget on a no-progress loop.
         return _decision(
             "manual_review", "deferred_comments", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if review_pending:
+        # Preserve the reviewed head until the outstanding request completes,
+        # including when CI, conflicts, or older comments need remediation.
+        return _decision(
+            "automated_review_wait", "automated_review_wait", ResolverAction.WAIT
         )
     if snapshot.actionable_comments:
         return _decision(

--- a/pr_resolver_core/classify.py
+++ b/pr_resolver_core/classify.py
@@ -32,6 +32,7 @@ def classify_snapshot(
     snapshot: CanonicalPullRequestSnapshot,
     *,
     known_ci_failures_precede_degraded: bool = True,
+    pending_review_precedes_remediation: bool = True,
 ) -> ResolverDecision:
     if snapshot.merged:
         return _decision(
@@ -52,6 +53,17 @@ def classify_snapshot(
     if not snapshot.publish_available:
         return _decision(
             "manual_review", "publish_unavailable", ResolverAction.STOP_MANUAL_REVIEW
+        )
+    if (
+        pending_review_precedes_remediation
+        and snapshot.review_loop_enabled
+        and snapshot.automated_review_requested
+        and not snapshot.fresh_automated_review
+    ):
+        # Preserve the reviewed head until the outstanding request completes,
+        # including when CI, conflicts, or older comments need remediation.
+        return _decision(
+            "automated_review_wait", "automated_review_wait", ResolverAction.WAIT
         )
     if snapshot.merge_conflict:
         return _decision(
@@ -100,9 +112,7 @@ def classify_snapshot(
         # the external request and the wait for its result.
         if snapshot.automated_review_requested:
             return _decision(
-                "automated_review_wait",
-                "automated_review_wait",
-                ResolverAction.WAIT,
+                "automated_review_wait", "automated_review_wait", ResolverAction.WAIT
             )
         return _decision(
             "review_request_required",

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -13,7 +13,7 @@ RESOLVER_CORE_VERSION = "1.0.0"
 # immutable package so workflow code never reads mutable filesystem state
 # during replay.
 RESOLVER_CORE_DIGEST = (
-    "sha256:28425192c252e941def6a0686dfd9890f27ba750cd0c03f3770889987eb3aabb"
+    "sha256:fda697b9670ea91a33459f01b87e25bc1128ade973b99ebb34b0e602560a3fdb"
 )
 
 

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -13,7 +13,7 @@ RESOLVER_CORE_VERSION = "1.0.0"
 # immutable package so workflow code never reads mutable filesystem state
 # during replay.
 RESOLVER_CORE_DIGEST = (
-    "sha256:dd0d41ce00529e4ac5752e699a4c0450af4b8a3cb7aaed7d64b9b912a7b46a4d"
+    "sha256:28425192c252e941def6a0686dfd9890f27ba750cd0c03f3770889987eb3aabb"
 )
 
 

--- a/pr_resolver_core/review_providers.py
+++ b/pr_resolver_core/review_providers.py
@@ -10,7 +10,9 @@ comment text.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from datetime import datetime
 from types import MappingProxyType
 
 
@@ -22,6 +24,7 @@ class AutomatedReviewProvider:
     command: str
     reviewer_logins: tuple[str, ...]
     clean_review_reactions: tuple[str, ...] = ("+1",)
+    clean_review_comments: tuple[str, ...] = ()
 
 
 AUTOMATED_REVIEW_PROVIDERS = MappingProxyType(
@@ -30,6 +33,7 @@ AUTOMATED_REVIEW_PROVIDERS = MappingProxyType(
             provider="codex",
             command="@codex review",
             reviewer_logins=("chatgpt-codex-connector",),
+            clean_review_comments=("Codex Review: Didn't find any major issues. 🚀",),
         ),
     }
 )
@@ -74,3 +78,46 @@ def is_automated_review_provider_login(provider: object, login: object) -> bool:
     if record is None:
         return False
     return normalize_reviewer_login(login) in record.reviewer_logins
+
+
+def is_clean_review_comment(
+    provider: AutomatedReviewProvider,
+    comment: dict,
+    *,
+    requested_at: datetime | None,
+    head_sha: str,
+) -> bool:
+    """Recognize a provider's clean response within an unchanged-head request.
+
+    A bare phrase inside arbitrary prose, a quoted response, or an edited old
+    comment is not completion evidence. Callers own verifying the current head.
+    """
+    user = comment.get("user")
+    login = user.get("login") if isinstance(user, dict) else user
+    if normalize_reviewer_login(login) not in provider.reviewer_logins:
+        return False
+    if requested_at is None or not head_sha:
+        return False
+    try:
+        created_at = datetime.fromisoformat(
+            str(comment.get("created_at") or "").replace("Z", "+00:00")
+        )
+    except ValueError:
+        return False
+    if created_at.tzinfo is None or created_at <= requested_at:
+        return False
+    commit = str(comment.get("commit_id") or "").strip()
+    if commit and commit != head_sha:
+        return False
+    body = str(comment.get("body") or "").strip()
+    # Provider boilerplate is outside the result. Keep any other text so a
+    # mixed clean/findings response cannot be mistaken for a clean result.
+    body = re.split(
+        r"<details>\s*<summary>\s*ℹ️ About Codex in GitHub\s*</summary>",
+        body,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+    body = re.sub(r"^#{1,6}\s+", "", body).replace("**", "")
+    body = " ".join(body.split())
+    return body in provider.clean_review_comments

--- a/pr_resolver_core/transition.py
+++ b/pr_resolver_core/transition.py
@@ -20,10 +20,12 @@ def reduce_resolver_state(
     policy: ResolverPolicy,
     event: ResolverEvent,
     known_ci_failures_precede_degraded: bool = True,
+    pending_review_precedes_remediation: bool = True,
 ) -> ResolverTransition:
     decision = classify_snapshot(
         snapshot,
         known_ci_failures_precede_degraded=known_ci_failures_precede_degraded,
+        pending_review_precedes_remediation=pending_review_precedes_remediation,
     )
     state = previous_state
     metadata: dict[str, str | int | bool | None] = {}

--- a/tests/fixtures/temporal/pr_review_completion/premature_readiness.json
+++ b/tests/fixtures/temporal/pr_review_completion/premature_readiness.json
@@ -1,0 +1,62 @@
+{
+  "sourceWorkflow": "mm:f2d05574-3c5b-47c2-bb6d-33dc12341378",
+  "description": "Minimized recorded readiness results that launched repair children while a Codex request was pending.",
+  "observations": [
+    {
+      "sourceEventId": "1155",
+      "observedAt": "2026-09-09T00:42:10.412099670Z",
+      "result": {
+        "headSha": "3a6588c828d713f6919ed37e0e3c2ea2a8a327f1",
+        "baseSha": "36bd384b4c7498d70df80575b4b6ef8beaede734",
+        "ready": false,
+        "pullRequestOpen": true,
+        "pullRequestMerged": false,
+        "checksComplete": true,
+        "checksPassing": false,
+        "automatedReviewComplete": null,
+        "automatedReviewCompletionKind": null,
+        "automatedReviewCompletionId": null,
+        "automatedReviewCompletedAt": null,
+        "automatedReviewRequestStale": null,
+        "policyAllowed": true,
+        "blockers": [
+          {
+            "kind": "checks_failed",
+            "summary": "One or more required checks failed.",
+            "retryable": false,
+            "source": "github"
+          }
+        ],
+        "jiraStatusAllowed": true
+      }
+    },
+    {
+      "sourceEventId": "2331",
+      "observedAt": "2026-09-09T02:22:58.367633262Z",
+      "result": {
+        "headSha": "3a6f80f5b6f6d21acd27888d26a042315d8b92d5",
+        "baseSha": "36bd384b4c7498d70df80575b4b6ef8beaede734",
+        "ready": true,
+        "pullRequestOpen": true,
+        "pullRequestMerged": false,
+        "checksComplete": null,
+        "checksPassing": null,
+        "automatedReviewComplete": null,
+        "automatedReviewCompletionKind": null,
+        "automatedReviewCompletionId": null,
+        "automatedReviewCompletedAt": null,
+        "automatedReviewRequestStale": null,
+        "policyAllowed": true,
+        "blockers": [
+          {
+            "kind": "merge_conflict",
+            "summary": "Pull request has merge conflicts.",
+            "retryable": false,
+            "source": "github"
+          }
+        ],
+        "jiraStatusAllowed": true
+      }
+    }
+  ]
+}

--- a/tests/unit/test_pr_resolver_finish_mode.py
+++ b/tests/unit/test_pr_resolver_finish_mode.py
@@ -130,7 +130,7 @@ def _run_finalize(
     monkeypatch.setitem(
         main.__globals__,
         "_merge_pr",
-        lambda selector, method: merged.append((selector, method)),
+        lambda selector, method, head: merged.append((selector, method)),
     )
     monkeypatch.setitem(main.__globals__, "_check_pr_merged", lambda _selector: True)
     monkeypatch.delenv("PR_RESOLVER_REVIEW_PROVIDER", raising=False)
@@ -432,3 +432,18 @@ def test_orchestration_exits_zero_for_review_clean(orchestrate_module) -> None:
 
     assert exit_code == 0
     assert result["mergeAutomationDisposition"] == "review_clean"
+
+
+def test_merge_command_guards_the_reviewed_head(finalize_module, monkeypatch):
+    merge = finalize_module["_merge_pr"]
+    calls = []
+    monkeypatch.setattr(
+        merge.__globals__["subprocess"], "run", lambda cmd, **kw: calls.append(cmd)
+    )
+    merge("350", "squash", HEAD)
+    assert calls == [
+        ["gh", "pr", "merge", "350", "--squash", "--match-head-commit", HEAD]
+    ]
+    with pytest.raises(RuntimeError, match="verified PR head"):
+        merge("350", "squash", "")
+    assert len(calls) == 1

--- a/tests/unit/test_pr_resolver_review_loop.py
+++ b/tests/unit/test_pr_resolver_review_loop.py
@@ -63,6 +63,7 @@ def _evidence(snapshot_module, **kwargs: Any) -> dict[str, Any]:
         "reviews": [],
         "head_committed_at": HEAD_COMMITTED_AT,
         "reactions_for_request": [],
+        "reactions_for_pr": [],
     }
     params.update(kwargs)
     return build(**params)
@@ -280,6 +281,256 @@ def test_pending_request_waits_instead_of_requesting_again() -> None:
     assert decision.reason_code == "automated_review_wait"
 
 
+@pytest.mark.parametrize("blocker", ["comments", "ci", "conflict"])
+def test_pending_review_precedes_every_remediation(blocker) -> None:
+    snapshot = _snapshot()
+    snapshot["automatedReview"]["requestPending"] = True
+    if blocker == "comments":
+        snapshot["commentsSummary"]["hasActionableComments"] = True
+    elif blocker == "ci":
+        snapshot["ci"]["hasFailures"] = True
+    else:
+        snapshot["pr"]["mergeable"] = False
+    decision = classify_snapshot(normalize_portable_snapshot(snapshot))
+    assert decision.action is ResolverAction.WAIT
+    assert decision.reason_code == "automated_review_wait"
+
+
+@pytest.mark.parametrize("kind", ["issue_comment", "pr_reaction"])
+def test_clean_response_finishes_without_requesting_another_review(
+    snapshot_module, kind
+) -> None:
+    comment = {
+        "id": 56,
+        "type": "issue_comment",
+        "user": "chatgpt-codex-connector[bot]",
+        "body": "**Codex Review:** Didn't find any major issues. 🚀",
+        "created_at": "2026-08-24T22:20:00Z",
+    }
+    params = (
+        {"comments": [_request_comment(), comment]}
+        if kind == "issue_comment"
+        else {
+            "comments": [_request_comment()],
+            "reactions_for_pr": [
+                {
+                    "id": 57,
+                    "content": "+1",
+                    "created_at": "2026-08-24T22:20:00Z",
+                    "user": {"login": "chatgpt-codex-connector[bot]"},
+                }
+            ],
+        }
+    )
+    evidence = _evidence(snapshot_module, **params)
+    assert evidence["freshReviewForHead"] is True
+    assert evidence["requestPending"] is False
+    snapshot = _snapshot(automatedReview=evidence)
+    assert (
+        classify_snapshot(normalize_portable_snapshot(snapshot)).action
+        is ResolverAction.ATTEMPT_MERGE
+    )
+
+
+@pytest.mark.parametrize(
+    "change", ["old", "human", "quoted", "findings", "no_request", "old_head"]
+)
+def test_clean_comment_cannot_complete_an_unrelated_review(
+    snapshot_module, change
+) -> None:
+    comment = {
+        "id": 56,
+        "type": "issue_comment",
+        "user": "chatgpt-codex-connector[bot]",
+        "body": "Codex Review: Didn't find any major issues. 🚀",
+        "created_at": "2026-08-24T22:20:00Z",
+    }
+    request = _request_comment()
+    if change == "old":
+        comment["created_at"] = "2026-08-24T22:14:00Z"
+    elif change == "human":
+        comment["user"] = "human"
+    elif change == "quoted":
+        comment["body"] = "> " + comment["body"]
+    elif change == "findings":
+        comment["body"] += "\n\n[P1] Fix the authorization bug."
+    elif change == "old_head":
+        comment["commit_id"] = OLD_HEAD
+    comments = [comment] if change == "no_request" else [request, comment]
+    assert _evidence(snapshot_module, comments=comments)["freshReviewForHead"] is False
+
+
+@pytest.mark.parametrize("state", ["PENDING", "DISMISSED", "", "FUTURE_STATE"])
+def test_unsubmitted_or_unknown_review_is_not_completion(snapshot_module, state):
+    evidence = _evidence(
+        snapshot_module,
+        comments=[_request_comment()],
+        reviews=[
+            {
+                "id": 1,
+                "state": state,
+                "commit_id": HEAD,
+                "submitted_at": "2026-08-24T22:19:00Z",
+                "user": {"login": "chatgpt-codex-connector"},
+            }
+        ],
+    )
+    assert evidence["freshReviewForHead"] is False
+    assert evidence["requestPending"] is True
+
+
+@pytest.mark.parametrize(
+    "reaction",
+    [
+        {
+            "content": "eyes",
+            "created_at": "2026-08-24T22:20:00Z",
+            "user": {"login": "chatgpt-codex-connector"},
+        },
+        {
+            "content": "+1",
+            "created_at": "2026-08-24T22:14:00Z",
+            "user": {"login": "chatgpt-codex-connector"},
+        },
+        {
+            "content": "+1",
+            "created_at": "2026-08-24T22:20:00Z",
+            "user": {"login": "human"},
+        },
+    ],
+)
+def test_pr_reaction_requires_provider_clean_completion_after_request(
+    snapshot_module, reaction
+):
+    evidence = _evidence(
+        snapshot_module, comments=[_request_comment()], reactions_for_pr=[reaction]
+    )
+    assert evidence["freshReviewForHead"] is False
+
+
+@pytest.mark.parametrize(
+    "fetcher,kwargs",
+    [
+        ("_fetch_pull_request_reviews", {"pr_number": 350}),
+        ("_fetch_comment_reactions", {"comment_id": 98765}),
+        ("_fetch_pr_reactions", {"pr_number": 350}),
+    ],
+)
+def test_portable_review_fetch_reads_all_pages(
+    snapshot_module, monkeypatch, fetcher, kwargs
+):
+    fn = snapshot_module[fetcher]
+    calls = []
+
+    def gh(cmd):
+        calls.append(cmd)
+        return [[{"id": n} for n in range(100)], [{"id": 101}]]
+
+    monkeypatch.setitem(fn.__globals__, "run_command_optional", gh)
+    records = fn(pr_repo="owner/repo", **kwargs)
+    assert records[-1] == {"id": 101}
+    assert len(records) == 101
+    assert "--paginate" in calls[0] and "--slurp" in calls[0]
+
+
+def test_historical_resolver_keeps_recorded_remediation_order():
+    from moonmind.workflows.temporal.workflows.pr_resolver import (
+        classify_pr_resolver_snapshot,
+    )
+
+    result = classify_pr_resolver_snapshot(
+        {
+            "headSha": HEAD,
+            "checksComplete": True,
+            "checksPassing": False,
+            "blockers": [{"kind": "checks_failed"}, {"kind": "automated_review_wait"}],
+        }
+    )
+    assert result["classification"] == "ci_failures"
+
+
+@pytest.mark.parametrize("inventory_available", [True, False])
+def test_snapshot_collects_findings_after_review_completion(
+    snapshot_module, monkeypatch, tmp_path, inventory_available
+):
+    main = snapshot_module["main"]
+    scope = main.__globals__
+    snapshot = _snapshot()
+    checks = [{"name": "unit", "status": "COMPLETED", "conclusion": "SUCCESS"}]
+    pr = {
+        **snapshot["pr"],
+        "url": "https://github.com/owner/repo/pull/350",
+        "statusCheckRollup": checks,
+    }
+    monkeypatch.setitem(scope, "fetch_pr_data", lambda _selector: (pr, "350", []))
+    monkeypatch.setitem(scope, "_fetch_required_status_checks", lambda **_kwargs: [])
+    monkeypatch.setitem(scope, "_fetch_commit_check_runs", lambda **_kwargs: checks)
+    monkeypatch.setitem(scope, "_fetch_previous_commit_sha", lambda **_kwargs: None)
+    monkeypatch.setitem(
+        scope, "_fetch_head_commit_timestamp", lambda **_kwargs: HEAD_COMMITTED_AT
+    )
+    monkeypatch.setitem(
+        scope,
+        "_fetch_pull_request_reviews",
+        lambda **_kwargs: [
+            {
+                "id": 50,
+                "state": "COMMENTED",
+                "commit_id": HEAD,
+                "submitted_at": "2026-08-24T22:19:00Z",
+                "user": {"login": "chatgpt-codex-connector"},
+            }
+        ],
+    )
+    reads = []
+
+    def read_comments(*_args):
+        reads.append(True)
+        if len(reads) == 1:
+            return {"comments": [_request_comment()]}
+        if not inventory_available:
+            return {}
+        return {
+            "comments": [
+                _request_comment(),
+                {
+                    "id": 51,
+                    "type": "review_comment",
+                    "user": "chatgpt-codex-connector[bot]",
+                    "body": "[P1] Fix the authorization check",
+                    "created_at": "2026-08-24T22:19:01Z",
+                },
+            ]
+        }
+
+    monkeypatch.setitem(scope, "run_command", read_comments)
+    path = tmp_path / "snapshot.json"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_snapshot.py",
+            "--pr",
+            "350",
+            "--review-provider",
+            "codex",
+            "--require-fresh-review",
+            "--snapshot-path",
+            str(path),
+        ],
+    )
+    main()
+    captured = json.loads(path.read_text())
+    assert len(reads) == 2
+    assert captured["automatedReview"]["freshReviewForHead"] is True
+    decision = classify_snapshot(normalize_portable_snapshot(captured))
+    if inventory_available:
+        assert captured["commentsSummary"]["actionableCommentIds"] == [51]
+        assert decision.remediation_skill == "fix-comments"
+    else:
+        assert decision.reason_code == "comments_unavailable"
+
+
 def test_fresh_review_and_clean_state_merges() -> None:
     snapshot = _snapshot()
     snapshot["automatedReview"]["freshReviewForHead"] = True
@@ -436,4 +687,3 @@ def test_finalize_writes_a_request_review_result(tmp_path, monkeypatch) -> None:
     assert payload["mergeAutomationDisposition"] == "request_review"
     assert payload["gatedContinuation"]["action"] == "request_review"
     assert payload["gatedContinuation"]["provider"] == "codex"
-

--- a/tests/unit/test_pr_resolver_review_loop.py
+++ b/tests/unit/test_pr_resolver_review_loop.py
@@ -450,8 +450,9 @@ def test_historical_resolver_keeps_recorded_remediation_order():
 
 
 @pytest.mark.parametrize("inventory_available", [True, False])
+@pytest.mark.parametrize("head_changed", [False, True])
 def test_snapshot_collects_findings_after_review_completion(
-    snapshot_module, monkeypatch, tmp_path, inventory_available
+    snapshot_module, monkeypatch, tmp_path, inventory_available, head_changed
 ):
     main = snapshot_module["main"]
     scope = main.__globals__
@@ -462,7 +463,16 @@ def test_snapshot_collects_findings_after_review_completion(
         "url": "https://github.com/owner/repo/pull/350",
         "statusCheckRollup": checks,
     }
-    monkeypatch.setitem(scope, "fetch_pr_data", lambda _selector: (pr, "350", []))
+    pr_reads = []
+
+    def fetch_pr(_selector):
+        pr_reads.append(True)
+        observed = (
+            {**pr, "headRefOid": OLD_HEAD} if head_changed and len(pr_reads) > 1 else pr
+        )
+        return observed, "350", []
+
+    monkeypatch.setitem(scope, "fetch_pr_data", fetch_pr)
     monkeypatch.setitem(scope, "_fetch_required_status_checks", lambda **_kwargs: [])
     monkeypatch.setitem(scope, "_fetch_commit_check_runs", lambda **_kwargs: checks)
     monkeypatch.setitem(scope, "_fetch_previous_commit_sha", lambda **_kwargs: None)
@@ -519,6 +529,12 @@ def test_snapshot_collects_findings_after_review_completion(
             str(path),
         ],
     )
+    if head_changed:
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert not path.exists()
+        return
     main()
     captured = json.loads(path.read_text())
     assert len(reads) == 2
@@ -687,3 +703,32 @@ def test_finalize_writes_a_request_review_result(tmp_path, monkeypatch) -> None:
     assert payload["mergeAutomationDisposition"] == "request_review"
     assert payload["gatedContinuation"]["action"] == "request_review"
     assert payload["gatedContinuation"]["provider"] == "codex"
+
+
+@pytest.mark.parametrize(
+    "field,reason",
+    [
+        ("comments_available", "comments_unavailable"),
+        ("comment_policy_enforced", "comment_policy_not_enforced"),
+        ("checks_degraded", "ci_signal_degraded"),
+        ("unknown_blocker", "unknown_blocker"),
+        ("malformed", "snapshot_malformed"),
+        ("deferred_comments", "deferred_comments"),
+    ],
+)
+@pytest.mark.parametrize("conflicted", [False, True])
+def test_terminal_evidence_precedes_pending_review(field, reason, conflicted):
+    from dataclasses import replace
+
+    snapshot = normalize_portable_snapshot(_snapshot())
+    snapshot = replace(
+        snapshot,
+        review_loop_enabled=True,
+        automated_review_requested=True,
+        fresh_automated_review=False,
+        merge_conflict=conflicted,
+        **{field: field not in {"comments_available", "comment_policy_enforced"}},
+    )
+    decision = classify_snapshot(snapshot)
+    assert decision.action == ResolverAction.STOP_MANUAL_REVIEW
+    assert decision.reason_code == reason

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1913,7 +1913,7 @@ def test_finalize_merge_request_waits_for_authoritative_merged_state(
     monkeypatch.setitem(
         globals_dict,
         "_merge_pr",
-        lambda selector, method: merge_calls.append((selector, method)),
+        lambda selector, method, head: merge_calls.append((selector, method)),
     )
     monkeypatch.setitem(globals_dict, "_check_pr_merged", lambda _selector: False)
 
@@ -2102,7 +2102,6 @@ def test_load_addressed_ids_reads_disposition_field(
     tmp_path: Path,
 ) -> None:
     """Ledger with 'disposition' field should be read correctly."""
-    import json
 
     extract = pr_resolve_snapshot_module["_extract_ids_from_entries"]
     entries = [

--- a/tests/unit/workflows/adapters/test_github_automated_review.py
+++ b/tests/unit/workflows/adapters/test_github_automated_review.py
@@ -788,3 +788,49 @@ async def test_review_loop_disabled_keeps_legacy_evaluation(monkeypatch):
 
     assert result.automated_review_complete is True
     assert result.ready is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("latest_clean", [True, False])
+async def test_requested_review_uses_latest_comment_across_pages(
+    monkeypatch, latest_clean
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    clean = {
+        "id": 56,
+        "body": "Codex Review: Didn't find any major issues. 🚀",
+        "created_at": (
+            "2026-08-24T22:20:00Z" if latest_clean else "2026-08-24T22:19:00Z"
+        ),
+        "user": {"login": "chatgpt-codex-connector[bot]"},
+    }
+    failure = {
+        "id": 55,
+        "body": "You have reached your Codex usage limits. Please try again later.",
+        "created_at": (
+            "2026-08-24T22:19:00Z" if latest_clean else "2026-08-24T22:20:00Z"
+        ),
+        "user": {"login": "chatgpt-codex-connector[bot]"},
+    }
+    first, last = (failure, clean) if latest_clean else (clean, failure)
+    page2 = f"https://api.github.com/repos/{_REPO}/issues/350/comments?page=2"
+    mock_client = _client(
+        get_responses=[
+            *_readiness_prefix(),
+            _get(200, []),
+            _get(200, []),
+            _get(200, []),
+            _get(200, [first], headers={"Link": f'<{page2}>; rel="next"'}),
+            _get(200, [last]),
+        ]
+    )
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+    assert (result.automated_review_complete is True) is latest_clean
+    assert result.ready is latest_clean

--- a/tests/unit/workflows/adapters/test_github_automated_review.py
+++ b/tests/unit/workflows/adapters/test_github_automated_review.py
@@ -278,6 +278,123 @@ _ACTIVE_REQUEST = {
 }
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocker", ["ci", "conflict"])
+async def test_pending_requested_review_blocks_remediation(monkeypatch, blocker):
+    from moonmind.workflows.temporal.workflows.merge_gate import classify_readiness
+
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    prefix = _readiness_prefix()
+    if blocker == "ci":
+        prefix[1] = _get(200, {"state": "failure", "statuses": []})
+        prefix[2] = _get(
+            200, {"check_runs": [{"status": "completed", "conclusion": "failure"}]}
+        )
+    else:
+        prefix = [
+            _get(
+                200,
+                {
+                    "state": "open",
+                    "merged": False,
+                    "head": {"sha": _HEAD},
+                    "mergeable": False,
+                    "mergeable_state": "dirty",
+                },
+            )
+        ]
+    mock_client = _client(get_responses=[*prefix, *[_get(200, []) for _ in range(4)]])
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+    assert result.automated_review_complete is False
+    assert (
+        classify_readiness(
+            result.model_dump(by_alias=True), tracked_head_sha=_HEAD
+        ).ready
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_requested_review_accepts_paginated_clean_comment(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    page2 = f"https://api.github.com/repos/{_REPO}/issues/350/comments?page=2"
+    mock_client = _client(
+        get_responses=[
+            *_readiness_prefix(),
+            _get(200, []),
+            _get(200, []),
+            _get(200, []),
+            _get(200, [], headers={"Link": f'<{page2}>; rel="next"'}),
+            _get(
+                200,
+                [
+                    {
+                        "id": 56,
+                        "body": "**Codex Review:** Didn't find any major issues. 🚀",
+                        "created_at": "2026-08-24T22:20:00Z",
+                        "user": {"login": "chatgpt-codex-connector[bot]"},
+                    }
+                ],
+            ),
+        ]
+    )
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+    assert result.automated_review_complete is True
+    assert result.automated_review_completion_kind == "issue_comment"
+    assert result.automated_review_completion_id == 56
+    assert result.ready is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["PENDING", "DISMISSED", "", "FUTURE_STATE"])
+async def test_requested_review_requires_a_submitted_known_state(monkeypatch, state):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+    mock_client = _client(
+        get_responses=[
+            *_readiness_prefix(),
+            _get(
+                200,
+                [
+                    {
+                        "id": 50,
+                        "state": state,
+                        "commit_id": _HEAD,
+                        "submitted_at": "2026-08-24T22:19:00Z",
+                        "user": {"login": "chatgpt-codex-connector"},
+                    }
+                ],
+            ),
+            _get(200, []),
+            _get(200, []),
+            _get(200, []),
+        ]
+    )
+    with _patch_client(mock_client):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo=_REPO,
+            pr_number=350,
+            head_sha=_HEAD,
+            review_loop_enabled=True,
+            review_request=_ACTIVE_REQUEST,
+        )
+    assert result.ready is False
+    assert result.automated_review_complete is False
+
+
 def _readiness_prefix():
     return [
         _get(

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -208,6 +208,7 @@ async def test_pr_resolver_bundle_includes_portable_core_and_runs_help(tmp_path)
         "SKILL.md",
         "bin/pr_resolve_contract.py",
         "bin/pr_resolve_finalize.py",
+        "bin/pr_resolve_snapshot.py",
     ):
         source = source_root / ".agents" / "skills" / "pr-resolver" / relative_path
         destination = skill_dir / relative_path
@@ -238,6 +239,32 @@ async def test_pr_resolver_bundle_includes_portable_core_and_runs_help(tmp_path)
 
     assert result.returncode == 0, result.stderr
     assert (extracted / "lib" / "pr_resolver_core" / "__init__.py").is_file()
+    # Exercise the packaged semantic entrypoint outside the repository. A
+    # runtime must receive the new completion protocol and wait ordering from
+    # its immutable Skill bundle, not import the host checkout by accident.
+    script = """
+import runpy, sys
+from datetime import datetime, timezone
+snapshot = runpy.run_path(sys.argv[1])
+from pr_resolver_core import CanonicalPullRequestSnapshot, ResolverAction, classify_snapshot
+request = {'id': 1, 'type': 'issue_comment', 'user': 'owner', 'body': '@codex review', 'created_at': '2026-09-09T01:00:00Z'}
+clean = {'id': 2, 'type': 'issue_comment', 'user': 'chatgpt-codex-connector[bot]', 'body': "Codex Review: Didn't find any major issues. 🚀", 'created_at': '2026-09-09T01:10:00Z'}
+evidence = snapshot['build_automated_review_evidence'](
+    provider='codex', require_fresh_review=True, pr_repo='owner/repo', pr_number=1,
+    head_sha='a'*40, head_committed_at=datetime(2026,9,9,tzinfo=timezone.utc),
+    comments=[request, clean], reviews=[], reactions_for_request=[], reactions_for_pr=[])
+assert evidence['freshReviewForHead'] and not evidence['requestPending']
+pending = CanonicalPullRequestSnapshot(review_loop_enabled=True, automated_review_requested=True, merge_conflict=True)
+assert classify_snapshot(pending).action is ResolverAction.WAIT
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(extracted / "bin/pr_resolve_snapshot.py")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 async def test_build_prompt_index_activity_returns_bundle():

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -68,6 +70,7 @@ def _ready(head_sha: str, **overrides: Any) -> dict[str, Any]:
         "policyAllowed": True,
         "checksComplete": True,
         "checksPassing": True,
+        "automatedReviewComplete": True,
         "jiraStatusAllowed": True,
     }
     payload.update(overrides)
@@ -252,6 +255,204 @@ def _posted(head_sha: str, comment_id: int = 98765) -> dict[str, Any]:
         "retryable": False,
         "summary": "Requested an automated codex review.",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("observation", [0, 1])
+@pytest.mark.parametrize("barrier_enabled", [True, False])
+async def test_recorded_pending_review_cannot_release_a_repair(
+    monkeypatch, observation, barrier_enabled
+):
+    fixture = (
+        Path(__file__).resolve().parents[4]
+        / "fixtures/temporal/pr_review_completion/premature_readiness.json"
+    )
+    recorded = json.loads(fixture.read_text())["observations"][observation]["result"]
+    head = recorded["headSha"]
+    payload = _payload()
+    payload["pullRequest"]["headSha"] = head
+    payload["mergeAutomationConfig"]["finishMode"] = "fix_only"
+    payload["activeReviewRequest"] = {
+        "provider": "codex",
+        "headSha": head,
+        "requestKey": "recorded-request",
+        "requestCommentId": 98765,
+        "requestedAt": "2026-08-24T22:15:00Z",
+    }
+    harness = _Harness(
+        monkeypatch,
+        readiness=[recorded, _ready(head, automatedReviewComplete=True)],
+        child_results=[
+            {"status": "success", "mergeAutomationDisposition": "review_clean"}
+        ],
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda name: (
+            barrier_enabled
+            if name == "merge-automation-active-review-barrier-v1"
+            else True
+        ),
+    )
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+    assert result["status"] == "review_clean"
+    assert len(harness.child_payloads) == 1
+    assert harness.wait_calls == int(barrier_enabled)
+    assert not harness.request_payloads
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["comment", "reaction"])
+async def test_clean_response_crosses_activity_skill_and_workflow_without_another_cycle(
+    monkeypatch, tmp_path, kind
+):
+    import httpx
+    import runpy
+    from moonmind.workflows.temporal.activity_runtime import (
+        TemporalIntegrationActivities,
+    )
+
+    root = Path(__file__).resolve().parents[5]
+    snapshot_module = runpy.run_path(
+        str(root / ".agents/skills/pr-resolver/bin/pr_resolve_snapshot.py")
+    )
+    finalize_module = runpy.run_path(
+        str(root / ".agents/skills/pr-resolver/bin/pr_resolve_finalize.py")
+    )
+    head = "a" * 40
+    request = {
+        "id": 98765,
+        "type": "issue_comment",
+        "user": "owner",
+        "body": "@codex review",
+        "created_at": "2026-08-24T22:15:00Z",
+    }
+    clean = {
+        "id": 56,
+        "type": "issue_comment",
+        "body": "**Codex Review:** Didn't find any major issues. 🚀",
+        "created_at": "2026-08-24T22:20:00Z",
+        "user": {"login": "chatgpt-codex-connector[bot]"},
+    }
+    reaction = {
+        "id": 57,
+        "content": "+1",
+        "created_at": clean["created_at"],
+        "user": clean["user"],
+    }
+    polls = []
+
+    def github_response(req):
+        path = req.url.path
+        if path.endswith("/pulls/350"):
+            data = {"state": "open", "head": {"sha": head}, "mergeable": True}
+        elif path.endswith("/status"):
+            data = {"state": "success", "statuses": []}
+        elif path.endswith("/check-runs"):
+            data = {"check_runs": [{"status": "completed", "conclusion": "success"}]}
+        elif path.endswith("/reviews"):
+            data = []
+        elif path.endswith("/issues/350/reactions"):
+            data = [reaction] if kind == "reaction" and len(polls) > 1 else []
+        elif path.endswith("/reactions"):
+            data = []
+        elif path.endswith("/comments"):
+            data = [clean] if kind == "comment" and len(polls) > 1 else []
+        else:
+            raise AssertionError(path)
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(github_response)
+    client_type = httpx.AsyncClient
+    monkeypatch.setattr(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        lambda **kwargs: client_type(transport=transport, **kwargs),
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    def finish(child_id, attempt):
+        assert len(polls) == 2  # No runtime is started during the pending poll.
+        comments = [request]
+        if kind == "comment":
+            comments.append({**clean, "user": clean["user"]["login"]})
+        evidence = snapshot_module["build_automated_review_evidence"](
+            provider="codex",
+            require_fresh_review=True,
+            pr_repo="owner/repo",
+            pr_number=350,
+            head_sha=head,
+            comments=comments,
+            reviews=[],
+            head_committed_at=datetime(2026, 8, 24, 22, 10, tzinfo=timezone.utc),
+            reactions_for_request=[],
+            reactions_for_pr=[reaction] if kind == "reaction" else [],
+        )
+        snapshot = {
+            "pr": {
+                "number": 350,
+                "state": "OPEN",
+                "headRefOid": head,
+                "mergeable": True,
+            },
+            "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+            "commentsFetch": {"succeeded": True},
+            "commentsSummary": snapshot_module["summarize_comments"](comments),
+            "automatedReview": evidence,
+        }
+        snapshot_path = tmp_path / "snapshot.json"
+        result_path = tmp_path / "result.json"
+        snapshot_path.write_text(json.dumps(snapshot))
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "pr_resolve_finalize.py",
+                "--skip-refresh",
+                "--finish-mode",
+                "fix_only",
+                "--snapshot-path",
+                str(snapshot_path),
+                "--result-path",
+                str(result_path),
+            ],
+        )
+        with pytest.raises(SystemExit) as exit_info:
+            finalize_module["main"]()
+        assert exit_info.value.code == finalize_module["EXIT_CODE_REVIEW_CLEAN"]
+        terminal = json.loads(result_path.read_text())
+        assert terminal["status"] == "review_clean"
+        # UserWorkflow wraps the Skill's terminal status in its execution status.
+        return {
+            "status": "success",
+            "mergeAutomationDisposition": terminal["mergeAutomationDisposition"],
+        }
+
+    harness = _Harness(monkeypatch, readiness=[], child_results=finish)
+    fake_activity = merge_automation_module.workflow.execute_activity
+    activities = TemporalIntegrationActivities()
+
+    async def activity(name, payload, **kwargs):
+        if name == "merge_automation.evaluate_readiness":
+            polls.append(payload)
+            return await activities.merge_automation_evaluate_readiness(payload)
+        return await fake_activity(name, payload, **kwargs)
+
+    monkeypatch.setattr(merge_automation_module.workflow, "execute_activity", activity)
+    payload = _payload()
+    payload["pullRequest"]["headSha"] = head
+    payload["mergeAutomationConfig"]["finishMode"] = "fix_only"
+    payload["activeReviewRequest"] = {
+        "provider": "codex",
+        "headSha": head,
+        "requestKey": "key",
+        "requestCommentId": request["id"],
+        "requestedAt": request["created_at"],
+    }
+    result = await MoonMindMergeAutomationWorkflow().run(payload)
+    assert result["status"] == "review_clean"
+    assert len(harness.child_payloads) == 1
+    assert harness.wait_calls == 1
+    assert harness.request_payloads == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Observed on [crash_server_main#783](https://github.com/g3-qrtr/crash_server_main/pull/783), workflow `mm:f2d05574-3c5b-47c2-bb6d-33dc12341378`.

## Summary

- Keep an active review pending before repairing CI, conflicts, or comments; missing completion evidence cannot release another resolver.
- Recognize Codex's provider-authored “Didn't find any major issues. 🚀” response and qualified PR reactions, paginate review evidence, and refresh comments after completion. Finish without another review request when the remaining gates are clear.
- Revalidate the remote head after collecting completion, guard merges with the verified SHA, and prefer the latest provider response while retaining terminal blockers.
- Update the Fix and Review Loop instructions and add production-derived regression fixtures, workflow boundary coverage, and portable Skill packaging checks.

ELI5: Let Codex finish reviewing the current revision before changing it, and recognize its clean result so the loop knows when to stop.

## Test Plan

375 targeted tests passed; Ruff and diff checks passed. The recorded 4,785-event production merge-automation history replayed successfully. Full CI passed on the final review-fix commit (6010984dc), including integration and workflow boundary checks.

```bash
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/test_pr_resolver_review_loop.py \
  tests/unit/test_pr_resolver_tools.py \
  tests/unit/test_pr_resolver_core.py \
  tests/unit/test_pr_resolver_finish_mode.py \
  tests/unit/workflows/adapters/test_github_automated_review.py \
  tests/unit/workflows/adapters/test_github_service.py \
  tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py \
  tests/unit/workflows/temporal/workflows/test_pr_resolver.py \
  tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py \
  tests/unit/workflows/agent_skills/test_agent_skills_activities.py \
  tests/unit/api/test_pr_review_resolve_preset.py
git diff --check
```

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Changes review readiness and remediation ordering. A Temporal patch preserves replay of existing merge-automation histories; the retired native resolver retains its historical ordering. Clean responses require the configured provider and fresh request context, and do not clear unrelated blockers. Existing immutable Skill snapshots remain pinned; changes are not deployed by this PR.

## Coverage notes

Manual verification includes production history inspection and offline replay. Automated coverage exercises the readiness Activity → portable Skill → workflow completion handoff, late inline findings, malformed comment inventories, stale/untrusted clean responses, unknown review states, and materialized Skill execution outside the repository.

## Changelog

Fix and Review Loop waits for complete reviews and stops after a clean Codex result when other checks are clear.
