### PR TITLE
Fix Omnigent mounted-tool readiness probes

### DIFF
--- a/moonmind/omnigent/host_services/attestation.py
+++ b/moonmind/omnigent/host_services/attestation.py
@@ -465,7 +465,7 @@ class DockerOmnigentHostAttestor:
                     (
                         'test -x "$1"; actual=$(sha256sum "$1" | awk \'{print $1}\'); ',
                         'case ",$2," in *,"$actual",*) :;; *) exit 1;; esac; ',
-                        '"$1" --version >/dev/null',
+                        'executable="$1"; shift 2; "$executable" "$@" >/dev/null',
                     )
                 )
                 _code, observed, _err = await self._backend.run(
@@ -479,7 +479,9 @@ class DockerOmnigentHostAttestor:
                         "--",
                         executable,
                         digests,
+                        *tool["versionProbe"],
                     ],
+                    timeout_seconds=10.0,
                     failure_code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
                 )
                 tool_mount_evidence.append(
@@ -489,6 +491,7 @@ class DockerOmnigentHostAttestor:
                         "path": executable,
                         "accessMode": "read-only",
                         "digestVerified": bool(digests),
+                        "versionProbe": list(tool["versionProbe"]),
                         "probe": observed.strip()[:128],
                     }
                 )

--- a/moonmind/omnigent/host_services/mounted_tools.py
+++ b/moonmind/omnigent/host_services/mounted_tools.py
@@ -102,6 +102,17 @@ class OmnigentMountedToolService:
                 f"resolved tools are absent from the deployment bundle: {unknown}",
                 code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
             )
+        for name in names:
+            probe = manifest[name].get("versionProbe")
+            if (
+                not isinstance(probe, list)
+                or not probe
+                or any(not isinstance(arg, str) or not arg for arg in probe)
+            ):
+                raise HarnessPlatformError(
+                    f"deployment mounted-tool probe is malformed for {name}",
+                    code=HarnessPlatformFailure.OMNIGENT_HOST_LAUNCH_FAILED,
+                )
         if not _SAFE_VOLUME.fullmatch(self._volume_ref):
             raise HarnessPlatformError(
                 "deployment mounted-tool volume identity is unsafe",
@@ -124,6 +135,7 @@ class OmnigentMountedToolService:
                         "name": name,
                         "version": str(manifest[name].get("version") or ""),
                         "path": str(manifest[name].get("path") or ""),
+                        "versionProbe": list(manifest[name]["versionProbe"]),
                         "executableDigests": sorted(
                             {
                                 str(platform.get("executableSha256") or "")

--- a/tests/integration/reliability/replays/omnigent-mounted-tool-probe/expected-outcome.json
+++ b/tests/integration/reliability/replays/omnigent-mounted-tool-probe/expected-outcome.json
@@ -1,0 +1,7 @@
+{
+  "invariant": "Exact-host attestation executes the deployment manifest's probe as literal arguments after verifying the read-only mount and executable digest, before publishing readiness.",
+  "versionProbe": ["--help"],
+  "probeTimeoutSeconds": 10,
+  "probeFailureExitCode": 2,
+  "failureCode": "OMNIGENT_HARNESS_BUILD_MISMATCH"
+}

--- a/tests/integration/reliability/replays/omnigent-mounted-tool-probe/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-mounted-tool-probe/manifest.json
@@ -1,0 +1,8 @@
+{
+  "incidentWorkflowId": "mm:1d72e336-30cc-434e-9443-c3f833c151bb-2026-09-09T05:41:20Z",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "failureStage": "exact_host_tool_attestation",
+  "failureCode": "OMNIGENT_HARNESS_BUILD_MISMATCH",
+  "requiredTools": ["docker"],
+  "failureShape": "Tool materialization discarded versionProbe and host attestation invoked moonmind --version instead of its declared --help probe. The real CLI exited 2 before the agent started."
+}

--- a/tests/integration/reliability/test_omnigent_mounted_tool_probe.py
+++ b/tests/integration/reliability/test_omnigent_mounted_tool_probe.py
@@ -16,7 +16,7 @@ from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolSer
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
 from tests.integration.reliability.helpers import load_replay
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.reliability_journey]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/reliability/test_omnigent_mounted_tool_probe.py
+++ b/tests/integration/reliability/test_omnigent_mounted_tool_probe.py
@@ -1,0 +1,221 @@
+"""Replay mounted-tool delivery through host attestation and the real CLI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from moonmind.omnigent.host_services import attestation
+from moonmind.omnigent.host_services.docker_backend import DockerCommandBackend
+from moonmind.omnigent.host_services.mounted_tools import OmnigentMountedToolService
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+@pytest.mark.parametrize(
+    "harness_id", ["opencode-native", "codex-native", "claude-native"]
+)
+@pytest.mark.parametrize("fault", [None, "digest", "probe", "writable_mount"])
+async def test_declared_tool_probe_reaches_exact_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_id: str,
+    fault: str | None,
+) -> None:
+    manifest = load_replay("omnigent-mounted-tool-probe", "manifest.json")
+    expected = load_replay("omnigent-mounted-tool-probe", "expected-outcome.json")
+    repo_root = Path(__file__).resolve().parents[3]
+    bundle = tmp_path / "tools"
+    (bundle / "bin").mkdir(parents=True)
+    executable = bundle / "bin/moonmind"
+    shutil.copyfile(
+        repo_root / "services/omnigent/scripts/moonmind-container-cli.py",
+        executable,
+    )
+    executable.chmod(0o555)
+    probes = []
+    spec = SimpleNamespace(
+        labels={},
+        stepExecutionId="replay-step",
+        workspaceAttachment={
+            "sourceRef": "workspace",
+            "targetPath": "/workspace",
+            "accessMode": "read-write",
+        },
+        skillAttachment={"sourceRef": "skills", "targetPath": "/skills"},
+        controlAttachment=None,
+        githubCredentialAttachment=None,
+    )
+    image_ref = "example/host@sha256:" + "1" * 64
+    build_digest = "sha256:" + "2" * 64
+
+    class Backend(DockerCommandBackend):
+        async def inspect_container(self, _name):
+            return {
+                "Config": {"Labels": {}, "Image": image_ref},
+                "Mounts": [
+                    {"Name": "workspace", "Destination": "/workspace", "RW": True},
+                    {"Name": "skills", "Destination": "/skills", "RW": False},
+                    {
+                        "Name": "replay-tools",
+                        "Destination": str(bundle),
+                        "RW": fault == "writable_mount",
+                    },
+                ],
+            }
+
+        async def run(self, argv, **kwargs):
+            if argv[:3] == ["docker", "volume", "inspect"]:
+                return 0, "[]", ""
+            if argv[:3] == ["docker", "image", "inspect"]:
+                return (
+                    0,
+                    json.dumps(
+                        [
+                            {
+                                "Config": {
+                                    "Labels": {
+                                        "moonmind.omnigent.build_digest": build_digest
+                                    }
+                                },
+                                "RepoDigests": [image_ref],
+                                "Os": "linux",
+                                "Architecture": "amd64",
+                            }
+                        ]
+                    ),
+                    "",
+                )
+            if argv[3:] == ["/opt/venv/bin/omnigent", "--version"]:
+                return 0, "omnigent 1.0", ""
+            if argv[3:6] == ["/bin/sh", "-ceu", 'test -d "$1"; test -r "$1"']:
+                return 0, "", ""
+            if argv[:2] == ["docker", "exec"] and "sha256sum" in argv[5]:
+                probes.append((argv, kwargs))
+                # Substitute only Docker transport: execute the production shell
+                # command, digest check, and real mounted CLI in a local process.
+                return await super().run(argv[3:], **kwargs)
+            raise AssertionError(f"unexpected attestation command: {argv}")
+
+    backend = Backend()
+    service = OmnigentMountedToolService(backend=backend, volume_ref="replay-tools")
+    spec.toolAttachments = await service.materialize(
+        {
+            "tools": manifest["requiredTools"],
+            "toolDeliveryRef": "tool-delivery:sha256:" + "3" * 64,
+        }
+    )
+    attachment = spec.toolAttachments[0]
+    attachment["targetPath"] = str(bundle)
+    tool = attachment["tools"][0]
+    assert tool["versionProbe"] == expected["versionProbe"]
+    if fault == "digest":
+        tool["executableDigests"] = ["0" * 64]
+    elif fault == "probe":
+        tool["versionProbe"] = ["--version"]
+        code, _out, _err = await DockerCommandBackend().run(
+            [str(executable), "--version"],
+            check=False,
+        )
+        assert code == expected["probeFailureExitCode"]
+
+    # Other attestation services are independent of mounted tools. Preserve the
+    # full attestor ordering and evidence publication while isolating those seams.
+    monkeypatch.setattr(
+        attestation,
+        "_run_exact_host_runner_command",
+        AsyncMock(return_value=(0, "", "")),
+    )
+    monkeypatch.setattr(
+        attestation,
+        "_run_exact_host_opencode_command",
+        AsyncMock(return_value=(0, "", "")),
+    )
+    monkeypatch.setattr(
+        attestation, "attest_docker_workload_egress", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(
+        attestation,
+        "_read_exact_host_model_options",
+        AsyncMock(
+            return_value=(
+                {"models": [{"id": "test/model"}]},
+                "test",
+            )
+        ),
+    )
+    artifacts = SimpleNamespace(
+        write_json=AsyncMock(side_effect=["artifact:host", "artifact:models"])
+    )
+    host_attestor = attestation.DockerOmnigentHostAttestor(
+        backend=backend,
+        client=SimpleNamespace(),
+        artifacts=artifacts,
+    )
+    arguments = dict(
+        request=SimpleNamespace(),
+        plan=SimpleNamespace(
+            payload=SimpleNamespace(
+                harnessId=harness_id,
+                harnessImplementationRef="test@1",
+                modelConfig=SimpleNamespace(qualifiedId="test/model"),
+            )
+        ),
+        spec=spec,
+        host_class=SimpleNamespace(
+            imageRef=image_ref,
+            omnigentBuildDigest=build_digest,
+            architectures=["linux/amd64"],
+            omnigentVersion="1.0",
+            declaredHarnessImplementations=[
+                SimpleNamespace(
+                    harnessId=harness_id,
+                    implementationRef="test@1",
+                    runtimeDependencies=[],
+                )
+            ],
+        ),
+        launch_result={"containerName": "replay-host"},
+        registration={
+            "omnigentHostId": "replay-host",
+            "host": {},
+            "harnessReady": True,
+        },
+        credential_handles=[],
+        egress_attestation={
+            "profileRef": "test",
+            "profileDigest": "test",
+            "enforcerImplementation": "test",
+            "backendRef": "test",
+            "networkRef": "test",
+            "gatewayRef": "test",
+            "appliedRuleDigest": "test",
+            "configDigest": "test",
+            "gatewayImageDigest": "test",
+            "validatedAt": "2026-09-09T05:41:20Z",
+            "attestationRef": "artifact:egress",
+        },
+    )
+    if fault:
+        with pytest.raises(HarnessPlatformError) as exc:
+            await host_attestor.attest(**arguments)
+        assert exc.value.code == expected["failureCode"]
+        artifacts.write_json.assert_not_awaited()
+    else:
+        result = await host_attestor.attest(**arguments)
+        assert result["hostHarnessAttestationRef"] == "artifact:host"
+        evidence = artifacts.write_json.await_args_list[0].kwargs["payload"]
+        assert evidence["toolMounts"][0]["digestVerified"] is True
+        assert evidence["toolMounts"][0]["versionProbe"] == expected["versionProbe"]
+    if fault == "writable_mount":
+        assert probes == []
+    else:
+        assert len(probes) == 1
+        assert probes[0][1]["timeout_seconds"] == expected["probeTimeoutSeconds"]

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -3010,6 +3010,7 @@ async def test_tool_delivery_uses_plan_names_and_deployment_owned_volume(
                         "name": "gh",
                         "version": "2.76.2",
                         "path": "bin/gh",
+                        "versionProbe": ["--version"],
                         "platforms": {"linux/amd64": {"executableSha256": "a" * 64}},
                     }
                 ]
@@ -3037,6 +3038,29 @@ async def test_tool_delivery_uses_plan_names_and_deployment_owned_volume(
     assert result[0]["sourceRef"] == "deployment-tools"
     assert result[0]["accessMode"] == "read-only"
     assert result[0]["tools"][0]["executableDigests"] == ["a" * 64]
+    assert result[0]["tools"][0]["versionProbe"] == ["--version"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("probe", [None, [], "--help", [None], [""]])
+async def test_tool_delivery_rejects_invalid_probe_before_docker(
+    tmp_path: Path,
+    probe: object,
+) -> None:
+    manifest = tmp_path / "manifest.lock.json"
+    manifest.write_text(
+        json.dumps({"tools": [{"name": "docker", "versionProbe": probe}]}),
+        encoding="utf-8",
+    )
+    backend = SimpleNamespace(run=AsyncMock())
+    service = OmnigentMountedToolService(backend=backend, manifest_path=manifest)
+
+    with pytest.raises(HarnessPlatformError, match="probe is malformed"):
+        await service.materialize(
+            {"toolDeliveryRef": "tool-delivery:sha256:" + "1" * 64, "tools": ["docker"]}
+        )
+
+    backend.run.assert_not_awaited()
 
 
 def test_deployment_mounted_tool_names_come_from_locked_manifest(


### PR DESCRIPTION
Omnigent host attestation discarded each mounted tool's declared probe and always invoked `--version`. Workflows requiring the MoonMind container CLI therefore failed before the agent started because that CLI declares `--help`, producing a misleading `OMNIGENT_HARNESS_BUILD_MISMATCH`.

Preserve and validate the manifest's `versionProbe`, execute its arguments literally after the existing mount and checksum checks, and bound the probe to 10 seconds. Record the selected probe in host evidence. Workflow/activity signatures and persisted plan inputs are unchanged.

Validation:

- 87 targeted unit tests passed through `tools/test_unit.sh`, including both repository prechecks.
- 12 required-CI replay cases passed across OpenCode, Codex, and Claude, exercising the real CLI and production attestation command. Digest mismatches, writable mounts, and unsuccessful probes continue to reject readiness.
- Deployed `gh` and MoonMind CLI probes passed against their pinned checksums in a temporary, unprivileged host container.
- The runtime worker was reloaded successfully; health, dashboard assets, and read-only workflow API checks passed.

Incident: `mm:1d72e336-30cc-434e-9443-c3f833c151bb-2026-09-09T05:41:20Z`.
