### PR TITLE
Fix checkpoint capture rejecting excluded Skill aliases

### DIFF
--- a/docs/Workflows/WorkspaceLocators.md
+++ b/docs/Workflows/WorkspaceLocators.md
@@ -13,6 +13,14 @@ and restores it through `workspace.apply_checkpoint`, retaining normal containme
 digest, and symlink checks. Omnigent session restore never applies a local archive,
 and workspace restore does not require the original Omnigent host.
 
+Sandbox archive safety checks use the same membership rules as archive capture.
+Excluded Skill projection trees (`.agents/skills` and `.gemini/skills`) are neither
+archived nor grounds for rejecting a checkpoint because of their links or owner.
+Included links must still resolve within the authoritative workspace, including
+links that reach an external target through an excluded projection. Runtime Skill
+materialization owns projection validation; checkpoint capture never follows or
+repairs those excluded trees.
+
 The **Codex via Omnigent** product path (canonical identity `agentKind=external`, `agentId=omnigent`, nested harness `codex-native`) applies this authority contract as specified by [`docs/Omnigent/CodexCreateToHostContract.md`](../Omnigent/CodexCreateToHostContract.md) and reconciled end-to-end by [`docs/Omnigent/NormalCodexProductPathReconciliation.md`](../Omnigent/NormalCodexProductPathReconciliation.md). Workflow Create never authors absolute paths or daemon bind sources.
 
 Durable workflow payloads identify workspaces with the discriminated

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2929,26 +2929,6 @@ class TemporalSandboxActivities:
     def _provider_lease_refs(self, context_ref: str | None) -> list[str]:
         return [context_ref] if context_ref else []
 
-    def _workspace_has_unsafe_skill_projection(self, workspace: Path) -> bool:
-        try:
-            workspace_uid = workspace.lstat().st_uid
-        except OSError:
-            return True
-        for relative in (".agents/skills", ".gemini/skills"):
-            candidate = workspace / relative
-            if not candidate.exists():
-                continue
-            try:
-                info = candidate.lstat()
-            except OSError:
-                continue
-            # A projection owned by a different principal than the authoritative
-            # workspace is unsafe. UID 0 alone is not evidence of a mismatch:
-            # hermetic CI legitimately creates the whole workspace as root.
-            if info.st_uid != workspace_uid or candidate.is_symlink():
-                return True
-        return False
-
     @staticmethod
     def _workspace_archive_excludes(relative: Path) -> bool:
         return any(part in {".git", "__pycache__"} for part in relative.parts) or (
@@ -3047,10 +3027,10 @@ class TemporalSandboxActivities:
             )
         )
 
-        if model.kind == "worktree_archive" and (
-            self._workspace_has_traversal(workspace)
-            or self._workspace_has_unsafe_skill_projection(workspace)
-        ):
+        # Validate the same members that the archive builder includes. Skill
+        # projections are excluded runtime state; their links and ownership
+        # cannot make an otherwise safe repository checkpoint unsafe.
+        if model.kind == "worktree_archive" and self._workspace_has_traversal(workspace):
             diagnostic_ref = await self._put_checkpoint_bytes(
                 b"unsafe workspace materialization",
                 content_type="text/plain",

--- a/tests/integration/reliability/replays/checkpoint-excluded-skill-alias/manifest.json
+++ b/tests/integration/reliability/replays/checkpoint-excluded-skill-alias/manifest.json
@@ -1,0 +1,14 @@
+{
+  "incidentWorkflowId": "mm:5c182f75-c005-4edc-aa1b-eca086a515c1-2026-09-09T07:34:56Z",
+  "runtime": "external/omnigent",
+  "harness": "opencode",
+  "failedActivityType": "workspace.capture_checkpoint",
+  "failureCode": "unsafe_checkpoint",
+  "failureShape": "An excluded repository-local .gemini/skills symlink was rejected after every successful agent step; the parent failed despite a merged PR.",
+  "workspace": {
+    "files": {"result.txt": "verified implementation\n", ".agents/skills/skills/example/SKILL.md": "repository skill\n"},
+    "symlinks": {".gemini/skills": "../.agents/skills/skills"}
+  },
+  "eventScript": ["capture through worker binding", "inspect durable archive", "delete source workspace", "restore archive"],
+  "expected": {"captureStatus": "captured", "excludedPrefixes": [".agents/skills", ".gemini/skills"], "includedEscapeStatus": "unsafe"}
+}

--- a/tests/integration/reliability/test_checkpoint_excluded_skill_alias.py
+++ b/tests/integration/reliability/test_checkpoint_excluded_skill_alias.py
@@ -18,7 +18,7 @@ from moonmind.workflows.temporal.activity_runtime import (
     build_activity_bindings,
 )
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.reliability_journey]
 
 
 @pytest.mark.parametrize("legacy_path", [False, True], ids=["locator", "historical-path"])

--- a/tests/integration/reliability/test_checkpoint_excluded_skill_alias.py
+++ b/tests/integration/reliability/test_checkpoint_excluded_skill_alias.py
@@ -1,0 +1,122 @@
+"""Archive membership is the safety boundary, including for Skill aliases."""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
+from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalSandboxActivities,
+    build_activity_bindings,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.integration_ci]
+
+
+@pytest.mark.parametrize("legacy_path", [False, True], ids=["locator", "historical-path"])
+@pytest.mark.parametrize("alias_target", ["internal", "external", "dangling"])
+async def test_excluded_skill_alias_capture_and_restore(
+    tmp_path: Path,
+    legacy_path: bool,
+    alias_target: str,
+) -> None:
+    fixture_path = (
+        Path(__file__).parent
+        / "replays/checkpoint-excluded-skill-alias/manifest.json"
+    )
+    fixture = json.loads(fixture_path.read_text())
+    repo = tmp_path / "temporal_sandbox/source/repo"
+    for name, contents in fixture["workspace"]["files"].items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+    outside = tmp_path / "resolved-skills"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("must never enter the checkpoint\n")
+    (repo / ".agents/skills/_shared").symlink_to(outside, target_is_directory=True)
+    for name, target in fixture["workspace"]["symlinks"].items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if alias_target != "internal":
+            target = str(
+                outside if alias_target == "external" else tmp_path / "missing-skills"
+            )
+        path.symlink_to(target, target_is_directory=True)
+
+    store = InMemoryArtifactStore()
+    sandbox = TemporalSandboxActivities(workspace_root=tmp_path, artifact_store=store)
+    binding = next(
+        item
+        for item in build_activity_bindings(
+            build_default_activity_catalog(),
+            sandbox_activities=sandbox,
+            fleets=["sandbox"],
+        )
+        if item.activity_type == fixture["failedActivityType"]
+    )
+    request = {
+        "identity": {
+            "workflowId": "replay",
+            "runId": "replay-run",
+            "logicalStepId": "implement",
+            "executionOrdinal": 1,
+        },
+        "boundary": "after_execution",
+        "kind": "worktree_archive",
+        "artifactNamespace": "checkpoint",
+        "idempotencyKey": "capture-replay",
+    }
+    if legacy_path:
+        request["workspacePath"] = str(repo)
+    else:
+        request["workspaceLocator"] = {
+            "kind": "sandbox",
+            "workspaceId": "source",
+            "relativePath": "repo",
+        }
+    capture = await ActivityEnvironment().run(binding.handler, request)
+    assert capture["status"] == fixture["expected"]["captureStatus"]
+    archive_bytes = store.get_bytes(capture["workspace"]["archiveRef"])
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+        assert archive.getnames() == ["result.txt"]
+    manifest = json.loads(store.get_bytes(capture["workspace"]["manifestRef"]))
+    assert [entry["path"] for entry in manifest["entries"]] == ["result.txt"]
+
+    # Exclusion is lexical: an included alias into the excluded external tree
+    # still escapes the workspace and must fail closed.
+    (repo / "escape").symlink_to(".agents/skills/_shared", target_is_directory=True)
+    rejected = await ActivityEnvironment().run(binding.handler, request)
+    assert rejected["status"] == fixture["expected"]["includedEscapeStatus"]
+    assert rejected["failureCode"] == "unsafe_checkpoint"
+
+    shutil.rmtree(repo)
+    restored = tmp_path / "temporal_sandbox/restored/repo"
+    checkpoint_ref = store.put_bytes(
+        json.dumps({"workspace": capture["workspace"]}).encode(),
+        content_type="application/json",
+    ).artifact_ref
+    restore = await sandbox.workspace_apply_policy(
+        {
+            "identity": request["identity"],
+            "workspacePolicy": "restore_pre_execution",
+            "checkpointRef": checkpoint_ref,
+            "targetWorkspaceRef": str(restored),
+            "idempotencyKey": "restore-replay",
+        }
+    )
+    assert restore["status"] == "applied"
+    assert (
+        (restored / "result.txt").read_text()
+        == fixture["workspace"]["files"]["result.txt"]
+    )
+    assert not (restored / ".agents").exists()
+    assert not (restored / ".gemini").exists()
+    assert (outside / "SKILL.md").read_text() == "must never enter the checkpoint\n"

--- a/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
+++ b/tests/integration/workflows/temporal/test_step_checkpoint_activities.py
@@ -1286,8 +1286,7 @@ async def test_checkpoint_activity_failures_are_typed_and_secret_safe(
     store = InMemoryArtifactStore()
     root = _workspace_root(tmp_path)
     repo = _repo(root)
-    (repo / ".agents").mkdir(parents=True)
-    (repo / ".agents" / "skills").symlink_to(tmp_path)
+    (repo / "unsafe-link").symlink_to(tmp_path)
     sandbox = TemporalSandboxActivities(workspace_root=root, artifact_store=store)
     checkpoint_activities = TemporalCheckpointActivities(artifact_store=store)
 


### PR DESCRIPTION
## Summary

Fix checkpoint capture rejecting excluded Skill aliases. Workflow `mm:5c182f75-c005-4edc-aa1b-eca086a515c1-2026-09-09T07:34:56Z` completed its agent work and merged Tactics PR #2673, but required checkpoints rejected the tracked `.gemini/skills -> ../.agents/skills/skills` link and left the parent failed.

Archive capture now uses its existing membership-aware traversal check instead of an additional blanket Skill-link/ownership veto. Excluded Skill trees stay out of archives; included links that escape through them still fail closed. Add a minimized incident replay covering worker-bound capture, durable archive inspection, source deletion, and restore with current and historical request shapes.

## Test Plan

```bash
MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_checkpoint_restore.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_step_checkpoint_contracts.py
MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest tests/integration/reliability/test_checkpoint_excluded_skill_alias.py tests/integration/workflows/temporal/test_step_checkpoint_activities.py -q --tb=short
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local MOONMIND_INTEGRATION_WORKERS=6 ./tools/test_integration.sh
```

The incident replay failed with `unsafe_checkpoint` before the fix. Targeted unit: 138 passed. Focused integration: 39 passed. Full hermetic integration: 736 passed.

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Security / policy / sandboxing change
- [x] Test / CI

## Test coverage

- [x] Integration tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Existing tests cover this change

## Risk notes

Archive membership and restore containment remain unchanged. Runtime projection validation stays with the materializer. No workflow command, activity signature, or persisted payload changes; the replay exercises both `workspaceLocator` and historical `workspacePath` inputs. This PR does not rewrite the historical failed run or redeploy services.

## Changelog

Repository Skill aliases no longer cause otherwise valid workspace checkpoints to fail.
