### PR TITLE
Key OpenCode host admission to the running Omnigent server

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -419,6 +419,7 @@ async def _sync_omnigent_deployment_images() -> bool:
 
     try:
         from moonmind.omnigent.bootstrap.image_resolution import (
+            pending_host_remediation,
             publish_resolved_omnigent_images,
         )
         from moonmind.omnigent.settings import (
@@ -458,15 +459,14 @@ async def _sync_omnigent_deployment_images() -> bool:
             else None
         )
         if isinstance(pending_host, dict) and pending_host.get("imageRef"):
-            # The registry published a host for a newer Omnigent server than
-            # the one Compose is running. The compatible admitted host stays
-            # launch authority; the operator adopts the newer pair by updating
-            # the omnigent service, not by MoonMind restarting it.
+            # The registry published a host the running server cannot admit.
+            # The compatible admitted host stays launch authority; the
+            # remediation depends on why the newer host failed, and MoonMind
+            # never performs it itself.
             logger.warning(
                 "Omnigent host image %s is pending: %s (host build %s, omnigent %s) "
                 "against the running server %s (omnigent %s). Keeping the "
-                "compatible host %s; update the omnigent Compose service to "
-                "adopt the newer image.",
+                "compatible host %s; %s.",
                 pending_host.get("imageRef"),
                 pending_host.get("failureCode"),
                 pending_host.get("buildDigest"),
@@ -474,6 +474,7 @@ async def _sync_omnigent_deployment_images() -> bool:
                 compatibility.get("serverImageRef"),
                 compatibility.get("serverVersion"),
                 state.opencode_host_image_ref,
+                pending_host_remediation(pending_host.get("failureCode")),
             )
         logger.info(
             "Resolved Omnigent deployment images: serverImageRef=%s "

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -452,6 +452,29 @@ async def _sync_omnigent_deployment_images() -> bool:
                 "host image is available for the configured image and tag",
             )
             return False
+        pending_host = (
+            compatibility.get("pendingHost")
+            if isinstance(compatibility, dict)
+            else None
+        )
+        if isinstance(pending_host, dict) and pending_host.get("imageRef"):
+            # The registry published a host for a newer Omnigent server than
+            # the one Compose is running. The compatible admitted host stays
+            # launch authority; the operator adopts the newer pair by updating
+            # the omnigent service, not by MoonMind restarting it.
+            logger.warning(
+                "Omnigent host image %s is pending: %s (host build %s, omnigent %s) "
+                "against the running server %s (omnigent %s). Keeping the "
+                "compatible host %s; update the omnigent Compose service to "
+                "adopt the newer image.",
+                pending_host.get("imageRef"),
+                pending_host.get("failureCode"),
+                pending_host.get("buildDigest"),
+                pending_host.get("version"),
+                compatibility.get("serverImageRef"),
+                compatibility.get("serverVersion"),
+                state.opencode_host_image_ref,
+            )
         logger.info(
             "Resolved Omnigent deployment images: serverImageRef=%s "
             "opencodeHostImageRef=%s",

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -563,6 +563,23 @@ disabled. Missing or incomplete caches, failed startup, and probe timeouts
 block compatibility even when labels and versions match. Host Class selection
 and advertised inventory consume that verdict until reconciliation succeeds.
 
+Host admission is keyed by the running server, not by the newest tag. On the
+default mutable-tag path the resolver judges the freshly resolved tag first and
+the currently admitted host second, and the first candidate that passes the
+full compatibility ladder becomes launch authority. When the registry has
+already published a host for a newer Omnigent server than Compose is running,
+the admitted compatible host stays authoritative and the newer image is
+recorded as `opencodeHostCompatibility.pendingHost` (image ref, host build,
+host version, and the failure code it would raise). The API logs that pending
+pair on every reconciliation pass; the operator adopts it by updating the
+`omnigent` Compose service, after which the fresh tag passes and replaces the
+admitted host. Quarantine is reserved for the case where no candidate is
+compatible with the running server. An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF`
+pin is a single candidate: it is quarantined, never replaced. When the shared
+host coordinates resolve to the same image the OpenCode path judged, the
+shared ref follows the admitted digest so Codex and Claude Host Classes never
+launch a host built for a different server.
+
 `OMNIGENT_BUILD_DIGEST` remains optional operator authority only for an independently paired server and host build. An image manifest digest must not be substituted for the separate portable Omnigent build identity.
 
 ## 14. Image release and compatibility

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -571,10 +571,16 @@ already published a host for a newer Omnigent server than Compose is running,
 the admitted compatible host stays authoritative and the newer image is
 recorded as `opencodeHostCompatibility.pendingHost` (image ref, host build,
 host version, and the failure code it would raise). The API logs that pending
-pair on every reconciliation pass; the operator adopts it by updating the
-`omnigent` Compose service, after which the fresh tag passes and replaces the
-admitted host. Quarantine is reserved for the case where no candidate is
-compatible with the running server. An explicit `OMNIGENT_OPENCODE_HOST_IMAGE_REF`
+pair on every reconciliation pass together with the remediation derived from
+its failure code: a server/host build or version drift is adopted by updating
+the `omnigent` Compose service, while a host that failed its own qualification
+or contradicts `OMNIGENT_BUILD_DIGEST` must be repaired or republished and never
+prompts a server update. Once the failure is cured the fresh tag passes and
+replaces the admitted host. When server evidence is temporarily unavailable
+(for example while the Omnigent container restarts) nothing is judged and the
+admitted host is retained as the persisted ref. Quarantine is reserved for the
+case where no candidate is compatible with the running server. An explicit
+`OMNIGENT_OPENCODE_HOST_IMAGE_REF`
 pin is a single candidate: it is quarantined, never replaced. When the shared
 host coordinates resolve to the same image the OpenCode path judged, the
 shared ref follows the admitted digest so Codex and Claude Host Classes never

--- a/docs/Omnigent/SharedHostImage.md
+++ b/docs/Omnigent/SharedHostImage.md
@@ -58,6 +58,14 @@ OMNIGENT_SHARED_HOST_IMAGE_TAG="1.18.11"
 
 Mutable tags never become launch authority. Startup resolution (`moonmind/omnigent/bootstrap/image_resolution.py`) resolves the tag to its immutable digest once, persists it in the resolved deployment state (`sharedHostImageRef`), exports it to `OMNIGENT_SHARED_HOST_IMAGE_REF`, and every selector (`get_shared_host_image_ref()`) reads that digest. A missing, mutable, or placeholder digest fails closed.
 
+The publish workflow tracks `omnigent-server:latest`, so a republished tag may
+carry a host built for a newer server than a deployment is running. When the
+shared coordinates resolve to the same image the OpenCode path judged against
+the running server, the shared ref follows the admitted OpenCode digest and the
+newer image waits as `pendingHost` until the operator updates the `omnigent`
+Compose service (see [`OpenCodeHost.md`](./OpenCodeHost.md) §13). An explicit
+`OMNIGENT_SHARED_HOST_IMAGE_REF` pin is never replaced.
+
 ## 2. Runtime packs (`moonmind.omnigent-harness-runtime-pack.v1`)
 
 A runtime pack is trusted deployment data, never workflow-authored. The registry is pure data: it carries no secret, image digest, or endpoint. One pack owns one harness family:

--- a/moonmind/omnigent/bootstrap/image_resolution.py
+++ b/moonmind/omnigent/bootstrap/image_resolution.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -46,6 +47,18 @@ def _extract_digest(ref: str) -> str | None:
         if len(digest) == 64 and all(c in "0123456789abcdef" for c in digest.lower()):
             return "sha256:" + digest.lower()
     return None
+
+
+def _is_operator_pin(value: object) -> bool:
+    """Return whether ``value`` is an explicit, non-placeholder digest pin."""
+
+    pinned = str(value or "").strip()
+    return bool(
+        pinned
+        and _is_digest_pinned(pinned)
+        and not pinned.endswith("0" * 64)
+        and not pinned.endswith("c" * 64)
+    )
 
 
 def _image_repository(image: str) -> str:
@@ -143,12 +156,7 @@ async def _resolve_image(
     """Resolve one image to a digest-pinned ref and its image digest."""
     source = os.environ if env is None else env
     pinned = str(source.get(ref_env) or "").strip()
-    if (
-        pinned
-        and _is_digest_pinned(pinned)
-        and not pinned.endswith("0" * 64)
-        and not pinned.endswith("c" * 64)
-    ):
+    if _is_operator_pin(pinned):
         # Valid pinned ref
         build_digest = _extract_digest(pinned)
         return pinned, build_digest
@@ -255,6 +263,62 @@ async def _image_omnigent_version(image_ref: str) -> str | None:
     return match.group(1) if match is not None else None
 
 
+@dataclass(frozen=True)
+class _OpenCodeHostVerdict:
+    """Compatibility verdict for one OpenCode host image candidate."""
+
+    image_ref: str
+    failure_code: str | None
+    build_digest: str | None
+    version: str | None
+
+    def pending_payload(self) -> dict[str, str | None]:
+        return {
+            "imageRef": self.image_ref,
+            "buildDigest": self.build_digest,
+            "version": self.version,
+            "failureCode": self.failure_code,
+        }
+
+
+async def _evaluate_opencode_host(
+    image_ref: str,
+    *,
+    server_ref: str | None,
+    server_image_digest: str | None,
+    server_version: str | None,
+    configured_build_digest: str,
+) -> _OpenCodeHostVerdict:
+    """Judge one host image against the running server's build identity.
+
+    The ladder is the paired-runtime contract: shared build identity, equal
+    executable Omnigent versions, then the release bootstrap probe. Every
+    candidate passes through the same ladder, so the admitted host is always
+    the one that proved compatibility with the server actually running.
+    """
+
+    build_digest = await _image_build_identity(image_ref)
+    version = await _image_omnigent_version(image_ref)
+    failure: str | None
+    if not server_ref or not server_image_digest:
+        failure = "omnigent_server_build_unavailable"
+    elif not build_digest:
+        failure = "omnigent_host_build_identity_unavailable"
+    elif configured_build_digest and configured_build_digest != build_digest:
+        failure = "omnigent_operator_host_build_mismatch"
+    elif not configured_build_digest and server_image_digest != build_digest:
+        failure = "omnigent_server_host_build_mismatch"
+    elif server_version is None or version is None:
+        failure = "omnigent_server_host_version_probe_failed"
+    elif server_version != version:
+        failure = "omnigent_server_host_version_mismatch"
+    elif not await _image_opencode_bootstrap_ready(image_ref):
+        failure = "omnigent_host_bootstrap_contract_missing"
+    else:
+        failure = None
+    return _OpenCodeHostVerdict(image_ref, failure, build_digest, version)
+
+
 async def resolve_omnigent_images(
     env: Mapping[str, str] | None = None,
 ) -> ResolvedOmnigentDeploymentState:
@@ -301,13 +365,38 @@ async def resolve_omnigent_images(
             "OMNIGENT_IMAGE", "OMNIGENT_IMAGE_TAG", "OMNIGENT_IMAGE_REF", source
         )
 
-    # OpenCode host image
-    opencode_ref, _ = await _resolve_image(
+    # OpenCode host image. The configured coordinate is a refreshable input;
+    # the running server's build identity is the admission key. Every
+    # candidate is judged against that key, so a newer registry image cannot
+    # displace a compatible admitted host until the server itself moves.
+    host_pinned = _is_operator_pin(source.get("OMNIGENT_OPENCODE_HOST_IMAGE_REF"))
+    fresh_host_ref, _ = await _resolve_image(
         "OMNIGENT_OPENCODE_HOST_IMAGE",
         "OMNIGENT_OPENCODE_HOST_IMAGE_TAG",
         "OMNIGENT_OPENCODE_HOST_IMAGE_REF",
         source,
     )
+    host_candidates: list[str] = [fresh_host_ref] if fresh_host_ref else []
+    previous_host_ref = (
+        str(previous.opencode_host_image_ref or "").strip() if previous else ""
+    )
+    configured_host_repository = _image_repository(
+        fresh_host_ref or str(source.get("OMNIGENT_OPENCODE_HOST_IMAGE") or "").strip()
+    )
+    if (
+        not host_pinned
+        and previous_host_ref
+        and previous_host_ref not in host_candidates
+        and _is_digest_pinned(previous_host_ref)
+        and (
+            not configured_host_repository
+            or _image_repository(previous_host_ref) == configured_host_repository
+        )
+    ):
+        # The currently admitted host stays a candidate on the mutable-tag
+        # path as long as it belongs to the configured repository. An explicit
+        # operator pin is quarantined, never replaced.
+        host_candidates.append(previous_host_ref)
 
     # Pi host (optional)
     pi_ref, _ = await _resolve_image(
@@ -334,8 +423,6 @@ async def resolve_omnigent_images(
     ):
         server_ref = previous.server_image_ref
         server_image_digest = _extract_digest(server_ref)
-    if not opencode_ref and previous and previous.opencode_host_image_ref:
-        opencode_ref = previous.opencode_host_image_ref
     if not pi_ref and previous and previous.pi_host_image_ref:
         pi_ref = previous.pi_host_image_ref
     if not shared_ref and previous and previous.shared_host_image_ref:
@@ -350,31 +437,56 @@ async def resolve_omnigent_images(
     configured_build_digest = str(source.get("OMNIGENT_BUILD_DIGEST") or "").strip()
     if configured_build_digest and not _SHA256_RE.fullmatch(configured_build_digest):
         raise ValueError("OMNIGENT_BUILD_DIGEST must be an exact sha256 identity")
-    host_build_digest = (
-        await _image_build_identity(opencode_ref) if opencode_ref else None
-    )
     server_version = (
         await _image_omnigent_version(server_ref)
-        if server_ref and opencode_ref
+        if server_ref and host_candidates
         else None
     )
-    host_version = await _image_omnigent_version(opencode_ref) if opencode_ref else None
-    compatibility_failure: str | None = None
-    if opencode_ref:
-        if not server_ref or not server_image_digest:
-            compatibility_failure = "omnigent_server_build_unavailable"
-        elif not host_build_digest:
-            compatibility_failure = "omnigent_host_build_identity_unavailable"
-        elif configured_build_digest and configured_build_digest != host_build_digest:
-            compatibility_failure = "omnigent_operator_host_build_mismatch"
-        elif not configured_build_digest and server_image_digest != host_build_digest:
-            compatibility_failure = "omnigent_server_host_build_mismatch"
-        elif server_version is None or host_version is None:
-            compatibility_failure = "omnigent_server_host_version_probe_failed"
-        elif server_version != host_version:
-            compatibility_failure = "omnigent_server_host_version_mismatch"
-        elif not await _image_opencode_bootstrap_ready(opencode_ref):
-            compatibility_failure = "omnigent_host_bootstrap_contract_missing"
+    verdicts: list[_OpenCodeHostVerdict] = []
+    admitted: _OpenCodeHostVerdict | None = None
+    for candidate in host_candidates:
+        verdict = await _evaluate_opencode_host(
+            candidate,
+            server_ref=server_ref,
+            server_image_digest=server_image_digest,
+            server_version=server_version,
+            configured_build_digest=configured_build_digest,
+        )
+        verdicts.append(verdict)
+        if verdict.failure_code is None:
+            admitted = verdict
+            break
+        if verdict.failure_code == "omnigent_server_build_unavailable":
+            # Without server authority no candidate can be admitted.
+            break
+
+    pending_host: _OpenCodeHostVerdict | None = None
+    if admitted is not None:
+        selected: _OpenCodeHostVerdict | None = admitted
+        if verdicts[0].image_ref != admitted.image_ref:
+            # The registry moved ahead of the running server. Keep the
+            # compatible admitted host as launch authority and surface the
+            # newer image as pending until the server is updated.
+            pending_host = verdicts[0]
+    else:
+        selected = verdicts[0] if verdicts else None
+    opencode_ref = selected.image_ref if selected else None
+    host_build_digest = selected.build_digest if selected else None
+    host_version = selected.version if selected else None
+    compatibility_failure = selected.failure_code if selected else None
+
+    if (
+        not _is_operator_pin(source.get("OMNIGENT_SHARED_HOST_IMAGE_REF"))
+        and shared_ref
+        and fresh_host_ref
+        and shared_ref == fresh_host_ref
+        and opencode_ref
+        and opencode_ref != shared_ref
+    ):
+        # The shared host resolved to the very image the OpenCode path judged
+        # incompatible. It is the same runtime pack, so it follows the admitted
+        # digest instead of launching a mismatched host for Codex or Claude.
+        shared_ref = opencode_ref
 
     if compatibility_failure:
         # Keep the current server as catalog authority while quarantining the
@@ -437,6 +549,9 @@ async def resolve_omnigent_images(
                 "hostBuildDigest": host_build_digest,
                 "serverVersion": server_version,
                 "hostVersion": host_version,
+                "pendingHost": (
+                    pending_host.pending_payload() if pending_host else None
+                ),
             },
         },
     )

--- a/moonmind/omnigent/bootstrap/image_resolution.py
+++ b/moonmind/omnigent/bootstrap/image_resolution.py
@@ -319,6 +319,53 @@ async def _evaluate_opencode_host(
     return _OpenCodeHostVerdict(image_ref, failure, build_digest, version)
 
 
+_SERVER_DRIFT_FAILURES = frozenset(
+    {
+        "omnigent_server_host_build_mismatch",
+        "omnigent_server_host_version_mismatch",
+    }
+)
+_HOST_QUALIFICATION_FAILURES = frozenset(
+    {
+        "omnigent_host_build_identity_unavailable",
+        "omnigent_server_host_version_probe_failed",
+        "omnigent_host_bootstrap_contract_missing",
+    }
+)
+
+
+def pending_host_remediation(failure_code: object) -> str:
+    """Name the operator action that lets a pending host become admissible.
+
+    Only a server/host drift is cured by moving the Omnigent server. A host
+    that failed its own qualification, or that contradicts an operator build
+    pin, must be repaired or republished; updating the server would only move
+    the deployment onto an unusable pair.
+    """
+
+    code = str(failure_code or "").strip()
+    if code in _SERVER_DRIFT_FAILURES:
+        return (
+            "the newer host targets a newer Omnigent server; update the "
+            "omnigent Compose service to adopt the pair"
+        )
+    if code == "omnigent_operator_host_build_mismatch":
+        return (
+            "the newer host does not match OMNIGENT_BUILD_DIGEST; update the "
+            "operator build identity or publish a host built for it (do not "
+            "update the omnigent server for this)"
+        )
+    if code in _HOST_QUALIFICATION_FAILURES:
+        return (
+            "the newer host failed its own qualification; repair or republish "
+            "the host image (no omnigent server update is indicated)"
+        )
+    return (
+        "repair or republish the host image, or update the omnigent Compose "
+        "service only if the host targets a newer server"
+    )
+
+
 async def resolve_omnigent_images(
     env: Mapping[str, str] | None = None,
 ) -> ResolvedOmnigentDeploymentState:
@@ -442,6 +489,18 @@ async def resolve_omnigent_images(
         if server_ref and host_candidates
         else None
     )
+    if host_candidates and (not server_ref or not server_image_digest):
+        # Without server authority nothing can be judged. Retain the admitted
+        # host as the persisted ref so this recoverable evidence gap (for
+        # example a restarting Omnigent container) cannot replace it with the
+        # unjudged fresh digest; the retry judges both once the server is
+        # observable again.
+        retained = (
+            previous_host_ref
+            if previous_host_ref in host_candidates
+            else host_candidates[0]
+        )
+        host_candidates = [retained]
     verdicts: list[_OpenCodeHostVerdict] = []
     admitted: _OpenCodeHostVerdict | None = None
     for candidate in host_candidates:
@@ -455,9 +514,6 @@ async def resolve_omnigent_images(
         verdicts.append(verdict)
         if verdict.failure_code is None:
             admitted = verdict
-            break
-        if verdict.failure_code == "omnigent_server_build_unavailable":
-            # Without server authority no candidate can be admitted.
             break
 
     pending_host: _OpenCodeHostVerdict | None = None

--- a/moonmind/omnigent/harness_platform/host_classes.py
+++ b/moonmind/omnigent/harness_platform/host_classes.py
@@ -61,6 +61,26 @@ def _persisted_image_ref(key: str) -> str:
     return str(getattr(state, attribute, "") or "").strip()
 
 
+def _short_digest(value: object) -> str:
+    text = str(value or "").strip()
+    if text.startswith("sha256:") and len(text) > 19:
+        return text[:19]
+    return text or "unknown"
+
+
+def _compatibility_pair_detail(compatibility: Mapping[str, Any]) -> str:
+    """Describe the judged server/host pair so the quarantine is actionable."""
+
+    return (
+        "server omnigent "
+        f"{compatibility.get('serverVersion') or 'unknown'} build "
+        f"{_short_digest(compatibility.get('serverBuildDigest'))} vs host omnigent "
+        f"{compatibility.get('hostVersion') or 'unknown'} built for "
+        f"{_short_digest(compatibility.get('hostBuildDigest'))}; update the "
+        "omnigent server image or pin a host built for the running server"
+    )
+
+
 def _require_image_ref(environment: Mapping[str, str], key: str) -> str:
     state = None
     if key == OMNIGENT_OPENCODE_HOST_IMAGE_ENV:
@@ -119,7 +139,7 @@ def _require_image_ref(environment: Mapping[str, str], key: str) -> str:
             raise HarnessPlatformError(
                 "OpenCode Host Class is quarantined because the resolved "
                 "Omnigent server and host images are incompatible "
-                f"({failure_code})",
+                f"({failure_code}): {_compatibility_pair_detail(compatibility)}",
                 code=HarnessPlatformFailure.OMNIGENT_HARNESS_BUILD_MISMATCH,
             )
         if compatibility.get("status") != "ready":

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -49,11 +49,30 @@ async def test_image_sync_blocks_a_quarantined_opencode_host(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_code, remediation_fragment, forbidden_fragment",
+    [
+        (
+            "omnigent_server_host_build_mismatch",
+            "update the omnigent Compose service",
+            "repair or republish",
+        ),
+        (
+            "omnigent_host_bootstrap_contract_missing",
+            "repair or republish the host image",
+            "update the omnigent Compose service",
+        ),
+    ],
+)
 async def test_image_sync_stays_ready_and_warns_about_a_pending_host(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    failure_code: str,
+    remediation_fragment: str,
+    forbidden_fragment: str,
 ) -> None:
-    """A newer host for a newer server is operator information, not an outage."""
+    """A newer host the server cannot admit is operator information, not an
+    outage, and the remediation follows the pending host's failure code."""
 
     from moonmind.omnigent import settings
     from moonmind.omnigent.bootstrap import image_resolution
@@ -82,7 +101,7 @@ async def test_image_sync_stays_ready_and_warns_about_a_pending_host(
                             "imageRef": pending_host,
                             "buildDigest": "sha256:" + "9" * 64,
                             "version": "0.13.0",
-                            "failureCode": "omnigent_server_host_build_mismatch",
+                            "failureCode": failure_code,
                         },
                     }
                 },
@@ -105,8 +124,9 @@ async def test_image_sync_stays_ready_and_warns_about_a_pending_host(
     message = warnings[0].getMessage()
     assert pending_host in message
     assert admitted_host in message
-    assert "omnigent_server_host_build_mismatch" in message
-    assert "update the omnigent Compose service" in message
+    assert failure_code in message
+    assert remediation_fragment in message
+    assert forbidden_fragment not in message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -49,6 +49,67 @@ async def test_image_sync_blocks_a_quarantined_opencode_host(
 
 
 @pytest.mark.asyncio
+async def test_image_sync_stays_ready_and_warns_about_a_pending_host(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A newer host for a newer server is operator information, not an outage."""
+
+    from moonmind.omnigent import settings
+    from moonmind.omnigent.bootstrap import image_resolution
+    from moonmind.omnigent.bootstrap.models import ResolvedOmnigentDeploymentState
+
+    admitted_host = "ghcr.io/example/host@sha256:" + "a" * 64
+    pending_host = "ghcr.io/example/host@sha256:" + "b" * 64
+
+    async def resolve() -> ResolvedOmnigentDeploymentState:
+        return ResolvedOmnigentDeploymentState.model_validate(
+            {
+                "serverImageRef": "ghcr.io/example/server@sha256:" + "1" * 64,
+                "opencodeHostImageRef": admitted_host,
+                "omnigentBuildDigest": "sha256:" + "1" * 64,
+                "architecture": "linux/arm64",
+                "resolvedAt": datetime(2026, 9, 9, tzinfo=UTC),
+                "details": {
+                    "opencodeHostCompatibility": {
+                        "status": "ready",
+                        "failureCode": None,
+                        "serverImageRef": "ghcr.io/example/server@sha256:" + "1" * 64,
+                        "hostImageRef": admitted_host,
+                        "serverVersion": "0.12.0",
+                        "hostVersion": "0.12.0",
+                        "pendingHost": {
+                            "imageRef": pending_host,
+                            "buildDigest": "sha256:" + "9" * 64,
+                            "version": "0.13.0",
+                            "failureCode": "omnigent_server_host_build_mismatch",
+                        },
+                    }
+                },
+            }
+        )
+
+    class _EnabledGate:
+        enabled = True
+
+    monkeypatch.setattr(image_resolution, "publish_resolved_omnigent_images", resolve)
+    monkeypatch.setattr(settings, "build_omnigent_gate", _EnabledGate)
+    monkeypatch.setattr(settings, "generic_host_enabled", lambda: True)
+    monkeypatch.setattr(settings, "opencode_support_enabled", lambda: True)
+
+    with caplog.at_level(logging.WARNING, logger="api_service.main"):
+        assert await api_main._sync_omnigent_deployment_images() is True
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert pending_host in message
+    assert admitted_host in message
+    assert "omnigent_server_host_build_mismatch" in message
+    assert "update the omnigent Compose service" in message
+
+
+@pytest.mark.asyncio
 async def test_omnigent_bootstrap_retries_with_capped_backoff_and_maintains_inventory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -374,6 +374,7 @@ async def test_default_resolution_requires_paired_build_identity_and_version(
             "hostBuildDigest": BUILD_DIGEST,
             "serverVersion": "0.12.0",
             "hostVersion": "0.12.0",
+            "pendingHost": None,
         },
     }
 
@@ -435,6 +436,7 @@ async def test_resolution_quarantines_operator_and_host_build_identity_mismatch(
         "hostBuildDigest": BUILD_DIGEST,
         "serverVersion": "0.12.0",
         "hostVersion": "0.12.0",
+        "pendingHost": None,
     }
 
 
@@ -546,6 +548,7 @@ async def test_resolution_quarantines_server_and_host_build_drift(
         "hostBuildDigest": stale_host_build,
         "serverVersion": "0.12.0",
         "hostVersion": "0.11.0",
+        "pendingHost": None,
     }
 
 
@@ -843,3 +846,297 @@ def test_host_selection_preserves_adjacent_image_failures(
             materializer_refs=["opencode-auth-json@1"],
             requested_host_class_ref="omnigent-opencode@1",
         )
+
+
+# --- Server-keyed host selection -------------------------------------------
+#
+# Replay of the 2026-09-09 production failure: the host publish workflow
+# tracks ``omnigent-server:latest`` and republished the mutable ``1.18.11`` tag
+# for Omnigent 0.13.0 while Compose was still running the 0.12.0 server. The
+# resolver must keep the admitted compatible host as launch authority and
+# surface the newer image as pending instead of quarantining the Host Class.
+
+HOST_REPOSITORY = "ghcr.io/moonladderstudios/omnigent-host-moonmind"
+RUNNING_SERVER_BUILD = "sha256:" + "1" * 64
+NEWER_SERVER_BUILD = "sha256:" + "9" * 64
+ADMITTED_HOST = HOST_REPOSITORY + "@sha256:" + "a" * 64
+NEWER_HOST = HOST_REPOSITORY + "@sha256:" + "b" * 64
+_HOST_BUILDS = {ADMITTED_HOST: RUNNING_SERVER_BUILD, NEWER_HOST: NEWER_SERVER_BUILD}
+_HOST_VERSIONS = {ADMITTED_HOST: "0.12.0", NEWER_HOST: "0.13.0"}
+
+
+def _install_paired_runtime_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    server_build: str,
+    server_version: str,
+    fresh_host: str | None,
+    shared_host: str | None = None,
+    previous: ResolvedOmnigentDeploymentState | None,
+) -> dict[str, list]:
+    from moonmind.omnigent.bootstrap import store
+
+    observed: dict[str, list] = {"probes": [], "version_probes": []}
+
+    async def resolve_image(image_env, tag_env, ref_env, env=None):
+        del tag_env, ref_env, env
+        if image_env == "OMNIGENT_IMAGE":
+            return SERVER_REF, server_build
+        if image_env == "OMNIGENT_OPENCODE_HOST_IMAGE":
+            return (fresh_host, _extract(fresh_host)) if fresh_host else (None, None)
+        if image_env == "OMNIGENT_SHARED_HOST_IMAGE":
+            return (shared_host, _extract(shared_host)) if shared_host else (None, None)
+        return None, None
+
+    async def run(cmd, timeout=30):
+        del timeout
+        if cmd[0] == "sh":
+            observed["probes"].append(cmd[2])
+            return 0, "", ""
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            ref = cmd[3]
+            if cmd[-1] == "{{json .Config.Labels}}":
+                build = _HOST_BUILDS.get(ref)
+                if build is None:
+                    return 1, "", "No such image"
+                return 0, '{"moonmind.omnigent.build_digest":"' + build + '"}', ""
+            if cmd[-1] == "{{.Architecture}}":
+                return 0, "arm64", ""
+        if cmd[:5] == ["docker", "run", "--rm", "--entrypoint", "/opt/venv/bin/omnigent"]:
+            ref = cmd[-2]
+            observed["version_probes"].append(ref)
+            version = server_version if ref == SERVER_REF else _HOST_VERSIONS.get(ref)
+            if version is None:
+                return 1, "", "No such image"
+            return 0, f"omnigent {version} (built for test)\n", ""
+        if cmd[:2] == ["docker", "pull"]:
+            return 1, "", "registry unavailable in test"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(image_resolution, "_resolve_image", resolve_image)
+    monkeypatch.setattr(image_resolution, "_run", run)
+    monkeypatch.setattr(store, "load_resolved_state", lambda: previous)
+    return observed
+
+
+def _extract(ref: str | None) -> str | None:
+    return "sha256:" + ref.rsplit("@sha256:", 1)[-1] if ref else None
+
+
+def _admitted_previous(host: str = ADMITTED_HOST) -> ResolvedOmnigentDeploymentState:
+    return _state(
+        opencodeHostImageRef=host,
+        sharedHostImageRef=host,
+        omnigentBuildDigest=RUNNING_SERVER_BUILD,
+        details={
+            "opencodeHostCompatibility": {
+                "status": "ready",
+                "failureCode": None,
+                "serverImageRef": SERVER_REF,
+                "hostImageRef": host,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_newer_host_for_a_newer_server_keeps_the_admitted_compatible_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay: registry host moved to 0.13.0 while Compose still runs 0.12.0."""
+
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=RUNNING_SERVER_BUILD,
+        server_version="0.12.0",
+        fresh_host=NEWER_HOST,
+        shared_host=NEWER_HOST,
+        previous=_admitted_previous(),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images({})
+
+    assert resolved.opencode_host_image_ref == ADMITTED_HOST
+    # The shared host resolved to the same incompatible image and follows the
+    # admitted digest: one paired runtime, not a mismatched Codex/Claude host.
+    assert resolved.shared_host_image_ref == ADMITTED_HOST
+    assert resolved.omnigent_build_digest == RUNNING_SERVER_BUILD
+    assert resolved.details["buildIdentitySource"] == "opencode-host-label"
+    assert resolved.details["opencodeHostCompatibility"] == {
+        "status": "ready",
+        "failureCode": None,
+        "serverImageRef": SERVER_REF,
+        "hostImageRef": ADMITTED_HOST,
+        "serverBuildDigest": RUNNING_SERVER_BUILD,
+        "hostBuildDigest": RUNNING_SERVER_BUILD,
+        "serverVersion": "0.12.0",
+        "hostVersion": "0.12.0",
+        "pendingHost": {
+            "imageRef": NEWER_HOST,
+            "buildDigest": NEWER_SERVER_BUILD,
+            "version": "0.13.0",
+            "failureCode": "omnigent_server_host_build_mismatch",
+        },
+    }
+    # Only the admitted host reached the bootstrap probe.
+    assert observed["probes"] == [ADMITTED_HOST]
+
+
+@pytest.mark.asyncio
+async def test_updated_server_adopts_the_pending_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator recovery path: once Compose runs 0.13.0 the fresh tag wins."""
+
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=NEWER_SERVER_BUILD,
+        server_version="0.13.0",
+        fresh_host=NEWER_HOST,
+        shared_host=NEWER_HOST,
+        previous=_admitted_previous(),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images({})
+
+    assert resolved.opencode_host_image_ref == NEWER_HOST
+    assert resolved.shared_host_image_ref == NEWER_HOST
+    compatibility = resolved.details["opencodeHostCompatibility"]
+    assert compatibility["status"] == "ready"
+    assert compatibility["pendingHost"] is None
+    # The fresh candidate was admitted first; the old host was never probed.
+    assert ADMITTED_HOST not in observed["version_probes"]
+    assert observed["probes"] == [NEWER_HOST]
+
+
+@pytest.mark.asyncio
+async def test_no_compatible_host_quarantines_the_fresh_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server moved past both the registry host and the admitted host."""
+
+    unrelated_server_build = "sha256:" + "5" * 64
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=unrelated_server_build,
+        server_version="0.14.0",
+        fresh_host=NEWER_HOST,
+        previous=_admitted_previous(),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images({})
+
+    assert resolved.opencode_host_image_ref == NEWER_HOST
+    assert resolved.omnigent_build_digest == unrelated_server_build
+    assert resolved.details["buildIdentitySource"] == "server-image-quarantine"
+    compatibility = resolved.details["opencodeHostCompatibility"]
+    assert compatibility["status"] == "blocked"
+    assert compatibility["failureCode"] == "omnigent_server_host_build_mismatch"
+    assert compatibility["hostImageRef"] == NEWER_HOST
+    assert compatibility["hostBuildDigest"] == NEWER_SERVER_BUILD
+    assert compatibility["pendingHost"] is None
+    # Both candidates were judged; neither reached the bootstrap probe.
+    assert set(observed["version_probes"]) >= {ADMITTED_HOST, NEWER_HOST}
+    assert observed["probes"] == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_operator_pin_is_quarantined_never_replaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=RUNNING_SERVER_BUILD,
+        server_version="0.12.0",
+        fresh_host=NEWER_HOST,
+        previous=_admitted_previous(),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images(
+        {"OMNIGENT_OPENCODE_HOST_IMAGE_REF": NEWER_HOST}
+    )
+
+    assert resolved.opencode_host_image_ref == NEWER_HOST
+    compatibility = resolved.details["opencodeHostCompatibility"]
+    assert compatibility["status"] == "blocked"
+    assert compatibility["failureCode"] == "omnigent_server_host_build_mismatch"
+    assert compatibility["pendingHost"] is None
+    assert ADMITTED_HOST not in observed["version_probes"]
+
+
+@pytest.mark.asyncio
+async def test_previous_host_from_another_repository_is_not_a_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    foreign_host = "ghcr.io/example/other-host@sha256:" + "d" * 64
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=RUNNING_SERVER_BUILD,
+        server_version="0.12.0",
+        fresh_host=NEWER_HOST,
+        previous=_admitted_previous(foreign_host),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images({})
+
+    assert resolved.opencode_host_image_ref == NEWER_HOST
+    assert resolved.details["opencodeHostCompatibility"]["status"] == "blocked"
+    assert foreign_host not in observed["version_probes"]
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_tag_still_judges_the_admitted_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registry outage: the persisted host is a candidate, not blind authority."""
+
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=RUNNING_SERVER_BUILD,
+        server_version="0.12.0",
+        fresh_host=None,
+        previous=_admitted_previous(),
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images({})
+
+    assert resolved.opencode_host_image_ref == ADMITTED_HOST
+    compatibility = resolved.details["opencodeHostCompatibility"]
+    assert compatibility["status"] == "ready"
+    assert compatibility["pendingHost"] is None
+    assert observed["probes"] == [ADMITTED_HOST]
+
+
+def test_quarantine_error_names_the_judged_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The escaped failure only said 'mismatch'; operators need the pair."""
+
+    from moonmind.omnigent.bootstrap import store
+    from moonmind.omnigent.harness_platform import host_classes
+
+    blocked = _state(
+        details={
+            "opencodeHostCompatibility": {
+                "status": "blocked",
+                "failureCode": "omnigent_server_host_build_mismatch",
+                "serverImageRef": SERVER_REF,
+                "hostImageRef": HOST_REF,
+                "serverBuildDigest": RUNNING_SERVER_BUILD,
+                "hostBuildDigest": NEWER_SERVER_BUILD,
+                "serverVersion": "0.12.0",
+                "hostVersion": "0.13.0",
+            }
+        }
+    )
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", HOST_REF)
+    monkeypatch.setattr(store, "load_resolved_state", lambda: blocked)
+
+    with pytest.raises(Exception) as caught:
+        host_classes.get_opencode_host_image_ref()
+
+    message = str(caught.value)
+    assert "omnigent_server_host_build_mismatch" in message
+    assert "server omnigent 0.12.0 build sha256:111111111111" in message
+    assert "host omnigent 0.13.0 built for sha256:999999999999" in message
+    assert "update the omnigent server image" in message

--- a/tests/unit/omnigent/test_bootstrap_image_publication.py
+++ b/tests/unit/omnigent/test_bootstrap_image_publication.py
@@ -873,10 +873,20 @@ def _install_paired_runtime_fakes(
     fresh_host: str | None,
     shared_host: str | None = None,
     previous: ResolvedOmnigentDeploymentState | None,
+    server_unavailable: bool = False,
 ) -> dict[str, list]:
     from moonmind.omnigent.bootstrap import store
 
     observed: dict[str, list] = {"probes": [], "version_probes": []}
+
+    if server_unavailable:
+
+        async def running_server(_image, _env):
+            return None
+
+        monkeypatch.setattr(
+            image_resolution, "_resolve_running_server_image", running_server
+        )
 
     async def resolve_image(image_env, tag_env, ref_env, env=None):
         del tag_env, ref_env, env
@@ -1140,3 +1150,64 @@ def test_quarantine_error_names_the_judged_pair(
     assert "server omnigent 0.12.0 build sha256:111111111111" in message
     assert "host omnigent 0.13.0 built for sha256:999999999999" in message
     assert "update the omnigent server image" in message
+
+
+@pytest.mark.asyncio
+async def test_unavailable_server_evidence_retains_the_admitted_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restarting Omnigent container must not let the fresh tag replace the
+    admitted digest before anything has been judged (PR #4170 review)."""
+
+    observed = _install_paired_runtime_fakes(
+        monkeypatch,
+        server_build=RUNNING_SERVER_BUILD,
+        server_version="0.12.0",
+        fresh_host=NEWER_HOST,
+        previous=_admitted_previous(),
+        server_unavailable=True,
+    )
+
+    resolved = await image_resolution.resolve_omnigent_images(
+        {
+            "OMNIGENT_IMAGE": "ghcr.io/omnigent-ai/omnigent-server",
+            "OMNIGENT_IMAGE_TAG": "latest",
+        }
+    )
+
+    assert resolved.server_image_ref is None
+    # The persisted ref is still the admitted host, so the next pass judges it.
+    assert resolved.opencode_host_image_ref == ADMITTED_HOST
+    compatibility = resolved.details["opencodeHostCompatibility"]
+    assert compatibility["status"] == "blocked"
+    assert compatibility["failureCode"] == "omnigent_server_build_unavailable"
+    assert compatibility["hostImageRef"] == ADMITTED_HOST
+    assert compatibility["pendingHost"] is None
+    assert NEWER_HOST not in observed["version_probes"]
+    assert observed["probes"] == []
+
+
+@pytest.mark.parametrize(
+    "failure_code, expects_server_update",
+    [
+        ("omnigent_server_host_build_mismatch", True),
+        ("omnigent_server_host_version_mismatch", True),
+        ("omnigent_operator_host_build_mismatch", False),
+        ("omnigent_host_build_identity_unavailable", False),
+        ("omnigent_server_host_version_probe_failed", False),
+        ("omnigent_host_bootstrap_contract_missing", False),
+        ("", False),
+    ],
+)
+def test_pending_host_remediation_matches_the_failure(
+    failure_code: str, expects_server_update: bool
+) -> None:
+    """Only server drift is cured by moving the server (PR #4170 review)."""
+
+    remediation = image_resolution.pending_host_remediation(failure_code)
+    prescribes_update = remediation.startswith(
+        "the newer host targets a newer Omnigent server"
+    )
+    assert prescribes_update is expects_server_update
+    if not expects_server_update:
+        assert "repair or republish" in remediation or "OMNIGENT_BUILD_DIGEST" in remediation


### PR DESCRIPTION
## Summary

Workflow `mm:f94c0b48-5c35-4914-a8c0-a39437c91aa1` failed in the merge-automation child with `no admissible Host Class for opencode-native: omnigent-opencode@1: OpenCode Host Class is quarantined ... (omnigent_server_host_build_mismatch)`.

**Root cause.** Two independently refreshed mutable tags drifted apart. `.github/workflows/docker-publish-moonmind-host.yml` rebuilds `omnigent-host-moonmind` every 6 hours against upstream `omnigent-server:latest` and republishes the mutable `1.18.11` tag. The API reconciliation loop re-pulls that tag every 2 minutes, but nothing refreshes the deployed Omnigent server. When upstream shipped Omnigent 0.13.0, the deployment adopted a host built for a server it was not running (0.12.0), and the resolver quarantined the whole OpenCode Host Class even though the previously admitted compatible host was still in the local cache. It also overwrote the persisted host ref, so the deployment forgot which host had been compatible.

**Fix.** Host admission is keyed by the running server's build identity rather than by the newest tag.

- `moonmind/omnigent/bootstrap/image_resolution.py`: judge the fresh tag first and the currently admitted host second through the same compatibility ladder (build label, `omnigent --version`, bootstrap probe); admit the first candidate that passes; record a newer-but-incompatible image as `opencodeHostCompatibility.pendingHost`; quarantine only when no candidate fits. An explicit operator pin is still quarantined, never replaced. A shared host that resolved to the same judged image follows the admitted digest so Codex/Claude Host Classes never launch a mismatched host.
- `api_service/main.py`: log the pending pair and its remediation (update the `omnigent` Compose service) on every pass while it persists.
- `moonmind/omnigent/harness_platform/host_classes.py`: the quarantine error names the judged server/host versions and builds plus the remediation.
- Docs: `docs/Omnigent/OpenCodeHost.md` §13 and `docs/Omnigent/SharedHostImage.md` §1 describe server-keyed admission and `pendingHost`.

## Test plan

- [x] `tests/unit/omnigent/test_bootstrap_image_publication.py`: replay of the 2026-09-09 failure (newer host for newer server keeps the admitted host, shared host follows it), operator recovery adopts the pending host, no compatible host quarantines the fresh candidate, explicit pin is never replaced, foreign-repository previous host is not a candidate, registry outage still judges the admitted host, quarantine error names the pair. 39 passed.
- [x] `tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py`: image sync stays ready and warns on a pending host. 19 passed.
- [x] `tests/unit/omnigent` plus the Omnigent services/router suites: 3645 passed; the 12 failures (`test_concurrency_qualification`, `test_faultlab_boundary`, `test_tool_bundle_initializer`) reproduce identically on `main` with these edits stashed.
- [x] `tests/integration/reliability/test_omnigent_plan_admission_replays.py` and `test_api_startup_provider_maintenance.py`: 13 passed.
- [x] Deployment: after updating only the `omnigent` Compose service to the current `latest`, the next reconciliation pass reported the pair ready and the bootstrap record returned to `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
