### PR TITLE
[Keycloak removal] Add application-bound sessions, durable revocation and CSRF protection (MoonLadderStudios/MoonMind#4121)

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -265,6 +265,12 @@ MOONMIND_TRUSTED_INGRESS=""
 # the dev cookie is restricted to explicit loopback HTTP.
 MOONMIND_PUBLIC_BASE_URL=""
 MOONMIND_TRUSTED_PROXIES=""
+# Credentialed CORS allowlist (comma-separated origins, #4121). Previously the
+# API answered credentialed CORS with a wildcard; #4121 fails closed to an
+# explicit list instead, so separate-origin browser clients lose access after
+# upgrading unless their origins are enumerated here (MOONMIND_PUBLIC_BASE_URL
+# is always included automatically). Never set "*": it fails startup.
+MOONMIND_CORS_ALLOWED_ORIGINS=""
 JWT_SECRET_KEY="replace_with_a_strong_random_jwt_secret"
 # Leave empty for local-first startup. MoonMind will generate and persist a
 # local encryption key in var/secrets/encryption_master_key (or the compose

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import uuid
 from typing import AsyncGenerator, Optional
 
@@ -20,6 +21,8 @@ from api_service.db.models import User
 from api_service.services.identity_service import ControlledEnrollmentRequiredError
 from api_service.services.profile_service import ProfileService
 from moonmind.config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
     pass
@@ -59,12 +62,21 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None
     ):
-        print(f"User {user.id} has forgot their password. Reset token: {token}")
+        # #4121: password-reset tokens must never enter logs, traces,
+        # Temporal payloads, or artifacts. Emit a redacted event only.
+        logger.info(
+            "auth_event revocation mode=password_reset reason=reset_requested user_id=%s",
+            user.id,
+        )
 
     async def on_after_request_verify(
         self, user: User, token: str, request: Optional[Request] = None
     ):
-        print(f"Verification requested for user {user.id}. Verification token: {token}")
+        # #4121: verification tokens must never be printed or logged.
+        logger.info(
+            "auth_event revocation mode=verify reason=verification_requested user_id=%s",
+            user.id,
+        )
 
 async def get_user_db(session: get_async_session = Depends(get_async_session)):
     yield SQLAlchemyUserDatabase(session, User)
@@ -238,8 +250,7 @@ async def get_or_create_default_user(
         return user
     except Exception as e:
         await db_session.rollback()
-        # Log error details here
-        print(f"Error creating default user: {e}")
+        logger.error("Error creating default user: %s", type(e).__name__)
         raise HTTPException(
             status_code=500, detail=f"Could not create default user: {e}"
         )

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -223,6 +223,70 @@ class IdentityMigrationRun(Base):
     )
 
 
+class MoonmindSession(Base):
+    """One durable browser-session row per issued MoonMind session JWT (K4, #4121).
+
+    Single durable session/revocation mechanism behind the portable
+    ``SessionRevocationStore`` interface. ``jti`` is the JWT ``jti`` claim;
+    ``generation`` captures the user's revocation generation at mint time so
+    validation can reject tokens minted before a password reset, disable, or
+    administrative revocation even when the per-session row is unknown.
+    Logout sets ``revoked_at`` on the current row; clearing a cookie alone is
+    never revocation. Expiry is enforced from the JWT ``exp`` claim; the row
+    persists so restarts and replicas share one revocation truth.
+    """
+
+    __tablename__ = "moonmind_sessions"
+    __table_args__ = (
+        Index("ix_moonmind_sessions_user", "user_id"),
+        Index("ix_moonmind_sessions_expires", "expires_at"),
+    )
+
+    jti: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
+    generation: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+
+class MoonmindUserSessionGeneration(Base):
+    """Per-user revocation generation for all-session invalidation (#4121).
+
+    Password reset, account disablement, administrative revocation, and key
+    rotation bump the generation; sessions minted at an older generation fail
+    closed at validation. Concurrent issuance versus disable/reset cannot
+    resurrect authority: the mint captures the live generation and the next
+    validation compares it, so a token minted before the bump never validates
+    after it.
+    """
+
+    __tablename__ = "moonmind_user_session_generations"
+    __table_args__ = ()
+
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), primary_key=True
+    )
+    generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class UserProfile(Base):
     __tablename__ = "user_profile"
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1153,9 +1153,47 @@ if _ENABLE_TEST_UI_ROUTE:
 # (docs/Security/AuthenticationContracts.md), and `disabled` mode resolves the
 # persisted default user via get_current_user().
 
+def _resolve_cors_allowed_origins() -> list[str]:
+    """Resolve explicit credentialed CORS origins (#4121 req 5).
+
+    Credentialed browsers must enumerate trusted origins explicitly via
+    ``MOONMIND_CORS_ALLOWED_ORIGINS`` (comma separated) and/or
+    ``MOONMIND_PUBLIC_BASE_URL`` (its scheme://host[:port] origin). A
+    configured ``"*"`` with credentials fails closed at startup rather
+    than silently allowing any site to issue credentialed mutations.
+    """
+    from moonmind.security.session_authority_4121 import (
+        resolve_credentialed_cors_origins,
+    )
+    from urllib.parse import urlsplit
+
+    raw = os.environ.get("MOONMIND_CORS_ALLOWED_ORIGINS", "")
+    explicit = [part.strip() for part in raw.split(",") if part.strip()]
+    public_base = os.environ.get("MOONMIND_PUBLIC_BASE_URL", "").strip()
+    if public_base:
+        try:
+            parts = urlsplit(public_base)
+            if parts.scheme and parts.hostname:
+                port = f":{parts.port}" if parts.port else ""
+                explicit.append(f"{parts.scheme}://{parts.hostname}{port}")
+        except ValueError:
+            pass
+    if any(origin == "*" for origin in explicit):
+        raise RuntimeError(
+            "MOONMIND_CORS_ALLOWED_ORIGINS cannot be '*' with credentialed "
+            "requests: enumerate explicit trusted origins for "
+            "cookie-authenticated browsers (#4121)."
+        )
+    return resolve_credentialed_cors_origins(explicit, allow_credentials=True)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    # #4121: credentialed wildcard CORS ("*" + allow_credentials) would let
+    # any site issue credentialed cross-origin cookie mutations. Resolve
+    # explicit trusted origins from MOONMIND_CORS_ALLOWED_ORIGINS (comma
+    # separated) plus MOONMIND_PUBLIC_BASE_URL; wildcard is only honored
+    # for non-credentialed deployments.
+    allow_origins=_resolve_cors_allowed_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1177,6 +1177,9 @@ def _resolve_cors_allowed_origins() -> list[str]:
                 port = f":{parts.port}" if parts.port else ""
                 explicit.append(f"{parts.scheme}://{parts.hostname}{port}")
         except ValueError:
+            # Invalid port in MOONMIND_PUBLIC_BASE_URL: base-URL validation
+            # in lifespan startup reports the misconfiguration; CORS simply
+            # skips deriving an origin from it here.
             pass
     if any(origin == "*" for origin in explicit):
         raise RuntimeError(

--- a/api_service/migrations/versions/375_session_authority_4121.py
+++ b/api_service/migrations/versions/375_session_authority_4121.py
@@ -28,10 +28,13 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "375_session_authority_4121"
-down_revision: Union[str, None] = "374_identity_mapping_k3"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, None] = None
+# Alembic consumes these module attributes at migration runtime; they are
+# intentionally assigned here even though this module never reads them
+# directly (unused-variable linters report them as false positives).
+revision: str = "375_session_authority_4121"  # noqa: F841
+down_revision: Union[str, None] = "374_identity_mapping_k3"  # noqa: F841
+branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
+depends_on: Union[str, None] = None  # noqa: F841
 
 
 def upgrade() -> None:
@@ -80,8 +83,15 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     bind = op.get_bind()
+    # Only unexpired, unrevoked rows carry live session authority. Expired
+    # rows linger until explicit logout/revocation cleanup, so the gate
+    # must ignore them or the "let them expire before rollback" path can
+    # never succeed once such a row exists.
     live_sessions = bind.execute(
-        sa.text("SELECT COUNT(*) FROM moonmind_sessions WHERE revoked_at IS NULL")
+        sa.text(
+            "SELECT COUNT(*) FROM moonmind_sessions "
+            "WHERE revoked_at IS NULL AND expires_at > CURRENT_TIMESTAMP"
+        )
     ).scalar()
     if live_sessions:
         raise RuntimeError(

--- a/api_service/migrations/versions/375_session_authority_4121.py
+++ b/api_service/migrations/versions/375_session_authority_4121.py
@@ -1,0 +1,107 @@
+"""K4 durable session/revocation tables (single authority).
+
+Revision ID: 375_session_authority_4121
+Revises: 374_identity_mapping_k3
+Create Date: 2026-09-09
+
+Source issue: MoonLadderStudios/MoonMind#4121 (parent #4116; plan session and
+browser security, K2/K4 in docs/tmp/KeycloakRemovalPlan.md).
+
+Additive migration: creates ``moonmind_sessions`` (one row per issued
+session JWT: jti, user, mint generation, expiry, revocation) and
+``moonmind_user_session_generations`` (per-user revocation generation for
+logout/reset/disable/admin-revoke/key-rotation). No existing table, column,
+constraint, or historical revision is altered; the legacy ``user.oidc_*``
+columns, K3 identity tables, and all ownership records stay untouched.
+
+Rollback compatibility (bounded window): until the cutover is accepted the
+previous application never reads these tables, so it keeps starting and
+serving against the upgraded schema. Downgrade refuses when rows still carry
+live session authority, so rollback cannot silently strand or resurrect a
+revoked session.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "375_session_authority_4121"
+down_revision: Union[str, None] = "374_identity_mapping_k3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "moonmind_user_session_generations",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "generation",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+    op.create_table(
+        "moonmind_sessions",
+        sa.Column("jti", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("generation", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_reason", sa.String(length=32), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("jti"),
+    )
+    op.create_index(
+        "ix_moonmind_sessions_user", "moonmind_sessions", ["user_id"]
+    )
+    op.create_index(
+        "ix_moonmind_sessions_expires", "moonmind_sessions", ["expires_at"]
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    live_sessions = bind.execute(
+        sa.text("SELECT COUNT(*) FROM moonmind_sessions WHERE revoked_at IS NULL")
+    ).scalar()
+    if live_sessions:
+        raise RuntimeError(
+            "Cannot downgrade K4 session authority: moonmind_sessions still "
+            f"holds {live_sessions} unrevoked session(s). Revoke or let them "
+            "expire before rollback so no live authority is stranded."
+        )
+    remaining_generations = bind.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM moonmind_user_session_generations WHERE generation <> 0"
+        )
+    ).scalar()
+    if remaining_generations:
+        raise RuntimeError(
+            "Cannot downgrade K4 session authority: "
+            f"{remaining_generations} user generation row(s) carry revocation "
+            "state. Rollback must restore a matching application set and "
+            "intentionally invalidate incompatible sessions."
+        )
+    op.drop_index("ix_moonmind_sessions_expires", table_name="moonmind_sessions")
+    op.drop_index("ix_moonmind_sessions_user", table_name="moonmind_sessions")
+    op.drop_table("moonmind_sessions")
+    op.drop_table("moonmind_user_session_generations")

--- a/api_service/migrations/versions/375_session_authority_4121.py
+++ b/api_service/migrations/versions/375_session_authority_4121.py
@@ -23,18 +23,19 @@ revoked session.
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
 
-# Alembic consumes these module attributes at migration runtime; they are
-# intentionally assigned here even though this module never reads them
-# directly (unused-variable linters report them as false positives).
-revision: str = "375_session_authority_4121"  # noqa: F841
-down_revision: Union[str, None] = "374_identity_mapping_k3"  # noqa: F841
-branch_labels: Union[str, Sequence[str], None] = None  # noqa: F841
-depends_on: Union[str, None] = None  # noqa: F841
+# Alembic discovers migration identity from these module attributes (it
+# reads ``branch_labels``/``depends_on`` via getattr with None defaults, so
+# only the non-null chain links are declared here); ``__all__`` keeps that
+# external contract explicit for static analysis.
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+revision: str = "375_session_authority_4121"
+down_revision: Union[str, None] = "374_identity_mapping_k3"
 
 
 def upgrade() -> None:
@@ -95,9 +96,10 @@ def downgrade() -> None:
     ).scalar()
     if live_sessions:
         raise RuntimeError(
-            "Cannot downgrade K4 session authority: moonmind_sessions still "
-            f"holds {live_sessions} unrevoked session(s). Revoke or let them "
-            "expire before rollback so no live authority is stranded."
+            f"Cannot downgrade session authority {revision} (parent "
+            f"{down_revision}): moonmind_sessions still holds "
+            f"{live_sessions} unrevoked, unexpired session(s). Revoke or let "
+            "them expire before rollback so no live authority is stranded."
         )
     remaining_generations = bind.execute(
         sa.text(
@@ -106,10 +108,11 @@ def downgrade() -> None:
     ).scalar()
     if remaining_generations:
         raise RuntimeError(
-            "Cannot downgrade K4 session authority: "
-            f"{remaining_generations} user generation row(s) carry revocation "
-            "state. Rollback must restore a matching application set and "
-            "intentionally invalidate incompatible sessions."
+            f"Cannot downgrade session authority {revision} (parent "
+            f"{down_revision}): {remaining_generations} user generation "
+            "row(s) carry revocation state. Rollback must restore a matching "
+            "application set and intentionally invalidate incompatible "
+            "sessions."
         )
     op.drop_index("ix_moonmind_sessions_expires", table_name="moonmind_sessions")
     op.drop_index("ix_moonmind_sessions_user", table_name="moonmind_sessions")

--- a/api_service/services/session_store.py
+++ b/api_service/services/session_store.py
@@ -1,0 +1,286 @@
+"""DB-backed session/revocation adapters for #4121.
+
+Production wiring of the portable ``SessionRevocationStore`` /
+``AsyncAccountStore`` protocols against the existing MoonMind database
+(one durable mechanism: ``moonmind_sessions`` +
+``moonmind_user_session_generations``). Composes the qualified #4118
+token primitives with #4119 UUID resolution (``UserExternalIdentity`` for
+OIDC/proxy, existing ``User`` row for ``moonmind-accounts`` logins) and
+#4120 configuration. Used by the session authority; account, OIDC, API,
+machine, and dashboard issues consume this interface rather than
+implementing independent validators.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    MoonmindSession,
+    MoonmindUserSessionGeneration,
+    User,
+    UserExternalIdentity,
+)
+from moonmind.security import omnigent_auth_qualification as q
+
+ACCOUNTS_ISSUER = "moonmind-accounts"
+
+UTC = timezone.utc
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class DbAccountStore:
+    """Production ``AsyncAccountStore`` over the MoonMind database."""
+
+    def __init__(self, session_factory: Callable[[], AsyncSession] | AsyncSession):
+        self._sessions = session_factory
+
+    def _session(self) -> AsyncSession:
+        if isinstance(self._sessions, AsyncSession):
+            return self._sessions
+        produced = self._sessions()
+        assert isinstance(produced, AsyncSession)
+        return produced
+
+    async def resolve_identity_to_user_id(
+        self, identity: q.ValidatedIdentity
+    ) -> uuid.UUID | None:
+        session = self._session()
+        if identity.issuer == ACCOUNTS_ISSUER:
+            result = await session.execute(
+                select(User.id).where(User.email == identity.subject)
+            )
+            return result.scalars().first()
+        result = await session.execute(
+            select(UserExternalIdentity.user_id).where(
+                UserExternalIdentity.issuer == identity.issuer,
+                UserExternalIdentity.subject == identity.subject,
+            )
+        )
+        return result.scalars().first()
+
+    async def get_account(self, user_id: uuid.UUID) -> q.AccountRecord | None:
+        session = self._session()
+        user = await session.get(User, user_id)
+        if user is None:
+            return None
+        return q.AccountRecord(
+            user_id=user.id,
+            is_active=bool(user.is_active),
+            is_superuser=bool(user.is_superuser),
+            email=user.email,
+        )
+
+    async def get_password_hash_by_login(self, login: str) -> str | None:
+        session = self._session()
+        result = await session.execute(
+            select(User.hashed_password).where(User.email == login.strip())
+        )
+        return result.scalars().first()
+
+    async def record_login(self, user_id: uuid.UUID, when_epoch_seconds: int) -> None:
+        return None
+
+
+class DbRevocationStore:
+    """Production ``SessionRevocationStore`` over the MoonMind database.
+
+    Unknown session/grant state, store outage, and unregistered tokens fail
+    closed at the authority layer (``UnavailableError`` / ``auth_invalid``);
+    this store never synthesizes an administrator and never returns stale
+    authority on error.
+    """
+
+    def __init__(self, session_factory: Callable[[], AsyncSession] | AsyncSession):
+        self._sessions = session_factory
+
+    def _session(self) -> AsyncSession:
+        if isinstance(self._sessions, AsyncSession):
+            return self._sessions
+        produced = self._sessions()
+        assert isinstance(produced, AsyncSession)
+        return produced
+
+    async def revoke_session(self, jti: str) -> None:
+        session = self._session()
+        row = await session.get(MoonmindSession, jti)
+        if row is None:
+            # Unknown jti: nothing durable to mark, and validation already
+            # fails closed on unknown state (is_session_revoked -> True).
+            # No synthetic row is inserted (it would violate the user FK).
+            return
+        row.revoked_at = _utcnow()
+        row.revoked_reason = row.revoked_reason or "logout"
+        await session.flush()
+
+    async def revoke_session_for_user(
+        self, jti: str, user_id: UUID, *, reason: str = "logout"
+    ) -> None:
+        """Revoke one session row owned by ``user_id`` (logout path)."""
+        session = self._session()
+        row = await session.get(MoonmindSession, jti)
+        if row is None:
+            return
+        if row.user_id != user_id:
+            return
+        row.revoked_at = _utcnow()
+        row.revoked_reason = reason
+        await session.flush()
+
+    async def is_session_revoked(self, jti: str) -> bool:
+        session = self._session()
+        row = await session.get(MoonmindSession, jti)
+        if row is None:
+            # Unknown session state fails closed upstream only when the jti
+            # was never issued here; rows are recorded at mint, so absence
+            # means unregistered token material.
+            return True
+        return row.revoked_at is not None
+
+    async def revoke_all_for_user(self, user_id: uuid.UUID) -> int:
+        from sqlalchemy import update
+
+        session = self._session()
+        # Atomic increment: concurrent revocations serialize on the row
+        # instead of lost-updating a read-modify-write cycle.
+        result = await session.execute(
+            update(MoonmindUserSessionGeneration)
+            .where(MoonmindUserSessionGeneration.user_id == user_id)
+            .values(
+                generation=MoonmindUserSessionGeneration.generation + 1,
+                updated_at=_utcnow(),
+            )
+            .returning(MoonmindUserSessionGeneration.generation)
+        )
+        current = result.scalar_one_or_none()
+        if current is not None:
+            await session.flush()
+            return int(current)
+        # No row yet: insert generation 1, converging on the winner when a
+        # concurrent inserter wins the race.
+        nested = await session.begin_nested()
+        try:
+            session.add(
+                MoonmindUserSessionGeneration(user_id=user_id, generation=1)
+            )
+            await session.flush()
+            await nested.commit()
+            return 1
+        except IntegrityError:
+            await nested.rollback()
+            result = await session.execute(
+                update(MoonmindUserSessionGeneration)
+                .where(MoonmindUserSessionGeneration.user_id == user_id)
+                .values(
+                    generation=MoonmindUserSessionGeneration.generation + 1,
+                    updated_at=_utcnow(),
+                )
+                .returning(MoonmindUserSessionGeneration.generation)
+            )
+            current = result.scalar_one_or_none()
+            assert current is not None
+            await session.flush()
+            return int(current)
+
+    async def generation_for_user(self, user_id: uuid.UUID) -> int:
+        session = self._session()
+        row = await session.get(MoonmindUserSessionGeneration, user_id)
+        return int(row.generation) if row is not None else 0
+
+    async def record_issued_session(
+        self,
+        *,
+        jti: str,
+        user_id: UUID,
+        generation: int,
+        expires_at_epoch: int,
+    ) -> None:
+        """Record an issued session so logout/replicas share one truth.
+
+        Converges on the existing row when a concurrent mint reuses a jti
+        (jtis are random; collisions converge rather than resurrect).
+        """
+        session = self._session()
+        expires_at = datetime.fromtimestamp(expires_at_epoch, tz=UTC)
+        existing = await session.get(MoonmindSession, jti)
+        if existing is not None:
+            return
+        session.add(
+            MoonmindSession(
+                jti=jti,
+                user_id=user_id,
+                generation=generation,
+                created_at=_utcnow(),
+                expires_at=expires_at,
+            )
+        )
+        try:
+            await session.flush()
+        except IntegrityError:
+            await session.rollback()
+
+
+async def mint_and_record_session(
+    identity: q.ValidatedIdentity,
+    account_store: DbAccountStore,
+    revocation: DbRevocationStore,
+    config: q.MoonmindAuthConfig,
+    session: AsyncSession,
+    *,
+    now: int | None = None,
+) -> tuple[str, UUID]:
+    """Mint via the #4118 primitive and record the row in one transaction.
+
+    The mint re-checks account active status; the generation captured at
+    mint is the live generation, so a concurrent disable/reset bump before
+    commit invalidates the token at the next validation (no resurrection).
+    """
+    token, user_id = await q.mint_moonmind_session(
+        identity, account_store, config, now=now, revocation=revocation
+    )
+    import jwt as _jwt
+
+    claims = _jwt.decode(token, options={"verify_signature": False})
+    await revocation.record_issued_session(
+        jti=str(claims["jti"]),
+        user_id=user_id,
+        generation=int(claims.get("gen", 0)),
+        expires_at_epoch=int(claims["exp"]),
+    )
+    await session.commit()
+    return token, user_id
+
+
+async def disable_user_and_revoke_sessions(
+    session: AsyncSession, user_id: UUID
+) -> int:
+    """Deactivate a user and invalidate all sessions transactionally."""
+    user = await session.get(User, user_id)
+    if user is not None:
+        user.is_active = False
+    store = DbRevocationStore(session)
+    generation = await store.revoke_all_for_user(user_id)
+    await session.commit()
+    return generation
+
+
+async def count_active_sessions(session: AsyncSession, user_id: UUID) -> int:
+    result = await session.execute(
+        select(func.count())
+        .select_from(MoonmindSession)
+        .where(
+            MoonmindSession.user_id == user_id,
+            MoonmindSession.revoked_at.is_(None),
+        )
+    )
+    return int(result.scalar() or 0)

--- a/moonmind/security/session_authority_4121.py
+++ b/moonmind/security/session_authority_4121.py
@@ -1,0 +1,638 @@
+"""Application-bound session authority (MoonLadderStudios/MoonMind#4121).
+
+Parent: #4116. Depends on #4118, #4119, #4120. Plan coverage: session and
+browser security, K2/K4 in ``docs/tmp/KeycloakRemovalPlan.md``.
+
+This module owns the one reusable MoonMind session authority that account,
+OIDC, API, machine, and dashboard issues consume rather than implementing
+independent validators. It composes the qualified #4118 session primitives
+(``moonmind.security.omnigent_auth_qualification``) with #4119 UUID
+resolution semantics and #4120 configuration, and adds the production
+seams the qualification library intentionally leaves to this owner:
+
+* bounded validation cache (size + TTL) that re-runs full validation on
+  every hit, so revocation/status changes take effect across replicas
+  within the declared bound;
+* key-ring validation for rotation without indefinite acceptance of old
+  application tokens;
+* MoonMind-specific cookie issue/clear policy (``__Host-`` production
+  cookie, separately named loopback development cookie);
+* shared CSRF/origin enforcement for cookie-authenticated unsafe requests
+  plus credentialed-CORS resolution that rejects wildcard+credentials;
+* single credential-precedence resolution (missing vs. invalid vs.
+  conflicting identities);
+* stream re-authorization interface for WebSocket/SSE reconnects and
+  active-stream termination within the agreed bound (no second store);
+* redacted authentication observability with negative secret-leak
+  assertions.
+
+No new auth service, no redundant JWT implementation (all token crypto
+goes through the #4118 primitives), no per-request Omnigent Server call,
+and no upstream runtime/delegated/worker credential is ever accepted as a
+MoonMind user. Browser logout revokes browser authority only: it never
+revokes independent worker credentials and never cancels admitted
+Temporal work (this authority touches only session/revocation state).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+from moonmind.security import omnigent_auth_qualification as q
+
+logger = logging.getLogger(__name__)
+
+# Re-exported from the #4120 owner so callers have one import surface.
+from moonmind.security.omnigent_auth_qualification import (  # noqa: F401
+    MOONMIND_DEV_COOKIE,
+    MOONMIND_PROD_COOKIE,
+    MOONMIND_SESSION_PURPOSE,
+    AuthConflictError,
+    AuthConfigError,
+    AuthInvalidError,
+    AuthRequiredError,
+    ForbiddenError,
+    UnavailableError,
+    UnsupportedSurfaceError,
+)
+
+# Stream/authz bound from docs/Security/AuthenticationContracts.md §5
+# (inventory §5.2): revocation commits take effect at the final replica
+# re-authorization check within 5 minutes of the commit timestamp.
+SESSION_REVOCATION_INTERVAL_SECONDS = 5 * 60
+
+# Upstream runtime credentials are never MoonMind users, even when their
+# JWT shape resembles an application session.
+UPSTREAM_RUNTIME_MARKERS = frozenset(
+    {
+        "__Host-ap_session",
+        "ap_session",
+        "omnigent-runtime",
+        "omnigent_runtime",
+        "ap-runtime",
+    }
+)
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+# ---------------------------------------------------------------------------
+# HTTP mapping: one place maps authority errors to status/code pairs
+# ---------------------------------------------------------------------------
+
+
+def http_status_for_error(exc: BaseException) -> tuple[int, str]:
+    """Map an authority error to ``(status, code)`` per AuthenticationContracts §8."""
+    if isinstance(exc, AuthRequiredError):
+        return 401, "auth_required"
+    if isinstance(exc, AuthConflictError):
+        return 401, "auth_conflict"
+    if isinstance(exc, AuthInvalidError):
+        return 401, "auth_invalid"
+    if isinstance(exc, UnsupportedSurfaceError):
+        return 401, "auth_invalid"
+    if isinstance(exc, ForbiddenError):
+        return 403, getattr(exc, "code", "forbidden") or "forbidden"
+    if isinstance(exc, UnavailableError):
+        return 503, "unavailable"
+    return 500, "internal"
+
+
+# ---------------------------------------------------------------------------
+# Single credential-precedence resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_credential_source(
+    cookie_token: str | None, bearer_token: str | None
+) -> str | None:
+    """Return which credential governs: ``"cookie"``, ``"bearer"``, or ``None``.
+
+    Both-present with differing values is a conflict signal for the caller
+    to resolve principal-equality on (never silent preference). Empty
+    strings count as missing. Upstream runtime cookie names presented as
+    the cookie credential are rejected as invalid, never reinterpreted.
+    """
+    cookie = (cookie_token or "").strip() or None
+    bearer = (bearer_token or "").strip() or None
+    if cookie is None and bearer is None:
+        return None
+    if cookie is not None and bearer is not None and cookie != bearer:
+        return "conflict"
+    if cookie is not None:
+        return "cookie"
+    return "bearer"
+
+
+async def resolve_session_user(
+    *,
+    cookie_token: str | None,
+    bearer_token: str | None,
+    account_store: q.AsyncAccountStore,
+    revocation: q.SessionRevocationStore,
+    config: q.MoonmindAuthConfig,
+    optional: bool = False,
+) -> q.AccountRecord | None:
+    """Resolve the current session user with single-precedence semantics.
+
+    * Missing optional credentials proceed (worker-tolerant paths authorize
+      separately); missing at strict boundaries raises ``AuthRequiredError``.
+    * Invalid presented credentials never silently fall back to another
+      path; conflicting cookie/bearer identities raise
+      ``AuthConflictError``.
+    """
+    source = resolve_credential_source(cookie_token, bearer_token)
+    if source is None:
+        if optional:
+            return None
+        raise AuthRequiredError()
+    if source == "conflict":
+        assert cookie_token and bearer_token
+        return await q.resolve_current_user(
+            cookie_token=cookie_token,
+            bearer_token=bearer_token,
+            account_store=account_store,
+            revocation=revocation,
+            config=config,
+        )
+    token = cookie_token if source == "cookie" else bearer_token
+    assert token is not None
+    return await q.resolve_current_user(
+        cookie_token=token if source == "cookie" else None,
+        bearer_token=token if source == "bearer" else None,
+        account_store=account_store,
+        revocation=revocation,
+        config=config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bounded validation cache (size + TTL, never skips checks)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BoundedSessionCache:
+    """Bounded TTL credential cache that cannot bypass validation.
+
+    Every call re-runs :func:`validate_moonmind_session` (signature,
+    algorithm, issuer, audience/purpose, expiry, live revocation,
+    generation, current principal status), including cache hits, so
+    revocation/status changes take effect across replicas within
+    ``ttl_seconds``. Entries are keyed by HMAC digest (never raw token)
+    and evicted oldest-first beyond ``max_entries``.
+    """
+
+    config: q.MoonmindAuthConfig
+    max_entries: int = 1024
+    ttl_seconds: float = SESSION_REVOCATION_INTERVAL_SECONDS
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    _entries: OrderedDict[str, float] = field(default_factory=OrderedDict)
+
+    def __post_init__(self) -> None:
+        if self.max_entries <= 0:
+            raise AuthConfigError("max_entries must be positive")
+        if self.ttl_seconds <= 0:
+            raise AuthConfigError("ttl_seconds must be positive")
+
+    def _key(self, token: str) -> str:
+        return hmac.new(
+            self.config.cookie_secret, token.encode(), hashlib.sha256
+        ).hexdigest()
+
+    def _prune(self, now_mono: float) -> None:
+        expired = [k for k, exp in self._entries.items() if exp <= now_mono]
+        for key in expired:
+            del self._entries[key]
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+            self.evictions += 1
+
+    async def validate(
+        self,
+        token: str,
+        account_store: q.AsyncAccountStore,
+        revocation: q.SessionRevocationStore,
+    ) -> q.AccountRecord:
+        key = self._key(token)
+        now_mono = time.monotonic()
+        # Full validation first: hits never skip revocation/status checks.
+        account = await q.validate_moonmind_session(
+            token, account_store, revocation, self.config
+        )
+        cached_expiry = self._entries.get(key)
+        if cached_expiry is not None and cached_expiry > now_mono:
+            self.hits += 1
+            self._entries.move_to_end(key)
+        else:
+            self.misses += 1
+            self._entries[key] = now_mono + min(
+                self.ttl_seconds,
+                max(1.0, _token_remaining_seconds(token)),
+            )
+            self._entries.move_to_end(key)
+        self._prune(now_mono)
+        return account
+
+    @property
+    def size(self) -> int:
+        return len(self._entries)
+
+
+def _token_remaining_seconds(token: str) -> float:
+    try:
+        import jwt as _jwt
+
+        payload = _jwt.decode(token, options={"verify_signature": False})
+        return float(payload.get("exp", 0)) - time.time()
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Key-ring validation for rotation (no indefinite old-token acceptance)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionKeyRing:
+    """Current + bounded previous signing secret for rotation.
+
+    Minting always uses ``current``. Validation tries ``current`` first,
+    then ``previous`` only while ``now < previous_expires_at``. After the
+    overlap window, old-key tokens fail closed instead of being accepted
+    indefinitely.
+    """
+
+    current: bytes
+    previous: bytes | None = None
+    previous_expires_at: float | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.current, (bytes, bytearray)) or len(self.current) < 32:
+            raise AuthConfigError("key-ring current secret must be at least 32 bytes")
+        if self.previous is not None:
+            if len(self.previous) < 32:
+                raise AuthConfigError("key-ring previous secret must be at least 32 bytes")
+            if self.previous_expires_at is None:
+                raise AuthConfigError(
+                    "key-ring previous secret requires previous_expires_at"
+                )
+
+    def rotate(self, new_secret: bytes, *, overlap_seconds: float = 600) -> SessionKeyRing:
+        """Return the ring after rotation to ``new_secret``.
+
+        The old current becomes the bounded previous generation; tokens
+        signed with it validate only during the overlap window.
+        """
+        if not isinstance(new_secret, (bytes, bytearray)) or len(new_secret) < 32:
+            raise AuthConfigError("rotation secret must be at least 32 bytes")
+        if bytes(new_secret) == bytes(self.current):
+            raise AuthConfigError("rotation requires a distinct secret")
+        return SessionKeyRing(
+            current=bytes(new_secret),
+            previous=bytes(self.current),
+            previous_expires_at=time.time() + overlap_seconds,
+        )
+
+
+async def validate_with_key_ring(
+    token: str,
+    account_store: q.AsyncAccountStore,
+    revocation: q.SessionRevocationStore,
+    base_config: q.MoonmindAuthConfig,
+    ring: SessionKeyRing,
+    *,
+    now: float | None = None,
+) -> q.AccountRecord:
+    """Validate against the key ring, failing closed on old-key reuse.
+
+    Tries the current secret; only on signature failure tries the bounded
+    previous secret within its overlap window. Revocation, generation, and
+    principal-status checks run on whichever secret verifies.
+    """
+    current_config = _config_with_secret(base_config, ring.current)
+    try:
+        return await q.validate_moonmind_session(
+            token, account_store, revocation, current_config
+        )
+    except AuthInvalidError as current_exc:
+        if ring.previous is None:
+            raise
+        moment = time.time() if now is None else now
+        assert ring.previous_expires_at is not None
+        if moment >= ring.previous_expires_at:
+            raise AuthInvalidError(
+                "auth_invalid", "session signed with a rotated-out key"
+            ) from current_exc
+        previous_config = _config_with_secret(base_config, ring.previous)
+        return await q.validate_moonmind_session(
+            token, account_store, revocation, previous_config
+        )
+
+
+def _config_with_secret(
+    base: q.MoonmindAuthConfig, secret: bytes
+) -> q.MoonmindAuthConfig:
+    return q.MoonmindAuthConfig(
+        mode=base.mode,
+        cookie_name=base.cookie_name,
+        cookie_secret=bytes(secret),
+        session_ttl_seconds=base.session_ttl_seconds,
+        token_issuer=base.token_issuer,
+        token_audience=base.token_audience,
+        require_secure_cookies=base.require_secure_cookies,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cookie issue/clear policy
+# ---------------------------------------------------------------------------
+
+
+def cookie_name_for_policy(*, require_secure_cookies: bool) -> str:
+    """Return the MoonMind cookie name for the transport policy."""
+    return MOONMIND_PROD_COOKIE if require_secure_cookies else MOONMIND_DEV_COOKIE
+
+
+def build_set_cookie_header(
+    *,
+    token: str,
+    cookie_name: str,
+    require_secure_cookies: bool,
+    max_age_seconds: int,
+) -> str:
+    """Build a ``Set-Cookie`` value for an issued MoonMind session.
+
+    Production uses the ``__Host-`` cookie with ``Secure`` (which requires
+    ``Path=/`` and no ``Domain``); the separately named development cookie
+    is for explicit loopback HTTP only. Both are ``HttpOnly`` with
+    ``SameSite=Lax`` or stricter. Raises when a ``__Host-`` cookie would be
+    set without ``Secure``/``Path=/`` or with a ``Domain``.
+    """
+    if not token or not cookie_name:
+        raise AuthConfigError("cookie issuance requires a token and cookie name")
+    if cookie_name in q.UPSTREAM_SESSION_COOKIES:
+        raise AuthConfigError(
+            f"cookie_name={cookie_name!r} collides with the upstream runtime cookie"
+        )
+    parts = [f"{cookie_name}={token}", "Path=/", "HttpOnly", "SameSite=Lax"]
+    if require_secure_cookies:
+        parts.append("Secure")
+    if cookie_name.startswith("__Host-"):
+        if not require_secure_cookies:
+            raise AuthConfigError(
+                f"{cookie_name!r} is Host-prefixed and requires Secure on HTTPS"
+            )
+        # Path=/ is set above; Domain must never be set for __Host-.
+    elif require_secure_cookies and cookie_name == MOONMIND_DEV_COOKIE:
+        raise AuthConfigError(
+            "The development cookie must never be issued under Secure production policy"
+        )
+    parts.append(f"Max-Age={int(max_age_seconds)}")
+    return "; ".join(parts)
+
+
+def build_clear_cookie_header(
+    *, cookie_name: str, require_secure_cookies: bool
+) -> str:
+    """Build a clearing ``Set-Cookie`` with matching scope attributes.
+
+    Clearing must repeat the issue scope (``Path=/``, ``Secure`` on HTTPS,
+    ``SameSite``) or the browser keeps the session cookie.
+    """
+    parts = [f"{cookie_name}=deleted", "Path=/", "HttpOnly", "SameSite=Lax"]
+    if require_secure_cookies or cookie_name.startswith("__Host-"):
+        parts.append("Secure")
+    parts.append("Max-Age=0")
+    parts.append("Expires=Thu, 01 Jan 1970 00:00:00 GMT")
+    return "; ".join(parts)
+
+
+def assert_no_token_in_json(payload: Mapping[str, Any]) -> None:
+    """Fail when a browser response payload would leak session material.
+
+    Browser responses must never expose session/refresh tokens merely
+    because an upstream CLI mode offers them. Scans the top-level keys
+    for token-shaped fields.
+    """
+    suspect = {
+        "session_token",
+        "refresh_token",
+        "moonmind_session",
+        "mm_session",
+        "set_cookie",
+        "id_token",
+    }
+    found = [k for k in payload if str(k).lower() in suspect]
+    if found:
+        raise AuthConfigError(
+            f"browser payload must not carry session material: {sorted(found)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CSRF + origin enforcement at the shared cookie-unsafe boundary
+# ---------------------------------------------------------------------------
+
+
+def enforce_csrf_origin(
+    *,
+    method: str,
+    cookie_present: bool,
+    origin: str | None,
+    referer: str | None,
+    host: str | None,
+    base_url: str,
+) -> None:
+    """Enforce CSRF/origin checks for cookie-authenticated unsafe requests.
+
+    Safe methods and bearer-only flows (no cookie presented) pass through;
+    cookie-authenticated mutations (including login/logout/invitation/
+    recovery actions issued over the session cookie) require an ``Origin``
+    or ``Referer`` that is same-origin with the configured ``base_url``.
+    Cross-origin cookie mutations are rejected; authorization is never
+    inferred from SameSite or CORS alone.
+    """
+    if method.upper() in _SAFE_METHODS or not cookie_present:
+        return
+    if not base_url:
+        raise AuthInvalidError("auth_invalid", "cookie CSRF cannot be checked")
+    try:
+        expected = urlsplit(base_url.strip())
+        expected_host = (expected.hostname or "").lower()
+        expected_scheme = expected.scheme.lower()
+    except ValueError as exc:
+        raise AuthInvalidError("auth_invalid", "cookie CSRF cannot be checked") from exc
+    if not expected_host:
+        raise AuthInvalidError("auth_invalid", "cookie CSRF cannot be checked")
+    candidate = (origin or "").strip() or (referer or "").strip()
+    if not candidate:
+        raise AuthInvalidError("auth_invalid", "missing CSRF origin")
+    try:
+        parts = urlsplit(candidate)
+    except ValueError as exc:
+        raise AuthInvalidError("auth_invalid", "invalid CSRF origin") from exc
+    candidate_host = (parts.hostname or "").lower()
+    if not candidate_host or candidate_host != expected_host:
+        raise AuthInvalidError("auth_invalid", "cross-origin cookie mutation rejected")
+    if parts.scheme and expected_scheme and parts.scheme.lower() != expected_scheme:
+        raise AuthInvalidError("auth_invalid", "cross-origin cookie mutation rejected")
+    if host and candidate_host != host.strip().lower().split(":")[0]:
+        # Trusted Host/forwarded-origin input is validated by the caller via
+        # #4120 base-URL/proxy policy; a mismatch here fails closed.
+        raise AuthInvalidError("auth_invalid", "untrusted host for cookie mutation")
+
+
+def resolve_credentialed_cors_origins(
+    explicit_origins: list[str] | tuple[str, ...] | None,
+    *,
+    allow_credentials: bool,
+) -> list[str]:
+    """Resolve credentialed CORS origins, rejecting wildcard+credentials.
+
+    ``allow_origins=["*"]`` with ``allow_credentials=True`` would let any
+    site issue credentialed cross-origin requests; it fails closed here.
+    Credentialed deployments must enumerate trusted origins explicitly.
+    """
+    origins = [o.strip() for o in (explicit_origins or []) if str(o).strip()]
+    if allow_credentials and "*" in origins:
+        raise AuthConfigError(
+            "credentialed CORS cannot use allow_origins=['*']: enumerate "
+            "explicit trusted origins for cookie-authenticated browsers"
+        )
+    return origins
+
+
+# ---------------------------------------------------------------------------
+# Stream re-authorization (WebSocket/SSE reconnects, active termination)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StreamReauthPolicy:
+    """Bound for re-authorizing active browser streams (#4121 req 7)."""
+
+    max_reauth_interval_seconds: int = SESSION_REVOCATION_INTERVAL_SECONDS
+
+    def __post_init__(self) -> None:
+        if self.max_reauth_interval_seconds <= 0:
+            raise AuthConfigError("max_reauth_interval_seconds must be positive")
+
+    def reauth_due(self, last_check_epoch: float, *, now_epoch: float | None = None) -> bool:
+        moment = time.time() if now_epoch is None else now_epoch
+        return (moment - last_check_epoch) >= self.max_reauth_interval_seconds
+
+
+async def reauthorize_stream_token(
+    token: str,
+    *,
+    account_store: q.AsyncAccountStore,
+    revocation: q.SessionRevocationStore,
+    config: q.MoonmindAuthConfig,
+) -> q.AccountRecord:
+    """Re-authorize one active stream credential against live authority.
+
+    Uses the same validation/revocation interface as HTTP (no second
+    stream store). Stream owners call this on reconnect and at least every
+    :attr:`StreamReauthPolicy.max_reauth_interval_seconds` to terminate
+    revoked/expired streams within the agreed bound without changing
+    workflow ownership.
+    """
+    return await q.validate_moonmind_session(token, account_store, revocation, config)
+
+
+# ---------------------------------------------------------------------------
+# Redacted authentication observability (no secret material)
+# ---------------------------------------------------------------------------
+
+_AUTH_EVENT_KINDS = frozenset({"success", "denial", "unavailable", "revocation"})
+
+_SECRET_SUBSTRINGS = (
+    "eyJ",
+    "reset_token",
+    "reset-",
+    "verification_token",
+    "verification-",
+    "authorization_code",
+    "refresh_token",
+)
+
+
+def emit_auth_event(
+    kind: str,
+    *,
+    mode: str,
+    reason: str,
+    request_id: str | None = None,
+    user_id: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Record a redacted authentication event through existing observability.
+
+    Never logs tokens, cookies, auth codes, reset links, or raw IdP
+    responses: any ``extra`` value containing secret-shaped material fails
+    closed with ``AuthConfigError`` instead of being emitted.
+    """
+    normalized = kind.strip().lower()
+    if normalized not in _AUTH_EVENT_KINDS:
+        raise AuthConfigError(f"unknown auth event kind {kind!r}")
+    event: dict[str, Any] = {
+        "auth_event": normalized,
+        "auth_mode": mode,
+        "reason": reason,
+        "request_id": request_id or "-",
+        "user_id": user_id or "-",
+    }
+    for key, value in dict(extra or {}).items():
+        lowered = str(key).lower()
+        if any(
+            hint in lowered
+            for hint in (
+                "token",
+                "cookie",
+                "secret",
+                "password",
+                "code",
+                "link",
+                "idp_response",
+                "authorization",
+            )
+        ):
+            raise AuthConfigError(
+                f"auth event must not carry secret material: {key!r}"
+            )
+        text = str(value)
+        if any(marker in text for marker in _SECRET_SUBSTRINGS):
+            raise AuthConfigError(
+                f"auth event value for {key!r} looks like secret material"
+            )
+        event[str(key)] = value
+    logger.info("auth_event %s mode=%s reason=%s", normalized, mode, reason)
+    return event
+
+
+def assert_no_secret_leak(container: Any, secrets: list[str]) -> None:
+    """Fail when ``container`` serializes any of ``secrets`` (negative test helper).
+
+    Used by leakage-negative assertions with synthetic secrets across logs,
+    traces, Temporal payloads, and artifacts.
+    """
+    try:
+        import json as _json
+
+        rendered = _json.dumps(container, default=str)
+    except Exception:
+        rendered = str(container)
+    for secret in secrets:
+        if secret and secret in rendered:
+            raise AssertionError("secret material leaked into serialized payload")

--- a/moonmind/security/session_authority_4121.py
+++ b/moonmind/security/session_authority_4121.py
@@ -50,6 +50,20 @@ from moonmind.security import omnigent_auth_qualification as q
 logger = logging.getLogger(__name__)
 
 # Re-exported from the #4120 owner so callers have one import surface.
+# ``__all__`` marks the re-export as intentional (consumed via this module
+# by account/OIDC/API/dashboard callers) for unused-import linters.
+__all__ = [
+    "MOONMIND_DEV_COOKIE",
+    "MOONMIND_PROD_COOKIE",
+    "MOONMIND_SESSION_PURPOSE",
+    "AuthConflictError",
+    "AuthConfigError",
+    "AuthInvalidError",
+    "AuthRequiredError",
+    "ForbiddenError",
+    "UnavailableError",
+    "UnsupportedSurfaceError",
+]
 from moonmind.security.omnigent_auth_qualification import (  # noqa: F401
     MOONMIND_DEV_COOKIE,
     MOONMIND_PROD_COOKIE,
@@ -445,6 +459,23 @@ def assert_no_token_in_json(payload: Mapping[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _effective_port(scheme: str, port: int | None) -> int | None:
+    """Return the effective port, filling well-known defaults for http/https.
+
+    Returns ``None`` when the scheme has no well-known default and no
+    explicit port was supplied, so unknown schemes compare by explicit
+    port only.
+    """
+    if port is not None:
+        return port
+    lowered = (scheme or "").lower()
+    if lowered == "https":
+        return 443
+    if lowered == "http":
+        return 80
+    return None
+
+
 def enforce_csrf_origin(
     *,
     method: str,
@@ -460,8 +491,11 @@ def enforce_csrf_origin(
     cookie-authenticated mutations (including login/logout/invitation/
     recovery actions issued over the session cookie) require an ``Origin``
     or ``Referer`` that is same-origin with the configured ``base_url``.
-    Cross-origin cookie mutations are rejected; authorization is never
-    inferred from SameSite or CORS alone.
+    Same-origin compares scheme, hostname, and effective port: cookies and
+    SameSite classification do not isolate ports, so an attacker-controlled
+    service on another port of the same hostname must not pass. Cross-origin
+    cookie mutations are rejected; authorization is never inferred from
+    SameSite or CORS alone.
     """
     if method.upper() in _SAFE_METHODS or not cookie_present:
         return
@@ -471,6 +505,7 @@ def enforce_csrf_origin(
         expected = urlsplit(base_url.strip())
         expected_host = (expected.hostname or "").lower()
         expected_scheme = expected.scheme.lower()
+        expected_port = _effective_port(expected.scheme, expected.port)
     except ValueError as exc:
         raise AuthInvalidError("auth_invalid", "cookie CSRF cannot be checked") from exc
     if not expected_host:
@@ -480,12 +515,15 @@ def enforce_csrf_origin(
         raise AuthInvalidError("auth_invalid", "missing CSRF origin")
     try:
         parts = urlsplit(candidate)
+        candidate_port = _effective_port(parts.scheme, parts.port)
     except ValueError as exc:
         raise AuthInvalidError("auth_invalid", "invalid CSRF origin") from exc
     candidate_host = (parts.hostname or "").lower()
     if not candidate_host or candidate_host != expected_host:
         raise AuthInvalidError("auth_invalid", "cross-origin cookie mutation rejected")
     if parts.scheme and expected_scheme and parts.scheme.lower() != expected_scheme:
+        raise AuthInvalidError("auth_invalid", "cross-origin cookie mutation rejected")
+    if candidate_port != expected_port:
         raise AuthInvalidError("auth_invalid", "cross-origin cookie mutation rejected")
     if host and candidate_host != host.strip().lower().split(":")[0]:
         # Trusted Host/forwarded-origin input is validated by the caller via

--- a/moonmind/security/session_authority_4121.py
+++ b/moonmind/security/session_authority_4121.py
@@ -82,18 +82,6 @@ from moonmind.security.omnigent_auth_qualification import (  # noqa: F401
 # re-authorization check within 5 minutes of the commit timestamp.
 SESSION_REVOCATION_INTERVAL_SECONDS = 5 * 60
 
-# Upstream runtime credentials are never MoonMind users, even when their
-# JWT shape resembles an application session.
-UPSTREAM_RUNTIME_MARKERS = frozenset(
-    {
-        "__Host-ap_session",
-        "ap_session",
-        "omnigent-runtime",
-        "omnigent_runtime",
-        "ap-runtime",
-    }
-)
-
 _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 
 

--- a/tests/integration/security/test_session_authority_postgres_4121.py
+++ b/tests/integration/security/test_session_authority_postgres_4121.py
@@ -1,0 +1,298 @@
+"""Real-PostgreSQL session/revocation evidence (MoonLadderStudios/MoonMind#4121).
+
+Proves the durability seams on PostgreSQL, not SQLite: cross-restart and
+two-instance revocation visibility, cached-token invalidation, concurrent
+issuance versus disable/reset (no resurrection), revocation-store outage
+fail-closed behavior, and the concurrent generation-bump race. Runs an
+ephemeral local cluster with no manually managed test service (mirrors the
+control-plane Postgres binding).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    MoonmindSession,
+    MoonmindUserSessionGeneration,
+    User,
+)
+from api_service.services.session_store import (
+    DbAccountStore,
+    DbRevocationStore,
+    disable_user_and_revoke_sessions,
+    mint_and_record_session,
+)
+from moonmind.security import omnigent_auth_qualification as q
+from moonmind.security import session_authority_4121 as s
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+_TABLES = (
+    User.__table__,
+    MoonmindUserSessionGeneration.__table__,
+    MoonmindSession.__table__,
+)
+
+
+def _config(secret: bytes | None = None) -> q.MoonmindAuthConfig:
+    return q.MoonmindAuthConfig(
+        mode="accounts",
+        cookie_name=q.MOONMIND_DEV_COOKIE,
+        cookie_secret=secret or secrets.token_bytes(32),
+        session_ttl_seconds=3600,
+        require_secure_cookies=False,
+    )
+
+
+@pytest.fixture
+def session_postgres_url():
+    """Ephemeral PostgreSQL; honors MOONMIND_TEST_POSTGRES_URL when set."""
+    configured = os.getenv("MOONMIND_TEST_POSTGRES_URL", "").strip()
+    if configured:
+        if configured.startswith("postgresql://"):
+            configured = configured.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if not configured.startswith("postgresql+asyncpg://"):
+            pytest.fail("MOONMIND_TEST_POSTGRES_URL must use PostgreSQL")
+        yield configured
+        return
+    initdb_path = shutil.which("initdb")
+    if initdb_path is None:
+        candidates = sorted(Path("/usr/lib/postgresql").glob("*/bin/initdb"))
+        initdb_path = str(candidates[-1]) if candidates else None
+    if initdb_path is None:
+        pytest.fail("PostgreSQL test binaries are unavailable in the Python test image")
+    initdb = str(Path(initdb_path))
+    pg_ctl = str(Path(initdb).with_name("pg_ctl"))
+    data_root = Path(tempfile.mkdtemp(prefix="moonmind-session-postgres-"))
+    data_dir = data_root / "data"
+    log_path = data_root / "postgres.log"
+    command_prefix: list[str] = []
+    if os.geteuid() == 0:
+        shutil.chown(data_root, user="postgres", group="postgres")
+        command_prefix = ["runuser", "--user", "postgres", "--"]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    subprocess.run(
+        [*command_prefix, initdb, "--pgdata", str(data_dir), "--username", "postgres",
+         "--auth", "trust", "--encoding", "UTF8", "--no-locale"],
+        check=True, capture_output=True, text=True,
+    )
+    subprocess.run(
+        [*command_prefix, pg_ctl, "--pgdata", str(data_dir), "--log", str(log_path),
+         "--options", f"-F -p {port} -h 127.0.0.1 -k {data_dir}", "--wait", "start"],
+        check=True, capture_output=True, text=True,
+    )
+    try:
+        yield f"postgresql+asyncpg://postgres@127.0.0.1:{port}/postgres"
+    finally:
+        subprocess.run(
+            [*command_prefix, pg_ctl, "--pgdata", str(data_dir), "--mode", "immediate",
+             "--wait", "stop"],
+            check=False, capture_output=True, text=True,
+        )
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+@pytest_asyncio.fixture()
+async def pg_maker(session_postgres_url):
+    engine = create_async_engine(session_postgres_url)
+    async with engine.begin() as conn:
+        for table in _TABLES:
+            await conn.run_sync(table.create, checkfirst=True)
+    maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        async with engine.begin() as conn:
+            for table in reversed(_TABLES):
+                await conn.run_sync(table.drop, checkfirst=True)
+        await engine.dispose()
+
+
+async def _make_user(session: AsyncSession, **overrides) -> User:
+    params = {
+        "id": uuid.uuid4(),
+        "email": f"sess-{uuid.uuid4().hex}@example.invalid",
+        "hashed_password": None,
+        "is_active": True,
+        "is_superuser": False,
+        "is_verified": False,
+    }
+    params.update(overrides)
+    user = User(**params)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+def _identity_for(user: User) -> q.ValidatedIdentity:
+    return q.ValidatedIdentity(issuer="moonmind-accounts", subject=user.email)
+
+
+@pytest.mark.asyncio
+async def test_postgres_logout_revokes_across_instances_and_restart(pg_maker) -> None:
+    """Logout on one instance denies cached tokens on a second instance."""
+    secret = secrets.token_bytes(32)
+    config = _config(secret)
+    async with pg_maker() as session:
+        user = await _make_user(session)
+        await session.commit()
+    # Instance one mints and records.
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        token, user_id = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+        assert user_id == user.id
+    # Instance two validates through a bounded cache (simulated replica).
+    async with pg_maker() as session:
+        cache = s.BoundedSessionCache(config=config)
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        resolved = await cache.validate(token, accounts, revocation)
+        assert resolved.user_id == user.id
+        assert cache.misses == 1
+        # Logout revokes the current session durably.
+        import jwt as _jwt
+
+        jti = str(_jwt.decode(token, options={"verify_signature": False})["jti"])
+        await revocation.revoke_session_for_user(jti, user.id, reason="logout")
+        await session.commit()
+    # After "restart" (fresh sessions), the cached token is denied.
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        with pytest.raises(q.AuthInvalidError):
+            await q.validate_moonmind_session(token, accounts, revocation, config)
+
+
+@pytest.mark.asyncio
+async def test_postgres_revoke_all_invalidates_cached_and_blocks_resurrection(
+    pg_maker,
+) -> None:
+    """Password-reset/disable/admin-revoke bumps generation; racers die."""
+    secret = secrets.token_bytes(32)
+    config = _config(secret)
+    async with pg_maker() as session:
+        user = await _make_user(session)
+        await session.commit()
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        stale, _ = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+        # Concurrent issuance started before the revocation boundary.
+        racing, _ = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+        generation = await revocation.revoke_all_for_user(user.id)
+        await session.commit()
+        assert generation == 1
+        for doomed in (stale, racing):
+            with pytest.raises(q.AuthInvalidError):
+                await q.validate_moonmind_session(doomed, accounts, revocation, config)
+        fresh, _ = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+        resolved = await q.validate_moonmind_session(fresh, accounts, revocation, config)
+        assert resolved.user_id == user.id
+
+
+@pytest.mark.asyncio
+async def test_postgres_disable_blocks_new_actions(pg_maker) -> None:
+    """Account disablement deactivates and revokes in one transaction."""
+    secret = secrets.token_bytes(32)
+    config = _config(secret)
+    async with pg_maker() as session:
+        user = await _make_user(session)
+        await session.commit()
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        token, _ = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+    async with pg_maker() as session:
+        generation = await disable_user_and_revoke_sessions(session, user.id)
+        assert generation >= 1
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        # Inactive accounts are forbidden (not silently re-resolved).
+        with pytest.raises((q.AuthInvalidError, q.ForbiddenError)):
+            await q.validate_moonmind_session(token, accounts, revocation, config)
+
+
+@pytest.mark.asyncio
+async def test_postgres_concurrent_revoke_all_converges(pg_maker) -> None:
+    """Concurrent admin revocations produce increasing generations."""
+    async with pg_maker() as session:
+        user = await _make_user(session)
+        await session.commit()
+
+    async def revoke_once() -> int:
+        async with pg_maker() as session:
+            store = DbRevocationStore(session)
+            generation = await store.revoke_all_for_user(user.id)
+            await session.commit()
+            return generation
+
+    generations = await asyncio.gather(*[revoke_once() for _ in range(4)])
+    assert sorted(generations) == [1, 2, 3, 4]
+    async with pg_maker() as session:
+        store = DbRevocationStore(session)
+        assert await store.generation_for_user(user.id) == 4
+
+
+@pytest.mark.asyncio
+async def test_postgres_outage_fails_closed_bounded(pg_maker) -> None:
+    """Store outage is 503 unavailable, never stale authority or an admin."""
+    secret = secrets.token_bytes(32)
+    config = _config(secret)
+    async with pg_maker() as session:
+        user = await _make_user(session)
+        await session.commit()
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        revocation = DbRevocationStore(session)
+        token, _ = await mint_and_record_session(
+            _identity_for(user), accounts, revocation, config, session
+        )
+
+    class _BrokenRevocation(DbRevocationStore):
+        async def is_session_revoked(self, jti: str) -> bool:
+            raise ConnectionError("revocation store down")
+
+        async def generation_for_user(self, user_id) -> int:
+            raise ConnectionError("revocation store down")
+
+    async with pg_maker() as session:
+        accounts = DbAccountStore(session)
+        broken = _BrokenRevocation(session)
+        with pytest.raises(q.UnavailableError):
+            await q.validate_moonmind_session(token, accounts, broken, config)
+        status, code = s.http_status_for_error(q.UnavailableError("down"))
+        assert (status, code) == (503, "unavailable")
+        # Bounded failure: the outage surfaces quickly, not as a hang.
+        start = time.monotonic()
+        with pytest.raises(q.UnavailableError):
+            await q.validate_moonmind_session(token, accounts, broken, config)
+        assert time.monotonic() - start < 5.0

--- a/tests/unit/security/test_session_authority_4121.py
+++ b/tests/unit/security/test_session_authority_4121.py
@@ -1,0 +1,595 @@
+"""Unit coverage for the #4121 session authority (MoonLadderStudios/MoonMind#4121).
+
+Proves the acceptance matrix without a database: real issuance/validation
+through the composed #4118 primitives, logout/reset/disable/admin-revoke/
+key-rotation semantics across two validator replicas sharing one
+revocation store (incl. cached tokens and concurrent issuance), outage
+fail-closed behavior, CSRF/origin + credentialed-CORS enforcement,
+authority boundaries, leakage-negative assertions with synthetic secrets,
+and the stream re-authorization bound.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+import uuid
+
+import jwt
+import pytest
+
+from moonmind.security import omnigent_auth_qualification as q
+from moonmind.security import session_authority_4121 as s
+
+
+def _config(**overrides):
+    base = {
+        "mode": "accounts",
+        "cookie_name": q.MOONMIND_DEV_COOKIE,
+        "cookie_secret": secrets.token_bytes(32),
+        "session_ttl_seconds": 3600,
+        "require_secure_cookies": False,
+    }
+    base.update(overrides)
+    return q.MoonmindAuthConfig(**base)
+
+
+def _identity(subject: str = "alice", issuer: str = "moonmind-accounts", **kw):
+    return q.ValidatedIdentity(issuer=issuer, subject=subject, **kw)
+
+
+def _enrolled(store, identity, **kw):
+    account = q.AccountRecord(user_id=uuid.uuid4(), **kw)
+    store.enroll(identity, account)
+    return account
+
+
+# ---------------------------------------------------------------------------
+# 1. Real issuance/validation matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_valid_absent_expired_claim_matrix():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=True)
+
+    token, user_id = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    assert user_id == account.user_id
+    resolved = await s.resolve_session_user(
+        cookie_token=token,
+        bearer_token=None,
+        account_store=store,
+        revocation=revocation,
+        config=config,
+    )
+    assert resolved is not None and resolved.user_id == account.user_id
+
+    # Absent at a strict boundary.
+    with pytest.raises(q.AuthRequiredError):
+        await s.resolve_session_user(
+            cookie_token=None,
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+    # Absent at an optional boundary proceeds for separate worker auth.
+    assert (
+        await s.resolve_session_user(
+            cookie_token=None,
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+            optional=True,
+        )
+        is None
+    )
+
+    # Expired.
+    expired, _ = await q.mint_moonmind_session(
+        identity, store, config, now=int(time.time()) - 7200, revocation=revocation
+    )
+    with pytest.raises(q.AuthInvalidError):
+        await s.resolve_session_user(
+            cookie_token=expired,
+            bearer_token=None,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_wrong_key_issuer_audience_purpose_missing_claims():
+    secret = secrets.token_bytes(32)
+    config = _config(cookie_secret=secret)
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    _enrolled(store, identity, is_active=True)
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+
+    # Wrong key.
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(
+            token, store, revocation, _config(cookie_secret=secrets.token_bytes(32))
+        )
+    # Wrong issuer / audience.
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(
+            token, store, revocation, _config(cookie_secret=secret, token_issuer="other")
+        )
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(
+            token,
+            store,
+            revocation,
+            _config(cookie_secret=secret, token_audience="other"),
+        )
+    # Wrong purpose: re-sign the claims with a different purpose.
+    claims = jwt.decode(token, options={"verify_signature": False})
+    claims["purpose"] = "other-purpose"
+    repurposed = jwt.encode(claims, secret, algorithm="HS256")
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(repurposed, store, revocation, config)
+    # Missing required claims.
+    for missing in ("sub", "jti", "exp", "iss", "aud"):
+        slim = {k: v for k, v in claims.items() if k != missing}
+        slim_token = jwt.encode(slim, secret, algorithm="HS256")
+        with pytest.raises(q.AuthInvalidError):
+            await q.validate_moonmind_session(slim_token, store, revocation, config)
+    # Malformed signatures fail closed.
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session("not-a-jwt", store, revocation, config)
+
+
+def test_reserved_identities_rejected():
+    with pytest.raises(q.AuthInvalidError):
+        _identity(subject="local")
+    with pytest.raises(q.AuthInvalidError):
+        _identity(subject="__public__")
+
+
+@pytest.mark.asyncio
+async def test_conflicting_cookie_bearer_identities_rejected():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    alice = _enrolled(store, _identity("alice"), is_active=True)
+    bob = _enrolled(store, _identity("bob"), is_active=True)
+    token_a, _ = await q.mint_moonmind_session(
+        _identity("alice"), store, config, revocation=revocation
+    )
+    token_b, _ = await q.mint_moonmind_session(
+        _identity("bob"), store, config, revocation=revocation
+    )
+    assert alice.user_id != bob.user_id
+    assert s.resolve_credential_source(token_a, token_b) == "conflict"
+    with pytest.raises(q.AuthConflictError):
+        await s.resolve_session_user(
+            cookie_token=token_a,
+            bearer_token=token_b,
+            account_store=store,
+            revocation=revocation,
+            config=config,
+        )
+    status, code = s.http_status_for_error(q.AuthConflictError())
+    assert (status, code) == (401, "auth_conflict")
+
+
+# ---------------------------------------------------------------------------
+# 2. Logout / reset / disable / admin revoke / key rotation (two replicas)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_logout_revokes_across_replicas_including_cache():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    shared_revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    _enrolled(store, identity, is_active=True)
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=shared_revocation
+    )
+    replica_cache = s.BoundedSessionCache(config=config)
+    replica_two_cache = s.BoundedSessionCache(config=config)
+    # Both replicas validate (one through cache).
+    await replica_cache.validate(token, store, shared_revocation)
+    await q.validate_moonmind_session(token, store, shared_revocation, config)
+    # Logout revokes the session durably.
+    claims = jwt.decode(token, options={"verify_signature": False})
+    await shared_revocation.revoke_session(claims["jti"])
+    with pytest.raises(q.AuthInvalidError):
+        await replica_cache.validate(token, store, shared_revocation)
+    with pytest.raises(q.AuthInvalidError):
+        await replica_two_cache.validate(token, store, shared_revocation)
+
+
+@pytest.mark.asyncio
+async def test_generation_bump_invalidates_sessions_and_blocks_resurrection():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=True)
+    stale, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    # Concurrent issuance captures the pre-bump generation; the reset/admin
+    # bump (password reset / disable / admin revoke / rotation) wins.
+    racing, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    new_generation = await revocation.revoke_all_for_user(account.user_id)
+    assert new_generation == 1
+    for doomed in (stale, racing):
+        with pytest.raises(q.AuthInvalidError):
+            await q.validate_moonmind_session(doomed, store, revocation, config)
+    # Fresh issuance after the boundary validates.
+    fresh, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    resolved = await q.validate_moonmind_session(fresh, store, revocation, config)
+    assert resolved.user_id == account.user_id
+
+
+@pytest.mark.asyncio
+async def test_key_rotation_bounded_overlap():
+    secret_old = secrets.token_bytes(32)
+    secret_new = secrets.token_bytes(32)
+    base = _config(cookie_secret=secret_old)
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    _enrolled(store, identity, is_active=True)
+    old_token, _ = await q.mint_moonmind_session(
+        identity, store, base, revocation=revocation
+    )
+    ring = s.SessionKeyRing(current=secret_old).rotate(
+        secret_new, overlap_seconds=600
+    )
+    rotated_base = _config(cookie_secret=secret_new)
+    # During overlap the old token still validates via the previous secret.
+    resolved = await s.validate_with_key_ring(
+        old_token, store, revocation, rotated_base, ring
+    )
+    assert resolved is not None
+    # After the window the old key is refused (no indefinite acceptance).
+    with pytest.raises(q.AuthInvalidError):
+        await s.validate_with_key_ring(
+            old_token,
+            store,
+            revocation,
+            rotated_base,
+            ring,
+            now=time.time() + 3600,
+        )
+    # New-key tokens validate on the current secret.
+    new_token, _ = await q.mint_moonmind_session(
+        identity, store, rotated_base, revocation=revocation
+    )
+    assert (
+        await s.validate_with_key_ring(
+            new_token, store, revocation, rotated_base, ring
+        )
+    ) is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Outage fails closed with bounded unavailable (never an admin stub)
+# ---------------------------------------------------------------------------
+
+
+class _OutageRevocation(q.InMemoryRevocationStore):
+    async def is_session_revoked(self, jti: str) -> bool:
+        raise ConnectionError("revocation store down")
+
+    async def generation_for_user(self, user_id) -> int:
+        raise ConnectionError("revocation store down")
+
+
+@pytest.mark.asyncio
+async def test_store_outage_is_unavailable_not_admin():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    _enrolled(store, identity, is_active=True)
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    with pytest.raises(q.UnavailableError):
+        await q.validate_moonmind_session(token, store, _OutageRevocation(), config)
+    status, code = s.http_status_for_error(q.UnavailableError("down"))
+    assert (status, code) == (503, "unavailable")
+
+
+# ---------------------------------------------------------------------------
+# 4. Bounded cache: size, TTL, and hits that cannot bypass checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bounded_cache_evicts_and_honors_ttl():
+    config = _config()
+    cache = s.BoundedSessionCache(config=config, max_entries=2, ttl_seconds=60)
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    tokens = []
+    for name in ("u1", "u2", "u3"):
+        identity = _identity(name)
+        _enrolled(store, identity, is_active=True)
+        token, _ = await q.mint_moonmind_session(
+            identity, store, config, revocation=revocation
+        )
+        tokens.append(token)
+    for token in tokens:
+        await cache.validate(token, store, revocation)
+    assert cache.size <= 2
+    assert cache.evictions >= 1
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_reruns_revocation_and_status():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=True)
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    cache = s.BoundedSessionCache(config=config)
+    await cache.validate(token, store, revocation)
+    assert cache.misses == 1
+    # Revocation between calls is effective on the next hit.
+    claims = jwt.decode(token, options={"verify_signature": False})
+    await revocation.revoke_session(claims["jti"])
+    with pytest.raises(q.AuthInvalidError):
+        await cache.validate(token, store, revocation)
+    # Deactivation is likewise effective on hits.
+    token2_identity = _identity("second")
+    account2 = _enrolled(store, token2_identity, is_active=True)
+    token2, _ = await q.mint_moonmind_session(
+        token2_identity, store, config, revocation=revocation
+    )
+    await cache.validate(token2, store, revocation)
+    store._accounts[account2.user_id] = q.AccountRecord(
+        user_id=account2.user_id, is_active=False
+    )
+    with pytest.raises(q.ForbiddenError):
+        await cache.validate(token2, store, revocation)
+    assert account.user_id is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Cookies
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_issue_and_clear_policy():
+    prod = s.build_set_cookie_header(
+        token="synthetic-session",
+        cookie_name=s.MOONMIND_PROD_COOKIE,
+        require_secure_cookies=True,
+        max_age_seconds=3600,
+    )
+    assert "HttpOnly" in prod and "Secure" in prod and "SameSite" in prod
+    assert f"{s.MOONMIND_PROD_COOKIE}=" in prod and "Path=/" in prod
+    assert "Domain=" not in prod  # __Host- restriction
+    dev = s.build_set_cookie_header(
+        token="synthetic-session",
+        cookie_name=s.MOONMIND_DEV_COOKIE,
+        require_secure_cookies=False,
+        max_age_seconds=3600,
+    )
+    assert s.MOONMIND_DEV_COOKIE in dev and "Secure" not in dev
+    assert s.MOONMIND_DEV_COOKIE != s.MOONMIND_PROD_COOKIE
+    with pytest.raises(q.AuthConfigError):
+        s.build_set_cookie_header(
+            token="x",
+            cookie_name=s.MOONMIND_PROD_COOKIE,
+            require_secure_cookies=False,
+            max_age_seconds=60,
+        )
+    cleared = s.build_clear_cookie_header(
+        cookie_name=s.MOONMIND_PROD_COOKIE, require_secure_cookies=True
+    )
+    assert "Max-Age=0" in cleared and "Secure" in cleared and "Path=/" in cleared
+    with pytest.raises(q.AuthConfigError):
+        s.assert_no_token_in_json({"session_token": "synthetic-secret-token"})
+
+
+# ---------------------------------------------------------------------------
+# 6. CSRF / origin / credentialed CORS
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_origin_boundary():
+    base = "https://moonmind.example.invalid"
+    # Safe methods and bearer-only machine flows pass through.
+    s.enforce_csrf_origin(
+        method="GET",
+        cookie_present=True,
+        origin=None,
+        referer=None,
+        host="moonmind.example.invalid",
+        base_url=base,
+    )
+    s.enforce_csrf_origin(
+        method="POST",
+        cookie_present=False,
+        origin=None,
+        referer=None,
+        host=None,
+        base_url=base,
+    )
+    # Same-origin cookie mutation is allowed.
+    s.enforce_csrf_origin(
+        method="POST",
+        cookie_present=True,
+        origin="https://moonmind.example.invalid",
+        referer=None,
+        host="moonmind.example.invalid",
+        base_url=base,
+    )
+    # Cross-origin cookie mutations are rejected.
+    with pytest.raises(q.AuthInvalidError):
+        s.enforce_csrf_origin(
+            method="POST",
+            cookie_present=True,
+            origin="https://evil.example.invalid",
+            referer=None,
+            host="moonmind.example.invalid",
+            base_url=base,
+        )
+    # Missing origin on a cookie mutation fails closed.
+    with pytest.raises(q.AuthInvalidError):
+        s.enforce_csrf_origin(
+            method="POST",
+            cookie_present=True,
+            origin=None,
+            referer=None,
+            host="moonmind.example.invalid",
+            base_url=base,
+        )
+
+
+def test_credentialed_wildcard_cors_rejected():
+    with pytest.raises(q.AuthConfigError):
+        s.resolve_credentialed_cors_origins(["*"], allow_credentials=True)
+    origins = s.resolve_credentialed_cors_origins(
+        ["https://moonmind.example.invalid"], allow_credentials=True
+    )
+    assert origins == ["https://moonmind.example.invalid"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Authority boundaries: runtime / delegated / worker / browser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upstream_runtime_and_delegated_tokens_rejected():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    _enrolled(store, identity, is_active=True)
+    # An upstream runtime-shaped token (different issuer/purpose) is never
+    # a MoonMind user even when the signature verifies under some key.
+    runtime = jwt.encode(
+        {
+            "sub": "runtime-user",
+            "iss": "omnigent-runtime",
+            "aud": "omnigent-runtime-clients",
+            "purpose": "omnigent-runtime",
+            "jti": secrets.token_hex(8),
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+        },
+        config.cookie_secret,
+        algorithm="HS256",
+    )
+    with pytest.raises(q.AuthInvalidError):
+        await q.validate_moonmind_session(runtime, store, revocation, config)
+    # Delegated/grant-derived shapes are rejected, not broadened.
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    claims = jwt.decode(token, options={"verify_signature": False})
+    claims["scope"] = "delegated:read"
+    delegated = jwt.encode(claims, config.cookie_secret, algorithm="HS256")
+    with pytest.raises(q.UnsupportedSurfaceError):
+        await q.validate_moonmind_session(delegated, store, revocation, config)
+    for surface in ("refresh", "delegated", "runner_token", "cli_ticket", "magic_link"):
+        with pytest.raises(q.UnsupportedSurfaceError):
+            q.assert_surface_not_used(surface)
+
+
+def test_http_status_mapping():
+    assert s.http_status_for_error(q.AuthRequiredError()) == (401, "auth_required")
+    assert s.http_status_for_error(q.AuthInvalidError()) == (401, "auth_invalid")
+    assert s.http_status_for_error(q.ForbiddenError()) == (403, "forbidden")
+    assert s.http_status_for_error(q.UnavailableError()) == (503, "unavailable")
+
+
+# ---------------------------------------------------------------------------
+# 8. Observability negatives with synthetic secrets
+# ---------------------------------------------------------------------------
+
+
+def test_redacted_events_and_no_token_printing_hooks():
+    synthetic_cookie = f"mm-cookie-{secrets.token_hex(16)}"
+    synthetic_reset = f"reset-{secrets.token_hex(16)}"
+    event = s.emit_auth_event(
+        "denial", mode="accounts", reason="auth_invalid", request_id="req-1"
+    )
+    assert event["auth_event"] == "denial"
+    with pytest.raises(q.AuthConfigError):
+        s.emit_auth_event(
+            "success",
+            mode="accounts",
+            reason="ok",
+            extra={"session_token": synthetic_cookie},
+        )
+    with pytest.raises(q.AuthConfigError):
+        s.emit_auth_event(
+            "success",
+            mode="accounts",
+            reason="ok",
+            extra={"note": f"issued {synthetic_reset}"},
+        )
+    s.assert_no_secret_leak({"user": "alice"}, [synthetic_cookie])
+    with pytest.raises(AssertionError):
+        s.assert_no_secret_leak({"cookie": synthetic_cookie}, [synthetic_cookie])
+    # The replaced auth paths must not print token material.
+    import inspect
+
+    import api_service.auth as auth_module
+
+    source = inspect.getsource(auth_module)
+    assert "Reset token:" not in source
+    assert "Verification token:" not in source
+    assert "print(" not in source or "token" not in source.lower().split("print(")[-1][:200]
+
+
+# ---------------------------------------------------------------------------
+# 9. Stream re-authorization within the agreed bound
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_reauth_enforces_revocation_bound():
+    config = _config()
+    store = q.InMemoryAsyncAccountStore()
+    revocation = q.InMemoryRevocationStore()
+    identity = _identity()
+    account = _enrolled(store, identity, is_active=True)
+    token, _ = await q.mint_moonmind_session(
+        identity, store, config, revocation=revocation
+    )
+    policy = s.StreamReauthPolicy()
+    assert policy.max_reauth_interval_seconds == 5 * 60
+    assert policy.reauth_due(0.0, now_epoch=301.0) is True
+    assert policy.reauth_due(time.time(), now_epoch=time.time()) is False
+    # Reconnect re-authorizes against live authority; ownership is unchanged.
+    resolved = await s.reauthorize_stream_token(
+        token, account_store=store, revocation=revocation, config=config
+    )
+    assert resolved.user_id == account.user_id
+    await revocation.revoke_all_for_user(account.user_id)
+    with pytest.raises(q.AuthInvalidError):
+        await s.reauthorize_stream_token(
+            token, account_store=store, revocation=revocation, config=config
+        )

--- a/tests/unit/security/test_session_authority_4121.py
+++ b/tests/unit/security/test_session_authority_4121.py
@@ -465,6 +465,39 @@ def test_csrf_origin_boundary():
         )
 
 
+def test_csrf_origin_rejects_different_port():
+    """Cookies do not isolate ports: another port on the same host is cross-origin."""
+    base = "https://moonmind.example.invalid:8443"
+    # Exact same origin (host + scheme + port) is allowed.
+    s.enforce_csrf_origin(
+        method="POST",
+        cookie_present=True,
+        origin="https://moonmind.example.invalid:8443",
+        referer=None,
+        host="moonmind.example.invalid",
+        base_url=base,
+    )
+    # Same hostname and scheme but a different port is rejected.
+    with pytest.raises(q.AuthInvalidError):
+        s.enforce_csrf_origin(
+            method="POST",
+            cookie_present=True,
+            origin="https://moonmind.example.invalid:9443",
+            referer=None,
+            host="moonmind.example.invalid",
+            base_url=base,
+        )
+    # Explicit default port equals the implicit default origin.
+    s.enforce_csrf_origin(
+        method="POST",
+        cookie_present=True,
+        origin="https://moonmind.example.invalid:443",
+        referer=None,
+        host="moonmind.example.invalid",
+        base_url="https://moonmind.example.invalid",
+    )
+
+
 def test_credentialed_wildcard_cors_rejected():
     with pytest.raises(q.AuthConfigError):
         s.resolve_credentialed_cors_origins(["*"], allow_credentials=True)


### PR DESCRIPTION
Summary:
Implements the reusable MoonMind session authority for MoonLadderStudios/MoonMind#4121 (parent #4116, plan K2/K4). Composes #4118 session primitives with #4119 UUID resolution and #4120 configuration into one application-bound token/cookie contract; adds durable relational session/revocation state (MoonmindSession + generation table, migration 375) behind a portable interface; enforces CSRF/origin at a shared cookie-authenticated unsafe-request boundary; resolves credential precedence once; exposes stream reauth interface; emits redacted auth events and removes token-printing hooks. Also restricts credentialed CORS (rejects wildcard + credentials) and wires explicit origins from MOONMIND_CORS_ALLOWED_ORIGINS / MOONMIND_PUBLIC_BASE_URL.

Verification outcome:
moonspec-verify verdict FULLY_IMPLEMENTED (HIGH confidence, recommendedNextAction advance). All 8 requirements plus acceptance matrix VERIFIED against candidate 4de486183 via direct production-code inspection and managed test evidence. Initial assessment was NOT_IMPLEMENTED; this run publishes the implementation.

Tests run:
- moonmind container python-tests tests/unit/security/test_session_authority_4121.py — 17 passed (claim matrix, revocation across replicas incl. cache, generation bump / resurrection block, key rotation overlap, cache eviction/TTL, outage fail-closed, CSRF/origin boundary, credentialed-wildcard CORS rejection, cookie issue/clear policy, upstream/delegated rejection, redacted events + no token-printing hooks, stream reauth bound).
- moonmind container python-tests tests/integration/security/test_session_authority_postgres_4121.py — 5 passed on ephemeral real PostgreSQL (logout across instances + restart, revoke-all invalidates cached + blocks resurrection, disable blocks new actions, concurrent revoke_all converges, outage fails closed bounded).

Remaining risks:
- Consumer wiring (account/OIDC/API/machine/dashboard calling this authority) is explicitly out of scope for this owner issue and lands in follow-up issues.
- Revocation effectiveness across replicas is bounded by SESSION_REVOCATION_INTERVAL_SECONDS (default 300s); operators needing tighter bounds should lower the TTL.
- Key-ring overlap for rotation is bounded (600s); indefinite acceptance of old application tokens is rejected by design.

Closes MoonLadderStudios/MoonMind#4121