### PR TITLE
Fix scheduled Omnigent deployment authority refresh

### DIFF
--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -294,11 +294,13 @@ async def resolve_agent_profile_snapshot(
     consumer_id: str,
     user: User | None,
     replace_existing_usage: bool = False,
+    persist_usage: bool = True,
 ) -> dict[str, Any]:
     """Validate, persist, and return one launch-authoritative profile snapshot.
 
     The caller must invoke this before committing the consumer so the usage row
-    and authored consumer are one database transaction.
+    and authored consumer are one database transaction. Candidate compilation
+    may set persist_usage=False and publish usage with the final consumer revision.
     """
     profile_id = str(selection.get("profileId") or "").strip()
     if not profile_id:
@@ -564,6 +566,8 @@ async def resolve_agent_profile_snapshot(
         "upstreamSnapshot": upstream_snapshot,
         "validationResult": version.validation_result,
     }
+    if not persist_usage:
+        return snapshot
     usage = await session.scalar(
         select(OmnigentAgentProfileUsage).where(
             OmnigentAgentProfileUsage.consumer_type == consumer_type,
@@ -765,6 +769,133 @@ async def resolve_default_agent_profile_snapshot(
     )
 
 
+async def refresh_schedule_deployment_snapshot(
+    session: AsyncSession,
+    *,
+    parameters: Mapping[str, Any],
+    consumer_id: str,
+    user: User | None,
+) -> dict[str, Any]:
+    """Advance deployment bindings only when the scheduled semantics are equal.
+
+    Image qualification can move catalog and policy versions independently of
+    a long-lived schedule. Verify durable profile/usage lineage and compare
+    every execution boundary before resolving a replacement snapshot. Existing
+    executions keep their original authority.
+    """
+    from api_service.services.omnigent_policies import OmnigentPolicyService
+
+    compiled = copy.deepcopy(dict(parameters))
+    previous = compiled.get("agentProfileSnapshot") or {}
+    document = previous.get("document") or {}
+    if document.get("schemaVersion") != "moonmind.omnigent-agent-profile.v2":
+        return compiled
+    profile_id = previous.get("profileId")
+    profile = await session.get(OmnigentAgentProfile, profile_id)
+    if profile is None or profile.state != "active" or not profile.active_version:
+        raise ValueError("scheduled Agent Profile is not active")
+    if profile.active_version == previous.get("version"):
+        return compiled
+    versions = {}
+    for number in (previous.get("version"), profile.active_version):
+        versions[number] = await session.scalar(
+            select(OmnigentAgentProfileVersion).where(
+                OmnigentAgentProfileVersion.profile_id == profile_id,
+                OmnigentAgentProfileVersion.version == number,
+            )
+        )
+    old, active = versions[previous.get("version")], versions[profile.active_version]
+    usage = await session.scalar(
+        select(OmnigentAgentProfileUsage).where(
+            OmnigentAgentProfileUsage.consumer_type == "schedule",
+            OmnigentAgentProfileUsage.consumer_id == consumer_id,
+        )
+    )
+    if (
+        old is None
+        or active is None
+        or old.digest != previous.get("digest")
+        or usage is None
+        or usage.profile_id != profile_id
+        or usage.version != previous.get("version")
+        or usage.digest != previous.get("digest")
+        or usage.effective_snapshot != previous
+    ):
+        raise ValueError("scheduled Agent Profile snapshot lineage conflicts")
+
+    def semantics(value: Mapping[str, Any]) -> dict[str, Any]:
+        result = copy.deepcopy(dict(value))
+        result.pop("allowedLaunchPolicyRefs", None)
+        result.get("harness", {}).pop("catalogRef", None)
+        source = result.get("source", {})
+        source.pop("upstreamVersion", None)
+        source.pop("upstreamSnapshotDigest", None)
+        return result
+
+    if semantics(old.document) != semantics(active.document):
+        raise ValueError(
+            "scheduled Agent Profile semantics changed; revise the schedule explicitly"
+        )
+    old_upstream = copy.deepcopy(old.upstream_snapshot or {})
+    active_upstream = copy.deepcopy(active.upstream_snapshot or {})
+    old_upstream.pop("version", None)
+    active_upstream.pop("version", None)
+    if old_upstream != active_upstream:
+        raise ValueError(
+            "scheduled upstream agent metadata changed; revise the schedule explicitly"
+        )
+    # Retain the chosen policy identity, including non-default selections.
+    old_ref = str(previous.get("launchPolicyRef") or "")
+    policy_id, separator, _version = old_ref.rpartition("@")
+    candidates = [
+        ref
+        for ref in active.document.get("allowedLaunchPolicyRefs", [])
+        if ref.rpartition("@")[0] == policy_id
+    ]
+    if not separator or len(candidates) != 1:
+        raise ValueError("scheduled launch policy identity is no longer available")
+    new_ref = candidates[0]
+    policies = OmnigentPolicyService(session)
+    old_policy = await policies.resolve_runtime_snapshot(old_ref)
+    new_policy = await policies.resolve_runtime_snapshot(new_ref)
+    boundaries = []
+    for policy in (old_policy, new_policy):
+        boundary = copy.deepcopy(policy["boundaries"])
+        host = boundary.get("host", {})
+        host.pop("serverImageRef", None)
+        host.pop("hostImageRef", None)
+        boundaries.append(boundary)
+    if boundaries[0] != boundaries[1]:
+        raise ValueError(
+            "scheduled launch policy boundaries changed; revise the schedule explicitly"
+        )
+
+    refreshed = await resolve_agent_profile_snapshot(
+        session,
+        selection={
+            "profileId": profile_id,
+            "version": active.version,
+            "digest": active.digest,
+            "providerProfileRef": previous.get("providerProfileRef"),
+            "launchPolicyRef": new_ref,
+            "overrides": {
+                section: {
+                    key: copy.deepcopy((document.get(section) or {}).get(key))
+                    for key in set(old.document.get(section) or {})
+                    | set(document.get(section) or {})
+                }
+                for section in _OVERRIDABLE_SECTIONS
+                if section in document or section in old.document
+            },
+        },
+        consumer_type="schedule",
+        consumer_id=consumer_id,
+        user=user,
+        persist_usage=False,
+    )
+    return compile_agent_profile_snapshot_parameters(compiled, snapshot=refreshed)
+
+
 async def refresh_managed_bootstrap_snapshot(
     session: AsyncSession,
     *,
@@ -888,6 +1019,7 @@ __all__ = [
     "compile_agent_profile_snapshot_parameters",
     "default_launch_policy_ref",
     "refresh_managed_bootstrap_snapshot",
+    "refresh_schedule_deployment_snapshot",
     "resolve_agent_profile_snapshot",
     "resolve_default_agent_profile_snapshot",
 ]

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import re
 from typing import Any, Mapping
 
 from fastapi import HTTPException, status
@@ -856,14 +857,22 @@ async def refresh_schedule_deployment_snapshot(
         raise ValueError("scheduled launch policy identity is no longer available")
     new_ref = candidates[0]
     policies = OmnigentPolicyService(session)
-    old_policy = await policies.resolve_runtime_snapshot(old_ref)
+    # A predecessor may already be superseded. Its immutable document is
+    # comparison evidence; only the replacement grants new runtime authority.
+    old_policy = await policies.snapshot(policy_id, int(_version))
     new_policy = await policies.resolve_runtime_snapshot(new_ref)
     boundaries = []
     for policy in (old_policy, new_policy):
         boundary = copy.deepcopy(policy["boundaries"])
         host = boundary.get("host", {})
-        host.pop("serverImageRef", None)
-        host.pop("hostImageRef", None)
+        for field in ("serverImageRef", "hostImageRef"):
+            image_ref = host.get(field)
+            if isinstance(image_ref, str) and re.fullmatch(
+                r"[^\s@]+@sha256:[0-9a-f]{64}", image_ref
+            ):
+                # Only the immutable digest may advance. Registry, repository,
+                # and any authored tag remain part of executable source authority.
+                host[field] = (image_ref.rpartition("@")[0], "sha256")
         boundaries.append(boundary)
     if boundaries[0] != boundaries[1]:
         raise ValueError(
@@ -893,7 +902,17 @@ async def refresh_schedule_deployment_snapshot(
         user=user,
         persist_usage=False,
     )
-    return compile_agent_profile_snapshot_parameters(compiled, snapshot=refreshed)
+    if refreshed.get("upstreamSnapshot") != active.upstream_snapshot:
+        raise ValueError(
+            "resolved upstream agent metadata differs from the checked profile version"
+        )
+    result = compile_agent_profile_snapshot_parameters(compiled, snapshot=refreshed)
+    # Schedule authoring resolves these after profile compilation, so the
+    # persisted top-level selections take precedence over profile defaults.
+    for field in ("model", "effort"):
+        if field in compiled:
+            result[field] = compiled[field]
+    return result
 
 
 async def refresh_managed_bootstrap_snapshot(

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -19,6 +19,7 @@ from api_service.db.models import (
     OmnigentAgentProfileUsage,
     OmnigentAgentProfileVersion,
     OmnigentOAuthHostBindingRecord,
+    OmnigentPolicyVersion,
     RecurringWorkflowDefinition,
     RecurringWorkflowRun,
     RecurringWorkflowRunOutcome,
@@ -916,6 +917,49 @@ class RecurringWorkflowsService:
             raise RecurringWorkflowConflictError(
                 "schedule changed during deployment refresh; retry from its current revision"
             )
+        # Compilation persists artifacts with commits, so its profile and
+        # policy reads no longer fence a concurrent bootstrap cutover. Lock
+        # fresh authority rows until the schedule action has been published.
+        if snapshot.get("document", {}).get("schemaVersion") == "moonmind.omnigent-agent-profile.v2":
+            from api_service.services.omnigent_policies import OmnigentPolicyService
+
+            profile = await self._session.scalar(
+                select(OmnigentAgentProfile)
+                .where(OmnigentAgentProfile.profile_id == snapshot["profileId"])
+                .execution_options(populate_existing=True)
+                .with_for_update()
+            )
+            if (
+                profile is None
+                or profile.state != "active"
+                or profile.active_version != snapshot["version"]
+            ):
+                raise RecurringWorkflowConflictError(
+                    "Agent Profile changed during deployment refresh; retry from current authority"
+                )
+            policy_id, policy_version = snapshot["launchPolicyRef"].rsplit("@", 1)
+            policy = await self._session.scalar(
+                select(OmnigentPolicyVersion)
+                .where(
+                    OmnigentPolicyVersion.policy_id == policy_id,
+                    OmnigentPolicyVersion.version == int(policy_version),
+                )
+                .execution_options(populate_existing=True)
+                .with_for_update()
+            )
+            if policy is None:
+                raise RecurringWorkflowConflictError(
+                    "launch policy disappeared during deployment refresh"
+                )
+            await OmnigentPolicyService(self._session).resolve_runtime_snapshot(
+                snapshot["launchPolicyRef"]
+            )
+
+        from moonmind.omnigent.deployment_identity import (
+            assert_plan_matches_deployed_runtime,
+        )
+
+        assert_plan_matches_deployed_runtime(persisted_plan.envelope.payload)
         if snapshot != previous_target.get("agentProfileSnapshot"):
             usage = await self._session.scalar(
                 select(OmnigentAgentProfileUsage).where(

--- a/api_service/services/recurring_workflows_service.py
+++ b/api_service/services/recurring_workflows_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload
 from api_service.db.models import (
     ManagedAgentProviderProfile,
     OmnigentAgentProfile,
+    OmnigentAgentProfileUsage,
     OmnigentAgentProfileVersion,
     OmnigentOAuthHostBindingRecord,
     RecurringWorkflowDefinition,
@@ -29,6 +30,7 @@ from api_service.db.models import (
 from api_service.services.omnigent_agent_profile_selection import (
     compile_agent_profile_snapshot_parameters,
     refresh_managed_bootstrap_snapshot,
+    refresh_schedule_deployment_snapshot,
     resolve_agent_profile_snapshot,
     resolve_default_agent_profile_snapshot,
 )
@@ -775,6 +777,9 @@ class RecurringWorkflowsService:
     ) -> bool:
         """Atomically advance time-limited admission evidence for a schedule."""
 
+        previous_version = definition.version
+        previous_target = definition.target
+
         from api_service.services.omnigent_execution_plan_service import (
             compile_and_persist_execution_plan,
         )
@@ -817,6 +822,17 @@ class RecurringWorkflowsService:
             else None
         )
         principal = str(getattr(actor, "id", "") or "system")
+        if initial_parameters.get("agentProfileSnapshot") != snapshot:
+            raise RecurringWorkflowValidationError(
+                "scheduled Agent Profile snapshot identities conflict"
+            )
+        initial_parameters = await refresh_schedule_deployment_snapshot(
+            self._session,
+            parameters=initial_parameters,
+            consumer_id=str(definition.id),
+            user=actor,
+        )
+        snapshot = initial_parameters["agentProfileSnapshot"]
         artifact_service = self._artifact_service or TemporalArtifactService(
             TemporalArtifactRepository(self._session)
         )
@@ -890,6 +906,33 @@ class RecurringWorkflowsService:
         ):
             return False
 
+        # Artifact persistence may commit its session. Reacquire the schedule
+        # fence before publishing usage and definition authority together.
+        await self._session.refresh(definition, with_for_update=True)
+        if (
+            definition.version != previous_version
+            or definition.target != previous_target
+        ):
+            raise RecurringWorkflowConflictError(
+                "schedule changed during deployment refresh; retry from its current revision"
+            )
+        if snapshot != previous_target.get("agentProfileSnapshot"):
+            usage = await self._session.scalar(
+                select(OmnigentAgentProfileUsage).where(
+                    OmnigentAgentProfileUsage.consumer_type == "schedule",
+                    OmnigentAgentProfileUsage.consumer_id == str(definition.id),
+                )
+            )
+            if usage is None or usage.effective_snapshot != previous_target.get(
+                "agentProfileSnapshot"
+            ):
+                raise RecurringWorkflowValidationError(
+                    "scheduled Agent Profile usage changed during deployment refresh"
+                )
+            usage.version = snapshot["version"]
+            usage.digest = snapshot["digest"]
+            usage.effective_snapshot = dict(snapshot)
+
         if current_target_payload is not None:
             target["runtimeProviderTarget"] = current_target_payload
         target.setdefault("runtimeProviderTargetUpdatePolicy", update_policy)
@@ -902,6 +945,9 @@ class RecurringWorkflowsService:
             persisted_plan.resolved_skillset_ref
         )
         target["initialParameters"] = initial_parameters
+        target["agentProfileSnapshot"] = dict(snapshot)
+        if "agentProfile" in initial_parameters:
+            target["agentProfile"] = dict(initial_parameters["agentProfile"])
         target["omnigentAuthorityArtifactRefs"] = [
             current_binding.task_input_snapshot_ref,
             *persisted_plan.artifact_refs,

--- a/docs/Temporal/TemporalScheduling.md
+++ b/docs/Temporal/TemporalScheduling.md
@@ -104,12 +104,13 @@ For generic Omnigent schedules, deployment maintenance advances the Agent Profil
 snapshot, selected launch-policy version, and execution plan together. It verifies
 the previous durable profile usage and permits only deployment binding changes:
 catalog observation, upstream version metadata for the same source identity, and
-server/host image references within the same launch-policy identity. Profile
+server/host image digests within the same image repository and launch-policy identity. Profile
 semantics and all other policy boundaries must match. Provider selection, model,
 effort, authored overrides (including nulls), task inputs, and the pinned
 runtime-provider target remain authoritative. A semantic or boundary change
 requires an explicit schedule revision. The normal compiler qualifies the new
-image combination before the schedule action and definition revision advance;
+image combination, then rechecks the active profile, launch policy, and deployed
+images under the publication fence before the schedule action and definition revision advance;
 already-started occurrences retain their immutable inputs.
 
 #### Authored policy and Auto

--- a/docs/Temporal/TemporalScheduling.md
+++ b/docs/Temporal/TemporalScheduling.md
@@ -100,6 +100,18 @@ Catchup, manual triggers, and backfills use the approved definition and fresh oc
 
 The schedule stores a Temporal workflow-start target with workflowType, initialParameters, and artifact refs where needed. UserWorkflow and ManifestIngest use their normal input contracts. Queue dispatch is not a separate scheduling authority; any supported legacy transport is normalized at the versioned ingress before use.
 
+For generic Omnigent schedules, deployment maintenance advances the Agent Profile
+snapshot, selected launch-policy version, and execution plan together. It verifies
+the previous durable profile usage and permits only deployment binding changes:
+catalog observation, upstream version metadata for the same source identity, and
+server/host image references within the same launch-policy identity. Profile
+semantics and all other policy boundaries must match. Provider selection, model,
+effort, authored overrides (including nulls), task inputs, and the pinned
+runtime-provider target remain authoritative. A semantic or boundary change
+requires an explicit schedule revision. The normal compiler qualifies the new
+image combination before the schedule action and definition revision advance;
+already-started occurrences retain their immutable inputs.
+
 #### Authored policy and Auto
 
 New authored publication values are default, none, branch, pr, and pr_with_merge_automation. Omission/default is the one user-facing Auto choice. Runtime modes remain none/branch/pr/auto. The compiler never forwards unresolved default to a worker or helper.

--- a/tests/integration/reliability/replays/scheduled-deployment-policy-drift/manifest.json
+++ b/tests/integration/reliability/replays/scheduled-deployment-policy-drift/manifest.json
@@ -1,0 +1,10 @@
+{
+  "incidentWorkflowId": "mm:12352fc2-44cb-4f82-8dbd-9283d0fa8f63-2026-09-09T22:00:00Z",
+  "runtime": "omnigent",
+  "harness": "opencode-native",
+  "failure": "Schedule refresh retained the previous profile and launch policy while Host Class and server image authority advanced.",
+  "events": ["deployment_image_update", "schedule_refresh", "temporal_schedule_action_update", "agent_dispatch"],
+  "expected": "Future occurrences receive matching profile, policy and deployment authority; historical inputs and authored execution semantics remain unchanged.",
+  "workspaceArtifacts": [],
+  "agentLaunched": false
+}

--- a/tests/integration/reliability/test_schedule_deployment_refresh.py
+++ b/tests/integration/reliability/test_schedule_deployment_refresh.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 import pytest
 
 from api_service.services import omnigent_execution_plan_service
+from api_service.db.models import OmnigentPolicyVersion
+from api_service.services.omnigent_policies import PolicyConflict
 from api_service.services.recurring_workflows_service import (
     RecurringWorkflowConflictError,
     RecurringWorkflowsService,
@@ -22,7 +24,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.reliabil
 
 
 @pytest.mark.parametrize("update_policy", [None, "pinned"])
-@pytest.mark.parametrize("concurrent_update", [False, True])
+@pytest.mark.parametrize("concurrent_update", [None, "schedule", "profile", "policy", "server", "host"])
 async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
     deployment_session, monkeypatch, update_policy, concurrent_update,
 ):
@@ -30,6 +32,16 @@ async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
     session = deployment_session
     session.flush = AsyncMock()
     session.refresh = AsyncMock()
+    scalar = session.scalar
+
+    async def locked_scalar(statement):
+        if statement.column_descriptions[0].get("entity") is OmnigentPolicyVersion:
+            assert statement._for_update_arg is not None
+            assert statement.get_execution_options()["populate_existing"] is True
+            return SimpleNamespace(state=session.policy_states["omnigent-on-demand@2"])
+        return await scalar(statement)
+
+    session.scalar = locked_scalar
     parameters = session.parameters()
     binding = OmnigentExecutionPlanBinding(
         planRef="omnigent-execution-plan:sha256:" + "1" * 64,
@@ -52,6 +64,7 @@ async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
         name="Scheduled deployment replay", policy={},
     )
     observed_launches = []
+    plan_payloads = []
     current_digest = "sha256:" + "2" * 64
     current_host = "ghcr.io/example/host@" + current_digest
     monkeypatch.setattr(deployment_identity, "resolve_deployed_server_build_digest", lambda: current_digest)
@@ -71,6 +84,7 @@ async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
             ),
         )
         deployment_identity.assert_plan_matches_deployed_runtime(payload)
+        plan_payloads.append(payload)
         return launch
 
     with pytest.raises(deployment_identity.OmnigentDeploymentIdentityConflict):
@@ -82,7 +96,18 @@ async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
         observed_launches.append(dispatch_authority(kwargs["agent_profile_snapshot"]))
         assert kwargs["task_input_snapshot_ref"] == binding.task_input_snapshot_ref
         assert kwargs["initial_parameters"]["model"] == historical_input["initialParameters"]["model"]
+        # Reproduce a second deployment during artifact persistence, after
+        # compilation validated its inputs and released its initial locks.
+        if concurrent_update == "profile":
+            session.profile.active_version += 1
+        elif concurrent_update == "policy":
+            session.policy_states["omnigent-on-demand@2"] = "superseded"
+        elif concurrent_update == "server":
+            monkeypatch.setattr(deployment_identity, "resolve_deployed_server_build_digest", lambda: "sha256:" + "3" * 64)
+        elif concurrent_update == "host":
+            monkeypatch.setattr(deployment_identity, "_resolve_deployed_host_image_ref", lambda _: current_host.replace("2" * 64, "3" * 64))
         return SimpleNamespace(
+            envelope=SimpleNamespace(payload=plan_payloads[-1]),
             binding=binding.model_copy(update={
                 "plan_ref": "omnigent-execution-plan:" + current_digest,
                 "plan_digest": current_digest, "plan_artifact_ref": "art_new_plan",
@@ -99,12 +124,20 @@ async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
         update_schedule=AsyncMock(),
     )
     service = RecurringWorkflowsService(session, temporal_client_adapter=adapter, artifact_service=object())
-    if concurrent_update:
+    if concurrent_update == "schedule":
         async def changed_definition(*_args, **_kwargs):
             definition.version += 1
 
         session.refresh.side_effect = changed_definition
-        with pytest.raises(RecurringWorkflowConflictError, match="schedule changed"):
+    if concurrent_update:
+        expected_error = {
+            "schedule": RecurringWorkflowConflictError,
+            "profile": RecurringWorkflowConflictError,
+            "policy": PolicyConflict,
+            "server": deployment_identity.OmnigentDeploymentIdentityConflict,
+            "host": deployment_identity.OmnigentDeploymentIdentityConflict,
+        }[concurrent_update]
+        with pytest.raises(expected_error):
             await service._refresh_managed_bootstrap_target(definition)
         adapter.update_schedule.assert_not_awaited()
         assert session.usage.version == 1

--- a/tests/integration/reliability/test_schedule_deployment_refresh.py
+++ b/tests/integration/reliability/test_schedule_deployment_refresh.py
@@ -1,0 +1,124 @@
+"""Replay the schedule-to-runtime handoff after a deployment image update."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from api_service.services import omnigent_execution_plan_service
+from api_service.services.recurring_workflows_service import (
+    RecurringWorkflowConflictError,
+    RecurringWorkflowsService,
+)
+from moonmind.omnigent import deployment_identity
+from moonmind.omnigent.profile_bound_execution import _compile_persisted_effective_launch
+from moonmind.schemas.agent_runtime_models import OmnigentExecutionPlanBinding
+from tests.integration.reliability.helpers import load_replay
+from tests.unit.services.test_schedule_deployment_refresh import deployment_session  # noqa: F401
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.reliability_journey]
+
+
+@pytest.mark.parametrize("update_policy", [None, "pinned"])
+@pytest.mark.parametrize("concurrent_update", [False, True])
+async def test_scheduled_image_update_reaches_dispatch_with_matching_authority(
+    deployment_session, monkeypatch, update_policy, concurrent_update,
+):
+    manifest = load_replay("scheduled-deployment-policy-drift", "manifest.json")
+    session = deployment_session
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    parameters = session.parameters()
+    binding = OmnigentExecutionPlanBinding(
+        planRef="omnigent-execution-plan:sha256:" + "1" * 64,
+        planDigest="sha256:" + "1" * 64,
+        planArtifactRef="art_old_plan",
+        taskInputSnapshotRef="art_original_task",
+        taskInputSnapshotDigest="sha256:" + "a" * 64,
+    )
+    parameters["omnigentExecutionPlan"] = binding.model_dump(by_alias=True)
+    target = {
+        "workflowType": "MoonMind.UserWorkflow",
+        "initialParameters": parameters,
+        "agentProfileSnapshot": deepcopy(parameters["agentProfileSnapshot"]),
+    }
+    if update_policy is not None:
+        target["runtimeProviderTargetUpdatePolicy"] = update_policy
+    historical_input = deepcopy(target)
+    definition = SimpleNamespace(
+        id=uuid4(), target=target, version=1, owner_user_id=None,
+        name="Scheduled deployment replay", policy={},
+    )
+    observed_launches = []
+    current_digest = "sha256:" + "2" * 64
+    current_host = "ghcr.io/example/host@" + current_digest
+    monkeypatch.setattr(deployment_identity, "resolve_deployed_server_build_digest", lambda: current_digest)
+    monkeypatch.setattr(deployment_identity, "_resolve_deployed_host_image_ref", lambda _: current_host)
+
+    def dispatch_authority(snapshot):
+        launch = _compile_persisted_effective_launch(
+            session.policies[snapshot["launchPolicyRef"]],
+            provider_profile_id=session.provider.profile_id,
+            follow_up_retrieval={},
+        )
+        payload = SimpleNamespace(
+            executionRealizerRef="generic-omnigent-host@1",
+            harnessId=manifest["harness"], hostImageRef=launch["hostImageRef"],
+            supportIdentity=SimpleNamespace(
+                omnigentServerBuildRef="sha256:" + launch["serverImageRef"].rsplit(":", 1)[-1]
+            ),
+        )
+        deployment_identity.assert_plan_matches_deployed_runtime(payload)
+        return launch
+
+    with pytest.raises(deployment_identity.OmnigentDeploymentIdentityConflict):
+        dispatch_authority(parameters["agentProfileSnapshot"])
+
+    async def persist_plan(**kwargs):
+        # Execute the real policy compiler and dispatch identity gate. The
+        # artifact transport is replaced by a compact persisted binding here.
+        observed_launches.append(dispatch_authority(kwargs["agent_profile_snapshot"]))
+        assert kwargs["task_input_snapshot_ref"] == binding.task_input_snapshot_ref
+        assert kwargs["initial_parameters"]["model"] == historical_input["initialParameters"]["model"]
+        return SimpleNamespace(
+            binding=binding.model_copy(update={
+                "plan_ref": "omnigent-execution-plan:" + current_digest,
+                "plan_digest": current_digest, "plan_artifact_ref": "art_new_plan",
+            }),
+            artifact_refs=["art_new_plan"], resolved_skillset_ref="art_skills",
+            runtime_provider_rollout=None,
+        )
+
+    monkeypatch.setattr(omnigent_execution_plan_service, "compile_and_persist_execution_plan", persist_plan)
+    adapter = SimpleNamespace(
+        describe_schedule=AsyncMock(return_value=SimpleNamespace(
+            schedule=SimpleNamespace(action=None),
+        )),
+        update_schedule=AsyncMock(),
+    )
+    service = RecurringWorkflowsService(session, temporal_client_adapter=adapter, artifact_service=object())
+    if concurrent_update:
+        async def changed_definition(*_args, **_kwargs):
+            definition.version += 1
+
+        session.refresh.side_effect = changed_definition
+        with pytest.raises(RecurringWorkflowConflictError, match="schedule changed"):
+            await service._refresh_managed_bootstrap_target(definition)
+        adapter.update_schedule.assert_not_awaited()
+        assert session.usage.version == 1
+        assert definition.target == historical_input
+        return
+    assert await service._refresh_managed_bootstrap_target(definition)
+    await service._ensure_schedule_action_current(definition)
+    new_input = adapter.update_schedule.await_args.kwargs["workflow_input"]["initial_parameters"]
+    assert new_input["agentProfileSnapshot"]["version"] == 2
+    assert new_input["omnigentExecutionPlan"]["planDigest"] == current_digest
+    assert new_input["effort"] == historical_input["initialParameters"]["effort"]
+    assert new_input["profileId"] == historical_input["initialParameters"]["profileId"]
+    assert dispatch_authority(new_input["agentProfileSnapshot"])["hostImageRef"] == current_host
+    assert historical_input["initialParameters"]["agentProfileSnapshot"]["version"] == 1
+    assert session.usage.version == 2
+    assert definition.version == 2
+    assert len(observed_launches) == 1

--- a/tests/unit/services/test_omnigent_execution_plan_service.py
+++ b/tests/unit/services/test_omnigent_execution_plan_service.py
@@ -584,6 +584,7 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
     """
 
     build_identity = "sha256:" + "b" * 64
+    monkeypatch.setenv("OMNIGENT_BUILD_DIGEST", build_identity)
     implementation_digest = "sha256:" + "c" * 64
     authority_catalog = create_catalog_snapshot(
         endpointRef="default",
@@ -719,8 +720,7 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
 
     envelope = result.envelope
     if catalog_access == "schedule_refresh":
-        from uuid import uuid4
-
+        from api_service.db.models import RecurringWorkflowDefinition
         from api_service.services.recurring_workflows_service import (
             RecurringWorkflowsService,
         )
@@ -734,6 +734,7 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
         )
         await db_session.flush()
         parameters = {
+            "agentProfileSnapshot": snapshot,
             "targetRuntime": "omnigent",
             "model": "example/model",
             "publishMode": "none",
@@ -743,9 +744,12 @@ async def test_product_boundary_uses_profile_catalog_build_identity(
             ),
         }
         target = {"initialParameters": parameters, "agentProfileSnapshot": snapshot}
-        definition = SimpleNamespace(
-            id=uuid4(), owner_user_id=None, version=1, target=target,
+        definition = RecurringWorkflowDefinition(
+            name="Catalog authority replay", cron="0 * * * *", timezone="UTC",
+            owner_user_id=None, version=1, target=target,
         )
+        db_session.add(definition)
+        await db_session.flush()
         schedules = RecurringWorkflowsService(db_session, artifact_service=artifacts)
         assert await schedules._refresh_omnigent_execution_plan_target(
             definition,

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -1709,6 +1709,7 @@ def _pinned_schedule_service(
     *,
     target: dict[str, object],
 ):
+    target["initialParameters"]["agentProfileSnapshot"] = target["agentProfileSnapshot"]
     session = AsyncMock(spec=AsyncSession)
     session.get = AsyncMock(
         return_value=SimpleNamespace(profile_id="codex_openai_oauth")

--- a/tests/unit/services/test_recurring_workflows_service.py
+++ b/tests/unit/services/test_recurring_workflows_service.py
@@ -1690,6 +1690,7 @@ def _stub_compiled_plan(
     from moonmind.schemas.agent_runtime_models import OmnigentExecutionPlanBinding
 
     compiled = SimpleNamespace(
+        envelope=SimpleNamespace(payload=SimpleNamespace()),
         binding=OmnigentExecutionPlanBinding.model_validate(binding),
         artifact_refs=("artifact:plan",),
         resolved_skillset_ref="artifact:skills",

--- a/tests/unit/services/test_schedule_deployment_refresh.py
+++ b/tests/unit/services/test_schedule_deployment_refresh.py
@@ -1,0 +1,179 @@
+"""Schedule deployment refresh preserves execution authority across image updates."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api_service.db.models import (
+    ManagedAgentProviderProfile,
+    OmnigentAgentProfileUsage,
+    OmnigentAgentProfileVersion,
+)
+from api_service.services import omnigent_agent_profile_selection as selection
+from api_service.services.omnigent_policies import OmnigentPolicyService
+from tests.unit.services.test_omnigent_agent_profile_selection import _GenericV2Session
+from tests.unit.services.test_omnigent_execution_plan_service import _policy_snapshot
+
+
+class DeploymentSession(_GenericV2Session):
+    def __init__(self, runtime="opencode", harness="opencode-native", provider="opencode-go"):
+        super().__init__(provider_runtime_id=runtime, harness_id=harness)
+        self.profile.owner_id = None
+        self.provider.provider_id = provider
+        self.version.document["credentialSlots"][0]["acceptedProviderIds"] = [provider]
+        self.version.document["model"] = {"qualifiedId": "example/default", "effort": "high"}
+        self.version.document["allowedLaunchPolicyRefs"] = ["omnigent-on-demand@2"]
+        self.old = deepcopy(self.version)
+        self.old.version = 1
+        self.old.digest = "sha256:" + "1" * 64
+        self.old.document["harness"]["catalogRef"] = "old-catalog"
+        self.old.document["allowedLaunchPolicyRefs"] = ["omnigent-on-demand@1"]
+        self.previous = {
+            "profileId": self.profile.profile_id,
+            "version": 1,
+            "digest": self.old.digest,
+            "providerProfileRef": self.provider.profile_id,
+            "executionProfileRef": f"omnigent-{harness.removesuffix('-native')}@1",
+            "launchPolicyRef": "omnigent-on-demand@1",
+            "agentId": "imported-agent",
+            "document": deepcopy(self.old.document),
+        }
+        # Historical exclude_none serialization removed authored nulls.
+        self.previous["document"]["model"] = {}
+        self.usage = SimpleNamespace(
+            profile_id=self.profile.profile_id, version=1,
+            digest=self.old.digest, effective_snapshot=deepcopy(self.previous),
+        )
+        self.policies = {
+            f"omnigent-on-demand@{v}": _policy_snapshot(
+                harness=harness, policy=f"omnigent-on-demand@{v}"
+            ) for v in (1, 2)
+        }
+        for v in (1, 2):
+            host = self.policies[f"omnigent-on-demand@{v}"]["boundaries"]["host"]
+            host["serverImageRef"] = "ghcr.io/example/server@sha256:" + str(v) * 64
+            host["hostImageRef"] = "ghcr.io/example/host@sha256:" + str(v) * 64
+
+    async def get(self, model, key):
+        if model is ManagedAgentProviderProfile:
+            return self.provider
+        return await super().get(model, key)
+
+    async def scalar(self, statement):
+        entity = statement.column_descriptions[0].get("entity")
+        if entity is OmnigentAgentProfileVersion:
+            number = statement.compile().params.get("version_1")
+            return self.old if number == 1 else self.version
+        return await super().scalar(statement)
+
+    def parameters(self):
+        return {
+            "agentProfileSnapshot": deepcopy(self.previous),
+            "model": "example/selected", "effort": "xhigh",
+            "profileId": self.provider.profile_id,
+            "workflow": {"instructions": "Preserve this task"},
+        }
+
+
+@pytest.fixture
+def deployment_session(monkeypatch, request):
+    session = DeploymentSession(**getattr(request, "param", {}))
+
+    async def policy(_self, ref):
+        return deepcopy(session.policies[ref])
+
+    monkeypatch.setattr(OmnigentPolicyService, "resolve_runtime_snapshot", policy)
+    monkeypatch.setattr(selection, "_managed_secret_statuses_for_profiles", AsyncMock(return_value={}))
+    monkeypatch.setattr(selection, "provider_profile_launch_ready", lambda *_a, **_kw: True)
+    return session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deployment_session", [
+    {},
+    {"runtime": "codex_cli", "harness": "codex-native", "provider": "openai"},
+    {"runtime": "claude_code", "harness": "claude-native", "provider": "anthropic"},
+    {"runtime": "omnigent", "harness": "pi-native", "provider": "anthropic"},
+], indirect=True, ids=["opencode", "codex", "claude", "pi"])
+async def test_refresh_resolves_real_profile_and_preserves_authored_nulls(deployment_session):
+    session = deployment_session
+    parameters = session.parameters()
+    refreshed = await selection.refresh_schedule_deployment_snapshot(
+        session, parameters=parameters, consumer_id="schedule", user=None,
+    )
+    assert refreshed["agentProfile"]["version"] == 2
+    assert refreshed["omnigent"]["launchPolicyRef"] == "omnigent-on-demand@2"
+    assert refreshed["model"] == parameters["model"]
+    assert refreshed["effort"] == parameters["effort"]
+    assert refreshed["workflow"] == parameters["workflow"]
+    assert refreshed["profileId"] == parameters["profileId"]
+    assert session.usage.version == 1  # Published only with the schedule revision.
+    assert parameters["agentProfileSnapshot"]["version"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["model", "harness", "source", "upstream", "network", "resources", "usage", "policy_identity"])
+async def test_refresh_rejects_authority_changes_before_usage_mutation(deployment_session, change):
+    session = deployment_session
+    if change == "model":
+        session.version.document["model"]["qualifiedId"] = "example/more-expensive"
+    elif change == "harness":
+        session.version.document["harness"]["id"] = "pi-native"
+    elif change == "source":
+        session.version.document["source"]["importedAgentId"] = "another-agent"
+    elif change == "upstream":
+        session.version.upstream_snapshot["capabilities"] = ["new-authority"]
+    elif change == "usage":
+        session.usage.digest = "sha256:" + "0" * 64
+    elif change == "policy_identity":
+        session.version.document["allowedLaunchPolicyRefs"] = ["another-policy@2"]
+    else:
+        session.policies["omnigent-on-demand@2"]["boundaries"][change] = {}
+    with pytest.raises(ValueError):
+        await selection.refresh_schedule_deployment_snapshot(
+            session, parameters=session.parameters(), consumer_id="schedule", user=None,
+        )
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+async def test_non_generic_historical_snapshot_is_unchanged():
+    parameters = {"agentProfileSnapshot": {"profileId": "historical-profile"}}
+    assert await selection.refresh_schedule_deployment_snapshot(
+        SimpleNamespace(), parameters=parameters, consumer_id="schedule", user=None,
+    ) == parameters
+
+
+@pytest.mark.asyncio
+async def test_failed_plan_compilation_cannot_commit_new_schedule_usage(
+    deployment_session, monkeypatch,
+):
+    from uuid import uuid4
+    from api_service.services import omnigent_execution_plan_service
+    from api_service.services.recurring_workflows_service import (
+        RecurringWorkflowsService, RecurringWorkflowValidationError,
+    )
+    from tests.unit.services.test_recurring_workflows_service import _schedule_plan_binding
+
+    session = deployment_session
+    parameters = session.parameters()
+    parameters["omnigentExecutionPlan"] = _schedule_plan_binding("1")
+    target = {
+        "initialParameters": parameters,
+        "agentProfileSnapshot": deepcopy(parameters["agentProfileSnapshot"]),
+    }
+    definition = SimpleNamespace(id=uuid4(), version=1, target=target, owner_user_id=None)
+
+    async def failing_compile(**_kwargs):
+        # Artifact repositories may commit independently before the compiler
+        # fails. There must be no new usage in that transaction to publish.
+        assert session.usage.version == 1
+        raise RuntimeError("qualification unavailable")
+
+    monkeypatch.setattr(omnigent_execution_plan_service, "compile_and_persist_execution_plan", failing_compile)
+    with pytest.raises(RecurringWorkflowValidationError, match="qualification unavailable"):
+        await RecurringWorkflowsService(session, artifact_service=object())._refresh_managed_bootstrap_target(definition)
+    assert session.usage.version == definition.version == 1
+    assert definition.target == target

--- a/tests/unit/services/test_schedule_deployment_refresh.py
+++ b/tests/unit/services/test_schedule_deployment_refresh.py
@@ -1,6 +1,7 @@
 """Schedule deployment refresh preserves execution authority across image updates."""
 
 from copy import deepcopy
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -8,11 +9,12 @@ import pytest
 
 from api_service.db.models import (
     ManagedAgentProviderProfile,
-    OmnigentAgentProfileUsage,
     OmnigentAgentProfileVersion,
+    OmnigentUpstreamAgentProjection,
 )
 from api_service.services import omnigent_agent_profile_selection as selection
 from api_service.services.omnigent_policies import OmnigentPolicyService
+from moonmind.omnigent.policies import document_digest
 from tests.unit.services.test_omnigent_agent_profile_selection import _GenericV2Session
 from tests.unit.services.test_omnigent_execution_plan_service import _policy_snapshot
 
@@ -55,6 +57,7 @@ class DeploymentSession(_GenericV2Session):
             host = self.policies[f"omnigent-on-demand@{v}"]["boundaries"]["host"]
             host["serverImageRef"] = "ghcr.io/example/server@sha256:" + str(v) * 64
             host["hostImageRef"] = "ghcr.io/example/host@sha256:" + str(v) * 64
+        self.policy_states = {ref: "active" for ref in self.policies}
 
     async def get(self, model, key):
         if model is ManagedAgentProviderProfile:
@@ -81,10 +84,15 @@ class DeploymentSession(_GenericV2Session):
 def deployment_session(monkeypatch, request):
     session = DeploymentSession(**getattr(request, "param", {}))
 
-    async def policy(_self, ref):
-        return deepcopy(session.policies[ref])
+    async def policy_version(_self, policy_id, version):
+        ref = f"{policy_id}@{version}"
+        document = deepcopy(session.policies[ref]["boundaries"])
+        return SimpleNamespace(
+            state=session.policy_states[ref], document_json=document,
+            validation_json={"valid": True}, digest=document_digest(document),
+        )
 
-    monkeypatch.setattr(OmnigentPolicyService, "resolve_runtime_snapshot", policy)
+    monkeypatch.setattr(OmnigentPolicyService, "get_version", policy_version)
     monkeypatch.setattr(selection, "_managed_secret_statuses_for_profiles", AsyncMock(return_value={}))
     monkeypatch.setattr(selection, "provider_profile_launch_ready", lambda *_a, **_kw: True)
     return session
@@ -111,6 +119,130 @@ async def test_refresh_resolves_real_profile_and_preserves_authored_nulls(deploy
     assert refreshed["profileId"] == parameters["profileId"]
     assert session.usage.version == 1  # Published only with the schedule revision.
     assert parameters["agentProfileSnapshot"]["version"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection_values", [
+    {"model": "example/selected", "effort": "xhigh"},
+    {"model": None, "effort": None},
+    {},
+], ids=["authored", "explicit-null", "omitted"])
+async def test_refresh_preserves_resolved_model_over_non_null_snapshot_defaults(
+    deployment_session, selection_values,
+):
+    session = deployment_session
+    session.previous["document"]["model"] = deepcopy(session.old.document["model"])
+    session.usage.effective_snapshot = deepcopy(session.previous)
+    parameters = session.parameters()
+    parameters.pop("model")
+    parameters.pop("effort")
+    parameters.update(selection_values)
+    refreshed = await selection.refresh_schedule_deployment_snapshot(
+        session, parameters=parameters, consumer_id="schedule", user=None,
+    )
+    expected = selection_values or {"model": "example/default", "effort": "high"}
+    assert {field: refreshed[field] for field in ("model", "effort")} == expected
+    assert refreshed["agentProfileSnapshot"]["document"]["model"] == session.old.document["model"]
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["serverImageRef", "hostImageRef"])
+@pytest.mark.parametrize("replacement", [
+    "other.example/same-image@sha256:" + "2" * 64,
+    "ghcr.io/example/different-image@sha256:" + "2" * 64,
+])
+async def test_refresh_rejects_changed_image_source(deployment_session, field, replacement):
+    session = deployment_session
+    session.policies["omnigent-on-demand@2"]["boundaries"]["host"][field] = replacement
+    with pytest.raises(ValueError, match="launch policy boundaries changed"):
+        await selection.refresh_schedule_deployment_snapshot(
+            session, parameters=session.parameters(), consumer_id="schedule", user=None,
+        )
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["serverImageRef", "hostImageRef"])
+async def test_refresh_rejects_removing_image_digest(deployment_session, field):
+    session = deployment_session
+    host = session.policies["omnigent-on-demand@2"]["boundaries"]["host"]
+    host[field] = host[field].partition("@")[0]
+    with pytest.raises(ValueError, match="launch policy boundaries changed"):
+        await selection.refresh_schedule_deployment_snapshot(
+            session, parameters=session.parameters(), consumer_id="schedule", user=None,
+        )
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("predecessor_state", ["deprecated", "superseded"])
+async def test_refresh_uses_inactive_predecessor_as_comparison_evidence(
+    deployment_session, predecessor_state,
+):
+    session = deployment_session
+    session.policy_states["omnigent-on-demand@1"] = predecessor_state
+    refreshed = await selection.refresh_schedule_deployment_snapshot(
+        session, parameters=session.parameters(), consumer_id="schedule", user=None,
+    )
+    assert refreshed["omnigent"]["launchPolicyRef"] == "omnigent-on-demand@2"
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replacement_state", ["deprecated", "superseded", "draft"])
+async def test_refresh_requires_active_replacement_policy(deployment_session, replacement_state):
+    session = deployment_session
+    session.policy_states["omnigent-on-demand@2"] = replacement_state
+    with pytest.raises(ValueError, match="runtime policy is not active"):
+        await selection.refresh_schedule_deployment_snapshot(
+            session, parameters=session.parameters(), consumer_id="schedule", user=None,
+        )
+    assert session.usage.version == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("projection_changed", [False, True], ids=["checked", "drifted"])
+async def test_refresh_checks_live_projection_against_immutable_upstream_snapshot(
+    deployment_session, monkeypatch, projection_changed,
+):
+    session = deployment_session
+    source = {
+        "kind": "upstream", "upstreamId": "agent", "upstreamVersion": "1",
+        "upstreamSnapshotDigest": "sha256:" + "3" * 64,
+    }
+    metadata = {"id": "agent", "version": "1", "harness": "opencode-native", "capabilities": []}
+    for version in (session.old, session.version):
+        version.document["source"] = deepcopy(source)
+        version.upstream_snapshot = deepcopy(metadata)
+    session.previous["document"]["source"] = deepcopy(source)
+    session.usage.effective_snapshot = deepcopy(session.previous)
+    projection = SimpleNamespace(
+        metadata_snapshot=deepcopy(metadata),
+        last_successful_sync_at=datetime.now(timezone.utc), last_attempt_at=None,
+        available=True, compatible=True, error=None,
+    )
+    if projection_changed:
+        projection.metadata_snapshot["capabilities"] = ["new-authority"]
+    original_get = session.get
+
+    async def get(model, key):
+        if model is OmnigentUpstreamAgentProjection:
+            return projection
+        return await original_get(model, key)
+
+    monkeypatch.setattr(session, "get", get)
+    if projection_changed:
+        with pytest.raises(ValueError, match="resolved upstream agent metadata differs"):
+            await selection.refresh_schedule_deployment_snapshot(
+                session, parameters=session.parameters(), consumer_id="schedule", user=None,
+            )
+    else:
+        refreshed = await selection.refresh_schedule_deployment_snapshot(
+            session, parameters=session.parameters(), consumer_id="schedule", user=None,
+        )
+        assert refreshed["agentProfileSnapshot"]["upstreamSnapshot"] == metadata
+    assert session.usage.version == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A. Production incident: `mm:12352fc2-44cb-4f82-8dbd-9283d0fa8f63-2026-09-09T22:00:00Z`.

## Summary

Automatic schedule refresh reused an old Agent Profile and launch policy after Omnigent's deployed images advanced. Compilation failed, leaving future occurrences pinned to a stale server build that dispatch correctly rejected.

Future occurrences now receive matching profile, policy, and execution-plan versions when only deployment bindings changed. Refresh preserves provider, model, effort, authored nulls, source identity, policy boundaries, and the selected runtime-provider target. Profile usage is published with the schedule revision after successful compilation and a fresh concurrency check.

## Test Plan

142 targeted unit/replay checks pass after review remediation, including 12 schedule-to-dispatch replay cases. Coverage includes omitted/explicit pinned policy, concurrent schedule/profile/policy/server/host changes, inactive predecessor policies, model/effort preservation, image repository identity, upstream projection drift, and the prior catalog-authority replay. Profile refresh tests cover OpenCode, Codex, Claude, and Pi.

```bash
# Run in the isolated Python test image with MOONMIND_FORCE_LOCAL_TESTS=1:
./tools/test_unit.sh --python-only --no-xdist \
  tests/unit/services/test_schedule_deployment_refresh.py \
  tests/unit/services/test_recurring_workflows_service.py \
  tests/unit/services/test_omnigent_agent_profile_selection.py \
  tests/unit/services/test_omnigent_execution_plan_service.py \
  tests/integration/reliability/test_schedule_deployment_refresh.py
```

All 740 hermetic integration tests passed before review remediation. Required CI revalidates the final pushed head.

```bash
MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-schedule-integration \
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local \
  ./tools/test_integration.sh
```

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [x] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Refresh may advance image qualification and version metadata only after durable lineage and unchanged execution semantics are verified. Semantic, source, credential-route, billing-relevant, and policy-boundary changes remain blocked for explicit revision. Already-started occurrences retain their immutable inputs; no Temporal workflow commands or payload schemas change.

## Coverage notes

Repaired the affected schedule and verified its database target, profile usage, decoded Temporal action, and deployed image identity agree. A subsequent occurrence launched an actual OpenCode process on the qualified host. Dashboard assets, health, and a read-only execution request passed through the existing operator VPN hostname and port after API reload.

## Changelog

Scheduled Omnigent workflows refresh matching runtime authority after deployment image updates while preserving their selected execution settings.
