### PR TITLE
Retry transient Omnigent publication reads before failing completed work

### DIFF
--- a/docs/Omnigent/OmnigentHarnessPlatformDesign.md
+++ b/docs/Omnigent/OmnigentHarnessPlatformDesign.md
@@ -1351,6 +1351,14 @@ PR adoption also requires the requested base branch and confirmed non-draft stat
 A changed or missing remote head rejects reuse before repository or issue mutation.
 New repository work continues through the ordinary publication path.
 
+Publication retries pre-connection transport failures on remote Git reads
+(`fetch` and `ls-remote`) in the same authoritative workspace, with unchanged
+credentials and command inputs. Four attempts with 2, 4, and 8 second delays
+bound recovery before the ordinary failure/checkpoint path takes over. Git's
+unstructured CLI diagnostics are classified only at the publication boundary;
+authentication, TLS, unknown errors, and remote mutations do not receive these
+retries. Success still requires exact remote-head evidence.
+
 ## 21. Native Workflow Chat and controls
 
 Native Workflow Chat continues to use the binding-scoped facade.

--- a/moonmind/omnigent/workspace_publication.py
+++ b/moonmind/omnigent/workspace_publication.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import logging
 import os
 import re
 from collections.abc import Mapping
@@ -38,6 +40,15 @@ from moonmind.workflows.temporal.runtime.workspace_locators import (
 
 _DEFAULT_PUBLISH_GIT_USER_NAME = "MoonMind Worker"
 _DEFAULT_PUBLISH_GIT_USER_EMAIL = "moonmind-worker@users.noreply.github.com"
+_LOGGER = logging.getLogger(__name__)
+_REMOTE_READ_ATTEMPTS = 4
+# Git collapses libcurl errors into exit 128 and exposes no typed transport
+# status. Classify only its anchored pre-connection diagnostic at this CLI
+# boundary; unknown, authentication, TLS, and repository errors fail closed.
+_PRE_CONNECTION_FAILURE = re.compile(
+    r"\Afatal: unable to access '[^'\n]+': "
+    r"(?:Could not resolve (?:host|proxy): [^\n]+|Failed to connect to [^\n]+)\s*\Z"
+)
 
 
 class OmnigentWorkspacePublicationService:
@@ -181,6 +192,7 @@ class OmnigentWorkspacePublicationService:
         ) -> SimpleNamespace:
             del cwd
             authored = [str(part) for part in command]
+            remote_read = authored[:2] in (["git", "fetch"], ["git", "ls-remote"])
             if authored and authored[0] == "git":
                 authored[1:1] = [
                     "-c",
@@ -192,11 +204,30 @@ class OmnigentWorkspacePublicationService:
                 token,
                 base_env=(dict(env) if env is not None else command_env),
             )
-            code, stdout, stderr = await self._run(
-                *authored,
-                env=selected_env,
-                check=False,
-            )
+            # Retry the read in place, never the agent turn or publication as a
+            # whole. Pushes and local mutations retain their existing authority.
+            for attempt in range(1, _REMOTE_READ_ATTEMPTS + 1):
+                code, stdout, stderr = await self._run(
+                    *authored,
+                    env=selected_env,
+                    check=False,
+                )
+                if (
+                    code != 128
+                    or not remote_read
+                    or not _PRE_CONNECTION_FAILURE.fullmatch(stderr.strip())
+                    or attempt == _REMOTE_READ_ATTEMPTS
+                ):
+                    break
+                delay = 2**attempt
+                _LOGGER.warning(
+                    "Repository publication remote read transport failure; "
+                    "retrying attempt %s/%s in %ss",
+                    attempt + 1,
+                    _REMOTE_READ_ATTEMPTS,
+                    delay,
+                )
+                await asyncio.sleep(delay)
             if check and code != 0:
                 detail = redact_sensitive_text(stderr or stdout or "git failed")
                 raise HarnessPlatformError(

--- a/tests/integration/reliability/replays/omnigent-publication-transient-transport/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-publication-transient-transport/manifest.json
@@ -1,0 +1,13 @@
+{
+  "incidentWorkflowId": "mm:5c182f75-c005-4edc-aa1b-eca086a515c1-2026-09-10T01:30:00Z",
+  "failureShapeId": "omnigent-publication-transient-transport",
+  "boundary": "completed generic Omnigent turn -> repository publication -> workflow publish evidence",
+  "escapedFailure": {
+    "command": "git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main",
+    "exitCode": 128,
+    "stderr": "fatal: unable to access 'https://github.com/MoonLadderStudios/Tactics.git/': Could not resolve host: github.com\n",
+    "providerErrorCode": "OMNIGENT_GENERIC_DISPATCH_FAILED"
+  },
+  "workspaceOutcome": "two modified tracked files retained; parent captured a failure checkpoint",
+  "cause": "A pre-connection transport failure on the publication base fetch terminated the completed turn without bounded read recovery."
+}

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -8148,6 +8148,151 @@ async def test_existing_pr_survives_unchanged_omnigent_publication(
     assert "state" not in json.loads(mutations[0].content)  # Code Review, not Done.
 
 
+@pytest.mark.parametrize("authored_base", [None, "main"])
+@pytest.mark.parametrize("entrypoint", ["generic", "profile_bound"])
+@pytest.mark.parametrize("operation", ["fetch", "ls-remote", "push"])
+@pytest.mark.parametrize(
+    "failure", ["recovered", "exhausted", "authentication", "cancelled"]
+)
+async def test_publication_transport_recovery_preserves_workspace_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authored_base: str | None,
+    entrypoint: str,
+    operation: str,
+    failure: str,
+) -> None:
+    """Replay the failed read through real Git, realizer, and parent evidence."""
+    manifest = load_replay("omnigent-publication-transient-transport", "manifest.json")
+    workflow_id = manifest["incidentWorkflowId"]
+    workspace_id = hashlib.sha256(f"{workflow_id}:{workflow_id}".encode()).hexdigest()[
+        :24
+    ]
+    repo, origin = _seed_no_commit_publication_repo(
+        workspace_root=tmp_path,
+        workspace_id=workspace_id,
+        relative_path="repo",
+        starting_branch="candidate",
+    )
+    SandboxWorkspaceRecordStore(tmp_path).ensure(
+        SandboxWorkspaceRecord(workspace_id, workflow_id, workflow_id, "repo")
+    )
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+    (repo / "implemented.txt").write_text("completed remediation\n")
+    initial_head = _git(repo, "rev-parse", "HEAD")
+    initial_refs = _git(repo, "ls-remote", "--heads", "origin")
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId=workflow_id,
+        idempotencyKey=f"{workflow_id}:publish",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/Tactics",
+            **({"startingBranch": authored_base} if authored_base else {}),
+            "workspaceLocator": {
+                "kind": "sandbox",
+                "workspaceId": workspace_id,
+                "relativePath": "repo",
+            },
+        },
+        parameters={"publishMode": "branch"},
+    )
+    # The existing serialized invocation needs no new retry field or cutover.
+    request = AgentExecutionRequest.model_validate_json(
+        request.model_dump_json(by_alias=True)
+    )
+    monkeypatch.setattr(settings.security, "high_security_mode", False)
+    credential = AsyncMock(return_value=SimpleNamespace(token="fixture-credential"))
+    monkeypatch.setattr(
+        "moonmind.omnigent.workspace_publication.resolve_github_credential",
+        credential,
+    )
+    realizer = _no_commit_publication_realizer(tmp_path)
+    publisher = realizer._workspace_publisher
+    original_run = publisher._run
+    attempts = []
+
+    async def transport(*args, env=None, check=True):
+        if operation in args:
+            attempts.append((args, dict(env)))
+            if failure != "recovered" or len(attempts) <= 2:
+                error = manifest["escapedFailure"]["stderr"]
+                if failure == "authentication":
+                    error = "fatal: Authentication failed for 'https://github.com/example/repo.git/'\n"
+                return 128, "", error
+        return await original_run(*args, env=env, check=check)
+
+    monkeypatch.setattr(
+        OmnigentWorkspacePublicationService, "_run", staticmethod(transport)
+    )
+    sleep = AsyncMock(
+        side_effect=asyncio.CancelledError if failure == "cancelled" else None
+    )
+    monkeypatch.setattr("moonmind.omnigent.workspace_publication.asyncio.sleep", sleep)
+
+    async def publish():
+        if entrypoint == "generic":
+            return await realizer._publish_repository(
+                request, AgentRunResult(summary="completed")
+            )
+        runtime = OmnigentOAuthHostRuntime(
+            client=SimpleNamespace(), workspace_root=tmp_path
+        )
+        publication = await runtime.publish_workspace(
+            workspace_locator=request.workspace_spec["workspaceLocator"],
+            current_workflow_id=workflow_id,
+            current_step_execution_id=workflow_id,
+            publication_identity=request.idempotency_key,
+            publish_mode="branch",
+            base_branch=authored_base,
+            repository="MoonLadderStudios/Tactics",
+            github_token="fixture-credential",
+        )
+        return AgentRunResult(metadata=publication)
+
+    if failure != "recovered" or operation == "push":
+        expected_error = (
+            asyncio.CancelledError
+            if failure == "cancelled" and operation != "push"
+            else RuntimeError if operation == "ls-remote" else HarnessPlatformError
+        )
+        with pytest.raises(expected_error):
+            await publish()
+        assert len(attempts) == (
+            4 if failure == "exhausted" and operation != "push" else 1
+        )
+        assert (repo / "implemented.txt").read_text() == "completed remediation\n"
+        assert _git(repo, "ls-remote", "--heads", "origin") == initial_refs
+        if operation == "fetch":
+            assert _git(repo, "rev-parse", "HEAD") == initial_head
+            assert "implemented.txt" in _git(repo, "status", "--porcelain")
+    else:
+        result = await publish()
+        assert result.metadata["remote_verified"] is True
+        assert result.metadata["push_head_sha"] == _git(
+            origin, "rev-parse", "refs/heads/main"
+        )
+        if entrypoint == "generic":
+            assert (
+                result.metadata["acceptedRepositoryEvidence"]["remoteVerified"] is True
+            )
+        assert _git(origin, "show", "main:implemented.txt") == "completed remediation"
+        parent = MoonMindRunWorkflow()
+        parent._record_publish_result(
+            parameters={"publishMode": "branch"},
+            execution_result=SimpleNamespace(outputs=result.metadata),
+        )
+        assert parent._publish_status == "published"
+        assert len(attempts) >= 3
+        assert [call.args[0] for call in sleep.await_args_list] == [2, 4]
+    assert all(attempt == attempts[0] for attempt in attempts[:3])
+    assert credential.await_count == (1 if entrypoint == "generic" else 0)
+    if operation == "push" or failure == "authentication":
+        sleep.assert_not_awaited()
+    elif failure == "exhausted":
+        assert [call.args[0] for call in sleep.await_args_list] == [2, 4, 8]
+
+
 async def test_verified_no_commit_publication_reaches_the_workflow_publish_handoff(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/omnigent/test_workspace_publication_base.py
+++ b/tests/unit/omnigent/test_workspace_publication_base.py
@@ -33,6 +33,30 @@ def git(*args: str, cwd: Path) -> str:
     ).stdout.strip()
 
 
+@pytest.mark.parametrize(
+    ("diagnostic", "retryable"),
+    [
+        ("Could not resolve host: github.com", True),
+        ("Could not resolve proxy: proxy.internal", True),
+        (
+            "Failed to connect to github.com port 443 after 10 ms: Couldn't connect to server",
+            True,
+        ),
+        ("The requested URL returned error: 403", False),
+        ("SSL certificate problem: unable to get local issuer certificate", False),
+        ("new transport failure", False),
+        ("", False),
+    ],
+)
+def test_publication_transport_diagnostics_fail_closed(diagnostic, retryable):
+    from moonmind.omnigent.workspace_publication import _PRE_CONNECTION_FAILURE
+
+    error = f"fatal: unable to access 'https://github.com/example/repo.git/': {diagnostic}\n"
+    assert bool(_PRE_CONNECTION_FAILURE.fullmatch(error.strip())) is retryable
+    # A marker inside an unrelated diagnostic is not transport authority.
+    assert not _PRE_CONNECTION_FAILURE.fullmatch(f"remote: {error}")
+
+
 @pytest.mark.asyncio
 async def test_checkpoint_restore_preserves_accepted_pr_publication(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
A transient DNS failure during the base-branch fetch terminated workflow `mm:5c182f75-c005-4edc-aa1b-eca086a515c1-2026-09-10T01:30:00Z` after the Omnigent agent completed its turn. The worker subsequently resolved GitHub normally; its two modified files and the parent failure checkpoint were preserved.

Publication now gives pre-connection failures on `git fetch` and `git ls-remote` four attempts, with 2/4/8-second backoff, in the same workspace using unchanged credentials and inputs. Authentication, TLS, unknown errors, and pushes keep their existing failure behavior. Exact remote-head verification remains required. No workflow payload or history changes are needed.

Validation: 174 targeted tests passed through `tools/test_unit.sh --python-only --no-xdist`, covering the publication unit suite and publication reliability journeys. The minimized incident replay exercises real Git publication and parent workflow evidence through both generic and profile-bound entrypoints, omitted/explicit base selection, recovery, exhaustion, cancellation, and authentication rejection. The test container masked local linked worktrees so repository audits stayed scoped to this checkout.

The fix is not deployed and the historical failed workflow has not been restarted.
