### PR TITLE
I do not want the Fix and Review Loop to request an additional review if the last review did not contain P0/critical or P1/high findings. It should en

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -391,10 +391,14 @@ def _classify_comment_actionability(
 
     Actionability rules are intentionally simple and deterministic:
     - Ignore comments with empty bodies.
-    - Ignore findings that carry only P2/medium-or-below severity: they end
-      the Fix and Review Loop instead of triggering remediation or another
-      review request. Only P0/critical or P1/high findings keep the loop
-      going. Comments without an explicit severity marker stay actionable.
+    - Ignore automated-review inline findings that carry only
+      P2/medium-or-below severity: they end the Fix and Review Loop instead
+      of triggering remediation or another review request. Only P0/critical
+      or P1/high findings keep the loop going. The threshold applies only
+      to bot-authored review comments from the latest automated review
+      round; human issue comments, review bodies, and other discussion
+      stay actionable even when they mention a low priority. Comments
+      without an explicit severity marker stay actionable.
     - Ignore review comments only when explicitly marked resolved/outdated.
     - Treat issue comments and review bodies as actionable.
     - Treat review comments as actionable except resolved/outdated threads and
@@ -413,14 +417,13 @@ def _classify_comment_actionability(
             return False, "thread_resolved"
         if comment.get("thread_outdated", False):
             return False, "thread_outdated"
-        if is_low_severity_only_finding(body):
+        if is_bot_user(comment.get("user") or "") and is_low_severity_only_finding(
+            body
+        ):
             return False, "low_severity_finding"
         if not include_bot_review_comments and is_bot_user(comment.get("user") or ""):
             return False, "bot_review_comment_excluded"
         return True, "actionable"
-
-    if is_low_severity_only_finding(body):
-        return False, "low_severity_finding"
 
     if (
         comment_type == "issue_comment"

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -26,6 +26,7 @@ for _package_root in (SCRIPT_DIR.parent / "lib", *SCRIPT_DIR.parents):
 
 from pr_resolver_core.review_providers import (  # noqa: E402
     is_clean_review_comment,
+    is_low_severity_only_finding,
     resolve_automated_review_provider,
 )
 
@@ -390,6 +391,10 @@ def _classify_comment_actionability(
 
     Actionability rules are intentionally simple and deterministic:
     - Ignore comments with empty bodies.
+    - Ignore findings that carry only P2/medium-or-below severity: they end
+      the Fix and Review Loop instead of triggering remediation or another
+      review request. Only P0/critical or P1/high findings keep the loop
+      going. Comments without an explicit severity marker stay actionable.
     - Ignore review comments only when explicitly marked resolved/outdated.
     - Treat issue comments and review bodies as actionable.
     - Treat review comments as actionable except resolved/outdated threads and
@@ -408,9 +413,14 @@ def _classify_comment_actionability(
             return False, "thread_resolved"
         if comment.get("thread_outdated", False):
             return False, "thread_outdated"
+        if is_low_severity_only_finding(body):
+            return False, "low_severity_finding"
         if not include_bot_review_comments and is_bot_user(comment.get("user") or ""):
             return False, "bot_review_comment_excluded"
         return True, "actionable"
+
+    if is_low_severity_only_finding(body):
+        return False, "low_severity_finding"
 
     if (
         comment_type == "issue_comment"

--- a/pr_resolver_core/evidence.py
+++ b/pr_resolver_core/evidence.py
@@ -13,7 +13,7 @@ RESOLVER_CORE_VERSION = "1.0.0"
 # immutable package so workflow code never reads mutable filesystem state
 # during replay.
 RESOLVER_CORE_DIGEST = (
-    "sha256:fda697b9670ea91a33459f01b87e25bc1128ade973b99ebb34b0e602560a3fdb"
+    "sha256:9023f24cb6af78bb30efb2693bc11fd4b10526ffaee3e1d32e4331579ddeec19"
 )
 
 

--- a/pr_resolver_core/review_providers.py
+++ b/pr_resolver_core/review_providers.py
@@ -78,9 +78,23 @@ def normalize_reviewer_login(login: object) -> str:
 # finding that carries only P2/medium-or-below severity ends the loop: it is
 # not actionable and a clean response carrying only such trailing findings
 # still counts as a clean review.
-_HIGH_SEVERITY_FINDING_RE = re.compile(
-    r"\bP\s*[01]\b|\bsev\s*[01]\b|\bcritical\b|\bhigh\b",
+#
+# High-severity detection is restricted to structured priority/severity
+# labels (for example `[P1]`, `priority: high`, or `severity: critical`)
+# so prose adjectives in explicitly low-priority findings (for example
+# `[P2] Avoid high memory usage`) cannot promote them back to high.
+_HIGH_SEVERITY_P_RE = re.compile(
+    r"\bP\s*[01]\b|\bsev\s*[01]\b",
     re.IGNORECASE,
+)
+_HIGH_SEVERITY_TEXT_RE = re.compile(
+    r"\bseverity\s*[:=\-]\s*(critical|high|major|severe|urgent|blocker|p[01])\b"
+    r"|\bpriority\s*[:=\-]\s*(critical|high|highest|urgent|blocker|p[01])\b"
+    r"|\[(critical|high|major|severe|urgent|blocker|p[01]|sev[01])\]"
+    r"|^(critical|high)\s*[:\-]"
+    r"|\b(critical|high)\s+(severity|priority)\b"
+    r"|\b(severity|priority)\s+(critical|high)\b",
+    re.IGNORECASE | re.MULTILINE,
 )
 _LOW_SEVERITY_P_RE = re.compile(
     r"\bP\s*[2-9]\b|\bsev\s*[2-9]\b",
@@ -102,9 +116,12 @@ _LOW_SEVERITY_BARE_RE = re.compile(
 
 
 def has_high_severity_finding(body: object) -> bool:
-    """Return True when *body* carries a P0/critical or P1/high marker."""
+    """Return True when *body* carries a structured P0/critical or P1/high marker."""
 
-    return bool(_HIGH_SEVERITY_FINDING_RE.search(str(body or "")))
+    text = str(body or "")
+    return bool(
+        _HIGH_SEVERITY_P_RE.search(text) or _HIGH_SEVERITY_TEXT_RE.search(text)
+    )
 
 
 def has_low_severity_marker(body: object) -> bool:

--- a/pr_resolver_core/review_providers.py
+++ b/pr_resolver_core/review_providers.py
@@ -73,6 +73,63 @@ def normalize_reviewer_login(login: object) -> str:
     return normalized
 
 
+# Finding severity for the Fix and Review Loop. Only P0/critical and P1/high
+# findings keep the loop going with another remediation + review cycle. A
+# finding that carries only P2/medium-or-below severity ends the loop: it is
+# not actionable and a clean response carrying only such trailing findings
+# still counts as a clean review.
+_HIGH_SEVERITY_FINDING_RE = re.compile(
+    r"\bP\s*[01]\b|\bsev\s*[01]\b|\bcritical\b|\bhigh\b",
+    re.IGNORECASE,
+)
+_LOW_SEVERITY_P_RE = re.compile(
+    r"\bP\s*[2-9]\b|\bsev\s*[2-9]\b",
+    re.IGNORECASE,
+)
+_LOW_SEVERITY_TEXT_RE = re.compile(
+    r"\bseverity\s*[:=\-]\s*(medium|low|minor|nit|info)\b"
+    r"|\bpriority\s*[:=\-]\s*(medium|low|minor|p[2-9])\b"
+    r"|\[(medium|low|minor|nit|info|p[2-9])\]"
+    r"|^(medium|low|minor|nit)\s*[:\-]"
+    r"|\b(medium|low|minor)\s+(severity|priority)\b"
+    r"|\b(severity|priority)\s+(medium|low|minor)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+_LOW_SEVERITY_BARE_RE = re.compile(
+    r"\bnits?\b",
+    re.IGNORECASE,
+)
+
+
+def has_high_severity_finding(body: object) -> bool:
+    """Return True when *body* carries a P0/critical or P1/high marker."""
+
+    return bool(_HIGH_SEVERITY_FINDING_RE.search(str(body or "")))
+
+
+def has_low_severity_marker(body: object) -> bool:
+    """Return True when *body* carries an explicit P2/medium-or-below marker."""
+
+    text = str(body or "")
+    return bool(
+        _LOW_SEVERITY_P_RE.search(text)
+        or _LOW_SEVERITY_TEXT_RE.search(text)
+        or _LOW_SEVERITY_BARE_RE.search(text)
+    )
+
+
+def is_low_severity_only_finding(body: object) -> bool:
+    """Return True when *body* is explicitly low severity and nothing higher.
+
+    Findings without any severity marker are conservatively treated as
+    requiring review (return False) so unmarked feedback is never silently
+    dropped from the Fix and Review Loop.
+    """
+
+    text = str(body or "")
+    return has_low_severity_marker(text) and not has_high_severity_finding(text)
+
+
 def is_automated_review_provider_login(provider: object, login: object) -> bool:
     record = resolve_automated_review_provider(provider)
     if record is None:
@@ -120,4 +177,16 @@ def is_clean_review_comment(
     )[0].strip()
     body = re.sub(r"^#{1,6}\s+", "", body).replace("**", "")
     body = " ".join(body.split())
-    return body in provider.clean_review_comments
+    if body in provider.clean_review_comments:
+        return True
+    # A clean response carrying only P2/medium-or-below trailing findings is
+    # still a clean review: there is nothing major left, so the Fix and Review
+    # Loop ends instead of requesting another review. Trailing P0/critical or
+    # P1/high findings keep the response non-clean.
+    for clean_phrase in provider.clean_review_comments:
+        normalized_clean = " ".join(str(clean_phrase).split())
+        if body.startswith(normalized_clean):
+            remainder = body[len(normalized_clean):].lstrip(" :.-–—\n\t")
+            if remainder and is_low_severity_only_finding(remainder):
+                return True
+    return False


### PR DESCRIPTION
I do not want the Fix and Review Loop to request an additional review if the last review did not contain P0/critical or P1/high findings. It should end the loop if there are only P2/medium or below findings in the last review round.