### PR TITLE
fix(skills): discover Docker tests before blocking verification

### DIFF
--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -320,6 +320,48 @@ test unavailable while the documented delegated capability exists. If that
 capability is missing or rejects the job, preserve its explicit evidence and
 classify the environment according to `AGENTS.md`.
 
+### Discover Docker Test Options
+
+In every verification mode, inspect the repository's testing documentation,
+test scripts, build targets, CI jobs, Dockerfiles, and Compose files for Docker
+build and test paths relevant to the changed area. Follow references from
+`AGENTS.md` and README to the actual testing playbook and entrypoint; a mention
+of CI or an absent local compiler is not enough to classify a check as unavailable.
+Use an applicable testing Skill if it is in the resolved active snapshot at
+`$MOONMIND_ACTIVE_SKILLS_DIR`; outside a managed run, use the host's available
+Skills and repository conventions. If no testing Skill is selected, continue
+discovery from repository documentation and scripts without broadening or
+mutating the active Skill set. Keep repository-specific commands and image
+choices in those sources, not in this verifier.
+
+Distinguish the agent's local tools from its authorized execution substrate.
+In MoonMind, inspect the exposed container tool contract and CLI help, and use
+the repository's managed test entrypoint or `moonmind container run --spec`
+with a job specification derived from documented test commands and approved
+image sources. The API-owned Docker Backend supplies the daemon and toolchain;
+neither a local Docker executable nor a daemon socket in the agent is required.
+Outside MoonMind, use documented Docker or Compose test commands when the host
+authorizes direct Docker access. Preserve test isolation, workspace access
+policy, bounded resources, and cleanup in either host. Do not bypass the managed
+boundary, guess image references, provision credentials, or alter deployment
+configuration to make a test runnable.
+
+When an applicable authorized container path exists, attempt the targeted build
+or test and inspect its terminal result and logs. CLI help, a submitted job ID,
+static checks, and a process wrapper's success are not test completion evidence.
+For a missing prerequisite, record the owning service's readiness/admission
+diagnostic or the explicit missing capability, image configuration, or authority
+that prevents submission. A missing local toolchain, an unselected testing Skill,
+or a previous report's environment claim alone does not establish that Docker
+testing is unavailable. Do not repeat an unchanged rejected request; complete
+independent checks and preserve its evidence for the handoff.
+
+Record the discovered entrypoint, execution substrate, exact command, candidate
+revision or workspace checkpoint, terminal job/test result and log/artifact refs,
+or the concrete pre-submission blocker in Test Results and Diagnostics. Complete
+this discovery before using `NOT RUN`, `recoverableInCurrentRuntime: false`,
+`needs_human`, or `blocked` on the grounds that build or test tooling is unavailable.
+
 Use `NOT RUN` with an exact reason when a command requires unavailable credentials, missing services, unsafe side effects, unsupported local tools, or excessive environment setup.
 Use the controlling/advisory split above when interpreting unavailable assets,
 services, credentials, or tooling. Preserve explicitly mandatory prerequisites;

--- a/.agents/skills/moonspec-verify/SKILL.md
+++ b/.agents/skills/moonspec-verify/SKILL.md
@@ -336,7 +336,8 @@ choices in those sources, not in this verifier.
 
 Distinguish the agent's local tools from its authorized execution substrate.
 In MoonMind, inspect the exposed container tool contract and CLI help, and use
-the repository's managed test entrypoint or `moonmind container run --spec`
+the repository's managed test entrypoint or
+`moonmind container run --spec <job.json> --request-id <stable-phase-id>`
 with a job specification derived from documented test commands and approved
 image sources. The API-owned Docker Backend supplies the daemon and toolchain;
 neither a local Docker executable nor a daemon socket in the agent is required.
@@ -345,6 +346,12 @@ authorizes direct Docker access. Preserve test isolation, workspace access
 policy, bounded resources, and cleanup in either host. Do not bypass the managed
 boundary, guess image references, provision credentials, or alter deployment
 configuration to make a test runnable.
+
+For generic jobs, persist a stable request ID for the verification phase,
+candidate revision or workspace checkpoint, and workload specification. Reuse
+that ID when retrying the same job after a client timeout or continuation;
+recover the existing job and its terminal evidence instead of creating another
+submission identity. Use a new ID when the candidate, phase, or workload changes.
 
 When an applicable authorized container path exists, attempt the targeted build
 or test and inspect its terminal result and logs. CLI help, a submitted job ID,

--- a/tests/integration/reliability/README.md
+++ b/tests/integration/reliability/README.md
@@ -42,3 +42,14 @@ inside the hermetic reliability-journey budget while still asserting stable
 session/thread/epoch identity across each continuation turn. Finalization faults
 use the shared fail-first injector so checkpoint or publication retries can be
 tested independently from the exactly-once primary agent execution.
+
+`test_verifier_docker_discovery_replay.py` retains the missing-local-compiler
+incident in `replays/verifier-docker-test-discovery/`. It materializes the real
+resolved verifier instructions, replays repository documentation reads, and runs
+the real managed container CLI and HTTP client against scripted service replies.
+The available route must return terminal state, logs, and artifact references;
+the rejected route must preserve the admission diagnostic without resubmission.
+Provider discovery/report actions are fixture inputs, so this is instruction
+projection and tool-boundary coverage, not proof of autonomous model compliance
+or a real compiler/Docker workload. No provider credentials are required, and the
+`reliability_journey` marker includes both cases in required CI when skills change.

--- a/tests/integration/reliability/replays/verifier-docker-test-discovery/manifest.json
+++ b/tests/integration/reliability/replays/verifier-docker-test-discovery/manifest.json
@@ -1,0 +1,56 @@
+{
+  "incidentWorkflowId": "mm:5c182f75-c005-4edc-aa1b-eca086a515c1-2026-09-10T04:30:00Z",
+  "failureShape": "Verifier declares required automation unavailable after a missing local compiler without attempting the repository-documented container path",
+  "boundary": "resolved verification instructions to managed container CLI submission and returned terminal evidence",
+  "runtimeId": "codex_cli",
+  "selectedSkills": [
+    "moonspec-verify"
+  ],
+  "candidateCheckpoint": "candidate-01",
+  "compiler": "sample-native-compiler",
+  "providerReadActions": [
+    "AGENTS.md",
+    "README.md",
+    "docs/testing.md",
+    "tools/automation-job.json"
+  ],
+  "requiredInstructionFragments": [
+    "continue discovery from repository documentation and scripts",
+    "neither a local Docker executable nor a daemon socket in the agent is required",
+    "attempt the targeted build or test and inspect its terminal result and logs",
+    "record the owning service's readiness/admission diagnostic",
+    "Complete this discovery before using `NOT RUN`",
+    "--request-id <stable-phase-id>",
+    "persist a stable request ID for the verification phase, candidate revision or workspace checkpoint, and workload specification",
+    "Reuse that ID when retrying the same job after a client timeout or continuation",
+    "Use a new ID when the candidate, phase, or workload changes"
+  ],
+  "cases": {
+    "available": {
+      "serviceStates": [
+        "queued",
+        "running",
+        "succeeded"
+      ],
+      "requiredToolEvidence": [
+        "native-smoke: 3 passed",
+        "succeeded",
+        "exitCode=0",
+        "artifact:automation-logs",
+        "artifact:automation-report"
+      ],
+      "providerReport": "PASS: native-smoke at candidate-01; terminal succeeded, exitCode=0; artifact:automation-logs; artifact:automation-report"
+    },
+    "rejected": {
+      "admissionStatus": 403,
+      "admissionDiagnostic": "image_source_unavailable: sample-native-tests is not configured by the deployment owner",
+      "requiredToolEvidence": [
+        "container.submit",
+        "HTTP 403",
+        "image_source_unavailable: sample-native-tests is not configured by the deployment owner"
+      ],
+      "providerReport": "NOT RUN: native-smoke at candidate-01; container.submit HTTP 403; image_source_unavailable: sample-native-tests is not configured by the deployment owner"
+    }
+  },
+  "limits": "The provider's discovery and report actions and service responses are scripted. This replay proves instruction delivery and real CLI/HTTP evidence handling, not autonomous model compliance or a real Docker workload."
+}

--- a/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/AGENTS.md
+++ b/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/AGENTS.md
@@ -1,0 +1,5 @@
+# Fixture repository
+
+For required native automation, follow the testing playbook linked from README.
+This managed workspace has no compiler or Docker socket. Run tests through the
+container job service; do not install host tools or change deployment settings.

--- a/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/README.md
+++ b/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/README.md
@@ -1,0 +1,3 @@
+# Sample native library
+
+The automation acceptance check is documented in [Testing](docs/testing.md).

--- a/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/docs/testing.md
+++ b/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/docs/testing.md
@@ -1,0 +1,11 @@
+# Testing
+
+The operator provides the approved `sample-native-tests` Docker image source.
+The generic managed entrypoint is:
+
+```sh
+moonmind container run --spec tools/automation-job.json --request-id verify-candidate-01-automation
+```
+
+Use the terminal job result and automation log/report artifacts as evidence.
+A local compiler probe does not determine container service availability.

--- a/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/tools/automation-job.json
+++ b/tests/integration/reliability/replays/verifier-docker-test-discovery/repo/tools/automation-job.json
@@ -1,0 +1,9 @@
+{
+  "imageSourceRef": "sample-native-tests",
+  "command": ["./tools/run_automation.sh", "--suite", "native-smoke"],
+  "workdir": "/workspace",
+  "networkMode": "none",
+  "resources": {"cpuMillis": 1000, "memoryMiB": 512, "pids": 64},
+  "timeoutSeconds": 60,
+  "outputs": [{"name": "automation-report", "relativePath": "artifacts/automation.xml"}]
+}

--- a/tests/integration/reliability/test_verifier_docker_discovery_replay.py
+++ b/tests/integration/reliability/test_verifier_docker_discovery_replay.py
@@ -1,0 +1,232 @@
+"""Replay the verifier's tool boundary without duplicating Skill semantics.
+
+Provider read/command/report actions and service responses are scripted fixture
+inputs. Production materialization, CLI parsing, submission identity, HTTP calls,
+polling, and terminal/diagnostic rendering are real. Autonomous interpretation
+of the prose Skill and Docker workload execution require separate live evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+import shutil
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import pytest
+from typer.testing import CliRunner
+
+from moonmind.cli import app
+from moonmind.schemas.agent_skill_models import (
+    AgentSkillProvenance,
+    AgentSkillSourceKind,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
+    RuntimeMaterializationMode,
+)
+from moonmind.services.skill_materialization import AgentSkillMaterializer
+from tests.integration.reliability.helpers import load_replay
+
+pytestmark = [pytest.mark.integration, pytest.mark.reliability_journey]
+_REPLAY = "verifier-docker-test-discovery"
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case_name", ["available", "rejected"])
+async def test_verifier_docker_discovery_tool_replay(tmp_path, monkeypatch, case_name):
+    manifest = load_replay(_REPLAY, "manifest.json")
+    case = manifest["cases"][case_name]
+    workspace = tmp_path / "repo"
+    shutil.copytree(Path(__file__).parent / "replays" / _REPLAY / "repo", workspace)
+    payload = (_ROOT / ".agents/skills/moonspec-verify/SKILL.md").read_bytes()
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    class ArtifactStore:
+        async def read(self, *, artifact_id, principal, allow_restricted_raw):
+            assert artifact_id == "artifact:resolved-verifier"
+            assert principal == "system" and allow_restricted_raw
+            return object(), payload
+
+    snapshot = ResolvedSkillSet(
+        snapshot_id="verifier-docker-discovery",
+        resolved_at=datetime(2026, 9, 10, tzinfo=UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="moonspec-verify",
+                content_ref="artifact:resolved-verifier",
+                content_digest=digest,
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.DEPLOYMENT
+                ),
+            )
+        ],
+    )
+    materialized = await AgentSkillMaterializer(
+        str(workspace), artifact_service=ArtifactStore()
+    ).materialize(
+        snapshot, manifest["runtimeId"], RuntimeMaterializationMode.WORKSPACE_MOUNTED
+    )
+    active = Path(materialized.metadata["visiblePath"])
+    assert materialized.metadata["activeSkills"] == manifest["selectedSkills"]
+    visible_payload = (active / "moonspec-verify/SKILL.md").read_bytes()
+    assert visible_payload == payload
+    instructions = " ".join(visible_payload.decode().split())
+    # Instruction-delivery regression check is intentionally separate from the
+    # scripted provider actions below. Removing discovery from the real bundle
+    # fails here; the replay never pretends to interpret prose as agent behavior.
+    for fragment in manifest["requiredInstructionFragments"]:
+        assert fragment in instructions, (
+            f"resolved verifier lost discovery guidance: {fragment}"
+        )
+
+    observed = ["skill.read"]
+    documents = {}
+    for relative_path in manifest["providerReadActions"]:
+        documents[relative_path] = (workspace / relative_path).read_text()
+        observed.append(f"read:{relative_path}")
+    assert "docs/testing.md" in documents["README.md"]
+    playbook = documents["docs/testing.md"]
+    command = next(line for line in playbook.splitlines() if line.startswith("moonmind "))
+    argv = shlex.split(command)[1:]
+    assert argv[argv.index("--spec") + 1] == "tools/automation-job.json"
+    assert manifest["candidateCheckpoint"] in argv[argv.index("--request-id") + 1]
+    # An empty local tool directory models the escaped missing-compiler input;
+    # no provider credentials, compiler, Docker executable or socket are used.
+    local_bin = tmp_path / "local-bin"
+    local_bin.mkdir()
+    monkeypatch.setenv("PATH", str(local_bin))
+    assert shutil.which(manifest["compiler"]) is None
+    assert shutil.which("docker") is None
+    observed.append("local-compiler:absent")
+
+    requests = []
+    states = iter(case.get("serviceStates", []))
+    job_id = "container-job:" + "a" * 32
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append(body)
+            tool = body["tool"]
+            observed.append(tool)
+            assert self.path == "/mcp/tools/call"
+            assert self.headers["Authorization"] == "Bearer replay-scoped-token"
+            status = 200
+            if tool == "container.submit":
+                if case_name == "rejected":
+                    status = case["admissionStatus"]
+                    response = {"detail": {"message": case["admissionDiagnostic"]}}
+                else:
+                    response = {"result": {"jobId": job_id, "state": "queued"}}
+            elif tool == "container.status":
+                state = next(states)
+                observed.append(f"state:{state}")
+                result = {"jobId": job_id, "state": state}
+                if state == "succeeded":
+                    result.update(
+                        terminal={"exitCode": 0},
+                        logsRef="artifact:automation-logs",
+                        artifactsRef="artifact:automation-report",
+                    )
+                response = {"result": result}
+            elif tool == "container.logs":
+                response = {
+                    "result": {
+                        "jobId": job_id,
+                        "entries": [{
+                            "sequence": 1,
+                            "stream": "stdout",
+                            "text": "native-smoke: 3 passed",
+                        }],
+                        "nextCursor": None,
+                    }
+                }
+            else:
+                raise AssertionError(f"unexpected tool {tool}")
+            encoded = json.dumps(response).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Isolate any operator credential selectors; only a synthetic session token
+    # may reach the replay HTTP service.
+    for key in (
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN_FILE",
+        "MOONMIND_CONTAINER_JOBS_SOURCE_KIND",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_KIND",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_ID",
+        "MOONMIND_CONTAINER_JOBS_WORKSPACE_RELATIVE_PATH",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.chdir(workspace)
+    env = {
+        "MOONMIND_ACTIVE_SKILLS_DIR": str(active),
+        "MOONMIND_CONTAINER_JOBS_MCP_URL": f"http://127.0.0.1:{server.server_port}/mcp",
+        "MOONMIND_AGENT_RUN_ID": manifest["incidentWorkflowId"],
+        "MOONMIND_TASK_WORKFLOW_ID": manifest["incidentWorkflowId"],
+        "MOONMIND_RUNTIME_ID": manifest["runtimeId"],
+        "MOONMIND_CONTAINER_JOBS_SESSION_ID": "replay-session",
+        "MOONMIND_CONTAINER_JOBS_BEARER_TOKEN": "replay-scoped-token",
+    }
+    try:
+        output = CliRunner().invoke(app, argv, env=env)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert output.exit_code == (0 if case_name == "available" else 1), output.output
+    for fragment in case["requiredToolEvidence"]:
+        assert fragment in output.output, f"CLI lost authoritative evidence: {fragment}"
+    observed.append("tool.evidence-returned")
+    # Replay the fixture's final provider action only after checking its tool
+    # evidence. This validates the recorded trace, not a native verifier policy.
+    report_path = tmp_path / "verification-report.txt"
+    report_path.write_text(case["providerReport"] + "\n" + output.output)
+    observed.append("provider.report")
+    assert observed.index("local-compiler:absent") < observed.index("container.submit")
+    assert observed[-2:] == ["tool.evidence-returned", "provider.report"]
+    submissions = [
+        request for request in requests if request["tool"] == "container.submit"
+    ]
+    assert len(submissions) == 1
+    submission = requests[0]["arguments"]
+    assert submission["idempotencyKey"].endswith(":verify-candidate-01-automation")
+    assert submission["spec"]["workspaceRef"] == {
+        "kind": "managed_runtime",
+        "runtimeId": "codex_cli",
+        "agentRunId": manifest["incidentWorkflowId"],
+        "relativePath": "repo",
+    }
+    assert submission["spec"]["imageSourceRef"] == "sample-native-tests"
+    documented_spec = json.loads(documents["tools/automation-job.json"])
+    assert submission["spec"]["command"] == documented_spec["command"]
+    if case_name == "available":
+        assert observed[-9:] == [
+            "container.status",
+            "state:queued",
+            "container.status",
+            "state:running",
+            "container.status",
+            "state:succeeded",
+            "container.logs",
+            "tool.evidence-returned",
+            "provider.report",
+        ]
+        assert "NOT RUN" not in report_path.read_text()
+    else:
+        assert [request["tool"] for request in requests] == ["container.submit"]
+        assert case["admissionDiagnostic"] in report_path.read_text()
+        assert "NOT RUN" in report_path.read_text()


### PR DESCRIPTION
## Related issue

Depends on MoonLadderStudios/MoonSpec#11 (merged).

## Summary

Require `moonspec-verify` to discover repository-documented Docker build and test paths before declaring tooling unavailable. Attempt authorized container tests and retain terminal evidence or a concrete submission blocker. Commands and images remain repository-owned; no repository-specific dependency or native verification logic is added. Generic jobs reuse stable request IDs on retries. The MoonSpec pin and vendored Skill are updated together, and a required-CI replay covers successful and rejected managed container submissions.

## Test Plan

```bash
./tools/test_unit.sh --python-only tests/unit/agents/test_moonspec_verify_skill.py tests/unit/docs/test_shipped_skill_contracts.py tests/unit/tools/test_sync_moonspec.py tests/unit/test_container_job_cli.py
python3 tools/sync_moonspec.py --check
MOONMIND_FORCE_LOCAL_TESTS=1 python3 -m pytest tests/integration/reliability/test_verifier_docker_discovery_replay.py -m reliability_journey -q
```

81 targeted unit tests passed with the CI umask (022). Skill and bundle validation, projection checks, and `git diff --check` passed. The upstream MoonSpec suite passed all 17 tests.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Portable instruction and regression-test change. Managed tests still use the API-owned Docker Backend and existing authorization; no daemon access, credentials, deployment changes, or unconditional Docker requirement is introduced. Existing immutable skill snapshots retain their original content.

## Coverage notes

The replay materializes the actual verifier Skill and exercises the real CLI through HTTP submission, polling, terminal logs/artifact references, and rejected-admission diagnostics with no local compiler or Docker CLI. Provider actions and backend responses are scripted: this proves instruction delivery and tool/evidence boundaries, not autonomous model compliance or actual Docker workloads. No live workflow rerun was performed.

## Changelog

Verification discovers authorized Docker test options before reporting unavailable build or test tooling.
