### PR TITLE
Prevent deployment updates from silently changing API network access

### DIFF
--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -28,6 +28,10 @@ metadata:
    - quiesce and coherently recreate the agent-runtime worker across changes to
      the live-mounted Skill catalog or its resolver code
    - checkout/reset local `<branch>` to the exact commit captured by that fetch
+   - run the repository's standard-library-only `moonmind/deployment_access.py`
+     deployment preflight against rendered Compose and installed API containers;
+     stop before replacement if bindings or access settings drift, preserving
+     the existing API until its deployment-owned configuration is reconciled
    - optionally `docker compose pull` while the resolver worker remains quiesced
      (unless `noComposePull` is set)
    - recreate the resolver worker only when it still exists in the post-checkout

--- a/.agents/skills/update-moonmind/SKILL.md
+++ b/.agents/skills/update-moonmind/SKILL.md
@@ -5,9 +5,18 @@ metadata:
   required-capabilities:
     - git
     - docker
+    - python3
 ---
 
 # Update MoonMind Deployment (default: without restarting orchestrator)
+
+## Prerequisites
+
+The host requires Git, Bash 4 or newer, Docker with the Compose V2 plugin, and
+Python 3.10 or newer (`python3`). The access preflight uses only Python's standard
+library; no project virtual environment or Python dependencies are required.
+The script validates Python and Compose before fetching, changing the checkout,
+or stopping services.
 
 ## Inputs
 - `repo` (optional): Path to the MoonMind git repository. Default `.`.
@@ -31,7 +40,9 @@ metadata:
    - run the repository's standard-library-only `moonmind/deployment_access.py`
      deployment preflight against rendered Compose and installed API containers;
      stop before replacement if bindings or access settings drift, preserving
-     the existing API until its deployment-owned configuration is reconciled
+     the existing API until its deployment-owned configuration is reconciled;
+     restore the pre-update checkout before resuming a quiesced worker when the
+     gate fails, and leave that worker stopped if restoring the checkout fails
    - optionally `docker compose pull` while the resolver worker remains quiesced
      (unless `noComposePull` is set)
    - recreate the resolver worker only when it still exists in the post-checkout

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -283,16 +283,6 @@ mark_not_running_services_for_restart() {
   done
 }
 
-compose_cmd() {
-  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-    echo docker compose
-  elif command -v docker-compose >/dev/null 2>&1; then
-    echo docker-compose
-  else
-    die "Docker compose command not found."
-  fi
-}
-
 detect_compose_project() {
   local repo_root="$1"
   local mount_root
@@ -369,8 +359,7 @@ resolve_workspace_mount_source() {
   return 1
 }
 
-COMPOSE_CMD=()
-read -r -a COMPOSE_CMD <<<"$(compose_cmd)"
+COMPOSE_CMD=(docker compose)
 
 REPO_PATH="."
 BRANCH="main"
@@ -434,6 +423,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+command -v python3 >/dev/null 2>&1 && \
+  python3 -c 'import sys; sys.exit(sys.version_info < (3, 10))' || \
+  die "Python 3.10 or newer is required on the host for deployment access checks; install python3 before updating."
+command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1 || \
+  die "Docker Compose V2 is required; install the Docker Compose plugin before updating."
+
 validate_branch "$BRANCH"
 if [[ -z "$COMPOSE_PROJECT" ]]; then
   COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-}"
@@ -486,6 +481,7 @@ if [[ "$ALLOW_DIRTY" != "true" ]]; then
 fi
 
 PRE_PULL_COMMIT="$(git rev-parse HEAD)"
+PRE_PULL_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
 
 say "Fetching remote branch '$BRANCH' from origin"
 run_cmd git fetch --prune origin -- "$BRANCH"
@@ -552,7 +548,24 @@ fi
 # revision selected before each long-lived application process is created, so a
 # later update can detect a stale process even when git was updated separately.
 export MOONMIND_RUNTIME_SOURCE_REVISION="$POST_PULL_COMMIT"
-run_cmd python3 "$(pwd)/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
+access_check_output=""
+if ! run_cmd_capture_into access_check_output python3 "$(pwd)/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"; then
+  # The checkout is live-mounted. Restore its authoritative source before the
+  # EXIT trap may resume the worker, and leave operator edits/.env intact.
+  warn "Deployment access preflight failed; restoring pre-update checkout $PRE_PULL_COMMIT."
+  if [[ -n "$PRE_PULL_BRANCH" ]]; then
+    restore_checkout=(git checkout -B "$PRE_PULL_BRANCH" "$PRE_PULL_COMMIT")
+  else
+    restore_checkout=(git checkout --detach "$PRE_PULL_COMMIT")
+  fi
+  if ! "${restore_checkout[@]}" || [[ "$(git rev-parse HEAD)" != "$PRE_PULL_COMMIT" ]]; then
+    SKILL_RESOLUTION_BARRIER_ACTIVE="false"
+    trap - EXIT
+    die "Could not restore the pre-update checkout; the Skill resolution worker remains stopped. Restore $PRE_PULL_COMMIT before resuming it."
+  fi
+  export MOONMIND_RUNTIME_SOURCE_REVISION="$PRE_PULL_COMMIT"
+  die "Deployment access preflight failed; restored the previous checkout. $access_check_output"
+fi
 persist_runtime_source_revision "$POST_PULL_COMMIT"
 
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then

--- a/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
+++ b/.agents/skills/update-moonmind/scripts/run-update-moonmind.sh
@@ -552,6 +552,7 @@ fi
 # revision selected before each long-lived application process is created, so a
 # later update can detect a stale process even when git was updated separately.
 export MOONMIND_RUNTIME_SOURCE_REVISION="$POST_PULL_COMMIT"
+run_cmd python3 "$(pwd)/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
 persist_runtime_source_revision "$POST_PULL_COMMIT"
 
 if [[ "$SKIP_COMPOSE_PULL" != "true" ]]; then

--- a/README.md
+++ b/README.md
@@ -89,10 +89,16 @@ Use the actual operator URL when verifying an update. Preserve these `.env`
 settings across upgrades; changing a fresh-install default must not remove an
 existing installation's access.
 
-The update scripts and deployment runner compare the installed API's published
-ports and access settings with rendered Compose before replacing containers.
+The host update scripts require Python 3.10+ and the Docker Compose plugin
+(V2 or newer); they validate both before changing source or services. The update
+scripts and deployment runner compare the installed API's published ports,
+network attachments, and access settings with rendered Compose before replacing
+containers.
 They stop on a change and identify the settings to preserve in `.env` or an
-override. Direct `docker compose up` does not run this preflight; use it for
+override. A rejected git update restores the previous checkout before resuming
+a quiesced worker. Maintenance targeting unrelated services does not require
+API reconciliation; dependency or orphan removal that can affect the API still
+runs the access check. Direct `docker compose up` does not run this preflight; use it for
 intentional access migrations and verify the operator URL afterward.
 
 ### OAuth Workflow

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Use the actual operator URL when verifying an update. Preserve these `.env`
 settings across upgrades; changing a fresh-install default must not remove an
 existing installation's access.
 
+The update scripts and deployment runner compare the installed API's published
+ports and access settings with rendered Compose before replacing containers.
+They stop on a change and identify the settings to preserve in `.env` or an
+override. Direct `docker compose up` does not run this preflight; use it for
+intentional access migrations and verify the operator URL afterward.
+
 ### OAuth Workflow
 
 When you already have a subscription with a model provider:

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -754,12 +754,25 @@ The Operations UI must not normally ask the operator to choose the runner image 
 Before replacement, the host scripts and deployment runner execute the shared
 `moonmind/deployment_access.py` preflight. It compares rendered Compose with
 installed API containers (including stopped containers) in the selected project.
-Changed published interfaces, ports, authentication mode, trusted ingress, public
-URL, trusted proxies, or CORS origins stop an ordinary update before recreation.
+Changed published interfaces, ports, authentication mode, OIDC login settings,
+trusted ingress, public URL, trusted proxies, or CORS origins stop an ordinary
+update before recreation. Existing API network attachment names must remain
+available, including external ingress networks for an API behind a reverse
+proxy. A renamed Compose network key preserves access when its resolved Docker
+network name stays the same.
 The operator preserves existing settings in the deployment-owned `.env` or
 override; intentional access migrations are applied separately and verified
 through the operator URL. The preflight never infers ingress authorization or
-prints rendered environment/inspect payloads. Direct Docker Compose commands
+prints rendered environment/inspect payloads, including OIDC credentials.
+
+The host scripts require Python 3.10+ and the Docker Compose plugin (V2 or
+newer), validated before source changes or service stops. On a failed access
+preflight, the git updater restores its previous checkout before resuming a
+quiesced worker; restoration failure keeps that worker stopped. Explicit service
+targets skip the API check only when their dependency closure and orphan removal
+cannot recreate or remove the API.
+
+Direct Docker Compose commands
 remain an explicit operator path and do not invoke this updater guard.
 
 The system verifies Compose state using:

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -751,6 +751,17 @@ The Operations UI must not normally ask the operator to choose the runner image 
 
 ## 12.1 Compose-level verification
 
+Before replacement, the host scripts and deployment runner execute the shared
+`moonmind/deployment_access.py` preflight. It compares rendered Compose with
+installed API containers (including stopped containers) in the selected project.
+Changed published interfaces, ports, authentication mode, trusted ingress, public
+URL, trusted proxies, or CORS origins stop an ordinary update before recreation.
+The operator preserves existing settings in the deployment-owned `.env` or
+override; intentional access migrations are applied separately and verified
+through the operator URL. The preflight never infers ingress authorization or
+prints rendered environment/inspect payloads. Direct Docker Compose commands
+remain an explicit operator path and do not invoke this updater guard.
+
 The system verifies Compose state using:
 
 - `docker compose ps`

--- a/moonmind/deployment_access.py
+++ b/moonmind/deployment_access.py
@@ -6,6 +6,7 @@ Never prints rendered environment variables or Docker inspect payloads.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
@@ -31,6 +32,43 @@ def _bindings(rows: Sequence[tuple[str, str, str]]) -> set[tuple[str, str, str]]
     # Empty HostIp means Docker chooses the published interfaces. Keep it
     # distinct from an explicit IPv4 bind: collapsing them can drop IPv6.
     return {(host or "*", port, target) for host, port, target in rows}
+
+
+def _candidate_networks(candidate: Mapping) -> set[str]:
+    api = candidate["services"]["api"]
+    if api.get("network_mode"):
+        return {api["network_mode"]}
+    return {
+        candidate.get("networks", {}).get(key, {}).get("name")
+        or f"{candidate['name']}_{key}"
+        for key in (api.get("networks") or {"default": None})
+    }
+
+
+def _reconciles_api(
+    candidate: Mapping,
+    services: Sequence[str],
+    *,
+    include_dependencies: bool,
+    remove_orphans: bool,
+) -> bool:
+    configured = candidate["services"]
+    if "api" not in configured:
+        return remove_orphans
+    if not services:
+        return True
+    pending = list(services)
+    visited: set[str] = set()
+    while pending:
+        service = pending.pop()
+        if service == "api":
+            return True
+        if service in visited:
+            continue
+        visited.add(service)
+        if include_dependencies:
+            pending.extend(configured[service].get("depends_on") or {})
+    return False
 
 
 def validate_access(candidate: Mapping, containers: Sequence[Mapping]) -> None:
@@ -63,11 +101,17 @@ def validate_access(candidate: Mapping, containers: Sequence[Mapping]) -> None:
         changed = []
         if previous != proposed:
             changed.append("published interfaces/ports")
+        previous_networks = set(container["NetworkSettings"]["Networks"])
+        if not previous_networks <= _candidate_networks(candidate):
+            changed.append("API network attachments")
         old_env = dict(
             entry.split("=", 1) for entry in (container["Config"]["Env"] or [])
         )
         new_env = api.get("environment") or {}
-        for name in ACCESS_SETTINGS:
+        settings = ACCESS_SETTINGS
+        if "oidc" in {old_env.get("AUTH_PROVIDER"), new_env.get("AUTH_PROVIDER")}:
+            settings += ("OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET")
+        for name in settings:
             if (old_env.get(name) or "") != (new_env.get(name) or ""):
                 changed.append(name)
         if changed:
@@ -85,6 +129,9 @@ def check_compose_access(
     *,
     cwd: str | None = None,
     env: Mapping[str, str] | None = None,
+    services: Sequence[str] = (),
+    include_dependencies: bool = True,
+    remove_orphans: bool = True,
 ) -> None:
     """Inspect the same Docker context and Compose inputs used by the updater."""
 
@@ -114,6 +161,13 @@ def check_compose_access(
         project = candidate["name"]
         if not isinstance(project, str) or not project.strip():
             raise ValueError("Missing Compose project identity")
+        if not _reconciles_api(
+            candidate,
+            services,
+            include_dependencies=include_dependencies,
+            remove_orphans=remove_orphans,
+        ):
+            return
         ids = run(
             [
                 "docker",
@@ -140,8 +194,17 @@ def check_compose_access(
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service", action="append", default=[])
+    parser.add_argument("compose", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    compose = args.compose[1:] if args.compose[:1] == ["--"] else args.compose
     try:
-        check_compose_access(sys.argv[1:] or ["docker", "compose"], env=os.environ)
+        check_compose_access(
+            compose or ["docker", "compose"],
+            env=os.environ,
+            services=args.service,
+        )
     except DeploymentAccessError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)

--- a/moonmind/deployment_access.py
+++ b/moonmind/deployment_access.py
@@ -1,0 +1,148 @@
+"""Read-only access preservation gate shared by deployment entrypoints.
+
+Uses only the standard library so host update scripts can run this file directly.
+Never prints rendered environment variables or Docker inspect payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+
+
+class DeploymentAccessError(RuntimeError):
+    """An update cannot prove preservation of the installed access boundary."""
+
+
+ACCESS_SETTINGS = (
+    "AUTH_PROVIDER",
+    "MOONMIND_API_PUBLISH_HOST",
+    "MOONMIND_TRUSTED_INGRESS",
+    "MOONMIND_PUBLIC_BASE_URL",
+    "MOONMIND_TRUSTED_PROXIES",
+    "MOONMIND_CORS_ALLOWED_ORIGINS",
+)
+
+
+def _bindings(rows: Sequence[tuple[str, str, str]]) -> set[tuple[str, str, str]]:
+    # Empty HostIp means Docker chooses the published interfaces. Keep it
+    # distinct from an explicit IPv4 bind: collapsing them can drop IPv6.
+    return {(host or "*", port, target) for host, port, target in rows}
+
+
+def validate_access(candidate: Mapping, containers: Sequence[Mapping]) -> None:
+    """Compare rendered Compose with installed containers, including stopped ones."""
+    api = candidate.get("services", {}).get("api")
+    for container in containers:
+        if api is None:
+            raise DeploymentAccessError(
+                "The candidate removes the installed API service."
+            )
+        previous = _bindings(
+            [
+                (binding.get("HostIp", ""), str(binding["HostPort"]), target)
+                for target, bindings in (
+                    container["HostConfig"]["PortBindings"] or {}
+                ).items()
+                for binding in (bindings or [])
+            ]
+        )
+        proposed = _bindings(
+            [
+                (
+                    port.get("host_ip", ""),
+                    str(port.get("published", "")),
+                    f"{port['target']}/{port.get('protocol', 'tcp')}",
+                )
+                for port in api.get("ports", [])
+            ]
+        )
+        changed = []
+        if previous != proposed:
+            changed.append("published interfaces/ports")
+        old_env = dict(
+            entry.split("=", 1) for entry in (container["Config"]["Env"] or [])
+        )
+        new_env = api.get("environment") or {}
+        for name in ACCESS_SETTINGS:
+            if (old_env.get(name) or "") != (new_env.get(name) or ""):
+                changed.append(name)
+        if changed:
+            raise DeploymentAccessError(
+                "Update would change installed API access: "
+                + ", ".join(changed)
+                + ". Preserve the running bindings and access settings in the deployment-owned "
+                ".env/override, then rerun. An intentional access migration must be applied "
+                "separately and verified through the operator URL before updating."
+            )
+
+
+def check_compose_access(
+    compose: Sequence[str],
+    *,
+    cwd: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Inspect the same Docker context and Compose inputs used by the updater."""
+
+    def run(command: Sequence[str]) -> str:
+        try:
+            result = subprocess.run(
+                command,
+                cwd=cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise DeploymentAccessError(
+                "Could not inspect deployment access; API replacement stopped."
+            ) from exc
+        if result.returncode:
+            raise DeploymentAccessError(
+                "Could not inspect deployment access; API replacement stopped."
+            )
+        return result.stdout
+
+    try:
+        candidate = json.loads(run([*compose, "config", "--format", "json"]))
+        project = candidate["name"]
+        if not isinstance(project, str) or not project.strip():
+            raise ValueError("Missing Compose project identity")
+        ids = run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "-q",
+                "--filter",
+                f"label=com.docker.compose.project={project}",
+                "--filter",
+                "label=com.docker.compose.service=api",
+                "--filter",
+                "label=com.docker.compose.oneoff=False",
+            ]
+        ).split()
+        if ids:
+            containers = json.loads(run(["docker", "inspect", *ids]))
+            if not isinstance(containers, list) or len(containers) != len(ids):
+                raise ValueError("Incomplete container inspection")
+            validate_access(candidate, containers)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise DeploymentAccessError(
+            "Invalid deployment access evidence; API replacement stopped."
+        ) from exc
+
+
+if __name__ == "__main__":
+    try:
+        check_compose_access(sys.argv[1:] or ["docker", "compose"], env=os.environ)
+    except DeploymentAccessError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    print("Deployment API access preflight passed.")

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -533,6 +533,9 @@ class HostDockerComposeRunner:
                 self._compose_base_command(project_dir=self._local_dir()),
                 cwd=str(self._local_dir()),
                 env={**os.environ, "MOONMIND_IMAGE": requested_image},
+                services=_compose_up_target_services(command),
+                include_dependencies="--no-deps" not in command,
+                remove_orphans="--remove-orphans" in command,
             )
         except DeploymentAccessError as exc:
             raise ToolFailure(

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
 
+from moonmind.deployment_access import DeploymentAccessError, check_compose_access
+
 from .deployment_tools import (
     DEPLOYMENT_UPDATE_TOOL_NAME,
     DEPLOYMENT_UPDATE_TOOL_VERSION,
@@ -523,6 +525,22 @@ class HostDockerComposeRunner:
         command: tuple[str, ...],
         requested_image: str,
     ) -> Mapping[str, Any]:
+        # Validate at the side-effect owner, before any Compose recreation.
+        # Config rendering uses worker-visible paths; it never creates mounts.
+        try:
+            await asyncio.to_thread(
+                check_compose_access,
+                self._compose_base_command(project_dir=self._local_dir()),
+                cwd=str(self._local_dir()),
+                env={**os.environ, "MOONMIND_IMAGE": requested_image},
+            )
+        except DeploymentAccessError as exc:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_ACCESS_CHANGED",
+                message=str(exc),
+                retryable=False,
+                details={"failureClass": "deployment_access_changed"},
+            ) from exc
         return await self._run_compose_command(command, requested_image=requested_image)
 
     async def inspect_image(self, requested_image: str) -> Mapping[str, Any]:

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -57,6 +57,14 @@ def selected_services(parts):
 args = sys.argv[1:]
 state = load_state()
 
+if args[:3] == ["ps", "-a", "-q"]:
+    # This infrastructure fixture has no API container. The production gate
+    # still queries the selected project's installed API before each up.
+    assert "label=com.docker.compose.service=api" in args
+    state["accessPreflightCalls"] = state.get("accessPreflightCalls", 0) + 1
+    save_state(state)
+    raise SystemExit(0)
+
 if args[:2] == ["image", "inspect"]:
     requested_image = args[2]
     print(
@@ -332,6 +340,7 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert result.status == "COMPLETED"
     assert result.outputs["status"] == "SUCCEEDED"
+    assert state["accessPreflightCalls"] >= 1
     assert state["composeConfigCalls"] >= 4
     assert state["pullServices"] == expected["pullServices"] + (
         ["init-db"] if windows_replay else []

--- a/tests/integration/reliability/test_deployment_update_replay.py
+++ b/tests/integration/reliability/test_deployment_update_replay.py
@@ -123,6 +123,7 @@ if command == "pull":
     save_state(state)
     raise SystemExit(0)
 
+state["orphanRemovalRequested"] = state.get("orphanRemovalRequested", False) or "--remove-orphans" in tail
 up_services = selected_services(tail)
 if "init-db" in up_services:
     config = json.loads(Path(args[args.index("-f") + 1]).read_text())
@@ -340,7 +341,7 @@ async def test_deployment_update_reconciles_non_image_infrastructure(
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert result.status == "COMPLETED"
     assert result.outputs["status"] == "SUCCEEDED"
-    assert state["accessPreflightCalls"] >= 1
+    assert bool(state.get("accessPreflightCalls", 0)) == state["orphanRemovalRequested"]
     assert state["composeConfigCalls"] >= 4
     assert state["pullServices"] == expected["pullServices"] + (
         ["init-db"] if windows_replay else []

--- a/tests/integration/test_api_publish_binding.py
+++ b/tests/integration/test_api_publish_binding.py
@@ -132,10 +132,20 @@ async def test_rendered_binding_matches_production_startup(
                 }
             },
             "Config": {"Env": [f"{key}={value}" for key, value in environment.items()]},
+            "NetworkSettings": {
+                "Networks": {
+                    json.loads(rendered.stdout)["networks"][key]["name"]: {}
+                    for key in api["networks"]
+                }
+            },
         }
     ]
     candidate = json.loads(rendered.stdout)
     validate_access(candidate, previous)
+    previous[0]["NetworkSettings"]["Networks"]["operator-proxy-ingress"] = {}
+    with pytest.raises(DeploymentAccessError, match="API network attachments"):
+        validate_access(candidate, previous)
+    del previous[0]["NetworkSettings"]["Networks"]["operator-proxy-ingress"]
     if expected_host == "127.0.0.1":
         # Replay the actual unpinned-install cutover, using the real newly
         # rendered local default rather than a synthetic replacement config.

--- a/tests/integration/test_api_publish_binding.py
+++ b/tests/integration/test_api_publish_binding.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 
 from api_service import main
+from moonmind.deployment_access import DeploymentAccessError, validate_access
 from moonmind.security import auth_modes_4120 as auth_modes
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
@@ -117,6 +118,45 @@ async def test_rendered_binding_matches_production_startup(
     assert str(api["ports"][0]["published"]) == expected_port
     assert api["ports"][0]["target"] == 8000
     environment = api["environment"]
+    # The deployed binding must survive reconciliation of the rendered config.
+    previous = [
+        {
+            "HostConfig": {
+                "PortBindings": {
+                    "8000/tcp": [
+                        {
+                            "HostIp": expected_host,
+                            "HostPort": expected_port,
+                        }
+                    ]
+                }
+            },
+            "Config": {"Env": [f"{key}={value}" for key, value in environment.items()]},
+        }
+    ]
+    candidate = json.loads(rendered.stdout)
+    validate_access(candidate, previous)
+    if expected_host == "127.0.0.1":
+        # Replay the actual unpinned-install cutover, using the real newly
+        # rendered local default rather than a synthetic replacement config.
+        previous[0]["HostConfig"]["PortBindings"]["8000/tcp"][0]["HostIp"] = "0.0.0.0"
+        with pytest.raises(DeploymentAccessError, match="published interfaces/ports"):
+            validate_access(candidate, previous)
+        previous[0]["HostConfig"]["PortBindings"]["8000/tcp"][0]["HostIp"] = (
+            expected_host
+        )
+    previous[0]["HostConfig"]["PortBindings"]["8000/tcp"][0]["HostPort"] = "19999"
+    with pytest.raises(DeploymentAccessError, match="published interfaces/ports"):
+        validate_access(candidate, previous)
+    if expected_host == "127.0.0.1":
+        # Replay the actual unpinned-install cutover, using the real newly
+        # rendered local default rather than a synthetic replacement config.
+        previous[0]["HostConfig"]["PortBindings"]["8000/tcp"][0]["HostIp"] = "0.0.0.0"
+        with pytest.raises(DeploymentAccessError, match="published interfaces/ports"):
+            validate_access(candidate, previous)
+        previous[0]["HostConfig"]["PortBindings"]["8000/tcp"][0]["HostIp"] = (
+            expected_host
+        )
     assert environment["MOONMIND_API_PUBLISH_HOST"] == expected_host
     assert environment["MOONMIND_TRUSTED_INGRESS"] == overrides.get(
         "MOONMIND_TRUSTED_INGRESS", ""

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -57,7 +57,12 @@ def activity_boundary(monkeypatch):
 
     def handler(request):
         requests.append(request)
-        if request.url.path.endswith("/issues"):
+        if request.method == "POST" and request.url.path.endswith("/labels"):
+            for label in json.loads(request.content)["labels"]:
+                if {"name": label} not in detail["labels"]:
+                    detail["labels"].append({"name": label})
+            payload = detail["labels"]
+        elif request.url.path.endswith("/issues"):
             payload = pages[int(request.url.params["page"]) - 1]
             if request.url.path == "/search/issues" and isinstance(payload, list):
                 payload = {"items": payload, "incomplete_results": False}
@@ -808,7 +813,7 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
         result = await activity_boundary.execute(
             tool["id"], {**tool["inputs"], "previousOutputs": previous}
         )
-        assert result.status == "COMPLETED"
+        assert result.status == "COMPLETED", result.outputs
         assert (
             result.outputs.get("issueRef") == f"{REPOSITORY}#4025"
             or result.outputs.get("issueUrl") == issue()["html_url"]
@@ -817,27 +822,25 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
         previous = workflow._merge_trusted_issue_context(result.outputs)
         assert previous["searchEvidence"]["candidatesExamined"] == 1
         assert previous["searchEvidence"]["pagesExamined"] == 1
-    patches = [
-        request for request in activity_boundary.requests if request.method == "PATCH"
+    mutations = [
+        request for request in activity_boundary.requests if request.method != "GET"
     ]
-    assert len(patches) == 1
-    assert patches[0].url.path == f"/repos/{REPOSITORY}/issues/4025"
+    assert [(request.method, request.url.path) for request in mutations] == [
+        ("POST", f"/repos/{REPOSITORY}/issues/4025/labels"),
+        ("POST", f"/repos/{REPOSITORY}/issues/4025/comments"),
+    ]
+    assert json.loads(mutations[0].content) == {"labels": ["status: in-progress"]}
+    assert result.outputs["mutationOutcome"] == "applied"
+    assert set(result.outputs["confirmedLabels"]) == {"bug", "status: in-progress"}
     # Finalization still requires its verification / PR evidence before mutation.
     final_tool = steps[-1]["tool"]
     final = await activity_boundary.execute(
         final_tool["id"], {**final_tool["inputs"], "previousOutputs": previous}
     )
     assert final.status == "FAILED"
-    assert (
-        len(
-            [
-                request
-                for request in activity_boundary.requests
-                if request.method == "PATCH"
-            ]
-        )
-        == 1
-    )
+    assert [
+        request for request in activity_boundary.requests if request.method != "GET"
+    ] == mutations
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_deployment_access.py
+++ b/tests/unit/test_deployment_access.py
@@ -2,10 +2,17 @@
 
 import json
 import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
-from moonmind.deployment_access import DeploymentAccessError, validate_access
+from moonmind.deployment_access import (
+    DeploymentAccessError,
+    check_compose_access,
+    validate_access,
+)
 from moonmind.workflows.skills.deployment_execution import HostDockerComposeRunner
 from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
 
@@ -34,6 +41,7 @@ def installed(host="192.0.2.10"):
                 }
             },
             "Config": {"Env": ["AUTH_PROVIDER=disabled", "MOONMIND_TRUSTED_INGRESS=1"]},
+            "NetworkSettings": {"Networks": {"moonmind-test-access_default": {}}},
         }
     ]
 
@@ -94,13 +102,17 @@ def test_unpublished_api_behind_proxy():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("preserved", [True, False])
+@pytest.mark.parametrize("target", [None, "api", "postgres", "client"])
+@pytest.mark.parametrize("entrypoint", ["worker", "cli"])
 async def test_worker_runner_blocks_before_real_up_subprocess(
-    tmp_path, monkeypatch, preserved
+    tmp_path, monkeypatch, preserved, target, entrypoint
 ):
     # The public runner invocation uses real subprocesses and the same gate as
     # host scripts. Only the Docker daemon is replaced; no deployment is touched.
     (tmp_path / "docker-compose.yaml").write_text("services: {}\n")
     proposed = candidate("192.0.2.10" if preserved else "127.0.0.1")
+    proposed["services"]["postgres"] = {"image": "postgres:test"}
+    proposed["services"]["client"] = {"image": "client:test", "depends_on": {"api": {}}}
     fixture = tmp_path / "fixture.json"
     fixture.write_text(json.dumps({"candidate": proposed, "installed": installed()}))
     fake_bin = tmp_path / "bin"
@@ -131,10 +143,31 @@ else:
     runner = HostDockerComposeRunner(
         project_dir=str(tmp_path), project_name="moonmind-test-access"
     )
-    if preserved:
+    allowed = preserved or target == "postgres"
+    targets = (target,) if target else ()
+    if entrypoint == "cli":
+        command = [
+            sys.executable,
+            str(Path(__file__).resolve().parents[2] / "moonmind/deployment_access.py"),
+        ]
+        if target:
+            command.extend(["--service", target])
+        result = subprocess.run(
+            [*command, "--", "docker", "compose"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert (result.returncode == 0) == allowed
+        if not allowed:
+            assert "published interfaces/ports" in result.stderr
+        assert not marker.exists()
+        return
+    if allowed:
         result = await runner.up(
             stack="moonmind",
-            command=("docker", "compose", "up", "-d", "api"),
+            command=("docker", "compose", "up", "-d", *targets),
             requested_image="moonmind:test",
         )
         assert result["exitCode"] == 0
@@ -143,8 +176,96 @@ else:
         with pytest.raises(ToolFailure) as exc:
             await runner.up(
                 stack="moonmind",
-                command=("docker", "compose", "up", "-d", "api"),
+                command=("docker", "compose", "up", "-d", *targets),
                 requested_image="moonmind:test",
             )
         assert exc.value.error_code == "DEPLOYMENT_ACCESS_CHANGED"
         assert not marker.exists()
+
+
+@pytest.mark.parametrize("published", [True, False])
+def test_ingress_network_name_survives_compose_key_rename(published):
+    old = installed()
+    proposed = candidate()
+    if not published:
+        old[0]["HostConfig"]["PortBindings"] = None
+        proposed["services"]["api"]["ports"] = []
+    old[0]["NetworkSettings"]["Networks"] = {"operator-ingress": {}}
+    proposed["services"]["api"]["networks"] = {"renamed-key": None}
+    proposed["networks"] = {
+        "renamed-key": {"name": "operator-ingress", "external": True}
+    }
+    validate_access(proposed, old)
+    proposed["networks"]["renamed-key"]["name"] = "different-ingress"
+    with pytest.raises(DeploymentAccessError, match="API network attachments"):
+        validate_access(proposed, old)
+    proposed["services"]["api"].pop("networks")
+    with pytest.raises(DeploymentAccessError, match="API network attachments"):
+        validate_access(proposed, old)
+
+
+@pytest.mark.parametrize(
+    "name", ["OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET"]
+)
+@pytest.mark.parametrize("replacement", [None, "changed-sensitive-value"])
+def test_oidc_login_inputs_cannot_change_silently(name, replacement):
+    old = installed()
+    old[0]["Config"]["Env"] = [
+        "AUTH_PROVIDER=oidc",
+        "MOONMIND_TRUSTED_INGRESS=1",
+        f"{name}=original-sensitive-value",
+    ]
+    proposed = candidate()
+    proposed["services"]["api"]["environment"].update(
+        {"AUTH_PROVIDER": "oidc", name: "original-sensitive-value"}
+    )
+    validate_access(proposed, old)
+    proposed["services"]["api"]["environment"][name] = replacement
+    with pytest.raises(DeploymentAccessError) as exc:
+        validate_access(proposed, old)
+    assert name in str(exc.value)
+    assert "sensitive-value" not in str(exc.value)
+
+
+def test_unrelated_service_still_protects_orphaned_api(tmp_path, monkeypatch):
+    proposed = candidate()
+    proposed["services"] = {"postgres": {}}
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if "config" in command:
+            payload = proposed
+        elif "ps" in command:
+            return subprocess.CompletedProcess(command, 0, "installed-api", "")
+        else:
+            payload = installed()
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(DeploymentAccessError, match="removes the installed API"):
+        check_compose_access(
+            ["docker", "compose"], services=["postgres"], remove_orphans=True
+        )
+    calls.clear()
+    check_compose_access(
+        ["docker", "compose"], services=["postgres"], remove_orphans=False
+    )
+    assert len(calls) == 1
+
+
+def test_no_deps_does_not_gate_untouched_api(monkeypatch):
+    proposed = candidate()
+    proposed["services"]["client"] = {"depends_on": {"api": {}}}
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        assert "config" in command
+        return subprocess.CompletedProcess(command, 0, json.dumps(proposed), "")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    check_compose_access(
+        ["docker", "compose"], services=["client"], include_dependencies=False
+    )
+    assert len(calls) == 1

--- a/tests/unit/test_deployment_access.py
+++ b/tests/unit/test_deployment_access.py
@@ -1,0 +1,150 @@
+"""Replay the healthy-container/LAN-lockout incident at the replacement gate."""
+
+import json
+import os
+
+import pytest
+
+from moonmind.deployment_access import DeploymentAccessError, validate_access
+from moonmind.workflows.skills.deployment_execution import HostDockerComposeRunner
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+
+
+def candidate(host="192.0.2.10"):
+    return {
+        "name": "moonmind-test-access",
+        "services": {
+            "api": {
+                "ports": [{"host_ip": host, "published": "7000", "target": 8000}],
+                "environment": {
+                    "AUTH_PROVIDER": "disabled",
+                    "MOONMIND_TRUSTED_INGRESS": "1",
+                },
+            }
+        },
+    }
+
+
+def installed(host="192.0.2.10"):
+    return [
+        {
+            "HostConfig": {
+                "PortBindings": {
+                    "8000/tcp": [{"HostIp": host, "HostPort": "7000"}],
+                }
+            },
+            "Config": {"Env": ["AUTH_PROVIDER=disabled", "MOONMIND_TRUSTED_INGRESS=1"]},
+        }
+    ]
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "192.0.2.10", "0.0.0.0", "::1"])
+def test_preserved_access_and_fresh_install(host):
+    validate_access(candidate(host), installed(host))
+    validate_access(candidate(host), [])
+
+
+@pytest.mark.parametrize("change", ["host", "port", "removed", "auth", "trust", "url"])
+def test_access_changes_require_explicit_migration(change):
+    proposed = candidate()
+    api = proposed["services"]["api"]
+    if change == "host":
+        api["ports"][0]["host_ip"] = "127.0.0.1"
+    elif change == "port":
+        api["ports"][0]["published"] = "7001"
+    elif change == "removed":
+        proposed["services"].clear()
+    else:
+        key = {
+            "auth": "AUTH_PROVIDER",
+            "trust": "MOONMIND_TRUSTED_INGRESS",
+            "url": "MOONMIND_PUBLIC_BASE_URL",
+        }[change]
+        api["environment"][key] = "changed"
+    with pytest.raises(DeploymentAccessError):
+        validate_access(proposed, installed())
+
+
+def test_historical_wildcard_and_dual_stack_inspect_shape():
+    old = installed("")
+    proposed = candidate("")
+    validate_access(proposed, old)
+    with pytest.raises(DeploymentAccessError, match="published interfaces/ports"):
+        validate_access(candidate("0.0.0.0"), old)
+    old = installed("0.0.0.0")
+    old[0]["HostConfig"]["PortBindings"]["8000/tcp"].append(
+        {"HostIp": "::", "HostPort": "7000"}
+    )
+    proposed = candidate("0.0.0.0")
+    with pytest.raises(DeploymentAccessError, match="published interfaces/ports"):
+        validate_access(proposed, old)
+    proposed["services"]["api"]["ports"].append(
+        {"host_ip": "::", "published": "7000", "target": 8000}
+    )
+    validate_access(proposed, old)
+
+
+def test_unpublished_api_behind_proxy():
+    old = installed()
+    old[0]["HostConfig"]["PortBindings"] = None
+    proposed = candidate()
+    proposed["services"]["api"]["ports"] = []
+    validate_access(proposed, old)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("preserved", [True, False])
+async def test_worker_runner_blocks_before_real_up_subprocess(
+    tmp_path, monkeypatch, preserved
+):
+    # The public runner invocation uses real subprocesses and the same gate as
+    # host scripts. Only the Docker daemon is replaced; no deployment is touched.
+    (tmp_path / "docker-compose.yaml").write_text("services: {}\n")
+    proposed = candidate("192.0.2.10" if preserved else "127.0.0.1")
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({"candidate": proposed, "installed": installed()}))
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake = fake_bin / "docker"
+    fake.write_text("""#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+data = json.loads(Path(os.environ["ACCESS_FIXTURE"]).read_text())
+if args[-3:] == ["config", "--format", "json"]:
+    print(json.dumps(data["candidate"]))
+elif args[0] == "ps":
+    assert "label=com.docker.compose.project=moonmind-test-access" in args
+    print("installed-api")
+elif args[0] == "inspect":
+    print(json.dumps(data["installed"]))
+elif "up" in args:
+    Path(os.environ["ACCESS_UP_MARKER"]).write_text("recreated")
+else:
+    sys.exit(2)
+""")
+    fake.chmod(0o755)
+    marker = tmp_path / "up"
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("ACCESS_FIXTURE", str(fixture))
+    monkeypatch.setenv("ACCESS_UP_MARKER", str(marker))
+    runner = HostDockerComposeRunner(
+        project_dir=str(tmp_path), project_name="moonmind-test-access"
+    )
+    if preserved:
+        result = await runner.up(
+            stack="moonmind",
+            command=("docker", "compose", "up", "-d", "api"),
+            requested_image="moonmind:test",
+        )
+        assert result["exitCode"] == 0
+        assert marker.exists()
+    else:
+        with pytest.raises(ToolFailure) as exc:
+            await runner.up(
+                stack="moonmind",
+                command=("docker", "compose", "up", "-d", "api"),
+                requested_image="moonmind:test",
+            )
+        assert exc.value.error_code == "DEPLOYMENT_ACCESS_CHANGED"
+        assert not marker.exists()

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -64,6 +64,8 @@ def _run_update_scenario(
     no_compose_pull: bool = False,
     remove_agent_runtime_after_update: bool = False,
     access_drift: bool = False,
+    initial_detached_head: bool = False,
+    rollback_fails: bool = False,
 ) -> list[str]:
     bash = _modern_bash()
     seed = tmp_path / "seed"
@@ -93,6 +95,8 @@ def _run_update_scenario(
     _run_git("symbolic-ref", "HEAD", "refs/heads/main", cwd=remote)
     _run_git("clone", str(remote), str(checkout), cwd=tmp_path)
     initial_head = _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip()
+    if initial_detached_head:
+        _run_git("checkout", "--detach", cwd=checkout)
     if initial_env_contents is not None:
         (checkout / ".env").write_text(initial_env_contents, encoding="utf-8")
 
@@ -120,6 +124,19 @@ def _run_update_scenario(
         )
 
     fake_bin.mkdir()
+    if rollback_fails:
+        real_git = shutil.which("git")
+        assert real_git is not None
+        fake_git = fake_bin / "git"
+        fake_git.write_text(
+            f"#!{bash}\n"
+            'if [[ "$1" == checkout && "${*: -1}" == "$UPDATE_INITIAL_HEAD" ]]; then\n'
+            "  exit 44\n"
+            "fi\n"
+            f'exec "{real_git}" "$@"\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(0o755)
     fake_docker = fake_bin / "docker"
     fake_docker_script = """#!/usr/bin/env bash
 set -euo pipefail
@@ -133,7 +150,7 @@ if [[ "${1:-}" == "ps" ]]; then
 fi
 if [[ "${1:-}" == "inspect" ]]; then
   if [[ "${2:-}" == "installed-api" ]]; then
-    printf '%s\\n' '[{"HostConfig":{"PortBindings":{"8000/tcp":[{"HostIp":"0.0.0.0","HostPort":"7000"}]}},"Config":{"Env":["AUTH_PROVIDER=disabled"]}}]'
+    printf '%s\\n' '[{"HostConfig":{"PortBindings":{"8000/tcp":[{"HostIp":"0.0.0.0","HostPort":"7000"}]}},"Config":{"Env":["AUTH_PROVIDER=disabled"]},"NetworkSettings":{"Networks":{}}}]'
     exit 0
   fi
   if [[ "$*" == *".State.Status"* ]]; then
@@ -184,6 +201,14 @@ case "${1:-} ${2:-}" in
     fi
     ;;
   "up -d")
+    if [[ "${FAKE_ACCESS_DRIFT:-false}" == "true" ]]; then
+      if [[ "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" != "$UPDATE_INITIAL_HEAD" ]] \
+        || [[ "$(cat "$UPDATE_CHECKOUT/$UPDATE_CHANGED_FILE")" != "VERSION = 1" ]]; then
+        printf 'worker resumed before source rollback\\n' >&2
+        exit 43
+      fi
+      printf '%s\\n' 'verified-pre-update-source-before-resume' >> "$DOCKER_LOG"
+    fi
     if [[ "${MOONMIND_RUNTIME_SOURCE_REVISION:-}" != "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" ]]; then
       printf 'runtime source revision was not exported for compose up\\n' >&2
       exit 42
@@ -206,6 +231,7 @@ esac
     env["DOCKER_LOG"] = str(docker_log)
     env["UPDATE_CHECKOUT"] = str(checkout)
     env["UPDATE_INITIAL_HEAD"] = initial_head
+    env["UPDATE_CHANGED_FILE"] = changed_file
     env["FAKE_AGENT_RUNTIME_CONTAINER"] = str(
         agent_runtime_revision_state is not None
     ).lower()
@@ -231,9 +257,22 @@ esac
     )
     if access_drift:
         assert update.returncode != 0
-        assert "published interfaces/ports" in update.stderr
+        assert "published interfaces/ports" in update.stdout + update.stderr
         commands = docker_log.read_text(encoding="utf-8").splitlines()
-        assert not any(line.startswith("compose up ") for line in commands)
+        if rollback_fails:
+            assert "worker remains stopped" in update.stderr
+            assert not any(line.startswith("compose up ") for line in commands)
+            return commands
+        assert _run_git("rev-parse", "HEAD", cwd=checkout).stdout.strip() == initial_head
+        assert (checkout / changed_file).read_text() == "VERSION = 1\n"
+        branch = _run_git("rev-parse", "--abbrev-ref", "HEAD", cwd=checkout).stdout.strip()
+        assert branch == ("HEAD" if initial_detached_head else "main")
+        assert not _run_git("status", "--porcelain", cwd=checkout).stdout.strip()
+        assert not any(
+            line.startswith("compose up ") and "api" in line.split()
+            for line in commands
+        )
+        assert "compose pull" not in commands
         return commands
     assert update.returncode == 0, (
         f"update script failed with exit code {update.returncode}\n"
@@ -440,3 +479,35 @@ def test_skill_barrier_does_not_restart_service_removed_by_update(
     assert expected["stopCommand"] in commands
     assert expected["composePullCommand"] in commands
     assert expected["recreateCommand"] not in commands
+
+
+@pytest.mark.parametrize("initial_detached_head", [False, True])
+def test_access_gate_restores_source_before_resuming_skill_worker(
+    tmp_path: Path, initial_detached_head: bool
+) -> None:
+    commands = _run_update_scenario(
+        tmp_path,
+        changed_file=".agents/skills/example/SKILL.md",
+        access_drift=True,
+        initial_detached_head=initial_detached_head,
+        initial_env_contents="KEEP_ME=yes\n",
+    )
+    assert "compose stop temporal-worker-agent-runtime" in commands
+    assert "verified-pre-update-source-before-resume" in commands
+    assert [line for line in commands if line.startswith("compose up ")] == [
+        "compose up -d --no-deps --force-recreate temporal-worker-agent-runtime"
+    ]
+    assert (tmp_path / "checkout/.env").read_text() == "KEEP_ME=yes\n"
+
+
+def test_failed_source_restore_leaves_quiesced_worker_stopped(tmp_path: Path) -> None:
+    commands = _run_update_scenario(
+        tmp_path,
+        changed_file=".agents/skills/example/SKILL.md",
+        access_drift=True,
+        rollback_fails=True,
+        initial_env_contents="KEEP_ME=yes\n",
+    )
+    assert "compose stop temporal-worker-agent-runtime" in commands
+    assert not any(line.startswith("compose up ") for line in commands)
+    assert (tmp_path / "checkout/.env").read_text() == "KEEP_ME=yes\n"

--- a/tests/unit/test_update_moonmind_skill.py
+++ b/tests/unit/test_update_moonmind_skill.py
@@ -63,6 +63,7 @@ def _run_update_scenario(
     initial_env_contents: str | None = None,
     no_compose_pull: bool = False,
     remove_agent_runtime_after_update: bool = False,
+    access_drift: bool = False,
 ) -> list[str]:
     bash = _modern_bash()
     seed = tmp_path / "seed"
@@ -76,8 +77,12 @@ def _run_update_scenario(
     _run_git("config", "user.name", "MoonMind Test", cwd=seed)
     _run_git("config", "user.email", "moonmind-test@example.invalid", cwd=seed)
     (seed / ".gitignore").write_text(".env\n", encoding="utf-8")
+    access_gate = seed / "moonmind/deployment_access.py"
+    access_gate.parent.mkdir(parents=True)
+    access_gate.write_bytes((ROOT / "moonmind/deployment_access.py").read_bytes())
+    _run_git("add", "moonmind/deployment_access.py", cwd=seed)
     source_file = seed / changed_file
-    source_file.parent.mkdir(parents=True)
+    source_file.parent.mkdir(parents=True, exist_ok=True)
     source_file.write_text("VERSION = 1\n", encoding="utf-8")
     _run_git("add", ".gitignore", changed_file, cwd=seed)
     _run_git("commit", "-m", "initial", cwd=seed)
@@ -121,9 +126,16 @@ set -euo pipefail
 printf '%s\\n' "$*" >> "$DOCKER_LOG"
 
 if [[ "${1:-}" == "ps" ]]; then
+  if [[ "${FAKE_ACCESS_DRIFT:-false}" == "true" ]]; then
+    printf '%s\\n' installed-api
+  fi
   exit 0
 fi
 if [[ "${1:-}" == "inspect" ]]; then
+  if [[ "${2:-}" == "installed-api" ]]; then
+    printf '%s\\n' '[{"HostConfig":{"PortBindings":{"8000/tcp":[{"HostIp":"0.0.0.0","HostPort":"7000"}]}},"Config":{"Env":["AUTH_PROVIDER=disabled"]}}]'
+    exit 0
+  fi
   if [[ "$*" == *".State.Status"* ]]; then
     printf '%s\\n' running
   elif [[ "$*" == *"moonmind.runtime_source_revision"* ]]; then
@@ -151,9 +163,9 @@ case "${1:-} ${2:-}" in
   "config --format")
     if [[ "__REMOVE_AGENT_RUNTIME_AFTER_UPDATE__" == "true" ]] \
       && [[ "$(git -C "$UPDATE_CHECKOUT" rev-parse HEAD)" != "$UPDATE_INITIAL_HEAD" ]]; then
-      printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+      printf '%s\\n' '{"name":"moonmind-test-update","services":{"api":{"image":"moonmind:test","ports":[{"host_ip":"127.0.0.1","published":"7000","target":8000}],"environment":{"AUTH_PROVIDER":"disabled"}},"postgres":{"image":"postgres:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
     else
-      printf '%s\\n' '{"services":{"api":{"image":"moonmind:test"},"postgres":{"image":"postgres:test"},"temporal-worker-agent-runtime":{"image":"moonmind:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
+      printf '%s\\n' '{"name":"moonmind-test-update","services":{"api":{"image":"moonmind:test","ports":[{"host_ip":"127.0.0.1","published":"7000","target":8000}],"environment":{"AUTH_PROVIDER":"disabled"}},"postgres":{"image":"postgres:test"},"temporal-worker-agent-runtime":{"image":"moonmind:test"},"temporal-worker-deployment-control":{"image":"moonmind:test"},"temporal-worker-workflow":{"image":"moonmind:test"}}}'
     fi
     ;;
   "pull ")
@@ -198,6 +210,7 @@ esac
         agent_runtime_revision_state is not None
     ).lower()
     env["FAKE_AGENT_RUNTIME_SOURCE_REVISION"] = agent_runtime_revision
+    env["FAKE_ACCESS_DRIFT"] = str(access_drift).lower()
     update_command = [
         bash,
         str(UPDATE_SCRIPT),
@@ -216,6 +229,12 @@ esac
         capture_output=True,
         text=True,
     )
+    if access_drift:
+        assert update.returncode != 0
+        assert "published interfaces/ports" in update.stderr
+        commands = docker_log.read_text(encoding="utf-8").splitlines()
+        assert not any(line.startswith("compose up ") for line in commands)
+        return commands
     assert update.returncode == 0, (
         f"update script failed with exit code {update.returncode}\n"
         f"stdout:\n{update.stdout}\n"
@@ -354,12 +373,21 @@ def test_update_preserves_operator_network_access(tmp_path: Path) -> None:
     assert {name: persisted[name] for name in operator_settings} == operator_settings
 
 
+def test_update_refuses_unpinned_installed_binding_cutover(tmp_path: Path) -> None:
+    _run_update_scenario(
+        tmp_path,
+        changed_file="api_service/main.py",
+        access_drift=True,
+        initial_env_contents="KEEP_ME=yes\n",
+        no_compose_pull=True,
+    )
+    assert (tmp_path / "checkout/.env").read_text() == "KEEP_ME=yes\n"
+
+
 def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
     tmp_path: Path,
 ) -> None:
-    manifest = json.loads(
-        (REPLAY_ROOT / "manifest.json").read_text(encoding="utf-8")
-    )
+    manifest = json.loads((REPLAY_ROOT / "manifest.json").read_text(encoding="utf-8"))
     expected = json.loads(
         (REPLAY_ROOT / "expected-outcome.json").read_text(encoding="utf-8")
     )
@@ -374,9 +402,7 @@ def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
     assert stop_command in commands
     assert barrier_recreate in commands
     assert commands.count(barrier_recreate) == 1
-    assert commands.index(stop_command) < commands.index(
-        expected["composePullCommand"]
-    )
+    assert commands.index(stop_command) < commands.index(expected["composePullCommand"])
     assert commands.index(expected["composePullCommand"]) < commands.index(
         barrier_recreate
     )
@@ -386,8 +412,7 @@ def test_skill_source_update_quiesces_resolver_before_checkout_mutation(
         if command.startswith("compose up ") and "--force-recreate" in command
     ]
     assert all(
-        expected["barrierService"] not in command
-        for command in final_force_recreates
+        expected["barrierService"] not in command for command in final_force_recreates
     )
 
 

--- a/tests/unit/test_update_shell_prerequisites.py
+++ b/tests/unit/test_update_shell_prerequisites.py
@@ -1,0 +1,70 @@
+"""Host updater prerequisites fail before any deployment or checkout mutation."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    "script_path",
+    [
+        "tools/update-moonmind.sh",
+        ".agents/skills/update-moonmind/scripts/run-update-moonmind.sh",
+    ],
+)
+@pytest.mark.parametrize("missing", ["python3", "supported_python", "compose_v2"])
+def test_updater_validates_host_prerequisites_before_mutation(
+    tmp_path: Path, script_path: str, missing: str
+) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    commands = tmp_path / "commands.log"
+    for executable in ("date", "id", "dirname"):
+        source = shutil.which(executable)
+        assert source is not None
+        (fake_bin / executable).symlink_to(source)
+
+    def executable(name: str, body: str) -> None:
+        script = fake_bin / name
+        script.write_text(f"#!{bash}\n{body}\n", encoding="utf-8")
+        script.chmod(0o755)
+
+    executable("git", 'printf "git %s\\n" "$*" >> "$COMMAND_LOG"; exit 0')
+    executable(
+        "docker",
+        'printf "docker %s\\n" "$*" >> "$COMMAND_LOG"; '
+        + ("exit 1" if missing == "compose_v2" else "exit 0"),
+    )
+    executable(
+        "docker-compose",
+        'printf "legacy-compose %s\\n" "$*" >> "$COMMAND_LOG"; exit 0',
+    )
+    if missing != "python3":
+        executable("python3", "exit 1" if missing == "supported_python" else "exit 0")
+
+    env = dict(os.environ, PATH=str(fake_bin), COMMAND_LOG=str(commands))
+    result = subprocess.run(
+        [bash, str(ROOT / script_path)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    if missing == "compose_v2":
+        assert "Docker Compose V2 is required" in result.stderr
+        assert commands.read_text().splitlines() == ["docker compose version"]
+    else:
+        assert "Python 3.10 or newer is required on the host" in result.stderr
+        assert not commands.exists()

--- a/tools/update-moonmind.sh
+++ b/tools/update-moonmind.sh
@@ -68,6 +68,8 @@ run_compose() {
 
 SERVICES=("$@")
 
+python3 "$ROOT_DIR/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
+
 if [[ "$REBUILD" -eq 1 ]]; then
   if [[ ${#BUILD_ARGS[@]} -eq 0 ]]; then
     run_compose build --pull "${SERVICES[@]}"
@@ -77,4 +79,5 @@ if [[ "$REBUILD" -eq 1 ]]; then
 else
   run_compose pull "${SERVICES[@]}"
 fi
+python3 "$ROOT_DIR/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
 run_compose up -d --remove-orphans --force-recreate "${SERVICES[@]}"

--- a/tools/update-moonmind.sh
+++ b/tools/update-moonmind.sh
@@ -24,13 +24,15 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+if ! command -v python3 >/dev/null 2>&1 || \
+  ! python3 -c 'import sys; sys.exit(sys.version_info < (3, 10))'; then
+  echo "Error: Python 3.10 or newer is required on the host for deployment access checks; install python3 before updating." >&2
+  exit 1
+fi
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   COMPOSE_CMD=(docker compose)
-elif command -v docker-compose >/dev/null 2>&1; then
-  COMPOSE_CMD=(docker-compose)
 else
-  echo "Error: docker compose CLI is not available." >&2
-  echo "Install Docker with Compose V2 plugin or legacy docker-compose." >&2
+  echo "Error: Docker Compose V2 is required; install the Docker Compose plugin before updating." >&2
   exit 1
 fi
 
@@ -67,8 +69,12 @@ run_compose() {
 }
 
 SERVICES=("$@")
+ACCESS_ARGS=()
+for service in "${SERVICES[@]}"; do
+  ACCESS_ARGS+=(--service "$service")
+done
 
-python3 "$ROOT_DIR/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
+python3 "$ROOT_DIR/moonmind/deployment_access.py" "${ACCESS_ARGS[@]}" -- "${COMPOSE_CMD[@]}"
 
 if [[ "$REBUILD" -eq 1 ]]; then
   if [[ ${#BUILD_ARGS[@]} -eq 0 ]]; then
@@ -79,5 +85,5 @@ if [[ "$REBUILD" -eq 1 ]]; then
 else
   run_compose pull "${SERVICES[@]}"
 fi
-python3 "$ROOT_DIR/moonmind/deployment_access.py" "${COMPOSE_CMD[@]}"
+python3 "$ROOT_DIR/moonmind/deployment_access.py" "${ACCESS_ARGS[@]}" -- "${COMPOSE_CMD[@]}"
 run_compose up -d --remove-orphans --force-recreate "${SERVICES[@]}"


### PR DESCRIPTION
## Related issue

Follow-up to #4155 and #4142.

## Summary

An update could replace an installed LAN-facing API with the fresh-install loopback binding while container health stayed green. Add one shared preflight to the host update scripts and deployment runner that compares rendered Compose with installed API bindings and access settings before recreation.

In plain terms, a routine update must keep the operator's address and login behavior working. Access changes require a separate, verified migration. A rejected git update restores its previous checkout before worker resume. The gate also preserves proxy network attachments and OIDC configuration, while allowing maintenance that cannot affect the API. Tests cover these handoffs through the host scripts and worker invocation.

## Test Plan

Pinned submodules were initialized; the isolated test environment used explicit disabled auth and a loopback publish host.

```bash
./tools/test_unit.sh --python-only --no-xdist tests/unit/test_deployment_access.py tests/unit/test_update_moonmind_skill.py tests/unit/test_update_shell_prerequisites.py tests/unit/workflows/skills/test_deployment_update_execution.py
.venv/bin/python -m pytest -q tests/integration/reliability/test_deployment_update_replay.py tests/integration/temporal/test_deployment_update_execution_contract.py tests/integration/test_api_publish_binding.py --tb=short
MOONMIND_PYTHON_TEST_IMAGE=moonmind-python-tests:local MOONMIND_TEST_COMPOSE_PROJECT_NAME=moonmind-test-access-pr ./tools/test_integration.sh
```

144 targeted unit tests and 16 integration/replay tests passed. The full hermetic integration suite passed: 740 tests.

The API component replay fixture also reflects confirmed targeted GitHub label mutations, preserving unrelated labels and rejecting finalization without evidence. Its 92 targeted tests passed; the complete API component shard passed with 2,215 tests and one expected failure.

## Demo

N/A — no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [x] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

The preflight is read-only and reports changed setting names without dumping environments or credentials. It blocks ordinary updates when installed access cannot be preserved or inspected. Direct Docker Compose remains the documented path for an intentional migration. Host scripts require Python 3.10+ and the Docker Compose plugin; the unsupported legacy docker-compose fallback is removed and prerequisites are checked before mutations. No Temporal payload or history shape changes.

## Coverage notes

Real Compose rendering and API startup checks cover omitted, blank, explicit-local, authorized-network, and unauthorized-network inputs. Deployment replay tests cover POSIX and Windows paths. Manual checks verified health, dashboard, assets, and a read-only API response through the operator hostname after restoring the installation's approved settings; a separate client device was not available for verification. Deployment-owned environment settings are outside this PR.

## Changelog

Prevent routine deployment updates from silently changing dashboard/API network access.
