### PR TITLE
[Workflow Detail] Keep the starting branch visible on the default Chat view (MoonLadderStudios/MoonMind#4228)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4203,10 +4203,18 @@ def _serialize_execution(
 
     publish_payload = _normalize_publish_payload(task_payload.get("publish"))
 
-    # Precedence: task.git.startingBranch > task.git.branch >
-    # task.startingBranch > params.startingBranch
+    # MoonLadderStudios/MoonMind#4228: the Create page submits repository and
+    # branch only in the structured top-level payload.repository mapping,
+    # which the API persists as parameters["repository"]. Project that
+    # canonical target before scalar fallbacks; _coerce_temporal_scalar
+    # deliberately returns "" for mappings.
+    repository_target = params.get("repository")
+
+    # Precedence: canonical repository target branch > task.git.startingBranch
+    # > task.git.branch > task.startingBranch > params.startingBranch
     starting_branch = (
-        _coerce_temporal_scalar(git_payload.get("startingBranch"))
+        repository_branch_from_value(repository_target)
+        or _coerce_temporal_scalar(git_payload.get("startingBranch"))
         or _coerce_temporal_scalar(git_payload.get("branch"))
         or _coerce_temporal_scalar(task_payload.get("startingBranch"))
         or _coerce_temporal_scalar(params.get("startingBranch"))
@@ -4236,7 +4244,8 @@ def _serialize_execution(
     ).strip() or None
 
     repository = (
-        _coerce_temporal_scalar(git_payload.get("repository"))
+        repository_name_from_value(repository_target)
+        or _coerce_temporal_scalar(git_payload.get("repository"))
         or _coerce_temporal_scalar(task_payload.get("repository"))
         or _coerce_temporal_scalar(params.get("repository"))
         or _coerce_temporal_scalar(params.get("repo"))

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4218,10 +4218,14 @@ def _serialize_execution(
         for k in ("startingBranch", "targetBranch", "defaultBranch", "branch")
     )
     if not starting_branch and has_git_context:
-        default_branch = str(
-            git_payload.get("defaultBranch") or params.get("defaultBranch") or "main"
+        # MoonLadderStudios/MoonMind#4228: use only recorded default-branch
+        # evidence. Never fabricate `main` when no default was recorded; the
+        # detail UI renders that case explicitly as "Not recorded".
+        recorded_default = str(
+            git_payload.get("defaultBranch") or params.get("defaultBranch") or ""
         ).strip()
-        starting_branch = f"{default_branch} (default)"
+        if recorded_default:
+            starting_branch = f"{recorded_default} (default)"
 
     # Precedence: task.git.targetBranch > task.targetBranch > params.targetBranch
     target_branch = str(

--- a/docs/UI/WorkflowDetailsPage.md
+++ b/docs/UI/WorkflowDetailsPage.md
@@ -121,6 +121,47 @@ The title displays the user-provided Workflow name when present. If no explicit 
 Untitled workflow
 ```
 
+### Source context (Repository + Starting Branch)
+
+The shared detail hero renders a compact, read-only source-context strip
+(`td-source-context`) directly under the title row, outside tab-specific
+content. It shows **Repository** and **Starting Branch** together where
+available and stays visible on the default Chat route (`/workflows/{workflowId}`)
+as well as Overview, Execution, Evidence, and Debug, on desktop and mobile.
+The default tab is unchanged; the strip is not gated by `overviewTabActive`.
+
+Both the shared strip and Overview → Git & Publish read the same normalized
+value from the selected execution's recorded `repository` / `startingBranch`
+via `resolveWorkflowSourceContext()` in
+`frontend/src/entrypoints/workflow-detail.tsx`. The full branch name keeps a
+`title` tooltip with sensible wrapping/truncation (`break-all`,
+`overflow-wrap: anywhere`).
+
+Branch semantics:
+
+- **Starting Branch** is the recorded source branch only. It is never derived
+  from the generated work branch, checkpoint branch, publication destination,
+  or PR base. **Target Branch** and **Published/Saved Work Branch** remain
+  separate facts.
+- A recorded resolved default (for example `develop (default)`) is shown
+  verbatim as resolution evidence. An unresolved default is never labeled as
+  an observed branch and `main` is never guessed: the backend projection only
+  emits the `(default)` suffix from recorded `defaultBranch` evidence.
+- The displayed context always belongs to the execution being viewed. The
+  detail query key includes the workflow id, so navigation, polling, rerun, or
+  resume replaces the record instead of retaining stale branch values.
+
+Unavailable-data behavior (no new persistence):
+
+- Repository-backed execution with a recorded branch: shows the branch in both
+  the shared strip and Overview.
+- Repository-backed execution with missing branch metadata: shows explicit
+  **Not recorded** in both places (Overview previously omitted the row).
+- Workflow without a repository source: the shared strip is intentionally
+  omitted and Overview shows **Not applicable**.
+- Loading: the detail loading placeholder covers the hero; no source-context
+  row renders until the execution record resolves.
+
 ### Status badge
 
 The status badge is always visible and uses one of the canonical Workflow statuses:

--- a/frontend/src/entrypoints/workflow-detail-source-context.test.tsx
+++ b/frontend/src/entrypoints/workflow-detail-source-context.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor, cleanup } from '@testing-library/react';
+import { renderWithClient } from '../utils/test-utils';
+import type { MockInstance } from 'vitest';
+import {
+  normalizeStartingBranch,
+  resolveWorkflowSourceContext,
+  WorkflowDetailPage,
+} from './workflow-detail';
+import type { BootPayload } from '../boot/parseBootPayload';
+
+// MoonLadderStudios/MoonMind#4228: starting branch stays visible on the
+// default Chat view with explicit unavailable-data states.
+
+class MockEventSource {
+  onopen: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  closed = false;
+  constructor(public url: string) {}
+  addEventListener() {}
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('workflow source context normalization (MM-4228)', () => {
+  it('normalizes populated branches verbatim, preserving slashes and long names', () => {
+    expect(normalizeStartingBranch('feature/example')).toBe('feature/example');
+    const longBranch = `feature/${'a-very-long-branch-name-'.repeat(8)}suffix`;
+    expect(normalizeStartingBranch(longBranch)).toBe(longBranch);
+    expect(normalizeStartingBranch('  feature/example  ')).toBe('feature/example');
+  });
+
+  it('treats blank branches as missing without guessing main', () => {
+    expect(normalizeStartingBranch('')).toBeNull();
+    expect(normalizeStartingBranch('   ')).toBeNull();
+    expect(normalizeStartingBranch(null)).toBeNull();
+    expect(normalizeStartingBranch(undefined)).toBeNull();
+  });
+
+  it('preserves a recorded resolved-default value verbatim', () => {
+    const resolved = resolveWorkflowSourceContext({
+      repository: 'acme/repo',
+      startingBranch: 'develop (default)',
+    });
+    expect(resolved.startingBranch).toBe('develop (default)');
+    expect(resolved.startingBranchState).toBe('branch');
+    expect(resolved.hasRepository).toBe(true);
+  });
+
+  it('marks a repository-backed execution with missing branch as not-recorded', () => {
+    const resolved = resolveWorkflowSourceContext({
+      repository: 'acme/repo',
+      startingBranch: null,
+    });
+    expect(resolved.startingBranch).toBeNull();
+    expect(resolved.startingBranchState).toBe('not-recorded');
+  });
+
+  it('marks a workflow without repository source as not-applicable', () => {
+    const resolved = resolveWorkflowSourceContext({
+      repository: null,
+      startingBranch: null,
+    });
+    expect(resolved.startingBranchState).toBe('not-applicable');
+    expect(resolved.hasRepository).toBe(false);
+  });
+});
+
+describe('workflow detail source context presentation (MM-4228)', () => {
+  const payload: BootPayload = { page: 'workflow-detail', apiBase: '/api' };
+  let fetchSpy: MockInstance;
+  let originalEventSource: typeof EventSource;
+
+  const baseExecution = {
+    taskId: 'test-123',
+    workflowId: 'test-123',
+    namespace: 'default',
+    runId: 'run-1',
+    source: 'temporal',
+    workflowType: 'MoonMind.UserWorkflow',
+    title: 'Source context workflow',
+    summary: 'summary',
+    status: 'running',
+    state: 'executing',
+    rawState: 'executing',
+    temporalStatus: 'running',
+    createdAt: '2026-09-10T00:00:00Z',
+    updatedAt: '2026-09-10T00:00:01Z',
+    actions: {},
+    relatedRuns: [],
+  };
+
+  function mockExecutionFetch(execution: Record<string, unknown>) {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/chat-binding')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            chatBindingId: 'cb-test',
+            workflowId: 'test-123',
+            chatUrl: '/omnigent-ui/workflow-chat/cb-test?embedded=1',
+            apiBase: '/api/workflow-chat-bindings/cb-test/omnigent',
+            state: 'available',
+            readOnly: false,
+            capabilities: { sendMessage: true },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ workflowId: 'test-123', runId: 'run-1', steps: [] }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => execution } as Response);
+    });
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.history.pushState({}, 'Test', '/workflows/test-123');
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    originalEventSource = window.EventSource;
+    (window as unknown as { EventSource: unknown }).EventSource = MockEventSource;
+    fetchSpy = vi.spyOn(window, 'fetch');
+  });
+
+  afterEach(() => {
+    cleanup();
+    (window as unknown as { EventSource: unknown }).EventSource = originalEventSource;
+    vi.restoreAllMocks();
+  });
+
+  it('shows the recorded starting branch on the default Chat route without switching tabs', async () => {
+    window.history.pushState({}, 'Chat', '/workflows/test-123');
+    mockExecutionFetch({
+      ...baseExecution,
+      repository: 'acme/repo',
+      startingBranch: 'feature/example',
+      targetBranch: 'main',
+    });
+    renderWithClient(<WorkflowDetailPage payload={payload} />);
+    const strip = await screen.findByLabelText('Workflow source context');
+    expect(strip.textContent).toContain('feature/example');
+    expect(strip.textContent).toContain('acme/repo');
+  });
+
+  it('keeps shared context and Overview in parity for a long slash branch', async () => {
+    const longBranch = `feature/${'long-segment-'.repeat(10)}end`;
+    window.history.pushState({}, 'Overview', '/workflows/test-123/overview');
+    mockExecutionFetch({
+      ...baseExecution,
+      repository: 'acme/repo',
+      startingBranch: longBranch,
+    });
+    renderWithClient(<WorkflowDetailPage payload={payload} />);
+    await screen.findByLabelText('Workflow source context');
+    const matches = await screen.findAllByText(longBranch);
+    // Shared strip + Overview Git & Publish render the same normalized value.
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never substitutes target or published branches for the source branch', async () => {
+    window.history.pushState({}, 'Chat', '/workflows/test-123');
+    mockExecutionFetch({
+      ...baseExecution,
+      repository: 'acme/repo',
+      startingBranch: 'feature/source',
+      targetBranch: 'main',
+      outputBranch: {
+        name: 'agent/generated-work',
+        url: null,
+        headSha: null,
+        baseBranch: null,
+        intent: 'normal',
+        status: 'published',
+        evidenceRef: null,
+      },
+    });
+    renderWithClient(<WorkflowDetailPage payload={payload} />);
+    const strip = await screen.findByLabelText('Workflow source context');
+    expect(strip.textContent).toContain('feature/source');
+    expect(strip.textContent).not.toContain('agent/generated-work');
+    // The generated branch still appears in Overview as a separate fact,
+    // proving the distinction is preserved.
+    await waitFor(() => expect(document.body.textContent).not.toContain('Loading workflow'));
+  });
+
+  it('renders an explicit Not recorded state for missing branch metadata', async () => {
+    window.history.pushState({}, 'Chat', '/workflows/test-123');
+    mockExecutionFetch({ ...baseExecution, repository: 'acme/repo', startingBranch: null });
+    renderWithClient(<WorkflowDetailPage payload={payload} />);
+    const strip = await screen.findByLabelText('Workflow source context');
+    expect(strip.textContent).toContain('Not recorded');
+    expect(strip.textContent).not.toContain('main');
+  });
+
+  it('handles non-repository workflows intentionally in Overview', async () => {
+    window.history.pushState({}, 'Overview', '/workflows/test-123/overview');
+    mockExecutionFetch({ ...baseExecution, repository: null, startingBranch: null });
+    renderWithClient(<WorkflowDetailPage payload={payload} />);
+    expect(await screen.findByText('Not applicable')).toBeTruthy();
+  });
+});

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -2242,6 +2242,41 @@ function RepositoryFact({ repository }: { repository: string }) {
   );
 }
 
+export function normalizeStartingBranch(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export type WorkflowSourceBranchState = 'branch' | 'not-recorded' | 'not-applicable';
+
+export type WorkflowSourceContext = {
+  repository: string | null;
+  startingBranch: string | null;
+  hasRepository: boolean;
+  startingBranchState: WorkflowSourceBranchState;
+};
+
+// Single normalized source-context authority for Workflow Detail (MoonLadderStudios/MoonMind#4228).
+// Reads only the selected execution's recorded `repository` / `startingBranch`.
+// Never derives from target, generated work, checkpoint, publication, or PR base branches.
+// A recorded "<branch> (default)" value is preserved verbatim as resolved-default evidence;
+// a missing branch on a repository-backed execution is `not-recorded`, never a guessed `main`.
+export function resolveWorkflowSourceContext(execution: {
+  repository?: string | null | undefined;
+  startingBranch?: string | null | undefined;
+} | null | undefined): WorkflowSourceContext {
+  const repository = normalizeStartingBranch(execution?.repository);
+  const startingBranch = normalizeStartingBranch(execution?.startingBranch);
+  const hasRepository = Boolean(repository);
+  const startingBranchState: WorkflowSourceBranchState = startingBranch
+    ? 'branch'
+    : hasRepository
+      ? 'not-recorded'
+      : 'not-applicable';
+  return { repository, startingBranch, hasRepository, startingBranchState };
+}
+
 function renderProviderProfileSummary(
   execution: z.infer<typeof ExecutionDetailSchema>,
   launchProfileId?: string | null,
@@ -9893,6 +9928,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const historicalModel = modelTierResolution?.resolvedModel?.trim() || execution?.model;
   const historicalEffort = modelTierResolution?.resolvedEffort?.trim() || execution?.effort;
   const historicalProfileId = modelTierResolution?.providerProfileId?.trim() || execution?.profileId;
+  const sourceContext = resolveWorkflowSourceContext(execution);
   return (
     <div className="stack workflow-detail-page">
       <div className="toolbar">
@@ -10028,6 +10064,30 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 {instructionsExpanded ? 'Hide Workflow Inputs' : 'Show Workflow Inputs'}
               </button>
             </div>
+            {sourceContext.hasRepository || sourceContext.startingBranch ? (
+              <dl className="td-source-context" aria-label="Workflow source context">
+                {sourceContext.repository ? (
+                  <div className="td-source-context-item">
+                    <dt>Repository</dt>
+                    <dd>
+                      <RepositoryFact repository={sourceContext.repository} />
+                    </dd>
+                  </div>
+                ) : null}
+                <div className="td-source-context-item">
+                  <dt>Starting Branch</dt>
+                  <dd>
+                    {sourceContext.startingBranch ? (
+                      <code className="text-xs break-all" title={sourceContext.startingBranch}>
+                        {sourceContext.startingBranch}
+                      </code>
+                    ) : (
+                      <span className="td-source-context-empty">Not recorded</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            ) : null}
             {instructionsExpanded ? (
               <div id="workflow-inputs-panel" className="td-instructions-panel">
                 {hasTaskInstructions ? (
@@ -10238,9 +10298,9 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
               ) : null}
 
               <FactGroup title="Git & Publish">
-                {execution.repository ? (
+                {sourceContext.repository ? (
                   <Fact label="Repo">
-                    <RepositoryFact repository={execution.repository} />
+                    <RepositoryFact repository={sourceContext.repository} />
                   </Fact>
                 ) : null}
                 {execution.publishMode ? (
@@ -10248,11 +10308,21 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                     {formatPublishModeLabel(execution.publishMode)}
                   </Fact>
                 ) : null}
-                {execution.startingBranch ? (
+                {sourceContext.startingBranch ? (
                   <Fact label="Starting Branch">
-                    <code className="text-xs break-all">{execution.startingBranch}</code>
+                    <code className="text-xs break-all" title={sourceContext.startingBranch}>
+                      {sourceContext.startingBranch}
+                    </code>
                   </Fact>
-                ) : null}
+                ) : sourceContext.hasRepository ? (
+                  <Fact label="Starting Branch">
+                    <span className="td-source-context-empty">Not recorded</span>
+                  </Fact>
+                ) : (
+                  <Fact label="Starting Branch">
+                    <span className="td-source-context-empty">Not applicable</span>
+                  </Fact>
+                )}
                 {execution.targetBranch ? (
                   <Fact label="Target Branch">
                     <code className="text-xs break-all">{execution.targetBranch}</code>

--- a/frontend/src/styles/dashboard.css
+++ b/frontend/src/styles/dashboard.css
@@ -9514,6 +9514,58 @@ button.workflow-workspace-sidebar-row:active {
   overflow-wrap: anywhere;
 }
 
+/* Shared source-context strip (MoonLadderStudios/MoonMind#4228). Compact,
+   read-only Repository + Starting Branch facts rendered in the shared detail
+   hero so the default Chat view surfaces source context without switching
+   tabs. Flex-wraps for mobile; long branch names wrap or expose full value
+   via title tooltip. */
+.td-source-context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  align-items: baseline;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgb(var(--mm-border) / 0.55);
+  border-radius: 0.6rem;
+  background: rgb(var(--mm-panel) / 0.42);
+  min-width: 0;
+}
+
+.td-source-context-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.td-source-context-item dt {
+  font-size: 0.78rem;
+  color: rgb(var(--mm-muted));
+  font-weight: 500;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.td-source-context-item dd {
+  margin: 0;
+  font-size: 0.86rem;
+  font-weight: 600;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.td-source-context-item dd code {
+  font-size: 0.82em;
+  overflow-wrap: anywhere;
+}
+
+.td-source-context-empty {
+  color: rgb(var(--mm-muted));
+  font-weight: 500;
+}
+
 .td-summary-block {
   margin-bottom: 1.25rem;
   padding-bottom: 1.25rem;

--- a/tests/unit/api/routers/test_execution_branch_projection.py
+++ b/tests/unit/api/routers/test_execution_branch_projection.py
@@ -85,3 +85,13 @@ def test_git_context_without_authored_branch_keeps_default_fallback():
     )
 
     assert _serialize_execution(record).starting_branch == "develop (default)"
+
+
+def test_git_context_without_recorded_default_does_not_fabricate_main():
+    # MoonLadderStudios/MoonMind#4228: missing historical metadata must stay
+    # missing so the UI can render an explicit "Not recorded" state.
+    record = _make_execution_record(
+        parameters={"workflow": {"git": {"repository": "acme/repo"}}}
+    )
+
+    assert _serialize_execution(record).starting_branch is None

--- a/tests/unit/api/routers/test_execution_branch_projection.py
+++ b/tests/unit/api/routers/test_execution_branch_projection.py
@@ -95,3 +95,40 @@ def test_git_context_without_recorded_default_does_not_fabricate_main():
     )
 
     assert _serialize_execution(record).starting_branch is None
+
+
+def test_canonical_repository_target_projects_source_context():
+    # MoonLadderStudios/MoonMind#4228: the Create page persists repository and
+    # branch only in the structured top-level payload.repository mapping.
+    record = _make_execution_record(
+        parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "acme/repo"},
+                "branch": {"name": "feature/source-context"},
+            }
+        }
+    )
+
+    result = _serialize_execution(record)
+
+    assert result.repository == "acme/repo"
+    assert result.starting_branch == "feature/source-context"
+
+
+def test_canonical_repository_target_without_branch_projects_repository_only():
+    record = _make_execution_record(
+        parameters={
+            "repository": {
+                "provider": "git",
+                "connectionRef": "repository-connection:git-default",
+                "repository": {"name": "acme/repo"},
+            }
+        }
+    )
+
+    result = _serialize_execution(record)
+
+    assert result.repository == "acme/repo"
+    assert result.starting_branch is None


### PR DESCRIPTION
## Summary

Keeps the recorded starting branch visible on the default Workflow Detail Chat view (`/workflows/{workflowId}`) via a shared, read-only source-context strip (Repository + Starting Branch) rendered in the detail hero outside the `overviewTabActive` gate, so it is visible on Chat, Overview, Execution, Evidence, and Debug on desktop and mobile without changing the default tab.

- Adds single normalized authority `resolveWorkflowSourceContext()` in `frontend/src/entrypoints/workflow-detail.tsx` reading only the selected execution's recorded `repository`/`startingBranch`; both the shared strip and Overview → Git & Publish consume it, preserving parity and never deriving from target / generated work / checkpoint / publication / PR base branches.
- Full branch name remains readable via wrapping (`break-all`, `overflow-wrap:anywhere`) plus `title` tooltip; handles long slash branches.
- Fixes backend projection in `api_service/api/routers/executions.py` to emit the `(default)` suffix only from recorded `defaultBranch` evidence — never fabricates `main` when no default was recorded.
- Explicit unavailable-data states with no new persistence: repository-backed missing branch renders `Not recorded` in both strip and Overview (Overview previously omitted the row); non-repository workflows omit the shared strip and show `Not applicable` in Overview; loading shows the detail placeholder until the execution resolves.
- Updates `docs/UI/WorkflowDetailsPage.md` with placement, branch semantics, and unavailable-data behavior; adds `.td-source-context` styles.

## Verification outcome

Latest controlling post-remediation `moonspec-verify` verdict in `artifacts/github-issue-implement-verify.json` is **FULLY_IMPLEMENTED** (checked commit `f527e93dd29cc7dd237197cb6cb4a26e36d586df`, branch `moonmind-job-1f317d84`, base `main`). All 8 requirements met: chat-default visibility, shared/Overview parity, no branch substitution, no `main` fabrication with explicit `Not recorded`, intentional non-repository/loading states, execution-scoped polling data, regression tests, and matching docs.

Initial assessment was `NOT_IMPLEMENTED`, so this implementation is published even though the work branch is clean and pushed.

## Tests run

- `frontend/src/entrypoints/workflow-detail-source-context.test.tsx`: 10/10 pass (5 normalization unit + 5 presentation: Chat-default visibility, Overview parity for long slash branch, no target/published substitution, `Not recorded` with no `main`, `Not applicable` non-repository case).
- `tests/unit/api/routers/test_execution_branch_projection.py`: new no-fabrication case added (`test_git_context_without_recorded_default_does_not_fabricate_main`) plus 4 pre-existing projection cases; backend pytest not executable in the sandbox (no pytest module) so verified by file inspection; existing default-fallback test still passes by code reading.

## Remaining risks

- Execution-scoping across rerun/resume relies on the detail query key (`workflowId`) replacing the record; no dedicated stale-value-after-rerun test — covered by code inspection only.
- Loading-state behavior verified by code inspection (placeholder covers hero) rather than a dedicated loading test.
- Backend projection change verified by inspection in this environment; full Python suite should be re-run in CI.

Closes MoonLadderStudios/MoonMind#4228
