### PR TITLE
Fix stale Omnigent inventory blocking workflow submission

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -691,6 +691,25 @@ async def _maintain_omnigent_bootstrap_reconciliation() -> None:
             retry_delay_seconds = min(retry_delay_seconds * 2, 120)
 
 
+_OMNIGENT_INVENTORY_REFRESH_INTERVAL_SECONDS = 120
+
+
+async def _maintain_omnigent_inventory() -> None:
+    """Keep discovery fresh even while bootstrap waits on credential authority."""
+    from api_service.services.omnigent_agent_profile_service import (
+        refresh_upstream_inventory,
+    )
+
+    while True:
+        try:
+            await refresh_upstream_inventory()
+        except Exception as exc:
+            logger.warning(
+                "Omnigent inventory refresh deferred (%s)", type(exc).__name__
+            )
+        await asyncio.sleep(_OMNIGENT_INVENTORY_REFRESH_INTERVAL_SECONDS)
+
+
 async def _initialize_oidc_provider(app: FastAPI):
     """Validate the authentication selector; generic OIDC discovery lives in #4124."""
     # The bundled Keycloak integration was removed (#4129): retired selectors
@@ -976,21 +995,23 @@ async def lifespan(app: FastAPI):
             _maintain_omnigent_bootstrap_reconciliation(),
             name="omnigent-bootstrap-reconciliation",
         )
+        app.state.omnigent_inventory_task = asyncio.create_task(
+            _maintain_omnigent_inventory(), name="omnigent-inventory-refresh"
+        )
     try:
         yield
     finally:
-        retry_task = getattr(
-            app.state,
-            "omnigent_bootstrap_reconciliation_task",
-            None,
-        )
-        if retry_task is not None and not retry_task.done():
-            retry_task.cancel()
-            try:
-                await retry_task
-            except asyncio.CancelledError:
-                # Shutdown owns this task, so cancellation is the expected outcome.
-                pass
+        maintenance_tasks = [
+            task
+            for name in (
+                "omnigent_bootstrap_reconciliation_task",
+                "omnigent_inventory_task",
+            )
+            if (task := getattr(app.state, name, None)) is not None
+        ]
+        for task in maintenance_tasks:
+            task.cancel()
+        await asyncio.gather(*maintenance_tasks, return_exceptions=True)
         # The pooled Omnigent HTTP/SSE transport lives for the process, so
         # this process closes it (MoonLadderStudios/MoonMind#3878).
         from moonmind.omnigent.production import close_omnigent_transport_pool

--- a/api_service/services/omnigent_agent_profile_selection.py
+++ b/api_service/services/omnigent_agent_profile_selection.py
@@ -19,8 +19,10 @@ from api_service.db.models import (
     User,
 )
 from api_service.services.omnigent_agent_profile_service import (
+    UpstreamInventoryRefreshError,
     projection_identity,
     projection_readiness,
+    refresh_upstream_inventory,
 )
 from api_service.services.provider_profile_readiness import (
     provider_profile_launch_ready,
@@ -360,14 +362,23 @@ async def resolve_agent_profile_snapshot(
     source = document.get("source") or {}
     upstream_snapshot = version.upstream_snapshot
     if source.get("upstreamId"):
-        projection = await session.get(
-            OmnigentUpstreamAgentProjection,
-            projection_identity(
-                document["endpointRef"],
-                source["upstreamId"],
-                source.get("upstreamVersion"),
-            ),
+        projection_id = projection_identity(
+            document["endpointRef"], source["upstreamId"], source.get("upstreamVersion")
         )
+        projection = await session.get(
+            OmnigentUpstreamAgentProjection, projection_id
+        )
+        if projection_readiness(projection)["freshness"] in {"stale", "missing"}:
+            try:
+                await refresh_upstream_inventory(endpoint_ref=document["endpointRef"])
+            except UpstreamInventoryRefreshError as exc:
+                raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+            # Refresh committed in its own session. Re-read the exact pinned
+            # identity instead of accepting the session's stale identity map or
+            # substituting the latest upstream version/profile default.
+            projection = await session.get(
+                OmnigentUpstreamAgentProjection, projection_id, populate_existing=True
+            )
         readiness = projection_readiness(
             projection,
             bridge_mode=(None if is_v2 else document["bridgeMode"]),

--- a/api_service/services/omnigent_agent_profile_service.py
+++ b/api_service/services/omnigent_agent_profile_service.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
+import logging
 import os
 import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import OmnigentUpstreamAgentProjection
@@ -20,6 +22,70 @@ _INVENTORY_FRESHNESS_TTL = timedelta(minutes=5)
 _METADATA_TEXT_LIMIT = 512
 _METADATA_LIST_LIMIT = 64
 _IMMUTABLE_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_INVENTORY_REFRESH_TIMEOUT_SECONDS = 15
+logger = logging.getLogger(__name__)
+
+
+class UpstreamInventoryRefreshError(RuntimeError):
+    """The configured endpoint could not supply fresh launch evidence."""
+
+
+async def refresh_upstream_inventory(*, endpoint_ref: str = "default") -> None:
+    """Refresh discovery independently of authoring and credential maintenance.
+
+    Only the configured endpoint is authorized. The separate transaction must
+    never commit a caller's partially authored workflow or immutable selection.
+    The deadline covers pagination and persistence, not just each HTTP page.
+    """
+    from api_service.db.base import async_session_maker
+    from moonmind.omnigent.bridge_config import (
+        HOST_PROTOCOL_MODE_PROXY,
+        resolve_bridge_config,
+    )
+    from moonmind.omnigent.settings import resolved_api_token, resolved_server_url
+    from moonmind.workflows.adapters.omnigent_client import OmnigentHttpClient
+
+    if endpoint_ref != "default":
+        raise UpstreamInventoryRefreshError(
+            "upstream inventory refresh requires the configured default endpoint"
+        )
+    config = resolve_bridge_config()
+    if not config.enabled or config.host_protocol_mode != HOST_PROTOCOL_MODE_PROXY:
+        raise UpstreamInventoryRefreshError("Omnigent inventory bridge is unavailable")
+    attempted_at = datetime.now(timezone.utc)
+    try:
+        async with asyncio.timeout(_INVENTORY_REFRESH_TIMEOUT_SECONDS):
+            inventory = await OmnigentHttpClient(
+                base_url=resolved_server_url(),
+                api_token=resolved_api_token(),
+                timeout_seconds=5,
+            ).list_agents()
+            async with async_session_maker() as session:
+                await synchronize_upstream_inventory(
+                    session,
+                    endpoint_ref=endpoint_ref,
+                    bridge_mode="proxy",
+                    inventory=inventory,
+                )
+    except Exception as exc:
+        # Provider exception strings can contain URLs or credentials. Retain a
+        # bounded, non-sensitive failure classification, never their raw text.
+        reason = (
+            f"upstream inventory refresh failed ({type(exc).__name__}); retry submission"
+        )
+        try:
+            async with asyncio.timeout(5):
+                async with async_session_maker() as session:
+                    await record_upstream_sync_failure(
+                        session,
+                        endpoint_ref=endpoint_ref,
+                        bridge_mode="proxy",
+                        error=reason,
+                        now=attempted_at,
+                    )
+        except Exception:
+            logger.warning("Could not persist upstream inventory refresh failure")
+        raise UpstreamInventoryRefreshError(reason) from exc
 
 
 async def computed_launchable_harnesses(session: AsyncSession) -> set[str]:
@@ -291,19 +357,21 @@ async def record_upstream_sync_failure(
     """Retain last-known metadata while explicitly recording stale error state."""
     attempted_at = now or datetime.now(timezone.utc)
     safe_error = error.replace("\n", " ")[:512]
-    rows = list(
-        (
-            await session.execute(
-                select(OmnigentUpstreamAgentProjection).where(
-                    OmnigentUpstreamAgentProjection.endpoint_ref == endpoint_ref,
-                    OmnigentUpstreamAgentProjection.bridge_mode == bridge_mode,
-                )
-            )
-        ).scalars()
+    # Compare at the database write boundary: an overlapping successful refresh
+    # must remain authoritative even if it commits while this write waits.
+    await session.execute(
+        update(OmnigentUpstreamAgentProjection)
+        .where(
+            OmnigentUpstreamAgentProjection.endpoint_ref == endpoint_ref,
+            OmnigentUpstreamAgentProjection.bridge_mode == bridge_mode,
+            or_(
+                OmnigentUpstreamAgentProjection.last_successful_sync_at.is_(None),
+                OmnigentUpstreamAgentProjection.last_successful_sync_at < attempted_at,
+            ),
+        )
+        .values(last_attempt_at=attempted_at, error=safe_error)
+        .execution_options(synchronize_session=False)
     )
-    for projection in rows:
-        projection.last_attempt_at = attempted_at
-        projection.error = safe_error
     await session.commit()
 
 

--- a/docs/Omnigent/AgentProfiles.md
+++ b/docs/Omnigent/AgentProfiles.md
@@ -4,7 +4,7 @@ Status: **Desired-State Design**
 Document Class: System / Feature Design View
 Owners: MoonMind Engineering  
 Issue: MoonLadderStudios/MoonMind#3517  
-Last updated: 2026-09-06
+Last updated: 2026-09-10
 
 ## Implementation status
 
@@ -50,6 +50,14 @@ Profiles never contain credentials, OAuth homes, registration secrets, Dockerfil
 ## Discovery and launch security
 
 MoonMind synchronizes the stock `/v1/agents` built-in catalog through its authenticated bridge boundary into a bounded last-known projection keyed by endpoint plus stable upstream id and version. The stock catalog's session bindability is projected as the canonical `session.start` capability. MoonMind records harness, capabilities, health, provenance, compatibility, successful-sync time, attempt time, and redacted error state. An outage retains the prior snapshot but marks it stale. Missing or incompatible agents block new launches; historical snapshots remain readable.
+
+The API refreshes discovery every two minutes independently of credential leases,
+provider validation, and deployment qualification. Each refresh has a fifteen-second
+deadline covering HTTP pagination and persistence. Authoring refreshes stale or
+missing discovery once before admission, then revalidates the exact selected
+upstream identity and version. Refresh commits only discovery in its own transaction;
+it cannot commit partial workflow authoring, change a selected profile, or replace
+an unavailable version. Failed refreshes remain actionable admission failures.
 
 Workflow, schedule, checkpoint-branch, and remediation authoring expose
 Runtime and one Profile selection. Runtime stays visible and names a stable

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import contextlib
 import fcntl
 import functools
@@ -5999,7 +6000,11 @@ class TemporalAgentRuntimeActivities:
         if not webhook_url and not email_configured:
             return {"status": "skipped", "reason": "no_channels"}
 
-        event = _build_execution_notification_payload(payload, redact=True)
+        # Inspect original content before redaction can erase a finding. The
+        # independently built delivery payload remains redacted for low-security
+        # sends and cannot mutate the scan input through nested references.
+        scan_event = _build_execution_notification_payload(payload, redact=False)
+        event = redact_sensitive_payload(copy.deepcopy(scan_event))
         results: list[dict[str, str]] = []
         errors: list[dict[str, str]] = []
         timeout_seconds = max(1, int(notification_settings.timeout_seconds or 5))
@@ -6009,7 +6014,7 @@ class TemporalAgentRuntimeActivities:
             if authorization:
                 headers["Authorization"] = authorization
             blocked_reason = _scan_execution_notification_before_send(
-                event,
+                scan_event,
                 surface="execution.notification.webhook.payload",
             )
             if blocked_reason is not None:
@@ -6047,7 +6052,7 @@ class TemporalAgentRuntimeActivities:
                     )
         if email_configured:
             blocked_reason = _scan_execution_notification_before_send(
-                event,
+                scan_event,
                 surface="execution.notification.email.payload",
             )
             if blocked_reason is not None:

--- a/tests/integration/reliability/replays/omnigent-stale-inventory/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-stale-inventory/manifest.json
@@ -1,0 +1,13 @@
+{
+  "failureShapeId": "omnigent-stale-inventory",
+  "observedFailure": "Workflow submission returned 409 after sequential bootstrap maintenance stopped refreshing inventory for more than five minutes.",
+  "inventoryAgeSeconds": 660,
+  "upstreamId": "selected-agent",
+  "upstreamVersion": "7",
+  "expected": {
+    "recoverWithoutChangingSelection": true,
+    "commitOnlyDiscovery": true,
+    "missingOrIncompatibleIdentityBlocks": true,
+    "maintenanceWaitDoesNotStopDiscovery": true
+  }
+}

--- a/tests/integration/reliability/test_api_startup_provider_maintenance.py
+++ b/tests/integration/reliability/test_api_startup_provider_maintenance.py
@@ -53,6 +53,19 @@ async def test_http_serves_while_bootstrap_waits_and_lifespan_owns_cleanup(
     monkeypatch.delattr(
         api_main.app.state, "omnigent_bootstrap_reconciliation_task", raising=False
     )
+    monkeypatch.delattr(api_main.app.state, "omnigent_inventory_task", raising=False)
+    from api_service.services import omnigent_agent_profile_service as inventory_service
+
+    inventory_calls = []
+    inventory_refreshed = asyncio.Event()
+
+    async def refresh_inventory():
+        inventory_calls.append(True)
+        if len(inventory_calls) > 1:
+            inventory_refreshed.set()
+
+    monkeypatch.setattr(inventory_service, "refresh_upstream_inventory", refresh_inventory)
+    monkeypatch.setattr(api_main, "_OMNIGENT_INVENTORY_REFRESH_INTERVAL_SECONDS", 0.05)
 
     # MoonLadderStudios/MoonMind#4192: native RAG retrieval is retired, so
     # startup no longer touches a retrieval service; no stub is needed.
@@ -157,6 +170,9 @@ async def test_http_serves_while_bootstrap_waits_and_lifespan_owns_cleanup(
             task = api_main.app.state.omnigent_bootstrap_reconciliation_task
             assert not task.done()
             assert not available.is_set(), "Startup must preserve the active lease"
+            await asyncio.wait_for(inventory_refreshed.wait(), timeout=1)
+            inventory_task = api_main.app.state.omnigent_inventory_task
+            assert not inventory_task.done()
             response = await client.get("/healthz")
             assert response.status_code == replay["expected"]["healthStatus"]
             assert response.json()["db"] == "connected"
@@ -179,5 +195,6 @@ async def test_http_serves_while_bootstrap_waits_and_lifespan_owns_cleanup(
             await engine.dispose()
 
     assert task.done(), "API shutdown must own reconciliation cleanup"
+    assert inventory_task.done(), "API shutdown must also stop inventory refresh"
     assert exited.is_set()
     assert cancelled == (not release_wait)

--- a/tests/integration/reliability/test_omnigent_inventory_refresh.py
+++ b/tests/integration/reliability/test_omnigent_inventory_refresh.py
@@ -1,0 +1,279 @@
+"""Expired discovery -> authenticated HTTP -> persisted exact-profile admission."""
+
+import asyncio
+import copy
+import socket
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api_service.db import base as db_base
+from api_service.db.models import (
+    Base, ManagedAgentProviderProfile, OmnigentAgentProfile,
+    OmnigentAgentProfileUsage, OmnigentAgentProfileVersion,
+    OmnigentUpstreamAgentProjection,
+)
+from api_service.services import omnigent_agent_profile_service as inventory_service
+from api_service.services.omnigent_agent_profile_selection import resolve_agent_profile_snapshot
+from tests.integration.reliability.helpers import load_replay
+from tests.unit.services.test_omnigent_agent_profile_selection import (
+    _MM3788_V2_DOCUMENT, _Session,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.reliability_journey]
+
+
+@pytest_asyncio.fixture(params=["v1", "v2"])
+async def inventory_boundary(monkeypatch, tmp_path, request):
+    replay = load_replay("omnigent-stale-inventory", "manifest.json")
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/inventory.db")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr(db_base, "async_session_maker", sessions)
+    monkeypatch.setenv("OMNIGENT_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_GENERIC_HOST_ENABLED", "false")
+    monkeypatch.delenv("OMNIGENT_BRIDGE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("OMNIGENT_API_TOKEN", "fixture-inventory-credential")
+    upstream = FastAPI()
+    state = SimpleNamespace(
+        rows=[], calls=0, fail=False, blocked=asyncio.Event(), mode="normal",
+    )
+
+    @upstream.get("/v1/agents")
+    async def agents(request: Request):
+        assert request.headers["authorization"] == "Bearer fixture-inventory-credential"
+        state.calls += 1
+        if state.mode == "timeout":
+            await state.blocked.wait()
+        if state.fail:
+            return JSONResponse({"error": "fixture-inventory-credential"}, status_code=503)
+        return {"data": state.rows, "has_more": False}
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    server = uvicorn.Server(uvicorn.Config(upstream, log_level="error"))
+    server_task = asyncio.create_task(server.serve(sockets=[listener]))
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", f"http://127.0.0.1:{listener.getsockname()[1]}")
+    async with asyncio.timeout(3):
+        while not server.started:
+            await asyncio.sleep(0.01)
+
+    # Reuse the established launch-ready profile fixture, but persist actual ORM
+    # records: identity-map refresh, commit ownership and usage are not mocked.
+    fixture = _Session()
+    document = copy.deepcopy(fixture.version.document)
+    document["source"] = {
+        "upstreamId": replay["upstreamId"], "upstreamVersion": replay["upstreamVersion"],
+    }
+    if request.param == "v2":
+        source = document["source"]
+        document = copy.deepcopy(_MM3788_V2_DOCUMENT)
+        document["source"] = {
+            **source, "kind": "upstream", "upstreamSnapshotDigest": "sha256:" + "b" * 64,
+        }
+        document["requirements"] = {"moonmind": {"required": ["session.start"]}}
+    row = {
+        "id": replay["upstreamId"], "version": replay["upstreamVersion"],
+        "harness": "codex-native", "capabilities": ["session.start"],
+    }
+    state.rows = [row]
+    projection_id = inventory_service.projection_identity("default", row["id"], row["version"])
+    old_time = datetime.now(timezone.utc) - timedelta(seconds=replay["inventoryAgeSeconds"])
+    async with sessions() as session:
+        session.add(OmnigentAgentProfile(
+            profile_id="team-codex", display_name="Selected profile", visibility="workspace",
+            state="active", active_version=2,
+        ))
+        session.add(OmnigentAgentProfileVersion(
+            profile_id="team-codex", version=2, digest=fixture.version.digest,
+            document=document, validation_result={"ready": True},
+        ))
+        provider_fields = {
+            key: value for key, value in vars(fixture.provider).items()
+            if key in ManagedAgentProviderProfile.__table__.columns
+        }
+        session.add(ManagedAgentProviderProfile(**provider_fields))
+        session.add(OmnigentUpstreamAgentProjection(
+            projection_id=projection_id, endpoint_ref="default", bridge_mode="proxy",
+            upstream_id=row["id"], upstream_version=row["version"],
+            metadata_snapshot=row, available=True, compatible=True,
+            last_successful_sync_at=old_time, last_attempt_at=old_time,
+        ))
+        await session.commit()
+    try:
+        yield sessions, state, projection_id
+    finally:
+        state.blocked.set()
+        server.should_exit = True
+        await asyncio.wait_for(server_task, 3)
+        listener.close()
+        await engine.dispose()
+
+
+async def _select(session):
+    return await resolve_agent_profile_snapshot(
+        session, selection={
+            "profileId": "team-codex", "version": 2, "providerProfileRef": "oauth-team",
+            "digest": "sha256:" + "a" * 64,
+        }, consumer_type="workflow", consumer_id="new-workflow", user=None,
+    )
+
+
+async def test_stale_admission_refreshes_exact_identity_without_committing_authoring(inventory_boundary):
+    sessions, state, projection_id = inventory_boundary
+    async with sessions() as session:
+        stale = await session.get(OmnigentUpstreamAgentProjection, projection_id)
+        assert inventory_service.projection_readiness(stale)["freshness"] == "stale"
+        snapshot = await _select(session)
+        assert snapshot["agentId"] == "selected-agent"
+        assert snapshot["version"] == 2
+        assert snapshot["document"]["source"]["upstreamVersion"] == "7"
+        assert inventory_service.projection_readiness(stale)["ready"] is True
+        assert state.calls == 1
+        await session.rollback()
+    async with sessions() as session:
+        assert await session.scalar(select(OmnigentAgentProfileUsage)) is None
+        refreshed = await session.get(OmnigentUpstreamAgentProjection, projection_id)
+        assert inventory_service.projection_readiness(refreshed)["ready"] is True
+        await _select(session)
+        await session.commit()
+        assert state.calls == 1, "Fresh inventory must not call upstream again"
+    async with sessions() as session:
+        usage = await session.scalar(select(OmnigentAgentProfileUsage))
+        assert usage.effective_snapshot == snapshot
+
+
+@pytest.mark.parametrize("fault", ["removed", "version_changed", "incompatible", "capability_removed", "outage", "timeout"])
+async def test_refresh_never_admits_unverified_or_substituted_authority(inventory_boundary, monkeypatch, fault):
+    sessions, state, projection_id = inventory_boundary
+    if fault == "removed":
+        state.rows = []
+    elif fault == "version_changed":
+        state.rows[0]["version"] = "8"
+    elif fault == "incompatible":
+        state.rows[0]["harness"] = "unknown-harness"
+    elif fault == "capability_removed":
+        state.rows[0]["capabilities"] = []
+    elif fault == "outage":
+        state.fail = True
+    elif fault == "timeout":
+        state.mode = "timeout"
+        monkeypatch.setattr(inventory_service, "_INVENTORY_REFRESH_TIMEOUT_SECONDS", 0.05)
+    async with sessions() as session:
+        with pytest.raises(HTTPException) as caught:
+            async with asyncio.timeout(2):
+                await _select(session)
+        assert caught.value.status_code == 409
+        assert "fixture-inventory-credential" not in str(caught.value.detail)
+        await session.rollback()
+    async with sessions() as session:
+        assert await session.scalar(select(OmnigentAgentProfileUsage)) is None
+        projection = await session.get(OmnigentUpstreamAgentProjection, projection_id)
+        assert inventory_service.projection_readiness(
+            projection, required_capabilities=["session.start"],
+        )["ready"] is False
+        if fault in {"outage", "timeout"}:
+            assert "retry submission" in projection.error
+            assert "fixture-inventory-credential" not in projection.error
+    assert state.calls == 1
+
+
+async def test_refresh_rejects_unconfigured_endpoint_without_network(inventory_boundary):
+    _sessions, state, _projection_id = inventory_boundary
+    with pytest.raises(inventory_service.UpstreamInventoryRefreshError, match="configured default"):
+        await inventory_service.refresh_upstream_inventory(endpoint_ref="other")
+    assert state.calls == 0
+
+
+@pytest.mark.parametrize("cache_state", ["missing", "error"])
+async def test_admission_recovers_missing_or_failed_discovery(inventory_boundary, cache_state):
+    sessions, state, projection_id = inventory_boundary
+    async with sessions() as session:
+        projection = await session.get(OmnigentUpstreamAgentProjection, projection_id)
+        if cache_state == "missing":
+            await session.delete(projection)
+        else:
+            projection.last_successful_sync_at = datetime.now(timezone.utc)
+            projection.error = "earlier refresh failed"
+        await session.commit()
+    async with sessions() as session:
+        assert (await _select(session))["agentId"] == "selected-agent"
+        await session.commit()
+    assert state.calls == 1
+
+
+async def test_older_failure_cannot_invalidate_a_newer_success(inventory_boundary):
+    sessions, _state, projection_id = inventory_boundary
+    attempted_at = datetime.now(timezone.utc)
+    await inventory_service.refresh_upstream_inventory()
+    async with sessions() as session:
+        await inventory_service.record_upstream_sync_failure(
+            session, endpoint_ref="default", bridge_mode="proxy",
+            error="an earlier attempt failed", now=attempted_at,
+        )
+    async with sessions() as session:
+        projection = await session.get(OmnigentUpstreamAgentProjection, projection_id)
+        assert inventory_service.projection_readiness(projection)["ready"] is True
+        assert projection.error is None
+
+
+async def test_refresh_covers_all_launchable_harnesses(inventory_boundary, monkeypatch, tmp_path):
+    from api_service.db.models import (
+        OmnigentHarnessCatalogSnapshotRecord, OmnigentHarnessTrustRecord,
+    )
+    from moonmind.omnigent.bootstrap.models import ResolvedOmnigentDeploymentState
+    from moonmind.omnigent.bootstrap.store import save_resolved_state
+    from moonmind.omnigent.harness_platform.catalog import create_catalog_snapshot
+
+    sessions, state, _projection_id = inventory_boundary
+    host_image = "example/host@sha256:" + "1" * 64
+    server_image = "example/server@sha256:" + "2" * 64
+    monkeypatch.setenv("OMNIGENT_GENERIC_HOST_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_OPENCODE_ENABLED", "true")
+    monkeypatch.setenv("OMNIGENT_OPENCODE_HOST_IMAGE_REF", host_image)
+    monkeypatch.setenv("OMNIGENT_IMAGE_REF", server_image)
+    monkeypatch.setenv("MOONMIND_OMNIGENT_RESOLVED_IMAGES_PATH", str(tmp_path / "images.json"))
+    save_resolved_state(ResolvedOmnigentDeploymentState(
+        server_image_ref=server_image, opencode_host_image_ref=host_image,
+        details={"opencodeHostCompatibility": {
+            "status": "ready", "serverImageRef": server_image, "hostImageRef": host_image,
+        }},
+    ))
+    catalog = create_catalog_snapshot(
+        endpointRef="default", omnigentVersion="0.12.0",
+        omnigentBuildDigest="sha256:" + "2" * 64, sourceDigest="sha256:" + "3" * 64,
+        harnesses=[inventory_service._synthetic_opencode_harness_row()],
+    )
+    async with sessions() as session:
+        session.add(OmnigentHarnessCatalogSnapshotRecord(
+            catalog_ref=catalog.catalogRef, endpoint_ref="default",
+            omnigent_version=catalog.omnigentVersion,
+            omnigent_build_digest=catalog.omnigentBuildDigest,
+            observed_at=catalog.observedAt, source_digest=catalog.sourceDigest,
+            snapshot_json=catalog.model_dump(mode="json", by_alias=True),
+        ))
+        session.add(OmnigentHarnessTrustRecord(
+            implementation_ref=catalog.harnesses[0].implementation.implementation_ref(),
+            harness_id="opencode-native", catalog_ref=catalog.catalogRef, trust_state="core_trusted",
+        ))
+        await session.commit()
+    harnesses = {"codex-native", "claude-native", "opencode-native"}
+    state.rows = [{"id": harness, "version": "1", "harness": harness} for harness in harnesses]
+    await inventory_service.refresh_upstream_inventory()
+    async with sessions() as session:
+        for harness in harnesses:
+            projection = await session.get(
+                OmnigentUpstreamAgentProjection,
+                inventory_service.projection_identity("default", harness, "1"),
+            )
+            assert inventory_service.projection_readiness(
+                projection, harness=harness, required_capabilities=["session.start"],
+            )["ready"] is True

--- a/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
+++ b/tests/unit/api_service/test_managed_session_reconcile_schedule_startup.py
@@ -11,6 +11,30 @@ from api_service import main as api_main
 
 
 @pytest.mark.asyncio
+async def test_inventory_maintenance_retries_failure_and_propagates_shutdown(monkeypatch):
+    from api_service.services import omnigent_agent_profile_service as inventory_service
+
+    calls = []
+    delays = []
+
+    async def refresh():
+        calls.append(True)
+        if len(calls) == 1:
+            raise inventory_service.UpstreamInventoryRefreshError("endpoint unavailable")
+        raise asyncio.CancelledError
+
+    async def sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(inventory_service, "refresh_upstream_inventory", refresh)
+    monkeypatch.setattr(api_main.asyncio, "sleep", sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await api_main._maintain_omnigent_inventory()
+    assert calls == [True, True]
+    assert delays == [120]
+
+
+@pytest.mark.asyncio
 async def test_image_sync_blocks_a_quarantined_opencode_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -561,9 +561,7 @@ async def test_execution_notify_completion_scans_unredacted_webhook_payload(
 
     def mutating_redact(payload: Any) -> Any:
         if isinstance(payload, dict):
-            result = payload.get("result")
-            if isinstance(result, dict):
-                result["summary"] = "summary=[REDACTED]"
+            payload["summary"] = "summary=[REDACTED]"
         return payload
 
     def fake_scan(event: Any, *, surface: str) -> str | None:


### PR DESCRIPTION
Workflow submission returned `409: upstream inventory is stale` once discovery aged past five minutes. Inventory refresh shared a sequential loop with credential maintenance and deployment qualification, so a wait in either stage could stop refresh; submission rejected the cache without attempting recovery.

Keep inventory fresh in a separate API lifespan task and attempt one bounded authenticated refresh when authoring encounters stale or missing discovery. Refresh only discovery in its own transaction, then re-read and validate the exact selected upstream identity/version. Preserve unavailable-agent, capability, and profile gates, and prevent an older failed refresh from overwriting newer successful evidence. Shutdown owns both maintenance tasks.

Also restore notification scanning before redaction. Required CI exposed an existing scan-order regression; the original notification content now goes through the security gate while delivery retains a separate redacted payload.

Validation:
- 610 targeted unit/API tests passed.
- All 172 agent-runtime Activity tests passed after reproducing and fixing the four notification scan failures.
- Hermetic regression tests exercise real HTTP and database persistence for both profile schema versions, timeout/outage recovery, pinned-version preservation, transaction ownership, and refresh during blocked bootstrap maintenance.
- The submission regression reproduces the exact original HTTP 409 against the pre-fix selection code.
- All 725 Compose-backed hermetic integration tests passed locally.
