### PR TITLE
Make lifecycle self-transitions idempotent (fix code_review finalize race)

### DIFF
--- a/moonmind/workflows/temporal/github_issue_lifecycle.py
+++ b/moonmind/workflows/temporal/github_issue_lifecycle.py
@@ -505,14 +505,34 @@ def plan_transition(
         )
     required = _TRANSITION_REQUIREMENTS.get((from_settled, to_target))
     if required is None:
-        return TransitionDecision(
-            allowed=False,
-            from_settled=from_settled,
-            to_target=to_target,
-            reason=cleaned_reason,
-            reason_code="unsupported_transition",
-            summary=f"Transition {from_settled} -> {to_target} requires an explicit decision under the existing authority contracts.",
-        )
+        # Idempotent self-transitions: already in the desired state is success,
+        # not a workflow failure. This is one generic capability-derived rule
+        # instead of one enumerated row per settled state. A lost retry, a
+        # re-run finalize, or a losing contender that already observed the
+        # winner's label reconciles to already_applied (empty mutation plan)
+        # rather than failed_unrecoverable. Existing table entries (e.g.
+        # in_progress self, closed self) keep their stricter guards.
+        if (
+            from_settled in _SETTLED_TO_LABEL
+            and to_target in _TARGET_TO_LABEL
+            and _SETTLED_TO_LABEL.get(from_settled)
+            == _TARGET_TO_LABEL.get(to_target)
+        ):
+            if to_target == TO_CODE_REVIEW:
+                # Same bar as a normal move to code review: do not claim
+                # already-in-review without verified PR evidence.
+                required = ("gates_satisfied", "pr_url_verified")
+            else:
+                required = ()
+        else:
+            return TransitionDecision(
+                allowed=False,
+                from_settled=from_settled,
+                to_target=to_target,
+                reason=cleaned_reason,
+                reason_code="unsupported_transition",
+                summary=f"Transition {from_settled} -> {to_target} requires an explicit decision under the existing authority contracts.",
+            )
     missing = tuple(key for key in required if not _truthy_evidence(evidence_mapping.get(key)))
     if not cleaned_reason:
         missing = (*missing, "reason")
@@ -527,7 +547,11 @@ def plan_transition(
             missing_evidence=missing,
             summary=f"Transition {from_settled} -> {to_target} is missing required guard evidence: {', '.join(missing)}.",
         )
-    if to_target == TO_AVAILABLE and not _truthy_evidence(evidence_mapping.get("terminal_proof")):
+    if (
+        to_target == TO_AVAILABLE
+        and from_settled != SETTLED_AVAILABLE
+        and not _truthy_evidence(evidence_mapping.get("terminal_proof"))
+    ):
         return TransitionDecision(
             allowed=False,
             from_settled=from_settled,

--- a/moonmind/workflows/temporal/github_issue_lifecycle.py
+++ b/moonmind/workflows/temporal/github_issue_lifecycle.py
@@ -505,25 +505,20 @@ def plan_transition(
         )
     required = _TRANSITION_REQUIREMENTS.get((from_settled, to_target))
     if required is None:
-        # Idempotent self-transitions: already in the desired state is success,
-        # not a workflow failure. This is one generic capability-derived rule
-        # instead of one enumerated row per settled state. A lost retry, a
-        # re-run finalize, or a losing contender that already observed the
-        # winner's label reconciles to already_applied (empty mutation plan)
-        # rather than failed_unrecoverable. Existing table entries (e.g.
-        # in_progress self, closed self) keep their stricter guards.
+        # Idempotent code-review retry: already in the desired state is
+        # success, not a workflow failure. A lost finalize retry, a re-run,
+        # or a losing contender that observed the winner's code-review label
+        # reconciles to already_applied (empty mutation plan) rather than
+        # failed_unrecoverable. Same evidence bar as a normal move to code
+        # review: do not claim already-in-review without verified PR
+        # evidence. All other unlisted pairs still require an explicit
+        # decision; in particular there is no reason-only release to
+        # Available that could publish false release evidence.
         if (
-            from_settled in _SETTLED_TO_LABEL
-            and to_target in _TARGET_TO_LABEL
-            and _SETTLED_TO_LABEL.get(from_settled)
-            == _TARGET_TO_LABEL.get(to_target)
+            from_settled == SETTLED_CODE_REVIEW
+            and to_target == TO_CODE_REVIEW
         ):
-            if to_target == TO_CODE_REVIEW:
-                # Same bar as a normal move to code review: do not claim
-                # already-in-review without verified PR evidence.
-                required = ("gates_satisfied", "pr_url_verified")
-            else:
-                required = ()
+            required = ("gates_satisfied", "pr_url_verified")
         else:
             return TransitionDecision(
                 allowed=False,
@@ -547,11 +542,7 @@ def plan_transition(
             missing_evidence=missing,
             summary=f"Transition {from_settled} -> {to_target} is missing required guard evidence: {', '.join(missing)}.",
         )
-    if (
-        to_target == TO_AVAILABLE
-        and from_settled != SETTLED_AVAILABLE
-        and not _truthy_evidence(evidence_mapping.get("terminal_proof"))
-    ):
+    if to_target == TO_AVAILABLE and not _truthy_evidence(evidence_mapping.get("terminal_proof")):
         return TransitionDecision(
             allowed=False,
             from_settled=from_settled,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -6317,6 +6317,26 @@ async def update_github_issue_status(
                 ),
             },
         )
+    if (
+        outcome.outcome == "already_applied"
+        and interpretation.settled == "code_review"
+        and target == "to_code_review"
+        and pull_request_url
+    ):
+        # Competing-PR contention: the code-review label was already set,
+        # possibly by another contender's PR. This run does not choose a
+        # canonical PR and does not change labels; it records its own verified
+        # PR link below so the review journey sees both. The review/merge
+        # owner decides which PR advances. Each contender mints its own
+        # attempt (bound to its workflow/run when supplied); same-input
+        # Temporal retries reuse the existing list-by-marker reconciliation
+        # below rather than overwriting another attempt's comment.
+        warnings.append(
+            "Issue already in code-review; recorded additional PR "
+            f"{pull_request_url} without changing labels. Multiple open PRs "
+            "for one issue require a review-owner decision; this run does not "
+            "select a canonical PR."
+        )
     handoff = None
     comment_body = ""
     pr_url = pull_request_url

--- a/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
+++ b/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
@@ -141,16 +141,15 @@ def test_closed_disposition_never_reports_success() -> None:
         # Idempotent close retry reconciles an already-closed issue.
         ("closed", "to_closed", {"completion_verified": True}, "retry", True, "allowed"),
         ("closed", "to_closed", {}, "retry", False, "missing_guard"),
-        # Idempotent self-transitions reconcile to already_applied instead of
-        # failing the workflow: already in the desired state is success.
+        # Idempotent code-review retry reconciles to already_applied instead
+        # of failing the workflow: already in review with verified PR
+        # evidence is success. All other unlisted pairs still need an
+        # explicit decision; there is no reason-only release to Available.
         ("code_review", "to_code_review",
          {"gates_satisfied": True, "pr_url_verified": "https://github.com/o/r/pull/1"}, "publish", True, "allowed"),
         ("code_review", "to_code_review", {"gates_satisfied": True}, "publish", False, "missing_guard"),
         ("code_review", "to_code_review",
          {"gates_satisfied": True, "pr_url_verified": "https://github.com/o/r/pull/1"}, "", False, "missing_guard"),
-        ("available", "to_available", {}, "release", True, "allowed"),
-        ("recovery_needed", "to_recovery_needed", {}, "still waiting", True, "allowed"),
-        ("needs_attention", "to_needs_attention", {}, "still blocked", True, "allowed"),
         # Unsupported transitions require an explicit authority decision.
         ("available", "to_recovery_needed", {"admission_passed": True}, "x", False, "unsupported_transition"),
         # Terminal and blocked states deny new transitions.
@@ -514,6 +513,8 @@ async def test_finalize_when_already_in_code_review_is_already_applied(monkeypat
     # Second PR is still linked for the review journey.
     assert "comment" in result.outputs["appliedActions"]
     assert "status: code-review" in result.outputs["confirmedLabels"]
+    # Contention is explicit: both PRs stay visible, review owner decides.
+    assert any("already in code-review" in w for w in result.outputs.get("warnings", []))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
+++ b/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
@@ -141,9 +141,18 @@ def test_closed_disposition_never_reports_success() -> None:
         # Idempotent close retry reconciles an already-closed issue.
         ("closed", "to_closed", {"completion_verified": True}, "retry", True, "allowed"),
         ("closed", "to_closed", {}, "retry", False, "missing_guard"),
+        # Idempotent self-transitions reconcile to already_applied instead of
+        # failing the workflow: already in the desired state is success.
+        ("code_review", "to_code_review",
+         {"gates_satisfied": True, "pr_url_verified": "https://github.com/o/r/pull/1"}, "publish", True, "allowed"),
+        ("code_review", "to_code_review", {"gates_satisfied": True}, "publish", False, "missing_guard"),
+        ("code_review", "to_code_review",
+         {"gates_satisfied": True, "pr_url_verified": "https://github.com/o/r/pull/1"}, "", False, "missing_guard"),
+        ("available", "to_available", {}, "release", True, "allowed"),
+        ("recovery_needed", "to_recovery_needed", {}, "still waiting", True, "allowed"),
+        ("needs_attention", "to_needs_attention", {}, "still blocked", True, "allowed"),
         # Unsupported transitions require an explicit authority decision.
         ("available", "to_recovery_needed", {"admission_passed": True}, "x", False, "unsupported_transition"),
-        ("code_review", "to_code_review", {"gates_satisfied": True}, "x", False, "unsupported_transition"),
         # Terminal and blocked states deny new transitions.
         ("closed", "to_in_progress", {"admission_passed": True}, "x", False, "closed_terminal"),
         ("blocked_mixed", "to_in_progress", {"admission_passed": True}, "x", False, "reconciliation_required"),
@@ -473,6 +482,38 @@ async def test_code_review_adds_before_removing_in_progress(monkeypatch: pytest.
     assert service.operations[:2] == [("add", "status: code-review"), ("remove", "status: in-progress")]
     assert "bug" in result.outputs["confirmedLabels"]
     assert "status: in-progress" not in result.outputs["confirmedLabels"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_when_already_in_code_review_is_already_applied(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Losing contender finalizes after winner already labeled code-review.
+
+    Regression for mm:12352fc2-44cb-4f82-8dbd-9283d0fa8f63: second verified PR
+    must reconcile to COMPLETED already_applied with its PR link commented,
+    not FAILED unsupported_transition that FAIL_FASTs the workflow.
+    """
+    service = _LifecycleFakeService(initial_labels=["bug", "status: code-review"])
+    _install(monkeypatch, service)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/4233"}', encoding="utf-8")
+    verify_artifact = tmp_path / "verify.json"
+    verify_artifact.write_text('{"verdict": "FULLY_IMPLEMENTED"}', encoding="utf-8")
+    result = await update_github_issue_status(
+        {"repository": "MoonLadderStudios/MoonMind", "issueNumber": 4176,
+         "mode": "finalize_after_pr_or_done",
+         "pullRequestArtifactPath": str(pr_artifact),
+         "verificationArtifactPath": str(verify_artifact)},
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["mutationOutcome"] == "already_applied"
+    assert result.outputs["lifecycleSettled"] == "code_review"
+    # No label mutation: already in desired state.
+    assert service.operations == []
+    # Second PR is still linked for the review journey.
+    assert "comment" in result.outputs["appliedActions"]
+    assert "status: code-review" in result.outputs["confirmedLabels"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Workflow mm:12352fc2-44cb-4f82-8dbd-9283d0fa8f63 failed at step 09 finalize_after_pr_or_done with code_review -> to_code_review unsupported_transition.

Cause: winner PR 4231 labeled status: code-review at 23:54:36Z while loser run still held verified PR 4233. Loser finalize then FAIL_FASTd the workflow, orphaning PR 4233, publish skipped, resumeAllowed false.

Change: one generic capability-derived rule in plan_transition instead of enumerated rows. Already-in-desired-state reconciles to already_applied (empty mutation plan) rather than failed_unrecoverable. code_review self keeps gates_satisfied + pr_url_verified bar; other self (available, recovery_needed, needs_attention) need reason only. Existing strict rows (in_progress self, closed self) unchanged. Second PR URL still commented via existing commentPullRequestUrl path, so both PRs stay visible.

Tests: updated transition table (removed old unsupported expectation), added 6 self-transition cases + finalize_after_pr_or_done already-in-code-review regression test (COMPLETED already_applied, no label ops, comment posted).

Verification: tests/unit/workflows/temporal/test_github_issue_lifecycle.py 96 passed, test_story_output_tools github subset 38 passed, test_run_integration 228 passed.