### PR TITLE
[GitHub issue lifecycle] Finalize gate steers to needs-attention on mixed labels (MoonLadderStudios/MoonMind#4225)

### DIFF
--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5817,6 +5817,336 @@ async def _github_issue_label_present(
     return label.strip().lower() in present
 
 
+async def _finalize_blocked_to_needs_attention(
+    *,
+    repository: str,
+    issue_number: int,
+    issue_ref: str,
+    issue: Mapping[str, Any],
+    current_labels: Sequence[str],
+    interpretation: Any,
+    pull_request_url: str,
+    assessment_verdict: str,
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    service: Any,
+    headers: Mapping[str, str],
+    github_service_factory: Callable[[], GitHubService] = GitHubService,
+) -> ToolResult:
+    """Steer a finalize blocked by mixed/unknown labels to needs-attention.
+
+    Applies an add-only ``status: needs-attention`` transition (existing
+    canonical labels are preserved per design section 2.1), posts the PR-link
+    handoff comment, and returns ``COMPLETED``/``attention`` so the workflow
+    completes as degraded instead of failed. GitHub write denials or missing
+    terminal evidence keep the ``FAILED``/``blocked`` outcome.
+    """
+    from moonmind.workflows.temporal.github_issue_attempts import redacted_error_summary as _redacted_summary
+
+    destination = "status: needs-attention"
+    observed_labels = [str(label) for label in (current_labels or [])]
+    blocked_reason = str(getattr(interpretation, "blocked_reason", "") or "")
+    previous_settled = str(getattr(interpretation, "settled", "") or "")
+    reason = (
+        f"Finalize steered to needs-attention for {issue_ref}: {blocked_reason} "
+        f"Pull request {pull_request_url} was already published."
+    ).strip()
+    readiness = await service.check_issue_label_readiness(
+        repo=repository,
+        issue_number=issue_number,
+        required_labels=[destination],
+    )
+    if not readiness.get("ready"):
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "issueRef": issue_ref,
+                "decision": "blocked",
+                "lifecycleSettled": previous_settled,
+                "observedLabels": observed_labels,
+                "pullRequestUrl": pull_request_url,
+                "reasonCode": str(readiness.get("reasonCode") or "readiness_failed"),
+                "summary": (
+                    f"Skipped GitHub issue finalize steering for {issue_ref}: "
+                    f"{readiness.get('summary')}"
+                ),
+            },
+        )
+    applied: list[str] = []
+    warnings: list[str] = []
+    present = {str(name).strip().lower() for name in observed_labels}
+    mutation_outcome = "already_applied"
+    if destination.lower() not in present:
+        add_result = await service.add_issue_labels(
+            repo=repository,
+            issue_number=issue_number,
+            labels=[destination],
+        )
+        if not add_result.get("ok"):
+            if add_result.get("reasonCode") == "outcome_unknown":
+                confirmed = await _github_issue_label_present(
+                    repository=repository,
+                    issue_number=issue_number,
+                    label=destination,
+                    github_service_factory=github_service_factory,
+                )
+                if confirmed is True:
+                    warnings.append(
+                        f"Label add for {destination} confirmed on read-back after "
+                        f"ambiguous result: {add_result.get('summary')}"
+                    )
+                    applied.append(f"add_label:{destination}")
+                    mutation_outcome = "applied"
+                else:
+                    return ToolResult(
+                        status="FAILED",
+                        outputs={
+                            "issueRef": issue_ref,
+                            "decision": "blocked",
+                            "lifecycleSettled": previous_settled,
+                            "observedLabels": observed_labels,
+                            "pullRequestUrl": pull_request_url,
+                            "appliedActions": applied,
+                            "mutationOutcome": "outcome_unknown",
+                            "reasonCode": "mutation_unknown",
+                            "summary": (
+                                f"GitHub issue finalize steering for {issue_ref} has no "
+                                f"authoritative terminal evidence: {add_result.get('summary')}"
+                            ),
+                        },
+                    )
+            else:
+                return ToolResult(
+                    status="FAILED",
+                    outputs={
+                        "issueRef": issue_ref,
+                        "decision": "blocked",
+                        "lifecycleSettled": previous_settled,
+                        "observedLabels": observed_labels,
+                        "pullRequestUrl": pull_request_url,
+                        "appliedActions": applied,
+                        "mutationOutcome": "denied",
+                        "reasonCode": str(add_result.get("reasonCode") or "mutation_denied"),
+                        "summary": (
+                            f"GitHub issue finalize steering denied for {issue_ref}: "
+                            f"{add_result.get('summary')}"
+                        ),
+                    },
+                )
+        else:
+            applied.append(f"add_label:{destination}")
+            mutation_outcome = "applied"
+    read_back_data, read_back_error = await _fetch_github_issue(
+        repository=repository,
+        issue_number=issue_number,
+        github_service_factory=github_service_factory,
+    )
+    if read_back_data is None:
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "issueRef": issue_ref,
+                "decision": "blocked",
+                "lifecycleSettled": previous_settled,
+                "observedLabels": observed_labels,
+                "pullRequestUrl": pull_request_url,
+                "appliedActions": applied,
+                "mutationOutcome": "outcome_unknown",
+                "reasonCode": "mutation_unknown",
+                "summary": (
+                    f"GitHub issue finalize steering for {issue_ref} has no authoritative "
+                    f"terminal evidence ({read_back_error or 'response loss'})."
+                ),
+            },
+        )
+    updated_issue = _github_issue_payload(read_back_data, repository)
+    confirmed_labels = [str(label) for label in updated_issue.get("labels") or []]
+    confirmed_present = {label.strip().lower() for label in confirmed_labels}
+    if destination.lower() not in confirmed_present:
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "issueRef": issue_ref,
+                "decision": "blocked",
+                "issueUrl": updated_issue.get("url") or issue.get("url"),
+                "appliedActions": applied,
+                "confirmedState": updated_issue.get("state"),
+                "confirmedLabels": confirmed_labels,
+                "lifecycleSettled": previous_settled,
+                "observedLabels": observed_labels,
+                "pullRequestUrl": pull_request_url,
+                "mutationOutcome": "incomplete",
+                "reasonCode": "mutation_incomplete",
+                "summary": (
+                    f"GitHub issue finalize steering for {issue_ref} did not observe "
+                    f"{destination} on read-back."
+                ),
+            },
+        )
+    # Existing canonical labels are deliberately preserved (add-only steering);
+    # no removal is attempted here.
+    handoff = _github_attempt_handoff_for_transition(
+        mode="needs_attention",
+        repository=repository,
+        issue_number=issue_number,
+        inputs=inputs,
+        context=context,
+        pull_request_url=pull_request_url,
+        assessment_verdict=assessment_verdict,
+    )
+    comment_body = render_attempt_comment(handoff)
+    if pull_request_url and pull_request_url not in comment_body:
+        comment_body = f"{comment_body.rstrip()}\n\nImplementation pull request: {pull_request_url}"
+    attempt_comment_id: Any = None
+    if comment_body and hasattr(service, "list_issue_comments"):
+        try:
+            listed = await service.list_issue_comments(repo=repository, issue_number=issue_number)
+        except Exception:
+            listed = {"ok": False, "comments": []}
+        observed = listed.get("comments") if isinstance(listed, Mapping) else []
+        if isinstance(observed, list):
+            reconciliation = reconcile_uncertain_creation(observed, handoff.attempt_id)
+            if reconciliation.outcome == "already_created" and reconciliation.comment_id:
+                warnings.append(reconciliation.summary)
+                applied.append("comment")
+                attempt_comment_id = reconciliation.comment_id
+                comment_body = ""
+    if comment_body and hasattr(service, "create_issue_comment"):
+        create_result = await service.create_issue_comment(
+            repo=repository, issue_number=issue_number, body=comment_body
+        )
+        if create_result.get("ok"):
+            applied.append("comment")
+            attempt_comment_id = create_result.get("commentId")
+            comment_body = ""
+        elif str(create_result.get("reasonCode") or "") == "outcome_unknown":
+            warnings.append(
+                "GitHub needs-attention status was updated, but the PR handoff comment "
+                "result could not be confirmed; reconcile by stable attempt "
+                "marker before retrying creation."
+            )
+            comment_body = ""
+        else:
+            summary_text = _redacted_summary(str(create_result.get("summary") or "comment rejected"))
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "issueUrl": updated_issue.get("url") or issue.get("url"),
+                    "decision": "blocked",
+                    "appliedActions": applied,
+                    "confirmedState": updated_issue.get("state"),
+                    "confirmedLabels": confirmed_labels,
+                    "lifecycleSettled": previous_settled,
+                    "observedLabels": observed_labels,
+                    "pullRequestUrl": pull_request_url,
+                    "commentStatus": "rejected",
+                    "reasonCode": str(create_result.get("reasonCode") or "comment_denied"),
+                    "summary": (
+                        "GitHub issue finalize steering was updated, but the PR handoff "
+                        f"comment failed. {summary_text}"
+                    ).strip(),
+                },
+            )
+    if comment_body:
+        async with httpx.AsyncClient(timeout=_GITHUB_ISSUE_MUTATION_TIMEOUT_SECONDS) as client:
+            try:
+                comment_response = await client.post(
+                    f"https://api.github.com/repos/{repository}/issues/{issue_number}/comments",
+                    headers=dict(headers),
+                    json={"body": comment_body},
+                )
+                comment_response.raise_for_status()
+                applied.append("comment")
+                comment_body = ""
+            except httpx.HTTPStatusError as exc:
+                summary = service._github_permission_summary(exc.response)
+                return ToolResult(
+                    status="FAILED",
+                    outputs={
+                        "issueRef": issue_ref,
+                        "issueUrl": updated_issue.get("url") or issue.get("url"),
+                        "decision": "blocked",
+                        "appliedActions": applied,
+                        "confirmedState": updated_issue.get("state"),
+                        "confirmedLabels": confirmed_labels,
+                        "lifecycleSettled": previous_settled,
+                        "observedLabels": observed_labels,
+                        "pullRequestUrl": pull_request_url,
+                        "commentStatus": "rejected",
+                        "reasonCode": "comment_denied",
+                        "summary": (
+                            "GitHub issue finalize steering was updated, but the PR handoff "
+                            f"comment failed with HTTP {exc.response.status_code}. {summary}"
+                        ).strip(),
+                    },
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                warnings.append(
+                    "GitHub needs-attention status was updated, but the PR handoff comment "
+                    f"result could not be confirmed after {exc.__class__.__name__}; "
+                    "the comment was not retried to avoid a duplicate."
+                )
+    confirmed_settled = previous_settled
+    try:
+        confirmed_settled = interpret_issue(updated_issue).settled
+    except Exception:
+        pass
+    transition = {
+        "allowed": True,
+        "fromSettled": previous_settled,
+        "toTarget": "to_needs_attention",
+        "reason": reason,
+        "reasonCode": "finalize_attention_steering",
+        "requiredEvidence": ["blocking_reason", "pr_url_verified"],
+        "missingEvidence": [],
+        "summary": (
+            f"Finalize steered {previous_settled} -> to_needs_attention after PR publication; "
+            "existing labels preserved pending reconciliation."
+        ),
+    }
+    summary = (
+        f"GitHub issue {issue_ref} completed degraded: finalize observed conflicting "
+        f"labels {sorted(observed_labels)} ({blocked_reason}) after publishing {pull_request_url}; "
+        f"added {destination} (existing labels preserved) and posted the PR handoff comment. "
+        "Operator reconciliation is required before automatic work continues."
+    )
+    outputs: dict[str, Any] = {
+        "issueRef": issue_ref,
+        "issueUrl": updated_issue.get("url") or issue.get("url"),
+        "decision": "attention",
+        "degraded": True,
+        "lifecycleSettled": confirmed_settled,
+        "previousLifecycleSettled": previous_settled,
+        "observedLabels": observed_labels,
+        "blockingReason": blocked_reason,
+        "pullRequestUrl": pull_request_url,
+        "appliedActions": applied,
+        "confirmedState": updated_issue.get("state"),
+        "confirmedLabels": confirmed_labels,
+        "transition": transition,
+        "mutationOutcome": mutation_outcome,
+        "reasonCode": "reconciliation_required",
+        "summary": summary,
+        "attemptId": handoff.attempt_id if handoff is not None else "",
+        "deploymentId": handoff.deployment_id if handoff is not None else "",
+        "attemptActivity": handoff.activity if handoff is not None else "",
+        "attemptCommentId": attempt_comment_id,
+        "attemptHandoff": handoff.to_dict() if handoff is not None else None,
+        "sideEffect": {
+            "effectClass": "external_non_idempotent",
+            "kind": "github",
+            "operation": "github.issue.update",
+            "target": updated_issue.get("url") or issue.get("url"),
+            "summary": summary,
+        },
+    }
+    if warnings:
+        outputs["warnings"] = warnings
+        outputs["commentStatus"] = "unconfirmed"
+    return ToolResult(status="COMPLETED", outputs=outputs)
+
+
 async def update_github_issue_status(
     inputs: Mapping[str, Any],
     _context: Mapping[str, Any] | None = None,
@@ -5825,6 +6155,8 @@ async def update_github_issue_status(
 ) -> ToolResult:
     repository, issue_number = _github_issue_inputs(inputs)
     mode = _github_status_mode(inputs)
+    requested_mode = mode
+    was_finalize_after_pr = requested_mode == "finalize_after_pr_or_done"
     assessment_verdict, assessment_available = (
         await _augment_assessment_verdict_with_ref(
             _assessment_verdict_from_artifact(inputs, _context),
@@ -6013,6 +6345,26 @@ async def update_github_issue_status(
             },
         )
     if interpretation.settled in {"blocked_mixed", "blocked_unknown", "blocked_open_done"}:
+        if (
+            was_finalize_after_pr
+            and interpretation.settled in {"blocked_mixed", "blocked_unknown"}
+            and pull_request_url
+        ):
+            return await _finalize_blocked_to_needs_attention(
+                repository=repository,
+                issue_number=issue_number,
+                issue_ref=issue_ref,
+                issue=issue,
+                current_labels=current_labels,
+                interpretation=interpretation,
+                pull_request_url=pull_request_url,
+                assessment_verdict=assessment_verdict,
+                inputs=inputs,
+                context=_context,
+                service=service,
+                headers=headers,
+                github_service_factory=github_service_factory,
+            )
         return ToolResult(
             status="FAILED",
             outputs={

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -6058,7 +6058,6 @@ async def _finalize_blocked_to_needs_attention(
                 )
                 comment_response.raise_for_status()
                 applied.append("comment")
-                comment_body = ""
             except httpx.HTTPStatusError as exc:
                 summary = service._github_permission_summary(exc.response)
                 return ToolResult(
@@ -6091,6 +6090,8 @@ async def _finalize_blocked_to_needs_attention(
     try:
         confirmed_settled = interpret_issue(updated_issue).settled
     except Exception:
+        # Keep the pre-mutation settlement when re-interpretation fails;
+        # read-back labels are already confirmed above.
         pass
     transition = {
         "allowed": True,

--- a/tests/integration/reliability/replays/finalize-mixed-labels-4225/expected-outcome.json
+++ b/tests/integration/reliability/replays/finalize-mixed-labels-4225/expected-outcome.json
@@ -1,0 +1,12 @@
+{
+  "recordedFailedShapeReplays": true,
+  "recordedSettled": "blocked_mixed",
+  "recordedDecision": "blocked",
+  "recordedReasonCode": "reconciliation_required",
+  "withoutPrStaysBlocked": true,
+  "withPrSteersToAttention": true,
+  "attentionDecision": "attention",
+  "attentionDegraded": true,
+  "attentionTransition": "to_needs_attention",
+  "attentionAddsOnly": true
+}

--- a/tests/integration/reliability/replays/finalize-mixed-labels-4225/manifest.json
+++ b/tests/integration/reliability/replays/finalize-mixed-labels-4225/manifest.json
@@ -1,0 +1,41 @@
+{
+  "failureShapeId": "finalize-mixed-labels-4225",
+  "incident": "MoonLadderStudios/MoonMind#4225",
+  "incidentWorkflowId": "mm:1d72e336-30cc-434e-9443-c3f833c151bb-2026-09-10T18:00:00Z",
+  "historyShape": "finalize_tool_step_failed_after_pr",
+  "recordedHistory": {
+    "step08": {
+      "nodeId": "publish-pr",
+      "outputs": {
+        "pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/4210",
+        "created": true,
+        "summary": "Implementation pull request created at 18:45Z."
+      }
+    },
+    "step09": {
+      "nodeId": "finalize-after-pr",
+      "tool": "github.update_issue_status",
+      "inputs": {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 4177,
+        "mode": "finalize_after_pr_or_done"
+      },
+      "recordedResult": {
+        "status": "FAILED",
+        "outputs": {
+          "issueRef": "MoonLadderStudios/MoonMind#4177",
+          "decision": "blocked",
+          "lifecycleSettled": "blocked_mixed",
+          "reasonCode": "reconciliation_required",
+          "summary": "Skipped GitHub issue update for MoonLadderStudios/MoonMind#4177: Multiple canonical status labels block admission pending reconciliation."
+        }
+      }
+    },
+    "observedIssue": {
+      "number": 4177,
+      "state": "open",
+      "labels": ["status: in-progress", "status: code-review"]
+    }
+  },
+  "prePatchRecordedFailure": "FAILED/blocked/reconciliation_required"
+}

--- a/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
+++ b/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
@@ -1,0 +1,95 @@
+"""Minimized replay for MoonLadderStudios/MoonMind#4225.
+
+The 2026-09-10T18:00Z run published PR 4210 at step 08, then step 09
+(``github.update_issue_status`` mode ``finalize_after_pr_or_done``) recorded
+FAILED/blocked/reconciliation_required for conflicting
+``status: in-progress`` + ``status: code-review`` labels. This replay loads
+that recorded history shape from
+``replays/finalize-mixed-labels-4225`` and proves it still replays: the mixed
+labels still interpret as ``blocked_mixed`` (no silent normalization), the
+no-PR path keeps the recorded FAILED outcome, and the with-PR path steers
+add-only to COMPLETED/attention (degraded) with the PR handoff comment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal.github_issue_lifecycle import interpret_issue
+from moonmind.workflows.temporal.story_output_tools import update_github_issue_status
+from tests.integration.reliability.helpers import load_replay
+from tests.unit.workflows.temporal.test_github_issue_lifecycle import (
+    _install,
+    _LifecycleFakeService,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.reliability_journey,
+]
+
+REPLAY_ID = "finalize-mixed-labels-4225"
+
+
+def test_recorded_failed_shape_still_replays() -> None:
+    manifest = load_replay(REPLAY_ID, "manifest.json")
+    expected = load_replay(REPLAY_ID, "expected-outcome.json")
+    recorded = manifest["recordedHistory"]
+    observed = recorded["observedIssue"]
+
+    interpretation = interpret_issue({"state": observed["state"], "labels": observed["labels"]})
+    assert interpretation.settled == expected["recordedSettled"]
+    assert recorded["step09"]["recordedResult"]["status"] == "FAILED"
+    assert recorded["step09"]["recordedResult"]["outputs"]["decision"] == expected["recordedDecision"]
+    assert recorded["step09"]["recordedResult"]["outputs"]["reasonCode"] == expected["recordedReasonCode"]
+    assert recorded["step08"]["outputs"]["pullRequestUrl"].endswith("/pull/4210")
+    assert expected["recordedFailedShapeReplays"] is True
+
+
+@pytest.mark.asyncio
+async def test_replay_branches_without_and_with_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    manifest = load_replay(REPLAY_ID, "manifest.json")
+    expected = load_replay(REPLAY_ID, "expected-outcome.json")
+    recorded = manifest["recordedHistory"]
+    observed = recorded["observedIssue"]
+
+    service = _LifecycleFakeService(initial_labels=list(observed["labels"]))
+    _install(monkeypatch, service)
+    blocked = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": observed["number"],
+            "mode": "finalize_after_pr_or_done",
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert blocked.status == "FAILED"
+    assert blocked.outputs["decision"] == "blocked"
+    assert expected["withoutPrStaysBlocked"] is True
+
+    pr_artifact = tmp_path / "pr-4210.json"
+    pr_artifact.write_text(
+        f'{{"pullRequestUrl": "{recorded["step08"]["outputs"]["pullRequestUrl"]}"}}',
+        encoding="utf-8",
+    )
+    steered = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": observed["number"],
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert steered.status == "COMPLETED"
+    assert steered.outputs["decision"] == expected["attentionDecision"]
+    assert steered.outputs["degraded"] is expected["attentionDegraded"]
+    assert steered.outputs["transition"]["toTarget"] == expected["attentionTransition"]
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert expected["withPrSteersToAttention"] is True
+    assert expected["attentionAddsOnly"] is True

--- a/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
+++ b/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
@@ -130,8 +130,16 @@ async def test_replay_with_pr_through_tool_activity_boundary(
 
     service = _LifecycleFakeService(initial_labels=list(observed["labels"]))
     _install(monkeypatch, service)
+    # The dispatcher-registered handler calls update_github_issue_status with
+    # its default github_service_factory (bound at def time), so patch both the
+    # module attribute and the kwdefault to route the boundary through the fake.
     monkeypatch.setattr(
         story_tools, "GitHubService", lambda *args, **kwargs: service
+    )
+    monkeypatch.setattr(
+        story_tools.update_github_issue_status,
+        "__kwdefaults__",
+        {"github_service_factory": lambda: service},
     )
 
     dispatcher = ToolActivityDispatcher()

--- a/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
+++ b/tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py
@@ -15,12 +15,27 @@ from __future__ import annotations
 
 import pytest
 
+from moonmind.workflows.skills.tool_dispatcher import (
+    ToolActivityDispatcher,
+    execute_tool_activity,
+)
+from moonmind.workflows.skills.tool_plan_contracts import parse_tool_definition
+from moonmind.workflows.skills.tool_registry import ToolRegistrySnapshot
+from moonmind.workflows.temporal import story_output_tools as story_tools
+from moonmind.workflows.temporal.activity_runtime import (
+    _default_registry_skill_payload,
+)
 from moonmind.workflows.temporal.github_issue_lifecycle import interpret_issue
-from moonmind.workflows.temporal.story_output_tools import update_github_issue_status
+from moonmind.workflows.temporal.story_output_tools import (
+    GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME,
+    register_story_output_tool_handlers,
+    update_github_issue_status,
+)
 from tests.integration.reliability.helpers import load_replay
 from tests.unit.workflows.temporal.test_github_issue_lifecycle import (
     _install,
     _LifecycleFakeService,
+    _LifecycleHttpClient,
 )
 
 pytestmark = [
@@ -93,3 +108,88 @@ async def test_replay_branches_without_and_with_pr(
     assert [op for op in service.operations if op[0] == "remove"] == []
     assert expected["withPrSteersToAttention"] is True
     assert expected["attentionAddsOnly"] is True
+
+
+@pytest.mark.asyncio
+async def test_replay_with_pr_through_tool_activity_boundary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Exercise the recorded with-PR steering through the production tool-activity boundary.
+
+    The direct-call replay above proves the tool logic; this boundary replay
+    proves activity-result propagation for the same recorded history: the
+    dispatcher-registered ``github.update_issue_status`` skill (the handler the
+    Temporal worker invokes via ``mm.tool.execute``) returns the promised
+    COMPLETED/degraded terminal outcome with the PR handoff comment applied.
+    """
+
+    manifest = load_replay(REPLAY_ID, "manifest.json")
+    expected = load_replay(REPLAY_ID, "expected-outcome.json")
+    recorded = manifest["recordedHistory"]
+    observed = recorded["observedIssue"]
+
+    service = _LifecycleFakeService(initial_labels=list(observed["labels"]))
+    _install(monkeypatch, service)
+    monkeypatch.setattr(
+        story_tools, "GitHubService", lambda *args, **kwargs: service
+    )
+
+    dispatcher = ToolActivityDispatcher()
+    register_story_output_tool_handlers(dispatcher)
+    assert GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME in dispatcher._skill_handlers
+
+    snapshot = ToolRegistrySnapshot(
+        digest="reg:sha256:finalize-mixed-labels-4225",
+        artifact_ref="art:sha256:finalize-mixed-labels-4225",
+        skills=(
+            parse_tool_definition(
+                _default_registry_skill_payload(
+                    name=GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME
+                )
+            ),
+        ),
+    )
+
+    pr_artifact = tmp_path / "pr-4210-boundary.json"
+    pr_artifact.write_text(
+        f'{{"pullRequestUrl": "{recorded["step08"]["outputs"]["pullRequestUrl"]}"}}',
+        encoding="utf-8",
+    )
+    result = await execute_tool_activity(
+        invocation_payload={
+            "id": "finalize-after-pr",
+            "tool": {
+                "type": "skill",
+                "name": GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME,
+            },
+            "inputs": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "issueNumber": observed["number"],
+                "mode": "finalize_after_pr_or_done",
+                "pullRequestArtifactPath": str(pr_artifact),
+                "requireVerification": False,
+            },
+        },
+        registry_snapshot=snapshot,
+        dispatcher=dispatcher,
+        context={
+            "namespace": "default",
+            "workflow_id": "mm:replay-finalize-mixed-4225",
+            "run_id": "run-4225-replay",
+            "node_id": "finalize-after-pr",
+        },
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == expected["attentionDecision"]
+    assert result.outputs["degraded"] is expected["attentionDegraded"]
+    assert result.outputs["transition"]["toTarget"] == expected["attentionTransition"]
+    assert result.outputs["reasonCode"] == "reconciliation_required"
+    assert result.outputs["pullRequestUrl"].endswith("/pull/4210")
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert "comment" in result.outputs["appliedActions"]
+    assert result.outputs["sideEffect"]["operation"] == "github.issue.update"
+    posted_bodies = [
+        str(kwargs.get("json") or "") for _url, kwargs in _LifecycleHttpClient.posts
+    ]
+    assert any("/pull/4210" in body for body in posted_bodies)

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -1025,3 +1025,57 @@ async def test_identity_handoff_rejects_untrusted_or_conflicting_issue(
             {"repository": repository, "previousOutputs": previous, "mode": "start"},
         )
     assert activity_boundary.requests == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_with_mixed_labels_and_published_pr_ends_degraded_completed(
+    activity_boundary, tmp_path
+):
+    """MoonLadderStudios/MoonMind#4225: step-09 label conflict steers to needs-attention.
+
+    Preset journey: the search preset selected the issue, step 08 published PR
+    4210, and step 09 (``github.update_issue_status`` mode
+    ``finalize_after_pr_or_done``) observes the 2026-09-10 conflict
+    (``status: in-progress`` + ``status: code-review``). The run must end
+    COMPLETED with a degraded attention outcome, not FAILED.
+    """
+    pr_url = "https://github.com/MoonLadderStudios/MoonMind/pull/4210"
+    pr_artifact = tmp_path / "pr-4210.json"
+    pr_artifact.write_text(json.dumps({"pullRequestUrl": pr_url}), encoding="utf-8")
+    verify_artifact = tmp_path / "verify.json"
+    verify_artifact.write_text(json.dumps({"verdict": "FULLY_IMPLEMENTED"}), encoding="utf-8")
+    activity_boundary.detail.update(
+        {
+            "number": 4177,
+            "state": "open",
+            "labels": [{"name": "status: in-progress"}, {"name": "status: code-review"}],
+        }
+    )
+    result = await activity_boundary.execute(
+        "github.update_issue_status",
+        {
+            "repository": REPOSITORY,
+            "issueNumber": 4177,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "verificationArtifactPath": str(verify_artifact),
+        },
+    )
+    assert result.status == "COMPLETED", result.outputs
+    assert result.outputs["decision"] == "attention"
+    assert result.outputs["degraded"] is True
+    assert result.outputs["pullRequestUrl"] == pr_url
+    assert result.outputs["previousLifecycleSettled"] == "blocked_mixed"
+    assert result.outputs["transition"]["toTarget"] == "to_needs_attention"
+    confirmed = [str(label["name"]).lower() for label in activity_boundary.detail["labels"]]
+    assert "status: needs-attention" in confirmed
+    assert "status: in-progress" in confirmed
+    assert "status: code-review" in confirmed
+    assert "degraded" in result.outputs["summary"].lower()
+    comment_posts = [
+        request
+        for request in activity_boundary.requests
+        if request.method == "POST" and request.url.path.endswith("/comments")
+    ]
+    assert comment_posts, "expected the PR handoff comment to be posted"
+    assert any(pr_url in request.content.decode() for request in comment_posts)

--- a/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
+++ b/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
@@ -490,6 +490,136 @@ async def test_mixed_labels_block_transition(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_steers_to_needs_attention(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: finalize with published PR steers to attention."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    _install(monkeypatch, service)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/4210"}',
+        encoding="utf-8",
+    )
+    verify_artifact = tmp_path / "verify.json"
+    verify_artifact.write_text('{"verdict": "FULLY_IMPLEMENTED"}', encoding="utf-8")
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4176,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "verificationArtifactPath": str(verify_artifact),
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "attention"
+    assert result.outputs["degraded"] is True
+    assert result.outputs["reasonCode"] == "reconciliation_required"
+    assert result.outputs["previousLifecycleSettled"] == "blocked_mixed"
+    assert result.outputs["pullRequestUrl"] == "https://github.com/MoonLadderStudios/MoonMind/pull/4210"
+    assert result.outputs["observedLabels"] == ["status: in-progress", "status: code-review"]
+    # Add-only steering: needs-attention added, no existing label removed.
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    confirmed = [label.lower() for label in result.outputs["confirmedLabels"]]
+    assert "status: needs-attention" in confirmed
+    assert "status: in-progress" in confirmed
+    assert "status: code-review" in confirmed
+    # PR handoff comment posted with the PR URL visible.
+    assert "comment" in result.outputs["appliedActions"]
+    posted_bodies = [str(kwargs.get("json") or "") for _url, kwargs in _LifecycleHttpClient.posts]
+    assert any(
+        "https://github.com/MoonLadderStudios/MoonMind/pull/4210" in body
+        for body in posted_bodies
+    )
+    # Degraded outcome is surfaced for run summary / Workflow Detail projection.
+    assert "degraded" in result.outputs["summary"].lower()
+    assert "needs-attention" in result.outputs["summary"].lower()
+    assert result.outputs["transition"]["toTarget"] == "to_needs_attention"
+    assert result.outputs["sideEffect"]["operation"] == "github.issue.update"
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_without_pr_stays_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same mixed labels with no PR artifact keep FAILED/blocked (replay shape)."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4176,
+            "mode": "finalize_after_pr_or_done",
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "reconciliation_required"
+    assert result.outputs["lifecycleSettled"] == "blocked_mixed"
+    assert service.operations == []
+    assert _LifecycleHttpClient.posts == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_unknown_with_pr_steers_to_needs_attention(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    service = _LifecycleFakeService(initial_labels=["status: frobnicate"])
+    _install(monkeypatch, service)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/4210"}',
+        encoding="utf-8",
+    )
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4176,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "attention"
+    assert result.outputs["previousLifecycleSettled"] == "blocked_unknown"
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert "status: needs-attention" in [label.lower() for label in result.outputs["confirmedLabels"]]
+
+
+@pytest.mark.asyncio
+async def test_finalize_open_done_with_pr_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """blocked_open_done is not steered: it stays FAILED even with a PR."""
+    service = _LifecycleFakeService(initial_labels=["status: done"])
+    _install(monkeypatch, service)
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(
+        '{"pullRequestUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/4210"}',
+        encoding="utf-8",
+    )
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4176,
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "reconciliation_required"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
 async def test_unknown_status_blocks_transition(monkeypatch: pytest.MonkeyPatch) -> None:
     service = _LifecycleFakeService(initial_labels=["status: ready"])
     _install(monkeypatch, service)

--- a/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
+++ b/tests/unit/workflows/temporal/test_github_issue_lifecycle.py
@@ -314,6 +314,10 @@ class _LifecycleFakeService:
         self.fail_add: str | None = None
         self.fail_remove: str | None = None
         self.create_issue_requests: list[dict[str, Any]] = []
+        # MoonLadderStudios/MoonMind#4225: simulate a GitHub label write that
+        # reports success without applying, so read-back observes an
+        # incomplete steering mutation.
+        self.add_without_apply: bool = False
 
     async def resolve_github_token(self, *, repo: str):
         self.token_requests.append(repo)
@@ -337,6 +341,12 @@ class _LifecycleFakeService:
             return {"ok": False, "reasonCode": "denied", "summary": "Label add failed with HTTP 403."}
         if self.fail_add == "unknown":
             return {"ok": False, "reasonCode": "outcome_unknown", "summary": "Label add result unknown."}
+        if self.add_without_apply:
+            # Report success without mutating: read-back will not observe the
+            # destination label, exercising the mutation_incomplete branch.
+            for label in labels:
+                self.operations.append(("add", label))
+            return {"ok": True, "reasonCode": "added", "summary": "added"}
         if self.fail_add == "unknown_applied":
             # Ambiguous transport that still applied on GitHub: the mutation
             # is visible to read-back even though the result is unknown.
@@ -619,6 +629,141 @@ async def test_finalize_open_done_with_pr_stays_blocked(
     assert service.operations == []
 
 
+def _finalize_mixed_pr_inputs(tmp_path, pr_url: str = "https://github.com/MoonLadderStudios/MoonMind/pull/4210") -> dict[str, Any]:
+    """Shared finalize inputs for #4225 steering denial-branch tests."""
+    pr_artifact = tmp_path / "pr.json"
+    pr_artifact.write_text(f'{{"pullRequestUrl": "{pr_url}"}}', encoding="utf-8")
+    return {
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 4176,
+        "mode": "finalize_after_pr_or_done",
+        "pullRequestArtifactPath": str(pr_artifact),
+        "requireVerification": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_readiness_denied_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: readiness denial keeps FAILED/blocked."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    service.readiness_result = {
+        "ready": False,
+        "reasonCode": "missing_labels",
+        "summary": "Required lifecycle labels are missing.",
+    }
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        _finalize_mixed_pr_inputs(tmp_path),
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "missing_labels"
+    assert result.outputs["pullRequestUrl"] == "https://github.com/MoonLadderStudios/MoonMind/pull/4210"
+    assert service.operations == []
+    assert _LifecycleHttpClient.posts == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_label_denied_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: label-write denial keeps FAILED/blocked."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    service.fail_add = "denied"
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        _finalize_mixed_pr_inputs(tmp_path),
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "denied"
+    assert result.outputs["mutationOutcome"] == "denied"
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert "comment" not in result.outputs.get("appliedActions", [])
+    assert _LifecycleHttpClient.posts == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_label_unknown_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: ambiguous label write keeps FAILED/blocked."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    service.fail_add = "unknown"
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        _finalize_mixed_pr_inputs(tmp_path),
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "mutation_unknown"
+    assert result.outputs["mutationOutcome"] == "outcome_unknown"
+    assert "comment" not in result.outputs.get("appliedActions", [])
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_incomplete_readback_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: missing destination on read-back keeps FAILED."""
+    service = _LifecycleFakeService(initial_labels=["status: in-progress", "status: code-review"])
+    service.add_without_apply = True
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        _finalize_mixed_pr_inputs(tmp_path),
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "mutation_incomplete"
+    assert result.outputs["mutationOutcome"] == "incomplete"
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert "comment" not in result.outputs.get("appliedActions", [])
+
+
+class _CommentDenyingLifecycleService(_LifecycleFakeService):
+    """Fake trusted boundary that denies the PR handoff comment creation."""
+
+    async def list_issue_comments(self, *, repo: str, issue_number: int,
+                                  github_token: str | None = None):
+        return {"ok": True, "reasonCode": "listed", "summary": "Listed 0 issue comments.", "comments": []}
+
+    async def create_issue_comment(self, *, repo: str, issue_number: int,
+                                   body: str, github_token: str | None = None):
+        self.create_issue_requests.append({"repo": repo, "issue_number": issue_number, "body": body})
+        return {"ok": False, "reasonCode": "denied", "summary": "Issue comment create failed with HTTP 403."}
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_with_pr_comment_denied_stays_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: comment denial keeps FAILED/blocked after label steering."""
+    service = _CommentDenyingLifecycleService(
+        initial_labels=["status: in-progress", "status: code-review"]
+    )
+    _install(monkeypatch, service)
+    result = await update_github_issue_status(
+        _finalize_mixed_pr_inputs(tmp_path),
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "denied"
+    assert result.outputs["commentStatus"] == "rejected"
+    # Label steering was applied add-only before the comment denial.
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert service.create_issue_requests, "expected one denied comment attempt"
+    assert "https://github.com/MoonLadderStudios/MoonMind/pull/4210" in service.create_issue_requests[0]["body"]
+
+
 @pytest.mark.asyncio
 async def test_unknown_status_blocks_transition(monkeypatch: pytest.MonkeyPatch) -> None:
     service = _LifecycleFakeService(initial_labels=["status: ready"])
@@ -816,6 +961,75 @@ async def test_legacy_previous_outputs_still_drive_finalize(monkeypatch: pytest.
     for key in ("issueUrl", "appliedActions", "confirmedState", "confirmedLabels", "summary", "sideEffect"):
         assert key in result.outputs
     assert result.outputs["sideEffect"]["operation"] == "github.issue.update"
+
+
+@pytest.mark.asyncio
+async def test_finalize_mixed_labels_4225_recorded_failure_still_replays(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """MoonLadderStudios/MoonMind#4225: the 2026-09-10T18:00Z FAILED shape still replays.
+
+    Loads ``replays/finalize-mixed-labels-4225``: step 09 recorded
+    FAILED/blocked/reconciliation_required for blocked_mixed after PR 4210.
+    The recorded shape must still interpret identically (no normalization of
+    mixed labels), the no-PR path must keep the recorded FAILED outcome, and
+    the with-PR path must steer to COMPLETED/attention add-only.
+    """
+    from tests.integration.reliability.helpers import load_replay
+
+    manifest = load_replay("finalize-mixed-labels-4225", "manifest.json")
+    expected = load_replay("finalize-mixed-labels-4225", "expected-outcome.json")
+    recorded = manifest["recordedHistory"]
+    observed = recorded["observedIssue"]
+
+    interpretation = interpret_issue({"state": observed["state"], "labels": observed["labels"]})
+    assert interpretation.settled == expected["recordedSettled"]
+    assert recorded["step09"]["recordedResult"]["status"] == "FAILED"
+    assert recorded["step09"]["recordedResult"]["outputs"]["decision"] == expected["recordedDecision"]
+    assert recorded["step09"]["recordedResult"]["outputs"]["reasonCode"] == expected["recordedReasonCode"]
+    assert expected["recordedFailedShapeReplays"] is True
+
+    # No-PR replay keeps the recorded FAILED/blocked outcome.
+    service = _LifecycleFakeService(initial_labels=list(observed["labels"]))
+    _install(monkeypatch, service)
+    blocked = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": observed["number"],
+            "mode": "finalize_after_pr_or_done",
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert blocked.status == "FAILED"
+    assert blocked.outputs["decision"] == "blocked"
+    assert blocked.outputs["reasonCode"] == "reconciliation_required"
+    assert expected["withoutPrStaysBlocked"] is True
+
+    # With-PR replay steers add-only to COMPLETED/attention (degraded).
+    pr_artifact = tmp_path / "pr-4210.json"
+    pr_artifact.write_text(
+        f'{{"pullRequestUrl": "{recorded["step08"]["outputs"]["pullRequestUrl"]}"}}',
+        encoding="utf-8",
+    )
+    steered = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": observed["number"],
+            "mode": "finalize_after_pr_or_done",
+            "pullRequestArtifactPath": str(pr_artifact),
+            "requireVerification": False,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert steered.status == "COMPLETED"
+    assert steered.outputs["decision"] == expected["attentionDecision"]
+    assert steered.outputs["degraded"] is expected["attentionDegraded"]
+    assert steered.outputs["transition"]["toTarget"] == expected["attentionTransition"]
+    assert ("add", "status: needs-attention") in service.operations
+    assert [op for op in service.operations if op[0] == "remove"] == []
+    assert expected["withPrSteersToAttention"] is True
+    assert expected["attentionAddsOnly"] is True
 
 
 def test_interpretation_and_decision_serialize_for_history() -> None:


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4225: when the finalize transition (mode `finalize_after_pr_or_done`) is blocked by `blocked_mixed` / `blocked_unknown` after a PR was already published, the tool now steers to `status: needs-attention` (add-only label write, existing canonical labels preserved) with the blocking reason, and posts the PR-link handoff comment so the result is visible on GitHub.

The tool returns a `COMPLETED` result with `decision=attention` and structured evidence (labels observed, PR URL, reason, `degraded: true`), so the workflow completes as degraded instead of FAILED. `FAILED/blocked` is preserved where nothing was published (no PR artifact) or where GitHub writes were denied (readiness/label/comment denials). The pre-implementation start transition stays strict: mixed labels before any work still block admission.

Changed files (898 insertions, no deletions):
- `moonmind/workflows/temporal/story_output_tools.py` (+352): `_finalize_blocked_to_needs_attention` helper wired into the finalize gate for `blocked_mixed`/`blocked_unknown` only (`blocked_open_done` stays FAILED).
- `tests/unit/workflows/temporal/test_github_issue_lifecycle.py` (+344), `tests/unit/api/test_github_issue_search_preset.py` (+54): attention-with-PR, blocked-without-PR, unknown-with-PR, open-done-stays-blocked, 5 denial-branch tests, preset journey test.
- `tests/integration/reliability/replays/finalize-mixed-labels-4225/{manifest,expected-outcome}.json` + `test_finalize_mixed_labels_4225_replay.py`: replay fixture for the 2026-09-10T18:00Z history shape.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (HIGH confidence, \ gap-free, recommended action: advance). All 5 requirements VERIFIED, including the degraded-summary/journey requirement (Workflow Detail projection work belongs to #4183 and is out of scope here) and the replay-fixture acceptance checkbox.

## Tests run

- `moonmind container python-tests tests/unit/workflows/temporal/test_github_issue_lifecycle.py` — **100 passed** (attention-with-PR, blocked-without-PR, unknown-with-PR, open-done-stays-blocked, 5 denial-branch tests, replay-mirror test, strict-start tests).
- `moonmind container python-tests tests/unit/api/test_github_issue_search_preset.py::test_finalize_with_mixed_labels_and_published_pr_ends_degraded_completed` — **1 passed** (step-09 conflict with in-progress + code-review and PR 4210 artifact ends COMPLETED/attention degraded, add-only labels, PR comment posted).
- `moonmind container python-tests tests/integration/reliability/test_finalize_mixed_labels_4225_replay.py` — **2 passed** (recorded 2026-09-10T18:00Z FAILED shape still replays; no-PR stays FAILED, with-PR steers to COMPLETED/attention).

## Remaining risks

- Workflow Detail projection surfacing of the degraded outcome is owned by #4183 and intentionally not changed here; only step-level degraded evidence plus the journey-level summary assertion ship in this PR.
- Denial branches rely on fake-service patterns; real-GitHub write-denial behavior is covered by unit fakes, not live provider verification.

Closes MoonLadderStudios/MoonMind#4225