### PR TITLE
Fix resolver review detection and repeated continuation loops

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -146,7 +146,9 @@ metadata flag.
    ```
 2. Run the finalize gate checker. It refreshes PR metadata, CI, the complete
    comment inventory, and automated-review evidence for the exact head SHA
-   before deciding whether merge is allowed. Always pass the review-loop inputs
+   before deciding whether merge is allowed. Review/reaction retrieval errors
+   must fail with their diagnostics; they are never evidence of a pending or
+   absent review. Always pass the review-loop inputs
    exactly as supplied; omitting them silently disables the fresh-review
    requirement:
 

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -130,6 +130,7 @@ def run_command(
     max_attempts=3,
     initial_delay_seconds=1.0,
     max_delay_seconds=8.0,
+    paginated=False,
 ):
     resolved_cmd = _resolve_command(cmd)
     env = _build_subprocess_env()
@@ -161,13 +162,30 @@ def run_command(
                     file=sys.stderr,
                 )
                 sys.exit(1)
-            if output.strip() == "":
+            if output.strip() == "" and not paginated:
                 return {}
+            if paginated:
+                # gh --paginate emits consecutive JSON arrays, including on the
+                # distribution-provided CLI. Do not require the newer --slurp.
+                decoder = json.JSONDecoder()
+                records = []
+                remaining = output.strip()
+                if not remaining:
+                    raise ValueError("empty paginated response")
+                while remaining:
+                    page, end = decoder.raw_decode(remaining)
+                    if not isinstance(page, list) or any(
+                        not isinstance(item, dict) for item in page
+                    ):
+                        raise ValueError("expected an array of records on every page")
+                    records.extend(page)
+                    remaining = remaining[end:].strip()
+                return records
             return json.loads(output)
         except FileNotFoundError:
             print(f"Command not found: {resolved_cmd[0]}", file=sys.stderr)
             sys.exit(1)
-        except json.JSONDecodeError:
+        except ValueError:
             print(
                 f"Command returned invalid JSON: {' '.join(resolved_cmd)}",
                 file=sys.stderr,
@@ -751,77 +769,35 @@ def _fetch_head_commit_timestamp(*, pr_repo: str | None, head_sha: str) -> datet
     return None
 
 
-def _fetch_pull_request_reviews(*, pr_repo: str | None, pr_number: object) -> list[dict]:
-    repo = str(pr_repo or "").strip()
-    number = str(pr_number or "").strip()
-    if not repo or not number:
-        return []
-    payload = run_command_optional(
-        [
-            "gh",
-            "api",
-            "--paginate",
-            "--slurp",
-            f"repos/{repo}/pulls/{number}/reviews?per_page=100",
-        ]
+def _fetch_review_collection(endpoint: str) -> list[dict]:
+    """Read every page or fail with the actual collection error.
+
+    Missing review evidence must never be converted into a pending review.
+    The same contract applies to review and reaction completion evidence.
+    """
+    return run_command(
+        ["gh", "api", "--paginate", endpoint],
+        "Unable to collect automated review evidence; repair GitHub access or tooling and retry.",
+        paginated=True,
     )
-    if not isinstance(payload, list):
-        return []
-    return [
-        item
-        for page in payload
-        if isinstance(page, list)
-        for item in page
-        if isinstance(item, dict)
-    ]
+
+
+def _fetch_pull_request_reviews(*, pr_repo: str | None, pr_number: object) -> list[dict]:
+    return _fetch_review_collection(
+        f"repos/{pr_repo}/pulls/{pr_number}/reviews?per_page=100"
+    )
 
 
 def _fetch_comment_reactions(*, pr_repo: str | None, comment_id: object) -> list[dict]:
-    repo = str(pr_repo or "").strip()
-    identifier = str(comment_id or "").strip()
-    if not repo or not identifier:
-        return []
-    payload = run_command_optional(
-        [
-            "gh",
-            "api",
-            "--paginate",
-            "--slurp",
-            f"repos/{repo}/issues/comments/{identifier}/reactions?per_page=100",
-        ]
+    return _fetch_review_collection(
+        f"repos/{pr_repo}/issues/comments/{comment_id}/reactions?per_page=100"
     )
-    if not isinstance(payload, list):
-        return []
-    return [
-        item
-        for page in payload
-        if isinstance(page, list)
-        for item in page
-        if isinstance(item, dict)
-    ]
 
 
 def _fetch_pr_reactions(*, pr_repo: str | None, pr_number: object) -> list[dict]:
-    if not pr_repo or not pr_number:
-        return []
-    payload = run_command_optional(
-        [
-            "gh",
-            "api",
-            "--paginate",
-            "--slurp",
-            f"repos/{pr_repo}/issues/{pr_number}/reactions?per_page=100",
-        ]
+    return _fetch_review_collection(
+        f"repos/{pr_repo}/issues/{pr_number}/reactions?per_page=100"
     )
-    if not isinstance(payload, list):
-        return []
-    return [
-        item
-        for page in payload
-        if isinstance(page, list)
-        for item in page
-        if isinstance(item, dict)
-    ]
 
 
 def build_automated_review_evidence(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3910,6 +3910,12 @@ def _serialize_execution_list_item(record) -> ExecutionListItemModel:
         title=title,
         status=dashboard_status,
         dashboard_status=dashboard_status,
+        completion_disposition=(
+            "gated_continuation"
+            if state_value == "completed"
+            and memo.get("completionDisposition") == "gated_continuation"
+            else None
+        ),
         state=state_value,
         raw_state=raw_state,
         temporal_status=temporal_status,
@@ -4392,6 +4398,12 @@ def _serialize_execution(
         task_instructions=_derive_full_workflow_instructions(task_payload),
         status=dashboard_status,
         dashboard_status=dashboard_status,
+        completion_disposition=(
+            "gated_continuation"
+            if state_value == "completed"
+            and memo.get("completionDisposition") == "gated_continuation"
+            else None
+        ),
         state=state_value,
         raw_state=raw_state,
         temporal_status=temporal_status,

--- a/docs/Workflows/PrMergeAutomation.md
+++ b/docs/Workflows/PrMergeAutomation.md
@@ -313,6 +313,23 @@ The resolver artifact, normally `var/pr_resolver/result.json`, includes mergeAut
 
 Review-clean requires admitted fix_only, an exact remotely verified branch revision in unified repository evidence, a permitted non-merge publication action, and the resolver's own result plus a live PR observation proving that the PR remains unmerged. Contradictory merge evidence fails `UNAUTHORIZED_MERGE_EVIDENCE`; unverified remote revision fails the shared parser. The Skill's live check emits blocked `unmerged_pr_verification_unavailable` when merged or unreadable state prevents no-merge proof. Do not require the retired Auto schema's `merged` boolean in `moonmind.publish.repository.v1`; semantic merge/no-merge fields belong to the resolver result, while publication mechanics use the shared schema. Review-clean and merged may both exit zero, so structured evidence distinguishes them.
 
+Review and reaction collection must read every page with the supported GitHub
+CLI. A command failure, malformed page, or incomplete response is an evidence
+collection failure, never an empty review inventory or a pending review.
+
+Both `request_review` and `reenter_gate` consume the existing review loop's
+`maxConsecutiveNoProgressCycles` budget when their progress signature repeats.
+Historical handoffs without a signature use their head and reason to bound
+repetition. Changed work resets the counter; elapsed waits do not establish
+progress. Budget exhaustion preserves resolver evidence and reports an actionable
+blocker rather than creating additional identical agent runs.
+
+A resolver child whose validated terminal disposition is `gated_continuation`
+is displayed as **Handed off** in the workflow list and detail. Its Temporal
+execution remains completed; the owning workflow remains responsible for the
+requested PR outcome. Failed or canceled runs never acquire a successful
+handoff label. Older records without a disposition keep their recorded status.
+
 A reenter_gate result is a durable handoff, not proof the PR merged. It carries completionDisposition gated_continuation and normalized gatedContinuation. The gate waits until the Skill-authored notBefore; old handoffs without timing use fallbackPollSeconds. The exact review-grace deadline is not recomputed or extended by the gate. Same-session continuation support is irrelevant to this parent-owned handoff.
 
 Only the synthetic PR_RESOLVER_REENTER_GATE terminal-contract failure can be cleared by an authorized handoff. Provider, auth, rate-limit, infrastructure, timeout, cancellation, stale-evidence, and malformed-evidence failures remain their own failures.

--- a/frontend/src/components/ExecutionStatusPill.test.tsx
+++ b/frontend/src/components/ExecutionStatusPill.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ExecutionStatusPill, StepExecutionStatusPill } from './ExecutionStatusPill';
+import { ExecutionStatusPill, StepExecutionStatusPill, WorkflowLifecycleStatusPill } from './ExecutionStatusPill';
 
 describe('ExecutionStatusPill', () => {
   afterEach(() => {
@@ -62,4 +62,15 @@ describe('ExecutionStatusPill', () => {
     expect(screen.getByText('Succeeded').className).toContain('status-completed');
     expect(warn).not.toHaveBeenCalled();
   });
+});
+
+
+it('shows a terminal continuation as handed off, preserving failures and ordinary completion', () => {
+  const { rerender } = render(<WorkflowLifecycleStatusPill status="completed" completionDisposition="gated_continuation" />);
+  expect(screen.getByText('Handed off').className).toContain('status-neutral');
+  expect(screen.queryByText('Completed')).toBeNull();
+  rerender(<WorkflowLifecycleStatusPill status="failed" completionDisposition="gated_continuation" />);
+  expect(screen.getByText('Failed')).toBeTruthy();
+  rerender(<WorkflowLifecycleStatusPill status="completed" />);
+  expect(screen.getByText('Completed')).toBeTruthy();
 });

--- a/frontend/src/components/ExecutionStatusPill.tsx
+++ b/frontend/src/components/ExecutionStatusPill.tsx
@@ -129,7 +129,14 @@ type DomainStatusPillProps = WorkflowStatusPillOptions & {
   status: string | null | undefined;
 };
 
-export function WorkflowLifecycleStatusPill({ status, enableMotion = true }: DomainStatusPillProps) {
+export function WorkflowLifecycleStatusPill({
+  status,
+  enableMotion = true,
+  completionDisposition,
+}: DomainStatusPillProps & { completionDisposition?: string | null | undefined }) {
+  if (status === 'completed' && completionDisposition === 'gated_continuation') {
+    return <StatusPill label="Handed off" pillProps={{ className: 'status status-neutral' }} />;
+  }
   return (
     <StatusPill
       label={formatWorkflowStatusLabel(status, '-')}

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -883,6 +883,7 @@ const ExecutionDetailSchema = z
     summary: z.string(),
     taskInstructions: z.string().nullable().optional(),
     status: z.string(),
+    completionDisposition: z.string().nullable().optional(),
     state: z.string(),
     rawState: z.string().optional(),
     temporalStatus: z.string().optional(),
@@ -9938,6 +9939,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
             <p className="page-meta">Workflow {taskId || '—'}</p>
             {execution ? (
               <WorkflowLifecycleStatusPill
+                completionDisposition={execution.completionDisposition}
                 status={resolveWorkflowDisplayStatus(
                   execution.rawState,
                   execution.state,
@@ -10109,6 +10111,7 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                 workflowTitle={workflowSubject}
                 statusPill={
                   <WorkflowLifecycleStatusPill
+                    completionDisposition={execution.completionDisposition}
                     status={resolveWorkflowDisplayStatus(
                       execution.rawState,
                       execution.state,

--- a/frontend/src/entrypoints/workflow-list.test.tsx
+++ b/frontend/src/entrypoints/workflow-list.test.tsx
@@ -708,6 +708,21 @@ describe('Workflows Entrypoint', () => {
     expect(updatedCell.getAttribute('title')).not.toBe(staleExact);
   });
 
+  it('shows completed resolver continuations as handed off', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [{
+        taskId: 'resolver-833', source: 'temporal', title: 'Resolve PR 833',
+        status: 'completed', state: 'completed', rawState: 'completed',
+        completionDisposition: 'gated_continuation', createdAt: '2026-09-11T00:40:00Z',
+      }] }),
+    } as Response);
+    renderWithClient(<WorkflowListPage payload={mockPayload} />);
+    const row = await screen.findByRole('row', { name: /Resolve PR 833/ });
+    expect(within(row).getByText('Handed off')).toBeTruthy();
+    expect(within(row).queryByText('Completed')).toBeNull();
+  });
+
   it('uses closedAt for terminal rows when synthetic updatedAt is older', async () => {
     const closedAt = '2026-04-15T20:00:00Z';
     const syntheticUpdatedAt = '2026-04-15T10:00:00Z';

--- a/frontend/src/entrypoints/workflow-list.tsx
+++ b/frontend/src/entrypoints/workflow-list.tsx
@@ -230,6 +230,7 @@ const ExecutionRowSchema = z
     taskSkills: z.array(z.string()).nullable().optional(),
     title: z.string(),
     status: z.string(),
+    completionDisposition: z.string().nullable().optional(),
     state: z.string(),
     rawState: z.string().optional(),
     temporalStatus: z.string().optional(),
@@ -2572,7 +2573,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                           </td>
                           {isColumnVisible('status') ? (
                             <td className="queue-table-cell-status">
-                              <WorkflowLifecycleStatusPill status={resolveWorkflowDisplayStatus(row.rawState, row.state, row.status)} />
+                              <WorkflowLifecycleStatusPill status={resolveWorkflowDisplayStatus(row.rawState, row.state, row.status)} completionDisposition={row.completionDisposition} />
                               {statusSupplements.map((item) => (
                                 <div key={item} className="workflow-list-status-supplement small">
                                   {item}
@@ -2632,7 +2633,7 @@ export function WorkflowListPage({ payload }: { payload: BootPayload }) {
                         </a>
                       </div>
                       <div className="queue-card-status">
-                        <WorkflowLifecycleStatusPill status={resolveWorkflowDisplayStatus(row.rawState, row.state, row.status)} />
+                        <WorkflowLifecycleStatusPill status={resolveWorkflowDisplayStatus(row.rawState, row.state, row.status)} completionDisposition={row.completionDisposition} />
                         {statusSupplements.map((item) => (
                           <div key={item} className="workflow-list-status-supplement small">
                             {item}

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -7602,6 +7602,8 @@ export interface components {
              * @enum {string}
              */
             status: "queued" | "running" | "awaiting_action" | "waiting" | "completed" | "failed" | "canceled";
+            /** Completiondisposition */
+            completionDisposition?: "gated_continuation" | null;
             /**
              * Dashboardstatus
              * @enum {string}
@@ -7983,6 +7985,8 @@ export interface components {
              * @enum {string}
              */
             status: "queued" | "running" | "awaiting_action" | "waiting" | "completed" | "failed" | "canceled";
+            /** Completiondisposition */
+            completionDisposition?: "gated_continuation" | null;
             /**
              * Dashboardstatus
              * @enum {string}

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -4068,6 +4068,9 @@ class ExecutionModel(BaseModel):
         "failed",
         "canceled",
     ] = Field(..., alias="status")
+    completion_disposition: Literal["gated_continuation"] | None = Field(
+        None, alias="completionDisposition"
+    )
     dashboard_status: Literal[
         "queued",
         "running",
@@ -4249,6 +4252,9 @@ class ExecutionListItemModel(BaseModel):
         "failed",
         "canceled",
     ] = Field(..., alias="status")
+    completion_disposition: Literal["gated_continuation"] | None = Field(
+        None, alias="completionDisposition"
+    )
     dashboard_status: Literal[
         "queued",
         "running",

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -1467,6 +1467,33 @@ class MoonMindMergeAutomationWorkflow:
                                 summary="pr-resolver returned an invalid gated continuation.",
                                 blocker_kind="resolver_continuation_invalid",
                             )
+                        if (
+                            workflow.patched("merge-automation-bound-reenter-progress-v1")
+                            and self._review_loop_active()
+                        ):
+                            continuation = resolver_result.get("gatedContinuation") or {}
+                            signature = continuation.get("progressSignature")
+                            # Older payloads have no signature: an unchanged
+                            # head/reason still cannot claim objective progress.
+                            signature = signature or (
+                                f"{self._input.pull_request.head_sha}|"
+                                f"{continuation.get('reason', '')}"
+                            )
+                            made_progress = self._register_progress_signature(signature)
+                            if (
+                                not made_progress
+                                and self._no_progress_cycles
+                                >= self._review_loop_config().max_consecutive_no_progress_cycles
+                            ):
+                                return await self._blocked_review_summary(
+                                    summary=(
+                                        "Resolver continuation budget exhausted: "
+                                        "the same head and outstanding work repeatedly "
+                                        "returned to the gate. Inspect the resolver "
+                                        "evidence and repair its blocker before retrying."
+                                    ),
+                                    blocker_kind="review_loop_no_progress",
+                                )
                         if expire_at is not None and continuation_deadline >= expire_at:
                             self._status = STATE_EXPIRED
                             self._summary = (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -11139,6 +11139,14 @@ class MoonMindRunWorkflow:
                 non_retryable=True,
             )
 
+        if self._gated_continuation_request and workflow.patched(
+            "run-completion-disposition-visibility-v1"
+        ):
+            output_message = (
+                "Execution handed off to its owning workflow; "
+                "the requested outcome remains pending."
+            )
+
         terminal_state = (
             STATE_NO_COMMIT if output_status == "no_commit" else STATE_COMPLETED
         )
@@ -23975,6 +23983,13 @@ class MoonMindRunWorkflow:
             memo_dict["incident_reconstruction_ref"] = self._incident_reconstruction_ref
         if self._pull_request_url:
             memo_dict["pull_request_url"] = self._pull_request_url
+        if (
+            workflow.patched("run-completion-disposition-visibility-v1")
+            and self._state == STATE_COMPLETED
+            and self._gated_continuation_request
+        ):
+            memo_dict["completionDisposition"] = "gated_continuation"
+
         merge_automation_summary = self._merge_automation_summary_from_context()
         if merge_automation_summary:
             memo_dict["merge_automation"] = merge_automation_summary

--- a/tests/fixtures/pr_resolver/review_collection_probe.py
+++ b/tests/fixtures/pr_resolver/review_collection_probe.py
@@ -1,0 +1,86 @@
+"""Exercise portable review collection with real gh and loopback-only fixtures."""
+
+import json
+import os
+import runpy
+import subprocess
+import threading
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[3]
+fixture = json.loads(
+    (root / "tests/fixtures/pr_resolver/review_wait_833.json").read_text()
+)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        first = "page=2" not in self.path
+        if first:
+            self.send_header(
+                "Link",
+                f'<http://127.0.0.1:{self.server.server_port}/reviews?page=2>; rel="next"',
+            )
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                [
+                    {
+                        **fixture["reviews"][0],
+                        "id": 1,
+                        "commit_id": "0" * 40,
+                        "submitted_at": "2026-09-11T00:00:00Z",
+                    }
+                ]
+                if first
+                else fixture["reviews"]
+            ).encode()
+        )
+
+    def log_message(self, *a):
+        pass
+
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+os.environ["GH_TOKEN"] = "isolated-fixture-token"
+m = runpy.run_path(str(root / ".agents/skills/pr-resolver/bin/pr_resolve_snapshot.py"))
+fn = m["build_automated_review_evidence"]
+g = fn.__globals__
+resolve = g["_resolve_command"]
+
+
+def route(cmd):
+    return resolve([*cmd[:-1], f"http://127.0.0.1:{server.server_port}/reviews"])
+
+
+g["_resolve_command"] = route
+try:
+    result = fn(
+        provider="codex",
+        require_fresh_review=True,
+        pr_repo="fixture/repo",
+        pr_number=833,
+        head_sha=fixture["headSha"],
+        comments=fixture["comments"],
+        head_committed_at=datetime.fromisoformat(fixture["headCommittedAt"]),
+        reactions_for_request=[],
+        reactions_for_pr=[],
+    )
+    assert result["freshReviewForHead"] and not result["requestPending"], result
+    print(subprocess.check_output(["gh", "--version"], text=True).splitlines()[0])
+    print(
+        json.dumps(
+            {
+                "freshReviewForHead": result["freshReviewForHead"],
+                "requestPending": result["requestPending"],
+                "completionId": result["completionId"],
+            }
+        )
+    )
+finally:
+    server.shutdown()

--- a/tests/fixtures/pr_resolver/review_wait_833.json
+++ b/tests/fixtures/pr_resolver/review_wait_833.json
@@ -1,0 +1,23 @@
+{
+  "headSha": "fe7be0bb26820947de00ea8108111250902add01",
+  "headCommittedAt": "2026-09-11T00:21:36+00:00",
+  "comments": [
+    {
+      "id": 5627447743,
+      "type": "issue_comment",
+      "body": "@codex review",
+      "created_at": "2026-09-11T00:26:17Z"
+    }
+  ],
+  "reviews": [
+    {
+      "id": 5173774567,
+      "user": {
+        "login": "chatgpt-codex-connector[bot]"
+      },
+      "state": "COMMENTED",
+      "commit_id": "fe7be0bb26820947de00ea8108111250902add01",
+      "submitted_at": "2026-09-11T00:39:11Z"
+    }
+  ]
+}

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -53,6 +53,7 @@ from api_service.api.routers.executions import (
     _optional_temporal_search_attributes_cache,
     get_temporal_client,
     _serialize_execution,
+    _serialize_execution_list_item,
     _verified_output_branch,
     router,
     update_execution as update_execution_route,
@@ -19411,3 +19412,28 @@ async def test_mm3835_step_runtime_override_is_allowed_while_the_class_admits() 
     )
 
     assert steps[0]["runtime"]["mode"] == "claude_code"
+
+
+@pytest.mark.parametrize(
+    "serializer", [_serialize_execution, _serialize_execution_list_item]
+)
+@pytest.mark.parametrize(
+    "state", [MoonMindWorkflowState.COMPLETED, MoonMindWorkflowState.FAILED]
+)
+@pytest.mark.parametrize("disposition", [None, "gated_continuation", "unknown"])
+def test_completion_disposition_does_not_change_terminal_lifecycle(
+    serializer, state, disposition
+):
+    record = _build_execution_record(state=state)
+    record.close_status = TemporalExecutionCloseStatus.COMPLETED
+    record.memo["completionDisposition"] = disposition
+    payload = serializer(record).model_dump(by_alias=True, mode="json")
+    expected = (
+        "gated_continuation"
+        if state == MoonMindWorkflowState.COMPLETED
+        and disposition == "gated_continuation"
+        else None
+    )
+    assert payload["completionDisposition"] == expected
+    assert payload["temporalStatus"] == "completed"
+    assert payload["state"] == state.value

--- a/tests/unit/test_pr_resolver_review_loop.py
+++ b/tests/unit/test_pr_resolver_review_loop.py
@@ -422,15 +422,16 @@ def test_portable_review_fetch_reads_all_pages(
     fn = snapshot_module[fetcher]
     calls = []
 
-    def gh(cmd):
+    def gh(cmd, *args, **kwargs):
         calls.append(cmd)
-        return [[{"id": n} for n in range(100)], [{"id": 101}]]
+        assert kwargs["paginated"] is True
+        return [{"id": n} for n in range(100)] + [{"id": 101}]
 
-    monkeypatch.setitem(fn.__globals__, "run_command_optional", gh)
+    monkeypatch.setitem(fn.__globals__, "run_command", gh)
     records = fn(pr_repo="owner/repo", **kwargs)
     assert records[-1] == {"id": 101}
     assert len(records) == 101
-    assert "--paginate" in calls[0] and "--slurp" in calls[0]
+    assert "--paginate" in calls[0] and "--slurp" not in calls[0]
 
 
 def test_historical_resolver_keeps_recorded_remediation_order():
@@ -732,3 +733,125 @@ def test_terminal_evidence_precedes_pending_review(field, reason, conflicted):
     decision = classify_snapshot(snapshot)
     assert decision.action == ResolverAction.STOP_MANUAL_REVIEW
     assert decision.reason_code == reason
+
+
+@pytest.mark.parametrize("output", ['[]\n[{"id": 2}]', '[{"id": 1}]\n[]'])
+def test_review_collection_decodes_gh_paginated_stream(
+    snapshot_module, monkeypatch, output
+):
+    from types import SimpleNamespace
+
+    run = snapshot_module["run_command"]
+    monkeypatch.setattr(
+        run.__globals__["subprocess"],
+        "run",
+        lambda *a, **kw: SimpleNamespace(returncode=0, stdout=output, stderr=""),
+    )
+    assert snapshot_module["_fetch_pull_request_reviews"](
+        pr_repo="owner/repo", pr_number=833
+    )
+
+
+@pytest.mark.parametrize(
+    "output", ["", "{}", "[null]", '[{"id": 1}]\n[', '[{"id": 1}] garbage']
+)
+def test_review_collection_rejects_missing_or_partial_evidence(
+    snapshot_module, monkeypatch, output
+):
+    from types import SimpleNamespace
+
+    run = snapshot_module["run_command"]
+    monkeypatch.setattr(
+        run.__globals__["subprocess"],
+        "run",
+        lambda *a, **kw: SimpleNamespace(returncode=0, stdout=output, stderr=""),
+    )
+    with pytest.raises(SystemExit):
+        snapshot_module["_fetch_pull_request_reviews"](
+            pr_repo="owner/repo", pr_number=833
+        )
+
+
+@pytest.mark.parametrize(
+    "error",
+    ["unknown flag: --slurp", "HTTP 401: Bad credentials", "HTTP 429: rate limit"],
+)
+def test_review_collection_preserves_command_failure(
+    snapshot_module, monkeypatch, capsys, error
+):
+    from types import SimpleNamespace
+
+    run = snapshot_module["run_command"]
+    monkeypatch.setattr(
+        run.__globals__["subprocess"],
+        "run",
+        lambda *a, **kw: SimpleNamespace(returncode=1, stdout="", stderr=error),
+    )
+    monkeypatch.setattr(run.__globals__["time"], "sleep", lambda _: None)
+    with pytest.raises(SystemExit):
+        snapshot_module["_fetch_pull_request_reviews"](
+            pr_repo="owner/repo", pr_number=833
+        )
+    assert error in capsys.readouterr().err
+
+
+def test_pr833_completed_review_replay_through_cli_collection(
+    snapshot_module, tmp_path, monkeypatch
+):
+    """Replay the escaped CLI boundary: old gh rejects --slurp; review is complete."""
+    import sys
+
+    fixture = json.loads(
+        (REPO_ROOT / "tests/fixtures/pr_resolver/review_wait_833.json").read_text()
+    )
+    gh = tmp_path / "gh"
+    gh.write_text(
+        f"#!{sys.executable}\n"
+        + "import json, sys\n"
+        + "if '--slurp' in sys.argv: sys.exit('unknown flag: --slurp')\n"
+        + f"print(json.dumps([])); print(json.dumps({fixture['reviews']!r}))\n"
+    )
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    evidence = _evidence(
+        snapshot_module,
+        reviews=None,
+        comments=fixture["comments"],
+        head_sha=fixture["headSha"],
+        head_committed_at=datetime.fromisoformat(fixture["headCommittedAt"]),
+    )
+    assert evidence["freshReviewForHead"] is True
+    assert evidence["requestPending"] is False
+    snapshot = normalize_portable_snapshot(
+        _snapshot(
+            automatedReview=evidence,
+            commentsSummary={
+                "includeBotReviewComments": True,
+                "hasActionableComments": True,
+                "actionableCommentIds": [3984847667],
+            },
+        )
+    )
+    assert classify_snapshot(snapshot).reason_code == "actionable_comments"
+
+
+def test_review_collection_with_installed_gh():
+    """Use real gh against an isolated HTTP fixture, including Link pagination."""
+    import shutil
+    import subprocess
+    import sys
+
+    if not shutil.which("gh"):
+        pytest.skip("GitHub CLI is absent; the hermetic CLI replay remains required")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tests/fixtures/pr_resolver/review_collection_probe.py"),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert '"freshReviewForHead": true' in completed.stdout

--- a/tests/unit/workflows/temporal/test_merge_automation_continuation_replayer.py
+++ b/tests/unit/workflows/temporal/test_merge_automation_continuation_replayer.py
@@ -41,7 +41,7 @@ class _RecordedResolverChild:
         )
         info = workflow.info()
         cycle = int(info.workflow_id.rsplit(":", 1)[-1])
-        if cycle > 1:
+        if cycle > 1 and scenario != "repeated_wait":
             return {
                 "status": "success",
                 "mergeAutomationDisposition": "merged",
@@ -66,7 +66,7 @@ class _RecordedResolverChild:
             "childWorkflowId": info.workflow_id,
             "childRunId": info.run_id,
         }
-        if scenario == "new_timed":
+        if scenario in {"new_timed", "repeated_wait"}:
             continuation["retryAfterSeconds"] = 2
         if scenario == "rejected":
             top_level_child_run_id = "forged-run"
@@ -98,6 +98,7 @@ def _payload(scenario: str) -> dict[str, Any]:
         },
         "mergeAutomationConfig": {
             "timeouts": {"fallbackPollSeconds": 2},
+            "reviewLoop": {"enabled": scenario == "repeated_wait", "maxConsecutiveNoProgressCycles": 2},
         },
         "resolverTemplate": {"model": scenario},
     }
@@ -111,6 +112,7 @@ def _payload(scenario: str) -> dict[str, Any]:
         ("new_timed", "merged"),
         ("legacy_untimed", "merged"),
         ("rejected", "failed"),
+        ("repeated_wait", "blocked"),
     ],
 )
 async def test_continuation_histories_replay_deterministically(

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_review_loop.py
@@ -1117,3 +1117,59 @@ async def test_review_clean_is_rejected_when_merge_authority_was_granted(
     assert result["status"] == "failed"
     assert result["blockers"][0]["kind"] == "resolver_disposition_invalid"
     assert "granted merge authority" in result["summary"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signature", ["fe7be0bb2682|3984847667|", None])
+@pytest.mark.parametrize("budget", [2, 5])
+async def test_repeated_reenter_handoff_exhausts_shared_progress_budget(
+    monkeypatch, signature, budget
+):
+    def result(child_id, attempt):
+        value = _request_review_result(child_workflow_id=child_id, head_sha=HEAD_1)
+        value["mergeAutomationDisposition"] = "reenter_gate"
+        value["gatedContinuation"].update(
+            schemaVersion="gated-continuation/v1",
+            action="reenter_gate",
+            reason="automated_review_wait",
+            retryAfterSeconds=60,
+            progressSignature=signature,
+        )
+        return value
+
+    harness = _Harness(monkeypatch, readiness=[_ready(HEAD_1)], child_results=result)
+    outcome = await MoonMindMergeAutomationWorkflow().run(
+        _payload(maxConsecutiveNoProgressCycles=budget)
+    )
+    assert outcome["status"] == "blocked"
+    assert outcome["blockers"][0]["kind"] == "review_loop_no_progress"
+    assert len(harness.child_workflow_ids) == budget + 1
+    assert outcome["reviewLoop"]["noProgressCycles"] == budget
+    assert not harness.request_payloads
+
+
+@pytest.mark.asyncio
+async def test_reenter_progress_budget_preserves_pre_patch_history(monkeypatch):
+    def result(child_id, attempt):
+        if attempt == 5:
+            return {"status": "success", "mergeAutomationDisposition": "merged"}
+        value = _request_review_result(child_workflow_id=child_id, head_sha=HEAD_1)
+        value["mergeAutomationDisposition"] = "reenter_gate"
+        value["gatedContinuation"].update(
+            schemaVersion="gated-continuation/v1",
+            action="reenter_gate",
+            reason="ci_running",
+            retryAfterSeconds=60,
+        )
+        return value
+
+    harness = _Harness(monkeypatch, readiness=[_ready(HEAD_1)], child_results=result)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda name: name != "merge-automation-bound-reenter-progress-v1",
+    )
+    assert (await MoonMindMergeAutomationWorkflow().run(_payload()))[
+        "status"
+    ] == "merged"
+    assert len(harness.child_workflow_ids) == 5

--- a/tests/unit/workflows/temporal/workflows/test_run_deferred_publication_4227.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_deferred_publication_4227.py
@@ -370,3 +370,19 @@ def test_deferred_handoff_preserves_required_finalization_failure(
     )
     assert status == "failed"
     assert failed is True
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [("completed", "gated_continuation"), ("failed", None), ("executing", None)],
+)
+def test_only_completed_handoff_publishes_disposition_memo(
+    deferred_workflow, monkeypatch, state, expected
+):
+    captured = []
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _: True)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", captured.append)
+    deferred_workflow._state = state
+    deferred_workflow._gated_continuation_request = {"action": "reenter_gate"}
+    deferred_workflow._update_memo()
+    assert captured[-1].get("completionDisposition") == expected


### PR DESCRIPTION
PR resolver runs could repeatedly report a pending automated review after the review had completed. The portable checker used `gh api --slurp`, which the deployed GitHub CLI 2.23.0 rejects, then silently converted that failure into an empty review list. Each resolver handed back control and merge automation launched another identical attempt.

This change reads paginated review and reaction responses without `--slurp` and preserves command/schema failures. Repeated `reenter_gate` handoffs consume the existing review-loop no-progress budget, including historical payloads without a progress signature. Validated terminal handoffs appear as “Handed off” in the workflow list and detail, with a pending-outcome summary; Temporal lifecycle and parent ownership remain unchanged. Workflow changes are patch-gated for replay.

Validation:
- Targeted resolver/core/workflow tests: 231 passed; API and deferred-publication coverage: 607 passed in the combined run.
- Five live Temporal execution/replay scenarios, including repeated waits and historical handoffs.
- Dashboard list/detail/component suites: 292 passed; updated list/component suites: 93 passed; TypeScript check passed.
- Real GitHub CLI 2.23.0 in the deployment image against a network-isolated, multi-page HTTP fixture; current host CLI covered by the same probe.
- Headless Chromium renders of the production status component in light and dark themes.

Includes a minimized regression fixture from the PR #833 incident. This PR changes repository code only; existing deployments and completed historical records are not rewritten.
