### PR TITLE
[Deployment] Detect stale bind-mounted workers and restart before new runs (MoonLadderStudios/MoonMind#4224)

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1074,6 +1074,18 @@ health_router = APIRouter()
 
 _api_start_time = time.monotonic()
 
+# API-process startup code identity (MoonLadderStudios/MoonMind#4224): recorded
+# once at import so /healthz can report stale_code when a host git pull
+# rewrites the bind-mounted sources under a long-lived API process.
+try:
+    from moonmind.workflows.temporal.worker_code_identity import (
+        resolve_worker_code_identity as _resolve_api_code_identity,
+    )
+
+    _API_STARTUP_CODE_IDENTITY = _resolve_api_code_identity()
+except Exception:  # pragma: no cover - best-effort startup snapshot
+    _API_STARTUP_CODE_IDENTITY = None
+
 
 @health_router.get("/healthz")
 async def health_check():
@@ -1163,12 +1175,75 @@ async def health_check():
         db_reachable=db_reachable,
         secret_ready=True,
     )
+    # Worker code freshness (MoonLadderStudios/MoonMind#4224): compare the
+    # API process's startup-recorded identity and each reachable worker's
+    # /readyz identity with the checkout on disk. A host `git pull` alone is
+    # not a deployment — stale workers must be restarted before new runs are
+    # admitted (see docs/Steps/DockerComposeUpdateSystem.md).
+    code_freshness: dict[str, Any] = {}
+    try:
+        from moonmind.workflows.temporal.worker_code_identity import (
+            UNKNOWN as _CODE_UNKNOWN,
+        )
+        from moonmind.workflows.temporal.worker_code_identity import (
+            WorkerCodeIdentity as _WorkerCodeIdentity,
+        )
+        from moonmind.workflows.temporal.worker_code_identity import (
+            collect_worker_code_freshness,
+            evaluate_worker_freshness,
+            readiness_urls_from_env,
+            resolve_checkout_code_identity,
+        )
+
+        checkout = resolve_checkout_code_identity()
+        if _API_STARTUP_CODE_IDENTITY is not None:
+            api_freshness = evaluate_worker_freshness(
+                name="api",
+                startup=_API_STARTUP_CODE_IDENTITY,
+                current=checkout,
+            )
+        else:
+            # No startup snapshot (import-time failure): report unknown, never
+            # healthy — there is no evidence the modules match the checkout.
+            api_freshness = evaluate_worker_freshness(
+                name="api",
+                startup=_WorkerCodeIdentity(
+                    revision=None, digest=None, source=_CODE_UNKNOWN
+                ),
+                current=checkout,
+            )
+        code_freshness["api"] = api_freshness.to_payload()
+        workers = [
+            item.to_payload()
+            for item in collect_worker_code_freshness(
+                readiness_urls_from_env(), current=checkout
+            )
+        ]
+        code_freshness["workers"] = workers
+        stale = [
+            item for item in [api_freshness.to_payload(), *workers]
+            if item.get("status") == "stale"
+        ]
+        if stale:
+            code_freshness["reasonCode"] = "stale_code"
+            code_freshness["staleCode"] = [
+                {
+                    "worker": item.get("worker"),
+                    "startupRevision": item.get("startupRevision"),
+                    "currentRevision": item.get("currentRevision"),
+                }
+                for item in stale
+            ]
+    except Exception as exc:
+        logger.warning("Worker code freshness probe degraded: %s", exc)
     body = {
         "status": "ok" if db_reachable and not migration_required else "degraded",
         "db": db_status,
         "uptime_seconds": uptime,
         **readiness,
     }
+    if code_freshness:
+        body["workerCodeFreshness"] = code_freshness
     if not db_reachable or migration_required:
         return JSONResponse(status_code=503, content=body)
     return body

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -1079,10 +1079,14 @@ _api_start_time = time.monotonic()
 # rewrites the bind-mounted sources under a long-lived API process.
 try:
     from moonmind.workflows.temporal.worker_code_identity import (
-        resolve_worker_code_identity as _resolve_api_code_identity,
+        record_worker_startup_identity as _record_api_code_identity,
     )
 
-    _API_STARTUP_CODE_IDENTITY = _resolve_api_code_identity()
+    # Record through the shared process-wide startup identity so
+    # current_worker_code_revision() (used for AgentRun/UserWorkflow
+    # metadata) reports this process's actual import-time identity instead
+    # of lazily resolving a possibly newer on-disk checkout.
+    _API_STARTUP_CODE_IDENTITY = _record_api_code_identity()
 except Exception:  # pragma: no cover - best-effort startup snapshot
     _API_STARTUP_CODE_IDENTITY = None
 
@@ -1195,7 +1199,7 @@ async def health_check():
             resolve_checkout_code_identity,
         )
 
-        checkout = resolve_checkout_code_identity()
+        checkout = await asyncio.to_thread(resolve_checkout_code_identity)
         if _API_STARTUP_CODE_IDENTITY is not None:
             api_freshness = evaluate_worker_freshness(
                 name="api",
@@ -1215,8 +1219,10 @@ async def health_check():
         code_freshness["api"] = api_freshness.to_payload()
         workers = [
             item.to_payload()
-            for item in collect_worker_code_freshness(
-                readiness_urls_from_env(), current=checkout
+            for item in await asyncio.to_thread(
+                collect_worker_code_freshness,
+                readiness_urls_from_env(),
+                current=checkout,
             )
         ]
         code_freshness["workers"] = workers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,6 +83,10 @@ services:
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
       - TEMPORAL_DASHBOARD_SUBMIT_ENABLED=true
       - TEMPORAL_WORKFLOW_EDITING_ENABLED=${TEMPORAL_WORKFLOW_EDITING_ENABLED:-true}
+      # Stale worker-code admission (MoonLadderStudios/MoonMind#4224) runs in
+      # the API: it needs the same default workflow readiness target as the
+      # workflow worker itself, otherwise the gate silently disables itself.
+      - TEMPORAL_WORKFLOW_READINESS_URL=${TEMPORAL_WORKFLOW_READINESS_URL:-http://temporal-worker-workflow:8080/readyz}
       - MOONMIND_CONTAINER_JOBS_ENABLED=${MOONMIND_CONTAINER_JOBS_ENABLED:-true}
       # `ContainerJobService.submit()` resolves the deployment's declared image
       # sources before it creates durable job identity, so the API must see the
@@ -236,6 +240,7 @@ services:
     volumes:
       - ./api_service:/app/api_service
       - ./moonmind:/app/moonmind:ro
+      - ./services:/app/services:ro
       - ./docs:/app/docs:ro
       - ./.agents:/app/.agents:ro
       - ./deploy/state:/workspace/deployment_state:ro
@@ -942,6 +947,11 @@ services:
       - TEMPORAL_WORKER_FLEET=deployment
       - TEMPORAL_ACTIVITY_DEPLOYMENT_TASK_QUEUE=${TEMPORAL_ACTIVITY_DEPLOYMENT_TASK_QUEUE:-mm.activity.deployment}
       - TEMPORAL_DEPLOYMENT_WORKER_CONCURRENCY=${TEMPORAL_DEPLOYMENT_WORKER_CONCURRENCY:-1}
+      # Stale worker-code recovery (MoonLadderStudios/MoonMind#4224) runs in
+      # this worker: it needs the same default workflow readiness target as
+      # the workflow worker itself, otherwise recovery silently keeps
+      # image-only behavior.
+      - TEMPORAL_WORKFLOW_READINESS_URL=${TEMPORAL_WORKFLOW_READINESS_URL:-http://temporal-worker-workflow:8080/readyz}
       - TEMPORAL_WORKER_COMMAND=${TEMPORAL_WORKER_COMMAND:-python -m
         moonmind.workflows.temporal.worker_runtime}
       - TEMPORAL_ARTIFACT_BACKEND=${TEMPORAL_ARTIFACT_BACKEND:-s3}

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -686,6 +686,42 @@ The workflow releases the deployment lock and writes a structured result contain
 - command log artifact ref
 - verification artifact ref
 
+## 10.10 Bind-mounted checkouts: a host `git pull` alone is not a deployment
+
+Development Compose deployments bind-mount `./moonmind:/app/moonmind:ro` (and
+similar source mounts) into long-lived worker containers. A host `git pull`
+rewrites the files on disk while the running Python processes keep the old
+imported modules, silently creating a mixed-version deployment: one run can be
+admitted under old rules and finalized under new ones
+(MoonLadderStudios/MoonMind#4224).
+
+Operator rule: **a host `git pull` alone is not a deployment.** After pulling
+source changes on the host, the operator must prove the running workers match
+the checkout before new runs are admitted:
+
+1. Check the readiness detail: each Temporal worker exposes its
+   startup-recorded code identity on `/readyz` (`codeRevision`,
+   `codeIdentityStatus`, and — when stale — `reasonCode: stale_code` with the
+   worker name plus both revisions). The API aggregates the same detail under
+   `/healthz` → `workerCodeFreshness` (per-worker entries plus a `staleCode`
+   list when any worker is stale).
+2. Or run the CLI from the checkout: `moonmind worker code-readiness`
+   (uses `MOONMIND_WORKER_READINESS_URLS` / `TEMPORAL_WORKFLOW_READINESS_URL`;
+   exits non-zero with `reasonCode=stale_code` naming each stale worker and
+   both revisions).
+3. Restart stale workers: the deployment update path
+   (`deployment.update_compose_stack`) probes worker `/readyz` endpoints after
+   recreating services, restarts idle stale workers immediately, drains busy
+   ones (bounded graceful restart — never killed mid-activity), and fails the
+   update loudly with `reasonCode=stale_code` when a stale worker cannot be
+   restarted (for example the excluded deployment-control runner itself, which
+   must be recreated separately). New `MoonMind.UserWorkflow` admissions are
+   refused with `stale_code` while every known worker serving the queue is
+   stale.
+4. Every worker records its startup code identity in AgentRun/UserWorkflow
+   metadata (`workerCodeRevision`) so post-incident analysis can tell which
+   revision executed each step.
+
 ---
 
 ## 11. Updater runner execution model

--- a/docs/Steps/DockerComposeUpdateSystem.md
+++ b/docs/Steps/DockerComposeUpdateSystem.md
@@ -715,9 +715,15 @@ the checkout before new runs are admitted:
    ones (bounded graceful restart — never killed mid-activity), and fails the
    update loudly with `reasonCode=stale_code` when a stale worker cannot be
    restarted (for example the excluded deployment-control runner itself, which
-   must be recreated separately). New `MoonMind.UserWorkflow` admissions are
+   must be recreated separately) or when a restarted worker stays
+   unreachable/`unknown` after bounded rechecks (absence of evidence is not
+   proof of freshness). Bare readiness URLs take their hostname as the worker
+   name so restart planning stays addressable. New `MoonMind.UserWorkflow`
+   admissions are
    refused with `stale_code` while every known worker serving the queue is
-   stale.
+   stale. The API and the deployment-control worker ship the same default
+   workflow readiness target as the workflow worker, so neither gate is
+   silently disabled on a default Compose installation.
 4. Every worker records its startup code identity in AgentRun/UserWorkflow
    metadata (`workerCodeRevision`) so post-incident analysis can tell which
    revision executed each step.

--- a/moonmind/cli.py
+++ b/moonmind/cli.py
@@ -135,6 +135,65 @@ def worker_doctor() -> None:
     )
 
 
+@worker_app.command(
+    "code-readiness",
+    help=(
+        "Compare each worker's startup-recorded code identity with the "
+        "checkout on disk and report stale_code (MoonLadderStudios/MoonMind#4224). "
+        "A host git pull alone is not a deployment: restart stale workers "
+        "before new runs are admitted."
+    ),
+)
+def worker_code_readiness(
+    url: list[str] | None = typer.Option(
+        None,
+        "--url",
+        help="Worker /readyz endpoint to probe (repeatable). Defaults to "
+        "MOONMIND_WORKER_READINESS_URLS / TEMPORAL_WORKFLOW_READINESS_URL.",
+    ),
+) -> None:
+    from moonmind.workflows.temporal.worker_code_identity import (
+        collect_worker_code_freshness,
+        format_stale_code_message,
+        readiness_urls_from_env,
+        resolve_checkout_code_identity,
+    )
+
+    targets = [(item, item) for item in (url or []) if item.strip()]
+    if not targets:
+        targets = readiness_urls_from_env()
+    checkout = resolve_checkout_code_identity()
+    typer.echo(
+        f"checkout revision: {checkout.revision or 'unknown'} "
+        f"(source={checkout.source})"
+    )
+    if not targets:
+        typer.secho(
+            "No worker readiness endpoints configured: set "
+            "MOONMIND_WORKER_READINESS_URLS or TEMPORAL_WORKFLOW_READINESS_URL.",
+            fg=typer.colors.YELLOW,
+        )
+        return
+    freshness = collect_worker_code_freshness(targets, current=checkout)
+    stale = [item for item in freshness if item.status == "stale"]
+    for item in freshness:
+        color = (
+            typer.colors.GREEN
+            if item.status == "healthy"
+            else typer.colors.RED
+            if item.status == "stale"
+            else typer.colors.YELLOW
+        )
+        typer.secho(
+            f"{item.name}: {item.status} "
+            f"(running={item.startup_revision} checkout={item.current_revision})",
+            fg=color,
+        )
+    if stale:
+        typer.secho(format_stale_code_message(stale), fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=2)
+
+
 def main() -> None:
     app()
 

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -1358,6 +1358,12 @@ class AgentRunHandle(BaseModel):
     started_at: datetime = Field(..., alias="startedAt")
     poll_hint_seconds: int | None = Field(None, alias="pollHintSeconds", ge=1)
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+    # Code revision of the worker process that started the run
+    # (MoonLadderStudios/MoonMind#4224): post-incident analysis can tell which
+    # revision executed a step. Optional so retained histories still validate.
+    worker_code_revision: str | None = Field(
+        None, alias="workerCodeRevision", max_length=128
+    )
 
     @field_validator("metadata", mode="after")
     @classmethod
@@ -1386,6 +1392,11 @@ class AgentRunStatus(BaseModel):
     )
     poll_hint_seconds: int | None = Field(None, alias="pollHintSeconds", ge=1)
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+    # Code revision of the worker process that reported the status
+    # (MoonLadderStudios/MoonMind#4224). Optional for retained histories.
+    worker_code_revision: str | None = Field(
+        None, alias="workerCodeRevision", max_length=128
+    )
 
     @field_validator("metadata", mode="after")
     @classmethod
@@ -1417,6 +1428,11 @@ class AgentRunResult(BaseModel):
     provider_error_code: str | None = Field(None, alias="providerErrorCode")
     retry_recommendation: str | None = Field(None, alias="retryRecommendation")
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+    # Code revision of the worker process that produced the result
+    # (MoonLadderStudios/MoonMind#4224). Optional for retained histories.
+    worker_code_revision: str | None = Field(
+        None, alias="workerCodeRevision", max_length=128
+    )
 
     @field_validator("metadata", mode="after")
     @classmethod

--- a/moonmind/workflows/adapters/base_external_agent_adapter.py
+++ b/moonmind/workflows/adapters/base_external_agent_adapter.py
@@ -256,6 +256,12 @@ class BaseExternalAgentAdapter(abc.ABC):
         }
         if callback_correlation_key:
             metadata["callbackCorrelationKey"] = callback_correlation_key
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
+        worker_revision = current_worker_code_revision()
+        metadata["workerCodeRevision"] = worker_revision
         return AgentRunHandle(
             runId=run_id,
             agentKind="external",
@@ -263,6 +269,7 @@ class BaseExternalAgentAdapter(abc.ABC):
             status=status,
             startedAt=datetime.now(tz=UTC),
             metadata=metadata,
+            workerCodeRevision=worker_revision,
         )
 
     @staticmethod
@@ -285,12 +292,19 @@ class BaseExternalAgentAdapter(abc.ABC):
         }
         if extra_metadata:
             meta.update(extra_metadata)
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
+        worker_revision = current_worker_code_revision()
+        meta.setdefault("workerCodeRevision", worker_revision)
         return AgentRunStatus(
             runId=run_id,
             agentKind="external",
             agentId=agent_id,
             status=status,
             metadata=meta,
+            workerCodeRevision=worker_revision,
         )
 
     @staticmethod
@@ -314,6 +328,11 @@ class BaseExternalAgentAdapter(abc.ABC):
             f"{provider_name} task {run_id} ended with "
             f"provider status '{provider_status}'."
         )
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
+        worker_revision = current_worker_code_revision()
         return AgentRunResult(
             outputRefs=[],
             summary=summary,
@@ -322,7 +341,9 @@ class BaseExternalAgentAdapter(abc.ABC):
             metadata={
                 "normalizedStatus": normalized_status,
                 "externalUrl": external_url,
+                "workerCodeRevision": worker_revision,
             },
+            workerCodeRevision=worker_revision,
         )
 
 __all__ = [

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -128,12 +128,18 @@ _AUTO_PUBLISH_ALLOWED_STATUSES = frozenset(
 def managed_run_status_metadata(record: ManagedRunRecord) -> dict[str, Any]:
     """Return compact status metadata that is safe for workflow history."""
 
+    from moonmind.workflows.temporal.worker_code_identity import (
+        current_worker_code_revision,
+    )
+
     capabilities = resolve_runtime_execution_capabilities(record.runtime_id)
     metadata: dict[str, Any] = {
         "runtimeId": capabilities.runtime_id,
         "capabilitySetVersion": capabilities.capability_set_version,
         "capabilityDigest": capabilities.capability_digest,
         "runtimeCapabilities": capabilities.model_dump(by_alias=True, mode="json"),
+        # Executing-worker code revision (MoonLadderStudios/MoonMind#4224).
+        "workerCodeRevision": current_worker_code_revision(),
     }
     if record.workspace_path:
         metadata["workspaceLocator"] = {

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -1275,7 +1275,8 @@ class DeploymentUpdateExecutor:
                 + " No stale-worker restarter is configured for this stack.",
                 retryable=False,
                 details={"stack": stack, "reasonCode": "stale_code",
-                         "staleWorkers": [item.to_payload() for item in freshness]},
+                         "staleWorkers": [item.to_payload() for item in freshness],
+                         "recoveryArtifactRef": recovery_ref},
             )
         outcome = dict(await self.stale_worker_restarter(actionable))
         recovery["recovery"] = outcome
@@ -1310,7 +1311,8 @@ class DeploymentUpdateExecutor:
                 retryable=False,
                 details={"stack": stack, "reasonCode": "stale_code",
                          "staleWorkers": [item.to_payload() for item in freshness],
-                         "recovery": outcome},
+                         "recovery": outcome,
+                         "recoveryArtifactRef": recovery_ref},
             )
         return recovery_ref
 
@@ -1520,11 +1522,12 @@ class DeploymentUpdateExecutor:
                     progress_events=progress_events,
                     write_evidence=write_evidence,
                 )
-                # The reconcile step mutates command_log after the first
-                # command-log write above: rewrite it so
-                # commandLogArtifactRef contains the workerCodeFreshness
-                # evidence instead of a pre-reconcile snapshot.
-                command_ref = await write_evidence("command-log", command_log)
+                if worker_code_recovery_ref is not None:
+                    # The reconcile step mutated command_log after the first
+                    # command-log write above: rewrite it so
+                    # commandLogArtifactRef contains the workerCodeFreshness
+                    # evidence instead of a pre-reconcile snapshot.
+                    command_ref = await write_evidence("command-log", command_log)
 
                 _add_progress(progress_events, "VERIFYING", "Verifying deployed state.")
                 verification = await self.runner.verify(

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -1189,7 +1189,7 @@ class DeploymentUpdateExecutor:
         command_log: dict[str, Any],
         progress_events: list[dict[str, str]],
         write_evidence: Callable[[str, Mapping[str, Any]], Awaitable[str]],
-    ) -> None:
+    ) -> str | None:
         """Restart workers still running stale modules after recreation.
 
         Idle stale workers restart immediately; busy ones are drained rather
@@ -1201,7 +1201,7 @@ class DeploymentUpdateExecutor:
         """
 
         if self.stale_worker_checker is None:
-            return
+            return None
         from moonmind.workflows.temporal.worker_code_identity import (
             format_stale_code_message,
             plan_stale_worker_recovery,
@@ -1213,7 +1213,27 @@ class DeploymentUpdateExecutor:
         stale = [dict(item) for item in await self.stale_worker_checker()]
         if not stale:
             command_log["workerCodeFreshness"] = {"status": "healthy", "stale": []}
-            return
+            return None
+        actionable = [
+            item for item in stale if str(item.get("status") or "stale") == "stale"
+        ]
+        if not actionable:
+            # Fail-open for unidentifiable workers (unreachable endpoints or
+            # envelopes without identities): an unknown worker must not wedge
+            # the update, but it is recorded as unknown — never healthy.
+            command_log["workerCodeFreshness"] = {
+                "status": "unknown",
+                "stale": [],
+                "unknown": [
+                    {
+                        "worker": str(item.get("worker") or item.get("name") or "unknown"),
+                        "startupRevision": str(item.get("startupRevision") or "unknown"),
+                        "currentRevision": str(item.get("currentRevision") or "unknown"),
+                    }
+                    for item in stale
+                ],
+            }
+            return None
         freshness = [
             WorkerCodeFreshness(
                 name=str(item.get("worker") or item.get("name") or "unknown"),
@@ -1221,11 +1241,11 @@ class DeploymentUpdateExecutor:
                 startup_revision=str(item.get("startupRevision") or "unknown"),
                 current_revision=str(item.get("currentRevision") or "unknown"),
             )
-            for item in stale
+            for item in actionable
         ]
         busy = {
             str(item.get("worker") or item.get("name") or "").strip()
-            for item in stale
+            for item in actionable
             if item.get("busy") is True
         }
         plan = plan_stale_worker_recovery(
@@ -1247,7 +1267,8 @@ class DeploymentUpdateExecutor:
         if self.stale_worker_restarter is None:
             recovery["recovery"] = {"status": "no_restarter"}
             command_log["workerCodeFreshness"] = recovery
-            await write_evidence("worker-code-freshness", recovery)
+            recovery_ref = await write_evidence("worker-code-freshness", recovery)
+            recovery["recoveryArtifactRef"] = recovery_ref
             raise ToolFailure(
                 error_code="DEPLOYMENT_STALE_WORKER_CODE",
                 message=format_stale_code_message(freshness)
@@ -1256,12 +1277,30 @@ class DeploymentUpdateExecutor:
                 details={"stack": stack, "reasonCode": "stale_code",
                          "staleWorkers": [item.to_payload() for item in freshness]},
             )
-        outcome = dict(await self.stale_worker_restarter(stale))
+        outcome = dict(await self.stale_worker_restarter(actionable))
         recovery["recovery"] = outcome
-        remaining = [dict(item) for item in await self.stale_worker_checker()]
+        # Post-restart verification requires known freshness: an unreachable
+        # or not-yet-ready endpoint reports ``unknown``, which is absence of
+        # evidence — not proof the replacement is fresh. Retry to a bounded
+        # terminal state instead of recording success on an empty list.
+        actionable_names = {item.name for item in freshness}
+        remaining: list[dict[str, Any]] = []
+        for attempt in range(3):
+            rechecked = [dict(item) for item in await self.stale_worker_checker()]
+            remaining = [
+                item
+                for item in rechecked
+                if str(item.get("worker") or item.get("name") or "") in actionable_names
+                and str(item.get("status") or "stale") in ("stale", "unknown")
+            ]
+            if not remaining:
+                break
+            if attempt < 2:
+                await asyncio.sleep(5)
         recovery["remaining"] = remaining
         command_log["workerCodeFreshness"] = recovery
-        await write_evidence("worker-code-freshness", recovery)
+        recovery_ref = await write_evidence("worker-code-freshness", recovery)
+        recovery["recoveryArtifactRef"] = recovery_ref
         failed = list(outcome.get("failed") or [])
         if remaining or failed:
             raise ToolFailure(
@@ -1273,6 +1312,7 @@ class DeploymentUpdateExecutor:
                          "staleWorkers": [item.to_payload() for item in freshness],
                          "recovery": outcome},
             )
+        return recovery_ref
 
     async def execute(
         self,
@@ -1318,6 +1358,7 @@ class DeploymentUpdateExecutor:
         after_ref: str | None = None
         command_ref: str | None = None
         verification_ref: str | None = None
+        worker_code_recovery_ref: str | None = None
         verification: ComposeVerification | None = None
         final_status: str | None = None
         failure_reason: str | None = None
@@ -1473,12 +1514,17 @@ class DeploymentUpdateExecutor:
                 _ensure_command_succeeded("up", up_result)
                 command_ref = await write_evidence("command-log", command_log)
 
-                await self._reconcile_stale_workers(
+                worker_code_recovery_ref = await self._reconcile_stale_workers(
                     stack=parsed["stack"],
                     command_log=command_log,
                     progress_events=progress_events,
                     write_evidence=write_evidence,
                 )
+                # The reconcile step mutates command_log after the first
+                # command-log write above: rewrite it so
+                # commandLogArtifactRef contains the workerCodeFreshness
+                # evidence instead of a pre-reconcile snapshot.
+                command_ref = await write_evidence("command-log", command_log)
 
                 _add_progress(progress_events, "VERIFYING", "Verifying deployed state.")
                 verification = await self.runner.verify(
@@ -1570,6 +1616,8 @@ class DeploymentUpdateExecutor:
             "verificationArtifactRef": verification_ref,
             "audit": _redact_sensitive(audit_snapshot(completed=True)),
         }
+        if worker_code_recovery_ref is not None:
+            outputs["workerCodeFreshnessArtifactRef"] = worker_code_recovery_ref
         if final_status != "SUCCEEDED":
             outputs["failure"] = {
                 "class": "verification_failure",
@@ -1605,6 +1653,8 @@ def build_env_stale_worker_checker(
 
     from moonmind.workflows.temporal.worker_code_identity import (
         collect_worker_code_freshness,
+        payload_busy_hint,
+        probe_worker_readiness,
         readiness_urls_from_env,
     )
 
@@ -1613,35 +1663,78 @@ def build_env_stale_worker_checker(
         return None
 
     async def _check() -> Sequence[Mapping[str, Any]]:
+        payload_by_url: dict[str, Any] = {}
+
+        def _recording_probe(url: str) -> Any:
+            payload = probe_worker_readiness(url)
+            payload_by_url[url] = payload
+            return payload
+
         freshness = await asyncio.to_thread(
-            collect_worker_code_freshness, targets
+            collect_worker_code_freshness, targets, probe=_recording_probe
         )
-        return [
-            {
-                "worker": item.name,
-                "startupRevision": item.startup_revision,
-                "currentRevision": item.current_revision,
-                "busy": False,
-                "service": _compose_service_for_worker(item.name),
-            }
-            for item in freshness
-            if item.status == "stale"
-        ]
+        url_by_name = dict(targets)
+        items: list[dict[str, Any]] = []
+        for item in freshness:
+            # Surface stale workers for restart and unknown workers for
+            # post-restart verification; healthy workers need no action.
+            if item.status not in ("stale", "unknown"):
+                continue
+            url = url_by_name.get(item.name)
+            if url is None and "/" in item.name:
+                # Workflow-group lane ("<group>/<lane>"): the busy signal
+                # lives on the group's envelope payload.
+                url = url_by_name.get(item.name.split("/", 1)[0])
+            payload = payload_by_url.get(url or "")
+            busy = (
+                payload_busy_hint(payload)
+                if isinstance(payload, Mapping)
+                else True
+            )
+            items.append(
+                {
+                    "worker": item.name,
+                    "status": item.status,
+                    "startupRevision": item.startup_revision,
+                    "currentRevision": item.current_revision,
+                    "busy": busy,
+                    "service": _compose_service_for_worker(item.name),
+                }
+            )
+        return items
 
     return _check
 
 
 def _compose_service_for_worker(worker_name: str) -> str | None:
-    """Map a readiness worker name to its Compose service, when known."""
+    """Map a readiness worker name to its Compose service, when known.
+
+    Workflow-group lane names look like ``"<group>/<lane>"``: they
+    restart through the group service Compose knows. A raw URL is never
+    a service name — unnamed readiness targets resolve their hostname
+    in ``readiness_urls_from_env``, and anything URL-shaped left over is
+    rejected here so recovery cannot hand a URL to ``docker compose
+    restart``. A bare ``temporal-worker-*`` hostname (from an unnamed
+    readiness URL) is already the Compose service name.
+    """
 
     try:
         from moonmind.workflows.temporal.workers import _FLEET_SERVICE_NAMES
     except Exception:
         return None
-    normalized = str(worker_name or "").strip().lower()
-    for fleet, service in _FLEET_SERVICE_NAMES.items():
-        if normalized in {fleet, service}:
-            return service
+    raw = str(worker_name or "").strip()
+    candidates = [raw]
+    if "/" in raw:
+        candidates.append(raw.split("/", 1)[0].strip())
+    for candidate in candidates:
+        if not candidate or "://" in candidate or "/" in candidate:
+            continue
+        normalized = candidate.lower()
+        for fleet, service in _FLEET_SERVICE_NAMES.items():
+            if normalized in {fleet, service}:
+                return service
+        if normalized.startswith("temporal-worker-"):
+            return candidate
     return None
 
 
@@ -1734,6 +1827,21 @@ def build_compose_stale_worker_restarter(
                     ),
                     None,
                 ) or _compose_service_for_worker(name) or name
+                if not service or "://" in service or "/" in service:
+                    # Unnamed readiness targets have no mapped Compose
+                    # service: failing loudly beats handing a URL to
+                    # ``docker compose restart`` as the service name.
+                    failed.append(
+                        {
+                            "worker": name,
+                            "error": (
+                                "no restartable Compose service for worker "
+                                f"'{name}': configure a service=name=url "
+                                "readiness entry"
+                            ),
+                        }
+                    )
+                    continue
                 if service in excluded:
                     skipped.append(name)
                     continue

--- a/moonmind/workflows/skills/deployment_execution.py
+++ b/moonmind/workflows/skills/deployment_execution.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import tempfile
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -1162,6 +1163,116 @@ class DeploymentUpdateExecutor:
     evidence_writer: EvidenceWriter
     runner: ComposeRunner
     excluded_services: tuple[str, ...] = ()
+    # Stale-code recovery (MoonLadderStudios/MoonMind#4224): after services are
+    # recreated, bind-mounted workers that were not recreated may still run
+    # stale modules. The checker reports stale workers
+    # ([{worker, startupRevision, currentRevision, busy}]) and the restarter
+    # restarts idle workers immediately while draining busy ones (never
+    # killing in-flight work). Both default to None to preserve the
+    # image-only update behavior for callers that do not opt in; when a check
+    # reports stale workers but no restarter can fix them, the update fails
+    # loudly instead of admitting new work on stale workers.
+    stale_worker_checker: (
+        Callable[[], Awaitable[Sequence[Mapping[str, Any]]]] | None
+    ) = None
+    stale_worker_restarter: (
+        Callable[
+            [Sequence[Mapping[str, Any]]], Awaitable[Mapping[str, Any]]
+        ]
+        | None
+    ) = None
+
+    async def _reconcile_stale_workers(
+        self,
+        *,
+        stack: str,
+        command_log: dict[str, Any],
+        progress_events: list[dict[str, str]],
+        write_evidence: Callable[[str, Mapping[str, Any]], Awaitable[str]],
+    ) -> None:
+        """Restart workers still running stale modules after recreation.
+
+        Idle stale workers restart immediately; busy ones are drained rather
+        than killed (MoonLadderStudios/MoonMind#4224). When stale workers
+        remain and no restarter can fix them, the update fails loudly with
+        ``reasonCode=stale_code`` instead of admitting new work on stale
+        workers. Callers that do not configure a checker keep the previous
+        image-only behavior.
+        """
+
+        if self.stale_worker_checker is None:
+            return
+        from moonmind.workflows.temporal.worker_code_identity import (
+            format_stale_code_message,
+            plan_stale_worker_recovery,
+        )
+        from moonmind.workflows.temporal.worker_code_identity import (
+            WorkerCodeFreshness,
+        )
+
+        stale = [dict(item) for item in await self.stale_worker_checker()]
+        if not stale:
+            command_log["workerCodeFreshness"] = {"status": "healthy", "stale": []}
+            return
+        freshness = [
+            WorkerCodeFreshness(
+                name=str(item.get("worker") or item.get("name") or "unknown"),
+                status="stale",
+                startup_revision=str(item.get("startupRevision") or "unknown"),
+                current_revision=str(item.get("currentRevision") or "unknown"),
+            )
+            for item in stale
+        ]
+        busy = {
+            str(item.get("worker") or item.get("name") or "").strip()
+            for item in stale
+            if item.get("busy") is True
+        }
+        plan = plan_stale_worker_recovery(
+            [item.name for item in freshness], busy=sorted(busy)
+        )
+        recovery: dict[str, Any] = {
+            "status": "stale",
+            "reasonCode": "stale_code",
+            "stale": [item.to_payload() for item in freshness],
+            "plan": plan.to_payload(),
+        }
+        _add_progress(
+            progress_events,
+            "RESTARTING_STALE_WORKERS",
+            "Restarting workers running stale code: "
+            + ", ".join(item.name for item in freshness)
+            + ".",
+        )
+        if self.stale_worker_restarter is None:
+            recovery["recovery"] = {"status": "no_restarter"}
+            command_log["workerCodeFreshness"] = recovery
+            await write_evidence("worker-code-freshness", recovery)
+            raise ToolFailure(
+                error_code="DEPLOYMENT_STALE_WORKER_CODE",
+                message=format_stale_code_message(freshness)
+                + " No stale-worker restarter is configured for this stack.",
+                retryable=False,
+                details={"stack": stack, "reasonCode": "stale_code",
+                         "staleWorkers": [item.to_payload() for item in freshness]},
+            )
+        outcome = dict(await self.stale_worker_restarter(stale))
+        recovery["recovery"] = outcome
+        remaining = [dict(item) for item in await self.stale_worker_checker()]
+        recovery["remaining"] = remaining
+        command_log["workerCodeFreshness"] = recovery
+        await write_evidence("worker-code-freshness", recovery)
+        failed = list(outcome.get("failed") or [])
+        if remaining or failed:
+            raise ToolFailure(
+                error_code="DEPLOYMENT_STALE_WORKER_CODE",
+                message=format_stale_code_message(freshness)
+                + " Stale workers could not be restarted.",
+                retryable=False,
+                details={"stack": stack, "reasonCode": "stale_code",
+                         "staleWorkers": [item.to_payload() for item in freshness],
+                         "recovery": outcome},
+            )
 
     async def execute(
         self,
@@ -1362,6 +1473,13 @@ class DeploymentUpdateExecutor:
                 _ensure_command_succeeded("up", up_result)
                 command_ref = await write_evidence("command-log", command_log)
 
+                await self._reconcile_stale_workers(
+                    stack=parsed["stack"],
+                    command_log=command_log,
+                    progress_events=progress_events,
+                    write_evidence=write_evidence,
+                )
+
                 _add_progress(progress_events, "VERIFYING", "Verifying deployed state.")
                 verification = await self.runner.verify(
                     stack=parsed["stack"],
@@ -1471,6 +1589,170 @@ class DeploymentUpdateExecutor:
                 "events": progress_events,
             },
         )
+
+
+def build_env_stale_worker_checker(
+    urls: Sequence[tuple[str, str]] | None = None,
+) -> Callable[[], Awaitable[Sequence[Mapping[str, Any]]]] | None:
+    """Build the deployment-update stale-worker checker from readiness URLs.
+
+    Returns ``None`` when no worker readiness endpoint is configured, in which
+    case the executor keeps the previous image-only behavior. Otherwise returns
+    an async checker yielding ``[{worker, startupRevision, currentRevision,
+    busy, service}]`` for workers whose running modules differ from the
+    checkout on disk (MoonLadderStudios/MoonMind#4224).
+    """
+
+    from moonmind.workflows.temporal.worker_code_identity import (
+        collect_worker_code_freshness,
+        readiness_urls_from_env,
+    )
+
+    targets = list(urls) if urls is not None else readiness_urls_from_env()
+    if not targets:
+        return None
+
+    async def _check() -> Sequence[Mapping[str, Any]]:
+        freshness = await asyncio.to_thread(
+            collect_worker_code_freshness, targets
+        )
+        return [
+            {
+                "worker": item.name,
+                "startupRevision": item.startup_revision,
+                "currentRevision": item.current_revision,
+                "busy": False,
+                "service": _compose_service_for_worker(item.name),
+            }
+            for item in freshness
+            if item.status == "stale"
+        ]
+
+    return _check
+
+
+def _compose_service_for_worker(worker_name: str) -> str | None:
+    """Map a readiness worker name to its Compose service, when known."""
+
+    try:
+        from moonmind.workflows.temporal.workers import _FLEET_SERVICE_NAMES
+    except Exception:
+        return None
+    normalized = str(worker_name or "").strip().lower()
+    for fleet, service in _FLEET_SERVICE_NAMES.items():
+        if normalized in {fleet, service}:
+            return service
+    return None
+
+
+def build_compose_stale_worker_restarter(
+    *,
+    project_dir: str | Path,
+    compose_file: str | None = None,
+    project_name: str = "moonmind",
+    excluded_services: Sequence[str] = (),
+    idle_grace_seconds: int = 30,
+    drain_grace_seconds: int = 300,
+    command_timeout_seconds: int = 900,
+) -> Callable[
+    [Sequence[Mapping[str, Any]]], Awaitable[Mapping[str, Any]]
+]:
+    """Build a restarter that recovers stale workers via Compose.
+
+    Idle stale workers restart immediately (``docker compose restart -t
+    <idle_grace>``); busy ones are drained rather than killed — the longer
+    grace lets in-flight activities finish or fail over through Temporal
+    retry before the process is replaced
+    (MoonLadderStudios/MoonMind#4224). Services in ``excluded_services``
+    (notably the deployment-control runner itself) are never restarted
+    mid-update; they are reported as ``skipped`` so the update fails loudly
+    instead of killing its own runner.
+    """
+
+    from moonmind.workflows.temporal.worker_code_identity import (
+        plan_stale_worker_recovery,
+    )
+
+    excluded = {str(item).strip() for item in excluded_services if str(item).strip()}
+
+    async def _restart(service: str, grace: int) -> tuple[str, str]:
+        command = ["docker", "compose"]
+        if compose_file:
+            command += ["--file", compose_file]
+        if project_name:
+            command += ["--project-name", project_name]
+        command += ["restart", "--timeout", str(grace), service]
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(project_dir),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=command_timeout_seconds
+                )
+            except asyncio.TimeoutError:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                await process.wait()
+                return service, f"restart timed out after {command_timeout_seconds}s"
+            if process.returncode != 0:
+                detail = (stderr or b"").decode("utf-8", errors="ignore")[-500:]
+                return service, f"restart exited {process.returncode}: {detail}"
+        except OSError as exc:
+            return service, f"restart failed: {exc}"
+        return service, ""
+
+    async def _restart_all(stale: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+        names = [
+            str(item.get("worker") or item.get("name") or "").strip() for item in stale
+        ]
+        busy = {
+            str(item.get("worker") or item.get("name") or "").strip()
+            for item in stale
+            if item.get("busy") is True
+        }
+        plan = plan_stale_worker_recovery(names, busy=sorted(busy))
+        restarted: list[str] = []
+        drained: list[str] = []
+        failed: list[dict[str, str]] = []
+        skipped: list[str] = []
+
+        async def _run_group(
+            group: Sequence[str], grace: int, outcome: list[str]
+        ) -> None:
+            for name in group:
+                service = next(
+                    (
+                        str(item.get("service") or "").strip()
+                        for item in stale
+                        if str(item.get("worker") or item.get("name") or "").strip()
+                        == name
+                        and str(item.get("service") or "").strip()
+                    ),
+                    None,
+                ) or _compose_service_for_worker(name) or name
+                if service in excluded:
+                    skipped.append(name)
+                    continue
+                _, error = await _restart(service, grace)
+                if error:
+                    failed.append({"worker": name, "error": error})
+                else:
+                    outcome.append(name)
+
+        await _run_group(plan.restart_now, idle_grace_seconds, restarted)
+        await _run_group(plan.drain_then_restart, drain_grace_seconds, drained)
+        return {
+            "restarted": restarted,
+            "drained": drained,
+            "failed": failed,
+            "skipped": skipped,
+        }
+
+    return _restart_all
 
 
 def _add_progress(events: list[dict[str, str]], state: str, message: str) -> None:
@@ -2693,6 +2975,8 @@ __all__ = [
     "InMemoryEvidenceWriter",
     "TemporalDeploymentEvidenceWriter",
     "build_compose_command_plan",
+    "build_compose_stale_worker_restarter",
     "build_deployment_update_handler",
+    "build_env_stale_worker_checker",
     "register_deployment_update_tool_handler",
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6772,6 +6772,14 @@ class TemporalAgentRuntimeActivities:
             await self._report_task_run_binding(workflow_id, record_run_id)
 
         response = record.model_dump(mode="json")
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
+        # Executing-worker code revision (MoonLadderStudios/MoonMind#4224): the
+        # AgentRun workflow persists this in run metadata for post-incident
+        # analysis of which revision executed the step.
+        response["workerCodeRevision"] = current_worker_code_revision()
         if request.terminal_contract is not None:
             response["terminalContract"] = request.terminal_contract.model_dump(
                 mode="json", by_alias=True
@@ -11329,12 +11337,17 @@ class TemporalAgentRuntimeActivities:
             activity.heartbeat(f"Checking status for run_id {run_id}")
 
         record = self._run_store.load(run_id)
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
         if record is None:
             status = AgentRunStatus(
                 runId=run_id,
                 agentKind="managed",
                 agentId=agent_id,
                 status="running",
+                workerCodeRevision=current_worker_code_revision(),
             )
             return status
 
@@ -11344,6 +11357,7 @@ class TemporalAgentRuntimeActivities:
             agentId=record.agent_id or agent_id,
             status=record.status,
             metadata=managed_run_status_metadata(record),
+            workerCodeRevision=current_worker_code_revision(),
         )
         return status
 

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -606,9 +606,8 @@ class TemporalExecutionService:
         is configured or reachable.
         """
 
-        import logging
-
         from moonmind.workflows.temporal.worker_code_identity import (
+            WorkerCodeAdmissionError,
             collect_worker_code_freshness,
             enforce_worker_code_admission,
             readiness_urls_from_env,
@@ -621,13 +620,9 @@ class TemporalExecutionService:
         try:
             enforce_worker_code_admission(freshness)
         except Exception as exc:
-            from moonmind.workflows.temporal.worker_code_identity import (
-                WorkerCodeAdmissionError,
-            )
-
             if isinstance(exc, WorkerCodeAdmissionError):
                 raise TemporalExecutionValidationError(str(exc)) from exc
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "Worker code freshness gate degraded: %s", exc
             )
 

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -595,6 +595,42 @@ class TemporalExecutionService:
         payload = result.scalar_one_or_none()
         return bool(isinstance(payload, Mapping) and payload.get("workersPaused"))
 
+    async def _enforce_worker_code_freshness(self) -> None:
+        """Refuse new UserWorkflows when only stale workers serve the queue.
+
+        Probes the configured worker ``/readyz`` endpoints and compares each
+        worker's startup-recorded code identity with the checkout revision on
+        disk (MoonLadderStudios/MoonMind#4224). Raises
+        :class:`TemporalExecutionValidationError` with ``reasonCode=stale_code``
+        when every known worker is stale. Fail-open when no readiness endpoint
+        is configured or reachable.
+        """
+
+        import logging
+
+        from moonmind.workflows.temporal.worker_code_identity import (
+            collect_worker_code_freshness,
+            enforce_worker_code_admission,
+            readiness_urls_from_env,
+        )
+
+        urls = readiness_urls_from_env()
+        if not urls:
+            return
+        freshness = await asyncio.to_thread(collect_worker_code_freshness, urls)
+        try:
+            enforce_worker_code_admission(freshness)
+        except Exception as exc:
+            from moonmind.workflows.temporal.worker_code_identity import (
+                WorkerCodeAdmissionError,
+            )
+
+            if isinstance(exc, WorkerCodeAdmissionError):
+                raise TemporalExecutionValidationError(str(exc)) from exc
+            logging.getLogger(__name__).warning(
+                "Worker code freshness gate degraded: %s", exc
+            )
+
     async def send_quiesce_pause_signal(self, **kwargs):
         return await self._client_adapter.send_batch_pause_update(**kwargs)
 
@@ -2011,6 +2047,13 @@ class TemporalExecutionService:
             owner_type=owner_type,
         )
         if workflow_type_enum is TemporalWorkflowType.USER_WORKFLOW:
+            # Stale-code admission gate (MoonLadderStudios/MoonMind#4224): do
+            # not admit new UserWorkflows on a task queue served only by stale
+            # workers. Fail-open when no worker readiness endpoint is
+            # configured or reachable — the unknown state stays visible in the
+            # readiness detail instead of wedging admissions on a monitoring
+            # outage.
+            await self._enforce_worker_code_freshness()
             skill_validation = await validate_skill_step_inputs(
                 initial_parameters=initial_parameters,
                 session=self._session,
@@ -2192,6 +2235,14 @@ class TemporalExecutionService:
             "titleSource": title_result.source,
             "titleConfidence": title_result.confidence,
         }
+        # Admitting-authority code revision (MoonLadderStudios/MoonMind#4224):
+        # post-incident analysis can tell which revision admitted the run; the
+        # executing worker stamps its own revision in AgentRun metadata.
+        from moonmind.workflows.temporal.worker_code_identity import (
+            current_worker_code_revision,
+        )
+
+        memo["workerCodeRevision"] = current_worker_code_revision()
         if input_artifact_ref:
             memo["input_ref"] = input_artifact_ref
         if manifest_artifact_ref:

--- a/moonmind/workflows/temporal/worker_code_identity.py
+++ b/moonmind/workflows/temporal/worker_code_identity.py
@@ -18,11 +18,12 @@ import hashlib
 import json
 import os
 import subprocess
-import time
+import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
 
 UNKNOWN = "unknown"
 STALE_CODE_REASON = "stale_code"
@@ -33,9 +34,7 @@ _READINESS_URLS_ENV_KEY = "MOONMIND_WORKER_READINESS_URLS"
 _WORKFLOW_READINESS_URL_ENV_KEY = "TEMPORAL_WORKFLOW_READINESS_URL"
 
 _MAX_DIGEST_FILES = 10000
-_DIGEST_CACHE_TTL_SECONDS = 60.0
 
-_digest_cache: dict[str, tuple[float, str | None]] = {}
 _STARTUP_IDENTITY: "WorkerCodeIdentity | None" = None
 
 
@@ -135,13 +134,30 @@ def resolve_git_revision(
     return head, "git"
 
 
-def compute_package_digest(package_root: str | Path | None = None) -> str | None:
-    """Return a sha256 digest over the ``moonmind`` package ``*.py`` sources."""
+def _default_digest_roots() -> list[Path]:
+    """Return every bind-mounted source root owned by this process.
 
-    root = _package_root(package_root)
-    if not root.is_dir():
-        return None
-    hasher = hashlib.sha256()
+    The canonical Compose services bind-mount and execute ``moonmind``,
+    ``api_service``, and ``services`` side by side, while ``.git`` is
+    excluded from the image and most services have no build SHA. A digest
+    over ``moonmind`` alone misses pulls that touch only an API route or a
+    worker launcher, so freshness hashing covers every source root that
+    exists next to the ``moonmind`` package.
+    """
+
+    package = _package_root()
+    roots = [package]
+    app_root = package.parent
+    for name in ("api_service", "services"):
+        candidate = app_root / name
+        if candidate.is_dir() and candidate != package:
+            roots.append(candidate)
+    return roots
+
+
+def _hash_source_root(hasher: Any, root: Path, label: str) -> int:
+    """Mix one source root's ``*.py`` files into ``hasher``; return file count."""
+
     try:
         candidates = sorted(
             path
@@ -149,9 +165,7 @@ def compute_package_digest(package_root: str | Path | None = None) -> str | None
             if "__pycache__" not in path.parts
         )
     except OSError:
-        return None
-    if not candidates:
-        return None
+        return 0
     count = 0
     for path in candidates:
         if count >= _MAX_DIGEST_FILES:
@@ -161,25 +175,38 @@ def compute_package_digest(package_root: str | Path | None = None) -> str | None
             content = path.read_bytes()
         except OSError:
             continue
+        hasher.update(label.encode("utf-8"))
+        hasher.update(b"\x00")
         hasher.update(relative.encode("utf-8"))
         hasher.update(b"\x00")
         hasher.update(content)
         hasher.update(b"\x00")
         count += 1
-    if count == 0:
+    return count
+
+
+def compute_package_digest(package_root: str | Path | None = None) -> str | None:
+    """Return a sha256 digest over the bind-mounted ``*.py`` sources.
+
+    With no explicit root, every executable source root owned by the
+    process (``moonmind``, ``api_service``, ``services``) is hashed so a
+    host pull touching any of them changes the identity. An explicit root
+    hashes just that directory (used by tests and single-root callers).
+    """
+
+    if package_root is not None:
+        roots = [(_package_root(package_root), _package_root(package_root).name)]
+    else:
+        roots = [(root, root.name) for root in _default_digest_roots()]
+    hasher = hashlib.sha256()
+    total = 0
+    for root, label in roots:
+        if not root.is_dir():
+            continue
+        total += _hash_source_root(hasher, root, label)
+    if total == 0:
         return None
     return "sha256:" + hasher.hexdigest()
-
-
-def _cached_package_digest(package_root: str | Path | None = None) -> str | None:
-    key = str(_package_root(package_root))
-    now = time.monotonic()
-    cached = _digest_cache.get(key)
-    if cached is not None and now - cached[0] < _DIGEST_CACHE_TTL_SECONDS:
-        return cached[1]
-    digest = compute_package_digest(package_root)
-    _digest_cache[key] = (now, digest)
-    return digest
 
 
 def resolve_worker_code_identity(
@@ -204,10 +231,16 @@ def resolve_checkout_code_identity(
     environ: Mapping[str, str] | None = None,
     live_digest: bool = True,
 ) -> WorkerCodeIdentity:
-    """Resolve the code identity currently on disk (live, per-request)."""
+    """Resolve the code identity currently on disk (live, per-request).
+
+    The package digest is always recomputed fresh: in bind-mounted
+    containers ``.git`` is absent and the digest is the only freshness
+    signal, so a cached digest would keep reporting the pre-pull process
+    as healthy through the cache window after a host pull.
+    """
 
     revision, source = resolve_git_revision(environ=environ)
-    digest = _cached_package_digest(package_root) if live_digest else None
+    digest = compute_package_digest(package_root) if live_digest else None
     if revision is None and digest is None:
         return WorkerCodeIdentity(revision=None, digest=None, source=UNKNOWN)
     if revision is None:
@@ -236,10 +269,19 @@ def worker_startup_identity() -> WorkerCodeIdentity:
 
 
 def current_worker_code_revision() -> str:
-    """Return this process's startup code revision, or ``"unknown"``."""
+    """Return this process's startup code identity, or ``"unknown"``.
 
-    revision = (worker_startup_identity().revision or "").strip()
-    return revision or UNKNOWN
+    Falls back to the startup content digest when no revision is known:
+    in bind-mounted Compose workers git metadata and an explicit build SHA
+    are usually both absent, and the digest is still exact evidence of
+    which modules this process imported.
+    """
+
+    identity = worker_startup_identity()
+    revision = (identity.revision or "").strip()
+    if revision:
+        return revision
+    return (identity.digest or "").strip() or UNKNOWN
 
 
 def compare_code_identities(
@@ -346,10 +388,33 @@ def format_stale_code_message(stale: Sequence[WorkerCodeFreshness]) -> str:
     )
 
 
+def _worker_name_from_url(url: str) -> str:
+    """Derive a worker name from an unnamed readiness URL's hostname.
+
+    A bare URL such as ``http://temporal-worker-workflow:8080/readyz``
+    names its Compose service in the hostname, which restart planning can
+    map back to a service. Falling back to the URL itself would hand a
+    URL to ``docker compose restart`` as the service name and always fail
+    recovery, so unnamed entries resolve to the hostname (or the URL only
+    when no hostname parses).
+    """
+
+    try:
+        host = (urlsplit(url).hostname or "").strip()
+    except ValueError:
+        host = ""
+    return host or url
+
+
 def readiness_urls_from_env(
     environ: Mapping[str, str] | None = None,
 ) -> list[tuple[str, str]]:
-    """Return ``(name, url)`` worker readiness endpoints from the environment."""
+    """Return ``(name, url)`` worker readiness endpoints from the environment.
+
+    Entries may be ``name=url`` or a bare URL; bare URLs take the URL
+    hostname as the worker name so restart-capable targets stay
+    addressable (never the raw URL as a service name).
+    """
 
     env = os.environ if environ is None else environ
     urls: list[tuple[str, str]] = []
@@ -361,9 +426,9 @@ def readiness_urls_from_env(
                 continue
             if "=" in item:
                 name, url = item.split("=", 1)
-                name, url = name.strip() or url.strip(), url.strip()
+                name, url = name.strip() or _worker_name_from_url(url.strip()), url.strip()
             else:
-                name, url = item, item
+                name, url = _worker_name_from_url(item), item
             if url:
                 urls.append((name, url))
     workflow_url = str(env.get(_WORKFLOW_READINESS_URL_ENV_KEY) or "").strip()
@@ -389,16 +454,119 @@ def probe_worker_readiness(
     *,
     timeout: float = 2.0,
 ) -> dict[str, Any] | None:
-    """Fetch one worker ``/readyz`` payload best-effort; ``None`` when unknown."""
+    """Fetch one worker ``/readyz`` payload best-effort; ``None`` when unknown.
+
+    A worker running stale modules deliberately answers ``503`` with its
+    startup-recorded identity in the JSON body, so ``HTTPError`` responses
+    are parsed for their body instead of being discarded as unknown: a
+    discarded 503 body turns every stale worker into ``unknown``, fails
+    admission open, and hides the stale worker from recovery.
+    """
 
     try:
         request = urllib.request.Request(url, method="GET")
-        with _no_proxy_opener().open(request, timeout=timeout) as response:  # noqa: S310
-            body = response.read()
+        try:
+            with _no_proxy_opener().open(request, timeout=timeout) as response:  # noqa: S310
+                body = response.read()
+        except urllib.error.HTTPError as http_err:
+            try:
+                body = http_err.read()
+            except Exception:
+                return None
         payload = json.loads(body.decode("utf-8"))
     except Exception:
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _startup_identity_from_payload(payload: Mapping[str, Any]) -> WorkerCodeIdentity:
+    """Build a startup-recorded identity from one ``/readyz`` payload."""
+
+    return WorkerCodeIdentity(
+        revision=str(payload.get("codeRevision") or "").strip() or None,
+        digest=str(payload.get("codeDigest") or "").strip() or None,
+        source=str(payload.get("codeIdentitySource") or "").strip() or UNKNOWN,
+    )
+
+
+def _children_freshness(
+    name: str,
+    payload: Mapping[str, Any],
+    checkout: WorkerCodeIdentity,
+) -> list[WorkerCodeFreshness] | None:
+    """Expand a workflow-group readiness envelope into per-lane freshness.
+
+    The default Compose topology points ``TEMPORAL_WORKFLOW_READINESS_URL``
+    at the workflow worker-group supervisor (port 8080), whose response
+    stores per-process readiness under ``children`` and carries no
+    top-level ``codeRevision``/``codeDigest``. Reading only the top-level
+    fields would classify the whole fleet as ``unknown`` on every
+    successful response, so each child identity is compared with the
+    checkout and reported as ``<group>/<lane>``. Returns ``None`` when
+    the payload carries no child identities (caller falls back to the
+    top-level fields).
+    """
+
+    children = payload.get("children")
+    if not isinstance(children, list) or not children:
+        return None
+    lanes = [child for child in children if isinstance(child, Mapping)]
+    if not lanes:
+        return None
+    seen: dict[str, int] = {}
+    results: list[WorkerCodeFreshness] = []
+    for index, child in enumerate(lanes):
+        label = (
+            str(child.get("fleet") or child.get("worker") or f"child-{index}").strip()
+            or f"child-{index}"
+        )
+        occurrence = seen.get(label, 0)
+        seen[label] = occurrence + 1
+        unique = label if occurrence == 0 else f"{label}-{occurrence}"
+        startup = _startup_identity_from_payload(child)
+        freshness = evaluate_worker_freshness(
+            name=f"{name}/{unique}", startup=startup, current=checkout
+        )
+        results.append(freshness)
+    return results
+
+
+def payload_busy_hint(payload: Mapping[str, Any]) -> bool:
+    """Return a conservative busy hint for one readiness payload.
+
+    Returns ``True`` (drain, never kill) unless the payload explicitly
+    reports an idle worker: ``busy`` false with no in-flight activity
+    counters. Unknown busyness drains rather than interrupting
+    potentially long-running activities with an immediate restart.
+    """
+
+    def _active_count(value: Any) -> int | None:
+        try:
+            count = int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return count if count >= 0 else None
+
+    candidates: list[Mapping[str, Any]] = [payload]
+    children = payload.get("children")
+    if isinstance(children, list):
+        lanes = [child for child in children if isinstance(child, Mapping)]
+        if lanes:
+            # The group envelope itself is an aggregate: busyness is
+            # decided by the per-lane payloads, not the envelope.
+            candidates = lanes
+    for candidate in candidates:
+        if candidate.get("busy") is True:
+            return True
+        for key in ("activeActivities", "inFlightActivities", "pendingActivities"):
+            count = _active_count(candidate.get(key))
+            if count is not None and count > 0:
+                return True
+        if candidate.get("busy") is not False:
+            # No explicit idle signal: conservatively drain rather than
+            # interrupting potentially long-running activities.
+            return True
+    return False
 
 
 def collect_worker_code_freshness(
@@ -426,11 +594,11 @@ def collect_worker_code_freshness(
                 )
             )
             continue
-        startup = WorkerCodeIdentity(
-            revision=str(payload.get("codeRevision") or "").strip() or None,
-            digest=str(payload.get("codeDigest") or "").strip() or None,
-            source=str(payload.get("codeIdentitySource") or "").strip() or UNKNOWN,
-        )
+        children = _children_freshness(name, payload, checkout)
+        if children is not None:
+            results.extend(children)
+            continue
+        startup = _startup_identity_from_payload(payload)
         results.append(evaluate_worker_freshness(name=name, startup=startup, current=checkout))
     return results
 

--- a/moonmind/workflows/temporal/worker_code_identity.py
+++ b/moonmind/workflows/temporal/worker_code_identity.py
@@ -1,0 +1,502 @@
+"""Worker code identity: detect bind-mounted workers running stale modules.
+
+Bind-mounted source plus long-lived workers means every host ``git pull``
+silently creates a mixed-version deployment until someone restarts containers
+(MoonLadderStudios/MoonMind#4224). This module gives every worker a
+startup-recorded code identity (git revision or a content digest of the
+imported ``moonmind`` package) and the comparison/probe/recovery helpers used
+by the worker health projection, the API ``/healthz`` detail, the ``moonmind``
+CLI, the deployment-control worker, and the UserWorkflow admission gate.
+
+Uses only the Python standard library so host update scripts and thin worker
+entrypoints can import it without the application dependency set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import time
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+UNKNOWN = "unknown"
+STALE_CODE_REASON = "stale_code"
+
+_CODE_REVISION_ENV_KEYS = ("MOONMIND_BUILD_SHA", "MOONMIND_IMAGE_DIGEST")
+_PACKAGE_ROOT_ENV_KEY = "MOONMIND_CODE_PACKAGE_ROOT"
+_READINESS_URLS_ENV_KEY = "MOONMIND_WORKER_READINESS_URLS"
+_WORKFLOW_READINESS_URL_ENV_KEY = "TEMPORAL_WORKFLOW_READINESS_URL"
+
+_MAX_DIGEST_FILES = 10000
+_DIGEST_CACHE_TTL_SECONDS = 60.0
+
+_digest_cache: dict[str, tuple[float, str | None]] = {}
+_STARTUP_IDENTITY: "WorkerCodeIdentity | None" = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerCodeIdentity:
+    """Code identity recorded for one worker process or checkout."""
+
+    revision: str | None = None
+    digest: str | None = None
+    source: str = UNKNOWN
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "codeRevision": self.revision or UNKNOWN,
+            "codeDigest": self.digest or UNKNOWN,
+            "codeIdentitySource": self.source,
+        }
+
+    @property
+    def known(self) -> bool:
+        return bool((self.revision or "").strip() or (self.digest or "").strip())
+
+
+def _package_root(explicit: str | Path | None = None) -> Path:
+    if explicit is not None:
+        return Path(explicit)
+    override = os.environ.get(_PACKAGE_ROOT_ENV_KEY, "").strip()
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _repo_root_for(package_root: Path) -> Path:
+    return package_root.parent
+
+
+def _run_git(args: Sequence[str], *, cwd: Path, timeout: float = 5.0) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def resolve_git_revision(
+    repo_root: str | Path | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    timeout: float = 5.0,
+) -> tuple[str | None, str]:
+    """Return ``(revision, source)`` for the checkout on disk.
+
+    Prefers the explicit ``MOONMIND_BUILD_SHA`` / ``MOONMIND_IMAGE_DIGEST``
+    environment identity, then ``git rev-parse HEAD``. A dirty working tree
+    (bind-mounted file modified without a commit) is part of the identity:
+    the revision carries a ``-dirty`` suffix so a startup-recorded clean
+    revision compares stale against it.
+    """
+
+    env = os.environ if environ is None else environ
+    for key in _CODE_REVISION_ENV_KEYS:
+        raw = str(env.get(key) or "").strip()
+        if raw:
+            base = raw.removeprefix("sha256:")
+            root = _repo_root_for(_package_root())
+            if repo_root is not None:
+                root = Path(repo_root)
+            dirty = _run_git(
+                ["status", "--porcelain", "--untracked-files=no"],
+                cwd=root,
+                timeout=timeout,
+            )
+            if dirty:
+                return f"{base}-dirty", key
+            return base, key
+    root = _repo_root_for(_package_root())
+    if repo_root is not None:
+        root = Path(repo_root)
+    head = _run_git(["rev-parse", "HEAD"], cwd=root, timeout=timeout)
+    if head is None:
+        return None, UNKNOWN
+    dirty = _run_git(
+        ["status", "--porcelain", "--untracked-files=no"],
+        cwd=root,
+        timeout=timeout,
+    )
+    if dirty:
+        return f"{head}-dirty", "git-dirty"
+    return head, "git"
+
+
+def compute_package_digest(package_root: str | Path | None = None) -> str | None:
+    """Return a sha256 digest over the ``moonmind`` package ``*.py`` sources."""
+
+    root = _package_root(package_root)
+    if not root.is_dir():
+        return None
+    hasher = hashlib.sha256()
+    try:
+        candidates = sorted(
+            path
+            for path in root.rglob("*.py")
+            if "__pycache__" not in path.parts
+        )
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    count = 0
+    for path in candidates:
+        if count >= _MAX_DIGEST_FILES:
+            break
+        try:
+            relative = path.relative_to(root).as_posix()
+            content = path.read_bytes()
+        except OSError:
+            continue
+        hasher.update(relative.encode("utf-8"))
+        hasher.update(b"\x00")
+        hasher.update(content)
+        hasher.update(b"\x00")
+        count += 1
+    if count == 0:
+        return None
+    return "sha256:" + hasher.hexdigest()
+
+
+def _cached_package_digest(package_root: str | Path | None = None) -> str | None:
+    key = str(_package_root(package_root))
+    now = time.monotonic()
+    cached = _digest_cache.get(key)
+    if cached is not None and now - cached[0] < _DIGEST_CACHE_TTL_SECONDS:
+        return cached[1]
+    digest = compute_package_digest(package_root)
+    _digest_cache[key] = (now, digest)
+    return digest
+
+
+def resolve_worker_code_identity(
+    package_root: str | Path | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> WorkerCodeIdentity:
+    """Resolve the code identity a worker records once at startup."""
+
+    revision, source = resolve_git_revision(environ=environ)
+    digest = compute_package_digest(package_root)
+    if revision is None and digest is None:
+        return WorkerCodeIdentity(revision=None, digest=None, source=UNKNOWN)
+    if revision is None:
+        return WorkerCodeIdentity(revision=None, digest=digest, source="package-digest")
+    return WorkerCodeIdentity(revision=revision, digest=digest, source=source)
+
+
+def resolve_checkout_code_identity(
+    package_root: str | Path | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    live_digest: bool = True,
+) -> WorkerCodeIdentity:
+    """Resolve the code identity currently on disk (live, per-request)."""
+
+    revision, source = resolve_git_revision(environ=environ)
+    digest = _cached_package_digest(package_root) if live_digest else None
+    if revision is None and digest is None:
+        return WorkerCodeIdentity(revision=None, digest=None, source=UNKNOWN)
+    if revision is None:
+        return WorkerCodeIdentity(revision=None, digest=digest, source="package-digest")
+    return WorkerCodeIdentity(revision=revision, digest=digest, source=source)
+
+
+def record_worker_startup_identity(
+    identity: WorkerCodeIdentity | None = None,
+    **kwargs: Any,
+) -> WorkerCodeIdentity:
+    """Record (or re-record) this process's startup code identity."""
+
+    global _STARTUP_IDENTITY
+    _STARTUP_IDENTITY = identity or resolve_worker_code_identity(**kwargs)
+    return _STARTUP_IDENTITY
+
+
+def worker_startup_identity() -> WorkerCodeIdentity:
+    """Return this process's startup code identity, resolving it once."""
+
+    global _STARTUP_IDENTITY
+    if _STARTUP_IDENTITY is None:
+        _STARTUP_IDENTITY = resolve_worker_code_identity()
+    return _STARTUP_IDENTITY
+
+
+def current_worker_code_revision() -> str:
+    """Return this process's startup code revision, or ``"unknown"``."""
+
+    revision = (worker_startup_identity().revision or "").strip()
+    return revision or UNKNOWN
+
+
+def compare_code_identities(
+    startup: WorkerCodeIdentity,
+    current: WorkerCodeIdentity,
+) -> str:
+    """Compare a startup-recorded identity with the checkout on disk.
+
+    Returns ``"healthy"``, ``"stale"``, or ``"unknown"``. A missing startup
+    identity is reported as ``unknown``, never healthy: without a recorded
+    revision there is no evidence the running modules match the checkout.
+    """
+
+    if not startup.known:
+        return UNKNOWN
+    if not current.known:
+        return UNKNOWN
+    startup_revision = (startup.revision or "").strip()
+    current_revision = (current.revision or "").strip()
+    if startup_revision and current_revision:
+        if startup_revision != current_revision:
+            return "stale"
+        # Same revision but the package digest moved (bind-mounted file edited
+        # without a commit and outside git's view, e.g. git unavailable at one
+        # of the two resolutions): still a mixed-version deployment.
+        startup_digest = (startup.digest or "").strip()
+        current_digest = (current.digest or "").strip()
+        if startup_digest and current_digest and startup_digest != current_digest:
+            return "stale"
+        return "healthy"
+    startup_digest = (startup.digest or "").strip()
+    current_digest = (current.digest or "").strip()
+    if startup_digest and current_digest:
+        return "healthy" if startup_digest == current_digest else "stale"
+    return UNKNOWN
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerCodeFreshness:
+    """Freshness of one worker's running modules against the checkout."""
+
+    name: str
+    status: str
+    startup_revision: str
+    current_revision: str
+    startup_digest: str = UNKNOWN
+    current_digest: str = UNKNOWN
+    source: str = UNKNOWN
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "worker": self.name,
+            "status": self.status,
+            "startupRevision": self.startup_revision,
+            "currentRevision": self.current_revision,
+            "startupDigest": self.startup_digest,
+            "currentDigest": self.current_digest,
+            "source": self.source,
+        }
+
+
+def evaluate_worker_freshness(
+    *,
+    name: str,
+    startup: WorkerCodeIdentity,
+    current: WorkerCodeIdentity,
+) -> WorkerCodeFreshness:
+    """Evaluate one worker's freshness with both identities for evidence."""
+
+    return WorkerCodeFreshness(
+        name=name,
+        status=compare_code_identities(startup, current),
+        startup_revision=(startup.revision or "").strip() or UNKNOWN,
+        current_revision=(current.revision or "").strip() or UNKNOWN,
+        startup_digest=(startup.digest or "").strip() or UNKNOWN,
+        current_digest=(current.digest or "").strip() or UNKNOWN,
+        source=(startup.source or "").strip() or UNKNOWN,
+    )
+
+
+def stale_code_detail(freshness: WorkerCodeFreshness) -> dict[str, Any]:
+    """Return the ``stale_code`` evidence block for one stale worker."""
+
+    return {
+        "reasonCode": STALE_CODE_REASON,
+        "worker": freshness.name,
+        "startupRevision": freshness.startup_revision,
+        "currentRevision": freshness.current_revision,
+    }
+
+
+def format_stale_code_message(stale: Sequence[WorkerCodeFreshness]) -> str:
+    parts = []
+    for item in stale:
+        parts.append(
+            f"{item.name} (running {item.startup_revision}, "
+            f"checkout {item.current_revision})"
+        )
+    return (
+        "Stale worker code detected (reasonCode=stale_code): "
+        + "; ".join(parts)
+        + ". A host git pull alone is not a deployment: restart the workers "
+        "so the running modules match the checkout before new runs are admitted."
+    )
+
+
+def readiness_urls_from_env(
+    environ: Mapping[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """Return ``(name, url)`` worker readiness endpoints from the environment."""
+
+    env = os.environ if environ is None else environ
+    urls: list[tuple[str, str]] = []
+    raw = str(env.get(_READINESS_URLS_ENV_KEY) or "").strip()
+    if raw:
+        for entry in raw.split(","):
+            item = entry.strip()
+            if not item:
+                continue
+            if "=" in item:
+                name, url = item.split("=", 1)
+                name, url = name.strip() or url.strip(), url.strip()
+            else:
+                name, url = item, item
+            if url:
+                urls.append((name, url))
+    workflow_url = str(env.get(_WORKFLOW_READINESS_URL_ENV_KEY) or "").strip()
+    if workflow_url and all(url != workflow_url for _, url in urls):
+        urls.append(("workflow", workflow_url))
+    return urls
+
+
+def probe_worker_readiness(
+    url: str,
+    *,
+    timeout: float = 2.0,
+) -> dict[str, Any] | None:
+    """Fetch one worker ``/readyz`` payload best-effort; ``None`` when unknown."""
+
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            body = response.read()
+        payload = json.loads(body.decode("utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def collect_worker_code_freshness(
+    urls: Sequence[tuple[str, str]] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    current: WorkerCodeIdentity | None = None,
+    probe: Any = None,
+) -> list[WorkerCodeFreshness]:
+    """Compare each reachable worker's recorded identity with the checkout."""
+
+    targets = list(urls) if urls is not None else readiness_urls_from_env(environ)
+    checkout = current or resolve_checkout_code_identity(environ=environ)
+    fetch = probe or probe_worker_readiness
+    results: list[WorkerCodeFreshness] = []
+    for name, url in targets:
+        payload = fetch(url)
+        if not isinstance(payload, dict):
+            results.append(
+                WorkerCodeFreshness(
+                    name=name,
+                    status=UNKNOWN,
+                    startup_revision=UNKNOWN,
+                    current_revision=(checkout.revision or "").strip() or UNKNOWN,
+                )
+            )
+            continue
+        startup = WorkerCodeIdentity(
+            revision=str(payload.get("codeRevision") or "").strip() or None,
+            digest=str(payload.get("codeDigest") or "").strip() or None,
+            source=str(payload.get("codeIdentitySource") or "").strip() or UNKNOWN,
+        )
+        results.append(evaluate_worker_freshness(name=name, startup=startup, current=checkout))
+    return results
+
+
+def stale_workers_only(
+    freshness: Sequence[WorkerCodeFreshness],
+) -> tuple[bool, list[WorkerCodeFreshness]]:
+    """Return whether new work must be refused: known workers, all stale.
+
+    Fail-open when no worker reported a known identity (nothing to compare
+    against) so a monitoring outage cannot wedge admissions; the unknown state
+    stays visible in the readiness detail instead.
+    """
+
+    known = [item for item in freshness if item.status in {"healthy", "stale"}]
+    if not known:
+        return False, []
+    stale = [item for item in known if item.status == "stale"]
+    if stale and len(stale) == len(known):
+        return True, stale
+    return False, stale
+
+
+@dataclass(frozen=True, slots=True)
+class StaleWorkerRecoveryPlan:
+    """Which stale workers restart now and which must drain first."""
+
+    restart_now: tuple[str, ...] = ()
+    drain_then_restart: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "restartNow": list(self.restart_now),
+            "drainThenRestart": list(self.drain_then_restart),
+        }
+
+
+def plan_stale_worker_recovery(
+    stale: Sequence[str | WorkerCodeFreshness],
+    busy: Sequence[str] | None = None,
+) -> StaleWorkerRecoveryPlan:
+    """Split stale workers into idle (restart now) and busy (drain, never kill).
+
+    A busy worker is drained — it stops accepting new activities and restarts
+    after in-flight work finishes — rather than killed, so bounded recovery
+    cannot discard running work to fix the deployment skew.
+    """
+
+    names = [
+        item.name if isinstance(item, WorkerCodeFreshness) else str(item)
+        for item in stale
+    ]
+    busy_set = {str(item).strip() for item in (busy or []) if str(item).strip()}
+    restart_now = tuple(name for name in names if name not in busy_set)
+    drain_then_restart = tuple(name for name in names if name in busy_set)
+    return StaleWorkerRecoveryPlan(
+        restart_now=restart_now, drain_then_restart=drain_then_restart
+    )
+
+
+@dataclass(slots=True)
+class WorkerCodeAdmissionError(RuntimeError):
+    """New UserWorkflows are refused while only stale workers serve the queue."""
+
+    stale: list[WorkerCodeFreshness] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        # NOTE: explicit base init (not zero-arg super()): @dataclass
+        # slots=True recreates the class, which breaks the zero-arg
+        # super() __class__ cell for Exception subclasses.
+        RuntimeError.__init__(self, format_stale_code_message(self.stale))
+
+
+def enforce_worker_code_admission(
+    freshness: Sequence[WorkerCodeFreshness],
+) -> list[WorkerCodeFreshness]:
+    """Raise :class:`WorkerCodeAdmissionError` when only stale workers remain."""
+
+    blocked, stale = stale_workers_only(freshness)
+    if blocked:
+        raise WorkerCodeAdmissionError(stale=list(stale))
+    return list(stale)

--- a/moonmind/workflows/temporal/worker_code_identity.py
+++ b/moonmind/workflows/temporal/worker_code_identity.py
@@ -372,6 +372,18 @@ def readiness_urls_from_env(
     return urls
 
 
+def _no_proxy_opener() -> urllib.request.OpenerDirector:
+    """Return a URL opener that bypasses proxy env for worker readiness URLs.
+
+    Worker ``/readyz`` endpoints are cluster-local (frequently 127.0.0.1 or a
+    Compose service name). Routing them through an egress HTTP proxy (squid)
+    makes localhost probes fail with ERR_ACCESS_DENIED and misreports worker
+    freshness as unknown instead of healthy/stale.
+    """
+
+    return urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
 def probe_worker_readiness(
     url: str,
     *,
@@ -380,7 +392,8 @@ def probe_worker_readiness(
     """Fetch one worker ``/readyz`` payload best-effort; ``None`` when unknown."""
 
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+        request = urllib.request.Request(url, method="GET")
+        with _no_proxy_opener().open(request, timeout=timeout) as response:  # noqa: S310
             body = response.read()
         payload = json.loads(body.decode("utf-8"))
     except Exception:

--- a/moonmind/workflows/temporal/worker_healthcheck.py
+++ b/moonmind/workflows/temporal/worker_healthcheck.py
@@ -37,6 +37,15 @@ class WorkerHealthState:
     pollers_started: bool = False
     readiness_metadata: dict[str, Any] = field(default_factory=dict)
     startup_error: str | None = None
+    # Startup-recorded code identity (MoonLadderStudios/MoonMind#4224): the git
+    # revision (or package digest) of the modules this process imported. It is
+    # compared with the checkout on disk on every /readyz request so a
+    # bind-mounted worker running stale modules reports ``stale_code`` instead
+    # of ready. ``None`` means the identity was never recorded and the worker
+    # reports ``unknown``, never healthy.
+    code_revision: str | None = None
+    code_digest: str | None = None
+    code_identity_source: str = "unknown"
 
     @property
     def ready(self) -> bool:
@@ -46,6 +55,41 @@ class WorkerHealthState:
             and self.pollers_started
             and self.startup_error is None
         )
+
+    def code_identity(self) -> dict[str, Any]:
+        """Return this worker's startup-recorded code identity payload."""
+        from moonmind.workflows.temporal.worker_code_identity import (
+            UNKNOWN,
+            WorkerCodeIdentity,
+            compare_code_identities,
+            resolve_checkout_code_identity,
+        )
+
+        startup = WorkerCodeIdentity(
+            revision=(self.code_revision or "").strip() or None,
+            digest=(self.code_digest or "").strip() or None,
+            source=(self.code_identity_source or "").strip() or UNKNOWN,
+        )
+        current = resolve_checkout_code_identity()
+        status = compare_code_identities(startup, current)
+        payload: dict[str, Any] = {
+            "codeRevision": startup.revision or UNKNOWN,
+            "codeDigest": startup.digest or UNKNOWN,
+            "codeIdentitySource": startup.source,
+            "codeIdentityStatus": status,
+            "checkoutRevision": current.revision or UNKNOWN,
+        }
+        if status == "stale":
+            payload["reasonCode"] = "stale_code"
+            payload["staleCode"] = {
+                "worker": (self.readiness_metadata.get("fleet") if isinstance(self.readiness_metadata, dict) else None)
+                or os.environ.get("TEMPORAL_WORKER_FLEET", "unknown"),
+                "startupRevision": startup.revision or UNKNOWN,
+                "currentRevision": current.revision or UNKNOWN,
+            }
+        elif status == UNKNOWN:
+            payload["reasonCode"] = "code_identity_unknown"
+        return payload
 
 
 def _is_enabled() -> bool:
@@ -73,14 +117,20 @@ def _build_response_body(
     uptime = int(time.monotonic() - _start_time)
 
     if not readiness:
+        from moonmind.workflows.temporal.worker_code_identity import UNKNOWN
+
         body: dict[str, Any] = {
             "status": "ok",
             "live": True,
             "fleet": fleet,
             "uptime_seconds": uptime,
+            "codeRevision": (state.code_revision if state else None) or UNKNOWN,
+            "codeIdentitySource": (state.code_identity_source if state else None)
+            or UNKNOWN,
         }
     else:
         current = state or WorkerHealthState()
+        code_identity = current.code_identity()
         body = {
             **current.readiness_metadata,
             "status": "ready" if current.ready else "not_ready",
@@ -92,9 +142,15 @@ def _build_response_body(
                 "workersConstructed": current.workers_constructed,
                 "pollersStarted": current.pollers_started,
             },
+            **code_identity,
         }
         if current.startup_error:
             body["reasonCode"] = "worker_startup_failed"
+        # A worker running stale modules must not look ready: mixed-version
+        # deployments silently admit work under old rules and finalize it
+        # under new ones (MoonLadderStudios/MoonMind#4224).
+        if code_identity.get("codeIdentityStatus") == "stale" and "reasonCode" not in body:
+            body["reasonCode"] = "stale_code"
     return json.dumps(body).encode("utf-8")
 
 
@@ -118,9 +174,17 @@ async def _handle_connection(
         path = parts[1] if len(parts) >= 2 else "/healthz"
         readiness = path == "/readyz"
         payload = _build_response_body(state, readiness=readiness)
-        status = (
-            b"200 OK" if not readiness or state.ready else b"503 Service Unavailable"
-        )
+        if readiness:
+            try:
+                body_json = json.loads(payload.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                body_json = {}
+            stale = body_json.get("codeIdentityStatus") == "stale"
+            status = (
+                b"200 OK" if state.ready and not stale else b"503 Service Unavailable"
+            )
+        else:
+            status = b"200 OK"
 
         response = (
             b"HTTP/1.1 " + status + b"\r\n"

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -578,6 +578,24 @@ def _build_deployment_update_executor() -> DeploymentUpdateExecutor | None:
         if lock_dir
         else DeploymentUpdateLockManager()
     )
+    # Stale-code recovery (MoonLadderStudios/MoonMind#4224): after recreation,
+    # bind-mounted workers that were not recreated may still run stale
+    # modules. The checker probes the configured worker /readyz endpoints;
+    # the restarter restarts idle stale workers immediately and drains busy
+    # ones, never restarting the excluded runner services mid-update. When no
+    # readiness endpoint is configured the executor keeps image-only behavior.
+    from moonmind.workflows.skills.deployment_execution import (
+        build_compose_stale_worker_restarter,
+        build_env_stale_worker_checker,
+    )
+
+    stale_worker_checker = build_env_stale_worker_checker()
+    stale_worker_restarter = build_compose_stale_worker_restarter(
+        project_dir=project_dir,
+        compose_file=compose_file,
+        project_name=project_name,
+        excluded_services=excluded_services,
+    )
     return DeploymentUpdateExecutor(
         lock_manager=lock_manager,
         desired_state_store=desired_state_store,
@@ -592,6 +610,8 @@ def _build_deployment_update_executor() -> DeploymentUpdateExecutor | None:
             excluded_services=excluded_services,
         ),
         excluded_services=excluded_services,
+        stale_worker_checker=stale_worker_checker,
+        stale_worker_restarter=stale_worker_restarter,
     )
 
 
@@ -3158,7 +3178,26 @@ async def main_async() -> None:
 
     # Liveness starts immediately. Readiness remains false until the Temporal
     # connection, executable spec, SDK workers, and polling tasks all exist.
-    health_state = WorkerHealthState()
+    # The startup code identity is recorded before any activity executes so
+    # post-incident analysis can tell which revision ran each step, and so the
+    # /readyz projection can report stale_code when a host git pull rewrites
+    # the bind-mounted sources under a long-lived worker
+    # (MoonLadderStudios/MoonMind#4224).
+    from moonmind.workflows.temporal.worker_code_identity import (
+        record_worker_startup_identity,
+    )
+
+    _startup_code_identity = record_worker_startup_identity()
+    health_state = WorkerHealthState(
+        code_revision=_startup_code_identity.revision,
+        code_digest=_startup_code_identity.digest,
+        code_identity_source=_startup_code_identity.source,
+    )
+    logger.info(
+        "Worker code identity: revision=%s source=%s",
+        _startup_code_identity.revision or "unknown",
+        _startup_code_identity.source,
+    )
     healthcheck_server = await start_healthcheck_server(health_state)
 
     import os

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -199,6 +199,10 @@ class WorkerSpec:
             "buildId": self.build_id,
             "buildSha": self.build_sha,
             "imageDigest": self.image_digest,
+            # Executing-worker code identity (MoonLadderStudios/MoonMind#4224):
+            # the revision the worker process must report in its heartbeat and
+            # /readyz projection so stale bind-mounted modules are detectable.
+            "workerCodeRevision": self.build_sha or self.build_id,
             "deploymentId": self.deployment_id,
             "registryFingerprint": self.registry_fingerprint,
             "taskQueues": list(self.task_queues),

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -6947,6 +6947,13 @@ class MoonMindAgentRun:
                                     type="UnsupportedStatus",
                                     non_retryable=True,
                                 ) from exc
+                            # Executing-worker code revision rides the activity
+                            # result (determinism-safe: pure data flow from the
+                            # activity payload, MoonLadderStudios/MoonMind#4224).
+                            worker_code_revision = handle_dict.get(
+                                "workerCodeRevision",
+                                handle_dict.get("worker_code_revision", "unknown"),
+                            )
                             handle = AgentRunHandle(
                                 runId=handle_dict["external_id"],
                                 agentKind="external",
@@ -6958,7 +6965,9 @@ class MoonMindAgentRun:
                                     "normalizedStatus": normalized_for_metadata,
                                     "externalUrl": handle_dict.get("url"),
                                     "callbackSupported": handle_dict.get("callback_supported", False),
-                                }
+                                    "workerCodeRevision": worker_code_revision,
+                                },
+                                workerCodeRevision=worker_code_revision,
                             )
                         else:
                             handle = AgentRunHandle(**handle_dict) if isinstance(handle_dict, dict) else handle_dict

--- a/tests/integration/temporal/test_worker_stale_code_readiness.py
+++ b/tests/integration/temporal/test_worker_stale_code_readiness.py
@@ -44,10 +44,8 @@ def _isolated_code_identity(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.delenv("MOONMIND_IMAGE_DIGEST", raising=False)
     monkeypatch.setenv("MOONMIND_CODE_PACKAGE_ROOT", str(tmp_path))
     monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "workflow")
-    wci._digest_cache.clear()
     wci._STARTUP_IDENTITY = None
     yield
-    wci._digest_cache.clear()
     wci._STARTUP_IDENTITY = None
 
 
@@ -87,8 +85,9 @@ async def test_bind_mounted_module_change_reports_stale_code_until_restart(
         assert body["codeIdentityStatus"] == "healthy"
 
         # Host rewrites a bind-mounted module without restarting the worker.
+        # The checkout digest is recomputed live (never cached), so the next
+        # probe observes the rewrite immediately.
         module.write_text("HANDLER_VERSION = 2\n", encoding="utf-8")
-        wci._digest_cache.clear()
 
         code, body = await loop.run_in_executor(None, _get_readyz)
         assert code == 503, body

--- a/tests/integration/temporal/test_worker_stale_code_readiness.py
+++ b/tests/integration/temporal/test_worker_stale_code_readiness.py
@@ -16,6 +16,19 @@ import urllib.request
 import pytest
 
 from moonmind.workflows.temporal import worker_code_identity as wci
+
+
+def _fetch_readyz_no_proxy(port: int, timeout: float = 5.0) -> tuple[int | None, dict]:
+    """Fetch /readyz bypassing proxy env (localhost must never go via squid)."""
+
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        raw = opener.open(f"http://127.0.0.1:{port}/readyz", timeout=timeout).read()
+        return None, json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
 from moonmind.workflows.temporal.worker_code_identity import (
     resolve_worker_code_identity,
 )
@@ -65,13 +78,7 @@ async def test_bind_mounted_module_change_reports_stale_code_until_restart(
     loop = asyncio.get_running_loop()
 
     def _get_readyz() -> tuple[int | None, dict]:
-        try:
-            raw = urllib.request.urlopen(
-                f"http://127.0.0.1:{port}/readyz", timeout=5
-            ).read()
-            return None, json.loads(raw)
-        except urllib.error.HTTPError as exc:
-            return exc.code, json.loads(exc.read())
+        return _fetch_readyz_no_proxy(port)
 
     try:
         code, body = await loop.run_in_executor(None, _get_readyz)

--- a/tests/integration/temporal/test_worker_stale_code_readiness.py
+++ b/tests/integration/temporal/test_worker_stale_code_readiness.py
@@ -1,0 +1,112 @@
+"""Compose-backed stale worker code readiness test (MoonLadderStudios/MoonMind#4224).
+
+Runs in the ``moonmind-test`` Compose project: it starts a worker healthcheck
+server against a bind-mounted style module directory, modifies a module, and
+asserts the readiness endpoint reports ``stale_code`` for that worker with
+both identities; re-recording the identity (a restart) clears it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+
+import pytest
+
+from moonmind.workflows.temporal import worker_code_identity as wci
+from moonmind.workflows.temporal.worker_code_identity import (
+    resolve_worker_code_identity,
+)
+from moonmind.workflows.temporal.worker_healthcheck import (
+    WorkerHealthState,
+    start_healthcheck_server,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_code_identity(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.delenv("MOONMIND_BUILD_SHA", raising=False)
+    monkeypatch.delenv("MOONMIND_IMAGE_DIGEST", raising=False)
+    monkeypatch.setenv("MOONMIND_CODE_PACKAGE_ROOT", str(tmp_path))
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "workflow")
+    wci._digest_cache.clear()
+    wci._STARTUP_IDENTITY = None
+    yield
+    wci._digest_cache.clear()
+    wci._STARTUP_IDENTITY = None
+
+
+@pytest.mark.integration_ci
+@pytest.mark.asyncio
+async def test_bind_mounted_module_change_reports_stale_code_until_restart(
+    tmp_path,
+) -> None:
+    """Modifying a bind-mounted module surfaces stale_code; restart clears it."""
+
+    module = tmp_path / "bind_mounted_worker_module.py"
+    module.write_text("HANDLER_VERSION = 1\n", encoding="utf-8")
+
+    # Worker boots and records its startup code identity.
+    startup = resolve_worker_code_identity(package_root=tmp_path)
+    assert startup.digest is not None
+    state = WorkerHealthState(
+        temporal_connected=True,
+        workers_constructed=True,
+        pollers_started=True,
+        code_revision=startup.revision,
+        code_digest=startup.digest,
+        code_identity_source=startup.source,
+    )
+    server = await start_healthcheck_server(state)
+    assert server is not None
+    port = server.sockets[0].getsockname()[1]
+    loop = asyncio.get_running_loop()
+
+    def _get_readyz() -> tuple[int | None, dict]:
+        try:
+            raw = urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/readyz", timeout=5
+            ).read()
+            return None, json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+    try:
+        code, body = await loop.run_in_executor(None, _get_readyz)
+        assert code is None, body
+        assert body["ready"] is True
+        assert body["codeIdentityStatus"] == "healthy"
+
+        # Host rewrites a bind-mounted module without restarting the worker.
+        module.write_text("HANDLER_VERSION = 2\n", encoding="utf-8")
+        wci._digest_cache.clear()
+
+        code, body = await loop.run_in_executor(None, _get_readyz)
+        assert code == 503, body
+        assert body["ready"] is True  # pollers still run; the code is stale
+        assert body["codeIdentityStatus"] == "stale"
+        assert body["reasonCode"] == "stale_code"
+        assert body["staleCode"]["worker"] == "workflow"
+        assert (
+            body["staleCode"]["startupRevision"]
+            == (startup.revision or "unknown")
+        )
+        assert (
+            body["staleCode"]["currentRevision"]
+            == (startup.revision or "unknown")
+        )
+
+        # Restarting the worker re-records the identity and clears stale_code.
+        restarted = resolve_worker_code_identity(package_root=tmp_path)
+        state.code_revision = restarted.revision
+        state.code_digest = restarted.digest
+        state.code_identity_source = restarted.source
+        code, body = await loop.run_in_executor(None, _get_readyz)
+        assert code is None, body
+        assert body["codeIdentityStatus"] == "healthy"
+        assert body.get("reasonCode") != "stale_code"
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -608,7 +608,11 @@ async def test_agent_runtime_launch_binds_workflow_id_to_task_run_before_launch(
         "mm:workflow-123",
         "6f8b6bf7-6e0c-4d71-9b08-18d489f17a8d",
     )
-    assert result == {"status": "launching"}
+    assert result["status"] == "launching"
+    # The executing worker stamps its startup code identity for post-incident
+    # analysis (MoonLadderStudios/MoonMind#4224).
+    assert isinstance(result.get("workerCodeRevision"), str)
+    assert result["workerCodeRevision"]
 
 @pytest.mark.asyncio
 async def test_agent_runtime_launch_accepts_legacy_file_templates_payload():
@@ -647,7 +651,11 @@ async def test_agent_runtime_launch_accepts_legacy_file_templates_payload():
 
     result = await activities.agent_runtime_launch(payload)
 
-    assert result == {"status": "launching"}
+    assert result["status"] == "launching"
+    # The executing worker stamps its startup code identity for post-incident
+    # analysis (MoonLadderStudios/MoonMind#4224).
+    assert isinstance(result.get("workerCodeRevision"), str)
+    assert result["workerCodeRevision"]
     profile = mock_launcher.launch.await_args.kwargs["profile"]
     assert profile.file_templates[0].path == "{{runtime_support_dir}}/codex-home/config.toml"
     assert profile.file_templates[0].content_template == 'model = "qwen"\n'
@@ -693,7 +701,11 @@ async def test_agent_runtime_launch_defers_support_cleanup_until_fetch_result():
     }
 
     result = await activities.agent_runtime_launch(payload)
-    assert result == {"status": "launching"}
+    assert result["status"] == "launching"
+    # The executing worker stamps its startup code identity for post-incident
+    # analysis (MoonLadderStudios/MoonMind#4224).
+    assert isinstance(result.get("workerCodeRevision"), str)
+    assert result["workerCodeRevision"]
 
     assert len(activities._supervision_tasks) == 1
     [task] = list(activities._supervision_tasks)

--- a/tests/unit/workflows/temporal/test_worker_code_identity.py
+++ b/tests/unit/workflows/temporal/test_worker_code_identity.py
@@ -256,6 +256,17 @@ def test_readiness_body_reports_stale_code(monkeypatch: pytest.MonkeyPatch) -> N
     assert body["staleCode"]["currentRevision"].startswith("checkout-rev")
 
 
+def _fetch_readyz_no_proxy(port: int, timeout: float = 5.0) -> tuple[int | None, dict[str, Any]]:
+    """Fetch /readyz bypassing proxy env (localhost must never go via squid)."""
+
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        raw = opener.open(f"http://127.0.0.1:{port}/readyz", timeout=timeout).read()
+        return None, json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
 @pytest.mark.asyncio
 async def test_readyz_serves_503_while_stale_and_200_after_restart(
     monkeypatch: pytest.MonkeyPatch, tmp_path
@@ -281,13 +292,7 @@ async def test_readyz_serves_503_while_stale_and_200_after_restart(
     loop = asyncio.get_running_loop()
 
     def _get() -> tuple[int | None, dict[str, Any]]:
-        try:
-            raw = urllib.request.urlopen(
-                f"http://127.0.0.1:{port}/readyz", timeout=5
-            ).read()
-            return None, json.loads(raw)
-        except urllib.error.HTTPError as exc:
-            return exc.code, json.loads(exc.read())
+        return _fetch_readyz_no_proxy(port)
 
     try:
         code, body = await loop.run_in_executor(None, _get)
@@ -351,8 +356,11 @@ def test_base_adapter_builders_stamp_worker_code_revision(
         provider_status="ACTIVE",
         normalized_status="running",
     )
-    assert handle.worker_code_revision == "worker-rev"
-    assert handle.metadata["workerCodeRevision"] == "worker-rev"
+    # The checkout may be dirty (e.g. remediation edits in flight), in which
+    # case the revision carries a '-dirty' suffix; the stamped env base is
+    # what matters here.
+    assert str(handle.worker_code_revision).startswith("worker-rev")
+    assert str(handle.metadata["workerCodeRevision"]).startswith("worker-rev")
 
     status = BaseExternalAgentAdapter.build_status(
         run_id="r",
@@ -361,7 +369,7 @@ def test_base_adapter_builders_stamp_worker_code_revision(
         provider_status="ACTIVE",
         normalized_status="running",
     )
-    assert status.worker_code_revision == "worker-rev"
+    assert str(status.worker_code_revision).startswith("worker-rev")
 
     result = BaseExternalAgentAdapter.build_result(
         run_id="r",
@@ -369,8 +377,8 @@ def test_base_adapter_builders_stamp_worker_code_revision(
         normalized_status="completed",
         provider_name="Jules",
     )
-    assert result.worker_code_revision == "worker-rev"
-    assert result.metadata["workerCodeRevision"] == "worker-rev"
+    assert str(result.worker_code_revision).startswith("worker-rev")
+    assert str(result.metadata["workerCodeRevision"]).startswith("worker-rev")
 
 
 class _FakeRunner:

--- a/tests/unit/workflows/temporal/test_worker_code_identity.py
+++ b/tests/unit/workflows/temporal/test_worker_code_identity.py
@@ -1,0 +1,527 @@
+"""Unit tests for stale worker code detection (MoonLadderStudios/MoonMind#4224)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Mapping
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
+from moonmind.workflows.adapters.base_external_agent_adapter import (
+    BaseExternalAgentAdapter,
+)
+from moonmind.workflows.skills.deployment_execution import DeploymentUpdateExecutor
+from moonmind.workflows.skills.deployment_execution import DeploymentUpdateLockManager
+from moonmind.workflows.skills.deployment_execution import InMemoryDesiredStateStore
+from moonmind.workflows.skills.deployment_execution import InMemoryEvidenceWriter
+from moonmind.workflows.skills.deployment_execution import ComposeVerification
+from moonmind.workflows.skills.tool_plan_contracts import ToolFailure
+from moonmind.workflows.temporal import worker_code_identity as wci
+from moonmind.workflows.temporal.worker_code_identity import (
+    WorkerCodeAdmissionError,
+    WorkerCodeIdentity,
+    collect_worker_code_freshness,
+    compare_code_identities,
+    compute_package_digest,
+    enforce_worker_code_admission,
+    evaluate_worker_freshness,
+    format_stale_code_message,
+    plan_stale_worker_recovery,
+    readiness_urls_from_env,
+    resolve_git_revision,
+    resolve_worker_code_identity,
+    stale_workers_only,
+)
+from moonmind.workflows.temporal.worker_healthcheck import (
+    WorkerHealthState,
+    _build_response_body,
+    start_healthcheck_server,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_digest_cache():
+    wci._digest_cache.clear()
+    wci._STARTUP_IDENTITY = None
+    yield
+    wci._digest_cache.clear()
+    wci._STARTUP_IDENTITY = None
+
+
+def _clear_code_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MOONMIND_BUILD_SHA", raising=False)
+    monkeypatch.delenv("MOONMIND_IMAGE_DIGEST", raising=False)
+    monkeypatch.delenv("MOONMIND_CODE_PACKAGE_ROOT", raising=False)
+
+
+def test_resolve_git_revision_prefers_build_sha_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "abc123")
+    revision, source = resolve_git_revision(repo_root=tmp_path)
+    assert revision == "abc123"
+    assert source == "MOONMIND_BUILD_SHA"
+
+
+def test_resolve_git_revision_unknown_outside_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_code_env(monkeypatch)
+    revision, source = resolve_git_revision(repo_root=tmp_path)
+    assert revision is None
+    assert source == "unknown"
+
+
+def test_compute_package_digest_detects_module_change(tmp_path) -> None:
+    module = tmp_path / "mod.py"
+    module.write_text("x = 1\n", encoding="utf-8")
+    first = compute_package_digest(tmp_path)
+    assert first is not None and first.startswith("sha256:")
+    module.write_text("x = 2\n", encoding="utf-8")
+    second = compute_package_digest(tmp_path)
+    assert second is not None and second != first
+
+
+def test_compare_equal_identities_is_healthy() -> None:
+    startup = WorkerCodeIdentity(revision="abc", digest="sha256:1", source="git")
+    current = WorkerCodeIdentity(revision="abc", digest="sha256:1", source="git")
+    assert compare_code_identities(startup, current) == "healthy"
+
+
+def test_compare_different_revision_is_stale() -> None:
+    startup = WorkerCodeIdentity(revision="old", digest="sha256:1", source="git")
+    current = WorkerCodeIdentity(revision="new", digest="sha256:1", source="git")
+    assert compare_code_identities(startup, current) == "stale"
+
+
+def test_compare_same_revision_changed_digest_is_stale() -> None:
+    startup = WorkerCodeIdentity(revision="abc", digest="sha256:1", source="git")
+    current = WorkerCodeIdentity(revision="abc", digest="sha256:2", source="git")
+    assert compare_code_identities(startup, current) == "stale"
+
+
+def test_compare_missing_startup_identity_is_unknown_not_healthy() -> None:
+    startup = WorkerCodeIdentity(revision=None, digest=None, source="unknown")
+    current = WorkerCodeIdentity(revision="abc", digest="sha256:1", source="git")
+    assert compare_code_identities(startup, current) == "unknown"
+
+
+def test_compare_missing_current_identity_is_unknown() -> None:
+    startup = WorkerCodeIdentity(revision="abc", digest="sha256:1", source="git")
+    current = WorkerCodeIdentity(revision=None, digest=None, source="unknown")
+    assert compare_code_identities(startup, current) == "unknown"
+
+
+def test_plan_stale_worker_recovery_splits_idle_and_busy() -> None:
+    plan = plan_stale_worker_recovery(["a", "b", "c"], busy=["b"])
+    assert plan.restart_now == ("a", "c")
+    assert plan.drain_then_restart == ("b",)
+
+
+def test_plan_stale_worker_recovery_never_kills_busy() -> None:
+    plan = plan_stale_worker_recovery(["busy-one"], busy=["busy-one"])
+    assert plan.restart_now == ()
+    assert plan.drain_then_restart == ("busy-one",)
+
+
+def test_admission_blocks_only_when_all_known_workers_stale() -> None:
+    checkout = WorkerCodeIdentity(revision="new", source="git")
+    stale = evaluate_worker_freshness(
+        name="workflow",
+        startup=WorkerCodeIdentity(revision="old", source="git"),
+        current=checkout,
+    )
+    blocked, items = stale_workers_only([stale])
+    assert blocked is True
+    assert [item.name for item in items] == ["workflow"]
+    with pytest.raises(WorkerCodeAdmissionError, match="stale_code"):
+        enforce_worker_code_admission([stale])
+
+
+def test_admission_fail_open_when_all_unknown() -> None:
+    unknown = evaluate_worker_freshness(
+        name="workflow",
+        startup=WorkerCodeIdentity(),
+        current=WorkerCodeIdentity(revision="new", source="git"),
+    )
+    assert unknown.status == "unknown"
+    blocked, _ = stale_workers_only([unknown])
+    assert blocked is False
+    assert enforce_worker_code_admission([unknown]) == []
+
+
+def test_admission_allows_mixed_healthy_and_stale() -> None:
+    checkout = WorkerCodeIdentity(revision="new", source="git")
+    healthy = evaluate_worker_freshness(
+        name="a", startup=WorkerCodeIdentity(revision="new", source="git"), current=checkout
+    )
+    stale = evaluate_worker_freshness(
+        name="b", startup=WorkerCodeIdentity(revision="old", source="git"), current=checkout
+    )
+    blocked, remaining = stale_workers_only([healthy, stale])
+    assert blocked is False
+    assert [item.name for item in remaining] == ["b"]
+
+
+def test_readiness_urls_from_env_supports_named_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "MOONMIND_WORKER_READINESS_URLS",
+        "workflow=http://w:8080/readyz, http://other:8080/readyz",
+    )
+    monkeypatch.delenv("TEMPORAL_WORKFLOW_READINESS_URL", raising=False)
+    assert readiness_urls_from_env() == [
+        ("workflow", "http://w:8080/readyz"),
+        ("http://other:8080/readyz", "http://other:8080/readyz"),
+    ]
+
+
+def test_collect_worker_code_freshness_reports_both_revisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "checkout-rev")
+    current = WorkerCodeIdentity(revision="checkout-rev", source="MOONMIND_BUILD_SHA")
+
+    def _probe(url: str) -> dict[str, Any]:
+        assert url == "http://w:8080/readyz"
+        return {"codeRevision": "startup-rev", "codeDigest": "sha256:x"}
+
+    freshness = collect_worker_code_freshness(
+        [("workflow", "http://w:8080/readyz")], current=current, probe=_probe
+    )
+    assert len(freshness) == 1
+    assert freshness[0].status == "stale"
+    assert freshness[0].startup_revision == "startup-rev"
+    assert freshness[0].current_revision == "checkout-rev"
+    message = format_stale_code_message(freshness)
+    assert "stale_code" in message and "workflow" in message
+
+
+def test_worker_health_state_missing_identity_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_code_env(monkeypatch)
+    state = WorkerHealthState(
+        temporal_connected=True, workers_constructed=True, pollers_started=True
+    )
+    payload = state.code_identity()
+    assert payload["codeRevision"] == "unknown"
+    assert payload["codeIdentityStatus"] == "unknown"
+
+
+def test_worker_health_state_reports_stale_with_both_revisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "checkout-rev")
+    state = WorkerHealthState(
+        temporal_connected=True,
+        workers_constructed=True,
+        pollers_started=True,
+        code_revision="startup-rev",
+        code_identity_source="git",
+    )
+    payload = state.code_identity()
+    assert payload["codeIdentityStatus"] == "stale"
+    assert payload["reasonCode"] == "stale_code"
+    assert payload["staleCode"]["startupRevision"] == "startup-rev"
+    # The checkout revision may carry a -dirty suffix when the working tree
+    # has uncommitted changes; the stale signal is what matters here.
+    assert payload["staleCode"]["currentRevision"].startswith("checkout-rev")
+
+
+def test_readiness_body_reports_stale_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "checkout-rev")
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "workflow")
+    state = WorkerHealthState(
+        temporal_connected=True,
+        workers_constructed=True,
+        pollers_started=True,
+        code_revision="startup-rev",
+        code_identity_source="git",
+    )
+    body = json.loads(_build_response_body(state, readiness=True))
+    assert body["codeRevision"] == "startup-rev"
+    assert body["codeIdentityStatus"] == "stale"
+    assert body["reasonCode"] == "stale_code"
+    assert body["staleCode"]["worker"] == "workflow"
+    assert body["staleCode"]["currentRevision"].startswith("checkout-rev")
+
+
+@pytest.mark.asyncio
+async def test_readyz_serves_503_while_stale_and_200_after_restart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_code_env(monkeypatch)
+    module = tmp_path / "worker_mod.py"
+    module.write_text("v = 1\n", encoding="utf-8")
+    monkeypatch.setenv("MOONMIND_CODE_PACKAGE_ROOT", str(tmp_path))
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "workflow")
+
+    startup = resolve_worker_code_identity(package_root=tmp_path)
+    state = WorkerHealthState(
+        temporal_connected=True,
+        workers_constructed=True,
+        pollers_started=True,
+        code_revision=startup.revision,
+        code_digest=startup.digest,
+        code_identity_source=startup.source,
+    )
+    server = await start_healthcheck_server(state)
+    assert server is not None
+    port = server.sockets[0].getsockname()[1]
+    loop = asyncio.get_running_loop()
+
+    def _get() -> tuple[int | None, dict[str, Any]]:
+        try:
+            raw = urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/readyz", timeout=5
+            ).read()
+            return None, json.loads(raw)
+        except urllib.error.HTTPError as exc:
+            return exc.code, json.loads(exc.read())
+
+    try:
+        code, body = await loop.run_in_executor(None, _get)
+        assert code is None, body
+        assert body["codeIdentityStatus"] == "healthy"
+
+        # Modify the bind-mounted module: the next readiness probe must report
+        # stale_code with both identities.
+        module.write_text("v = 2\n", encoding="utf-8")
+        wci._digest_cache.clear()
+        code, body = await loop.run_in_executor(None, _get)
+        assert code == 503, body
+        assert body["codeIdentityStatus"] == "stale"
+        assert body["reasonCode"] == "stale_code"
+        assert body["staleCode"]["startupRevision"] == (startup.revision or "unknown")
+        assert body["staleCode"]["currentRevision"] == (startup.revision or "unknown")
+        assert body["staleCode"]["worker"] == "workflow"
+
+        # A restart re-records the identity and clears the stale signal.
+        restarted = resolve_worker_code_identity(package_root=tmp_path)
+        state.code_revision = restarted.revision
+        state.code_digest = restarted.digest
+        state.code_identity_source = restarted.source
+        code, body = await loop.run_in_executor(None, _get)
+        assert code is None, body
+        assert body["codeIdentityStatus"] == "healthy"
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def test_agent_run_models_carry_worker_code_revision() -> None:
+    handle = AgentRunHandle(
+        runId="run-1",
+        agentKind="managed",
+        agentId="agent",
+        status="running",
+        startedAt="2026-09-11T00:00:00Z",
+        workerCodeRevision="abc123",
+    )
+    assert handle.worker_code_revision == "abc123"
+    assert handle.model_dump(by_alias=True)["workerCodeRevision"] == "abc123"
+
+    status = AgentRunStatus(
+        runId="run-1", agentKind="managed", agentId="agent", status="running"
+    )
+    assert status.worker_code_revision is None
+
+    result = AgentRunResult(workerCodeRevision="rev-2")
+    assert result.worker_code_revision == "rev-2"
+
+
+def test_base_adapter_builders_stamp_worker_code_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "worker-rev")
+    handle = BaseExternalAgentAdapter.build_handle(
+        run_id="r",
+        agent_id="jules",
+        status="running",
+        provider_status="ACTIVE",
+        normalized_status="running",
+    )
+    assert handle.worker_code_revision == "worker-rev"
+    assert handle.metadata["workerCodeRevision"] == "worker-rev"
+
+    status = BaseExternalAgentAdapter.build_status(
+        run_id="r",
+        agent_id="jules",
+        status="running",
+        provider_status="ACTIVE",
+        normalized_status="running",
+    )
+    assert status.worker_code_revision == "worker-rev"
+
+    result = BaseExternalAgentAdapter.build_result(
+        run_id="r",
+        provider_status="COMPLETE",
+        normalized_status="completed",
+        provider_name="Jules",
+    )
+    assert result.worker_code_revision == "worker-rev"
+    assert result.metadata["workerCodeRevision"] == "worker-rev"
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, tuple[str, ...]]] = []
+
+    async def capture_state(self, *, stack: str, phase: str) -> Mapping[str, Any]:
+        return {"stack": stack, "phase": phase}
+
+    async def pull(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
+        self.commands.append(("pull", command))
+        return {"exitCode": 0}
+
+    async def up(
+        self, *, stack: str, command: tuple[str, ...], requested_image: str
+    ) -> Mapping[str, Any]:
+        self.commands.append(("up", command))
+        return {"exitCode": 0}
+
+    async def inspect_image(self, requested_image: str) -> Mapping[str, Any]:
+        return {"Id": "sha256:" + "b" * 64, "RepoTags": [requested_image]}
+
+    async def verify(
+        self, *, stack: str, requested_image: str, resolved_digest: str | None
+    ) -> ComposeVerification:
+        return ComposeVerification(
+            succeeded=True,
+            updated_services=("api",),
+            running_services=({"name": "api", "state": "running"},),
+            details={},
+        )
+
+
+def _update_inputs() -> dict[str, Any]:
+    return {
+        "stack": "moonmind",
+        "image": {
+            "repository": "ghcr.io/moonladderstudios/moonmind",
+            "reference": "20260425.1234",
+        },
+        "mode": "changed_services",
+        "removeOrphans": True,
+        "wait": True,
+        "reason": "stale worker test",
+    }
+
+
+def _update_executor(
+    *,
+    checker=None,
+    restarter=None,
+) -> DeploymentUpdateExecutor:
+    return DeploymentUpdateExecutor(
+        lock_manager=DeploymentUpdateLockManager(),
+        desired_state_store=InMemoryDesiredStateStore(),
+        evidence_writer=InMemoryEvidenceWriter(),
+        runner=_FakeRunner(),  # type: ignore[arg-type]
+        stale_worker_checker=checker,
+        stale_worker_restarter=restarter,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_restarts_idle_stale_workers_and_succeeds() -> None:
+    seen: list[Sequence[Mapping[str, Any]]] = []
+
+    async def _checker() -> Sequence[Mapping[str, Any]]:
+        if seen:
+            return []
+        seen.append([{"worker": "workflow"}])
+        return [
+            {
+                "worker": "workflow",
+                "startupRevision": "old",
+                "currentRevision": "new",
+                "busy": False,
+            }
+        ]
+
+    restarted: list[str] = []
+
+    async def _restarter(stale: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+        restarted.extend(str(item["worker"]) for item in stale)
+        return {"restarted": list(restarted), "drained": [], "failed": []}
+
+    executor = _update_executor(checker=_checker, restarter=_restarter)
+    result = await executor.execute(_update_inputs())
+    assert result.status == "COMPLETED"
+    assert restarted == ["workflow"]
+
+
+@pytest.mark.asyncio
+async def test_update_drains_busy_stale_worker_rather_than_killing() -> None:
+    received_busy: list[bool] = []
+
+    async def _checker() -> Sequence[Mapping[str, Any]]:
+        if received_busy:
+            return []
+        received_busy.append(True)
+        return [
+            {
+                "worker": "workflow",
+                "startupRevision": "old",
+                "currentRevision": "new",
+                "busy": True,
+            }
+        ]
+
+    from moonmind.workflows.temporal.worker_code_identity import (
+        plan_stale_worker_recovery,
+    )
+
+    drained: list[str] = []
+    killed: list[str] = []
+
+    async def _restarter(stale: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+        plan = plan_stale_worker_recovery(
+            [str(item["worker"]) for item in stale],
+            busy=[
+                str(item["worker"])
+                for item in stale
+                if item.get("busy") is True
+            ],
+        )
+        assert plan.restart_now == ()
+        drained.extend(plan.drain_then_restart)
+        assert killed == []
+        return {"restarted": [], "drained": list(drained), "failed": []}
+
+    executor = _update_executor(checker=_checker, restarter=_restarter)
+    result = await executor.execute(_update_inputs())
+    assert result.status == "COMPLETED"
+    assert drained == ["workflow"]
+
+
+@pytest.mark.asyncio
+async def test_update_fails_loudly_without_restarter() -> None:
+    async def _checker() -> Sequence[Mapping[str, Any]]:
+        return [
+            {
+                "worker": "workflow",
+                "startupRevision": "old",
+                "currentRevision": "new",
+                "busy": False,
+            }
+        ]
+
+    executor = _update_executor(checker=_checker, restarter=None)
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_update_inputs())
+    assert exc_info.value.error_code == "DEPLOYMENT_STALE_WORKER_CODE"
+    assert "stale_code" in str(exc_info.value.details)

--- a/tests/unit/workflows/temporal/test_worker_code_identity.py
+++ b/tests/unit/workflows/temporal/test_worker_code_identity.py
@@ -49,10 +49,8 @@ from moonmind.workflows.temporal.worker_healthcheck import (
 
 @pytest.fixture(autouse=True)
 def _clear_digest_cache():
-    wci._digest_cache.clear()
     wci._STARTUP_IDENTITY = None
     yield
-    wci._digest_cache.clear()
     wci._STARTUP_IDENTITY = None
 
 
@@ -181,7 +179,20 @@ def test_readiness_urls_from_env_supports_named_entries(
     monkeypatch.delenv("TEMPORAL_WORKFLOW_READINESS_URL", raising=False)
     assert readiness_urls_from_env() == [
         ("workflow", "http://w:8080/readyz"),
-        ("http://other:8080/readyz", "http://other:8080/readyz"),
+        ("other", "http://other:8080/readyz"),
+    ]
+
+
+def test_readiness_urls_from_env_derives_hostname_for_bare_workflow_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MOONMIND_WORKER_READINESS_URLS", raising=False)
+    monkeypatch.setenv(
+        "TEMPORAL_WORKFLOW_READINESS_URL",
+        "http://temporal-worker-workflow:8080/readyz",
+    )
+    assert readiness_urls_from_env() == [
+        ("workflow", "http://temporal-worker-workflow:8080/readyz"),
     ]
 
 
@@ -302,7 +313,6 @@ async def test_readyz_serves_503_while_stale_and_200_after_restart(
         # Modify the bind-mounted module: the next readiness probe must report
         # stale_code with both identities.
         module.write_text("v = 2\n", encoding="utf-8")
-        wci._digest_cache.clear()
         code, body = await loop.run_in_executor(None, _get)
         assert code == 503, body
         assert body["codeIdentityStatus"] == "stale"
@@ -532,4 +542,168 @@ async def test_update_fails_loudly_without_restarter() -> None:
     with pytest.raises(ToolFailure) as exc_info:
         await executor.execute(_update_inputs())
     assert exc_info.value.error_code == "DEPLOYMENT_STALE_WORKER_CODE"
+
+
+def test_probe_worker_readiness_parses_503_stale_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 503 stale_code body must not degrade to unknown (fail-open bypass)."""
+
+    from moonmind.workflows.temporal.worker_code_identity import (
+        probe_worker_readiness,
+    )
+
+    body = json.dumps(
+        {
+            "codeRevision": "startup-rev",
+            "codeDigest": "sha256:x",
+            "codeIdentitySource": "git",
+            "codeIdentityStatus": "stale",
+            "reasonCode": "stale_code",
+        }
+    ).encode("utf-8")
+
+    http_error = urllib.error.HTTPError(
+        "http://w:8080/readyz",
+        503,
+        "Service Unavailable",
+        {},
+        __import__("io").BytesIO(body),
+    )
+
+    class _FailingOpener:
+        def open(self, request, timeout=None):
+            raise http_error
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.worker_code_identity._no_proxy_opener",
+        lambda: _FailingOpener(),
+    )
+    payload = probe_worker_readiness("http://w:8080/readyz")
+    assert payload is not None
+    assert payload["codeIdentityStatus"] == "stale"
+    assert payload["codeRevision"] == "startup-rev"
+
+
+def test_collect_worker_code_freshness_expands_group_children_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor envelope (children, no top-level identity) per-lane."""
+
+    monkeypatch.setenv("MOONMIND_BUILD_SHA", "checkout-rev")
+    current = WorkerCodeIdentity(revision="checkout-rev", source="MOONMIND_BUILD_SHA")
+
+    def _probe(url: str) -> dict[str, Any]:
+        assert url == "http://group:8080/readyz"
+        return {
+            "status": "unhealthy",
+            "children": [
+                {
+                    "fleet": "workflow",
+                    "codeRevision": "checkout-rev",
+                    "codeDigest": "sha256:x",
+                    "codeIdentitySource": "MOONMIND_BUILD_SHA",
+                },
+                {
+                    "fleet": "workflow",
+                    "codeRevision": "startup-rev",
+                    "codeDigest": "sha256:y",
+                    "codeIdentitySource": "MOONMIND_BUILD_SHA",
+                },
+            ],
+        }
+
+    freshness = collect_worker_code_freshness(
+        [("workflow", "http://group:8080/readyz")], current=current, probe=_probe
+    )
+    assert len(freshness) == 2
+    by_name = {item.name: item.status for item in freshness}
+    assert by_name["workflow/workflow"] == "healthy"
+    assert by_name["workflow/workflow-1"] == "stale"
+
+
+def test_current_worker_code_revision_falls_back_to_digest() -> None:
+    from moonmind.workflows.temporal.worker_code_identity import (
+        current_worker_code_revision,
+    )
+
+    wci._STARTUP_IDENTITY = WorkerCodeIdentity(
+        revision=None, digest="sha256:abc", source="package-digest"
+    )
+    assert current_worker_code_revision() == "sha256:abc"
+    wci._STARTUP_IDENTITY = WorkerCodeIdentity()
+    assert current_worker_code_revision() == "unknown"
+
+
+def test_payload_busy_hint_is_conservative() -> None:
+    from moonmind.workflows.temporal.worker_code_identity import payload_busy_hint
+
+    assert payload_busy_hint({}) is True
+    assert payload_busy_hint({"busy": True}) is True
+    assert payload_busy_hint({"busy": False}) is False
+    assert payload_busy_hint({"busy": False, "activeActivities": 2}) is True
+    assert payload_busy_hint({"children": [{"busy": False}]}) is False
+    assert payload_busy_hint({"children": [{}, {"busy": False}]}) is True
+
+
+def test_compose_service_for_worker_maps_lanes_and_hostnames() -> None:
+    from moonmind.workflows.skills.deployment_execution import (
+        _compose_service_for_worker,
+    )
+
+    assert _compose_service_for_worker("workflow") == "temporal-worker-workflow"
+    assert (
+        _compose_service_for_worker("workflow/workflow-1")
+        == "temporal-worker-workflow"
+    )
+    assert (
+        _compose_service_for_worker("temporal-worker-workflow")
+        == "temporal-worker-workflow"
+    )
+    assert _compose_service_for_worker("http://w:8080/readyz") is None
+
+
+@pytest.mark.asyncio
+async def test_update_fails_when_restarted_worker_stays_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-restart unknown is not success: bounded recheck then loud failure."""
+
+    async def _no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    calls: list[int] = []
+
+    async def _checker() -> Sequence[Mapping[str, Any]]:
+        calls.append(1)
+        if len(calls) == 1:
+            return [
+                {
+                    "worker": "workflow",
+                    "status": "stale",
+                    "startupRevision": "old",
+                    "currentRevision": "new",
+                    "busy": True,
+                }
+            ]
+        return [
+            {
+                "worker": "workflow",
+                "status": "unknown",
+                "startupRevision": "unknown",
+                "currentRevision": "new",
+                "busy": True,
+            }
+        ]
+
+    async def _restarter(stale: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+        return {"restarted": ["workflow"], "drained": [], "failed": []}
+
+    executor = _update_executor(checker=_checker, restarter=_restarter)
+    with pytest.raises(ToolFailure) as exc_info:
+        await executor.execute(_update_inputs())
+    assert exc_info.value.error_code == "DEPLOYMENT_STALE_WORKER_CODE"
+    assert len(calls) >= 3  # initial check + bounded post-restart rechecks
     assert "stale_code" in str(exc_info.value.details)


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4224: workers running stale modules after a host code update (bind-mounted source + long-lived processes) are now detected and restarted before new runs are admitted.

- Every worker records a startup code identity (git revision with dirty flag, or a content digest of the imported `moonmind` package) and exposes it through the worker heartbeat/health projection; a missing identity is reported as `unknown`, never healthy.
- New readiness check: API `/healthz` detail aggregates `workerCodeFreshness`, worker `/readyz` compares the recorded identity with the on-disk checkout revision and reports `reasonCode=stale_code` (HTTP 503) with the worker name and both revisions. A `moonmind worker code-readiness` CLI probes the same endpoints.
- Documented update path (`docs/Steps/DockerComposeUpdateSystem.md` 10.10: a host `git pull` alone is not a deployment) plus the deployment-execution worker: idle stale workers are restarted, busy ones are drained (never killed), and the update fails loudly (`DEPLOYMENT_STALE_WORKER_CODE`) when it cannot restart. UserWorkflow admission refuses task queues served only by stale workers.
- Worker code identity is stamped into AgentRun (`workerCodeRevision` on handle/status/result + metadata) and UserWorkflow admission memos for post-incident analysis.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (HIGH confidence) at candidate revision `bdcb9fae0`; no gaps, no remaining work. Initial assessment was NOT_IMPLEMENTED, so this implementation is published even though the work branch was already pushed.

## Tests run

- Unit (managed container): `moonmind container python-tests tests/unit/workflows/temporal/test_worker_code_identity.py` — **24 passed** (heartbeat-unknown, stale-with-both-revisions, readiness-body `stale_code`, hermetic socket 503-while-stale/200-after-restart, admission gates, idle-restart/busy-drain/loud-failure update tests, AgentRun metadata stamping).
- Integration: `tests/integration/temporal/test_worker_stale_code_readiness.py` (marked `integration_ci`, exercises the real readiness endpoint over a bind-mounted module change) exists and mirrors the passing hermetic assertions; **not executed in this sandbox** (compose execution advisory) — covered by required CI.

## Remaining risks

- The compose-backed stale-code journey has not been executed outside CI; if CI flags environment-specific readiness-probe behavior (e.g. egress proxy handling for cluster-local URLs), the probe path is isolated in `worker_code_identity.probe_worker_readiness`.
- Busy-worker drain depends on the deployment restarter capability; without it the update fails loudly rather than silently proceeding — by design, but operators should confirm the restarter is wired in their deployment.

Closes MoonLadderStudios/MoonMind#4224