### PR TITLE
[Merge automation] Route pr-resolver next_step and stop identical blocked cycles (MoonLadderStudios/MoonMind#4223)

### DIFF
--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -669,6 +669,24 @@ class MoonMindMergeAutomationWorkflow:
         self._resolver_verdict_cycles.append(cycle)
         return cycle
 
+    @staticmethod
+    def _normalize_remediation_artifact_ref(value: Any) -> str:
+        """Normalize a terminal evidence ref to an ``artifact://`` ref.
+
+        The runtime materializer only recognizes top-level ``gateResultRef`` /
+        ``remainingWorkRef`` values using the ``artifact://`` scheme, while the
+        ``remediate-issue`` Skill requires materialized local paths and stops
+        when it receives only an unreadable reference.
+        """
+
+        candidate = str(value or "").strip()
+        if not candidate:
+            return ""
+        if candidate.startswith("artifact://"):
+            remainder = candidate.removeprefix("artifact://").strip()
+            return candidate if remainder else ""
+        return f"artifact://{candidate}"
+
     def _build_remediation_run_request(
         self,
         *,
@@ -677,42 +695,82 @@ class MoonMindMergeAutomationWorkflow:
     ) -> dict[str, Any]:
         """Build a bounded remediate-issue child request from Skill evidence.
 
-        The Skill's validated evidence ref becomes the remediation
-        ``remainingWorkPath``; MoonMind only routes, it never reclassifies the
-        blocker or invents a fix plan.
+        The Skill's validated evidence ref is routed through the supported
+        ``gateResultRef`` / ``remainingWorkRef`` fields so the Activity can
+        materialize it, and the child runs in the authoritative PR-head
+        workspace with a workflow-owned publication handoff. MoonMind only
+        routes, it never reclassifies the blocker or invents a fix plan.
         """
 
         pr = self._input.pull_request if self._input is not None else None
+        evidence_ref = self._normalize_remediation_artifact_ref(
+            verdict.get("terminalContractEvidenceRef")
+        )
+        head_sha = str(verdict.get("headSha") or "").strip()
+        final_reason = str(verdict.get("finalReason") or "").strip()
+        repo = pr.repo if pr is not None else ""
+        head_branch = (
+            str(pr.head_branch or "").strip()
+            if pr is not None and pr.head_branch
+            else ""
+        )
+        base_branch = (
+            str(pr.base_branch or "").strip()
+            if pr is not None and pr.base_branch
+            else ""
+        )
+        target_branch = head_branch or base_branch
+        initial_parameters: dict[str, Any] = {
+            "repository": repo,
+            "repo": repo,
+            "publishMode": "auto",
+            "task": {
+                "instructions": (
+                    "Apply the bounded remediate-issue Skill contract to the "
+                    "validated pr-resolver terminal evidence. "
+                    f"Reason: {final_reason or 'unknown'}. "
+                    "Do not reimplement Skill semantics."
+                ),
+                "tool": {"type": "skill", "name": "remediate-issue"},
+                "skill": {
+                    "id": "remediate-issue",
+                    "args": {
+                        "gateResultRef": evidence_ref,
+                        "remainingWorkRef": evidence_ref,
+                        "remainingWorkPath": str(
+                            verdict.get("terminalContractEvidenceRef") or ""
+                        ),
+                        "headSha": head_sha,
+                        "finalReason": final_reason,
+                        "resolverChildWorkflowId": resolver_workflow_id,
+                    },
+                },
+                "publish": {"mode": "auto"},
+            },
+            "workspaceSpec": {
+                "repository": repo,
+                "branch": head_branch,
+                "startingBranch": base_branch or target_branch,
+                "targetBranch": target_branch,
+            },
+        }
+        if evidence_ref:
+            initial_parameters["gateResultRef"] = evidence_ref
+            initial_parameters["remainingWorkRef"] = evidence_ref
+        if pr is not None:
+            initial_parameters["mergeGate"] = {
+                "parentWorkflowId": self._resolver_parent_workflow_id(),
+                "pullRequestUrl": pr.url,
+                "headSha": head_sha or pr.head_sha,
+            }
         return {
             "workflowType": "MoonMind.UserWorkflow",
             "parentWorkflowId": self._resolver_parent_workflow_id(),
             "title": (
-                f"Remediate {verdict.get('finalReason') or 'pr-resolver blocker'} "
+                f"Remediate {final_reason or 'pr-resolver blocker'} "
                 f"for PR #{pr.number if pr is not None else '?'}"
             ),
-            "initial_parameters": {
-                "repository": pr.repo if pr is not None else "",
-                "task": {
-                    "instructions": (
-                        "Apply the bounded remediate-issue Skill contract to the "
-                        "validated pr-resolver terminal evidence. "
-                        f"Reason: {verdict.get('finalReason') or 'unknown'}. "
-                        "Do not reimplement Skill semantics."
-                    ),
-                    "tool": {"type": "skill", "name": "remediate-issue"},
-                    "skill": {
-                        "id": "remediate-issue",
-                        "args": {
-                            "remainingWorkPath": str(
-                                verdict.get("terminalContractEvidenceRef") or ""
-                            ),
-                            "headSha": str(verdict.get("headSha") or ""),
-                            "finalReason": str(verdict.get("finalReason") or ""),
-                            "resolverChildWorkflowId": resolver_workflow_id,
-                        },
-                    },
-                },
-            },
+            "initial_parameters": initial_parameters,
         }
 
     async def _run_bounded_remediation(

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -98,6 +98,17 @@ MERGE_AUTOMATION_OMNIGENT_RESOLVER_PLAN_PATCH = (
 # original gate decisions.
 MERGE_AUTOMATION_REVIEW_LOOP_PATCH = "merge-automation-review-loop-v1"
 MAX_PUBLISHED_REVIEW_CYCLES = 20
+# Typed routing for validated pr-resolver terminal verdicts
+# (MoonLadderStudios/MoonMind#4223). Guarded so histories recorded before the
+# policy existed keep replaying the legacy immediate-fail gate decision.
+MERGE_AUTOMATION_PR_RESOLVER_VERDICT_ROUTING_PATCH = (
+    "merge-automation-pr-resolver-verdict-routing-v1"
+)
+NEXT_STEP_RUN_FULL_REMEDIATION = "run_full_remediation"
+NEXT_STEP_RETRY_FINALIZE_AFTER_BACKOFF = "retry_finalize_after_backoff"
+NEXT_STEP_MANUAL_REVIEW = "manual_review"
+NEXT_STEP_ATTEMPTS_EXHAUSTED = "attempts_exhausted"
+MAX_PUBLISHED_RESOLVER_VERDICT_CYCLES = 20
 RESOLVER_ISSUE_RECOVERY_NONE = "none"
 RESOLVER_ISSUE_RECOVERY_COMPLETED = "completed"
 RESOLVER_ISSUE_RECOVERY_REENTER_GATE = "reenter_gate"
@@ -149,6 +160,12 @@ class MoonMindMergeAutomationWorkflow:
         self._last_progress_signature: str | None = None
         self._no_progress_cycles = 0
         self._summary: str | None = None
+        # Validated pr-resolver verdict routing (#4223): one record per
+        # resolver child, bounded by verdict+reason+head progress.
+        self._resolver_verdict_cycles: list[dict[str, Any]] = []
+        self._resolver_verdict_stop_reason: str | None = None
+        self._remediation_child_workflow_ids: list[str] = []
+        self._verdict_routing_enabled = False
 
     def _summary_payload(self) -> dict[str, Any]:
         pr = self._input.pull_request if self._input is not None else None
@@ -201,6 +218,20 @@ class MoonMindMergeAutomationWorkflow:
             }
         if self._continuation_observability_enabled:
             payload["continuationCounters"] = dict(self._continuation_counters)
+        if self._verdict_routing_enabled or self._resolver_verdict_cycles:
+            payload["resolverVerdictCycles"] = [
+                dict(cycle)
+                for cycle in self._resolver_verdict_cycles[
+                    -MAX_PUBLISHED_RESOLVER_VERDICT_CYCLES:
+                ]
+            ]
+            payload["remediationChildWorkflowIds"] = list(
+                self._remediation_child_workflow_ids
+            )
+            if self._resolver_verdict_stop_reason:
+                payload["resolverVerdictStopReason"] = (
+                    self._resolver_verdict_stop_reason
+                )
         if self._summary:
             payload["summary"] = self._summary
         if self._post_merge_jira_result is not None:
@@ -420,6 +451,18 @@ class MoonMindMergeAutomationWorkflow:
                 "mergeAutomationDisposition": result.get("mergeAutomationDisposition"),
                 "headSha": result.get("headSha"),
             }
+            if self._verdict_routing_enabled:
+                verdict = self._pr_resolver_verdict(result)
+                for key in (
+                    "prResolverStatus",
+                    "finalReason",
+                    "nextStep",
+                    "terminalContractEvidenceRef",
+                    "retryAfterSeconds",
+                    "prResolverVerdictSummary",
+                ):
+                    if verdict.get(key) is not None:
+                        payload["result"][key] = verdict.get(key)
             continuation = result.get("gatedContinuation")
             if isinstance(continuation, Mapping):
                 normalized = {
@@ -496,6 +539,366 @@ class MoonMindMergeAutomationWorkflow:
         if not isinstance(resolver_result, Mapping):
             return ""
         return str(resolver_result.get("mergeAutomationDisposition") or "").strip()
+
+    @staticmethod
+    def _compact_verdict_text(value: Any, *, max_chars: int = 500) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            return ""
+        if len(candidate) > max_chars:
+            return candidate[: max_chars - 3].rstrip() + "..."
+        return candidate
+
+    @classmethod
+    def _pr_resolver_verdict(cls, resolver_result: Mapping[str, Any]) -> dict[str, Any]:
+        """Project the Skill's validated terminal verdict without reinterpreting it.
+
+        Only the verdict facts the Skill wrote are carried (status, reason,
+        next step, evidence ref, retry delay, head). MoonMind routes on these
+        values; it never reclassifies the blocker or selects a different fix.
+        """
+
+        status = cls._compact_verdict_text(
+            resolver_result.get("prResolverStatus")
+            or resolver_result.get("pr_resolver_status")
+            or resolver_result.get("status"),
+            max_chars=80,
+        )
+        reason = cls._compact_verdict_text(
+            resolver_result.get("prResolverReason")
+            or resolver_result.get("pr_resolver_reason")
+            or resolver_result.get("final_reason")
+            or resolver_result.get("finalReason")
+            or resolver_result.get("reason"),
+            max_chars=500,
+        )
+        next_step = cls._compact_verdict_text(
+            resolver_result.get("prResolverNextStep")
+            or resolver_result.get("pr_resolver_next_step")
+            or resolver_result.get("next_step")
+            or resolver_result.get("nextStep"),
+            max_chars=80,
+        )
+        head_sha = cls._compact_verdict_text(
+            resolver_result.get("headSha")
+            or resolver_result.get("head_sha")
+            or resolver_result.get("latestHeadSha"),
+            max_chars=80,
+        )
+        evidence_ref = cls._compact_verdict_text(
+            resolver_result.get("terminalContractEvidenceRef")
+            or resolver_result.get("terminal_contract_evidence_ref"),
+            max_chars=200,
+        )
+        retry_after: int | None = None
+        for key in (
+            "retryAfterSeconds",
+            "retry_after_seconds",
+            "prResolverRetryAfterSeconds",
+        ):
+            raw = resolver_result.get(key)
+            if raw is None or isinstance(raw, bool):
+                continue
+            try:
+                candidate = int(raw) if not isinstance(raw, int) else raw
+            except (TypeError, ValueError):
+                continue
+            if candidate >= 1:
+                retry_after = candidate
+                break
+        if retry_after is None:
+            continuation = resolver_result.get("gatedContinuation")
+            if isinstance(continuation, Mapping):
+                raw = continuation.get("retryAfterSeconds")
+                if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 1:
+                    retry_after = raw
+        summary = cls._compact_verdict_text(
+            resolver_result.get("prResolverVerdictSummary")
+            or resolver_result.get("summary"),
+            max_chars=1600,
+        )
+        verdict: dict[str, Any] = {}
+        if status:
+            verdict["prResolverStatus"] = status
+        if reason:
+            verdict["finalReason"] = reason
+        if next_step:
+            verdict["nextStep"] = next_step
+        if head_sha:
+            verdict["headSha"] = head_sha
+        if evidence_ref:
+            verdict["terminalContractEvidenceRef"] = evidence_ref
+        if retry_after is not None:
+            verdict["retryAfterSeconds"] = retry_after
+        if summary:
+            verdict["prResolverVerdictSummary"] = summary
+        return verdict
+
+    @staticmethod
+    def _resolver_verdict_signature(verdict: Mapping[str, Any]) -> str:
+        """Bound cycles by progress: identical verdict+reason+head means no progress."""
+
+        status = str(verdict.get("prResolverStatus") or "").strip().lower()
+        reason = str(verdict.get("finalReason") or "").strip().lower()
+        head = str(verdict.get("headSha") or "").strip().lower()
+        return f"{status}|{reason}|{head}"
+
+    def _record_resolver_verdict_cycle(
+        self,
+        *,
+        resolver_workflow_id: str,
+        disposition: str,
+        verdict: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        cycle = {
+            "cycle": len(self._resolver_verdict_cycles) + 1,
+            "resolverChildWorkflowId": resolver_workflow_id,
+            "disposition": disposition,
+            "headSha": str(verdict.get("headSha") or ""),
+            "prResolverStatus": str(verdict.get("prResolverStatus") or ""),
+            "finalReason": str(verdict.get("finalReason") or ""),
+            "nextStep": str(verdict.get("nextStep") or ""),
+            "terminalContractEvidenceRef": str(
+                verdict.get("terminalContractEvidenceRef") or ""
+            ),
+        }
+        if verdict.get("retryAfterSeconds") is not None:
+            cycle["retryAfterSeconds"] = verdict.get("retryAfterSeconds")
+        if verdict.get("prResolverVerdictSummary"):
+            cycle["summary"] = verdict.get("prResolverVerdictSummary")
+        self._resolver_verdict_cycles.append(cycle)
+        return cycle
+
+    def _build_remediation_run_request(
+        self,
+        *,
+        verdict: Mapping[str, Any],
+        resolver_workflow_id: str,
+    ) -> dict[str, Any]:
+        """Build a bounded remediate-issue child request from Skill evidence.
+
+        The Skill's validated evidence ref becomes the remediation
+        ``remainingWorkPath``; MoonMind only routes, it never reclassifies the
+        blocker or invents a fix plan.
+        """
+
+        pr = self._input.pull_request if self._input is not None else None
+        return {
+            "workflowType": "MoonMind.UserWorkflow",
+            "parentWorkflowId": self._resolver_parent_workflow_id(),
+            "title": (
+                f"Remediate {verdict.get('finalReason') or 'pr-resolver blocker'} "
+                f"for PR #{pr.number if pr is not None else '?'}"
+            ),
+            "initial_parameters": {
+                "repository": pr.repo if pr is not None else "",
+                "task": {
+                    "instructions": (
+                        "Apply the bounded remediate-issue Skill contract to the "
+                        "validated pr-resolver terminal evidence. "
+                        f"Reason: {verdict.get('finalReason') or 'unknown'}. "
+                        "Do not reimplement Skill semantics."
+                    ),
+                    "tool": {"type": "skill", "name": "remediate-issue"},
+                    "skill": {
+                        "id": "remediate-issue",
+                        "args": {
+                            "remainingWorkPath": str(
+                                verdict.get("terminalContractEvidenceRef") or ""
+                            ),
+                            "headSha": str(verdict.get("headSha") or ""),
+                            "finalReason": str(verdict.get("finalReason") or ""),
+                            "resolverChildWorkflowId": resolver_workflow_id,
+                        },
+                    },
+                },
+            },
+        }
+
+    async def _run_bounded_remediation(
+        self,
+        *,
+        verdict: Mapping[str, Any],
+        resolver_workflow_id: str,
+    ) -> None:
+        remediation_request = self._build_remediation_run_request(
+            verdict=verdict,
+            resolver_workflow_id=resolver_workflow_id,
+        )
+        remediation_workflow_id = f"{resolver_workflow_id}:remediation"
+        self._remediation_child_workflow_ids.append(remediation_workflow_id)
+        try:
+            remediation_result = await workflow.execute_child_workflow(
+                "MoonMind.UserWorkflow",
+                remediation_request,
+                id=remediation_workflow_id,
+                task_queue=self._workflow_child_task_queue(),
+                search_attributes=self._resolver_search_attributes(),
+                cancellation_type=ChildWorkflowCancellationType.TRY_CANCEL,
+                static_summary="Bounded pr-resolver remediation for merge automation",
+                static_details=(
+                    f"Remediate {verdict.get('finalReason') or 'pr-resolver blocker'}"
+                ),
+            )
+        except CancelledError:
+            raise
+        except Exception:
+            # A failed remediation step must not mask the Skill's validated
+            # verdict; the gate re-opens and the progress bound decides.
+            return
+        if isinstance(remediation_result, Mapping):
+            self._refresh_tracked_head_sha(remediation_result)
+
+    async def _wait_for_pr_resolver_backoff(self, *, retry_after_seconds: int) -> None:
+        try:
+            await workflow.sleep(timedelta(seconds=int(retry_after_seconds)))
+        except CancelledError:
+            raise
+        except Exception as exc:
+            # Direct unit-boundary tests invoke run() without a Temporal
+            # event loop. Production histories always use the timer above.
+            if type(exc).__name__ != "_NotInWorkflowEventLoopError":
+                raise
+
+    def _skill_verdict_summary(
+        self, *, verdict: Mapping[str, Any], disposition: str
+    ) -> str:
+        explicit = str(verdict.get("prResolverVerdictSummary") or "").strip()
+        if explicit:
+            return explicit
+        status = str(verdict.get("prResolverStatus") or "").strip()
+        reason = str(verdict.get("finalReason") or "").strip()
+        next_step = str(verdict.get("nextStep") or "").strip()
+        if status or reason or next_step:
+            parts = [f"pr-resolver reported status '{status or 'unknown'}'"]
+            if reason:
+                parts.append(reason)
+            if next_step:
+                parts.append(f"next_step={next_step}")
+            return "; ".join(parts)
+        if disposition == DISPOSITION_MANUAL_REVIEW:
+            return "pr-resolver requested manual review."
+        return "pr-resolver reported failure."
+
+    async def _route_pr_resolver_terminal(
+        self,
+        *,
+        resolver_result: Mapping[str, Any],
+        resolver_workflow_id: str,
+        resolver_disposition: str,
+    ) -> dict[str, Any] | None:
+        """Route a validated terminal verdict; None means re-enter the gate.
+
+        One typed policy (MoonLadderStudios/MoonMind#4223):
+        - ``run_full_remediation`` → one bounded remediate-issue child, then
+          re-enter the gate on the (possibly new) head.
+        - ``retry_finalize_after_backoff`` → wait the Skill-supplied
+          ``retryAfterSeconds`` with no agent launch, then re-enter.
+        - ``manual_review``/``attempts_exhausted`` (or unrecognized) → stop
+          with the Skill's summary.
+        Cycles are bounded by progress, not count: an identical
+        verdict+reason+head to the previous cycle stops instead of launching
+        another resolver.
+        """
+
+        verdict = self._pr_resolver_verdict(resolver_result)
+        # Fall back to the tracked head when the child omits it so progress
+        # bounding still compares the revision the gate acted on.
+        if not verdict.get("headSha") and self._input is not None:
+            tracked = str(self._input.pull_request.head_sha or "").strip()
+            if tracked:
+                verdict = {**verdict, "headSha": tracked}
+        cycle = self._record_resolver_verdict_cycle(
+            resolver_workflow_id=resolver_workflow_id,
+            disposition=resolver_disposition,
+            verdict=verdict,
+        )
+        # Keep the gate's tracked head aligned with the revision the Skill
+        # actually evaluated before any routing decision.
+        self._refresh_tracked_head_sha(resolver_result)
+        signature = self._resolver_verdict_signature(verdict)
+        if len(self._resolver_verdict_cycles) >= 2:
+            previous = self._resolver_verdict_cycles[-2]
+            previous_signature = self._resolver_verdict_signature(previous)
+            if signature and signature == previous_signature:
+                self._resolver_verdict_stop_reason = (
+                    "identical_verdict_head_no_progress"
+                )
+                cycle["stopReason"] = self._resolver_verdict_stop_reason
+                return await self._failed_resolver_summary(
+                    summary=self._skill_verdict_summary(
+                        verdict=verdict, disposition=resolver_disposition
+                    ),
+                    blocker_kind=resolver_disposition,
+                )
+        next_step = str(verdict.get("nextStep") or "").strip().lower()
+        if next_step == NEXT_STEP_RUN_FULL_REMEDIATION:
+            await self._run_bounded_remediation(
+                verdict=verdict,
+                resolver_workflow_id=resolver_workflow_id,
+            )
+            self._status = STATE_WAITING
+            self._publish_visibility()
+            return None
+        if next_step == NEXT_STEP_RETRY_FINALIZE_AFTER_BACKOFF:
+            retry_after = verdict.get("retryAfterSeconds")
+            if not isinstance(retry_after, int) or retry_after < 1:
+                retry_after = (
+                    self._input.config.timeouts.fallback_poll_seconds
+                    if self._input is not None
+                    else 300
+                )
+            self._resolver_verdict_stop_reason = None
+            cycle["waitedRetryAfterSeconds"] = retry_after
+            self._status = STATE_WAITING
+            self._summary = (
+                "pr-resolver requested a finalize retry after backoff; "
+                f"waiting {retry_after}s before re-entering the gate."
+            )
+            self._publish_visibility()
+            await self._wait_for_pr_resolver_backoff(
+                retry_after_seconds=int(retry_after)
+            )
+            return None
+        # ``manual_review``/``attempts_exhausted`` (or any unrecognized
+        # next_step) stops the cycle with the Skill's summary.
+        has_verdict_facts = any(
+            str(resolver_result.get(key) or "").strip()
+            for key in (
+                "prResolverStatus",
+                "prResolverReason",
+                "prResolverNextStep",
+                "final_reason",
+                "finalReason",
+                "next_step",
+                "nextStep",
+                "terminalContractEvidenceRef",
+                "retryAfterSeconds",
+                "prResolverVerdictSummary",
+            )
+        )
+        if not has_verdict_facts:
+            if resolver_disposition == DISPOSITION_MANUAL_REVIEW:
+                self._resolver_verdict_stop_reason = "manual_review"
+                return await self._failed_resolver_summary(
+                    summary="pr-resolver requested manual review.",
+                    blocker_kind=DISPOSITION_MANUAL_REVIEW,
+                )
+            self._resolver_verdict_stop_reason = "failed"
+            return await self._failed_resolver_summary(
+                summary="pr-resolver reported failure.",
+                blocker_kind=DISPOSITION_FAILED,
+            )
+        self._resolver_verdict_stop_reason = (
+            next_step if next_step else resolver_disposition
+        )
+        cycle["stopReason"] = self._resolver_verdict_stop_reason
+        return await self._failed_resolver_summary(
+            summary=self._skill_verdict_summary(
+                verdict=verdict, disposition=resolver_disposition
+            ),
+            blocker_kind=resolver_disposition,
+        )
 
     def _continuation_deadline(
         self, resolver_result: Mapping[str, Any], *, resolver_workflow_id: str
@@ -1231,6 +1634,9 @@ class MoonMindMergeAutomationWorkflow:
         self._review_loop_enabled = workflow.patched(
             MERGE_AUTOMATION_REVIEW_LOOP_PATCH
         )
+        self._verdict_routing_enabled = workflow.patched(
+            MERGE_AUTOMATION_PR_RESOLVER_VERDICT_ROUTING_PATCH
+        )
         self._review_cycles = [
             cycle.model_dump(by_alias=True, mode="json")
             for cycle in self._input.review_cycles
@@ -1570,11 +1976,33 @@ class MoonMindMergeAutomationWorkflow:
                     self._publish_visibility()
                     return await self._finish()
                 if resolver_disposition == DISPOSITION_MANUAL_REVIEW:
+                    if self._verdict_routing_enabled:
+                        routed = await self._route_pr_resolver_terminal(
+                            resolver_result=resolver_result
+                            if isinstance(resolver_result, Mapping)
+                            else {},
+                            resolver_workflow_id=resolver_workflow_id,
+                            resolver_disposition=resolver_disposition,
+                        )
+                        if routed is not None:
+                            return routed
+                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver requested manual review.",
                         blocker_kind=DISPOSITION_MANUAL_REVIEW,
                     )
                 if resolver_disposition == DISPOSITION_FAILED:
+                    if self._verdict_routing_enabled:
+                        routed = await self._route_pr_resolver_terminal(
+                            resolver_result=resolver_result
+                            if isinstance(resolver_result, Mapping)
+                            else {},
+                            resolver_workflow_id=resolver_workflow_id,
+                            resolver_disposition=resolver_disposition,
+                        )
+                        if routed is not None:
+                            return routed
+                        continue
                     return await self._failed_resolver_summary(
                         summary="pr-resolver reported failure.",
                         blocker_kind=DISPOSITION_FAILED,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -17315,7 +17315,13 @@ class MoonMindRunWorkflow:
         )
         if merge_automation_head_sha:
             self._merge_automation_head_sha = merge_automation_head_sha
-        self._record_pr_resolver_verdict_context(outputs)
+        # Guard the verdict-state mutation behind the propagation patch so
+        # histories recorded before run-pr-resolver-verdict-propagation-v1
+        # replay without emitting different memo/finalization arguments.
+        if self._patched_or_false_outside_workflow(
+            RUN_PR_RESOLVER_VERDICT_PROPAGATION_PATCH
+        ):
+            self._record_pr_resolver_verdict_context(outputs)
 
         publish_branch = self._coerce_text(
             outputs.get("push_branch") or outputs.get("branch"),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -424,6 +424,7 @@ RUN_AUTO_PUBLISH_METADATA_EVIDENCE_PATCH = "run-auto-publish-metadata-evidence-v
 RUN_CHECKPOINT_RECOVERY_STATE_MACHINE_PATCH = "run-checkpoint-recovery-state-machine-v1"
 RUN_PR_RESOLVER_OWNED_CONTINUATION_PATCH = "run-pr-resolver-owned-continuation-v1"
 RUN_PR_RESOLVER_CONTINUATION_IDENTITY_PATCH = "run-pr-resolver-continuation-identity-v1"
+RUN_PR_RESOLVER_VERDICT_PROPAGATION_PATCH = "run-pr-resolver-verdict-propagation-v1"
 _JIRA_ISSUE_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
 _JIRA_BACKED_AGENT_SKILLS = frozenset({"jira-implement", *JIRA_BACKED_AGENT_SKILLS})
 _PLAIN_TEXT_BLOCKED_OUTCOME_PATTERN = re.compile(
@@ -1627,6 +1628,15 @@ class MoonMindRunWorkflow:
         self._merge_automation_head_sha: Optional[str] = None
         self._gated_continuation_request: Optional[dict[str, Any]] = None
         self._gated_continuation_execution_ref: Optional[str] = None
+        # Validated pr-resolver terminal verdict facts (MoonLadderStudios/MoonMind#4223).
+        # Projected from the flattened terminal-contract outputs without
+        # reinterpreting Skill semantics; consumed by the owning
+        # MoonMind.MergeAutomation gate for typed next_step routing.
+        self._pr_resolver_status: Optional[str] = None
+        self._pr_resolver_reason: Optional[str] = None
+        self._pr_resolver_next_step: Optional[str] = None
+        self._terminal_contract_evidence_ref: Optional[str] = None
+        self._pr_resolver_retry_after_seconds: Optional[int] = None
         self._report_created: bool = False
         self._report_ref: Optional[str] = None
         # MM-880: compact reference to the versioned ResiliencePolicy envelope
@@ -11207,6 +11217,29 @@ class MoonMindRunWorkflow:
                 output["headSha"] = gated_continuation.get("headSha")
         if self._merge_automation_head_sha:
             output["headSha"] = self._merge_automation_head_sha
+        if workflow.patched(RUN_PR_RESOLVER_VERDICT_PROPAGATION_PATCH):
+            if self._pr_resolver_status:
+                output["prResolverStatus"] = self._pr_resolver_status
+            if self._pr_resolver_reason:
+                output["prResolverReason"] = self._pr_resolver_reason
+            if self._pr_resolver_next_step:
+                output["prResolverNextStep"] = self._pr_resolver_next_step
+            if self._terminal_contract_evidence_ref:
+                output["terminalContractEvidenceRef"] = (
+                    self._terminal_contract_evidence_ref
+                )
+            if self._pr_resolver_retry_after_seconds is not None:
+                output["retryAfterSeconds"] = self._pr_resolver_retry_after_seconds
+            verdict_summary = self._coerce_text(
+                self._publish_context.get("prResolverStatus")
+                and self._last_step_summary,
+                max_chars=1600,
+            )
+            if verdict_summary and self._merge_automation_disposition in {
+                "manual_review",
+                "failed",
+            }:
+                output["prResolverVerdictSummary"] = verdict_summary
         return output
 
     def _initialize_from_payload(
@@ -17282,6 +17315,7 @@ class MoonMindRunWorkflow:
         )
         if merge_automation_head_sha:
             self._merge_automation_head_sha = merge_automation_head_sha
+        self._record_pr_resolver_verdict_context(outputs)
 
         publish_branch = self._coerce_text(
             outputs.get("push_branch") or outputs.get("branch"),
@@ -17348,6 +17382,118 @@ class MoonMindRunWorkflow:
         self._record_accepted_published_head(outputs)
 
         self._record_report_result(execution_result)
+
+    def _record_pr_resolver_verdict_context(
+        self, outputs: Mapping[str, Any]
+    ) -> None:
+        """Project validated pr-resolver verdict facts for the owning gate.
+
+        Only the terminal verdict facts the Skill wrote (status, reason,
+        next step, evidence ref, retry delay) are carried; MoonMind does not
+        reinterpret them. Skill semantic authority stays with the resolved
+        Skill bundle.
+        """
+
+        terminal_contract_id = str(
+            outputs.get("terminalContractId")
+            or outputs.get("terminal_contract_id")
+            or ""
+        ).strip()
+        merge_disposition = str(
+            outputs.get("mergeAutomationDisposition")
+            or outputs.get("merge_automation_disposition")
+            or ""
+        ).strip()
+        status = self._coerce_text(
+            outputs.get("prResolverStatus")
+            or outputs.get("pr_resolver_status"),
+            max_chars=80,
+        )
+        is_pr_resolver_terminal = (
+            status is not None
+            or terminal_contract_id == "pr_resolver_terminal.v1"
+            or merge_disposition in {"manual_review", "failed"}
+        )
+        if status is None and is_pr_resolver_terminal:
+            status = self._coerce_text(
+                outputs.get("status"),
+                max_chars=80,
+            )
+        reason = self._coerce_text(
+            outputs.get("prResolverReason")
+            or outputs.get("pr_resolver_reason")
+            or (
+                outputs.get("final_reason") or outputs.get("finalReason")
+                if is_pr_resolver_terminal
+                else None
+            ),
+            max_chars=500,
+        )
+        next_step = self._coerce_text(
+            outputs.get("prResolverNextStep")
+            or outputs.get("pr_resolver_next_step")
+            or (
+                outputs.get("next_step") or outputs.get("nextStep")
+                if is_pr_resolver_terminal
+                else None
+            ),
+            max_chars=80,
+        )
+        evidence_ref = self._coerce_text(
+            outputs.get("terminalContractEvidenceRef")
+            or outputs.get("terminal_contract_evidence_ref"),
+            max_chars=200,
+        )
+        retry_after: int | None = None
+        for key in (
+            "retryAfterSeconds",
+            "retry_after_seconds",
+            "prResolverRetryAfterSeconds",
+        ):
+            raw = outputs.get(key)
+            if raw is None:
+                continue
+            if isinstance(raw, bool):
+                continue
+            try:
+                candidate = int(raw) if not isinstance(raw, int) else raw
+            except (TypeError, ValueError):
+                continue
+            if candidate >= 1:
+                retry_after = candidate
+                break
+        # A gated continuation may also carry the Skill-supplied delay.
+        if retry_after is None:
+            continuation = self._gated_continuation_request
+            if isinstance(continuation, Mapping):
+                raw = continuation.get("retryAfterSeconds")
+                if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 1:
+                    retry_after = raw
+        self._pr_resolver_status = status or None
+        self._pr_resolver_reason = reason or None
+        self._pr_resolver_next_step = next_step or None
+        self._terminal_contract_evidence_ref = evidence_ref or None
+        self._pr_resolver_retry_after_seconds = retry_after
+        if status:
+            self._publish_context["prResolverStatus"] = status
+        else:
+            self._publish_context.pop("prResolverStatus", None)
+        if reason:
+            self._publish_context["prResolverReason"] = reason
+        else:
+            self._publish_context.pop("prResolverReason", None)
+        if next_step:
+            self._publish_context["prResolverNextStep"] = next_step
+        else:
+            self._publish_context.pop("prResolverNextStep", None)
+        if evidence_ref:
+            self._publish_context["terminalContractEvidenceRef"] = evidence_ref
+        else:
+            self._publish_context.pop("terminalContractEvidenceRef", None)
+        if retry_after is not None:
+            self._publish_context["prResolverRetryAfterSeconds"] = retry_after
+        else:
+            self._publish_context.pop("prResolverRetryAfterSeconds", None)
 
     def _record_publish_metadata_context(self, source: Mapping[str, Any]) -> None:
         raw_metadata = source.get("prMetadata") or source.get("pr_metadata")

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_pr_resolver_verdict_routing.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_pr_resolver_verdict_routing.py
@@ -297,6 +297,28 @@ async def test_blocked_ci_failures_runs_one_remediation_then_stops_on_repeat(
     skill_args = remediation_payload["initial_parameters"]["task"]["skill"]["args"]
     assert skill_args["remainingWorkPath"] == "art_01M264P832WTY8ZFRVH9AX88E3"
     assert skill_args["finalReason"] == "ci_failures"
+    # Materializable verifier refs use the artifact:// scheme for the runtime.
+    assert (
+        skill_args["gateResultRef"] == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert (
+        skill_args["remainingWorkRef"] == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert (
+        remediation_payload["initial_parameters"]["gateResultRef"]
+        == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert (
+        remediation_payload["initial_parameters"]["remainingWorkRef"]
+        == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    # The remediation child runs in the authoritative PR-head workspace with
+    # a workflow-owned publication handoff.
+    workspace_spec = remediation_payload["initial_parameters"]["workspaceSpec"]
+    assert workspace_spec["repository"] == "MoonLadderStudios/MoonMind"
+    assert workspace_spec["branch"] == "feature"
+    assert workspace_spec["targetBranch"] == "feature"
+    assert remediation_payload["initial_parameters"]["publishMode"] == "auto"
     # Per-cycle record lists head/reason/nextStep and the stop reason.
     cycles = result["resolverVerdictCycles"]
     assert len(cycles) == 2
@@ -419,3 +441,48 @@ def test_run_workflow_projects_pr_resolver_verdict_for_owning_gate(
     )
     assert workflow._merge_automation_disposition == "manual_review"
     assert workflow._merge_automation_head_sha == HEAD_1
+
+
+def test_remediation_artifact_ref_normalization() -> None:
+    workflow_obj = MoonMindMergeAutomationWorkflow()
+    assert (
+        workflow_obj._normalize_remediation_artifact_ref(
+            "art_01M264P832WTY8ZFRVH9AX88E3"
+        )
+        == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert (
+        workflow_obj._normalize_remediation_artifact_ref(
+            "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+        )
+        == "artifact://art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert workflow_obj._normalize_remediation_artifact_ref("") == ""
+    assert workflow_obj._normalize_remediation_artifact_ref(None) == ""
+
+
+def test_run_workflow_skips_verdict_mutation_without_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "patched", lambda _patch_id: False
+    )
+    workflow = run_workflow_module.MoonMindRunWorkflow()
+    outputs = {
+        "mergeAutomationDisposition": "manual_review",
+        "terminalContractId": "pr_resolver_terminal.v1",
+        "prResolverStatus": "blocked",
+        "prResolverReason": "ci_failures",
+        "prResolverNextStep": "run_full_remediation",
+        "terminalContractEvidenceRef": "art_01M264P832WTY8ZFRVH9AX88E3",
+        "headSha": HEAD_1,
+    }
+    workflow._record_execution_context(
+        node_id="node-1", execution_result={"outputs": outputs}
+    )
+    # Old histories replay without the new verdict-state mutation.
+    assert workflow._pr_resolver_status is None
+    assert workflow._pr_resolver_reason is None
+    assert workflow._pr_resolver_next_step is None
+    assert workflow._terminal_contract_evidence_ref is None
+    assert "prResolverStatus" not in workflow._publish_context

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_pr_resolver_verdict_routing.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_pr_resolver_verdict_routing.py
@@ -1,0 +1,421 @@
+"""Workflow-boundary tests for pr-resolver verdict routing (#4223)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal.workflows import (
+    merge_automation as merge_automation_module,
+)
+from moonmind.workflows.temporal.workflows import run as run_workflow_module
+from moonmind.workflows.temporal.workflows.merge_automation import (
+    MoonMindMergeAutomationWorkflow,
+)
+
+MERGE_AUTOMATION_WORKFLOW_ID = "merge-automation:wf-parent"
+OWNER_RUN_ID = "owner-run"
+HEAD_1 = "abc1234"
+HEAD_2 = "def4567"
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "workflowType": "MoonMind.MergeAutomation",
+        "parentWorkflowId": "wf-parent",
+        "parentRunId": "run-parent",
+        "publishContextRef": "artifact://publish-context",
+        "pullRequest": {
+            "repo": "MoonLadderStudios/MoonMind",
+            "number": 4207,
+            "url": "https://github.com/MoonLadderStudios/MoonMind/pull/4207",
+            "headSha": HEAD_1,
+            "headBranch": "feature",
+            "baseBranch": "main",
+        },
+        "jiraIssueKey": "MM-4207",
+        "mergeAutomationConfig": {
+            "gate": {
+                "github": {"checks": "required", "automatedReview": "required"},
+                "jira": {"status": "optional"},
+            },
+            "resolver": {"mergeMethod": "squash"},
+            "timeouts": {"fallbackPollSeconds": 60},
+        },
+        "idempotencyKey": "merge-automation:wf-parent:MoonLadderStudios/MoonMind:4207:abc1234",
+    }
+
+
+def _ready(head_sha: str) -> dict[str, Any]:
+    return {
+        "headSha": head_sha,
+        "ready": True,
+        "pullRequestOpen": True,
+        "policyAllowed": True,
+        "checksComplete": True,
+        "checksPassing": True,
+        "automatedReviewComplete": True,
+        "jiraStatusAllowed": True,
+    }
+
+
+def _blocked_ci_failures_result(head_sha: str) -> dict[str, Any]:
+    """Mirror var/pr_resolver/result.json blocked shape (art_01M264P832...)."""
+    return {
+        "status": "success",
+        "mergeAutomationDisposition": "manual_review",
+        "headSha": head_sha,
+        "prResolverStatus": "blocked",
+        "prResolverReason": "ci_failures",
+        "final_reason": "ci_failures",
+        "prResolverNextStep": "run_full_remediation",
+        "next_step": "run_full_remediation",
+        "terminalContractEvidenceRef": "art_01M264P832WTY8ZFRVH9AX88E3",
+        "summary": (
+            "pr-resolver reported status 'blocked'; ci_failures; "
+            "next_step=run_full_remediation"
+        ),
+    }
+
+
+def _reenter_gate_result(child_workflow_id: str, head_sha: str) -> dict[str, Any]:
+    """Mirror var/pr_resolver/result.json reenter_gate shape (art_01M25S1A...)."""
+    return {
+        "status": "success",
+        "completionDisposition": "gated_continuation",
+        "mergeAutomationDisposition": "reenter_gate",
+        "headSha": head_sha,
+        "executionRef": "step:1",
+        "childRunId": "child-run",
+        "gatedContinuation": {
+            "schemaVersion": "gated-continuation/v1",
+            "gateType": "merge_automation",
+            "action": "reenter_gate",
+            "reason": "codex_review_grace_wait",
+            "retryAfterSeconds": 1,
+            "executionRef": "step:1",
+            "headSha": head_sha,
+            "ownerWorkflowId": MERGE_AUTOMATION_WORKFLOW_ID,
+            "ownerRunId": OWNER_RUN_ID,
+            "ownerWorkflowType": "MoonMind.MergeAutomation",
+            "childWorkflowId": child_workflow_id,
+            "childRunId": "child-run",
+        },
+    }
+
+
+class _Harness:
+    def __init__(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        readiness: list[dict[str, Any]],
+        child_results,
+    ) -> None:
+        self.readiness = list(readiness)
+        self.child_results = child_results
+        self.child_workflow_ids: list[str] = []
+        self.child_payloads: list[dict[str, Any]] = []
+        self.resolver_ids: list[str] = []
+        self.remediation_ids: list[str] = []
+        self.sleep_seconds: list[float] = []
+        self._now = datetime(2026, 9, 10, 11, 20, tzinfo=timezone.utc)
+
+        async def fake_execute_activity(
+            activity_type: str,
+            payload: dict[str, Any],
+            **_kwargs: Any,
+        ) -> Any:
+            if activity_type == "merge_automation.evaluate_readiness":
+                return self.readiness.pop(0) if self.readiness else _ready(HEAD_1)
+            if activity_type == "artifact.create":
+                return ({"artifact_id": "art-test"}, {})
+            raise AssertionError(f"unexpected activity {activity_type}")
+
+        async def fake_execute_typed_activity(
+            _activity_type: str, _payload: Any, **_kwargs: Any
+        ) -> Any:
+            return None
+
+        async def fake_execute_child_workflow(
+            workflow_type: str,
+            payload: dict[str, Any],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            assert workflow_type == "MoonMind.UserWorkflow"
+            child_id = str(kwargs["id"])
+            self.child_workflow_ids.append(child_id)
+            self.child_payloads.append(payload)
+            skill_id = ""
+            try:
+                skill_id = str(
+                    payload.get("initial_parameters", {})
+                    .get("task", {})
+                    .get("skill", {})
+                    .get("id")
+                    or ""
+                )
+            except AttributeError:
+                skill_id = ""
+            if skill_id == "remediate-issue" or child_id.endswith(":remediation"):
+                self.remediation_ids.append(child_id)
+                result = self.child_results
+                if callable(result):
+                    return result(child_id, len(self.child_workflow_ids), "remediation")
+                return {"status": "success", "headSha": HEAD_1}
+            self.resolver_ids.append(child_id)
+            if callable(self.child_results):
+                return self.child_results(
+                    child_id, len(self.resolver_ids), "resolver"
+                )
+            return self.child_results.pop(0)
+
+        async def fake_wait_condition(*_args: Any, **_kwargs: Any) -> None:
+            self._now = self._now + timedelta(seconds=60)
+
+        async def fake_sleep(delay: timedelta, **_kwargs: Any) -> None:
+            self.sleep_seconds.append(delay.total_seconds())
+
+        monkeypatch.setattr(
+            merge_automation_module.workflow, "execute_activity", fake_execute_activity
+        )
+        monkeypatch.setattr(
+            merge_automation_module,
+            "execute_typed_activity",
+            fake_execute_typed_activity,
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow,
+            "execute_child_workflow",
+            fake_execute_child_workflow,
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow, "wait_condition", fake_wait_condition
+        )
+        monkeypatch.setattr(merge_automation_module.workflow, "sleep", fake_sleep)
+        monkeypatch.setattr(
+            merge_automation_module.workflow, "now", lambda: self._now
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow, "upsert_memo", lambda _memo: None
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow,
+            "upsert_search_attributes",
+            lambda _attrs: None,
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow,
+            "info",
+            lambda: SimpleNamespace(
+                workflow_id=MERGE_AUTOMATION_WORKFLOW_ID, run_id=OWNER_RUN_ID
+            ),
+        )
+        monkeypatch.setattr(
+            merge_automation_module.workflow, "patched", lambda _patch_id: True
+        )
+
+
+@pytest.fixture(autouse=True)
+def _default_patch_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        merge_automation_module.workflow, "patched", lambda _patch_id: True
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "info",
+        lambda: SimpleNamespace(
+            workflow_id=MERGE_AUTOMATION_WORKFLOW_ID, run_id=OWNER_RUN_ID
+        ),
+    )
+
+
+def test_pr_resolver_verdict_projects_skill_facts_without_reinterpretation() -> None:
+    verdict = MoonMindMergeAutomationWorkflow._pr_resolver_verdict(
+        _blocked_ci_failures_result(HEAD_1)
+    )
+    assert verdict["prResolverStatus"] == "blocked"
+    assert verdict["finalReason"] == "ci_failures"
+    assert verdict["nextStep"] == "run_full_remediation"
+    assert verdict["headSha"] == HEAD_1
+    assert verdict["terminalContractEvidenceRef"] == "art_01M264P832WTY8ZFRVH9AX88E3"
+
+
+def test_resolver_verdict_signature_bounds_identical_head_reason() -> None:
+    first = MoonMindMergeAutomationWorkflow._pr_resolver_verdict(
+        _blocked_ci_failures_result(HEAD_1)
+    )
+    second = MoonMindMergeAutomationWorkflow._pr_resolver_verdict(
+        _blocked_ci_failures_result(HEAD_1)
+    )
+    assert (
+        MoonMindMergeAutomationWorkflow._resolver_verdict_signature(first)
+        == MoonMindMergeAutomationWorkflow._resolver_verdict_signature(second)
+    )
+    moved = MoonMindMergeAutomationWorkflow._pr_resolver_verdict(
+        _blocked_ci_failures_result(HEAD_2)
+    )
+    assert (
+        MoonMindMergeAutomationWorkflow._resolver_verdict_signature(first)
+        != MoonMindMergeAutomationWorkflow._resolver_verdict_signature(moved)
+    )
+
+
+@pytest.mark.asyncio
+async def test_blocked_ci_failures_runs_one_remediation_then_stops_on_repeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def child_results(child_id: str, resolver_n: int, kind: str) -> dict[str, Any]:
+        if kind == "remediation":
+            return {"status": "success", "headSha": HEAD_1}
+        return _blocked_ci_failures_result(HEAD_1)
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1), _ready(HEAD_1), _ready(HEAD_1)],
+        child_results=child_results,
+    )
+    result = await MoonMindMergeAutomationWorkflow().run(_payload())
+
+    assert result["status"] == "failed"
+    assert "ci_failures" in result["summary"]
+    assert "run_full_remediation" in result["summary"]
+    # One remediation step and one re-entry: two resolver children total.
+    assert len(harness.resolver_ids) == 2
+    assert len(harness.remediation_ids) == 1
+    # The remediation child carries the Skill evidence as remaining work.
+    remediation_payload = next(
+        payload
+        for payload, child_id in zip(
+            harness.child_payloads, harness.child_workflow_ids
+        )
+        if child_id in harness.remediation_ids
+    )
+    skill_args = remediation_payload["initial_parameters"]["task"]["skill"]["args"]
+    assert skill_args["remainingWorkPath"] == "art_01M264P832WTY8ZFRVH9AX88E3"
+    assert skill_args["finalReason"] == "ci_failures"
+    # Per-cycle record lists head/reason/nextStep and the stop reason.
+    cycles = result["resolverVerdictCycles"]
+    assert len(cycles) == 2
+    for cycle in cycles:
+        assert cycle["headSha"] == HEAD_1
+        assert cycle["finalReason"] == "ci_failures"
+        assert cycle["nextStep"] == "run_full_remediation"
+    assert result["resolverVerdictStopReason"] == "identical_verdict_head_no_progress"
+    assert cycles[-1]["stopReason"] == "identical_verdict_head_no_progress"
+
+
+@pytest.mark.asyncio
+async def test_retry_finalize_after_backoff_waits_without_launching_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"resolvers": 0}
+
+    def child_results(child_id: str, resolver_n: int, kind: str) -> dict[str, Any]:
+        assert kind == "resolver"
+        calls["resolvers"] += 1
+        if calls["resolvers"] == 1:
+            return {
+                "status": "success",
+                "mergeAutomationDisposition": "manual_review",
+                "headSha": HEAD_1,
+                "prResolverStatus": "blocked",
+                "final_reason": "snapshot_refresh_failed",
+                "next_step": "retry_finalize_after_backoff",
+                "retryAfterSeconds": 90,
+                "summary": "pr-resolver reported status 'blocked'; "
+                "snapshot_refresh_failed; "
+                "next_step=retry_finalize_after_backoff",
+            }
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1), _ready(HEAD_1)],
+        child_results=child_results,
+    )
+    result = await MoonMindMergeAutomationWorkflow().run(_payload())
+
+    assert result["status"] == "merged"
+    assert harness.sleep_seconds == [90]
+    assert harness.remediation_ids == []
+    assert len(harness.resolver_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_reenter_gate_handoff_unchanged_for_cycle_1_history_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def child_results(child_id: str, resolver_n: int, kind: str) -> dict[str, Any]:
+        assert kind == "resolver"
+        if resolver_n == 1:
+            return _reenter_gate_result(child_id, HEAD_1)
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    harness = _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1), _ready(HEAD_2)],
+        child_results=child_results,
+    )
+    result = await MoonMindMergeAutomationWorkflow().run(_payload())
+
+    assert result["status"] == "merged"
+    assert result["cycles"] == 2
+    assert result.get("resolverVerdictCycles") == []
+    assert harness.remediation_ids == []
+    assert harness.sleep_seconds == [1]
+
+
+@pytest.mark.asyncio
+async def test_manual_review_without_verdict_facts_keeps_legacy_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = _Harness(
+        monkeypatch,
+        readiness=[_ready(HEAD_1)],
+        child_results=[
+            {"status": "success", "mergeAutomationDisposition": "manual_review"}
+        ],
+    )
+    result = await MoonMindMergeAutomationWorkflow().run(_payload())
+
+    assert result["status"] == "failed"
+    assert result["summary"] == "pr-resolver requested manual review."
+    assert harness.remediation_ids == []
+
+
+def test_run_workflow_projects_pr_resolver_verdict_for_owning_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_workflow_module.workflow, "patched", lambda _patch_id: True
+    )
+    workflow = run_workflow_module.MoonMindRunWorkflow()
+    outputs = {
+        "summary": (
+            "pr-resolver reported status 'blocked'; ci_failures; "
+            "next_step=run_full_remediation"
+        ),
+        "mergeAutomationDisposition": "manual_review",
+        "terminalContractId": "pr_resolver_terminal.v1",
+        "prResolverStatus": "blocked",
+        "prResolverReason": "ci_failures",
+        "prResolverNextStep": "run_full_remediation",
+        "terminalContractEvidenceRef": "art_01M264P832WTY8ZFRVH9AX88E3",
+        "headSha": HEAD_1,
+    }
+    workflow._record_execution_context(
+        node_id="node-1", execution_result={"outputs": outputs}
+    )
+    assert workflow._pr_resolver_status == "blocked"
+    assert workflow._pr_resolver_reason == "ci_failures"
+    assert workflow._pr_resolver_next_step == "run_full_remediation"
+    assert (
+        workflow._terminal_contract_evidence_ref
+        == "art_01M264P832WTY8ZFRVH9AX88E3"
+    )
+    assert workflow._merge_automation_disposition == "manual_review"
+    assert workflow._merge_automation_head_sha == HEAD_1


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4223: MergeAutomation stops relaunching an identical pr-resolver when the skill returns `blocked`/`ci_failures`, and instead routes the skill's `next_step` through one typed policy.

- `run_full_remediation` launches one bounded `remediate-issue` child with `remainingWorkPath=terminalContractEvidenceRef`, then re-enters the gate on the new head.
- `retry_finalize_after_backoff` waits the skill-supplied `retryAfterSeconds` with no agent launch.
- `manual_review` / `attempts_exhausted` stop the cycle with the skill's summary (no further resolver child).
- Cycles are bounded by progress, not count: a second identical `status|reason|head` signature on the same head ends the workflow with `stopReason=identical_verdict_head_no_progress` and the skill reason.
- Routing only, no native reclassification: verdict projection (`_pr_resolver_verdict`, `_record_pr_resolver_verdict_context`) carries skill facts (`finalReason`, `nextStep`, evidence ref) without reinterpretation.
- Merge-automation record artifact now lists per-cycle `headSha`, `finalReason`, `nextStep` (plus evidence ref, disposition, retry delay, summary), remediation child ids, and the stop reason.
- Existing `reenter_gate` / `request_review` handoffs unchanged (replay-covered).

## Verification outcome

Post-remediation `moonspec-verify` verdict: **FULLY_IMPLEMENTED** (confidence HIGH, mode main, candidate `b4789c3c8dcea36212c25cb52dab19d13880b14a`).
All four requirements verified: R1-consume-next-step-and-route, R2-bound-cycles-by-progress, R3-routing-only-no-native-semantics, R4-per-cycle-record-artifact. No blocking gaps, no remaining work.

## Tests run

- `moonmind container python-tests tests/unit/workflows/temporal/workflows/test_merge_automation_pr_resolver_verdict_routing.py` — **7 passed in 42.81s** (hermetic workflow-boundary suite via managed container backend). Covers: verdict projection without reinterpretation, run-workflow propagation to the owning gate, blocked/ci_failures -> one remediation then stop on repeat (asserts 2 resolvers + 1 remediation), backoff wait without agent, reenter_gate replay unchanged, legacy manual_review summary, run-workflow propagation.

## Remaining risks

- Bounded-remediation child depends on the existing `remediate-issue` Skill contract and the persisted `terminalContractEvidenceRef`; if the evidence ref is missing/unreadable the re-entry falls back to stopping with the skill summary rather than retrying blindly.
- `retryAfterSeconds` honors the skill-supplied delay only; unusually large values extend gate latency by design (no agent cost, but wall-clock wait).
- Identical-signature stop compares `status|reason|head`; a resolver that changes any one field (e.g. new head after partial push) correctly re-enters, so a slow-drifting head could still cost extra cycles before stabilizing.

Closes MoonLadderStudios/MoonMind#4223
