### PR TITLE
[GitHub issue lifecycle] Share advisory admission and conflict checks across issue workflows (MoonLadderStudios/MoonMind#4178)

### DIFF
--- a/moonmind/workflows/temporal/github_issue_admission.py
+++ b/moonmind/workflows/temporal/github_issue_admission.py
@@ -1,0 +1,887 @@
+"""One shared advisory admission/guard boundary for an exact GitHub issue.
+
+Single policy entrypoint for MoonLadderStudios/MoonMind#4178 (design:
+docs/Workflows/GitHubIssueStatusStateMachineDesign.md, sections 5.1, 5.2,
+8.2, and 9). Deterministic and side-effect-free: no network I/O. Trusted
+Activities/services perform reads/writes; this module decides what the reads
+mean for one pinned repository/issue identity.
+
+Contract summary (advisory, not a distributed lock):
+
+* Search-selected work, explicit implementation/orchestration, retries, and
+  operator continuations invoke the SAME :func:`admit_exact_issue` boundary
+  with pinned identities (repository, issue number, workflow/run,
+  installation/attempt, entrypoint). Discovery results and local caches are
+  not admission authority.
+* Eligible Available or Recovery-needed work announces a stable attempt and
+  applies in-progress BEFORE expensive assessment/implementation, then
+  re-reads before launching work.
+* The selected issue + predecessor persist exactly once with the workflow's
+  trusted input context; retry/replay/recovery cannot silently substitute a
+  different issue.
+* Observed competing preparing/active attempts, operator holds, or
+  contradictory evidence quiesce this attempt through the existing runtime
+  boundary: stop shared publication, preserve output, report attention. Never
+  pick a timestamp winner and never clear another attempt's in-progress.
+* Paused/reconnected resumes and pre-mutation checks revalidate shared
+  evidence at trusted launch/publication boundaries. Released/superseded
+  attempts perform no new shared mutation.
+* Internal remediation and PR-review/merge children share the controlling
+  attempt. Review waits are not disappeared owners. Existing-PR repair needs
+  an admitted route plus an exact PR target.
+
+This module reuses (never duplicates) the portable Skill-adjacent semantics
+owned elsewhere: lifecycle interpretation in ``github_issue_lifecycle`` and
+attempt handoff / retry lineage in ``github_issue_attempt``. It adds only the
+shared exact-issue admission composition those modules do not own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from moonmind.workflows.temporal import github_issue_attempt as _attempt
+from moonmind.workflows.temporal.github_issue_lifecycle import (
+    SETTLED_AVAILABLE,
+    SETTLED_BLOCKED_MIXED,
+    SETTLED_BLOCKED_OPEN_DONE,
+    SETTLED_BLOCKED_UNKNOWN,
+    SETTLED_CLOSED,
+    SETTLED_CODE_REVIEW,
+    SETTLED_IN_PROGRESS,
+    SETTLED_NEEDS_ATTENTION,
+    SETTLED_RECOVERY_NEEDED,
+    TO_IN_PROGRESS,
+    interpret_issue,
+    plan_label_mutation,
+    plan_transition,
+    should_abandon_retry,
+)
+
+#: Entrypoints that share this ONE admission boundary (acceptance A). The
+#: separate search-preset issue owns candidate ranking; this issue owns the
+#: exact-issue admission/guard contract used by every entrypoint below.
+ENTRYPOINT_SEARCH = "search"
+ENTRYPOINT_EXPLICIT = "explicit"
+ENTRYPOINT_ORCHESTRATION = "orchestration"
+ENTRYPOINT_CONTINUATION = "continuation"
+ENTRYPOINT_RETRY = "retry"
+
+ENTRYPOINTS = frozenset(
+    {
+        ENTRYPOINT_SEARCH,
+        ENTRYPOINT_EXPLICIT,
+        ENTRYPOINT_ORCHESTRATION,
+        ENTRYPOINT_CONTINUATION,
+        ENTRYPOINT_RETRY,
+    }
+)
+
+#: Explicit documentation of the remaining unfenced check-to-write race
+#: (design sections 8.1-8.2). A read immediately before pushing/merging cannot
+#: eliminate every pause-between-check-and-write race; GitHub label/comment
+#: operations provide no conditional ownership acquisition. Revalidation
+#: rejects observable stale work but never claims to fence a delayed external
+#: request. Tests assert this limitation instead of claiming exclusivity.
+UNFENCED_CHECK_TO_WRITE_RACE_NOTE = (
+    "Unfenced check-to-write race remains: GitHub labels/comments offer no "
+    "transactional compare-and-swap, so two devices may both announce and a "
+    "delayed label/PR mutation may still race a later read. Revalidation at "
+    "resume and pre-mutation boundaries rejects observable stale work; it "
+    "does not fence every delayed external request. Unknown push/merge "
+    "outcomes block automatic release/takeover until resolved."
+)
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, bool):
+        return ""
+    return str(value or "").strip()
+
+
+def _label_names(labels: Any) -> list[str]:
+    if not isinstance(labels, Sequence) or isinstance(labels, (str, bytes, bytearray)):
+        return []
+    names: list[str] = []
+    for item in labels:
+        if isinstance(item, Mapping):
+            name = str(item.get("name") or "").strip()
+        else:
+            name = str(item or "").strip()
+        if name:
+            names.append(name)
+    return names
+
+
+@dataclass(frozen=True)
+class AdmissionRequest:
+    """Pinned identity + trusted evidence for one exact-issue admission check."""
+
+    repository: str = ""
+    issue_number: int = 0
+    workflow_id: str = ""
+    run_id: str = ""
+    installation_id: str = ""
+    attempt_id: str = ""
+    entrypoint: str = ENTRYPOINT_EXPLICIT
+    predecessor_attempt_id: str = ""
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Shared typed decision for one exact-issue admission check."""
+
+    allowed: bool
+    reason_code: str
+    summary: str
+    settled: str = ""
+    entrypoint: str = ""
+    issue_ref: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reasonCode": self.reason_code,
+            "summary": self.summary,
+            "settled": self.settled,
+            "entrypoint": self.entrypoint,
+            "issueRef": self.issue_ref,
+        }
+
+
+def _deny(
+    *,
+    reason_code: str,
+    summary: str,
+    settled: str = "",
+    entrypoint: str = "",
+    issue_ref: str = "",
+) -> AdmissionDecision:
+    return AdmissionDecision(
+        allowed=False,
+        reason_code=reason_code,
+        summary=summary,
+        settled=settled,
+        entrypoint=entrypoint,
+        issue_ref=issue_ref,
+    )
+
+
+def admit_exact_issue(
+    request: AdmissionRequest,
+    *,
+    issue: Mapping[str, Any] | None,
+    attempt_context: Mapping[str, Any] | None = None,
+    blockers: Sequence[Mapping[str, Any]] | None = None,
+    pr_identities: Sequence[Mapping[str, Any]] | None = None,
+    retry_policy: Mapping[str, Any] | None = None,
+    reads_complete: Mapping[str, Any] | None = None,
+    active_attempt_comments: Sequence[Mapping[str, Any]] | None = None,
+    trusted_posters: Sequence[str] | None = None,
+) -> AdmissionDecision:
+    """Decide admission for one exact pinned repository/issue identity.
+
+    Every entrypoint (search, explicit, orchestration, continuation, retry)
+    calls this same function with its pinned identity. Discovery results and
+    local caches are not consulted here: callers pass trusted reads only.
+
+    ``reads_complete`` carries per-read completeness (``labels``,
+    ``comments``, ``prs``, ``blockers``, ``retryPolicy`` booleans). Incomplete
+    pagination or failed reads are unknown evidence and block admission; they
+    are never treated as an empty owner set.
+
+    ``active_attempt_comments`` are validated competing handoff metadata dicts
+    observed for this issue (preparing/active, not released). Any observed
+    contender blocks shared mutation admission for this attempt.
+    """
+    repository = _string(request.repository)
+    entrypoint = _string(request.entrypoint) or ENTRYPOINT_EXPLICIT
+    issue_ref = f"{repository}#{request.issue_number}" if repository and request.issue_number else ""
+    if entrypoint not in ENTRYPOINTS:
+        return _deny(
+            reason_code="unknown_entrypoint",
+            summary=f"Unknown admission entrypoint {request.entrypoint!r}; "
+            "search, explicit, orchestration, continuation, and retry share one boundary.",
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if not repository or type(request.issue_number) is not int or request.issue_number <= 0:
+        return _deny(
+            reason_code="unpinned_identity",
+            summary="Admission requires a pinned owner/repository#number identity.",
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    reads = dict(reads_complete or {})
+    for key in ("labels", "comments", "prs", "blockers", "retryPolicy"):
+        if key in reads and not reads[key]:
+            return _deny(
+                reason_code="read_failure",
+                summary=(
+                    f"GitHub {key} evidence is incomplete or unreadable for {issue_ref or 'the pinned issue'}; "
+                    "unknown evidence blocks admission rather than inferring an empty owner set."
+                ),
+                entrypoint=entrypoint,
+                issue_ref=issue_ref,
+            )
+    if issue is None:
+        return _deny(
+            reason_code="read_failure",
+            summary=f"Trusted issue read for {issue_ref or 'the pinned issue'} failed; admission is blocked.",
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    interpretation = interpret_issue(
+        {"state": issue.get("state", "open"), "labels": _label_names(issue.get("labels"))}
+    )
+    settled = interpretation.settled
+    if settled == SETTLED_CLOSED:
+        return _deny(
+            reason_code="closed_terminal",
+            summary=f"{issue_ref or 'Issue'} is closed; closed issues are excluded from admission.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if settled in {SETTLED_BLOCKED_MIXED, SETTLED_BLOCKED_OPEN_DONE}:
+        return _deny(
+            reason_code="mixed_state",
+            summary=f"{issue_ref or 'Issue'} carries a mixed/inconsistent label combination; "
+            "reconciliation is required before admission.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if settled == SETTLED_BLOCKED_UNKNOWN:
+        return _deny(
+            reason_code="unknown_format",
+            summary=f"{issue_ref or 'Issue'} carries an unrecognized workflow-status value; "
+            "classification is required rather than silent admission.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if settled == SETTLED_NEEDS_ATTENTION:
+        return _deny(
+            reason_code="operator_hold",
+            summary=f"{issue_ref or 'Issue'} requires attention; authorized resolution is required.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if settled in {SETTLED_IN_PROGRESS, SETTLED_CODE_REVIEW}:
+        # A missing label plus an active comment, and a manual in-progress
+        # label without a trusted owner, both block: the label is respected
+        # and never age-cleared, and unresolved attempt evidence always wins
+        # over a missing label.
+        if settled == SETTLED_IN_PROGRESS and _has_active_attempt_evidence(
+            attempt_context, active_attempt_comments
+        ):
+            return _deny(
+                reason_code="active_attempt_conflict",
+                summary=f"{issue_ref or 'Issue'} shows an active attempt; "
+                "a missing label never overrides unresolved attempt evidence.",
+                settled=settled,
+                entrypoint=entrypoint,
+                issue_ref=issue_ref,
+            )
+        if settled == SETTLED_IN_PROGRESS:
+            return _deny(
+                reason_code="manual_in_progress_without_trusted_owner",
+                summary=f"{issue_ref or 'Issue'} carries a manual in-progress label with no trusted owner; "
+                "the label is respected and not age-cleared.",
+                settled=settled,
+                entrypoint=entrypoint,
+                issue_ref=issue_ref,
+            )
+        return _deny(
+            reason_code="active_attempt_conflict",
+            summary=f"{issue_ref or 'Issue'} is already owned ({settled}); "
+            "excluded from new independent admission.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    # Only Available (fresh) and Recovery-needed (continuation) remain.
+    if settled not in {SETTLED_AVAILABLE, SETTLED_RECOVERY_NEEDED}:
+        return _deny(
+            reason_code="unknown_format",
+            summary=f"{issue_ref or 'Issue'} is in an unrecognized settled state {settled!r}.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    # Missing label plus an active comment blocks even when labels look free.
+    if settled == SETTLED_AVAILABLE and _has_active_attempt_evidence(
+        attempt_context, active_attempt_comments
+    ):
+        return _deny(
+            reason_code="missing_label_with_active_attempt",
+            summary=f"{issue_ref or 'Issue'} has no status label but unresolved active-attempt "
+            "evidence contradicts availability; no fresh work starts on the assumption it is unowned.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    if blockers:
+        known = [item for item in blockers if isinstance(item, Mapping)]
+        if known:
+            return _deny(
+                reason_code="blocked_prerequisite",
+                summary=f"{issue_ref or 'Issue'} has {len(known)} unresolved blocker(s); "
+                "prerequisites apply before admission.",
+                settled=settled,
+                entrypoint=entrypoint,
+                issue_ref=issue_ref,
+            )
+    pr_list = [item for item in (pr_identities or []) if isinstance(item, Mapping)]
+    if any(_string(item.get("ambiguous")) in {"1", "true", "yes"} or item.get("ambiguous") is True for item in pr_list):
+        return _deny(
+            reason_code="ambiguous_pr_identity",
+            summary=f"{issue_ref or 'Issue'} has multiple competing or ambiguous PR identities; "
+            "no silent canonical selection is made.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
+    linked = _linked_attempts(attempt_context)
+    if linked or (retry_policy is not None):
+        retry_state = _attempt.derive_retry_state(
+            linked, policy=dict(retry_policy) if isinstance(retry_policy, Mapping) else None
+        )
+        if retry_state.get("blocked"):
+            code = str(retry_state.get("reasonCode") or "retry_exhausted")
+            if code in {"operator_hold", "retry_budget_exhausted", "race_approximate",
+                        "lineage_gap", "incompatible_policy_lineage", "missing_policy_lineage"}:
+                reason = "operator_hold" if code == "operator_hold" else (
+                    "retry_exhausted" if code in {"retry_budget_exhausted", "race_approximate"} else code
+                )
+                return _deny(
+                    reason_code=reason,
+                    summary=str(retry_state.get("summary") or "Retry policy blocks automatic admission."),
+                    settled=settled,
+                    entrypoint=entrypoint,
+                    issue_ref=issue_ref,
+                )
+            return _deny(
+                reason_code="retry_exhausted",
+                summary=str(retry_state.get("summary") or "Retry policy blocks automatic admission."),
+                settled=settled,
+                entrypoint=entrypoint,
+                issue_ref=issue_ref,
+            )
+    _ = trusted_posters
+    return AdmissionDecision(
+        allowed=True,
+        reason_code="admitted",
+        summary=f"{issue_ref or 'Issue'} admitted for {entrypoint} as {settled}.",
+        settled=settled,
+        entrypoint=entrypoint,
+        issue_ref=issue_ref,
+    )
+
+
+def _linked_attempts(attempt_context: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    context = attempt_context or {}
+    for key in ("linkedAttempts", "linked_attempts"):
+        linked = context.get(key)
+        if isinstance(linked, Sequence) and not isinstance(linked, (str, bytes, bytearray)):
+            return [dict(item) for item in linked if isinstance(item, Mapping)]
+    return []
+
+
+def _has_active_attempt_evidence(
+    attempt_context: Mapping[str, Any] | None,
+    active_attempt_comments: Sequence[Mapping[str, Any]] | None,
+) -> bool:
+    context = attempt_context or {}
+    for key in (
+        "hasUnresolvedActiveAttempt",
+        "has_unresolved_active_attempt",
+        "unresolvedActiveAttempt",
+        "unresolved_active_attempt",
+        "activeAttemptUnresolved",
+        "active_attempt_unresolved",
+    ):
+        value = context.get(key)
+        if value is True or (isinstance(value, str) and value.strip().lower() in {"1", "true", "yes"}):
+            return True
+    for comment in active_attempt_comments or []:
+        if not isinstance(comment, Mapping):
+            continue
+        activity = _string(comment.get("activity")).lower()
+        if activity in {"preparing", "active", "awaiting-review", "awaiting_review", "releasing"}:
+            if comment.get("released") is True:
+                continue
+            return True
+    return False
+
+
+def admit_for_entrypoint(
+    entrypoint: str,
+    *,
+    repository: str,
+    issue_number: int,
+    workflow_id: str = "",
+    run_id: str = "",
+    installation_id: str = "",
+    attempt_id: str = "",
+    predecessor_attempt_id: str = "",
+    issue: Mapping[str, Any] | None,
+    attempt_context: Mapping[str, Any] | None = None,
+    blockers: Sequence[Mapping[str, Any]] | None = None,
+    pr_identities: Sequence[Mapping[str, Any]] | None = None,
+    retry_policy: Mapping[str, Any] | None = None,
+    reads_complete: Mapping[str, Any] | None = None,
+    active_attempt_comments: Sequence[Mapping[str, Any]] | None = None,
+    trusted_posters: Sequence[str] | None = None,
+) -> AdmissionDecision:
+    """Invoke the SAME admission boundary for one named entrypoint.
+
+    Acceptance A: search, explicit, orchestration, continuation, and retry all
+    route through :func:`admit_exact_issue` with pinned identities. There are
+    no preset-name exemptions.
+    """
+    return admit_exact_issue(
+        AdmissionRequest(
+            repository=repository,
+            issue_number=issue_number,
+            workflow_id=workflow_id,
+            run_id=run_id,
+            installation_id=installation_id,
+            attempt_id=attempt_id,
+            entrypoint=entrypoint,
+            predecessor_attempt_id=predecessor_attempt_id,
+        ),
+        issue=issue,
+        attempt_context=attempt_context,
+        blockers=blockers,
+        pr_identities=pr_identities,
+        retry_policy=retry_policy,
+        reads_complete=reads_complete,
+        active_attempt_comments=active_attempt_comments,
+        trusted_posters=trusted_posters,
+    )
+
+
+def announce_before_assessment(
+    *,
+    settled: str,
+    repository: str,
+    issue_number: int,
+    attempt_id: str,
+    current_labels: Sequence[Any] | None = None,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Plan the advisory claim (attempt announcement + in-progress) for Req 2.
+
+    For eligible Available or Recovery-needed work only: announce a stable
+    attempt and apply in-progress BEFORE expensive assessment/implementation.
+    Callers re-read after the announcement and immediately before launching
+    work. Claiming for assessment never authorizes changing blocked code or
+    bypassing completion gates.
+    """
+    issue_ref = f"{repository}#{issue_number}"
+    if settled == SETTLED_AVAILABLE:
+        decision = plan_transition(
+            from_settled=settled,
+            to_target=TO_IN_PROGRESS,
+            evidence={"admission_passed": True, "prior_work_inspected": True},
+            reason=reason or f"Advisory claim for {issue_ref} before assessment",
+        )
+    elif settled == SETTLED_RECOVERY_NEEDED:
+        decision = plan_transition(
+            from_settled=settled,
+            to_target=TO_IN_PROGRESS,
+            evidence={
+                "predecessor_stopped": True,
+                "handoff_usable": True,
+                "admission_passed": True,
+            },
+            reason=reason or f"Advisory continuation claim for {issue_ref} before assessment",
+        )
+    else:
+        return {
+            "planned": False,
+            "reasonCode": "ineligible_state",
+            "summary": f"{issue_ref} in state {settled} is not eligible for an advisory claim.",
+            "transition": None,
+            "mutation": None,
+        }
+    if not decision.allowed:
+        return {
+            "planned": False,
+            "reasonCode": decision.reason_code,
+            "summary": decision.summary,
+            "transition": decision.to_dict(),
+            "mutation": None,
+        }
+    mutation = plan_label_mutation(
+        from_settled=settled, to_target=TO_IN_PROGRESS, current_labels=current_labels
+    )
+    return {
+        "planned": True,
+        "reasonCode": "claim_planned",
+        "summary": (
+            f"Announce attempt {attempt_id} for {issue_ref} and apply in-progress "
+            "before assessment; re-read after the announcement and before launching work."
+        ),
+        "transition": decision.to_dict(),
+        "mutation": mutation.to_dict(),
+    }
+
+
+def persist_admission_identity(
+    trusted_input_context: Mapping[str, Any] | None,
+    previously_persisted: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Persist the selected issue + predecessor exactly once (Req 3).
+
+    Activity retry, workflow replay, and failed-step recovery cannot rerun
+    search and silently substitute a different issue: when a persisted
+    identity already exists, a differing candidate is rejected instead of
+    overwriting the admitted identity.
+    """
+    current = dict(trusted_input_context or {})
+    previous = dict(previously_persisted or {})
+    repo = _string(current.get("repository")).lower()
+    number = current.get("issueNumber", current.get("issue_number", current.get("number")))
+    predecessor = _string(
+        current.get("predecessorAttemptId") or current.get("predecessor_attempt_id")
+    )
+    if not repo or type(number) is not int or number <= 0:
+        # Accept string numbers from workflow payloads without widening the
+        # pinned-identity contract: coerce here, keep admission strict.
+        try:
+            number = int(str(number).strip())
+        except (TypeError, ValueError):
+            number = 0
+    if not repo or type(number) is not int or number <= 0:
+        return {
+            "persisted": False,
+            "reasonCode": "unpinned_identity",
+            "summary": "Admission identity requires a pinned repository and issue number.",
+            "identity": {},
+        }
+    identity = {"repository": _string(current.get("repository")), "issueNumber": number}
+    if predecessor:
+        identity["predecessorAttemptId"] = predecessor
+    if not previous:
+        return {
+            "persisted": True,
+            "reasonCode": "persisted_once",
+            "summary": f"Persisted admitted identity {identity['repository']}#{number} exactly once.",
+            "identity": identity,
+        }
+    prev_repo = _string(previous.get("repository")).lower()
+    prev_number = previous.get("issueNumber", previous.get("issue_number", previous.get("number")))
+    try:
+        prev_number = int(str(prev_number).strip())
+    except (TypeError, ValueError):
+        prev_number = 0
+    if prev_repo != repo or prev_number != number:
+        return {
+            "persisted": False,
+            "reasonCode": "substitution_denied",
+            "summary": (
+                f"Retry/replay candidate {identity['repository']}#{number} differs from "
+                f"persisted {previous.get('repository')}#{prev_number}; "
+                "re-running search cannot silently substitute a different issue."
+            ),
+            "identity": dict(previous),
+        }
+    merged = dict(previous)
+    if predecessor and not _string(merged.get("predecessorAttemptId")):
+        merged["predecessorAttemptId"] = predecessor
+    return {
+        "persisted": True,
+        "reasonCode": "already_persisted",
+        "summary": "Persisted identity unchanged across retry/replay.",
+        "identity": merged,
+    }
+
+
+def contender_quiesce_decision(
+    *,
+    own_attempt_id: str,
+    observed_contenders: Sequence[Mapping[str, Any]] | None,
+    operator_hold: bool = False,
+    contradictory_evidence: bool = False,
+) -> dict[str, Any]:
+    """Decide self-quiesce on observed conflicts (Req 4, acceptance C).
+
+    When another preparing/active attempt, an operator hold, or contradictory
+    evidence is observed: stop shared publication and self-quiesce through the
+    existing runtime boundary, preserve this attempt's output within its
+    admitted policy, and report attention. Never select a timestamp winner and
+    never remove another attempt's in-progress status. A search may consider
+    another candidate only after its own abandoned announcement and writers
+    are conclusively settled.
+    """
+    contenders = [dict(item) for item in (observed_contenders or []) if isinstance(item, Mapping)]
+    others = [item for item in contenders if _string(item.get("attemptId")) != _string(own_attempt_id)]
+    active_others = [
+        item
+        for item in others
+        if _string(item.get("activity")).lower()
+        in {"preparing", "active", "awaiting-review", "awaiting_review", "releasing"}
+        and item.get("released") is not True
+    ]
+    if operator_hold or contradictory_evidence or active_others:
+        detail = (
+            "operator hold observed"
+            if operator_hold
+            else "contradictory evidence observed"
+            if contradictory_evidence
+            else f"{len(active_others)} competing attempt(s) observed"
+        )
+        return {
+            "quiesce": True,
+            "reasonCode": "contender_observed",
+            "summary": (
+                f"Attempt {own_attempt_id or 'unknown'} quiesces: {detail}. "
+                "Shared publication stops; output is preserved within the admitted policy; "
+                "no timestamp winner is selected and no other attempt's in-progress status is cleared."
+            ),
+            "stopSharedPublication": True,
+            "preserveOutput": True,
+            "clearOtherInProgress": False,
+            "contenders": [_string(item.get("attemptId")) for item in active_others],
+            "recandidateAllowed": False,
+        }
+    return {
+        "quiesce": False,
+        "reasonCode": "no_contender",
+        "summary": "No competing attempt, hold, or contradiction observed.",
+        "stopSharedPublication": False,
+        "preserveOutput": False,
+        "clearOtherInProgress": False,
+        "contenders": [],
+        "recandidateAllowed": False,
+    }
+
+
+def recandidate_after_abandon(
+    *, own_announcement_abandoned: bool, writers_settled: bool
+) -> dict[str, Any]:
+    """Gate search recandidacy after this attempt's own contender loss."""
+    if own_announcement_abandoned and writers_settled:
+        return {
+            "allowed": True,
+            "reasonCode": "recandidate_allowed",
+            "summary": "Own abandoned announcement and writers are conclusively settled; "
+            "a search may consider another candidate.",
+        }
+    return {
+        "allowed": False,
+        "reasonCode": "recandidate_blocked",
+        "summary": "Another candidate may be considered only after this attempt's own "
+        "abandoned announcement and writers are conclusively settled.",
+    }
+
+
+def revalidate_for_mutation(
+    *,
+    own_attempt_id: str,
+    observed: Mapping[str, Any] | None,
+    known_successor_attempt_id: str = "",
+    released: bool = False,
+    superseded: bool = False,
+) -> dict[str, Any]:
+    """Revalidate shared evidence before code/PR mutations (Req 5).
+
+    A known released or superseded attempt cannot replay publication or stale
+    cleanup. Call at trusted launch/publication boundaries, not only as agent
+    instructions. Returns ``allowed=False`` to stop new shared effects.
+    """
+    observed_mapping = dict(observed or {})
+    settled = _string(observed_mapping.get("settled"))
+    if released or superseded or _string(observed_mapping.get("activity")) == "released":
+        return {
+            "allowed": False,
+            "reasonCode": "released_or_superseded",
+            "summary": (
+                f"Attempt {own_attempt_id or 'unknown'} is released/superseded; "
+                "no new shared mutation is authorized."
+            ),
+            "raceNote": UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+        }
+    if known_successor_attempt_id:
+        return {
+            "allowed": False,
+            "reasonCode": "known_successor",
+            "summary": (
+                f"Attempt {own_attempt_id or 'unknown'} observed successor "
+                f"{known_successor_attempt_id}; reconnection stops new shared effects."
+            ),
+            "raceNote": UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+        }
+    if settled in {SETTLED_BLOCKED_MIXED, SETTLED_BLOCKED_UNKNOWN, SETTLED_BLOCKED_OPEN_DONE}:
+        return {
+            "allowed": False,
+            "reasonCode": "conflicting_evidence",
+            "summary": "Conflicting shared evidence blocks new mutations pending reconciliation.",
+            "raceNote": UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+        }
+    if settled == SETTLED_NEEDS_ATTENTION:
+        return {
+            "allowed": False,
+            "reasonCode": "operator_hold",
+            "summary": "Operator hold blocks new shared mutations.",
+            "raceNote": UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+        }
+    return {
+        "allowed": True,
+        "reasonCode": "revalidated",
+        "summary": "Shared evidence revalidated; mutation may proceed under the admitted policy. "
+        + UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+        "raceNote": UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+    }
+
+
+def should_stop_on_resume(
+    *,
+    own_attempt_id: str,
+    released: bool = False,
+    superseded: bool = False,
+    known_successor_attempt_id: str = "",
+    operator_hold: bool = False,
+) -> dict[str, Any]:
+    """Decide whether a paused/reconnected attempt must stop (Req 5)."""
+    if released or superseded or known_successor_attempt_id or operator_hold:
+        reason = (
+            "released" if released
+            else "superseded" if superseded
+            else f"known successor {known_successor_attempt_id}"
+            if known_successor_attempt_id
+            else "operator hold"
+        )
+        return {
+            "stop": True,
+            "reasonCode": "resume_blocked",
+            "summary": (
+                f"Resumed attempt {own_attempt_id or 'unknown'} stops after {reason}; "
+                "it performs no further issue-state or PR writes."
+            ),
+        }
+    return {
+        "stop": False,
+        "reasonCode": "resume_allowed",
+        "summary": "No release, successor, or hold observed; resume may revalidate before effects.",
+    }
+
+
+def child_attempt_context(
+    controlling_attempt_id: str,
+    *,
+    child_kind: str,
+    pr_url: str = "",
+) -> dict[str, Any]:
+    """Propagate the controlling attempt to remediation/review children (Req 6).
+
+    Internal child retries share the controlling issue attempt. A legitimate
+    review wait does not become a disappeared owner. Existing-PR repair needs
+    an admitted route plus an exact PR target, never fresh implementation
+    permission from a code-review label.
+    """
+    kind = _string(child_kind).lower()
+    if not _string(controlling_attempt_id):
+        return {
+            "allowed": False,
+            "reasonCode": "missing_controlling_attempt",
+            "summary": "Child activity requires the controlling issue attempt.",
+            "attemptId": "",
+        }
+    if kind in {"internal_retry", "remediation", "internal_remediation"}:
+        return {
+            "allowed": True,
+            "reasonCode": "internal_retry_within_attempt",
+            "summary": f"Internal retry stays within controlling attempt {controlling_attempt_id}.",
+            "attemptId": controlling_attempt_id,
+            "stayInProgress": True,
+        }
+    if kind in {"review", "review_wait", "pr_review", "merge"}:
+        return {
+            "allowed": True,
+            "reasonCode": "review_child_retains_attempt",
+            "summary": (
+                f"Review/merge child retains controlling attempt {controlling_attempt_id}; "
+                "a legitimate review wait is not a disappeared owner."
+            ),
+            "attemptId": controlling_attempt_id,
+            "stayInProgress": True,
+        }
+    if kind in {"existing_pr_repair", "pr_repair", "admitted_repair"}:
+        if not _string(pr_url):
+            return {
+                "allowed": False,
+                "reasonCode": "missing_pr_target",
+                "summary": "Existing-PR repair requires an admitted route and an exact PR target.",
+                "attemptId": controlling_attempt_id,
+            }
+        return {
+            "allowed": True,
+            "reasonCode": "admitted_repair",
+            "summary": (
+                f"Existing-PR repair continues {pr_url} under controlling attempt "
+                f"{controlling_attempt_id}; a code-review label alone grants no fresh permission."
+            ),
+            "attemptId": controlling_attempt_id,
+            "prUrl": _string(pr_url),
+            "stayInProgress": True,
+        }
+    return {
+        "allowed": False,
+        "reasonCode": "unknown_child_kind",
+        "summary": f"Unknown child kind {child_kind!r}; no ownership handoff is granted.",
+        "attemptId": controlling_attempt_id,
+    }
+
+
+def check_delayed_mutation_fenced(*, mutation_issued_before_check: bool) -> dict[str, Any]:
+    """Expose the unfenced race honestly (acceptance D).
+
+    An injected delayed already-issued mutation is NOT falsely reported as
+    fenced: when the mutation was already issued before the ownership check,
+    the result reports ``fenced=False`` with the documented race note.
+    """
+    if mutation_issued_before_check:
+        return {
+            "fenced": False,
+            "reasonCode": "unfenced_race",
+            "summary": (
+                "An already-issued delayed mutation is not fenced by a later ownership check. "
+                + UNFENCED_CHECK_TO_WRITE_RACE_NOTE
+            ),
+        }
+    return {
+        "fenced": True,
+        "reasonCode": "check_precedes_mutation",
+        "summary": "The ownership check precedes the mutation under the admitted policy; "
+        "observable successors still abandon retries via should_abandon_retry. "
+        + UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+    }
+
+
+__all__ = [
+    "ENTRYPOINT_CONTINUATION",
+    "ENTRYPOINT_EXPLICIT",
+    "ENTRYPOINT_ORCHESTRATION",
+    "ENTRYPOINT_RETRY",
+    "ENTRYPOINT_SEARCH",
+    "ENTRYPOINTS",
+    "UNFENCED_CHECK_TO_WRITE_RACE_NOTE",
+    "AdmissionDecision",
+    "AdmissionRequest",
+    "admit_exact_issue",
+    "admit_for_entrypoint",
+    "announce_before_assessment",
+    "check_delayed_mutation_fenced",
+    "child_attempt_context",
+    "contender_quiesce_decision",
+    "persist_admission_identity",
+    "recandidate_after_abandon",
+    "revalidate_for_mutation",
+    "should_stop_on_resume",
+]

--- a/moonmind/workflows/temporal/github_issue_admission.py
+++ b/moonmind/workflows/temporal/github_issue_admission.py
@@ -56,7 +56,6 @@ from moonmind.workflows.temporal.github_issue_lifecycle import (
     interpret_issue,
     plan_label_mutation,
     plan_transition,
-    should_abandon_retry,
 )
 
 #: Entrypoints that share this ONE admission boundary (acceptance A). The
@@ -345,6 +344,27 @@ def admit_exact_issue(
             entrypoint=entrypoint,
             issue_ref=issue_ref,
         )
+    distinct_prs = {
+        _string(
+            item.get("prUrl")
+            or item.get("pull_request_url")
+            or item.get("pullRequestUrl")
+            or item.get("url")
+            or item.get("number")
+            or item.get("id")
+        ).strip().lower()
+        for item in pr_list
+    }
+    distinct_prs.discard("")
+    if len(distinct_prs) > 1:
+        return _deny(
+            reason_code="ambiguous_pr_identity",
+            summary=f"{issue_ref or 'Issue'} has multiple distinct open PR identities; "
+            "no silent canonical selection is made.",
+            settled=settled,
+            entrypoint=entrypoint,
+            issue_ref=issue_ref,
+        )
     linked = _linked_attempts(attempt_context)
     if linked or (retry_policy is not None):
         retry_state = _attempt.derive_retry_state(
@@ -473,6 +493,8 @@ def announce_before_assessment(
     attempt_id: str,
     current_labels: Sequence[Any] | None = None,
     reason: str = "",
+    predecessor_stopped: Any = None,
+    handoff_usable: Any = None,
 ) -> dict[str, Any]:
     """Plan the advisory claim (attempt announcement + in-progress) for Req 2.
 
@@ -480,7 +502,9 @@ def announce_before_assessment(
     attempt and apply in-progress BEFORE expensive assessment/implementation.
     Callers re-read after the announcement and immediately before launching
     work. Claiming for assessment never authorizes changing blocked code or
-    bypassing completion gates.
+    bypassing completion gates. Recovery-needed claims require the caller's
+    validated recovery handoff (predecessor_stopped plus handoff_usable);
+    fabricated defaults are never substituted.
     """
     issue_ref = f"{repository}#{issue_number}"
     if settled == SETTLED_AVAILABLE:
@@ -491,6 +515,18 @@ def announce_before_assessment(
             reason=reason or f"Advisory claim for {issue_ref} before assessment",
         )
     elif settled == SETTLED_RECOVERY_NEEDED:
+        if predecessor_stopped is not True or handoff_usable is not True:
+            return {
+                "planned": False,
+                "reasonCode": "recovery_handoff_missing",
+                "summary": (
+                    f"{issue_ref} is recovery-needed but the validated recovery "
+                    "handoff (predecessor_stopped plus handoff_usable) is absent; "
+                    "the transition is denied until the caller supplies observed handoff evidence."
+                ),
+                "transition": None,
+                "mutation": None,
+            }
         decision = plan_transition(
             from_settled=settled,
             to_target=TO_IN_PROGRESS,
@@ -591,14 +627,26 @@ def persist_admission_identity(
             ),
             "identity": dict(previous),
         }
-    merged = dict(previous)
-    if predecessor and not _string(merged.get("predecessorAttemptId")):
-        merged["predecessorAttemptId"] = predecessor
+    prev_predecessor = _string(
+        previous.get("predecessorAttemptId") or previous.get("predecessor_attempt_id")
+    )
+    if predecessor != prev_predecessor:
+        return {
+            "persisted": False,
+            "reasonCode": "substitution_denied",
+            "summary": (
+                "Replay predecessor "
+                f"{predecessor or '<absent>'} differs from persisted "
+                f"{prev_predecessor or '<absent>'}; continuation lineage and "
+                "preserved-work ownership cannot change after first persistence."
+            ),
+            "identity": dict(previous),
+        }
     return {
         "persisted": True,
         "reasonCode": "already_persisted",
         "summary": "Persisted identity unchanged across retry/replay.",
-        "identity": merged,
+        "identity": dict(previous),
     }
 
 

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -14,6 +14,7 @@ from moonmind.workflows.adapters.github_service import GitHubService
 from moonmind.workflows.temporal.github_issue_admission import (
     ENTRYPOINT_SEARCH,
     admit_for_entrypoint,
+    recandidate_after_abandon,
 )
 from moonmind.workflows.temporal.github_issue_lifecycle import (
     ELIGIBLE_SETTLED_STATES,
@@ -300,6 +301,8 @@ async def resolve_issue(
     retry_policy: Mapping[str, Any] | None = None,
     reads_complete: Mapping[str, Any] | None = None,
     active_attempt_comments: Sequence[Mapping[str, Any]] | None = None,
+    own_announcement_abandoned: bool | None = None,
+    writers_settled: bool | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     """Select the best search match, or first unblocked open issue, within 500 rows.
 
@@ -329,6 +332,25 @@ async def resolve_issue(
         raise ValueError(
             "GitHub issue search requires an explicit owner/repository scope."
         )
+    # Req 4 recandidate gate (issue #4178): a search may consider another
+    # candidate only after its own abandoned announcement and writers are
+    # conclusively settled. Ordinary first selections pass no signals and
+    # proceed; a present-but-unsettled recandidate context blocks selection
+    # rather than silently scanning on.
+    if own_announcement_abandoned is not None or writers_settled is not None:
+        gate = recandidate_after_abandon(
+            own_announcement_abandoned=bool(own_announcement_abandoned),
+            writers_settled=bool(writers_settled),
+        )
+        if not gate["allowed"]:
+            return None, {
+                "searchEvidence": {
+                    "fallbackScanning": not query,
+                    "pagesExamined": 0,
+                    "candidatesExamined": 0,
+                },
+                "error": gate["summary"],
+            }
     evidence: dict[str, Any] = {
         "searchEvidence": {
             "fallbackScanning": not query,
@@ -424,9 +446,12 @@ async def resolve_issue(
                     candidate_attempt_context = attempt_context
                 # Same shared exact-issue admission boundary as explicit /
                 # orchestration / continuation paths (issue #4178): the
-                # search entrypoint admits with its pinned identity. The
-                # fallback-scan path already resolves trusted blocker
-                # evidence per candidate; reuse that read for admission.
+                # search entrypoint admits with its pinned identity plus the
+                # full Req-1 bundle. The fallback-scan path already resolves
+                # trusted blocker evidence per candidate and reuses that read
+                # for admission. The query path resolves blockers for the
+                # admitted candidate only (one bounded read): a blocked
+                # admitted candidate is skipped rather than selected.
                 candidate_blockers: list[dict[str, Any]] | None = None
                 if not query:
                     candidate_blockers = await blockers_from_issue(normalized)
@@ -446,6 +471,10 @@ async def resolve_issue(
                     continue
                 if not query and candidate_blockers:
                     continue
+                if query:
+                    admitted_blockers = await blockers_from_issue(normalized)
+                    if admitted_blockers:
+                        continue
                 return candidate["number"], evidence
             if len(candidates) < 100:
                 return None, {

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -11,6 +11,10 @@ import httpx
 from markdown_it import MarkdownIt
 
 from moonmind.workflows.adapters.github_service import GitHubService
+from moonmind.workflows.temporal.github_issue_admission import (
+    ENTRYPOINT_SEARCH,
+    admit_for_entrypoint,
+)
 from moonmind.workflows.temporal.github_issue_lifecycle import (
     ELIGIBLE_SETTLED_STATES,
     SETTLED_RECOVERY_NEEDED,
@@ -399,6 +403,18 @@ async def resolve_issue(
                 if attempt_evidence_resolver is not None:
                     attempt_context = await attempt_evidence_resolver(normalized)
                     if attempt_evidence_blocks_admission(attempt_context):
+                        continue
+                    # Same shared exact-issue admission boundary as explicit /
+                    # orchestration / continuation paths (issue #4178): the
+                    # search entrypoint admits with its pinned identity.
+                    shared = admit_for_entrypoint(
+                        ENTRYPOINT_SEARCH,
+                        repository=repository,
+                        issue_number=int(candidate["number"]),
+                        issue={"state": "open", "labels": normalized["labels"]},
+                        attempt_context=attempt_context,
+                    )
+                    if not shared.allowed:
                         continue
                 if not query and await blockers_from_issue(normalized):
                     continue

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -295,6 +295,11 @@ async def resolve_issue(
     blockers_from_issue: Callable[[Mapping[str, Any]], Awaitable[list[dict[str, Any]]]],
     attempt_evidence_resolver: Callable[[Mapping[str, Any]], Awaitable[Mapping[str, Any] | None]] | None = None,
     recovery_handoff: Mapping[str, Any] | None = None,
+    attempt_context: Mapping[str, Any] | None = None,
+    pr_identities: Sequence[Mapping[str, Any]] | None = None,
+    retry_policy: Mapping[str, Any] | None = None,
+    reads_complete: Mapping[str, Any] | None = None,
+    active_attempt_comments: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[int | None, dict[str, Any]]:
     """Select the best search match, or first unblocked open issue, within 500 rows.
 
@@ -307,6 +312,17 @@ async def resolve_issue(
     (``predecessor_stopped`` plus ``handoff_usable``): without it the later
     start transition denies the continuation deterministically, so the scan
     passes the candidate over instead of returning it.
+
+    Every surviving candidate additionally passes the one shared exact-issue
+    admission boundary used by explicit/orchestration/continuation paths
+    (issue #4178) with its pinned repository/issue identity. Per-candidate
+    attempt evidence comes from ``attempt_evidence_resolver`` when supplied,
+    otherwise from the caller-supplied ``attempt_context``; the remaining
+    Req-1 bundle entries (blockers on the fallback-scan path, PR identities,
+    retry policy, read completeness, validated attempt comments) are threaded
+    through when the caller supplies them. Incomplete pagination or failed
+    reads remain unknown evidence upstream of this function and never an
+    empty owner set.
     """
 
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
@@ -401,22 +417,34 @@ async def resolve_issue(
                 ):
                     continue
                 if attempt_evidence_resolver is not None:
-                    attempt_context = await attempt_evidence_resolver(normalized)
-                    if attempt_evidence_blocks_admission(attempt_context):
+                    candidate_attempt_context: Mapping[str, Any] | None = await attempt_evidence_resolver(normalized)
+                    if attempt_evidence_blocks_admission(candidate_attempt_context):
                         continue
-                    # Same shared exact-issue admission boundary as explicit /
-                    # orchestration / continuation paths (issue #4178): the
-                    # search entrypoint admits with its pinned identity.
-                    shared = admit_for_entrypoint(
-                        ENTRYPOINT_SEARCH,
-                        repository=repository,
-                        issue_number=int(candidate["number"]),
-                        issue={"state": "open", "labels": normalized["labels"]},
-                        attempt_context=attempt_context,
-                    )
-                    if not shared.allowed:
-                        continue
-                if not query and await blockers_from_issue(normalized):
+                else:
+                    candidate_attempt_context = attempt_context
+                # Same shared exact-issue admission boundary as explicit /
+                # orchestration / continuation paths (issue #4178): the
+                # search entrypoint admits with its pinned identity. The
+                # fallback-scan path already resolves trusted blocker
+                # evidence per candidate; reuse that read for admission.
+                candidate_blockers: list[dict[str, Any]] | None = None
+                if not query:
+                    candidate_blockers = await blockers_from_issue(normalized)
+                shared = admit_for_entrypoint(
+                    ENTRYPOINT_SEARCH,
+                    repository=repository,
+                    issue_number=int(candidate["number"]),
+                    issue={"state": "open", "labels": normalized["labels"]},
+                    attempt_context=candidate_attempt_context,
+                    blockers=candidate_blockers,
+                    pr_identities=pr_identities,
+                    retry_policy=retry_policy,
+                    reads_complete=reads_complete,
+                    active_attempt_comments=active_attempt_comments,
+                )
+                if not shared.allowed:
+                    continue
+                if not query and candidate_blockers:
                     continue
                 return candidate["number"], evidence
             if len(candidates) < 100:

--- a/moonmind/workflows/temporal/github_issue_search.py
+++ b/moonmind/workflows/temporal/github_issue_search.py
@@ -447,14 +447,13 @@ async def resolve_issue(
                 # Same shared exact-issue admission boundary as explicit /
                 # orchestration / continuation paths (issue #4178): the
                 # search entrypoint admits with its pinned identity plus the
-                # full Req-1 bundle. The fallback-scan path already resolves
-                # trusted blocker evidence per candidate and reuses that read
-                # for admission. The query path resolves blockers for the
-                # admitted candidate only (one bounded read): a blocked
-                # admitted candidate is skipped rather than selected.
-                candidate_blockers: list[dict[str, Any]] | None = None
-                if not query:
-                    candidate_blockers = await blockers_from_issue(normalized)
+                # full Req-1 bundle. Trusted blocker evidence is resolved per
+                # candidate and threaded into the admit decision itself (not a
+                # post-hoc skip): a blocked candidate is denied as
+                # blocked_prerequisite on both the query and fallback paths.
+                candidate_blockers: list[dict[str, Any]] | None = await blockers_from_issue(
+                    normalized
+                )
                 shared = admit_for_entrypoint(
                     ENTRYPOINT_SEARCH,
                     repository=repository,
@@ -469,12 +468,8 @@ async def resolve_issue(
                 )
                 if not shared.allowed:
                     continue
-                if not query and candidate_blockers:
+                if candidate_blockers:
                     continue
-                if query:
-                    admitted_blockers = await blockers_from_issue(normalized)
-                    if admitted_blockers:
-                        continue
                 return candidate["number"], evidence
             if len(candidates) < 100:
                 return None, {

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -1979,21 +1979,57 @@ def _github_downstream_workflow_payload(
         issue_number=issue_number,
         summary=summary,
     )
+    # Acceptance A (issue #4178): downstream GitHub orchestrate/implement
+    # children are real orchestration producers for the shared admission
+    # boundary. The child brief infers ENTRYPOINT_ORCHESTRATION from these
+    # trusted signals via _github_admission_entrypoint (orchestrationRunId /
+    # parentWorkflowId / nestedImplement). Continuation/retry lineage present
+    # in the parent channel is preserved so the same boundary infers
+    # continuation/retry instead of falling back to explicit.
+    child_inputs: dict[str, Any] = {
+        **configured_inputs,
+        "github_issue": github_issue_input,
+        "github_issue_ref": github_issue_ref,
+        "source_design_path": source_design_path,
+        "source_claim_ids": source_claim_ids,
+        "constraints": (
+            f"Preserve source issue {source_issue_key} traceability."
+            if source_issue_key
+            else ""
+        ),
+    }
+    for signal_source in (task_payload, configured_inputs, traceability, mapping):
+        if not isinstance(signal_source, Mapping):
+            continue
+        for key in (
+            "orchestrationRunId",
+            "orchestration_run_id",
+            "parentWorkflowId",
+            "parent_workflow_id",
+            "predecessorAttemptId",
+            "predecessor_attempt_id",
+            "predecessorStopped",
+            "predecessor_stopped",
+            "handoffUsable",
+            "handoff_usable",
+            "retryOf",
+            "retry_of",
+            "attemptRetry",
+            "attempt_retry",
+            "linkedAttempts",
+            "linked_attempts",
+        ):
+            if key in signal_source and key not in child_inputs:
+                child_inputs[key] = signal_source.get(key)
+    if source_issue_key and not _string(
+        child_inputs.get("parentWorkflowId") or child_inputs.get("parent_workflow_id")
+    ):
+        child_inputs["parentWorkflowId"] = source_issue_key
+    child_inputs["nestedImplement"] = True
     task: dict[str, Any] = {
         "title": f"Run {preset_label} for {github_issue_ref}: {summary}",
         "instructions": instructions,
-        "inputs": {
-            **configured_inputs,
-            "github_issue": github_issue_input,
-            "github_issue_ref": github_issue_ref,
-            "source_design_path": source_design_path,
-            "source_claim_ids": source_claim_ids,
-            "constraints": (
-                f"Preserve source issue {source_issue_key} traceability."
-                if source_issue_key
-                else ""
-            ),
-        },
+        "inputs": child_inputs,
         "taskTemplate": {
             "slug": preset_slug,
         },
@@ -4698,13 +4734,12 @@ async def load_github_issue_preset_brief(
         "artifacts/github-issue-implement-brief.json",
     )
     # Req 2 + Req 3 (issue #4178): for eligible Available / Recovery-needed
-    # work, plan the stable attempt announcement + in-progress BEFORE expensive
-    # assessment/implementation and persist the selected issue + predecessor
-    # exactly once with the trusted input context. Advisory only: a claim
-    # plan never bypasses prerequisite/authority/readiness checks, and the
-    # persisted identity flows forward so retry/replay/recovery cannot
-    # silently substitute a different issue. The caller re-reads after the
-    # announcement and immediately before launching work.
+    # work, announce the stable attempt and apply in-progress BEFORE expensive
+    # assessment/implementation, then re-read after the announcement. Advisory
+    # only: a claim never bypasses prerequisite/authority/readiness checks, and
+    # the persisted identity flows forward so retry/replay/recovery cannot
+    # silently substitute a different issue. substitution_denied blocks the
+    # brief; contender/resume observations block the announcement write.
     brief_settled = interpret_issue(
         {"state": issue.get("state", "open"), "labels": issue.get("labels") or []}
     ).settled
@@ -4718,6 +4753,49 @@ async def load_github_issue_preset_brief(
             settled=brief_settled,
             current_labels=[str(label) for label in labels],
         )
+        persisted_check = _mapping(admission_handoff.get("admissionPersisted"))
+        if _string(persisted_check.get("reasonCode")) == "substitution_denied":
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "repository": repository,
+                    "issueNumber": int(issue.get("number") or issue_number),
+                    "reasonCode": "substitution_denied",
+                    "decision": "blocked",
+                    **admission_handoff,
+                    "error": str(
+                        persisted_check.get("summary")
+                        or "Retry/replay candidate differs from the persisted admitted identity."
+                    ),
+                },
+            )
+        claim_check = _mapping(admission_handoff.get("admissionClaim"))
+        if bool(claim_check.get("planned")):
+            claim_execution = await _execute_brief_admission_claim(
+                repository=repository,
+                issue_number=int(issue.get("number") or issue_number),
+                settled=brief_settled,
+                current_labels=[str(label) for label in labels],
+                claim=dict(claim_check),
+                inputs=inputs,
+                context=_context,
+                github_service_factory=github_service_factory,
+            )
+            admission_handoff["admissionClaimExecuted"] = claim_execution
+            if bool(claim_execution.get("blocked")):
+                return ToolResult(
+                    status="FAILED",
+                    outputs={
+                        "repository": repository,
+                        "issueNumber": int(issue.get("number") or issue_number),
+                        "reasonCode": str(claim_execution.get("reasonCode") or "claim_blocked"),
+                        "decision": "blocked",
+                        **admission_handoff,
+                        "error": str(
+                            claim_execution.get("summary") or "Advisory claim execution blocked."
+                        ),
+                    },
+                )
     return ToolResult(
         status="COMPLETED",
         outputs={
@@ -5811,6 +5889,241 @@ def _github_admission_claim_and_identity(
             "admissionPersisted": persisted}
 
 
+async def _execute_brief_admission_claim(
+    *,
+    repository: str,
+    issue_number: int,
+    settled: str,
+    current_labels: Sequence[str] | None = None,
+    claim: Mapping[str, Any],
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    github_service_factory: Callable[[], GitHubService] = GitHubService,
+) -> dict[str, Any]:
+    """Execute the Req-2 advisory claim write and re-read (issue #4178).
+
+    The brief path announces a stable attempt and applies in-progress BEFORE
+    expensive assessment/implementation, then re-reads after the announcement.
+    Prerequisite/authority/readiness checks stay intact: contender and resume
+    observations block the write, readiness gates the label mutation, and a
+    failed re-read blocks launching work on unknown evidence. The mutation is
+    the planned add-before-remove ops from ``announce_before_assessment``;
+    read-back mismatch is recorded honestly (unfenced race) without claiming
+    exclusivity.
+    """
+    issue_ref = f"{repository}#{issue_number}"
+    bundle = _github_admission_bundle(inputs, context)
+    own_attempt_id = _string(bundle.get("own_attempt_id")) or _string(
+        _mapping(inputs.get("previousOutputs")).get("attemptId")
+    )
+    if bundle.get("released") or bundle.get("superseded") or bundle.get(
+        "known_successor_attempt_id"
+    ) or bundle.get("operator_hold"):
+        gate = should_stop_on_resume(
+            own_attempt_id=own_attempt_id,
+            released=bool(bundle.get("released")),
+            superseded=bool(bundle.get("superseded")),
+            known_successor_attempt_id=_string(bundle.get("known_successor_attempt_id")),
+            operator_hold=bool(bundle.get("operator_hold")),
+        )
+        if gate["stop"]:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": str(gate.get("reasonCode") or "resume_blocked"),
+                "summary": str(gate.get("summary") or "Resume blocked; claim not executed."),
+                "issueRef": issue_ref,
+            }
+    if bundle.get("observed_contenders") or bundle.get("contradictory_evidence"):
+        gate = contender_quiesce_decision(
+            own_attempt_id=own_attempt_id,
+            observed_contenders=bundle.get("observed_contenders"),
+            operator_hold=bool(bundle.get("operator_hold")),
+            contradictory_evidence=bool(bundle.get("contradictory_evidence")),
+        )
+        if gate["quiesce"]:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": str(gate.get("reasonCode") or "contender_observed"),
+                "summary": str(gate.get("summary") or "Contender observed; claim not executed."),
+                "issueRef": issue_ref,
+            }
+    mutation = _mapping(claim.get("mutation"))
+    labels_to_add = [str(item) for item in _list(mutation.get("labelsToAdd")) if _string(item)]
+    labels_to_remove = [
+        str(item) for item in _list(mutation.get("labelsToRemove")) if _string(item)
+    ]
+    if not labels_to_add and not labels_to_remove:
+        reread_data, reread_error = await _fetch_github_issue(
+            repository=repository,
+            issue_number=issue_number,
+            github_service_factory=github_service_factory,
+        )
+        if reread_data is None:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": "read_failure",
+                "summary": (
+                    f"Advisory claim for {issue_ref} has no label change but the "
+                    f"re-read failed ({reread_error or 'unknown'}); unknown evidence "
+                    "blocks launching work."
+                ),
+                "issueRef": issue_ref,
+            }
+        reread_issue = _github_issue_payload(reread_data, repository)
+        return {
+            "executed": True,
+            "blocked": False,
+            "reasonCode": "already_applied",
+            "summary": f"Advisory claim for {issue_ref} already applied; re-read confirmed.",
+            "issueRef": issue_ref,
+            "appliedActions": [],
+            "rereadLabels": reread_issue.get("labels"),
+            "rereadSettled": interpret_issue(reread_issue).settled,
+            "rereadOk": True,
+        }
+    service = github_service_factory()
+    if hasattr(service, "check_issue_label_readiness"):
+        try:
+            readiness = await service.check_issue_label_readiness(
+                repo=repository, issue_number=issue_number, required_labels=labels_to_add
+            )
+        except Exception as exc:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": "readiness_failed",
+                "summary": f"Advisory claim readiness check failed for {issue_ref}: {exc}.",
+                "issueRef": issue_ref,
+            }
+        if isinstance(readiness, Mapping) and not readiness.get("ready"):
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": str(readiness.get("reasonCode") or "readiness_failed"),
+                "summary": str(
+                    readiness.get("summary")
+                    or f"Advisory claim readiness failed for {issue_ref}."
+                ),
+                "issueRef": issue_ref,
+                "readiness": dict(readiness),
+            }
+    applied: list[str] = []
+    for label in labels_to_add:
+        try:
+            result = await service.add_issue_labels(
+                repo=repository, issue_number=issue_number, labels=[label]
+            )
+        except Exception as exc:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": "claim_write_failed",
+                "summary": f"Advisory claim label add failed for {issue_ref}: {exc}.",
+                "issueRef": issue_ref,
+                "appliedActions": applied,
+            }
+        if not (isinstance(result, Mapping) and result.get("ok")):
+            code = _string(result.get("reasonCode") if isinstance(result, Mapping) else "")
+            summary = _string(result.get("summary") if isinstance(result, Mapping) else "")
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": code or "claim_write_failed",
+                "summary": summary or f"Advisory claim label add denied for {issue_ref}.",
+                "issueRef": issue_ref,
+                "appliedActions": applied,
+            }
+        applied.append(f"add_label:{label}")
+    for label in labels_to_remove:
+        try:
+            result = await service.remove_issue_label(
+                repo=repository, issue_number=issue_number, label=label
+            )
+        except Exception as exc:
+            return {
+                "executed": False,
+                "blocked": True,
+                "reasonCode": "claim_write_failed",
+                "summary": f"Advisory claim label remove failed for {issue_ref}: {exc}.",
+                "issueRef": issue_ref,
+                "appliedActions": applied,
+            }
+        if not (isinstance(result, Mapping) and result.get("ok")):
+            # A failed removal after a successful add leaves the destination
+            # applied; report honestly without rolling back shared state.
+            code = _string(result.get("reasonCode") if isinstance(result, Mapping) else "")
+            summary = _string(result.get("summary") if isinstance(result, Mapping) else "")
+            reread_data, _ = await _fetch_github_issue(
+                repository=repository,
+                issue_number=issue_number,
+                github_service_factory=github_service_factory,
+            )
+            reread_labels: list[str] = []
+            reread_settled = settled
+            if reread_data is not None:
+                reread_issue = _github_issue_payload(reread_data, repository)
+                reread_labels = [str(item) for item in reread_issue.get("labels") or []]
+                try:
+                    reread_settled = interpret_issue(reread_issue).settled
+                except Exception:
+                    pass
+            return {
+                "executed": True,
+                "blocked": True,
+                "reasonCode": code or "claim_remove_failed",
+                "summary": summary or f"Advisory claim removal failed for {issue_ref}.",
+                "issueRef": issue_ref,
+                "appliedActions": applied,
+                "rereadLabels": reread_labels,
+                "rereadSettled": reread_settled,
+                "rereadOk": reread_data is not None,
+            }
+        applied.append(f"remove_label:{label}")
+    reread_data, reread_error = await _fetch_github_issue(
+        repository=repository,
+        issue_number=issue_number,
+        github_service_factory=github_service_factory,
+    )
+    if reread_data is None:
+        return {
+            "executed": True,
+            "blocked": True,
+            "reasonCode": "read_failure",
+            "summary": (
+                f"Advisory claim for {issue_ref} applied {applied} but the re-read "
+                f"failed ({reread_error or 'unknown'}); unknown evidence blocks "
+                "launching work."
+            ),
+            "issueRef": issue_ref,
+            "appliedActions": applied,
+            "rereadOk": False,
+        }
+    reread_issue = _github_issue_payload(reread_data, repository)
+    try:
+        reread_settled = interpret_issue(reread_issue).settled
+    except Exception:
+        reread_settled = settled
+    return {
+        "executed": True,
+        "blocked": False,
+        "reasonCode": "claim_executed",
+        "summary": (
+            f"Announced attempt for {issue_ref} and applied in-progress before "
+            "assessment; re-read after the announcement. GitHub offers no "
+            "conditional ownership acquisition, so the remaining check-to-write "
+            "race stays unfenced."
+        ),
+        "issueRef": issue_ref,
+        "appliedActions": applied,
+        "rereadLabels": reread_issue.get("labels"),
+        "rereadSettled": reread_settled,
+        "rereadOk": True,
+    }
+
+
 def _github_recandidate_context(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
@@ -5851,8 +6164,31 @@ def _github_child_attempt_gate(
     if not child_kind:
         return None
     bundle = _github_admission_bundle(inputs, context)
-    controlling = _string(bundle.get("own_attempt_id")) or _string(
-        inputs.get("controllingAttemptId") or inputs.get("controlling_attempt_id")
+    # Controlling-attempt sourcing fallback chain (Req 6): explicit
+    # controlling id first, then the shared attempt id from the trusted
+    # channel (direct inputs, previous outputs, workflow context), then
+    # attempt ids carried in previous/context outputs. The first non-empty
+    # value wins; an empty chain denies the handoff.
+    previous = _mapping(inputs.get("previousOutputs"))
+    context_previous = _mapping((context or {}).get("previousOutputs"))
+    controlling = (
+        _string(bundle.get("own_attempt_id"))
+        or _string(
+            inputs.get("controllingAttemptId") or inputs.get("controlling_attempt_id")
+        )
+        or _string(
+            previous.get("controllingAttemptId")
+            or previous.get("controlling_attempt_id")
+            or previous.get("attemptId")
+            or previous.get("attempt_id")
+        )
+        or _string(
+            context_previous.get("controllingAttemptId")
+            or context_previous.get("controlling_attempt_id")
+            or context_previous.get("attemptId")
+            or context_previous.get("attempt_id")
+        )
+        or _string((context or {}).get("controllingAttemptId"))
     )
     pr_url = _string(
         inputs.get("pullRequestUrl") or inputs.get("pull_request_url") or inputs.get("prUrl")

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -38,7 +38,12 @@ from moonmind.workflows.temporal.github_issue_attempts import (
 )
 from moonmind.workflows.temporal.github_issue_admission import (
     ENTRYPOINT_EXPLICIT,
+    ENTRYPOINT_SEARCH,
+    ENTRYPOINTS,
     admit_for_entrypoint,
+    contender_quiesce_decision,
+    revalidate_for_mutation,
+    should_stop_on_resume,
 )
 from moonmind.workflows.temporal.github_issue_lifecycle import (
     attempt_evidence_blocks_admission,
@@ -4552,6 +4557,11 @@ async def load_github_issue_preset_brief(
                 github_service=github_service_factory(),
                 blockers_from_issue=blockers_for_issue,
                 recovery_handoff=recovery_handoff or None,
+                # Same shared exact-issue admission boundary as explicit /
+                # orchestration / continuation paths (issue #4178): the
+                # selector admits the search entrypoint with this pinned
+                # identity plus supplied attempt evidence.
+                attempt_context=_github_status_attempt_context(inputs, _context),
             )
         except ValueError as exc:
             return ToolResult(status="FAILED", outputs={"error": str(exc)})
@@ -4609,18 +4619,19 @@ async def load_github_issue_preset_brief(
         or not is_lifecycle_selectable_candidate(
             issue_data, _github_status_attempt_context(inputs, _context)
         )
-        or not admit_for_entrypoint(
-            ENTRYPOINT_EXPLICIT,
+        or not _github_shared_admission_decision(
+            inputs=inputs,
+            context=_context,
             repository=repository,
             issue_number=issue_number,
             issue=issue_data,
-            attempt_context=_github_status_attempt_context(inputs, _context),
         ).allowed
     ):
         # Direct issue loads run the same admission policy as search: an
         # explicit issue reference is not a bypass around lifecycle state.
         # Both paths route through the one shared exact-issue admission
-        # boundary (issue #4178); search uses ENTRYPOINT_SEARCH instead.
+        # boundary (issue #4178) with the full Req-1 evidence bundle; search
+        # selections use ENTRYPOINT_SEARCH instead.
         return ToolResult(
             status="FAILED",
             outputs={
@@ -5513,6 +5524,143 @@ def _github_status_attempt_context(
     return collected
 
 
+def _github_admission_entrypoint(
+    inputs: Mapping[str, Any],
+    *,
+    search_selected: bool = False,
+) -> str:
+    """Select the pinned admission entrypoint for one GitHub issue boundary call.
+
+    Search-selected work, explicit implementation/orchestration, retries, and
+    operator continuations invoke the same shared admission boundary with
+    pinned identities (issue #4178). A caller-supplied entrypoint is honored
+    only when it names that shared boundary; otherwise direct loads use
+    explicit admission and search selections use search admission. There are no
+    preset-name exemptions: an unknown entrypoint value falls back to the
+    path default and the boundary itself rejects unknown entrypoints.
+    """
+    explicit = _string(
+        inputs.get("entrypoint")
+        or inputs.get("admissionEntrypoint")
+        or inputs.get("admission_entrypoint")
+    )
+    if explicit in ENTRYPOINTS:
+        return explicit
+    return ENTRYPOINT_SEARCH if search_selected else ENTRYPOINT_EXPLICIT
+
+
+def _github_admission_bundle(
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Collect caller-supplied Req-1 evidence for the shared admission boundary.
+
+    Sources are the trusted workflow input channel only (direct inputs,
+    previous step outputs, and workflow context) — never discovery results or
+    local caches. Absent evidence stays absent rather than becoming an empty
+    owner set: ``admit_exact_issue`` treats missing bundle entries as no
+    evidence, while an explicit ``reads_complete`` failure blocks admission as
+    unknown evidence. Known upstream producers: the blocker check step emits
+    ``blockingIssues`` for the later In Progress step, and resume/observation
+    signals arrive as explicit workflow inputs.
+    """
+    previous = _mapping(inputs.get("previousOutputs"))
+    context_previous = _mapping((context or {}).get("previousOutputs"))
+    sources: tuple[Any, ...] = (inputs, previous, context_previous, context or {})
+
+    def _first_list(*names: str) -> list[dict[str, Any]] | None:
+        for source in sources:
+            if not isinstance(source, Mapping):
+                continue
+            for name in names:
+                value = source.get(name)
+                if isinstance(value, list):
+                    return [dict(item) for item in value if isinstance(item, Mapping)]
+        return None
+
+    def _first_mapping(*names: str) -> dict[str, Any] | None:
+        for source in sources:
+            if not isinstance(source, Mapping):
+                continue
+            for name in names:
+                value = source.get(name)
+                if isinstance(value, Mapping):
+                    return dict(value)
+        return None
+
+    def _first_raw(*names: str) -> Any:
+        for source in sources:
+            if not isinstance(source, Mapping):
+                continue
+            for name in names:
+                if name in source:
+                    return source.get(name)
+        return None
+
+    bundle: dict[str, Any] = {}
+    blockers = _first_list("blockingIssues", "blocking_issues", "blockers")
+    if blockers is not None:
+        bundle["blockers"] = blockers
+    pr_identities = _first_list("prIdentities", "pr_identities", "pullRequests", "pull_requests")
+    if pr_identities is not None:
+        bundle["pr_identities"] = pr_identities
+    retry_policy = _first_mapping("retryPolicy", "retry_policy")
+    if retry_policy is not None:
+        bundle["retry_policy"] = retry_policy
+    reads_complete = _first_mapping("readsComplete", "reads_complete")
+    if reads_complete is not None:
+        bundle["reads_complete"] = reads_complete
+    active_comments = _first_list("activeAttemptComments", "active_attempt_comments")
+    if active_comments is not None:
+        bundle["active_attempt_comments"] = active_comments
+    contenders = _first_list("observedContenders", "observed_contenders")
+    if contenders is not None:
+        bundle["observed_contenders"] = contenders
+    for key, names in (
+        ("known_successor_attempt_id", ("knownSuccessorAttemptId", "known_successor_attempt_id")),
+        ("released", ("released",)),
+        ("superseded", ("superseded",)),
+        ("operator_hold", ("operatorHold", "operator_hold")),
+        ("contradictory_evidence", ("contradictoryEvidence", "contradictory_evidence")),
+        ("own_attempt_id", ("attemptId", "attempt_id")),
+    ):
+        value = _first_raw(*names)
+        if value is not None:
+            bundle[key] = value
+    return bundle
+
+
+def _github_shared_admission_decision(
+    *,
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    repository: str,
+    issue_number: int,
+    issue: Mapping[str, Any] | None,
+    search_selected: bool = False,
+) -> Any:
+    """Invoke the one shared exact-issue admission boundary (issue #4178).
+
+    Forwards the pinned identity plus the full Req-1 evidence bundle collected
+    from the trusted input channel. Callers keep their existing
+    prerequisite/authority/readiness checks intact; this boundary only adds the
+    shared ownership/conflict decision.
+    """
+    bundle = _github_admission_bundle(inputs, context)
+    return admit_for_entrypoint(
+        _github_admission_entrypoint(inputs, search_selected=search_selected),
+        repository=repository,
+        issue_number=issue_number,
+        issue=issue,
+        attempt_context=_github_status_attempt_context(inputs, context),
+        blockers=bundle.get("blockers"),
+        pr_identities=bundle.get("pr_identities"),
+        retry_policy=bundle.get("retry_policy"),
+        reads_complete=bundle.get("reads_complete"),
+        active_attempt_comments=bundle.get("active_attempt_comments"),
+    )
+
+
 def _github_status_transition_reason(
     mode: str,
     inputs: Mapping[str, Any],
@@ -6324,28 +6472,63 @@ async def update_github_issue_status(
     # evidence. The start transition additionally revalidates through the one
     # shared exact-issue admission boundary (issue #4178).
     attempt_context = _github_status_attempt_context(inputs, _context)
-    if target == "to_in_progress":
-        shared_admission = admit_for_entrypoint(
-            ENTRYPOINT_EXPLICIT,
-            repository=repository,
-            issue_number=issue_number,
-            issue={"state": issue.get("state", "open"), "labels": current_labels},
-            attempt_context=attempt_context,
+    admission_bundle = _github_admission_bundle(inputs, _context)
+    own_attempt_id = _string(admission_bundle.get("own_attempt_id"))
+    if target == "to_in_progress" and (
+        admission_bundle.get("released")
+        or admission_bundle.get("superseded")
+        or admission_bundle.get("known_successor_attempt_id")
+        or admission_bundle.get("operator_hold")
+    ):
+        # Req 5 resume gate: a paused/reconnected attempt that observed a
+        # release, a successor, or an operator hold performs no new shared
+        # mutation. Only explicit resume signals trigger this gate; ordinary
+        # starts pass through to the retained checks below.
+        resume_gate = should_stop_on_resume(
+            own_attempt_id=own_attempt_id,
+            released=bool(admission_bundle.get("released")),
+            superseded=bool(admission_bundle.get("superseded")),
+            known_successor_attempt_id=_string(admission_bundle.get("known_successor_attempt_id")),
+            operator_hold=bool(admission_bundle.get("operator_hold")),
         )
-        if not shared_admission.allowed and shared_admission.reason_code in {
-            "active_attempt_conflict",
-            "missing_label_with_active_attempt",
-            "manual_in_progress_without_trusted_owner",
-        }:
+        if resume_gate["stop"]:
             return ToolResult(
                 status="FAILED",
                 outputs={
                     "issueRef": issue_ref,
                     "decision": "blocked",
                     "lifecycleSettled": interpretation.settled,
-                    "reasonCode": shared_admission.reason_code,
+                    "reasonCode": resume_gate["reasonCode"],
                     "summary": (
-                        f"Skipped GitHub issue update for {issue_ref}: {shared_admission.summary}"
+                        f"Skipped GitHub issue update for {issue_ref}: {resume_gate['summary']}"
+                    ),
+                },
+            )
+    if target == "to_in_progress" and (
+        admission_bundle.get("observed_contenders")
+        or admission_bundle.get("contradictory_evidence")
+    ):
+        # Req 4 contender gate: an observed competing preparing/active
+        # attempt or contradictory evidence stops shared publication through
+        # this existing tool boundary. Output is preserved in the FAILED
+        # result; no timestamp winner is selected and no other attempt's
+        # in-progress status is cleared (this path only skips its own write).
+        quiesce_gate = contender_quiesce_decision(
+            own_attempt_id=own_attempt_id,
+            observed_contenders=admission_bundle.get("observed_contenders"),
+            operator_hold=bool(admission_bundle.get("operator_hold")),
+            contradictory_evidence=bool(admission_bundle.get("contradictory_evidence")),
+        )
+        if quiesce_gate["quiesce"]:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "lifecycleSettled": interpretation.settled,
+                    "reasonCode": quiesce_gate["reasonCode"],
+                    "summary": (
+                        f"Skipped GitHub issue update for {issue_ref}: {quiesce_gate['summary']}"
                     ),
                 },
             )
@@ -6384,6 +6567,45 @@ async def update_github_issue_status(
                 "summary": f"Abandoned obsolete GitHub issue update for {issue_ref}: {abandon_reason}.",
             },
         )
+    if target == "to_in_progress" and not caller_expected_settled:
+        # Shared exact-issue admission with the full Req-1 evidence bundle.
+        # Narrowed to denies with no retained downstream equivalent: the
+        # caller's expected-state path above owns abandon/idempotent
+        # already-applied outcomes, and mixed/unknown states stay with the
+        # reconciliation handler below (reasonCode reconciliation_required).
+        shared_admission = _github_shared_admission_decision(
+            inputs=inputs,
+            context=_context,
+            repository=repository,
+            issue_number=issue_number,
+            issue={"state": issue.get("state", "open"), "labels": current_labels},
+        )
+        if not shared_admission.allowed and shared_admission.reason_code in {
+            "active_attempt_conflict",
+            "missing_label_with_active_attempt",
+            "manual_in_progress_without_trusted_owner",
+            "blocked_prerequisite",
+            "ambiguous_pr_identity",
+            "retry_exhausted",
+            "operator_hold",
+            "lineage_gap",
+            "incompatible_policy_lineage",
+            "missing_policy_lineage",
+            "read_failure",
+            "closed_terminal",
+        }:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "lifecycleSettled": interpretation.settled,
+                    "reasonCode": shared_admission.reason_code,
+                    "summary": (
+                        f"Skipped GitHub issue update for {issue_ref}: {shared_admission.summary}"
+                    ),
+                },
+            )
     if interpretation.settled in {"blocked_mixed", "blocked_unknown", "blocked_open_done"}:
         if (
             was_finalize_after_pr
@@ -6496,6 +6718,40 @@ async def update_github_issue_status(
     applied: list[str] = []
     warnings: list[str] = []
     comment_body = ""
+    if (
+        admission_bundle.get("released")
+        or admission_bundle.get("superseded")
+        or admission_bundle.get("known_successor_attempt_id")
+    ):
+        # Req 5 pre-mutation revalidation at the trusted publication
+        # boundary: a known released or superseded attempt cannot replay
+        # publication or stale cleanup, even for non-start targets that
+        # passed the guards above. Only explicit resume signals trigger this
+        # gate. GitHub label/comment operations offer no conditional
+        # ownership acquisition, so the remaining check-to-write race stays
+        # unfenced (see UNFENCED_CHECK_TO_WRITE_RACE_NOTE); revalidation
+        # rejects observable stale work but never claims to fence a delayed
+        # external request.
+        mutation_gate = revalidate_for_mutation(
+            own_attempt_id=own_attempt_id,
+            observed={"settled": interpretation.settled},
+            known_successor_attempt_id=_string(admission_bundle.get("known_successor_attempt_id")),
+            released=bool(admission_bundle.get("released")),
+            superseded=bool(admission_bundle.get("superseded")),
+        )
+        if not mutation_gate["allowed"]:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "lifecycleSettled": interpretation.settled,
+                    "reasonCode": mutation_gate["reasonCode"],
+                    "summary": (
+                        f"Skipped GitHub issue update for {issue_ref}: {mutation_gate['summary']}"
+                    ),
+                },
+            )
     # Targeted additions/removals only: never replace the complete label list.
     # The destination status is added before any old blocking status is
     # removed. This is eventual reconciliation, not an atomic compare-and-swap

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -37,11 +37,19 @@ from moonmind.workflows.temporal.github_issue_attempts import (
     resolve_installation_id,
 )
 from moonmind.workflows.temporal.github_issue_admission import (
+    ENTRYPOINT_CONTINUATION,
     ENTRYPOINT_EXPLICIT,
+    ENTRYPOINT_ORCHESTRATION,
+    ENTRYPOINT_RETRY,
     ENTRYPOINT_SEARCH,
     ENTRYPOINTS,
     admit_for_entrypoint,
+    announce_before_assessment,
+    check_delayed_mutation_fenced,
+    child_attempt_context,
     contender_quiesce_decision,
+    persist_admission_identity,
+    recandidate_after_abandon,
     revalidate_for_mutation,
     should_stop_on_resume,
 )
@@ -4551,6 +4559,13 @@ async def load_github_issue_preset_brief(
         # lets the selector admit it, otherwise the selector scans on for an
         # Available candidate.
         try:
+            # Forward the full Req-1 evidence bundle from the trusted input
+            # channel so the query path can trigger blocker / PR-identity /
+            # retry-policy / read-failure denies exactly like the explicit
+            # and start paths (issue #4178). Absent bundle entries stay
+            # absent rather than becoming an empty owner set.
+            _search_bundle = _github_admission_bundle(inputs, _context)
+            _recandidate = _github_recandidate_context(inputs, _context)
             issue_number, search_evidence = await resolve_issue(
                 repository=repository,
                 query=_string(inputs.get("issueSearch")),
@@ -4560,8 +4575,18 @@ async def load_github_issue_preset_brief(
                 # Same shared exact-issue admission boundary as explicit /
                 # orchestration / continuation paths (issue #4178): the
                 # selector admits the search entrypoint with this pinned
-                # identity plus supplied attempt evidence.
+                # identity plus the full trusted evidence bundle.
                 attempt_context=_github_status_attempt_context(inputs, _context),
+                pr_identities=_search_bundle.get("pr_identities"),
+                retry_policy=_search_bundle.get("retry_policy"),
+                reads_complete=_search_bundle.get("reads_complete"),
+                active_attempt_comments=_search_bundle.get("active_attempt_comments"),
+                own_announcement_abandoned=_recandidate.get("own_announcement_abandoned")
+                if _recandidate.get("present")
+                else None,
+                writers_settled=_recandidate.get("writers_settled")
+                if _recandidate.get("present")
+                else None,
             )
         except ValueError as exc:
             return ToolResult(status="FAILED", outputs={"error": str(exc)})
@@ -4672,6 +4697,27 @@ async def load_github_issue_preset_brief(
         inputs.get("brief_artifact_path"),
         "artifacts/github-issue-implement-brief.json",
     )
+    # Req 2 + Req 3 (issue #4178): for eligible Available / Recovery-needed
+    # work, plan the stable attempt announcement + in-progress BEFORE expensive
+    # assessment/implementation and persist the selected issue + predecessor
+    # exactly once with the trusted input context. Advisory only: a claim
+    # plan never bypasses prerequisite/authority/readiness checks, and the
+    # persisted identity flows forward so retry/replay/recovery cannot
+    # silently substitute a different issue. The caller re-reads after the
+    # announcement and immediately before launching work.
+    brief_settled = interpret_issue(
+        {"state": issue.get("state", "open"), "labels": issue.get("labels") or []}
+    ).settled
+    admission_handoff: dict[str, Any] = {}
+    if brief_settled in {"available", "recovery_needed"}:
+        admission_handoff = _github_admission_claim_and_identity(
+            inputs=inputs,
+            context=_context,
+            repository=repository,
+            issue_number=int(issue.get("number") or issue_number),
+            settled=brief_settled,
+            current_labels=[str(label) for label in labels],
+        )
     return ToolResult(
         status="COMPLETED",
         outputs={
@@ -4679,6 +4725,10 @@ async def load_github_issue_preset_brief(
             "issue": issue,
             **search_evidence,
             **recovery_routing,
+            **admission_handoff,
+            "admissionEntrypoint": _github_admission_entrypoint(
+                inputs, search_selected=bool(search_evidence)
+            ),
             "presetBrief": preset_brief,
             "artifactPath": artifact_path,
             "summary": f"Loaded GitHub issue preset brief for {issue_ref} from trusted GitHub data.",
@@ -5534,10 +5584,14 @@ def _github_admission_entrypoint(
     Search-selected work, explicit implementation/orchestration, retries, and
     operator continuations invoke the same shared admission boundary with
     pinned identities (issue #4178). A caller-supplied entrypoint is honored
-    only when it names that shared boundary; otherwise direct loads use
-    explicit admission and search selections use search admission. There are no
-    preset-name exemptions: an unknown entrypoint value falls back to the
-    path default and the boundary itself rejects unknown entrypoints.
+    only when it names that shared boundary. When no explicit entrypoint is
+    supplied, trusted workflow signals select the real orchestration /
+    continuation / retry call site: usable recovery handoff evidence means an
+    operator continuation, retry linkage means a retry, and orchestration
+    linkage means orchestration. Otherwise direct loads use explicit admission
+    and search selections use search admission. There are no preset-name
+    exemptions: an unknown entrypoint value falls back to the path default
+    and the boundary itself rejects unknown entrypoints.
     """
     explicit = _string(
         inputs.get("entrypoint")
@@ -5546,7 +5600,51 @@ def _github_admission_entrypoint(
     )
     if explicit in ENTRYPOINTS:
         return explicit
+    previous = _mapping(inputs.get("previousOutputs"))
+    for source in (inputs, previous):
+        if not isinstance(source, Mapping):
+            continue
+        if _string(source.get("orchestrationRunId") or source.get("orchestration_run_id")):
+            return ENTRYPOINT_ORCHESTRATION
+        if _string(source.get("parentWorkflowId") or source.get("parent_workflow_id")):
+            return ENTRYPOINT_ORCHESTRATION
+        if source.get("nestedImplement") is True or source.get("nested_implement") is True:
+            return ENTRYPOINT_ORCHESTRATION
+    for source in (inputs, previous):
+        if not isinstance(source, Mapping):
+            continue
+        stopped = source.get("predecessorStopped", source.get("predecessor_stopped"))
+        usable = source.get("handoffUsable", source.get("handoff_usable"))
+        if _truthy_like(stopped) and _truthy_like(usable):
+            return ENTRYPOINT_CONTINUATION
+        if _string(source.get("predecessorAttemptId") or source.get("predecessor_attempt_id")):
+            return ENTRYPOINT_CONTINUATION
+    for source in (inputs, previous):
+        if not isinstance(source, Mapping):
+            continue
+        if _string(source.get("retryOf") or source.get("retry_of")):
+            return ENTRYPOINT_RETRY
+        if source.get("attemptRetry") is True or source.get("attempt_retry") is True:
+            return ENTRYPOINT_RETRY
+        linked = source.get("linkedAttempts", source.get("linked_attempts"))
+        if isinstance(linked, list) and any(
+            isinstance(item, Mapping)
+            and _string(item.get("outcome")).lower()
+            in {"failed", "abandoned", "released", "superseded"}
+            for item in linked
+        ):
+            return ENTRYPOINT_RETRY
     return ENTRYPOINT_SEARCH if search_selected else ENTRYPOINT_EXPLICIT
+
+
+def _truthy_like(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, str) and value.strip().lower() in {"1", "true", "yes"}:
+        return True
+    if isinstance(value, Mapping):
+        return bool(value)
+    return False
 
 
 def _github_admission_bundle(
@@ -5659,6 +5757,109 @@ def _github_shared_admission_decision(
         reads_complete=bundle.get("reads_complete"),
         active_attempt_comments=bundle.get("active_attempt_comments"),
     )
+
+
+def _github_admission_claim_and_identity(
+    *,
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    repository: str,
+    issue_number: int,
+    settled: str,
+    current_labels: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Plan the Req-2 advisory claim and Req-3 persist-once identity (issue #4178).
+
+    Called on the eligible Available / Recovery-needed path BEFORE expensive
+    assessment/implementation. Callers re-read after the announcement and
+    immediately before launching work; prerequisite/authority/readiness checks
+    stay intact. Claiming for assessment never authorizes changing blocked
+    code or bypassing completion gates. The persist-once identity pins the
+    selected issue + predecessor from the trusted input context so activity
+    retry / workflow replay / failed-step recovery cannot silently substitute
+    a different issue.
+    """
+    bundle = _github_admission_bundle(inputs, context)
+    own_attempt_id = _string(bundle.get("own_attempt_id"))
+    if not own_attempt_id:
+        own_attempt_id = _string(
+            _github_status_attempt_context(inputs, context).get("attemptId")
+        ) or _string(
+            _mapping(inputs.get("previousOutputs")).get("attemptId")
+        )
+    claim = announce_before_assessment(
+        settled=settled,
+        repository=repository,
+        issue_number=issue_number,
+        attempt_id=own_attempt_id or f"pending-{repository}#{issue_number}",
+        current_labels=list(current_labels or []),
+    )
+    persisted = persist_admission_identity(
+        {
+            "repository": repository,
+            "issueNumber": issue_number,
+            "predecessorAttemptId": _string(
+                inputs.get("predecessorAttemptId")
+                or inputs.get("predecessor_attempt_id")
+                or _mapping(inputs.get("previousOutputs")).get("predecessorAttemptId")
+            ),
+        },
+        _mapping(inputs.get("previousOutputs")).get("admittedIdentity")
+        or _mapping((context or {}).get("previousOutputs")).get("admittedIdentity"),
+    )
+    return {"admissionClaim": claim, "admittedIdentity": persisted["identity"],
+            "admissionPersisted": persisted}
+
+
+def _github_recandidate_context(
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Collect the trusted recandidate gate signals for the search path (Req 4).
+
+    A search may consider another candidate only after its own abandoned
+    announcement and writers are conclusively settled. Absent signals mean an
+    ordinary first selection; present-but-unsettled signals block recandidacy.
+    """
+    for source in (inputs, _mapping(inputs.get("previousOutputs")),
+                   _mapping((context or {}).get("previousOutputs"))):
+        if not isinstance(source, Mapping):
+            continue
+        if "ownAnnouncementAbandoned" in source or "own_announcement_abandoned" in source:
+            abandoned = source.get("ownAnnouncementAbandoned", source.get("own_announcement_abandoned"))
+            settled_writers = source.get("writersSettled", source.get("writers_settled"))
+            return {
+                "own_announcement_abandoned": abandoned is True,
+                "writers_settled": settled_writers is True,
+                "present": True,
+            }
+    return {"present": False}
+
+
+def _github_child_attempt_gate(
+    inputs: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Enforce the Req-6 ownership handoff for remediation/review children.
+
+    Internal child retries share the controlling issue attempt; a legitimate
+    review wait is not a disappeared owner. Existing-PR repair requires an
+    admitted route plus an exact PR target, never fresh permission from a
+    code-review label. Returns None when the caller is not a child activity.
+    """
+    child_kind = _string(inputs.get("childKind") or inputs.get("child_kind"))
+    if not child_kind:
+        return None
+    bundle = _github_admission_bundle(inputs, context)
+    controlling = _string(bundle.get("own_attempt_id")) or _string(
+        inputs.get("controllingAttemptId") or inputs.get("controlling_attempt_id")
+    )
+    pr_url = _string(
+        inputs.get("pullRequestUrl") or inputs.get("pull_request_url") or inputs.get("prUrl")
+    ) or _string((_github_status_pull_request_url(inputs, context) or ""))
+    decision = child_attempt_context(controlling, child_kind=child_kind, pr_url=pr_url)
+    return {"childKind": child_kind, "controllingAttemptId": controlling,
+            "prUrl": pr_url, "decision": decision}
 
 
 def _github_status_transition_reason(
@@ -6474,6 +6675,26 @@ async def update_github_issue_status(
     attempt_context = _github_status_attempt_context(inputs, _context)
     admission_bundle = _github_admission_bundle(inputs, _context)
     own_attempt_id = _string(admission_bundle.get("own_attempt_id"))
+    # Req 6 child handoff gate (issue #4178): internal remediation retries
+    # and PR-review/merge children share the controlling issue attempt. A
+    # legitimate review wait is not a disappeared owner. Existing-PR repair
+    # requires an admitted route plus an exact PR target at this trusted
+    # publication boundary, never fresh permission from a code-review label.
+    child_gate = _github_child_attempt_gate(inputs, _context)
+    if child_gate is not None and not bool(child_gate["decision"].get("allowed")):
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "issueRef": issue_ref,
+                "decision": "blocked",
+                "lifecycleSettled": interpretation.settled,
+                "reasonCode": str(child_gate["decision"].get("reasonCode") or "child_handoff_denied"),
+                "childKind": child_gate["childKind"],
+                "summary": (
+                    f"Skipped GitHub issue update for {issue_ref}: {child_gate['decision'].get('summary')}"
+                ),
+            },
+        )
     if target == "to_in_progress" and (
         admission_bundle.get("released")
         or admission_bundle.get("superseded")
@@ -7161,6 +7382,14 @@ async def update_github_issue_status(
     if warnings:
         outputs["warnings"] = warnings
         outputs["commentStatus"] = "unconfirmed"
+    if child_gate is not None:
+        # Req 6 evidence: the controlling attempt stays pinned on child work.
+        outputs["childAttempt"] = child_gate["decision"]
+        outputs["childKind"] = child_gate["childKind"]
+    if inputs.get("mutationIssuedBeforeCheck") is True or inputs.get("mutation_issued_before_check") is True:
+        # Acceptance D honesty: an already-issued delayed mutation is never
+        # falsely reported as fenced by this later check (unfenced race note).
+        outputs["mutationFenced"] = check_delayed_mutation_fenced(mutation_issued_before_check=True)
     return ToolResult(
         status="COMPLETED",
         outputs=outputs,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -49,7 +49,6 @@ from moonmind.workflows.temporal.github_issue_admission import (
     child_attempt_context,
     contender_quiesce_decision,
     persist_admission_identity,
-    recandidate_after_abandon,
     revalidate_for_mutation,
     should_stop_on_resume,
 )
@@ -4647,6 +4646,22 @@ async def load_github_issue_preset_brief(
                 "issueNumber": issue_number,
             },
         )
+    live_comments = await _github_live_comments_readable(
+        repository=repository,
+        issue_number=issue_number,
+        github_service_factory=github_service_factory,
+    )
+    if live_comments is not None and not live_comments.get("ok"):
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "error": str(live_comments.get("summary") or "Issue comment evidence unreadable."),
+                "repository": repository,
+                "issueNumber": issue_number,
+                "reasonCode": "read_failure",
+                "decision": "blocked",
+            },
+        )
     try:
         selected_blockers = (
             await _resolved_github_blockers(
@@ -4654,7 +4669,7 @@ async def load_github_issue_preset_brief(
                 repository=repository,
                 github_service=github_service_factory(),
             )
-            if search_evidence and not _string(inputs.get("issueSearch"))
+            if search_evidence
             else []
         )
     except ValueError as exc:
@@ -4662,9 +4677,17 @@ async def load_github_issue_preset_brief(
     if search_evidence and (
         not is_complete_open_issue(issue_data, repository)
         or issue_data["number"] != issue_number
-        or (not _string(inputs.get("issueSearch")) and selected_blockers)
+        or selected_blockers
         or has_in_progress_status(issue_data)
         or not is_lifecycle_selectable_candidate(issue_data)
+        or not _github_shared_admission_decision(
+            inputs=inputs,
+            context=_context,
+            repository=repository,
+            issue_number=issue_number,
+            issue=issue_data,
+            search_selected=True,
+        ).allowed
     ):
         return ToolResult(
             status="FAILED",
@@ -5630,7 +5653,13 @@ def _github_status_attempt_context(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
-    """Collect supplied validated attempt context for admission decisions."""
+    """Collect supplied validated attempt context for admission decisions.
+
+    Forwards the top-level ``linkedAttempts`` history into the retry
+    admission context so exhausted failures, cooldowns, lineage gaps, and
+    operator holds supplied there reach ``derive_retry_state`` instead of
+    being admitted as fresh.
+    """
     collected: dict[str, Any] = {}
     for source in (inputs, _mapping((context or {}).get("previousOutputs")), context or {}):
         if not isinstance(source, Mapping):
@@ -5642,6 +5671,8 @@ def _github_status_attempt_context(
             "unresolved_active_attempt",
             "attemptContext",
             "attempt_context",
+            "linkedAttempts",
+            "linked_attempts",
         ):
             if key in source:
                 value = source.get(key)
@@ -5649,6 +5680,11 @@ def _github_status_attempt_context(
                     collected.update(dict(value))
                 else:
                     collected[key] = value
+        nested = source.get("attemptContext", source.get("attempt_context"))
+        if isinstance(nested, Mapping):
+            for key in ("linkedAttempts", "linked_attempts"):
+                if key in nested and key not in collected:
+                    collected[key] = nested.get(key)
     return collected
 
 
@@ -5806,6 +5842,43 @@ def _github_admission_bundle(
     return bundle
 
 
+async def _github_live_comments_readable(
+    *,
+    repository: str,
+    issue_number: int,
+    github_service_factory: Callable[[], GitHubService] = GitHubService,
+) -> dict[str, Any] | None:
+    """Verify live issue-comment readability at the Activity boundary.
+
+    Returns None when readability cannot be checked (no list method or no
+    credential); callers keep the existing trusted-channel behavior in that
+    case. Otherwise returns {ok, reasonCode, summary}: unreadable or
+    incompletely paginated evidence must block admission as unknown rather
+    than being interpreted as an empty owner set.
+    """
+    try:
+        service = github_service_factory()
+    except Exception:
+        return None
+    if not hasattr(service, "list_issue_comments"):
+        return None
+    try:
+        listed = await service.list_issue_comments(repo=repository, issue_number=issue_number)
+    except Exception as exc:
+        return {"ok": False, "reasonCode": "outcome_unknown",
+                "summary": f"Issue comment list result unknown: {exc}."}
+    if not isinstance(listed, Mapping):
+        return {"ok": False, "reasonCode": "outcome_unknown",
+                "summary": "Issue comment list returned malformed evidence."}
+    if listed.get("ok"):
+        return {"ok": True, "reasonCode": "listed", "summary": str(listed.get("summary") or "listed")}
+    code = str(listed.get("reasonCode") or "list_failed")
+    if code in {"auth_unavailable", "denied"}:
+        return None
+    return {"ok": False, "reasonCode": code,
+            "summary": str(listed.get("summary") or "Issue comment listing failed.")}
+
+
 def _github_shared_admission_decision(
     *,
     inputs: Mapping[str, Any],
@@ -5865,12 +5938,15 @@ def _github_admission_claim_and_identity(
         ) or _string(
             _mapping(inputs.get("previousOutputs")).get("attemptId")
         )
+    handoff = _github_brief_recovery_handoff(inputs, context)
     claim = announce_before_assessment(
         settled=settled,
         repository=repository,
         issue_number=issue_number,
         attempt_id=own_attempt_id or f"pending-{repository}#{issue_number}",
         current_labels=list(current_labels or []),
+        predecessor_stopped=handoff.get("predecessor_stopped"),
+        handoff_usable=handoff.get("handoff_usable"),
     )
     persisted = persist_admission_identity(
         {
@@ -6069,6 +6145,8 @@ async def _execute_brief_admission_claim(
                 try:
                     reread_settled = interpret_issue(reread_issue).settled
                 except Exception:
+                    # Keep the pre-write settled value: a failed
+                    # reinterpretation must not mask the remove failure.
                     pass
             return {
                 "executed": True,
@@ -6106,6 +6184,22 @@ async def _execute_brief_admission_claim(
         reread_settled = interpret_issue(reread_issue).settled
     except Exception:
         reread_settled = settled
+    if reread_settled != "in_progress":
+        return {
+            "executed": True,
+            "blocked": True,
+            "reasonCode": "claim_not_confirmed",
+            "summary": (
+                f"Advisory claim for {issue_ref} applied {applied} but the re-read "
+                f"settled as {reread_settled!r}; the in-progress claim was not "
+                "confirmed, so work does not launch."
+            ),
+            "issueRef": issue_ref,
+            "appliedActions": applied,
+            "rereadLabels": reread_issue.get("labels"),
+            "rereadSettled": reread_settled,
+            "rereadOk": True,
+        }
     return {
         "executed": True,
         "blocked": False,
@@ -7001,6 +7095,24 @@ async def update_github_issue_status(
     )
     if issue_data is None:
         return ToolResult(status="FAILED", outputs={"issueRef": issue_ref, "summary": error or "GitHub issue update fetch failed."})
+    live_comments = await _github_live_comments_readable(
+        repository=repository,
+        issue_number=issue_number,
+        github_service_factory=github_service_factory,
+    )
+    if live_comments is not None and not live_comments.get("ok"):
+        return ToolResult(
+            status="FAILED",
+            outputs={
+                "issueRef": issue_ref,
+                "decision": "blocked",
+                "reasonCode": "read_failure",
+                "summary": (
+                    f"Skipped GitHub issue update for {issue_ref}: {live_comments.get('summary')}; "
+                    "unknown comment evidence blocks admission."
+                ),
+            },
+        )
     issue = _github_issue_payload(issue_data, repository)
     current_labels = [str(label) for label in issue.get("labels") or []]
     interpretation = interpret_issue({"state": issue.get("state", "open"), "labels": current_labels})
@@ -7151,6 +7263,27 @@ async def update_github_issue_status(
             "read_failure",
             "closed_terminal",
         }:
+            if (
+                shared_admission.reason_code == "manual_in_progress_without_trusted_owner"
+                and interpretation.settled == "in_progress"
+                and own_attempt_id
+            ):
+                # The pre-assessment brief already applied in-progress for this
+                # same workflow attempt; the redundant start transition is
+                # idempotent rather than a manual claim by another owner.
+                return ToolResult(
+                    status="COMPLETED",
+                    outputs={
+                        "issueRef": issue_ref,
+                        "decision": "already_applied",
+                        "lifecycleSettled": interpretation.settled,
+                        "reasonCode": "already_applied",
+                        "summary": (
+                            f"GitHub issue update for {issue_ref} already applied: "
+                            "in-progress claim from this attempt is present."
+                        ),
+                    },
+                )
             return ToolResult(
                 status="FAILED",
                 outputs={

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -36,6 +36,10 @@ from moonmind.workflows.temporal.github_issue_attempts import (
     render_attempt_comment,
     resolve_installation_id,
 )
+from moonmind.workflows.temporal.github_issue_admission import (
+    ENTRYPOINT_EXPLICIT,
+    admit_for_entrypoint,
+)
 from moonmind.workflows.temporal.github_issue_lifecycle import (
     attempt_evidence_blocks_admission,
     classify_mutation_outcome,
@@ -4605,9 +4609,18 @@ async def load_github_issue_preset_brief(
         or not is_lifecycle_selectable_candidate(
             issue_data, _github_status_attempt_context(inputs, _context)
         )
+        or not admit_for_entrypoint(
+            ENTRYPOINT_EXPLICIT,
+            repository=repository,
+            issue_number=issue_number,
+            issue=issue_data,
+            attempt_context=_github_status_attempt_context(inputs, _context),
+        ).allowed
     ):
         # Direct issue loads run the same admission policy as search: an
         # explicit issue reference is not a bypass around lifecycle state.
+        # Both paths route through the one shared exact-issue admission
+        # boundary (issue #4178); search uses ENTRYPOINT_SEARCH instead.
         return ToolResult(
             status="FAILED",
             outputs={
@@ -6308,8 +6321,34 @@ async def update_github_issue_status(
     interpretation = interpret_issue({"state": issue.get("state", "open"), "labels": current_labels})
     # Re-read validated attempt context before mutating: a missing
     # in-progress label never overrides supplied unresolved active-attempt
-    # evidence.
+    # evidence. The start transition additionally revalidates through the one
+    # shared exact-issue admission boundary (issue #4178).
     attempt_context = _github_status_attempt_context(inputs, _context)
+    if target == "to_in_progress":
+        shared_admission = admit_for_entrypoint(
+            ENTRYPOINT_EXPLICIT,
+            repository=repository,
+            issue_number=issue_number,
+            issue={"state": issue.get("state", "open"), "labels": current_labels},
+            attempt_context=attempt_context,
+        )
+        if not shared_admission.allowed and shared_admission.reason_code in {
+            "active_attempt_conflict",
+            "missing_label_with_active_attempt",
+            "manual_in_progress_without_trusted_owner",
+        }:
+            return ToolResult(
+                status="FAILED",
+                outputs={
+                    "issueRef": issue_ref,
+                    "decision": "blocked",
+                    "lifecycleSettled": interpretation.settled,
+                    "reasonCode": shared_admission.reason_code,
+                    "summary": (
+                        f"Skipped GitHub issue update for {issue_ref}: {shared_admission.summary}"
+                    ),
+                },
+            )
     if target == "to_in_progress" and attempt_evidence_blocks_admission(attempt_context):
         return ToolResult(
             status="FAILED",

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -8152,6 +8152,9 @@ async def test_existing_pr_survives_unchanged_omnigent_publication(
 
     def github_api(request):
         requests.append(request)
+        if "/comments" in request.url.path:
+            # Live comment readability gate expects a GitHub comment list.
+            return httpx.Response(200, json=[])
         if request.url.path.endswith("/pulls"):
             assert request.method == "GET"  # Adoption must never create a duplicate PR.
             assert request.url.params["head"] == f"MoonLadderStudios:{branch}"

--- a/tests/integration/reliability/test_issue_search_publication.py
+++ b/tests/integration/reliability/test_issue_search_publication.py
@@ -95,6 +95,9 @@ async def test_search_publication_recovers_missing_pr_before_status(
 
     def github_http(request):
         operations.append((request.method, request.url.path))
+        if "/comments" in request.url.path:
+            # Live comment readability gate expects a GitHub comment list.
+            return httpx.Response(200, json=[])
         if request.method == "PATCH":
             assert operations[0][0] == "repo.create_pr"
             issue.update(json.loads(request.content))

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -405,9 +405,38 @@ class _AdmissionHttpClient:
             return _AdmissionFakeHttpResponse(dict(type(self).search_payload))
         return _AdmissionFakeHttpResponse(dict(type(self).issue_payload))
 
+    async def post(self, url: str, **kwargs: Any):
+        return _AdmissionFakeHttpResponse({})
+
 
 def _install_admission_http(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(story_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+
+
+def _install_dynamic_issue_fetch(
+    monkeypatch: pytest.MonkeyPatch, service: _AdmissionFakeService, number: int
+) -> None:
+    """Serve issue reads from the fake service labels so read-back observes writes."""
+
+    async def _fetch(
+        *,
+        repository: str,
+        issue_number: int,
+        github_service_factory=None,  # type: ignore[no-untyped-def]
+    ):
+        return (
+            {
+                "number": number,
+                "title": "admission",
+                "body": "body",
+                "html_url": f"https://github.com/{repository}/issues/{number}",
+                "state": "open",
+                "labels": [{"name": label} for label in service.labels],
+            },
+            None,
+        )
+
+    monkeypatch.setattr(story_tools, "_fetch_github_issue", _fetch)
 
 
 def _admission_issue_payload(number: int, labels: list[str]) -> dict[str, Any]:
@@ -615,3 +644,229 @@ def test_real_transition_and_retry_shapes_preserved() -> None:
 
     # Retained history: legacy in-progress spellings still count.
     assert has_in_progress_status({"labels": ["status: in-progress"]}) is True
+
+
+# ---------------------------------------------------------------------------
+# Remediation wiring: announce/persist, recandidate, child handoffs,
+# entrypoint inference, interleaving + delayed-mutation through real shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brief_load_plans_claim_and_persists_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 2+3 are wired: the brief plans the advisory claim and pins identity."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "attemptId": "att_" + "a" * 24,
+            "predecessorAttemptId": "att_" + "b" * 24,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    claim = result.outputs["admissionClaim"]
+    assert claim["planned"] is True
+    assert claim["reasonCode"] == "claim_planned"
+    assert result.outputs["admittedIdentity"] == {
+        "repository": "o/r",
+        "issueNumber": 4178,
+        "predecessorAttemptId": "att_" + "b" * 24,
+    }
+    assert result.outputs["admissionPersisted"]["persisted"] is True
+
+
+@pytest.mark.asyncio
+async def test_brief_entrypoint_inference_continuation_retry_orchestration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance A: continuation/retry/orchestration reach the same boundary."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+
+    continued = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "predecessorStopped": True,
+            "handoffUsable": True,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert continued.status == "COMPLETED"
+    assert continued.outputs["admissionEntrypoint"] == ENTRYPOINT_CONTINUATION
+
+    retried = await story_tools.load_github_issue_preset_brief(
+        {"repository": "o/r", "issueNumber": 4178, "retryOf": "att_" + "c" * 24},
+        github_service_factory=lambda: service,
+    )
+    assert retried.status == "COMPLETED"
+    assert retried.outputs["admissionEntrypoint"] == ENTRYPOINT_RETRY
+
+    orchestrated = await story_tools.load_github_issue_preset_brief(
+        {"repository": "o/r", "issueNumber": 4178, "orchestrationRunId": "orch-1"},
+        github_service_factory=lambda: service,
+    )
+    assert orchestrated.status == "COMPLETED"
+    assert orchestrated.outputs["admissionEntrypoint"] == ENTRYPOINT_ORCHESTRATION
+
+
+@pytest.mark.asyncio
+async def test_search_query_path_forwards_read_failure_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 1: the query caller forwards reads_complete so denies trigger."""
+    from moonmind.workflows.temporal import github_issue_search as search_tools
+    from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+    def _candidate(number: int) -> dict[str, Any]:
+        return {
+            "number": number,
+            "title": "candidate",
+            "body": "body",
+            "html_url": f"https://github.com/o/r/issues/{number}",
+            "state": "open",
+            "labels": [],
+        }
+
+    _AdmissionHttpClient.search_payload = {
+        "incomplete_results": False,
+        "items": [_candidate(31), _candidate(32)],
+    }
+    monkeypatch.setattr(search_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+    service = _AdmissionFakeService()
+
+    async def no_blockers(issue: dict[str, Any]) -> list[dict[str, Any]]:
+        return []
+
+    blocked, evidence = await resolve_issue(
+        repository="o/r",
+        query="task",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=no_blockers,
+        reads_complete={"labels": True, "comments": False},
+    )
+    assert blocked is None
+    assert evidence["searchEvidence"]["candidatesExamined"] == 2
+
+
+@pytest.mark.asyncio
+async def test_search_recandidate_gate_blocks_unsettled_writers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 4: recandidacy requires own abandoned announcement + settled writers."""
+    from moonmind.workflows.temporal import github_issue_search as search_tools
+    from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+    monkeypatch.setattr(search_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+    service = _AdmissionFakeService()
+
+    async def no_blockers(issue: dict[str, Any]) -> list[dict[str, Any]]:
+        return []
+
+    blocked, evidence = await resolve_issue(
+        repository="o/r",
+        query="",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=no_blockers,
+        own_announcement_abandoned=True,
+        writers_settled=False,
+    )
+    assert blocked is None
+    assert "conclusively settled" in evidence["error"]
+
+
+@pytest.mark.asyncio
+async def test_child_repair_requires_exact_pr_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 6 through the trusted status boundary: repair needs an exact PR."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    denied = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "childKind": "existing_pr_repair",
+            "attemptId": "att_" + "a" * 24,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert denied.status == "FAILED"
+    assert denied.outputs["reasonCode"] == "missing_pr_target"
+    assert service.operations == []
+
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    allowed = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "childKind": "existing_pr_repair",
+            "attemptId": "att_" + "a" * 24,
+            "pullRequestUrl": "https://github.com/o/r/pull/7",
+        },
+        github_service_factory=lambda: service,
+    )
+    assert allowed.status == "COMPLETED"
+    assert allowed.outputs["childAttempt"]["reasonCode"] == "admitted_repair"
+    assert allowed.outputs["childKind"] == "existing_pr_repair"
+
+
+@pytest.mark.asyncio
+async def test_two_interleaved_attempts_quiesce_through_tool_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance C through the real boundary: both contenders stop, neither clears."""
+    attempt_a = "att_" + "a" * 24
+    attempt_b = "att_" + "b" * 24
+    for own, other in ((attempt_a, attempt_b), (attempt_b, attempt_a)):
+        service = _AdmissionFakeService(labels=["status: in-progress"])
+        _install_admission_http(monkeypatch)
+        _AdmissionHttpClient.issue_payload = _admission_issue_payload(
+            4178, ["status: in-progress"]
+        )
+        result = await story_tools.update_github_issue_status(
+            {
+                "repository": "o/r",
+                "issueNumber": 4178,
+                "mode": "start",
+                "attemptId": own,
+                "observedContenders": [{"attemptId": other, "activity": "active"}],
+            },
+            github_service_factory=lambda: service,
+        )
+        assert result.status == "FAILED"
+        assert result.outputs["reasonCode"] == "contender_observed"
+        assert service.operations == []
+        assert service.labels == ["status: in-progress"]
+
+
+@pytest.mark.asyncio
+async def test_delayed_mutation_honesty_through_mutation_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance D through the real mutation path: delayed mutation not fenced."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "mutationIssuedBeforeCheck": True,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["mutationFenced"]["fenced"] is False
+    assert result.outputs["mutationFenced"]["reasonCode"] == "unfenced_race"

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -870,3 +870,309 @@ async def test_delayed_mutation_honesty_through_mutation_path(
     assert result.status == "COMPLETED"
     assert result.outputs["mutationFenced"]["fenced"] is False
     assert result.outputs["mutationFenced"]["reasonCode"] == "unfenced_race"
+
+
+# ---------------------------------------------------------------------------
+# Remediation round 3: Req-2 execution, Req-3 enforcement, Req-6/E child
+# shapes, Acceptance-A producers, query blocker + recandidate + 3-way
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brief_claim_executes_write_and_rereads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 2 through the real brief path: claim writes in-progress + re-reads."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "attemptId": "att_" + "a" * 24,
+            "predecessorAttemptId": "att_" + "b" * 24,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    executed = result.outputs["admissionClaimExecuted"]
+    assert executed["executed"] is True
+    assert executed["blocked"] is False
+    assert executed["reasonCode"] == "claim_executed"
+    assert executed["rereadOk"] is True
+    assert any(action.startswith("add_label:") for action in executed["appliedActions"])
+    assert service.operations != []
+    assert any(op == ("add", "status: in-progress") for op in service.operations)
+
+
+@pytest.mark.asyncio
+async def test_brief_substitution_denied_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 3 enforcement: retry/replay cannot silently substitute another issue."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 2)
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 2,
+            "previousOutputs": {
+                "admittedIdentity": {"repository": "o/r", "issueNumber": 1},
+            },
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "substitution_denied"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_brief_contender_blocks_claim_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 2 keeps conflict checks: an observed contender blocks the claim write."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "attemptId": "att_" + "a" * 24,
+            "observedContenders": [{"attemptId": "att_" + "b" * 24, "activity": "active"}],
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "contender_observed"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_brief_resume_blocks_claim_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 5 at the brief boundary: a known successor blocks the claim write."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "attemptId": "att_" + "a" * 24,
+            "knownSuccessorAttemptId": "att_" + "b" * 24,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "resume_blocked"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_child_internal_retry_retains_controlling_through_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 6 + Acceptance E: internal retry shares the controlling attempt."""
+    controlling = "att_" + "a" * 24
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "childKind": "internal_retry",
+            "attemptId": controlling,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["childKind"] == "internal_retry"
+    assert result.outputs["childAttempt"]["allowed"] is True
+    assert result.outputs["childAttempt"]["attemptId"] == controlling
+    assert result.outputs["childAttempt"]["reasonCode"] == "internal_retry_within_attempt"
+
+
+@pytest.mark.asyncio
+async def test_child_review_wait_retains_controlling_through_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 6 + Acceptance E: a review wait is not a disappeared owner."""
+    controlling = "att_" + "c" * 24
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "childKind": "review_wait",
+            "attemptId": controlling,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["childKind"] == "review_wait"
+    assert result.outputs["childAttempt"]["allowed"] is True
+    assert result.outputs["childAttempt"]["attemptId"] == controlling
+    assert result.outputs["childAttempt"]["reasonCode"] == "review_child_retains_attempt"
+
+
+@pytest.mark.asyncio
+async def test_child_controlling_fallback_chain_through_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 6 fallback: controlling attempt resolves from previous outputs."""
+    controlling = "att_" + "d" * 24
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "childKind": "remediation",
+            "previousOutputs": {"attemptId": controlling},
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["childAttempt"]["allowed"] is True
+    assert result.outputs["childAttempt"]["attemptId"] == controlling
+
+
+def test_downstream_payload_emits_orchestration_signals() -> None:
+    """Acceptance A: downstream children are real orchestration producers."""
+    title, task = story_tools._github_downstream_workflow_payload(
+        mapping={"repository": "o/r", "issueNumber": "4178", "summary": "work"},
+        task_payload={},
+        traceability={},
+        depends_on=[],
+        source_issue_key="o/r#4175",
+        target_preset="orchestrate",
+    )
+    assert "4178" in title
+    child_inputs = task["inputs"]
+    assert child_inputs["nestedImplement"] is True
+    assert str(child_inputs.get("parentWorkflowId") or "").strip() != ""
+    entrypoint = story_tools._github_admission_entrypoint(child_inputs)
+    assert entrypoint == ENTRYPOINT_ORCHESTRATION
+
+
+@pytest.mark.asyncio
+async def test_query_path_blocked_candidate_skipped_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance B: the query admit decision itself sees blocker evidence."""
+    from moonmind.workflows.temporal import github_issue_search as search_tools
+    from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+    def _candidate(number: int) -> dict[str, Any]:
+        return {
+            "number": number,
+            "title": "candidate",
+            "body": "body",
+            "html_url": f"https://github.com/o/r/issues/{number}",
+            "state": "open",
+            "labels": [],
+        }
+
+    _AdmissionHttpClient.search_payload = {
+        "incomplete_results": False,
+        "items": [_candidate(41), _candidate(42)],
+    }
+    monkeypatch.setattr(search_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+    service = _AdmissionFakeService()
+
+    async def blockers(issue: dict[str, Any]) -> list[dict[str, Any]]:
+        if issue.get("number") == 41:
+            return [{"source": "prerequisite", "done": False}]
+        return []
+
+    number, _ = await resolve_issue(
+        repository="o/r",
+        query="task",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=blockers,
+    )
+    assert number == 42
+
+
+@pytest.mark.asyncio
+async def test_recandidate_allowed_positive_through_resolve_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Req 4 positive: abandoned announcement + settled writers may recandidate."""
+    from moonmind.workflows.temporal import github_issue_search as search_tools
+    from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+    def _candidate(number: int) -> dict[str, Any]:
+        return {
+            "number": number,
+            "title": "candidate",
+            "body": "body",
+            "html_url": f"https://github.com/o/r/issues/{number}",
+            "state": "open",
+            "labels": [],
+        }
+
+    _AdmissionHttpClient.search_payload = {
+        "incomplete_results": False,
+        "items": [_candidate(51)],
+    }
+    monkeypatch.setattr(search_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+    service = _AdmissionFakeService()
+
+    async def no_blockers(issue: dict[str, Any]) -> list[dict[str, Any]]:
+        return []
+
+    number, _ = await resolve_issue(
+        repository="o/r",
+        query="task",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=no_blockers,
+        own_announcement_abandoned=True,
+        writers_settled=True,
+    )
+    assert number == 51
+
+
+@pytest.mark.asyncio
+async def test_three_interleaved_attempts_quiesce_through_tool_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance C: three contenders stop through the real boundary, none clear."""
+    attempts = ["att_" + c * 24 for c in ("a", "b", "c")]
+    for own in attempts:
+        others = [
+            {"attemptId": other, "activity": "active"}
+            for other in attempts
+            if other != own
+        ]
+        service = _AdmissionFakeService(labels=["status: in-progress"])
+        _install_admission_http(monkeypatch)
+        _AdmissionHttpClient.issue_payload = _admission_issue_payload(
+            4178, ["status: in-progress"]
+        )
+        result = await story_tools.update_github_issue_status(
+            {
+                "repository": "o/r",
+                "issueNumber": 4178,
+                "mode": "start",
+                "attemptId": own,
+                "observedContenders": others,
+            },
+            github_service_factory=lambda: service,
+        )
+        assert result.status == "FAILED"
+        assert result.outputs["reasonCode"] == "contender_observed"
+        assert service.operations == []
+        assert service.labels == ["status: in-progress"]

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -10,9 +10,12 @@ attempt propagation; and retained-history behavior.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from moonmind.workflows.temporal import github_issue_attempt as attempt_mod
+from moonmind.workflows.temporal import story_output_tools as story_tools
 from moonmind.workflows.temporal.github_issue_admission import (
     ENTRYPOINT_CONTINUATION,
     ENTRYPOINT_EXPLICIT,
@@ -335,6 +338,268 @@ def test_internal_retry_and_review_children_retain_controlling_attempt() -> None
 # ---------------------------------------------------------------------------
 # Acceptance F: real workflow/Activity shapes + retained history
 # ---------------------------------------------------------------------------
+
+
+class _AdmissionFakeService:
+    """Minimal trusted GitHub boundary: fetch + token only (no writes)."""
+
+    def __init__(self, labels: list[str] | None = None) -> None:
+        self.labels = list(labels) if labels is not None else []
+        self.operations: list[tuple[str, str]] = []
+
+    async def resolve_github_token(self, *, repo: str):
+        return "ghs-test", None
+
+    def _github_headers(self, token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _github_permission_summary(self, response) -> str:
+        return f"github status {response.status_code}"
+
+    async def check_issue_label_readiness(self, *, repo: str, issue_number: int,
+                                          required_labels: list[str], github_token: str | None = None):
+        return {"ready": True, "reasonCode": "ready", "summary": "ready"}
+
+    async def add_issue_labels(self, *, repo: str, issue_number: int,
+                               labels: list[str], github_token: str | None = None):
+        for label in labels:
+            self.operations.append(("add", label))
+            self.labels.append(label)
+        return {"ok": True, "reasonCode": "added", "summary": "added"}
+
+    async def remove_issue_label(self, *, repo: str, issue_number: int,
+                                 label: str, github_token: str | None = None):
+        self.operations.append(("remove", label))
+        self.labels = [existing for existing in self.labels if existing != label]
+        return {"ok": True, "reasonCode": "removed", "summary": "removed"}
+
+
+class _AdmissionFakeHttpResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _AdmissionHttpClient:
+    """HTTP fake serving one issue payload (or search items) for admission tests."""
+
+    issue_payload: dict[str, Any] = {}
+    search_payload: dict[str, Any] = {}
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str, **kwargs: Any):
+        if "search/issues" in url:
+            return _AdmissionFakeHttpResponse(dict(type(self).search_payload))
+        return _AdmissionFakeHttpResponse(dict(type(self).issue_payload))
+
+
+def _install_admission_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(story_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+
+
+def _admission_issue_payload(number: int, labels: list[str]) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": "admission",
+        "body": "body",
+        "html_url": f"https://github.com/o/r/issues/{number}",
+        "state": "open",
+        "labels": [{"name": label} for label in labels],
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_guard_blocks_threaded_blockers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Req-1 blocker bundle from the trusted channel blocks the start write."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "blockingIssues": [{"repository": "o/r", "number": 1}],
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["reasonCode"] == "blocked_prerequisite"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_start_guard_blocks_incomplete_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit failed read is unknown evidence, never an empty owner set."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "readsComplete": {"labels": True, "comments": False},
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "read_failure"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_start_guard_blocks_exhausted_retry_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An invalid retry policy blocks automatic admission rather than assuming fresh."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "retryPolicy": {"maxAttempts": "many"},
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "retry_exhausted"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_resume_after_known_successor_stops_shared_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnection after a known successor performs no new shared mutation."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "attemptId": "att_" + "a" * 24,
+            "knownSuccessorAttemptId": "att_" + "b" * 24,
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "resume_blocked"
+    assert service.operations == []
+
+
+@pytest.mark.asyncio
+async def test_observed_contender_quiesces_without_clearing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An observed competing attempt stops this write; its label is never cleared."""
+    service = _AdmissionFakeService(labels=["status: in-progress"])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, ["status: in-progress"])
+    result = await story_tools.update_github_issue_status(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "mode": "start",
+            "attemptId": "att_" + "a" * 24,
+            "observedContenders": [{"attemptId": "att_" + "b" * 24, "activity": "active"}],
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["reasonCode"] == "contender_observed"
+    assert service.operations == []
+    assert service.labels == ["status: in-progress"]
+
+
+@pytest.mark.asyncio
+async def test_search_admission_runs_without_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolve_issue enforces the shared boundary on the production path (no resolver)."""
+    from moonmind.workflows.temporal import github_issue_search as search_tools
+    from moonmind.workflows.temporal.github_issue_search import resolve_issue
+
+    def _candidate(number: int, labels: list[str]) -> dict[str, Any]:
+        return {
+            "number": number,
+            "title": "candidate",
+            "body": "body",
+            "html_url": f"https://github.com/o/r/issues/{number}",
+            "state": "open",
+            "labels": [{"name": label} for label in labels],
+        }
+
+    _AdmissionHttpClient.search_payload = {
+        "incomplete_results": False,
+        "items": [_candidate(21, []), _candidate(22, [])],
+    }
+    monkeypatch.setattr(search_tools.httpx, "AsyncClient", _AdmissionHttpClient)
+    service = _AdmissionFakeService()
+
+    async def no_blockers(issue: dict[str, Any]) -> list[dict[str, Any]]:
+        return []
+
+    number, _ = await resolve_issue(
+        repository="o/r",
+        query="task",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=no_blockers,
+    )
+    assert number == 21
+
+    # Supplied unresolved attempt evidence blocks selection even when the
+    # in-progress label is missing — through the async search shape.
+    blocked, _ = await resolve_issue(
+        repository="o/r",
+        query="task",
+        github_service=service,  # type: ignore[arg-type]
+        blockers_from_issue=no_blockers,
+        attempt_context={"has_unresolved_active_attempt": True},
+    )
+    assert blocked is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_load_honors_entrypoint_and_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct loads route orchestration/continuation identities via the same boundary."""
+    service = _AdmissionFakeService(labels=[])
+    _install_admission_http(monkeypatch)
+    _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
+    result = await story_tools.load_github_issue_preset_brief(
+        {
+            "repository": "o/r",
+            "issueNumber": 4178,
+            "entrypoint": "orchestration",
+            "blockingIssues": [{"repository": "o/r", "number": 1}],
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert "lifecycle admission" in result.outputs["error"]
+
+    admitted = await story_tools.load_github_issue_preset_brief(
+        {"repository": "o/r", "issueNumber": 4178, "entrypoint": "continuation"},
+        github_service_factory=lambda: service,
+    )
+    assert admitted.status == "COMPLETED"
 
 
 def test_real_transition_and_retry_shapes_preserved() -> None:

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -1,0 +1,352 @@
+"""Shared exact-issue admission/guard boundary (issue #4178).
+
+Covers MoonLadderStudios/MoonMind#4178 acceptance criteria through the real
+workflow/Activity call shapes: the same admit_exact_issue boundary backs
+search, explicit, orchestration, continuation, and retry entrypoints with
+pinned identities; blocking evidence classes; interleaved announcements;
+resume/pre-mutation revalidation with the documented unfenced race; child
+attempt propagation; and retained-history behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.temporal import github_issue_attempt as attempt_mod
+from moonmind.workflows.temporal.github_issue_admission import (
+    ENTRYPOINT_CONTINUATION,
+    ENTRYPOINT_EXPLICIT,
+    ENTRYPOINT_ORCHESTRATION,
+    ENTRYPOINT_RETRY,
+    ENTRYPOINT_SEARCH,
+    UNFENCED_CHECK_TO_WRITE_RACE_NOTE,
+    AdmissionRequest,
+    admit_exact_issue,
+    admit_for_entrypoint,
+    announce_before_assessment,
+    check_delayed_mutation_fenced,
+    child_attempt_context,
+    contender_quiesce_decision,
+    persist_admission_identity,
+    recandidate_after_abandon,
+    revalidate_for_mutation,
+    should_stop_on_resume,
+)
+from moonmind.workflows.temporal.github_issue_lifecycle import (
+    SETTLED_AVAILABLE,
+    interpret_issue,
+    plan_transition,
+    should_abandon_retry,
+)
+from moonmind.workflows.temporal.github_issue_search import (
+    has_in_progress_status,
+    is_lifecycle_selectable_candidate,
+)
+
+
+def _req(entrypoint: str = ENTRYPOINT_EXPLICIT) -> AdmissionRequest:
+    return AdmissionRequest(
+        repository="o/r",
+        issue_number=4178,
+        workflow_id="wf-1",
+        run_id="run-1",
+        installation_id="inst-abc12345",
+        attempt_id="att_" + "a" * 24,
+        entrypoint=entrypoint,
+    )
+
+
+def _linked_failure(attempt_id: str) -> dict:
+    return {"attemptId": attempt_id, "outcome": "failed"}
+
+
+# ---------------------------------------------------------------------------
+# Acceptance A: one boundary, pinned identities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    [ENTRYPOINT_SEARCH, ENTRYPOINT_EXPLICIT, ENTRYPOINT_ORCHESTRATION, ENTRYPOINT_CONTINUATION, ENTRYPOINT_RETRY],
+)
+def test_all_entrypoints_share_one_boundary(entrypoint: str) -> None:
+    decision = admit_for_entrypoint(
+        entrypoint,
+        repository="o/r",
+        issue_number=4178,
+        issue={"state": "open", "labels": []},
+    )
+    assert decision.allowed is True
+    assert decision.entrypoint == entrypoint
+    assert decision.issue_ref == "o/r#4178"
+    assert decision.settled == SETTLED_AVAILABLE
+
+
+def test_unknown_entrypoint_and_unpinned_identity_block() -> None:
+    denied = admit_exact_issue(
+        AdmissionRequest(repository="o/r", issue_number=1, entrypoint="preset-exempt"),
+        issue={"state": "open", "labels": []},
+    )
+    assert denied.allowed is False
+    assert denied.reason_code == "unknown_entrypoint"
+
+    unpinned = admit_exact_issue(
+        AdmissionRequest(repository="", issue_number=0, entrypoint=ENTRYPOINT_SEARCH),
+        issue={"state": "open", "labels": []},
+    )
+    assert unpinned.allowed is False
+    assert unpinned.reason_code == "unpinned_identity"
+
+
+def test_search_and_explicit_use_same_interpretation() -> None:
+    # Real workflow call shape: search selector + explicit admission agree.
+    issue = {"state": "open", "labels": ["bug"], "number": 1}
+    assert is_lifecycle_selectable_candidate({"state": "open", "labels": ["bug"]}) is True
+    for entrypoint in (ENTRYPOINT_SEARCH, ENTRYPOINT_EXPLICIT):
+        decision = admit_for_entrypoint(
+            entrypoint, repository="o/r", issue_number=1,
+            issue={"state": "open", "labels": ["bug"]},
+        )
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Acceptance B: blocking evidence classes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_label_plus_active_comment_blocks() -> None:
+    decision = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        attempt_context={"hasUnresolvedActiveAttempt": True},
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == "missing_label_with_active_attempt"
+
+
+def test_manual_in_progress_without_trusted_owner_blocks() -> None:
+    decision = admit_exact_issue(
+        _req(), issue={"state": "open", "labels": ["status: in-progress"]}
+    )
+    assert decision.allowed is False
+    assert decision.reason_code == "manual_in_progress_without_trusted_owner"
+
+
+def test_unknown_format_mixed_read_failure_exhausted_block() -> None:
+    unknown = admit_exact_issue(_req(), issue={"state": "open", "labels": ["status: frobnicate"]})
+    assert unknown.reason_code == "unknown_format"
+
+    mixed = admit_exact_issue(
+        _req(), issue={"state": "open", "labels": ["status: in-progress", "status: code-review"]}
+    )
+    assert mixed.reason_code == "mixed_state"
+
+    read_failure = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        reads_complete={"labels": True, "comments": False},
+    )
+    assert read_failure.reason_code == "read_failure"
+
+    exhausted = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        attempt_context={"linkedAttempts": [
+            {"attemptId": "att_" + c * 24, "outcome": "failed"} for c in ("b", "c", "d")
+        ]},
+        retry_policy={"maxAttempts": 3},
+    )
+    # derive_retry_state counts 3 linked failures against allowance 3.
+    assert exhausted.allowed is False
+    assert exhausted.reason_code in {"retry_exhausted", "missing_policy_lineage"}
+
+
+def test_operator_hold_and_blockers_and_ambiguous_pr_block() -> None:
+    hold = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        attempt_context={
+            "linkedAttempts": [{"attemptId": "att_" + "c" * 24, "operatorHold": True}],
+        },
+        retry_policy={"maxAttempts": 3},
+    )
+    assert hold.allowed is False
+    assert hold.reason_code in {"operator_hold", "missing_policy_lineage"}
+
+    blocked = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        blockers=[{"source": "prerequisite", "done": False}],
+    )
+    assert blocked.reason_code == "blocked_prerequisite"
+
+    ambiguous = admit_exact_issue(
+        _req(),
+        issue={"state": "open", "labels": []},
+        pr_identities=[{"prUrl": "https://github.com/o/r/pull/1"}, {"ambiguous": True}],
+    )
+    assert ambiguous.reason_code == "ambiguous_pr_identity"
+
+
+# ---------------------------------------------------------------------------
+# Req 2: announce before assessment
+# ---------------------------------------------------------------------------
+
+
+def test_announce_before_assessment_plans_in_progress() -> None:
+    planned = announce_before_assessment(
+        settled=SETTLED_AVAILABLE, repository="o/r", issue_number=1,
+        attempt_id="att_" + "d" * 24, current_labels=[],
+    )
+    assert planned["planned"] is True
+    assert planned["transition"]["allowed"] is True
+    assert planned["mutation"]["labelsToAdd"] == ["status: in-progress"]
+
+    recovery = announce_before_assessment(
+        settled="recovery_needed", repository="o/r", issue_number=1,
+        attempt_id="att_" + "d" * 24, current_labels=["status: recovery-needed"],
+    )
+    assert recovery["planned"] is True
+
+    ineligible = announce_before_assessment(
+        settled="in_progress", repository="o/r", issue_number=1,
+        attempt_id="att_" + "d" * 24,
+    )
+    assert ineligible["planned"] is False
+
+
+# ---------------------------------------------------------------------------
+# Req 3: persist exactly once
+# ---------------------------------------------------------------------------
+
+
+def test_persist_once_and_substitution_denied() -> None:
+    first = persist_admission_identity({"repository": "o/r", "issueNumber": 1}, None)
+    assert first["persisted"] is True
+    assert first["reasonCode"] == "persisted_once"
+
+    replay = persist_admission_identity(
+        {"repository": "o/r", "issueNumber": 1}, first["identity"]
+    )
+    assert replay["persisted"] is True
+
+    substituted = persist_admission_identity(
+        {"repository": "o/r", "issueNumber": 2}, first["identity"]
+    )
+    assert substituted["persisted"] is False
+    assert substituted["reasonCode"] == "substitution_denied"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance C: two- and three-interleaved announcements
+# ---------------------------------------------------------------------------
+
+
+def test_two_interleaved_announcements_quiesce_without_clearing() -> None:
+    own = "att_" + "e" * 24
+    other = {"attemptId": "att_" + "f" * 24, "activity": "preparing"}
+    decision = contender_quiesce_decision(own_attempt_id=own, observed_contenders=[other])
+    assert decision["quiesce"] is True
+    assert decision["stopSharedPublication"] is True
+    assert decision["preserveOutput"] is True
+    assert decision["clearOtherInProgress"] is False
+    assert decision["contenders"] == ["att_" + "f" * 24]
+
+
+def test_three_simultaneous_announcements_all_observe_contenders() -> None:
+    attempts = ["att_" + c * 24 for c in ("a", "b", "c")]
+    for own in attempts:
+        others = [
+            {"attemptId": other, "activity": "active"}
+            for other in attempts if other != own
+        ]
+        decision = contender_quiesce_decision(own_attempt_id=own, observed_contenders=others)
+        assert decision["quiesce"] is True
+        assert decision["clearOtherInProgress"] is False
+        assert len(decision["contenders"]) == 2
+
+
+def test_recandidate_only_after_abandon_and_settled_writers() -> None:
+    assert recandidate_after_abandon(own_announcement_abandoned=True, writers_settled=True)["allowed"] is True
+    assert recandidate_after_abandon(own_announcement_abandoned=True, writers_settled=False)["allowed"] is False
+    assert recandidate_after_abandon(own_announcement_abandoned=False, writers_settled=True)["allowed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Acceptance D: successor resume + delayed mutation honesty
+# ---------------------------------------------------------------------------
+
+
+def test_reconnection_after_known_successor_stops_effects() -> None:
+    stopped = revalidate_for_mutation(
+        own_attempt_id="att_" + "a" * 24, observed={"settled": "available"},
+        known_successor_attempt_id="att_" + "b" * 24,
+    )
+    assert stopped["allowed"] is False
+    assert stopped["reasonCode"] == "known_successor"
+    assert "Unfenced" in stopped["raceNote"] or "unfenced" in stopped["raceNote"].lower()
+
+    resume = should_stop_on_resume(
+        own_attempt_id="att_" + "a" * 24, known_successor_attempt_id="att_" + "b" * 24
+    )
+    assert resume["stop"] is True
+
+
+def test_delayed_already_issued_mutation_not_falsely_fenced() -> None:
+    unfenced = check_delayed_mutation_fenced(mutation_issued_before_check=True)
+    assert unfenced["fenced"] is False
+    assert unfenced["reasonCode"] == "unfenced_race"
+    assert UNFENCED_CHECK_TO_WRITE_RACE_NOTE.split(":")[0][:8] in unfenced["summary"]
+
+    # should_abandon_retry remains the honest successor detector for real shapes.
+    observed = interpret_issue({"state": "open", "labels": ["status: code-review"]})
+    abandon, _ = should_abandon_retry(intended_from_settled="available", observed=observed)
+    assert abandon is True
+
+
+# ---------------------------------------------------------------------------
+# Acceptance E: child attempt propagation
+# ---------------------------------------------------------------------------
+
+
+def test_internal_retry_and_review_children_retain_controlling_attempt() -> None:
+    controlling = "att_" + "a" * 24
+    retry = child_attempt_context(controlling, child_kind="internal_retry")
+    assert retry["allowed"] is True
+    assert retry["attemptId"] == controlling
+    assert retry["stayInProgress"] is True
+
+    review = child_attempt_context(controlling, child_kind="review_wait")
+    assert review["allowed"] is True
+    assert review["attemptId"] == controlling
+
+    repair_denied = child_attempt_context(controlling, child_kind="existing_pr_repair")
+    assert repair_denied["allowed"] is False
+    assert repair_denied["reasonCode"] == "missing_pr_target"
+
+    repair = child_attempt_context(
+        controlling, child_kind="existing_pr_repair", pr_url="https://github.com/o/r/pull/7"
+    )
+    assert repair["allowed"] is True
+    assert repair["reasonCode"] == "admitted_repair"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance F: real workflow/Activity shapes + retained history
+# ---------------------------------------------------------------------------
+
+
+def test_real_transition_and_retry_shapes_preserved() -> None:
+    decision = plan_transition(
+        from_settled="available", to_target="to_in_progress",
+        evidence={"admission_passed": True, "prior_work_inspected": True}, reason="admit",
+    )
+    assert decision.allowed is True
+
+    # Portable retry lineage still owns the budget (no duplicate implementation).
+    state = attempt_mod.derive_retry_state([], policy={"maxAttempts": 3})
+    assert state["blocked"] is False
+
+    # Retained history: legacy in-progress spellings still count.
+    assert has_in_progress_status({"labels": ["status: in-progress"]}) is True

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -104,11 +104,11 @@ def test_unknown_entrypoint_and_unpinned_identity_block() -> None:
 def test_search_and_explicit_use_same_interpretation() -> None:
     # Real workflow call shape: search selector + explicit admission agree.
     issue = {"state": "open", "labels": ["bug"], "number": 1}
-    assert is_lifecycle_selectable_candidate({"state": "open", "labels": ["bug"]}) is True
+    assert is_lifecycle_selectable_candidate(issue) is True
     for entrypoint in (ENTRYPOINT_SEARCH, ENTRYPOINT_EXPLICIT):
         decision = admit_for_entrypoint(
             entrypoint, repository="o/r", issue_number=1,
-            issue={"state": "open", "labels": ["bug"]},
+            issue=issue,
         )
         assert decision.allowed is True
 
@@ -209,8 +209,16 @@ def test_announce_before_assessment_plans_in_progress() -> None:
     recovery = announce_before_assessment(
         settled="recovery_needed", repository="o/r", issue_number=1,
         attempt_id="att_" + "d" * 24, current_labels=["status: recovery-needed"],
+        predecessor_stopped=True, handoff_usable=True,
     )
     assert recovery["planned"] is True
+
+    recovery_missing = announce_before_assessment(
+        settled="recovery_needed", repository="o/r", issue_number=1,
+        attempt_id="att_" + "d" * 24, current_labels=["status: recovery-needed"],
+    )
+    assert recovery_missing["planned"] is False
+    assert recovery_missing["reasonCode"] == "recovery_handoff_missing"
 
     ineligible = announce_before_assessment(
         settled="in_progress", repository="o/r", issue_number=1,

--- a/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
+++ b/tests/unit/workflows/temporal/test_github_issue_admission_4178.py
@@ -619,6 +619,7 @@ async def test_explicit_load_honors_entrypoint_and_bundle(
     """Direct loads route orchestration/continuation identities via the same boundary."""
     service = _AdmissionFakeService(labels=[])
     _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
     _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
     result = await story_tools.load_github_issue_preset_brief(
         {
@@ -667,6 +668,7 @@ async def test_brief_load_plans_claim_and_persists_identity(
     """Req 2+3 are wired: the brief plans the advisory claim and pins identity."""
     service = _AdmissionFakeService(labels=[])
     _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
     _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
     result = await story_tools.load_github_issue_preset_brief(
         {
@@ -696,6 +698,7 @@ async def test_brief_entrypoint_inference_continuation_retry_orchestration(
     """Acceptance A: continuation/retry/orchestration reach the same boundary."""
     service = _AdmissionFakeService(labels=[])
     _install_admission_http(monkeypatch)
+    _install_dynamic_issue_fetch(monkeypatch, service, 4178)
     _AdmissionHttpClient.issue_payload = _admission_issue_payload(4178, [])
 
     continued = await story_tools.load_github_issue_preset_brief(
@@ -710,6 +713,11 @@ async def test_brief_entrypoint_inference_continuation_retry_orchestration(
     assert continued.status == "COMPLETED"
     assert continued.outputs["admissionEntrypoint"] == ENTRYPOINT_CONTINUATION
 
+    # Each brief applies the in-progress claim; reset the fake issue state so
+    # subsequent entrypoint admissions start from Available like an isolated
+    # issue rather than observing the prior call's claim.
+    service.labels = []
+    service.operations = []
     retried = await story_tools.load_github_issue_preset_brief(
         {"repository": "o/r", "issueNumber": 4178, "retryOf": "att_" + "c" * 24},
         github_service_factory=lambda: service,
@@ -717,6 +725,8 @@ async def test_brief_entrypoint_inference_continuation_retry_orchestration(
     assert retried.status == "COMPLETED"
     assert retried.outputs["admissionEntrypoint"] == ENTRYPOINT_RETRY
 
+    service.labels = []
+    service.operations = []
     orchestrated = await story_tools.load_github_issue_preset_brief(
         {"repository": "o/r", "issueNumber": 4178, "orchestrationRunId": "orch-1"},
         github_service_factory=lambda: service,

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -368,7 +368,15 @@ async def test_load_github_issue_preset_brief_uses_requested_artifact_path(
         "artifacts/github-issue-orchestrate-brief.json"
     )
     assert result.outputs["issue"]["number"] == 1067
-    assert service.token_requests == ["MoonLadderStudios/MoonMind"]
+    # Req 2 (issue #4178): the eligible brief announces the attempt and
+    # re-reads, so the initial fetch plus the post-claim re-read each resolve
+    # a token.
+    assert service.token_requests == [
+        "MoonLadderStudios/MoonMind",
+        "MoonLadderStudios/MoonMind",
+    ]
+    assert result.outputs["admissionClaim"]["planned"] is True
+    assert result.outputs["admissionClaimExecuted"]["executed"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements one shared advisory exact-issue admission/guard boundary used by search-selected work, explicit implementation/orchestration, retries, and operator continuations (issue MoonLadderStudios/MoonMind#4178, parent #4175, depends on #4176/#4177).

- Req 1: resolve exact repo/issue through trusted GitHub reads; thread labels, validated attempt history, PR identities, blocker evidence, retry/hold policy, read-completeness and attempt comments into the admit decision on both query and fallback paths. Incomplete/failed reads block as unknown evidence.
- Req 2: eligible Available/Recovery-needed briefs announce a stable attempt and apply in-progress BEFORE expensive assessment, then re-read before launching work (executed writes, not planned).
- Req 3: persist selected issue + predecessor exactly once; retry/replay with a different issue is denied as substitution_denied.
- Req 4: observed preparing/active contenders, operator holds, or contradictory evidence quiesce through the runtime boundary (stop shared publication, preserve output, never clear another attempt's in-progress); recandidate only after own abandoned announcement with writers settled.
- Req 5: resume-after-successor and pre-mutation revalidation at trusted launch/publication boundaries; delayed already-issued mutations honestly reported as unfenced; remaining unfenced check-to-write race explicitly documented by design (advisory path, not a distributed lock).
- Req 6: internal remediation retries and PR-review/merge children share the controlling issue attempt via fallback chain (explicit controlling id, shared attempt channel, previous/context outputs); existing-PR repair requires an admitted route plus exact PR target.
- No coordination branch, per-device labels, heartbeat-expiry takeover, or automatic force-push.

## Verification outcome

Latest controlling post-remediation moonspec-verify: FULLY_IMPLEMENTED (high confidence, recommendedNextAction advance, remainingWork empty) for candidate 3e7a58361ba5a5ce970b2d4f39f469748472b716 on branch moonmind-job-fd976c60. Initial assessment was PARTIALLY_IMPLEMENTED, so this run publishes the implementation even though the branch is clean and already pushed.

## Tests run

- Unit (new #4178 suite): moonmind container python-tests -- tests/unit/workflows/temporal/test_github_issue_admission_4178.py => 45 passed (includes 11 real-shape boundary tests: claim execute+reread, substitution block, contender/resume claim block, internal_retry, review_wait, fallback chain, downstream orchestration signals, query blocker skip, recandidate-allowed, three-way interleave).
- Unit (retained): lifecycle + attempt + attempts_4177 + story_output_tools suites => 361 passed, retained-history behavior preserved (no regressions).

## Remaining risks

- Advisory-only guarantee: three independent devices may still announce simultaneously; the duplicate-start window is detected and quiesced, not locked out. Documented unfenced check-to-write race remains.
- Mixed/unknown-state handling stays with downstream reconciliation by design.
- No credentialed provider-verification or live GitHub runs in this step; evidence is hermetic unit/boundary tests via managed container jobs.

Closes MoonLadderStudios/MoonMind#4178