### PR TITLE
[Qdrant removal] Retire native retrieval gateway, session capabilities and follow-up tools (MoonLadderStudios/MoonMind#4107)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1385,46 +1385,36 @@ async def _prepare_checkpoint_branch_launch(
 def _bound_branch_follow_up_retrieval(
     authored: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Narrow a branch-turn override to deployment-owned retrieval ceilings."""
+    """Retire branch-turn retrieval overrides (MoonLadderStudios/MoonMind#4107).
+
+    Built-in vector retrieval is retired (#4105): explicit branch-turn
+    ``followUpRetrieval`` requirements fail before any artifact write or
+    persistence, without silently weakening the request. Absent/empty/disabled
+    values return ``None`` so normal branch preparation needs no vector
+    settings and stale drafts cannot reintroduce retired authority.
+    """
 
     if authored is None:
         return None
-    bounded = dict(authored)
-    budgets = bounded.pop("budgets", None)
-    if isinstance(budgets, Mapping):
-        if "maxContextTokens" not in bounded:
-            bounded["maxContextTokens"] = budgets.get("tokens")
-        if "latencyMs" not in bounded:
-            bounded["latencyMs"] = budgets.get("latency_ms")
-    allowed = tuple(
-        item.strip()
-        for item in os.getenv(
-            "MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", "repo,docs"
-        ).split(",")
-        if item.strip()
+    from moonmind.workflows.executions.execution_contract import (
+        WorkflowContractError,
+        reject_retired_vector_fields,
     )
-    requested = list(dict.fromkeys(bounded.get("collections") or []))
-    if not all(isinstance(item, str) and item in allowed for item in requested):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"code": "retrieval_collections_exceed_server_policy"},
+
+    try:
+        reject_retired_vector_fields(
+            {"followUpRetrieval": dict(authored)},
+            field_path="payload",
         )
-    bounded["collections"] = requested
-    ceilings = {
-        "topK": ("MAX_TOP_K", 8),
-        "maxContextTokens": ("MAX_CONTEXT_TOKENS", 8192),
-        "maxQueries": ("MAX_QUERIES", 12),
-        "latencyMs": ("MAX_LATENCY_MS", 5000),
-        "maxLifetimeSeconds": ("MAX_LIFETIME_SECONDS", 900),
-    }
-    for field, (env_suffix, default) in ceilings.items():
-        value = bounded.get(field)
-        if isinstance(value, int) and not isinstance(value, bool):
-            bounded[field] = min(
-                value,
-                int(os.getenv(f"MOONMIND_FOLLOWUP_RETRIEVAL_{env_suffix}", default)),
-            )
-    return bounded
+    except WorkflowContractError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "retired_vector_retrieval",
+                "message": str(exc),
+            },
+        ) from exc
+    return None
 
 
 def _branch_comparison_record(

--- a/api_service/api/routers/omnigent_bridge.py
+++ b/api_service/api/routers/omnigent_bridge.py
@@ -79,12 +79,15 @@ from api_service.retrieval_capabilities import RetrievalCapabilityRegistry
 
 
 def get_capability_registry(request: Request) -> RetrievalCapabilityRegistry:
-    """Return the process-cached retrieval-authority registry.
+    """Return the process-cached drain-only retrieval-authority registry.
 
     MoonLadderStudios/MoonMind#4192: relocated here from the retired
-    ``retrieval_gateway`` router. The bridge keeps only session-authority
-    lifecycle (revocation on session teardown); no retrieval query path
-    remains.
+    ``retrieval_gateway`` router. MoonLadderStudios/MoonMind#4107: new
+    issuance is retired; the bridge keeps only scoped session-authority
+    drain (revocation on session teardown) plus historical-evidence reads
+    for already-issued capabilities. No retrieval query or issuance path
+    remains. Historical state drainage beyond scoped revocation is owned by
+    the epic cutover issue.
     """
 
     registry = getattr(request.app.state, "retrieval_capability_registry", None)
@@ -1565,7 +1568,13 @@ async def _revoke_session_retrieval_authority(
     store: OmnigentBridgeSessionStore,
     reason: str,
 ) -> list[str]:
-    """Close scoped retrieval authority before a destructive host boundary.
+    """Close scoped retired-retrieval authority before a destructive boundary.
+
+    MoonLadderStudios/MoonMind#4107: no new retrieval authority is issued;
+    this is the bounded drain for already-issued capabilities under the
+    epic cutover rule. Request/result correlation and durable artifacts are
+    preserved by the registry evidence readers; session retry never discovers
+    a changed tool set mid-work because new launches carry no retrieval tool.
 
     When the session cannot be scoped precisely — no bridge row, or a partially
     established one — the outcome depends on whether live authority still names

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -697,14 +697,6 @@ def build_runtime_config(
         if jira_runtime_config
         else {}
     )
-    retrieval_collections = [
-        item.strip()
-        for item in os.environ.get(
-            "MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", "repo,docs"
-        ).split(",")
-        if item.strip()
-    ]
-
     return {
         "initialPath": initial_path,
         "pollIntervalsMs": {
@@ -788,14 +780,6 @@ def build_runtime_config(
             "defaultModelByRuntime": default_model_by_runtime,
             "defaultEffortByRuntime": default_effort_by_runtime,
             "defaultPublishMode": default_publish_mode,
-            "retrievalAuthoring": {
-                "collections": retrieval_collections,
-                "topK": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_TOP_K", "8")),
-                "maxContextTokens": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_CONTEXT_TOKENS", "8192")),
-                "maxQueries": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_QUERIES", "12")),
-                "latencyMs": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_LATENCY_MS", "5000")),
-                "maxLifetimeSeconds": int(os.environ.get("MOONMIND_FOLLOWUP_RETRIEVAL_MAX_LIFETIME_SECONDS", "900")),
-            },
             "workerRuntimeEnv": "MOONMIND_WORKER_RUNTIME",
             "supportedRuntimes": supported_runtimes,
             "supportedWorkerRuntimes": list(_SUPPORTED_WORKER_RUNTIMES),

--- a/api_service/retrieval_capabilities.py
+++ b/api_service/retrieval_capabilities.py
@@ -1,7 +1,12 @@
-"""Ephemeral retrieval authority and bounded evidence for managed sessions.
+"""Retired native retrieval authority: drain-only evidence for managed sessions.
 
-The raw capability is returned once to the host.  Only its digest is retained;
-durable evidence therefore cannot be used to replay retrieval authority.
+Built-in vector retrieval is retired (MoonLadderStudios/MoonMind#4105,
+#4107): no new retrieval capability may be issued. ``RetrievalCapabilityRegistry``
+retains only the drain and historical-evidence paths -- scoped revocation,
+durable status/summaries, secret-free evidence, and result reads for
+already-issued capabilities -- so already-issued authority drains under the
+epic cutover rule and historical artifacts remain authorized and readable.
+New issuance fails closed via :meth:`RetrievalCapabilityRegistry.issue`.
 """
 
 from __future__ import annotations
@@ -92,10 +97,12 @@ class RetrievalCapabilityError(RuntimeError):
 
 
 class RetrievalCapabilityRegistry:
-    """Durable live authority with artifact-backed, secret-free evidence.
+    """Drain-only authority for retired native retrieval.
 
-    SQLite is the authority for capability lifecycle, accounting and
-    deduplication.  The in-memory objects are short-lived projections only.
+    SQLite remains the authority for already-issued capability lifecycle,
+    accounting and deduplication so in-flight work drains and historical
+    evidence stays readable after restart. New issuance is retired: :meth:`issue`
+    always fails closed. The in-memory objects are short-lived projections only.
     """
 
     def __init__(self, evidence_root: Path | None = None) -> None:
@@ -181,32 +188,21 @@ class RetrievalCapabilityRegistry:
     def issue(
         self, budget: RetrievalBudgetSnapshot, *, lifetime_seconds: int
     ) -> tuple[str, RetrievalCapability]:
-        now = time.time()
-        token = secrets.token_urlsafe(32)
-        capability = RetrievalCapability(
-            capability_id=f"rcap_{secrets.token_hex(12)}",
-            token_digest=_digest(token),
-            budget=budget,
-            issued_at=now,
-            expires_at=now + lifetime_seconds,
+        """Refuse new native retrieval issuance (retired #4105/#4107).
+
+        Already-issued capabilities continue to drain through ``revoke``,
+        ``revoke_scope``, ``resolve`` (revoked/expired/identity checks),
+        ``status`` and the evidence readers. No new token is ever minted,
+        so no newly issued token can grant retired vector authority and no
+        host manifest can receive a dead retrieval tool or credential.
+        """
+        raise RetrievalCapabilityError(
+            "retired",
+            "Built-in vector retrieval has been retired "
+            "(MoonLadderStudios/MoonMind#4105, #4107). Remove followUpRetrieval "
+            "and use explicit attachments, artifact refs, or scoped workspace "
+            "access instead. Historical details remain readable.",
         )
-        with self._lock:
-            self._capabilities[capability.capability_id] = capability
-            self._by_digest[capability.token_digest] = capability.capability_id
-            with self._connect() as connection:
-                connection.execute(
-                    """INSERT INTO retrieval_capabilities
-                       (capability_id, token_digest, budget_json, issued_at, expires_at)
-                       VALUES (?, ?, ?, ?, ?)""",
-                    (
-                        capability.capability_id,
-                        capability.token_digest,
-                        json.dumps(asdict(budget), sort_keys=True),
-                        capability.issued_at,
-                        capability.expires_at,
-                    ),
-                )
-        return token, capability
 
     def resolve(
         self,

--- a/frontend/src/components/ContextRetrievalControls.tsx
+++ b/frontend/src/components/ContextRetrievalControls.tsx
@@ -2,13 +2,11 @@ import { JSX } from 'react';
 
 import {
   ContextRetrievalAuthoring,
-  RetrievalCeilings,
 } from '../lib/contextRetrievalAuthoring';
 
 interface ContextRetrievalControlsProps {
   value: ContextRetrievalAuthoring;
   onChange: (next: ContextRetrievalAuthoring) => void;
-  ceilings?: RetrievalCeilings;
   /** Optional heading/context copy tailored to the hosting surface. */
   description?: string;
   disabled?: boolean;

--- a/frontend/src/entrypoints/omnigent-inventory.tsx
+++ b/frontend/src/entrypoints/omnigent-inventory.tsx
@@ -7,7 +7,6 @@ import { ContextRetrievalControls } from '../components/ContextRetrievalControls
 import {
   type ContextRetrievalAuthoring,
   defaultContextRetrievalAuthoring,
-  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 
 type InventoryKind = 'agents' | 'policies';
@@ -234,10 +233,7 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
   const queryKey = kind === 'agents' ? 'omnigent_agents_q' : 'omnigent_policies_q';
   const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const filter = params.get(queryKey) ?? '';
-  const initialData = payload.initialData as { uiEndpoints?: Record<string, unknown>; dashboardConfig?: { system?: { retrievalAuthoring?: Record<string, unknown> } } } | undefined;
-  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
-    initialData?.dashboardConfig?.system?.retrievalAuthoring,
-  );
+  const initialData = payload.initialData as { uiEndpoints?: Record<string, unknown>; dashboardConfig?: { system?: Record<string, unknown> } } | undefined;
   const endpoints = initialData?.uiEndpoints;
   const enabled = payload.features?.[featureKey] === true;
   const discoveredEndpoint = endpoints?.[kind === 'agents' ? 'omnigentAgents' : 'omnigentPolicies'];
@@ -514,7 +510,6 @@ export default function OmnigentInventoryPage({ payload }: { payload: BootPayloa
               <summary>Context retrieval (RAG) defaults</summary>
               <ContextRetrievalControls
                 value={retrieval.value}
-                ceilings={retrievalCeilings}
                 onChange={(next) =>
                   setEditor({
                     ...editor,

--- a/frontend/src/entrypoints/schedules.tsx
+++ b/frontend/src/entrypoints/schedules.tsx
@@ -22,7 +22,6 @@ import {
   type ContextRetrievalAuthoring,
   compileContextRetrievalParameters,
   parseContextRetrievalParameters,
-  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 
 const SCHEDULES_MOBILE_MEDIA_QUERY = '(max-width: 720px)';
@@ -204,7 +203,6 @@ const SchedulesBootDataSchema = z
           })
           .partial()
           .optional(),
-        system: z.object({ retrievalAuthoring: z.record(z.string(), z.unknown()).optional() }).partial().optional(),
       })
       .partial()
       .optional(),
@@ -1024,9 +1022,6 @@ function ScheduleDetailPage({
   onSidebarRetry?: () => void;
 }) {
   const queryClient = useQueryClient();
-  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
-    scheduleBootData(payload)?.dashboardConfig?.system?.retrievalAuthoring,
-  );
   const [isEditing, setIsEditing] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [editForm, setEditForm] = useState<ScheduleEditForm | null>(null);
@@ -1532,7 +1527,6 @@ function ScheduleDetailPage({
                     <summary>Context retrieval (RAG)</summary>
                     <ContextRetrievalControls
                       value={retrieval.value}
-                      ceilings={retrievalCeilings}
                       onChange={(next) => {
                         const targetJson = writeScheduleContextRetrieval(
                           retrieval.parsed,

--- a/frontend/src/entrypoints/workflow-detail.tsx
+++ b/frontend/src/entrypoints/workflow-detail.tsx
@@ -31,7 +31,6 @@ import {
   compileContextRetrievalParameters,
   defaultContextRetrievalAuthoring,
   hasAuthoredContextRetrieval,
-  retrievalCeilingsFromRuntimeConfig,
 } from '../lib/contextRetrievalAuthoring';
 import {
   DashboardToastProvider,
@@ -124,7 +123,6 @@ type DashboardConfig = {
     temporal?: Record<string, string>;
     agentRuns?: Record<string, string>;
   };
-  system?: { retrievalAuthoring?: Record<string, unknown> };
 };
 
 type LiveLogsSessionTimelineRollout = 'off' | 'internal' | 'codex_managed' | 'all_managed';
@@ -4950,7 +4948,6 @@ function BranchExplorerPanel({
   latestCompare,
   onSelectBranch,
   onBranchAction,
-  retrievalCeilings,
 }: {
   apiBase: string;
   workflowId: string;
@@ -4967,7 +4964,6 @@ function BranchExplorerPanel({
   latestCompare: z.infer<typeof CheckpointBranchCompareSchema> | null;
   onSelectBranch: (branchId: string) => void;
   onBranchAction: (request: BranchMutationRequest) => void;
-  retrievalCeilings: ReturnType<typeof retrievalCeilingsFromRuntimeConfig>;
 }) {
   const profilesQuery = useQuery({
     queryKey: ['checkpoint-branch', 'profiles'],
@@ -5292,7 +5288,6 @@ function BranchExplorerPanel({
             <ContextRetrievalControls
               value={branchContextRetrieval}
               onChange={setBranchContextRetrieval}
-              ceilings={retrievalCeilings}
               showInitialControls={false}
               disabled={busy}
               description="Continue/fork turns inherit the parent run's retrieval policy. Set an override here to narrow in-session follow-up retrieval for the new turn within deployment ceilings."
@@ -8762,9 +8757,6 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const toast = useDashboardToast();
   const cfg = readDashboardConfig(payload);
-  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
-    cfg?.system?.retrievalAuthoring,
-  );
   const agentRunRoutes = readAgentRunRouteTemplates(cfg);
   const detailPoll = cfg?.pollIntervalsMs?.detail ?? 2000;
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
@@ -10728,7 +10720,6 @@ function WorkflowDetailPageContent({ payload }: { payload: BootPayload }) {
                       setActionError(null);
                       checkpointBranchMutation.mutate(request);
                     }}
-                    retrievalCeilings={retrievalCeilings}
                   />
                 </>
               ) : (

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -61,7 +61,6 @@ import {
   defaultContextRetrievalAuthoring,
   hasAuthoredContextRetrieval,
   parseContextRetrievalParameters,
-  retrievalCeilingsFromRuntimeConfig,
 } from "../lib/contextRetrievalAuthoring";
 
 type WorkflowStartDashboardConfig = {
@@ -402,7 +401,6 @@ interface DashboardConfig {
       defaultBoardId?: string;
       rememberLastBoardInSession?: boolean;
     };
-    retrievalAuthoring?: Record<string, unknown>;
   };
 }
 
@@ -5979,9 +5977,6 @@ function StepContextBar({
 function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   useLiquidGL({ options: LIQUID_GL_OPTIONS });
   const dashboardConfig = readDashboardConfig(payload);
-  const retrievalCeilings = retrievalCeilingsFromRuntimeConfig(
-    dashboardConfig.system?.retrievalAuthoring,
-  );
   const pageMode = useMemo(
     () => resolveTaskSubmitPageMode(window.location.search),
     [],
@@ -14396,7 +14391,6 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
             <ContextRetrievalControls
               value={contextRetrieval}
               onChange={setContextRetrieval}
-              ceilings={retrievalCeilings}
               description="Choose which collections the run may search and whether the session may request additional context during the run. Requests are always bounded by deployment policy."
             />
           </details>

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -41,7 +41,6 @@ def test_status_maps_returns_copy() -> None:
     assert dashboard_view_model.status_maps()["temporal"]["queued"] == "queued"
 
 def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
-    monkeypatch.delenv("MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS", raising=False)
     monkeypatch.setattr(settings.anthropic, "anthropic_api_key", None)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
@@ -55,7 +54,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     )
 
     config = dashboard_view_model.build_runtime_config("/workflows")
-    assert config["system"]["retrievalAuthoring"]["collections"] == ["repo", "docs"]
+    assert "retrievalAuthoring" not in config["system"]
     assert config["initialPath"] == "/workflows"
     assert config["pollIntervalsMs"]["list"] > 0
     assert config["sources"]["temporal"]["list"] == "/api/executions"

--- a/tests/unit/api/test_retrieval_capabilities.py
+++ b/tests/unit/api/test_retrieval_capabilities.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import secrets
+import time
+from dataclasses import asdict
 
 import pytest
 
 from api_service.retrieval_capabilities import (
     RetrievalBudgetSnapshot,
+    RetrievalCapability,
     RetrievalCapabilityError,
     RetrievalCapabilityRegistry,
 )
@@ -31,9 +36,60 @@ def _budget(**overrides):
     return RetrievalBudgetSnapshot(**values)
 
 
+def _seed_issued_capability(
+    registry: RetrievalCapabilityRegistry,
+    budget: RetrievalBudgetSnapshot,
+    *,
+    lifetime_seconds: int,
+) -> tuple[str, RetrievalCapability]:
+    """Seed an already-issued capability for drain tests (retired #4107).
+
+    Test-only white-box seeding for the drain-only contract: production
+    ``RetrievalCapabilityRegistry.issue`` always raises ``retired`` and must
+    never be used to mint authority. This inserts the durable row directly so
+    revoke/resolve/begin/finish/abort/status/evidence assertions keep covering
+    already-issued lifecycle, budget, redaction and idempotency behavior.
+    """
+    now = time.time()
+    token = secrets.token_urlsafe(32)
+    token_digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    capability = RetrievalCapability(
+        capability_id=f"rcap_{secrets.token_hex(12)}",
+        token_digest=token_digest,
+        budget=budget,
+        issued_at=now,
+        expires_at=now + lifetime_seconds,
+    )
+    with registry._lock:
+        registry._capabilities[capability.capability_id] = capability
+        registry._by_digest[token_digest] = capability.capability_id
+        with registry._connect() as connection:
+            connection.execute(
+                """INSERT INTO retrieval_capabilities
+                   (capability_id, token_digest, budget_json, issued_at, expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    capability.capability_id,
+                    capability.token_digest,
+                    json.dumps(asdict(budget), sort_keys=True),
+                    capability.issued_at,
+                    capability.expires_at,
+                ),
+            )
+    return token, capability
+
+
+def test_issue_refuses_new_issuance_after_retirement(tmp_path) -> None:
+    """New native retrieval issuance fails closed (#4105/#4107)."""
+    registry = RetrievalCapabilityRegistry(tmp_path)
+    with pytest.raises(RetrievalCapabilityError) as retired:
+        registry.issue(_budget(), lifetime_seconds=60)
+    assert retired.value.reason == "retired"
+
+
 def test_capability_is_identity_bound_and_stores_only_token_digest(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    token, capability = registry.issue(_budget(), lifetime_seconds=60)
+    token, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
 
     assert token not in repr(capability)
     assert registry.resolve(
@@ -47,7 +103,7 @@ def test_capability_is_identity_bound_and_stores_only_token_digest(tmp_path) -> 
 
 def test_query_accounting_deduplicates_and_enforces_ceiling(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(_budget(max_queries=1), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(max_queries=1), lifetime_seconds=60)
 
     assert registry.begin(capability, "tool-1") is None
     result = {"kind": "retrieval_tool_result"}
@@ -59,14 +115,14 @@ def test_query_accounting_deduplicates_and_enforces_ceiling(tmp_path) -> None:
 
 def test_revoke_and_expiry_are_deterministic(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    token, capability = registry.issue(_budget(), lifetime_seconds=0)
+    token, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=0)
     with pytest.raises(RetrievalCapabilityError) as expired:
         registry.resolve(
             token, host_id="host-1", session_id="session-1", run_id="run-1"
         )
     assert expired.value.reason == "expired"
 
-    token, capability = registry.issue(_budget(), lifetime_seconds=60)
+    token, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     registry.revoke(capability.capability_id)
     with pytest.raises(RetrievalCapabilityError) as revoked:
         registry.resolve(
@@ -77,7 +133,7 @@ def test_revoke_and_expiry_are_deterministic(tmp_path) -> None:
 
 def test_evidence_is_bounded_and_contains_no_capability_secret(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    token, capability = registry.issue(_budget(), lifetime_seconds=60)
+    token, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     ref = registry.record(
         capability,
         {
@@ -98,7 +154,7 @@ def test_evidence_is_bounded_and_contains_no_capability_secret(tmp_path) -> None
 
 def test_capability_accounting_and_revocation_survive_registry_restart(tmp_path) -> None:
     first = RetrievalCapabilityRegistry(tmp_path)
-    token, capability = first.issue(_budget(max_queries=2), lifetime_seconds=60)
+    token, capability = _seed_issued_capability(first, _budget(max_queries=2), lifetime_seconds=60)
     first.begin(capability, "tool-1")
     first.finish(capability, "tool-1", {"deliveryState": "delivery_unknown"})
 
@@ -122,7 +178,7 @@ def test_capability_accounting_and_revocation_survive_registry_restart(tmp_path)
 
 def test_evidence_index_and_artifact_backed_result_survive_restart(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(_budget(), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     result_ref = registry.store_result(
         capability, "tool-1", {"items": [{"text": "large result"}]}
     )
@@ -144,7 +200,7 @@ def test_evidence_index_and_artifact_backed_result_survive_restart(tmp_path) -> 
 
 def test_delivery_requires_explicit_bridge_acknowledgement(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(_budget(), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     registry.begin(capability, "tool-1")
     registry.finish(
         capability,
@@ -166,7 +222,7 @@ def test_delivery_requires_explicit_bridge_acknowledgement(tmp_path) -> None:
 
 def test_per_minute_rate_limit_is_durable_and_deduplicated(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(
+    _, capability = _seed_issued_capability(registry, 
         _budget(max_queries=10, max_requests_per_minute=1), lifetime_seconds=60
     )
     registry.begin(capability, "tool-1")
@@ -185,7 +241,7 @@ def test_per_minute_rate_limit_is_durable_and_deduplicated(tmp_path) -> None:
 
 def test_authorization_denial_is_correlated_without_exposing_token(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    token, capability = registry.issue(_budget(), lifetime_seconds=60)
+    token, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
 
     with pytest.raises(RetrievalCapabilityError) as mismatch:
         registry.resolve(
@@ -206,8 +262,8 @@ def test_authorization_denial_is_correlated_without_exposing_token(tmp_path) -> 
 
 def test_revoke_scope_drains_only_the_exact_session_authority(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    first_token, first = registry.issue(_budget(), lifetime_seconds=60)
-    second_token, second = registry.issue(
+    first_token, first = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
+    second_token, second = _seed_issued_capability(registry, 
         _budget(session_id="session-2", step_id="step-2"), lifetime_seconds=60
     )
 
@@ -237,7 +293,7 @@ def test_revoke_scope_drains_only_the_exact_session_authority(tmp_path) -> None:
 def test_revoke_scope_refuses_partial_identity(tmp_path, scope) -> None:
     """A missing identifier must never be treated as a run-wide wildcard."""
     registry = RetrievalCapabilityRegistry(tmp_path)
-    token, _ = registry.issue(_budget(), lifetime_seconds=60)
+    token, _ = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
 
     with pytest.raises(RetrievalCapabilityError) as refused:
         registry.revoke_scope(**scope)
@@ -258,7 +314,7 @@ def test_issuance_accounting_reports_live_scope_capability(tmp_path) -> None:
     }
     assert registry.live_scope_capability(**scope) is None
 
-    _, capability = registry.issue(_budget(), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     live = registry.live_scope_capability(**scope)
     assert live is not None and live.capability_id == capability.capability_id
 
@@ -269,7 +325,7 @@ def test_issuance_accounting_reports_live_scope_capability(tmp_path) -> None:
 def test_expired_reservation_is_reclaimed_after_process_interruption(tmp_path) -> None:
     """An abandoned in-progress request must not wedge the concurrency slot."""
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(
+    _, capability = _seed_issued_capability(registry, 
         _budget(max_queries=5, max_concurrency=1), lifetime_seconds=60
     )
     assert registry.begin(capability, "tool-1") is None
@@ -292,7 +348,7 @@ def test_expired_reservation_is_reclaimed_after_process_interruption(tmp_path) -
 def test_concurrent_retry_of_one_tool_call_is_reserved_not_duplicated(tmp_path) -> None:
     """The idempotency key must be reserved before execution, not after."""
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(
+    _, capability = _seed_issued_capability(registry, 
         _budget(max_queries=5, max_concurrency=4), lifetime_seconds=60
     )
     assert registry.begin(capability, "tool-1") is None
@@ -309,7 +365,7 @@ def test_concurrent_retry_of_one_tool_call_is_reserved_not_duplicated(tmp_path) 
 
 def test_aborted_request_releases_its_reservation(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(
+    _, capability = _seed_issued_capability(registry, 
         _budget(max_queries=5, max_concurrency=1), lifetime_seconds=60
     )
     registry.begin(capability, "tool-1")
@@ -321,7 +377,7 @@ def test_aborted_request_releases_its_reservation(tmp_path) -> None:
 
 def test_assert_active_rejects_authority_revoked_in_flight(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(_budget(), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     registry.begin(capability, "tool-1")
     registry.assert_active(capability.capability_id)
 
@@ -334,8 +390,8 @@ def test_assert_active_rejects_authority_revoked_in_flight(tmp_path) -> None:
 def test_stored_results_are_namespaced_by_capability(tmp_path) -> None:
     """Two sessions in one run may reuse a tool-call id without colliding."""
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, first = registry.issue(_budget(), lifetime_seconds=60)
-    _, second = registry.issue(
+    _, first = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
+    _, second = _seed_issued_capability(registry, 
         _budget(session_id="session-2", step_id="step-2"), lifetime_seconds=60
     )
 
@@ -349,7 +405,7 @@ def test_stored_results_are_namespaced_by_capability(tmp_path) -> None:
 
 def test_stored_result_reference_is_dereferenceable(tmp_path) -> None:
     registry = RetrievalCapabilityRegistry(tmp_path)
-    _, capability = registry.issue(_budget(), lifetime_seconds=60)
+    _, capability = _seed_issued_capability(registry, _budget(), lifetime_seconds=60)
     ref = registry.store_result(capability, "tool call/1", {"pack": "value"})
 
     assert ref == (


### PR DESCRIPTION
## Summary

Retires MoonMind's native vector retrieval plane for MoonLadderStudios/MoonMind#4107 (parent #4103, depends on #4105):

- Deletes the native `retrieval_gateway.py` router, registration, and vector-only health/admin routes; generated OpenAPI carries no `/retrieval` routes (no 501/empty-success stubs).
- Fail-closes issuance: `RetrievalCapabilityRegistry.issue()` raises `RetrievalCapabilityError('retired')`; `compile_follow_up_retrieval_policy` always returns disabled; explicit authored blocks rejected with `OMNIGENT_RETIRED_VECTOR_RETRIEVAL`; executions/branch/schedule/plan-service boundaries reject with 422 `retired_vector_retrieval`.
- Removes dashboard `retrievalAuthoring` ceilings and `MOONMIND_FOLLOWUP_RETRIEVAL_COLLECTIONS/_MAX_TOP_K/_MAX_CONTEXT_TOKENS/_MAX_QUERIES/_MAX_LATENCY_MS/_MAX_LIFETIME_SECONDS` env exports plus all four frontend `retrievalCeilingsFromRuntimeConfig` call sites; `ContextRetrievalControls` renders retired notice only.
- Migrates `tests/unit/api/test_retrieval_capabilities.py` to the drain-only contract via test-only `_seed_issued_capability` (direct SQLite insert, never production `issue()`) plus `test_issue_refuses_new_issuance_after_retirement`.
- Retains `moonmind_retrieval_state` volume as live drain authority + durable evidence (distinct from `qdrant-storage`); no whole bridge/session table deletion; bounded revocation/drain via `_revoke_session_retrieval_authority` with `retrieval.capabilities.revoked` events and request/result correlation preserved across restart.

## Verification outcome

Latest controlling post-remediation moonspec-verify: **FULLY_IMPLEMENTED** (HIGH confidence, candidate `959c83ae42d3849ed8589c4bef958965eb312e8b`, `recommendedNextAction: advance`, gaps: none).
- Initial assessment: `PARTIALLY_IMPLEMENTED` (gateway gone but issuance plane intact).
- Pre-remediation verify at `4d8adee7e`: `ADDITIONAL_WORK_NEEDED` (20 stale issuance-based tests red + ceilings env exports live).
- Post-remediation verify: all 8 coverage nodes VERIFIED (req1–req7 + compat/test-discipline), gaps `[]`, remaining work `[]`.

## Tests run

- `moonmind container python-tests tests/unit/api/test_retrieval_capabilities.py` — PASS (21 passed, incl. new retirement refusal test; drain/security/budget/redaction/idempotency preserved via test-only seeding).
- `moonmind container python-tests tests/unit/omnigent/test_follow_up_retrieval_policy.py tests/unit/workflows/executions/test_execution_contract_retired_vector.py tests/unit/config/test_vector_free_regression_4114.py tests/unit/api/routers/test_workflow_console_view_model.py` — PASS (retired-policy, contract rejection, vector-free regression, view-model absence assertion).
- `moonmind container python-tests tests/unit/api/routers/test_omnigent_bridge.py` — PASS (80 passed incl. scope/denial/revocation).
- `moonmind container python-tests tests/unit/api/routers/test_executions.py::test_create_execution_rejects_retired_vector_retrieval tests/unit/api/routers/test_executions.py::test_build_recurring_target_rejects_retired_vector_in_task_path` — PASS.
- Frontend dashboard suite — NOT RUN (advisory; retired-notice + ceilings-removal covered by view-model unit tests and entrypoint diffs).
- Hermetic `integration_ci` — NOT RUN (no integration-boundary change beyond unit-covered seams).

## Remaining risks

- Workflow Detail facade journey without Qdrant not verified end-to-end (unit-covered only).
- Surviving-interface adversarial matrix (unsafe destinations, redirects, secret leakage) sampled, not exhaustively audited.
- Explicit cross-release old-version cutover rule owned by the epic cutover issue, not #4107, per brief.

Closes MoonLadderStudios/MoonMind#4107
